### PR TITLE
feat: win visible installer ui

### DIFF
--- a/packages/browseros/bos_build/features.yaml
+++ b/packages/browseros/bos_build/features.yaml
@@ -448,3 +448,13 @@ features:
       - chrome/browser/extensions/manifest_v2_experiment_manager.cc
       - chrome/browser/ui/webui/extensions/extensions_ui.cc
       - extensions/common/extension.cc
+
+  win-visible-installer-ui:
+    description: "feat: win visible installer ui"
+    files:
+      - chrome/installer/setup/BUILD.gn
+      - chrome/installer/setup/browseros_install_ui.cc
+      - chrome/installer/setup/browseros_install_ui.h
+      - chrome/installer/setup/setup_main.cc
+      - chrome/installer/util/util_constants.cc
+      - chrome/installer/util/util_constants.h

--- a/packages/browseros/chromium_patches/chrome/browser/win/winsparkle_glue.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/win/winsparkle_glue.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/win/winsparkle_glue.cc b/chrome/browser/win/winsparkle_glue.cc
 new file mode 100644
-index 0000000000000..93e1ec7170840
+index 0000000000000000000000000000000000000000..08612fa1795d97550c56f02254ea89168fc5b9e6
 --- /dev/null
 +++ b/chrome/browser/win/winsparkle_glue.cc
-@@ -0,0 +1,375 @@
+@@ -0,0 +1,377 @@
 +// Copyright 2024 BrowserOS Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -33,6 +33,7 @@ index 0000000000000..93e1ec7170840
 +#include "base/version_info/version_info.h"
 +#include "build/build_config.h"
 +#include "chrome/browser/browseros/core/browseros_product.h"
++#include "chrome/installer/util/util_constants.h"
 +#include "content/public/browser/browser_thread.h"
 +#include "third_party/winsparkle/include/winsparkle.h"
 +
