### PR TITLE
fix(bos_build): resolve user-level Chrome installs for crx packing

### DIFF
--- a/packages/browseros/bos_build/release/extensions/crx.py
+++ b/packages/browseros/bos_build/release/extensions/crx.py
@@ -15,6 +15,10 @@ from ...lib.utils import log_info, log_success
 _DARWIN_CANDIDATES = (
     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    # User-level installs (e.g. the self-hosted mac runner keeps Chrome
+    # in ~/Applications).
+    "~/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "~/Applications/Chromium.app/Contents/MacOS/Chromium",
 )
 _LINUX_CANDIDATES = (
     "google-chrome-stable",
@@ -30,7 +34,7 @@ _WINDOWS_CANDIDATES = (
 
 
 def _is_valid_binary(path: str) -> bool:
-    p = Path(path)
+    p = Path(path).expanduser()
     if p.exists() and p.is_file():
         return os.access(p, os.X_OK)
     return subprocess.run(["which", path], capture_output=True).returncode == 0
@@ -67,8 +71,9 @@ def find_chrome_binary(
         raise RuntimeError(f"Unsupported platform for CRX packing: {system}")
 
     for binary in candidates:
-        if is_valid(binary):
-            return binary
+        expanded = str(Path(binary).expanduser())
+        if is_valid(expanded):
+            return expanded
 
     raise RuntimeError(
         "Chrome/Chromium binary not found — install Chrome, set CHROME_BINARY, "


### PR DESCRIPTION
nightly-browserclaw take 2 (run 28837755325) failed the bundled_extensions preflight: Chrome lives at `~/Applications/Google Chrome.app` on the runner and `_DARWIN_CANDIDATES` only checks `/Applications`. Add user-level candidates, expand `~` in validation, and return the expanded path (subprocess argv gets no shell expansion). Live-verified on the runner: candidate fallback resolves without CHROME_BINARY. Full suite + ruff green. (CHROME_BINARY is also now set in the runner's .env as belt-and-suspenders.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)