### PR TITLE
fix(bos_build): product-scoped artifact collection for upload and release.json

### DIFF
--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -347,6 +347,26 @@ jobs:
         if: always()
         run: df -h || true
 
+      - name: Resolve artifact filename prefix
+        id: artifact_prefix
+        if: always()
+        env:
+          PRODUCT: ${{ inputs.product }}
+        run: |
+          set -euo pipefail
+          case "$PRODUCT" in
+            browseros)
+              echo "value=BrowserOS" >> "$GITHUB_OUTPUT"
+              ;;
+            browserclaw)
+              echo "value=BrowserClaw" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::product must be one of: browseros, browserclaw"
+              exit 1
+              ;;
+          esac
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v7
@@ -356,8 +376,8 @@ jobs:
           retention-days: 14
           compression-level: 0
           path: |
-            packages/browseros/releases/*/*.dmg
-            packages/browseros/releases/*/*.AppImage
-            packages/browseros/releases/*/*.deb
-            packages/browseros/releases/*/*_installer.exe
-            packages/browseros/releases/*/*_installer.zip
+            packages/browseros/releases/*/${{ steps.artifact_prefix.outputs.value }}_*.dmg
+            packages/browseros/releases/*/${{ steps.artifact_prefix.outputs.value }}_*.AppImage
+            packages/browseros/releases/*/${{ steps.artifact_prefix.outputs.value }}_*.deb
+            packages/browseros/releases/*/${{ steps.artifact_prefix.outputs.value }}_*_installer.exe
+            packages/browseros/releases/*/${{ steps.artifact_prefix.outputs.value }}_*_installer.zip

--- a/packages/browseros/bos_build/steps/sign/sparkle.py
+++ b/packages/browseros/bos_build/steps/sign/sparkle.py
@@ -14,12 +14,21 @@ from ...lib.utils import (
 )
 
 
-def find_signable_artifacts(dist_dir: Path) -> List[Path]:
+def find_signable_artifacts(
+    dist_dir: Path, filename_prefix: str | None = None
+) -> List[Path]:
     """Update artifacts the appcast points at: DMGs on macOS, the installer
     EXE on Windows (WinSparkle downloads and runs the installer directly;
     the portable ZIP is not an update enclosure, so it is not signed).
     """
-    return sorted(dist_dir.glob("*.dmg")) + sorted(dist_dir.glob("*.exe"))
+    artifacts = sorted(dist_dir.glob("*.dmg")) + sorted(dist_dir.glob("*.exe"))
+    if filename_prefix:
+        artifacts = [
+            artifact
+            for artifact in artifacts
+            if artifact.name.startswith(filename_prefix)
+        ]
+    return artifacts
 
 
 @step("sparkle_sign", phase="sign", optional=True, env=("SPARKLE_PRIVATE_KEY",))
@@ -32,9 +41,7 @@ class SparkleSignModule(Step):
 
     def validate(self, ctx: Context) -> None:
         if not ctx.env.has_sparkle_key():
-            raise ValidationError(
-                "SPARKLE_PRIVATE_KEY environment variable not set"
-            )
+            raise ValidationError("SPARKLE_PRIVATE_KEY environment variable not set")
 
     def execute(self, ctx: Context) -> None:
         log_info("\n🔐 Signing update artifacts with Sparkle...")
@@ -44,7 +51,10 @@ class SparkleSignModule(Step):
             log_warning(f"Dist directory not found: {dist_dir}")
             return
 
-        artifact_files = find_signable_artifacts(dist_dir)
+        artifact_files = find_signable_artifacts(
+            dist_dir,
+            f"{ctx.product.artifact_prefix}_v{ctx.get_semantic_version()}_",
+        )
         if not artifact_files:
             log_warning("No signable artifacts (*.dmg, *.exe) found to sign")
             return

--- a/packages/browseros/bos_build/steps/sign/sparkle_test.py
+++ b/packages/browseros/bos_build/steps/sign/sparkle_test.py
@@ -31,6 +31,25 @@ class FindSignableArtifactsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             self.assertEqual(find_signable_artifacts(Path(tmp)), [])
 