@@ -129,8 +130,9 @@ index 0000000000000..93e1ec7170840
 +  bool LaunchInstaller(const base::FilePath& installer_path) {
 +    base::LaunchOptions options;
 +    options.start_hidden = true;
-+    base::Process process =
-+        base::LaunchProcess(base::CommandLine(installer_path), options);
++    base::CommandLine command_line(installer_path);
++    command_line.AppendSwitch(installer::switches::kSilent);
++    base::Process process = base::LaunchProcess(command_line, options);
 +    if (!process.IsValid()) {
 +      LOG(ERROR) << "WinSparkle: failed to launch installer "
 +                 << installer_path.value();

--- a/packages/browseros/chromium_patches/chrome/installer/setup/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/installer/setup/BUILD.gn
@@ -1,0 +1,25 @@
+diff --git a/chrome/installer/setup/BUILD.gn b/chrome/installer/setup/BUILD.gn
+index 2b1d7cb7ae257669d56bcfefb2b4a31e4aa035f7..83a2f242b7e2375c563f0a98503e2b3c55a23eb5 100644
+--- a/chrome/installer/setup/BUILD.gn
++++ b/chrome/installer/setup/BUILD.gn
+@@ -11,6 +11,8 @@ import("//testing/test.gni")
+ if (is_win) {
+   executable("setup") {
+     sources = [
++      "browseros_install_ui.cc",
++      "browseros_install_ui.h",
+       "setup.rc",
+       "setup_main.cc",
+       "setup_main.h",
+@@ -48,7 +50,10 @@ if (is_win) {
+       "//url",
+     ]
+ 
+-    libs = [ "netapi32.lib" ]
++    libs = [
++      "comctl32.lib",
++      "netapi32.lib",
++    ]
+   }
+ 
+   static_library("lib") {

--- a/packages/browseros/chromium_patches/chrome/installer/setup/browseros_install_ui.cc
+++ b/packages/browseros/chromium_patches/chrome/installer/setup/browseros_install_ui.cc
@@ -1,0 +1,268 @@
+diff --git a/chrome/installer/setup/browseros_install_ui.cc b/chrome/installer/setup/browseros_install_ui.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..93da7d596dbc87a85996de1b36cf702d94e813fe
+--- /dev/null
++++ b/chrome/installer/setup/browseros_install_ui.cc
+@@ -0,0 +1,262 @@
++// Copyright 2026 BrowserOS Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/installer/setup/browseros_install_ui.h"
++
++#include <windows.h>
++
++#include <commctrl.h>
++
++#include <string>
++#include <utility>
++
++#include "base/logging.h"
++#include "base/strings/strcat_win.h"
++#include "base/synchronization/waitable_event.h"
++#include "chrome/installer/util/install_util.h"
++#include "chrome/installer/util/l10n_string_util.h"
++
++namespace installer {
++
++namespace {
++
++constexpr wchar_t kInstallWindowClass[] = L"BrowserOSInstallProgressWindow";
++constexpr int kWindowWidthDips = 420;
++constexpr int kWindowHeightDips = 150;
++constexpr int kMarginDips = 24;
++constexpr int kTextHeightDips = 24;
++constexpr int kProgressHeightDips = 18;
++constexpr int kProgressTopDips = 76;
++
++LRESULT CALLBACK InstallWindowProc(HWND hwnd,
++                                   UINT message,
++                                   WPARAM wparam,
++                                   LPARAM lparam) {
++  if (message == WM_CLOSE) {
++    return 0;
++  }
++
++  return ::DefWindowProc(hwnd, message, wparam, lparam);
++}
++
++int GetSystemDpi() {
++  HDC screen_dc = ::GetDC(nullptr);
++  if (!screen_dc) {
++    return USER_DEFAULT_SCREEN_DPI;
++  }
++
++  const int dpi = ::GetDeviceCaps(screen_dc, LOGPIXELSX);
++  ::ReleaseDC(nullptr, screen_dc);
++  return dpi > 0 ? dpi : USER_DEFAULT_SCREEN_DPI;
++}
++
++int ScaleForDpi(int dips, int dpi) {
++  return ::MulDiv(dips, dpi, USER_DEFAULT_SCREEN_DPI);
++}
++
++RECT GetCenteredWindowBounds(int width, int height) {
++  RECT work_area = {};
++  if (!::SystemParametersInfo(SPI_GETWORKAREA, 0, &work_area, 0)) {
++    work_area.right = ::GetSystemMetrics(SM_CXSCREEN);
++    work_area.bottom = ::GetSystemMetrics(SM_CYSCREEN);
++  }
++
++  const int x =
++      work_area.left + ((work_area.right - work_area.left - width) / 2);
++  const int y =
++      work_area.top + ((work_area.bottom - work_area.top - height) / 2);
++  return {x, y, x + width, y + height};
++}
++
++std::wstring GetWindowTitle(const std::wstring& display_name) {
++  return base::StrCat({display_name, L" Installer"});
++}
++
++std::wstring GetInstallMessage(const std::wstring& display_name) {
++  return base::StrCat({L"Installing ", display_name, L"..."});
++}
++
++std::wstring GetFailureMessage(int install_msg_base,
++                               const std::wstring& display_name) {
++  if (install_msg_base != 0) {
++    std::wstring message = installer::GetLocalizedString(install_msg_base);
++    if (!message.empty()) {
++      return message;
++    }
++  }
++
++  return base::StrCat({L"Failed to install ", display_name, L"."});
++}
++
++}  // namespace
++
++class BrowserOSInstallUI::UIThreadDelegate final
++    : public base::PlatformThread::Delegate {
++ public:
++  explicit UIThreadDelegate(std::wstring display_name)
++      : display_name_(std::move(display_name)) {}
++
++  UIThreadDelegate(const UIThreadDelegate&) = delete;
++  UIThreadDelegate& operator=(const UIThreadDelegate&) = delete;
++
++  void ThreadMain() override {
++    base::PlatformThread::SetName("Installer UI");
++    thread_id_ = ::GetCurrentThreadId();
++
++    MSG msg;
++    ::PeekMessage(&msg, nullptr, WM_USER, WM_USER, PM_NOREMOVE);
++
++    const INITCOMMONCONTROLSEX init_controls = {
++        .dwSize = sizeof(INITCOMMONCONTROLSEX),
++        .dwICC = ICC_PROGRESS_CLASS,
++    };
++    if (!::InitCommonControlsEx(&init_controls)) {
++      LOG(ERROR) << "Failed to initialize installer progress control: "
++                 << ::GetLastError();
++      ready_event_.Signal();
++      return;
++    }
++
++    const HINSTANCE instance = ::GetModuleHandle(nullptr);
++    WNDCLASSEX window_class = {
++        .cbSize = sizeof(WNDCLASSEX),
++        .lpfnWndProc = InstallWindowProc,
++        .hInstance = instance,
++        .hCursor = ::LoadCursor(nullptr, IDC_ARROW),
++        .hbrBackground = reinterpret_cast<HBRUSH>(COLOR_WINDOW + 1),
++        .lpszClassName = kInstallWindowClass,
++    };
++
++    if (!::RegisterClassEx(&window_class) &&
++        ::GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
++      LOG(ERROR) << "Failed to register installer progress window: "
++                 << ::GetLastError();
++      ready_event_.Signal();
++      return;
++    }
++
++    const int dpi = GetSystemDpi();
++    RECT bounds = GetCenteredWindowBounds(ScaleForDpi(kWindowWidthDips, dpi),
++                                          ScaleForDpi(kWindowHeightDips, dpi));
++    const std::wstring title = GetWindowTitle(display_name_);
++    hwnd_ = ::CreateWindowEx(WS_EX_DLGMODALFRAME | WS_EX_APPWINDOW,
++                             kInstallWindowClass, title.c_str(),
++                             WS_CAPTION | WS_POPUP, bounds.left, bounds.top,
++                             bounds.right - bounds.left,
++                             bounds.bottom - bounds.top, nullptr, nullptr,
++                             instance, nullptr);
++    if (!hwnd_) {
++      LOG(ERROR) << "Failed to create installer progress window: "
++                 << ::GetLastError();
++      ready_event_.Signal();
++      return;
++    }
++
++    const HFONT font =
++        reinterpret_cast<HFONT>(::GetStockObject(DEFAULT_GUI_FONT));
++    const int margin = ScaleForDpi(kMarginDips, dpi);
++    const int content_width = bounds.right - bounds.left - (2 * margin);
++
++    const std::wstring install_message = GetInstallMessage(display_name_);
++    HWND text = ::CreateWindowEx(
++        0, L"STATIC", install_message.c_str(), WS_CHILD | WS_VISIBLE | SS_LEFT,
++        margin, margin, content_width, ScaleForDpi(kTextHeightDips, dpi), hwnd_,
++        nullptr, instance, nullptr);
++    if (text && font) {
++      ::SendMessage(text, WM_SETFONT, reinterpret_cast<WPARAM>(font), TRUE);
++    }
++
++    HWND progress = ::CreateWindowEx(
++        0, PROGRESS_CLASS, nullptr, WS_CHILD | WS_VISIBLE | PBS_MARQUEE, margin,
++        ScaleForDpi(kProgressTopDips, dpi), content_width,
++        ScaleForDpi(kProgressHeightDips, dpi), hwnd_, nullptr, instance,
++        nullptr);
++    if (progress) {
++      ::SendMessage(progress, PBM_SETMARQUEE, TRUE, 0);
++    }
++
++    ::ShowWindow(hwnd_, SW_SHOWNORMAL);
++    ::UpdateWindow(hwnd_);
++    ready_event_.Signal();
++
++    while (::GetMessage(&msg, nullptr, 0, 0) > 0) {
++      ::TranslateMessage(&msg);
++      ::DispatchMessage(&msg);
++    }
++
++    if (hwnd_) {
++      ::DestroyWindow(hwnd_);
++      hwnd_ = nullptr;
++    }
++  }
++
++  void WaitUntilReady() { ready_event_.Wait(); }
++
++  void RequestClose() {
++    if (thread_id_ != 0) {
++      ::PostThreadMessage(thread_id_, WM_QUIT, 0, 0);
++    }
++  }
++
++ private:
++  const std::wstring display_name_;
++  base::WaitableEvent ready_event_{
++      base::WaitableEvent::ResetPolicy::MANUAL,
++      base::WaitableEvent::InitialState::NOT_SIGNALED};
++  DWORD thread_id_ = 0;
++  HWND hwnd_ = nullptr;
++};
++
++BrowserOSInstallUI::BrowserOSInstallUI(bool should_show)
++    : should_show_(should_show) {}
++
++BrowserOSInstallUI::~BrowserOSInstallUI() {
++  Close();
++}
++
++void BrowserOSInstallUI::Show() {
++  if (!should_show_ || ui_thread_) {
++    return;
++  }
++
++  ui_thread_ =
++      std::make_unique<UIThreadDelegate>(InstallUtil::GetDisplayName());
++  if (!base::PlatformThread::Create(0, ui_thread_.get(), &thread_handle_)) {
++    LOG(ERROR) << "Failed to start installer progress UI thread";
++    ui_thread_.reset();
++    return;
++  }
++
++  ui_thread_->WaitUntilReady();
++}
++
++void BrowserOSInstallUI::Close() {
++  if (!ui_thread_) {
++    return;
++  }
++
++  ui_thread_->RequestClose();
++  base::PlatformThread::Join(thread_handle_);
++  thread_handle_ = base::PlatformThreadHandle();
++  ui_thread_.reset();
++}
++
++void BrowserOSInstallUI::CloseAndShowFailureMessage(int install_msg_base) {
++  if (!should_show_) {
++    return;
++  }
++
++  Close();
++  ShowBrowserOSInstallFailureMessageBox(install_msg_base);
++}
++
++void ShowBrowserOSInstallFailureMessageBox(int install_msg_base) {
++  const std::wstring display_name = InstallUtil::GetDisplayName();
++  const std::wstring title = GetWindowTitle(display_name);
++  const std::wstring message = GetFailureMessage(install_msg_base, display_name);
++  ::MessageBox(nullptr, message.c_str(), title.c_str(),
++               MB_OK | MB_ICONERROR | MB_SETFOREGROUND | MB_TASKMODAL);
++}
++
++}  // namespace installer

--- a/packages/browseros/chromium_patches/chrome/installer/setup/browseros_install_ui.h
+++ b/packages/browseros/chromium_patches/chrome/installer/setup/browseros_install_ui.h
@@ -1,0 +1,45 @@
+diff --git a/chrome/installer/setup/browseros_install_ui.h b/chrome/installer/setup/browseros_install_ui.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..ec4ff1db633b205076e3132d690a9c4691282678
+--- /dev/null
++++ b/chrome/installer/setup/browseros_install_ui.h
+@@ -0,0 +1,39 @@
++// Copyright 2026 BrowserOS Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_INSTALLER_SETUP_BROWSEROS_INSTALL_UI_H_
++#define CHROME_INSTALLER_SETUP_BROWSEROS_INSTALL_UI_H_
++
++#include <memory>
++
++#include "base/threading/platform_thread.h"
++
++namespace installer {
++
++// Minimal progress UI for interactive BrowserOS first installs. The UI runs on
++// its own thread so setup's install work can continue on the caller's thread.
++class BrowserOSInstallUI {
++ public:
++  explicit BrowserOSInstallUI(bool should_show);
++  BrowserOSInstallUI(const BrowserOSInstallUI&) = delete;
++  BrowserOSInstallUI& operator=(const BrowserOSInstallUI&) = delete;
++  ~BrowserOSInstallUI();
++
++  void Show();
++  void Close();
++  void CloseAndShowFailureMessage(int install_msg_base);
++
++ private:
++  class UIThreadDelegate;
++
++  const bool should_show_;
++  std::unique_ptr<UIThreadDelegate> ui_thread_;
++  base::PlatformThreadHandle thread_handle_;
++};
++
++void ShowBrowserOSInstallFailureMessageBox(int install_msg_base);
++
++}  // namespace installer
++
++#endif  // CHROME_INSTALLER_SETUP_BROWSEROS_INSTALL_UI_H_

--- a/packages/browseros/chromium_patches/chrome/installer/setup/setup_main.cc
+++ b/packages/browseros/chromium_patches/chrome/installer/setup/setup_main.cc
@@ -1,0 +1,150 @@
+diff --git a/chrome/installer/setup/setup_main.cc b/chrome/installer/setup/setup_main.cc
+index accfea57a58b7ade93a5f25ec200cfc5293c76a9..545f3430710b615d91b60dafcf715f28f5ddc9ae 100644
+--- a/chrome/installer/setup/setup_main.cc
++++ b/chrome/installer/setup/setup_main.cc
+@@ -47,7 +47,6 @@
+ #include "base/task/single_thread_task_executor.h"
+ #include "base/threading/platform_thread.h"
+ #include "base/time/time.h"
+-#include "base/types/expected_macros.h"
+ #include "base/values.h"
+ #include "base/version.h"
+ #include "base/win/current_module.h"
+@@ -69,6 +68,7 @@
+ #include "chrome/install_static/install_details.h"
+ #include "chrome/install_static/install_util.h"
+ #include "chrome/installer/setup/brand_behaviors.h"
++#include "chrome/installer/setup/browseros_install_ui.h"
+ #include "chrome/installer/setup/configure_app_container_sandbox.h"
+ #include "chrome/installer/setup/downgrade_cleanup.h"
+ #include "chrome/installer/setup/install.h"
+@@ -1196,12 +1196,55 @@ bool HandleNonInstallCmdLineOptions(installer::ModifyParams& modify_params,
+ 
+ namespace installer {
+ 
++namespace {
++
++bool ShouldShowBrowserOSInstallUI(const InstallationState& original_state,
++                                  const base::CommandLine& cmd_line,
++                                  const InstallerState& installer_state) {
++  const bool system_install = installer_state.system_install();
++  return installer_state.operation() ==
++             InstallerState::SINGLE_INSTALL_OR_UPDATE &&
++         !system_install && !installer_state.is_msi() &&
++         !cmd_line.HasSwitch(switches::kMsi) &&
++         !cmd_line.HasSwitch(switches::kSilent) &&
++         original_state.GetProductState(system_install) == nullptr;
++}
++
++int GetInstallFailureMessageBase(InstallStatus status) {
++  switch (status) {
++    case TEMP_DIR_FAILED:
++      return IDS_INSTALL_TEMP_DIR_FAILED_BASE;
++    case UNCOMPRESSION_FAILED:
++    case UNPACKING_FAILED:
++      return IDS_INSTALL_UNCOMPRESSION_FAILED_BASE;
++    case INVALID_ARCHIVE:
++      return IDS_INSTALL_INVALID_ARCHIVE_BASE;
++    case HIGHER_VERSION_EXISTS:
++      return IDS_INSTALL_HIGHER_VERSION_BASE;
++    case SAME_VERSION_REPAIR_FAILED:
++      return IDS_SAME_VERSION_REPAIR_FAILED_BASE;
++    case OS_ERROR:
++      return IDS_INSTALL_OS_ERROR_BASE;
++    case INSUFFICIENT_RIGHTS:
++      return IDS_INSTALL_INSUFFICIENT_RIGHTS_BASE;
++    case SETUP_SINGLETON_ACQUISITION_FAILED:
++      return IDS_INSTALL_SINGLETON_ACQUISITION_FAILED_BASE;
++    default:
++      return IDS_INSTALL_FAILED_BASE;
++  }
++}
++
++}  // namespace
++
+ InstallStatus InstallProductsHelper(InstallationState& original_state,
+                                     const base::FilePath& setup_exe,
+                                     const base::CommandLine& cmd_line,
+                                     const InitialPreferences& prefs,
+                                     InstallerState& installer_state) {
+   const bool system_install = installer_state.system_install();
++  BrowserOSInstallUI install_ui(
++      ShouldShowBrowserOSInstallUI(original_state, cmd_line, installer_state));
++  install_ui.Show();
+ 
+   // Create a temp folder where we will unpack Chrome archive. If it fails,
+   // then we are doomed, so return immediately and no cleanup is required.
+@@ -1211,21 +1254,30 @@ InstallStatus InstallProductsHelper(InstallationState& original_state,
+                                            &unpack_path)) {
+     installer_state.WriteInstallerResult(
+         TEMP_DIR_FAILED, IDS_INSTALL_TEMP_DIR_FAILED_BASE, nullptr);
++    install_ui.CloseAndShowFailureMessage(
++        GetInstallFailureMessageBase(TEMP_DIR_FAILED));
+     return TEMP_DIR_FAILED;
+   }
+ 
+-  RETURN_IF_ERROR(UnpackChromeArchive(unpack_path, original_state, setup_exe,
+-                                      cmd_line, installer_state));
++  const auto unpack_result = UnpackChromeArchive(
++      unpack_path, original_state, setup_exe, cmd_line, installer_state);
++  if (!unpack_result.has_value()) {
++    install_ui.CloseAndShowFailureMessage(
++        GetInstallFailureMessageBase(unpack_result.error()));
++    return unpack_result.error();
++  }
+ 
+   VLOG(1) << "unpacked to " << unpack_path.value();
+ 
+   InstallStatus install_status = UNKNOWN_STATUS;
++  int failure_msg_base = IDS_INSTALL_FAILED_BASE;
+   base::FilePath src_path(unpack_path.Append(kInstallSourceChromeDir));
+   std::unique_ptr<base::Version> installer_version(
+       GetMaxVersionFromArchiveDir(src_path));
+   if (!installer_version.get()) {
+     LOG(ERROR) << "Did not find any valid version in installer.";
+     install_status = INVALID_ARCHIVE;
++    failure_msg_base = GetInstallFailureMessageBase(install_status);
+     installer_state.WriteInstallerResult(
+         install_status, IDS_INSTALL_INVALID_ARCHIVE_BASE, nullptr);
+   } else {
+@@ -1241,6 +1293,7 @@ InstallStatus InstallProductsHelper(InstallationState& original_state,
+         int message_id = IDS_INSTALL_HIGHER_VERSION_BASE;
+         proceed_with_installation = false;
+         install_status = HIGHER_VERSION_EXISTS;
++        failure_msg_base = message_id;
+         installer_state.WriteInstallerResult(install_status, message_id,
+                                              nullptr);
+       }
+@@ -1280,6 +1333,8 @@ InstallStatus InstallProductsHelper(InstallationState& original_state,
+           install_msg_base = 0;
+         }
+       }
++      failure_msg_base =
++          install_msg_base != 0 ? install_msg_base : IDS_INSTALL_FAILED_BASE;
+ 
+       installer_state.SetStage(FINISHING);
+ 
+@@ -1296,10 +1351,13 @@ InstallStatus InstallProductsHelper(InstallationState& original_state,
+ 
+       if (install_status == FIRST_INSTALL_SUCCESS) {
+         VLOG(1) << "First install successful.";
++        install_ui.Close();
+         // We never want to launch Chrome in system level install mode.
+         bool do_not_launch_chrome = false;
+         prefs.GetBool(initial_preferences::kDoNotLaunchChrome,
+                       &do_not_launch_chrome);
++        do_not_launch_chrome =
++            do_not_launch_chrome || cmd_line.HasSwitch(switches::kSilent);
+         if (!system_install && !do_not_launch_chrome) {
+           LaunchChromeBrowser(installer_state.target_path());
+         }
+@@ -1352,6 +1410,9 @@ InstallStatus InstallProductsHelper(InstallationState& original_state,
+   // temp_path's dtor will take care of deleting or scheduling itself for
+   // deletion at reboot when this scope closes.
+   VLOG(1) << "Deleting temporary directory " << temp_path.path().value();
++  if (InstallUtil::GetInstallReturnCode(install_status) != 0) {
++    install_ui.CloseAndShowFailureMessage(failure_msg_base);
++  }
+ 
+   return install_status;
+ }

--- a/packages/browseros/chromium_patches/chrome/installer/util/util_constants.cc
+++ b/packages/browseros/chromium_patches/chrome/installer/util/util_constants.cc
@@ -1,0 +1,14 @@
+diff --git a/chrome/installer/util/util_constants.cc b/chrome/installer/util/util_constants.cc
+index ea766d884fbda0a4e8ee1e9c7493ae9b68b3a319..0bfa855d119057fc5a181b572f635d948a708aaf 100644
+--- a/chrome/installer/util/util_constants.cc
++++ b/chrome/installer/util/util_constants.cc
+@@ -53,6 +53,9 @@ const char kDmServerUrl[] = "dm-server-url";
+ // Prevent installer from launching Chrome after a successful first install.
+ const char kDoNotLaunchChrome[] = "do-not-launch-chrome";
+ 
++// Suppress the interactive install UI.
++const char kSilent[] = "silent";
++
+ // Prevents installer from writing the Google Update key that causes Google
+ // Update to launch Chrome after a first install.
+ const char kDoNotRegisterForUpdateLaunch[] =

--- a/packages/browseros/chromium_patches/chrome/installer/util/util_constants.h
+++ b/packages/browseros/chromium_patches/chrome/installer/util/util_constants.h
@@ -1,0 +1,12 @@
+diff --git a/chrome/installer/util/util_constants.h b/chrome/installer/util/util_constants.h
+index f7805daf50a3a1d5868d0d5311e5bec65b44f5e3..92681ed94b34c8361e94ac03708fc629f0243a70 100644
+--- a/chrome/installer/util/util_constants.h
++++ b/chrome/installer/util/util_constants.h
+@@ -194,6 +194,7 @@ extern const char kRotateDeviceTrustKey[];
+ extern const char kRunAsAdmin[];
+ extern const char kSelfDestruct[];
+ extern const char kShowEula[];
++extern const char kSilent[];
+ extern const char kStoreDMToken[];
+ extern const char kSystemLevel[];
+ extern const char kTriggerActiveSetup[];


### PR DESCRIPTION
## Summary

- add a BrowserOS/BrowserClaw-safe Win32 progress UI for interactive fresh user-level Windows installs
- add `--silent` to suppress installer UI and fresh-install browser auto-launch
- keep WinSparkle update installs explicit and quiet by appending `--silent` when launching setup

## Verification

- Chromium build: `/Users/shadowfax/.skills/sf-mux/scripts/sfmux pool build -- autoninja -C out/Default_arm64 chrome`
- `bpatch feature lint`
- `verify-patches.sh --chromium-src /Users/shadowfax/ch-1 --worktree /Users/shadowfax/worktrees/main/feat-win-installer-ui-patches --tip 62475e43a0d46 ...`

## Manual Windows Checklist

- Fresh user-level install: progress window appears with "Installing <product>...", install completes, browser launches.
- WinSparkle update or any over-install: no progress window, no failure dialog, no browser auto-launch.
- Fresh install with `--silent`: no progress window and no browser auto-launch.
- Failure dialog appears only on the gated interactive fresh user-level install path.
