### PR TITLE
feat(claw-app): cockpit onboarding state for first-run users

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitOnboarding.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitOnboarding.tsx
@@ -194,12 +194,7 @@ function StepBadge({ number, kicker, status }: StepBadgeProps) {
       : status === 'done'
         ? 'text-green'
         : 'text-ink-3'
-  const numberTone =
-    status === 'active'
-      ? 'text-ink'
-      : status === 'done'
-        ? 'text-ink-3'
-        : 'text-ink-3'
+  const numberTone = status === 'active' ? 'text-ink' : 'text-ink-3'
   return (
     <div className="flex items-center justify-between">
       <span

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitOnboarding.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitOnboarding.tsx
@@ -1,0 +1,323 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * First-run guidance rendered by the Cockpit screen when the reader
+ * has no session activity yet. Walks the three actual steps to a
+ * first agent run: install the MCP, ask an agent to try BrowserClaw,
+ * watch the run land here.
+ *
+ * Two visual variants keyed off the `state` prop.
+ *
+ *   first-run  no connections + no activity
+ *              Step 01 active, Steps 02/03 muted upcoming.
+ *
+ *   waiting    at least one MCP connection + no activity
+ *              Step 01 dimmed done, Step 02 active, Step 03 muted.
+ *
+ * State transitions are handled by the parent (Cockpit) via query
+ * refetches; the component is a stateless presenter.
+ */
+
+import {
+  Activity,
+  ArrowRight,
+  Check,
+  MessageSquare,
+  PlugZap,
+  RotateCcw,
+} from 'lucide-react'
+import type { ReactNode } from 'react'
+import { NavLink } from 'react-router'
+import {
+  FOOTER_COPY,
+  HERO_COPY,
+  type OnboardingState,
+  STEP_COPY,
+  STEP_KICKERS,
+} from '@/screens/cockpit/cockpit-onboarding.helpers'
+
+interface CockpitOnboardingProps {
+  state: Exclude<OnboardingState, 'ready'>
+  onRefresh: () => void
+}
+
+export function CockpitOnboarding({
+  state,
+  onRefresh,
+}: CockpitOnboardingProps) {
+  const kickers = STEP_KICKERS[state]
+  const isWaiting = state === 'waiting'
+  return (
+    <section className="flex flex-col gap-8" aria-label={HERO_COPY.eyebrow}>
+      <OnboardingHero />
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <StepCard
+          number="01"
+          kicker={kickers[0]}
+          status={isWaiting ? 'done' : 'active'}
+          icon={<PlugZap className="size-5" />}
+          title={
+            isWaiting ? STEP_COPY.install.doneTitle : STEP_COPY.install.title
+          }
+          body={isWaiting ? STEP_COPY.install.doneBody : STEP_COPY.install.body}
+          action={
+            <StepLink
+              to={STEP_COPY.install.href}
+              label={
+                isWaiting ? STEP_COPY.install.doneCta : STEP_COPY.install.cta
+              }
+              variant={isWaiting ? 'muted' : 'accent'}
+            />
+          }
+        />
+        <StepCard
+          number="02"
+          kicker={kickers[1]}
+          status={isWaiting ? 'active' : 'upcoming'}
+          icon={<MessageSquare className="size-5" />}
+          title={STEP_COPY.ask.title}
+          body={STEP_COPY.ask.body}
+          action={<Terminal lines={STEP_COPY.ask.terminal} />}
+        />
+        <StepCard
+          number="03"
+          kicker={kickers[2]}
+          status="upcoming"
+          icon={<Activity className="size-5" />}
+          title={STEP_COPY.watch.title}
+          body={STEP_COPY.watch.body}
+        />
+      </div>
+      <OnboardingFooter onRefresh={onRefresh} />
+    </section>
+  )
+}
+
+/* ── Hero ─────────────────────────────────────────────────────────── */
+
+function OnboardingHero() {
+  return (
+    <header className="flex flex-col gap-3 pt-1">
+      <span className="font-mono text-[11px] text-ink-3 uppercase tracking-[0.14em]">
+        {HERO_COPY.eyebrow}
+      </span>
+      <h1 className="font-extrabold text-3xl leading-[1.15] tracking-tight md:text-4xl">
+        {HERO_COPY.h1Prefix}{' '}
+        <span className="font-medium font-serif text-accent italic">
+          {HERO_COPY.h1Accent}
+        </span>
+      </h1>
+      <p className="text-ink-3 text-sm">{HERO_COPY.subhead}</p>
+    </header>
+  )
+}
+
+/* ── Step card ────────────────────────────────────────────────────── */
+
+type StepStatus = 'active' | 'upcoming' | 'done'
+
+interface StepCardProps {
+  number: string
+  kicker: string
+  status: StepStatus
+  icon: ReactNode
+  title: string
+  body: string
+  action?: ReactNode
+}
+
+function StepCard({
+  number,
+  kicker,
+  status,
+  icon,
+  title,
+  body,
+  action,
+}: StepCardProps) {
+  const shell =
+    status === 'active'
+      ? 'border-accent bg-card shadow-card'
+      : status === 'done'
+        ? 'border-border-2 bg-bg-sunken'
+        : 'border-border-2 border-dashed bg-bg-sunken'
+  const iconTint =
+    status === 'active'
+      ? 'bg-accent-tint text-accent-ink'
+      : 'bg-card-tint text-ink-3'
+  const titleTone = status === 'active' ? 'text-ink' : 'text-ink-2'
+  const bodyTone = status === 'done' ? 'text-ink-3' : 'text-ink-2'
+  return (
+    <article
+      className={[
+        'flex flex-col gap-4 rounded-2xl border p-6 transition-colors motion-reduce:transition-none',
+        shell,
+      ].join(' ')}
+    >
+      <StepBadge number={number} kicker={kicker} status={status} />
+      <span
+        aria-hidden
+        className={[
+          'flex size-10 items-center justify-center rounded-lg',
+          iconTint,
+        ].join(' ')}
+      >
+        {icon}
+      </span>
+      <div className="flex flex-col gap-2">
+        <h3
+          className={['font-bold text-base leading-tight', titleTone].join(' ')}
+        >
+          {title}
+        </h3>
+        <p className={['text-sm leading-relaxed', bodyTone].join(' ')}>
+          {body}
+        </p>
+      </div>
+      {action && <div className="mt-auto pt-1">{action}</div>}
+    </article>
+  )
+}
+
+interface StepBadgeProps {
+  number: string
+  kicker: string
+  status: StepStatus
+}
+
+function StepBadge({ number, kicker, status }: StepBadgeProps) {
+  const kickerTone =
+    status === 'active'
+      ? 'text-accent'
+      : status === 'done'
+        ? 'text-green'
+        : 'text-ink-3'
+  const numberTone =
+    status === 'active'
+      ? 'text-ink'
+      : status === 'done'
+        ? 'text-ink-3'
+        : 'text-ink-3'
+  return (
+    <div className="flex items-center justify-between">
+      <span
+        className={[
+          'font-bold font-mono text-sm tracking-tight',
+          numberTone,
+        ].join(' ')}
+      >
+        {number}
+      </span>
+      <span
+        className={[
+          'inline-flex items-center gap-1.5 font-mono text-[10.5px] uppercase tracking-[0.12em]',
+          kickerTone,
+        ].join(' ')}
+      >
+        <StatusDot status={status} />
+        {kicker}
+      </span>
+    </div>
+  )
+}
+
+function StatusDot({ status }: { status: StepStatus }) {
+  if (status === 'done') {
+    return (
+      <span
+        aria-hidden
+        className="flex size-3.5 items-center justify-center rounded-full bg-green-tint text-green"
+      >
+        <Check className="size-2.5" strokeWidth={3} />
+      </span>
+    )
+  }
+  if (status === 'active') {
+    return (
+      <span
+        aria-hidden
+        className="inline-block size-2 rounded-full bg-accent shadow-[0_0_8px_hsl(221_90%_55%/0.5)]"
+      />
+    )
+  }
+  return (
+    <span
+      aria-hidden
+      className="inline-block size-2 rounded-full border border-ink-3/60"
+    />
+  )
+}
+
+/* ── Step action primitives ───────────────────────────────────────── */
+
+function StepLink({
+  to,
+  label,
+  variant,
+}: {
+  to: string
+  label: string
+  variant: 'accent' | 'muted'
+}) {
+  const tone =
+    variant === 'accent'
+      ? 'text-accent hover:text-accent-2'
+      : 'text-ink-3 hover:text-ink'
+  return (
+    <NavLink
+      to={to}
+      className={[
+        'group inline-flex items-center gap-1.5 font-mono text-[12px] uppercase tracking-[0.08em] transition-colors motion-reduce:transition-none',
+        tone,
+      ].join(' ')}
+    >
+      {label}
+      <ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none" />
+    </NavLink>
+  )
+}
+
+function Terminal({ lines }: { lines: readonly string[] }) {
+  return (
+    <figure
+      className="overflow-hidden rounded-lg bg-ink-deep p-3 font-mono text-[11.5px] text-white/90 leading-[1.6]"
+      aria-label="Example prompt in Claude Code"
+    >
+      {lines.map((line) => (
+        <div key={line}>{line || ' '}</div>
+      ))}
+    </figure>
+  )
+}
+
+/* ── Footer ───────────────────────────────────────────────────────── */
+
+function OnboardingFooter({ onRefresh }: { onRefresh: () => void }) {
+  return (
+    <footer className="flex flex-wrap items-center gap-x-3 gap-y-2 text-ink-3 text-sm">
+      <span>{FOOTER_COPY.refreshQuestion}</span>
+      <button
+        type="button"
+        onClick={onRefresh}
+        className="inline-flex items-center gap-1 text-ink-2 underline decoration-border-2 underline-offset-4 transition-colors hover:decoration-ink motion-reduce:transition-none"
+      >
+        <RotateCcw className="size-3" />
+        {FOOTER_COPY.refresh}
+      </button>
+      <span aria-hidden className="text-ink-3">
+        ·
+      </span>
+      <a
+        href={FOOTER_COPY.docsHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group inline-flex items-center gap-1 text-ink-2 underline decoration-border-2 underline-offset-4 transition-colors hover:decoration-ink motion-reduce:transition-none"
+      >
+        {FOOTER_COPY.docs}
+        <ArrowRight className="size-3 transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none" />
+      </a>
+    </footer>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/harness/harness.types.ts
+++ b/packages/browseros-agent/apps/claw-app/components/harness/harness.types.ts
@@ -15,3 +15,22 @@ export type Harness = (typeof HARNESSES)[number]
 export const RETIRED_HARNESSES = [
   'Claude Desktop',
 ] as const satisfies readonly Harness[]
+
+/**
+ * Harnesses the /mcp screen filters out of the Connected agents list.
+ * Retired + BrowserOS-internal harnesses that a user never intentionally
+ * installs. Shared with the cockpit onboarding detector so `MCP installed`
+ * only lights up for a harness the reader could plausibly have connected
+ * from the /mcp screen.
+ */
+export const HIDDEN_HARNESSES: readonly Harness[] = [
+  ...RETIRED_HARNESSES,
+  'Hermes',
+  'OpenClaw',
+  'Gemini CLI',
+]
+
+/** True when the harness appears in the /mcp Connected agents list. */
+export function isUserFacingHarness(h: Harness): boolean {
+  return !HIDDEN_HARNESSES.includes(h)
+}

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.tsx
@@ -3,6 +3,7 @@ import { CockpitHero } from '@/components/cockpit/CockpitHero'
 import { CockpitOnboarding } from '@/components/cockpit/CockpitOnboarding'
 import { RecentActivity } from '@/components/cockpit/RecentActivity'
 import { RunningGrid } from '@/components/cockpit/RunningGrid'
+import { isUserFacingHarness } from '@/components/harness/harness.types'
 import { useTasks } from '@/modules/api/audit.hooks'
 import { useBrowserosConnections } from '@/modules/api/connections.hooks'
 import { useCockpitData } from './cockpit.data'
@@ -23,8 +24,14 @@ export function Cockpit() {
   const taskProbe = useTasks({
     variables: { limit: ONBOARDING_PROBE_LIMIT },
   })
+  // Only count harnesses that appear on the /mcp screen. Hidden ones
+  // (Hermes, OpenClaw, Gemini CLI, retired Claude Desktop) may be
+  // preinstalled but are never something the reader intentionally
+  // connected, so lighting up 'MCP installed' for them is misleading.
   const hasConnection =
-    connections.data?.connections.some((c) => c.installed) ?? false
+    connections.data?.connections.some(
+      (c) => c.installed && isUserFacingHarness(c.harness),
+    ) ?? false
   const hasActivity = (taskProbe.data?.pages ?? []).some(
     (p) => p.tasks.length > 0,
   )

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.tsx
@@ -1,11 +1,60 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { CockpitHero } from '@/components/cockpit/CockpitHero'
+import { CockpitOnboarding } from '@/components/cockpit/CockpitOnboarding'
 import { RecentActivity } from '@/components/cockpit/RecentActivity'
 import { RunningGrid } from '@/components/cockpit/RunningGrid'
+import { useTasks } from '@/modules/api/audit.hooks'
+import { useBrowserosConnections } from '@/modules/api/connections.hooks'
 import { useCockpitData } from './cockpit.data'
+import { getOnboardingState } from './cockpit-onboarding.helpers'
+
+const ONBOARDING_PROBE_LIMIT = 1
 
 /** Renders the Claw cockpit homepage. */
 export function Cockpit() {
   const { agents } = useCockpitData()
+  const queryClient = useQueryClient()
+
+  // Probe the two data sources the onboarding state hinges on. Both
+  // queries live in react-query's cache under stable keys, so the
+  // downstream components (RecentActivity / Mcp screen) that read
+  // the same keys hit the cache instead of refetching.
+  const connections = useBrowserosConnections()
+  const taskProbe = useTasks({
+    variables: { limit: ONBOARDING_PROBE_LIMIT },
+  })
+  const hasConnection =
+    connections.data?.connections.some((c) => c.installed) ?? false
+  const hasActivity = (taskProbe.data?.pages ?? []).some(
+    (p) => p.tasks.length > 0,
+  )
+
+  // Wait for both probes to resolve at least once before deciding
+  // which shell to render. Otherwise the onboarding block flashes on
+  // first paint for returning users whose tasks are still in-flight.
+  const probesResolved =
+    connections.data !== undefined && taskProbe.data !== undefined
+  const state = probesResolved
+    ? getOnboardingState({ hasConnection, hasActivity })
+    : 'ready'
+
+  if (state !== 'ready') {
+    return (
+      <div className="mx-auto flex max-w-7xl flex-col px-8 pt-8 pb-16">
+        <CockpitOnboarding
+          state={state}
+          onRefresh={() => {
+            void queryClient.invalidateQueries({
+              queryKey: useBrowserosConnections.getKey(),
+            })
+            void queryClient.invalidateQueries({
+              queryKey: useTasks.getKey(),
+            })
+          }}
+        />
+      </div>
+    )
+  }
 
   return (
     <div className="mx-auto flex max-w-7xl flex-col gap-8 px-8 pt-8 pb-16">

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit-onboarding.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit-onboarding.helpers.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { getOnboardingState } from './cockpit-onboarding.helpers'
+
+describe('getOnboardingState', () => {
+  it('returns first-run when no connection and no activity', () => {
+    expect(
+      getOnboardingState({ hasConnection: false, hasActivity: false }),
+    ).toBe('first-run')
+  })
+
+  it('returns waiting when connection is installed but no activity yet', () => {
+    expect(
+      getOnboardingState({ hasConnection: true, hasActivity: false }),
+    ).toBe('waiting')
+  })
+
+  it('returns ready as soon as any activity exists, regardless of connection state', () => {
+    expect(
+      getOnboardingState({ hasConnection: false, hasActivity: true }),
+    ).toBe('ready')
+    expect(getOnboardingState({ hasConnection: true, hasActivity: true })).toBe(
+      'ready',
+    )
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit-onboarding.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit-onboarding.helpers.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Pure helpers for the cockpit onboarding block. The Cockpit screen
+ * reads live query state, feeds the two derived booleans through
+ * `getOnboardingState()`, and renders the returned discriminant.
+ *
+ * Keeping the selector pure means every state variant is trivially
+ * unit-testable without React. The onboarding component consumes the
+ * discriminant and the copy constants; it never re-derives state.
+ */
+
+export type OnboardingState = 'first-run' | 'waiting' | 'ready'
+
+export interface OnboardingSignals {
+  /** True when at least one MCP connection is installed. */
+  hasConnection: boolean
+  /** True when the recent-activity list has at least one task row. */
+  hasActivity: boolean
+}
+
+/**
+ * Discriminant for the cockpit view. `ready` means the reader has
+ * already completed the loop at least once, so the normal cockpit
+ * renders unchanged.
+ */
+export function getOnboardingState({
+  hasConnection,
+  hasActivity,
+}: OnboardingSignals): OnboardingState {
+  if (hasActivity) return 'ready'
+  if (hasConnection) return 'waiting'
+  return 'first-run'
+}
+
+/** Status labels for the three step badges, per state. */
+export const STEP_KICKERS = {
+  'first-run': ['Next up', 'Then', 'Finally'] as const,
+  waiting: ['Done', 'Now', 'Next'] as const,
+} as const
+
+export const HERO_COPY = {
+  eyebrow: 'Get started',
+  h1Prefix: "Let's get your first agent",
+  h1Accent: 'running.',
+  subhead: 'Three steps. About two minutes.',
+} as const
+
+export const STEP_COPY = {
+  install: {
+    title: 'Install the MCP.',
+    body: 'One endpoint that connects BrowserClaw to Claude Code, Cursor, Codex, and every harness that speaks MCP.',
+    doneTitle: 'MCP installed.',
+    doneBody:
+      'Your endpoint is live. Any agent on your list can now open a browser session.',
+    cta: 'Set up',
+    doneCta: 'View endpoints',
+    href: '/mcp',
+  },
+  ask: {
+    title: 'Ask your agent to try it.',
+    body: 'Any tool that speaks MCP works. Claude Code, Cursor, Codex. Kick off a task on the web.',
+    terminal: [
+      '$ claude',
+      '> Try BrowserClaw. Book me',
+      '  the cheapest flight to',
+      '  London for next weekend.',
+      '> opening BrowserClaw...',
+    ] as const,
+  },
+  watch: {
+    title: 'Watch it happen right here.',
+    body: 'Every tool call, screenshot, and result shows up on this page as your agent works. Rewind any session from the audit view.',
+  },
+} as const
+
+export const FOOTER_COPY = {
+  refreshQuestion: 'Already set up?',
+  refresh: 'Refresh the page.',
+  docs: 'Read the docs',
+  docsHref: 'https://docs.browseros.com/',
+} as const

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.tsx
@@ -2,7 +2,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useMemo, useState } from 'react'
 import {
   type Harness,
-  RETIRED_HARNESSES,
+  isUserFacingHarness,
 } from '@/components/harness/harness.types'
 import { EditorialEmpty } from '@/components/ui/EditorialEmpty'
 import {
@@ -13,14 +13,6 @@ import {
 import { resolveCanonicalMcpEndpointUrl } from '@/modules/api/mcp-endpoint'
 import { ConnectionRow } from './ConnectionRow'
 import { HeroCard } from './HeroCard'
-
-/** Harnesses that should not show a user-facing Connect flow. */
-const HIDDEN_HARNESSES: readonly Harness[] = [
-  ...RETIRED_HARNESSES,
-  'Hermes',
-  'OpenClaw',
-  'Gemini CLI',
-]
 
 export function Mcp() {
   const [url, setUrl] = useState<string | null>(null)
@@ -44,7 +36,7 @@ export function Mcp() {
 
   const visibleRows = useMemo(() => {
     const list = connections.data?.connections ?? []
-    return list.filter((c) => !HIDDEN_HARNESSES.includes(c.harness))
+    return list.filter((c) => isUserFacingHarness(c.harness))
   }, [connections.data])
 
   const connectedCount = visibleRows.filter((c) => c.installed).length


### PR DESCRIPTION
## Summary

The Cockpit home currently renders a passive `No recent activity` empty state whenever the reader has no session activity, which leaves first-time users staring at `Tool calls from connected agents will appear here.` with zero guidance. This PR swaps that empty state (only while there's no activity) for a three-step onboarding block that walks the actual journey to a first agent run.

Design plan at `plans/browseros-ai/BrowserOS/features/2026-07-07-1013-claude-code-claw-app-cockpit-onboarding-state.md` (in the control-center repo) documents the full design read, ASCII wireframes, motion budget, and anti-Tell audit.

## Detection

Two signals derived from the two existing queries:

| Signal | Source |
|---|---|
| `hasConnection` | `useBrowserosConnections().data.connections.some(c => c.installed)` |
| `hasActivity` | `useTasks({limit:1}).data.pages.some(p => p.tasks.length > 0)` |

Three states drop out:

| State | Condition | Render |
|---|---|---|
| `first-run` | no connection, no activity | onboarding, Step 01 active, 02/03 muted |
| `waiting` | connection installed, no activity | onboarding, Step 01 done, 02 active, 03 muted |
| `ready` | any activity | existing cockpit renders unchanged |

Cockpit waits for both probes to resolve before deciding which shell to render, so returning users do not see the onboarding flash on first paint while their tasks are still in-flight. Both queries live under stable react-query keys, so the downstream components (`RecentActivity`, `Mcp`) hit the shared cache instead of refetching.

## Content

- **Hero**: `GET STARTED` eyebrow, big H1 `Let's get your first agent running.` with Newsreader italic accent on `running.` (matches the existing `CockpitHero` italic on `working on`), `Three steps. About two minutes.` subhead.
- **01**: `Install the MCP.` `Set up →` routes to `/mcp`. When waiting: `MCP installed. Your endpoint is live.` + `View endpoints` link.
- **02**: `Ask your agent to try it.` Body names Claude Code, Cursor, Codex. Terminal figure in JetBrains Mono on the ink-deep surface shows a realistic Claude Code prompt.
- **03**: `Watch it happen right here.` No CTA. This IS the payoff that renders itself the moment the first tool call lands.
- **Footer**: `Already set up? Refresh the page. · Read the docs →` — refresh invalidates the two probe queries, not a full page reload.

## Design decisions

- **Wiz Signal Blue palette locked**. Single `--accent` token (`#0254ec`) across active border, active dot, hero italic, `Set up` link. Green (`--green` + `--green-tint`) reserved for the `Done` check on the badge slot.
- **3-column-equal-cards Tell mitigated** by numbered progressive state, differentiated content shape per card (link CTA vs terminal figure vs no CTA), and state-driven backgrounds (`bg-card` + shadow for active, `bg-bg-sunken` + dashed border for upcoming, `bg-bg-sunken` + solid border for done).
- **Shape consistency**: `rounded-2xl` for cards, `rounded-lg` for icon squares, `rounded-full` for badges. Same radius family as the existing `EmptyState` primitive.
- **Icons**: `lucide-react` primitives (`PlugZap`, `MessageSquare`, `Activity`, `Check`, `RotateCcw`, `ArrowRight`). No hand-rolled decorative SVG.
- **Motion**: `transition-colors` on the shell so state changes read as progress. `motion-reduce:transition-none` on every animated class.
- **Real content, no fake product previews**: `Set up` routes to the real `/mcp` screen; the terminal figure is text-only, not a fake product UI; `Rewind any session from the audit view` refers to the shipped `/audit/:sessionId/replay` route.

## Files

- new: `components/cockpit/CockpitOnboarding.tsx`
- new: `screens/cockpit/cockpit-onboarding.helpers.ts`
- new: `screens/cockpit/cockpit-onboarding.helpers.test.ts` (3 tests)
- edit: `screens/cockpit/Cockpit.tsx`

## Local verification

- [x] `bun test cockpit-onboarding.helpers.test.ts`: 3 pass, 0 fail
- [x] `bun run typecheck`: pass
- [x] `bunx biome check` on new + edited files: no errors
- [x] `bun run build:dev`: 2 MB extension bundle, no warnings
- [x] Rendered at 1440×900 via a local static serve of `dist/chrome-mv3-dev`; State B (waiting) confirmed live in the screenshot at `~/workbench/screenshots/browseros-ai/BrowserOS/newtab-onboarding-2026-07-07/3-onboarding-first-render.png`.

## Test plan

- [ ] Visual QA: `first-run` state (disconnect all MCP connections, then visit `/newtab#/`)
- [ ] Visual QA: `waiting` state (one connection installed, no tasks yet)
- [ ] Visual QA: transition to `ready` when the first task lands (should cross-fade to the existing cockpit)
- [ ] `prefers-reduced-motion: reduce` disables the `transition-colors` on the step cards
- [ ] Sidebar nav still works from the onboarding shell
- [ ] Set up link navigates to `/mcp` and back-navigation restores state