+    def test_filters_by_product_filename_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dist = Path(tmp)
+            (dist / "BrowserClaw_v0.31.0_arm64.dmg").write_bytes(b"claw")
+            (dist / "BrowserOS_v0.31.0_arm64.dmg").write_bytes(b"os")
+            (dist / "BrowserClaw_v0.31.0_x64_installer.exe").write_bytes(b"exe")
+
+            names = [
+                p.name for p in find_signable_artifacts(dist, "BrowserClaw_v0.31.0_")
+            ]
+
+            self.assertEqual(
+                names,
+                [
+                    "BrowserClaw_v0.31.0_arm64.dmg",
+                    "BrowserClaw_v0.31.0_x64_installer.exe",
+                ],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/browseros/bos_build/steps/storage/upload.py
+++ b/packages/browseros/bos_build/steps/storage/upload.py
@@ -193,6 +193,25 @@ def _get_artifact_key(filename: str, platform: str) -> str:
     return Path(filename).stem
 
 
+def _product_artifact_filename_prefix(ctx: Context) -> str:
+    """Return the exact filename prefix for this product/version's artifacts."""
+    return f"{ctx.product.artifact_prefix}_v{ctx.get_semantic_version()}_"
+
+
+def _filter_product_artifacts(ctx: Context, artifacts: List[Path]) -> List[Path]:
+    expected_prefix = _product_artifact_filename_prefix(ctx)
+    filtered = [
+        artifact for artifact in artifacts if artifact.name.startswith(expected_prefix)
+    ]
+    skipped = [artifact.name for artifact in artifacts if artifact not in filtered]
+    if skipped:
+        log_warning(
+            "Ignoring artifact(s) that do not belong to "
+            f"{ctx.product.id} v{ctx.get_semantic_version()}: {', '.join(skipped)}"
+        )
+    return filtered
+
+
 def detect_artifacts(ctx: Context) -> List[Path]:
     """Detect artifacts in dist directory based on platform
 
@@ -214,7 +233,7 @@ def detect_artifacts(ctx: Context) -> List[Path]:
         artifacts.extend(dist_dir.glob("*.AppImage"))
         artifacts.extend(dist_dir.glob("*.deb"))
 
-    return sorted(artifacts)
+    return sorted(_filter_product_artifacts(ctx, artifacts))
 
 
 def upload_release_artifacts(

--- a/packages/browseros/bos_build/steps/storage/upload_test.py
+++ b/packages/browseros/bos_build/steps/storage/upload_test.py
@@ -15,6 +15,34 @@ from bos_build.steps.storage.upload import (
 )
 
 
+def _upload_ctx(
+    dist_dir: Path,
+    *,
+    product_id: str = "browseros",
+    display_name: str = "BrowserOS",
+    artifact_prefix: str = "BrowserOS",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        env=SimpleNamespace(
+            r2_bucket="browseros",
+            r2_cdn_base_url="https://cdn.browseros.com",
+            has_r2_config=lambda: True,
+        ),
+        artifact_registry=ArtifactRegistry(),
+        product=SimpleNamespace(
+            id=product_id,
+            display_name=display_name,
+            artifact_prefix=artifact_prefix,
+        ),
+        chromium_version="136.0.0.0",
+        browseros_chromium_version="136.0.0.0.1",
+        get_dist_dir=lambda: dist_dir,
+        get_semantic_version=lambda: "1.2.3",
+        get_sparkle_version=lambda: "10000.1.2.3",
+        get_release_path=lambda platform: (f"releases/{product_id}/1.2.3/{platform}/"),
+    )
+
+
 class UploadMetadataTest(unittest.TestCase):
     def test_linux_x64_artifacts_use_x64_keys(self) -> None:
         self.assertEqual(
@@ -75,21 +103,7 @@ class UploadMetadataTest(unittest.TestCase):
             dist_dir = Path(tmp)
             dmg_name = "BrowserOS_v1.2.3_arm64.dmg"
             (dist_dir / dmg_name).write_bytes(b"dmg")
-            ctx = SimpleNamespace(
-                env=SimpleNamespace(
-                    r2_bucket="browseros",
-                    r2_cdn_base_url="https://cdn.browseros.com",
-                    has_r2_config=lambda: True,
-                ),
-                artifact_registry=ArtifactRegistry(),
-                product=SimpleNamespace(id="browseros", display_name="BrowserOS"),
-                chromium_version="136.0.0.0",
-                browseros_chromium_version="136.0.0.0.1",
-                get_dist_dir=lambda: dist_dir,
-                get_semantic_version=lambda: "1.2.3",
-                get_sparkle_version=lambda: "10000.1.2.3",
-                get_release_path=lambda platform: f"releases/browseros/1.2.3/{platform}/",
-            )
+            ctx = _upload_ctx(dist_dir)
 
             success, release = upload_release_artifacts(
                 ctx,
@@ -101,6 +115,105 @@ class UploadMetadataTest(unittest.TestCase):
         self.assertEqual(artifact["filename"], dmg_name)
         self.assertEqual(artifact["sparkle_signature"], "SIG==")
         self.assertEqual(artifact["sparkle_length"], 3)
+
+    def test_upload_filters_macos_artifacts_to_context_product(self) -> None:
+        cases = [
+            (
+                "browserclaw",
+                "BrowserClaw",
+                "BrowserClaw",
+                "BrowserClaw_v1.2.3_arm64.dmg",
+                "BrowserOS_v1.2.3_arm64.dmg",
+            ),
+            (
+                "browseros",
+                "BrowserOS",
+                "BrowserOS",
+                "BrowserOS_v1.2.3_arm64.dmg",
+                "BrowserClaw_v1.2.3_arm64.dmg",
+            ),
+        ]
+
+        for product_id, display_name, prefix, selected_name, stale_name in cases:
+            with (
+                self.subTest(product_id=product_id),
+                tempfile.TemporaryDirectory() as tmp,
+                mock.patch("bos_build.steps.storage.upload.BOTO3_AVAILABLE", True),
+                mock.patch("bos_build.steps.storage.upload.IS_MACOS", lambda: True),
+                mock.patch("bos_build.steps.storage.upload.IS_WINDOWS", lambda: False),
+                mock.patch(
+                    "bos_build.steps.storage.upload.get_r2_client",
+                    return_value=object(),
+                ),
+                mock.patch(
+                    "bos_build.steps.storage.upload.upload_file_to_r2",
+                    return_value=True,
+                ) as upload_file,
+            ):
+                dist_dir = Path(tmp)
+                (dist_dir / selected_name).write_bytes(b"selected")
+                (dist_dir / stale_name).write_bytes(b"stale")
+                ctx = _upload_ctx(
+                    dist_dir,
+                    product_id=product_id,
+                    display_name=display_name,
+                    artifact_prefix=prefix,
+                )
+
+                success, release = upload_release_artifacts(ctx)
+
+                self.assertTrue(success)
+                self.assertEqual(
+                    release["artifacts"]["arm64"]["filename"], selected_name
+                )
+                uploaded_names = [
+                    Path(call.args[1]).name for call in upload_file.call_args_list
+                ]
+                self.assertEqual(uploaded_names, [selected_name, "release.json"])
+
+    def test_upload_keeps_same_product_macos_arch_artifacts(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            mock.patch("bos_build.steps.storage.upload.BOTO3_AVAILABLE", True),
+            mock.patch("bos_build.steps.storage.upload.IS_MACOS", lambda: True),
+            mock.patch("bos_build.steps.storage.upload.IS_WINDOWS", lambda: False),
+            mock.patch(
+                "bos_build.steps.storage.upload.get_r2_client", return_value=object()
+            ),
+            mock.patch(
+                "bos_build.steps.storage.upload.upload_file_to_r2",
+                return_value=True,
+            ) as upload_file,
+        ):
+            dist_dir = Path(tmp)
+            product_names = [
+                "BrowserClaw_v1.2.3_arm64.dmg",
+                "BrowserClaw_v1.2.3_x64.dmg",
+                "BrowserClaw_v1.2.3_universal.dmg",
+            ]
+            for name in product_names:
+                (dist_dir / name).write_bytes(name.encode())
+            (dist_dir / "BrowserOS_v1.2.3_arm64.dmg").write_bytes(b"stale")
+            ctx = _upload_ctx(
+                dist_dir,
+                product_id="browserclaw",
+                display_name="BrowserClaw",
+                artifact_prefix="BrowserClaw",
+            )
+
+            success, release = upload_release_artifacts(ctx)
+
+        self.assertTrue(success)
+        self.assertEqual(set(release["artifacts"]), {"arm64", "x64", "universal"})
+        self.assertEqual(
+            {artifact["filename"] for artifact in release["artifacts"].values()},
+            set(product_names),
+        )
+        uploaded_names = [
+            Path(call.args[1]).name for call in upload_file.call_args_list
+        ]
+        self.assertEqual(uploaded_names[:-1], sorted(product_names))
+        self.assertEqual(uploaded_names[-1], "release.json")
 
     def test_merge_release_metadata_preserves_existing_artifacts(self) -> None:
         existing = {
@@ -148,7 +261,9 @@ class UploadMetadataTest(unittest.TestCase):
 
         merged = merge_release_metadata(existing, new)
 
-        self.assertEqual(merged["artifacts"]["x64_appimage"]["filename"], "new.AppImage")
+        self.assertEqual(
+            merged["artifacts"]["x64_appimage"]["filename"], "new.AppImage"
+        )
         self.assertEqual(merged["artifacts"]["x64_appimage"]["size"], 2)
 
 


### PR DESCRIPTION
## Summary
- filter upload artifact collection by the current product/version filename prefix before uploading or generating release.json
- keep same-product multi-arch mac artifacts together while excluding stale sibling-product files
- filter Sparkle signing and reusable build workflow artifact globs by product prefix

## Verification
- uv run python -m unittest bos_build.steps.storage.upload_test bos_build.steps.sign.sparkle_test
- uv run python -m unittest discover -s . -p '*_test.py'
- uv run ruff check bos_build
- actionlint .github/workflows/build-browseros.yml

No uploads or dispatch workflows were run.