### PR TITLE
feat(claw-server): tri-bucket ownership visibility for tabs list

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/lib/agent-tabs/agent-tabs.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/agent-tabs/agent-tabs.ts
@@ -5,11 +5,18 @@
  *
  * Per-agent ownership ledger for browser pages. Populated by
  * successful `tabs new` dispatches and drained by `tabs close`.
- * The cockpit's `tabs list` handler filters its result to only
- * this agent's owned pages, and the page-targeted tools reject
- * dispatches whose `page` arg is not owned by the caller. Together
- * with `tabGroupTracker`, this guarantees an agent can only see /
- * touch tabs it opened; the operator's own tabs are invisible.
+ * Two indices stay coherent:
+ *   - `records: Map<agentId, Set<pageId>>` powers `ownedBy(agentId)`.
+ *   - `owners:  Map<pageId, agentId>`      powers `resolveOwner(pageId)`.
+ * `markOpened` writes both; `markClosed` and `forgetAgent` remove
+ * from both. The `owners.get(pageId) === agentId` guard on removal
+ * handles the (defensive) case of two agents claiming the same
+ * pageId: only the recorded owner clears its entry.
+ *
+ * The cockpit's `tabs list` handler uses `resolveOwner` to classify
+ * every open page as `mine` (owner === caller), `user` (no owner),
+ * or `other-agent` (owner !== caller). Page-targeted tools still
+ * gate on `ownedBy` in register.ts for cross-ownership rejection.
  *
  * Different lifecycle than `tabActivityRegistry`: that one is
  * targetId-keyed and prunes on a 30s window for the /tabs/activity
@@ -26,6 +33,13 @@ export interface AgentTabsRegistry {
    * `owned.has(page)` without null-checking.
    */
   ownedBy(agentId: string): ReadonlySet<number>
+  /**
+   * Returns the agentId currently listed as owner of `pageId`, or
+   * null when the page has no agent owner (operator-opened tab).
+   * O(1). Used by the `tabs list` handler to classify every page
+   * by ownership without walking every agent's ownedBy set.
+   */
+  resolveOwner(pageId: number): string | null
   /**
    * Drops all pages tracked for an agent. Called from
    * `cleanupSessionState` so the next session for the same agentId
@@ -58,6 +72,7 @@ const EMPTY: ReadonlySet<number> = new Set<number>()
 
 export function createAgentTabsRegistry(): AgentTabsRegistry {
   const records = new Map<string, Set<number>>()
+  const owners = new Map<number, string>()
   const firstCaptures = new Map<string, Set<number>>()
   return {
     markOpened(agentId, pageId) {
@@ -67,18 +82,29 @@ export function createAgentTabsRegistry(): AgentTabsRegistry {
         records.set(agentId, set)
       }
       set.add(pageId)
+      owners.set(pageId, agentId)
     },
     markClosed(agentId, pageId) {
       const set = records.get(agentId)
       if (!set) return
       set.delete(pageId)
+      if (owners.get(pageId) === agentId) owners.delete(pageId)
       if (set.size === 0) records.delete(agentId)
     },
     ownedBy(agentId) {
       return records.get(agentId) ?? EMPTY
     },
+    resolveOwner(pageId) {
+      return owners.get(pageId) ?? null
+    },
     forgetAgent(agentId) {
-      records.delete(agentId)
+      const set = records.get(agentId)
+      if (set) {
+        for (const pageId of set) {
+          if (owners.get(pageId) === agentId) owners.delete(pageId)
+        }
+        records.delete(agentId)
+      }
       firstCaptures.delete(agentId)
     },
     hasFirstCapture(agentId, pageId) {
@@ -97,6 +123,7 @@ export function createAgentTabsRegistry(): AgentTabsRegistry {
     },
     clear() {
       records.clear()
+      owners.clear()
       firstCaptures.clear()
     },
   }

--- a/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
@@ -25,6 +25,7 @@ import { logger } from '../lib/logger'
 import {
   agentIdentityFromClient,
   type ClientIdentity,
+  identityService,
 } from '../lib/mcp-session'
 import {
   extractPageId,
@@ -41,6 +42,10 @@ import { persistScreenshot } from '../services/screenshots'
 import { ensureAgentTabGroup } from '../services/tab-group-ops'
 import { cancellationErrorResult } from './cancellation-result'
 import { asRegister, type ToolResult } from './register-fn'
+import {
+  annotateTabsListWithOwnership,
+  buildOwnershipDeps,
+} from './tabs-ownership'
 
 /**
  * Schemes the cockpit refuses to forward to `navigate`, regardless of
@@ -199,44 +204,6 @@ function dispatchErrorText(content: unknown): string | null {
     }
   }
   return null
-}
-
-/**
- * Rewrite a successful `tabs list` result to only include pages the
- * calling agent owns. Both channels are rebuilt from the surviving
- * subset:
- *   - `structuredContent.pages` is filtered.
- *   - `content[0].text` is rebuilt via the tool's `formatPageLine`
- *     shape (`[N] URL (title)` or `[N] URL` when no title). Empty
- *     survivors yield `(no open pages)` which matches the underlying
- *     tool's empty output so codex's LLM interprets it as "no tabs,
- *     open one" and dispatches `tabs new` instead of hijacking.
- *
- * Exported for unit tests; production callers reach it via the
- * dispatch handler.
- */
-export function filterTabsListToAgent<
-  R extends {
-    content: unknown
-    isError?: boolean
-    structuredContent?: unknown
-  },
->(result: R, owned: ReadonlySet<number>): R {
-  const sc = result.structuredContent as
-    | { pages?: Array<{ page: number; url?: string; title?: string }> }
-    | undefined
-  const allPages = sc?.pages ?? []
-  const surviving = allPages.filter((p) => owned.has(p.page))
-  const lines = surviving.map(
-    (p) => `[${p.page}] ${p.url ?? ''}${p.title ? ` (${p.title})` : ''}`,
-  )
-  const text = lines.length > 0 ? lines.join('\n') : '(no open pages)'
-  return {
-    ...result,
-    isError: false,
-    content: [{ type: 'text', text }],
-    structuredContent: { pages: surviving },
-  } as R
 }
 
 /**
@@ -627,16 +594,19 @@ export function registerBrowserToolsForSingleServer(
                   agentTabs.markClosed(agentId, closedPage)
                 }
               } else if ((args?.action ?? 'list') === 'list') {
-                // Filter the list to only pages this agent owns.
-                // With no owned pages, the surviving text is
-                // `(no open pages)` which mirrors the tool's own
-                // empty output; the LLM interprets it as "I have no
-                // tabs, I need to open one" and calls `tabs new`.
-                const { agentId } = agentIdentityFromClient(identity)
-                result = filterTabsListToAgent(
-                  result,
-                  agentTabs.ownedBy(agentId),
+                // Annotate every open page with an ownership tag and
+                // group the text output into Your tabs / User's tabs
+                // / Other agents' tabs. Every page in the underlying
+                // result survives; the cross-agent page guard above
+                // still hard-rejects a page-targeted dispatch on a
+                // foreign page, so broader visibility does not open
+                // a broader action surface.
+                const deps = buildOwnershipDeps(
+                  identity,
+                  agentTabs,
+                  identityService,
                 )
+                result = annotateTabsListWithOwnership(result, deps)
               }
             }
           } else {

--- a/packages/browseros-agent/apps/claw-server/src/mcp/tabs-ownership.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/tabs-ownership.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Tri-bucket ownership annotation for the `tabs list` MCP result.
+ *
+ * Every open page is classified as one of:
+ *   - `mine`         owner === caller (this session)
+ *   - `user`         no agent owner recorded (operator-opened tab)
+ *   - `other-agent`  owner is a different session's agentId
+ *
+ * The classifier keeps every page in the response (no filtering) and
+ * decorates the text + structuredContent channels so the LLM can
+ * distinguish ownership at a glance. Empty buckets are omitted from
+ * the text output; a fully empty list still renders `(no open pages)`
+ * for backwards compatibility with the pre-refactor empty-state cue.
+ *
+ * The cross-agent page guard in register.ts still hard-rejects a
+ * dispatch on a foreign page. This annotator only affects visibility.
+ */
+
+import {
+  agentIdentityFromClient,
+  type ClientIdentity,
+  type IdentityService,
+} from '../lib/mcp-session'
+
+export type TabOwnership = 'mine' | 'user' | 'other-agent'
+
+export interface StructuredPage {
+  page: number
+  url?: string
+  title?: string
+}
+
+export interface AnnotatedPage extends StructuredPage {
+  ownership: TabOwnership
+  ownerAgentId: string | null
+  ownerLabel: string | null
+}
+
+export interface OwnershipDeps {
+  callerAgentId: string
+  resolveOwner: (pageId: number) => string | null
+  labelForAgentId: (agentId: string) => string | null
+}
+
+export function classify(
+  page: StructuredPage,
+  deps: OwnershipDeps,
+): AnnotatedPage {
+  const owner = deps.resolveOwner(page.page)
+  if (owner === null) {
+    return {
+      ...page,
+      ownership: 'user',
+      ownerAgentId: null,
+      ownerLabel: null,
+    }
+  }
+  if (owner === deps.callerAgentId) {
+    return {
+      ...page,
+      ownership: 'mine',
+      ownerAgentId: owner,
+      ownerLabel: null,
+    }
+  }
+  return {
+    ...page,
+    ownership: 'other-agent',
+    ownerAgentId: owner,
+    ownerLabel: deps.labelForAgentId(owner),
+  }
+}
+
+interface TabsListResult {
+  content: unknown
+  isError?: boolean
+  structuredContent?: unknown
+}
+
+export function annotateTabsListWithOwnership<R extends TabsListResult>(
+  result: R,
+  deps: OwnershipDeps,
+): R {
+  const sc = result.structuredContent as
+    | { pages?: StructuredPage[] }
+    | undefined
+  const raw = sc?.pages ?? []
+  const annotated = raw.map((p) => classify(p, deps))
+  return {
+    ...result,
+    isError: false,
+    content: [{ type: 'text', text: renderText(annotated) }],
+    structuredContent: { pages: annotated },
+  } as R
+}
+
+function renderText(pages: AnnotatedPage[]): string {
+  if (pages.length === 0) return '(no open pages)'
+  const mine = pages.filter((p) => p.ownership === 'mine')
+  const user = pages.filter((p) => p.ownership === 'user')
+  const other = pages.filter((p) => p.ownership === 'other-agent')
+  const sections: string[] = []
+  if (mine.length > 0) sections.push(section('Your tabs:', mine))
+  if (user.length > 0) sections.push(section("User's tabs:", user))
+  if (other.length > 0) sections.push(section("Other agents' tabs:", other))
+  return sections.join('\n\n')
+}
+
+function section(header: string, pages: AnnotatedPage[]): string {
+  return `${header}\n${pages.map(formatLine).join('\n')}`
+}
+
+function formatLine(p: AnnotatedPage): string {
+  const title = p.title ? ` (${p.title})` : ''
+  const suffix =
+    p.ownership === 'other-agent' && p.ownerLabel
+      ? `, owned by ${p.ownerLabel}`
+      : ''
+  return `[${p.page}] ${p.url ?? ''}${title}${suffix}`
+}
+
+/**
+ * Builds an OwnershipDeps for a given caller identity. The label
+ * cache snapshots `identityService.list()` at call time; an agent
+ * whose session already closed will have no entry and `labelForAgentId`
+ * returns null (the text render then omits the "owned by ..." suffix).
+ */
+export function buildOwnershipDeps(
+  callerIdentity: ClientIdentity,
+  agentTabs: { resolveOwner: (pageId: number) => string | null },
+  identityService: IdentityService,
+): OwnershipDeps {
+  const { agentId: callerAgentId } = agentIdentityFromClient(callerIdentity)
+  const labelCache = new Map<string, string>()
+  for (const id of identityService.list()) {
+    const { agentId, slug } = agentIdentityFromClient(id)
+    const label = slug || id.clientName || 'unknown'
+    labelCache.set(agentId, label)
+  }
+  return {
+    callerAgentId,
+    resolveOwner: (pageId) => agentTabs.resolveOwner(pageId),
+    labelForAgentId: (agentId) => labelCache.get(agentId) ?? null,
+  }
+}

--- a/packages/browseros-agent/apps/claw-server/tests/lib/agent-tabs-resolve-owner.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/agent-tabs-resolve-owner.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Unit tests for the `resolveOwner(pageId)` reverse lookup added to
+ * agent-tabs. Ensures the second index stays coherent with the
+ * per-agent Set across every mutation path.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { createAgentTabsRegistry } from '../../src/lib/agent-tabs/agent-tabs'
+
+describe('agentTabs.resolveOwner', () => {
+  test('unknown page id returns null', () => {
+    const reg = createAgentTabsRegistry()
+    expect(reg.resolveOwner(42)).toBeNull()
+  })
+
+  test('returns the agentId that opened the page', () => {
+    const reg = createAgentTabsRegistry()
+    reg.markOpened('agent-a', 7)
+    expect(reg.resolveOwner(7)).toBe('agent-a')
+  })
+
+  test('foreign owner is returned to a non-owner caller', () => {
+    const reg = createAgentTabsRegistry()
+    reg.markOpened('agent-a', 7)
+    // A different agent asking about the same page still gets the
+    // owner id; the classifier is what interprets it as `other-agent`.
+    expect(reg.resolveOwner(7)).toBe('agent-a')
+  })
+
+  test('markClosed drops the owner entry', () => {
+    const reg = createAgentTabsRegistry()
+    reg.markOpened('agent-a', 7)
+    reg.markClosed('agent-a', 7)
+    expect(reg.resolveOwner(7)).toBeNull()
+  })
+
+  test('forgetAgent clears ownership for every page the agent owned', () => {
+    const reg = createAgentTabsRegistry()
+    reg.markOpened('agent-a', 1)
+    reg.markOpened('agent-a', 2)
+    reg.markOpened('agent-b', 3)
+    reg.forgetAgent('agent-a')
+    expect(reg.resolveOwner(1)).toBeNull()
+    expect(reg.resolveOwner(2)).toBeNull()
+    expect(reg.resolveOwner(3)).toBe('agent-b')
+  })
+
+  test('two-agent collision preserves the LAST writer as owner', () => {
+    // A defensive edge case: two agents claim the same pageId. The
+    // library-level invariant is that `tabs new` allocates a fresh
+    // page id per open, so this should not happen in production;
+    // if it ever does, ownership goes to whoever wrote last.
+    const reg = createAgentTabsRegistry()
+    reg.markOpened('agent-a', 7)
+    reg.markOpened('agent-b', 7)
+    expect(reg.resolveOwner(7)).toBe('agent-b')
+    // A close from the original writer must NOT clear the owner
+    // slot; only the recorded owner clears its entry.
+    reg.markClosed('agent-a', 7)
+    expect(reg.resolveOwner(7)).toBe('agent-b')
+    reg.markClosed('agent-b', 7)
+    expect(reg.resolveOwner(7)).toBeNull()
+  })
+
+  test('clear resets the owner index', () => {
+    const reg = createAgentTabsRegistry()
+    reg.markOpened('agent-a', 1)
+    reg.clear()
+    expect(reg.resolveOwner(1)).toBeNull()
+  })
+})

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-isolation.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-isolation.test.ts
@@ -156,11 +156,12 @@ describe('per-agent tabs isolation', () => {
     resetAuditDbForTesting()
   })
 
-  it('tabs new populates the ledger; follow-up tabs list returns only that page', async () => {
+  it('tabs new populates the ledger; follow-up tabs list groups your tab and the user tab separately', async () => {
     stubSessionForPage(7, 'target-7', 'https://news.google.com/', 'News')
     // Queue: tabs new -> ensureAgentTabGroup fires create + update ->
     // then tabs list underlying result contains BOTH the agent's tab
-    // AND the operator's tab. The cockpit filter should reduce it.
+    // AND the operator's tab. The cockpit annotator keeps both and
+    // groups them into `Your tabs:` and `User's tabs:` sections.
     queue(
       ok({ page: 7 }), // tabs new
       ok({ group: { groupId: 'G1', windowId: 42 } }), // tab_groups create
@@ -184,23 +185,40 @@ describe('per-agent tabs isolation', () => {
     })) as TabsListResult
     expect(listResult.isError).toBeFalsy()
     expect(listResult.structuredContent?.pages).toEqual([
-      { page: 7, url: 'https://news.google.com/', title: 'News' },
+      {
+        page: 7,
+        url: 'https://news.google.com/',
+        title: 'News',
+        ownership: 'mine',
+        ownerAgentId: agentId,
+        ownerLabel: null,
+      },
+      {
+        page: 42,
+        url: 'https://operator.example/',
+        title: "Op's tab",
+        ownership: 'user',
+        ownerAgentId: null,
+        ownerLabel: null,
+      },
     ])
     const text = (
       listResult.content as Array<{ type: string; text?: string }>
     )?.[0]?.text
-    expect(text).toContain('[7] https://news.google.com/')
-    expect(text).not.toContain("Op's tab")
-    expect(text).not.toContain('operator.example')
+    expect(text).toContain('Your tabs:')
+    expect(text).toContain('[7] https://news.google.com/ (News)')
+    expect(text).toContain("User's tabs:")
+    expect(text).toContain("[42] https://operator.example/ (Op's tab)")
     await client.close()
   })
 
-  it('two agents are isolated: one agent list does not include the other agent pages', async () => {
-    // Two connected sessions.
-    // agent-a opens page 1, agent-b opens page 2.
-    // Both call tabs list and see only their own.
+  it('two agents see each other tabs as "other-agent" with the owner label', async () => {
+    // Two connected sessions. agent-a opens page 1, agent-b opens
+    // page 2. Both call tabs list. Each sees its OWN page under
+    // "Your tabs:", the peer's page under "Other agents' tabs:" with
+    // the peer's slug in ownerLabel, and the operator page under
+    // "User's tabs:".
     stubSessionForPage(1, 't1', 'https://a.example/', 'A')
-    // agent-a: tabs new (page 1) + tab_groups create + update
     queue(ok({ page: 1 }), ok({ group: { groupId: 'GA', windowId: 1 } }), ok())
     const a = await connect('claude-code')
     await a.client.callTool({
@@ -208,8 +226,6 @@ describe('per-agent tabs isolation', () => {
       arguments: { action: 'new', url: 'https://a.example/' },
     })
 
-    // Switch session stub to a page id both agents can see (agent-b
-    // opens page 2 while page 1 also exists). We stub pages 1 and 2.
     setBrowserSession({
       pages: {
         getInfo: (id: number) =>
@@ -229,7 +245,6 @@ describe('per-agent tabs isolation', () => {
       },
       // biome-ignore lint/suspicious/noExplicitAny: test stub
     } as any)
-    // agent-b: tabs new (page 2) + tab_groups create + update
     queue(ok({ page: 2 }), ok({ group: { groupId: 'GB', windowId: 1 } }), ok())
     const b = await connect('cursor')
     await b.client.callTool({
@@ -237,8 +252,6 @@ describe('per-agent tabs isolation', () => {
       arguments: { action: 'new', url: 'https://b.example/' },
     })
 
-    // Underlying tabs list returns BOTH pages plus operator tab 99.
-    // Filter must reduce per-agent.
     const opTabs = [
       { page: 1, url: 'https://a.example/', title: 'A' },
       { page: 2, url: 'https://b.example/', title: 'B' },
@@ -249,14 +262,48 @@ describe('per-agent tabs isolation', () => {
       name: 'tabs',
       arguments: { action: 'list' },
     })) as TabsListResult
-    expect(listA.structuredContent?.pages).toEqual([opTabs[0]])
+    expect(listA.structuredContent?.pages).toEqual([
+      {
+        ...opTabs[0],
+        ownership: 'mine',
+        ownerAgentId: a.agentId,
+        ownerLabel: null,
+      },
+      {
+        ...opTabs[1],
+        ownership: 'other-agent',
+        ownerAgentId: b.agentId,
+        ownerLabel: 'cursor',
+      },
+      { ...opTabs[2], ownership: 'user', ownerAgentId: null, ownerLabel: null },
+    ])
+    const textA = (listA.content as Array<{ type: string; text?: string }>)?.[0]
+      ?.text
+    expect(textA).toContain('Your tabs:')
+    expect(textA).toContain("Other agents' tabs:")
+    expect(textA).toContain(', owned by cursor')
+    expect(textA).toContain("User's tabs:")
 
     queue(ok({ pages: opTabs }))
     const listB = (await b.client.callTool({
       name: 'tabs',
       arguments: { action: 'list' },
     })) as TabsListResult
-    expect(listB.structuredContent?.pages).toEqual([opTabs[1]])
+    expect(listB.structuredContent?.pages).toEqual([
+      {
+        ...opTabs[0],
+        ownership: 'other-agent',
+        ownerAgentId: a.agentId,
+        ownerLabel: 'claude-code',
+      },
+      {
+        ...opTabs[1],
+        ownership: 'mine',
+        ownerAgentId: b.agentId,
+        ownerLabel: null,
+      },
+      { ...opTabs[2], ownership: 'user', ownerAgentId: null, ownerLabel: null },
+    ])
 
     await a.client.close()
     await b.client.close()
@@ -296,23 +343,36 @@ describe('per-agent tabs isolation', () => {
       name: 'tabs',
       arguments: { action: 'list' },
     })) as TabsListResult
-    expect(listB.structuredContent?.pages).toEqual([])
-    expect(
-      (listB.content as Array<{ type: string; text?: string }>)?.[0]?.text,
-    ).toBe('(no open pages)')
+    // Page 1 shows up as an other-agent tab (session A's ownership)
+    // even though the two sessions share the same client slug.
+    expect(listB.structuredContent?.pages).toEqual([
+      {
+        page: 1,
+        url: 'https://a.example/',
+        title: 'A',
+        ownership: 'other-agent',
+        ownerAgentId: a.agentId,
+        ownerLabel: 'claude-code',
+      },
+    ])
+    const textB = (listB.content as Array<{ type: string; text?: string }>)?.[0]
+      ?.text
+    expect(textB).toContain("Other agents' tabs:")
+    expect(textB).toContain(', owned by claude-code')
 
     await a.client.close()
     await b.client.close()
   })
 
-  it('tabs list on an empty ledger returns "(no open pages)"', async () => {
+  it('tabs list with no owned pages shows the operator tabs under "User\'s tabs:"', async () => {
     setBrowserSession({
       pages: {
         getInfo: (_id: number) => undefined,
       },
       // biome-ignore lint/suspicious/noExplicitAny: test stub
     } as any)
-    // Underlying tool returns some operator tabs; filter drops them.
+    // Underlying tool returns operator tabs; the annotator groups
+    // them under "User's tabs:" instead of hiding them.
     queue(
       ok({
         pages: [
@@ -320,6 +380,37 @@ describe('per-agent tabs isolation', () => {
         ],
       }),
     )
+    const { client } = await connect('claude-code')
+    const list = (await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'list' },
+    })) as TabsListResult
+    expect(list.structuredContent?.pages).toEqual([
+      {
+        page: 100,
+        url: 'https://only-operator.example/',
+        title: 'Op',
+        ownership: 'user',
+        ownerAgentId: null,
+        ownerLabel: null,
+      },
+    ])
+    const text = (list.content as Array<{ type: string; text?: string }>)?.[0]
+      ?.text
+    expect(text).toContain("User's tabs:")
+    expect(text).toContain('[100] https://only-operator.example/ (Op)')
+    expect(text).not.toContain('Your tabs:')
+    await client.close()
+  })
+
+  it('tabs list with truly zero open pages still renders "(no open pages)"', async () => {
+    setBrowserSession({
+      pages: {
+        getInfo: (_id: number) => undefined,
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: test stub
+    } as any)
+    queue(ok({ pages: [] }))
     const { client } = await connect('claude-code')
     const list = (await client.callTool({
       name: 'tabs',
@@ -435,10 +526,32 @@ describe('per-agent tabs isolation', () => {
       name: 'tabs',
       arguments: { action: 'list' },
     })) as TabsListResult
-    expect(list.structuredContent?.pages).toEqual([])
-    expect(
-      (list.content as Array<{ type: string; text?: string }>)?.[0]?.text,
-    ).toBe('(no open pages)')
+    // After the reap, ownership of page 7 was dropped, so the new
+    // session sees both pages under "User's tabs:" rather than
+    // remembering the stale ownership.
+    expect(list.structuredContent?.pages).toEqual([
+      {
+        page: 7,
+        url: 'https://x.com/',
+        title: 'Stale',
+        ownership: 'user',
+        ownerAgentId: null,
+        ownerLabel: null,
+      },
+      {
+        page: 99,
+        url: 'https://operator.example/',
+        title: 'Op',
+        ownership: 'user',
+        ownerAgentId: null,
+        ownerLabel: null,
+      },
+    ])
+    const text = (list.content as Array<{ type: string; text?: string }>)?.[0]
+      ?.text
+    expect(text).toContain("User's tabs:")
+    expect(text).not.toContain('Your tabs:')
+    expect(text).not.toContain("Other agents' tabs:")
     await second.client.close()
   })
 })

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-ownership.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-ownership.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Unit tests for the `classify` + `annotateTabsListWithOwnership`
+ * pair. Deps are injected as plain functions so the tests never
+ * touch the process-wide agentTabs or identityService singletons.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import {
+  annotateTabsListWithOwnership,
+  classify,
+  type OwnershipDeps,
+} from '../../src/mcp/tabs-ownership'
+
+function makeDeps(overrides: Partial<OwnershipDeps> = {}): OwnershipDeps {
+  return {
+    callerAgentId: 'me',
+    resolveOwner: () => null,
+    labelForAgentId: () => null,
+    ...overrides,
+  }
+}
+
+describe('classify', () => {
+  test('no owner returns the "user" bucket', () => {
+    const result = classify({ page: 1, url: 'https://u.example/' }, makeDeps())
+    expect(result.ownership).toBe('user')
+    expect(result.ownerAgentId).toBeNull()
+    expect(result.ownerLabel).toBeNull()
+  })
+
+  test('caller-owned page returns the "mine" bucket', () => {
+    const deps = makeDeps({ resolveOwner: () => 'me' })
+    const result = classify({ page: 7 }, deps)
+    expect(result.ownership).toBe('mine')
+    expect(result.ownerAgentId).toBe('me')
+    expect(result.ownerLabel).toBeNull()
+  })
+
+  test('foreign owner returns the "other-agent" bucket with a label', () => {
+    const deps = makeDeps({
+      resolveOwner: () => 'other',
+      labelForAgentId: (id) => (id === 'other' ? 'cursor' : null),
+    })
+    const result = classify({ page: 9 }, deps)
+    expect(result.ownership).toBe('other-agent')
+    expect(result.ownerAgentId).toBe('other')
+    expect(result.ownerLabel).toBe('cursor')
+  })
+
+  test('foreign owner with no label (session already closed) leaves ownerLabel null', () => {
+    const deps = makeDeps({
+      resolveOwner: () => 'other',
+      labelForAgentId: () => null,
+    })
+    const result = classify({ page: 9 }, deps)
+    expect(result.ownership).toBe('other-agent')
+    expect(result.ownerLabel).toBeNull()
+  })
+})
+
+describe('annotateTabsListWithOwnership', () => {
+  const oneOfEach = {
+    isError: false,
+    content: [{ type: 'text', text: '(placeholder)' }],
+    structuredContent: {
+      pages: [
+        { page: 3, url: 'https://my.example/', title: 'Mine' },
+        { page: 1, url: 'https://u.example/', title: 'User' },
+        { page: 7, url: 'https://o.example/', title: 'Other' },
+      ],
+    },
+  }
+
+  test('groups one page per bucket with headers in the fixed order', () => {
+    const deps = makeDeps({
+      resolveOwner: (id) => (id === 3 ? 'me' : id === 7 ? 'other' : null),
+      labelForAgentId: (id) => (id === 'other' ? 'claude-code' : null),
+    })
+    const result = annotateTabsListWithOwnership(oneOfEach, deps)
+    const text = (result.content as Array<{ text: string }>)[0].text
+    // Fixed order across the response: Your tabs / User's tabs /
+    // Other agents' tabs. Blank line separates sections.
+    expect(text).toBe(
+      [
+        'Your tabs:',
+        '[3] https://my.example/ (Mine)',
+        '',
+        "User's tabs:",
+        '[1] https://u.example/ (User)',
+        '',
+        "Other agents' tabs:",
+        '[7] https://o.example/ (Other), owned by claude-code',
+      ].join('\n'),
+    )
+    const sc = result.structuredContent as { pages: unknown[] }
+    expect(sc.pages).toHaveLength(3)
+  })
+
+  test('omits empty bucket headers when the section is empty', () => {
+    const result = annotateTabsListWithOwnership(
+      {
+        content: [{ type: 'text', text: 'x' }],
+        structuredContent: {
+          pages: [{ page: 3, url: 'https://my.example/' }],
+        },
+      },
+      makeDeps({ resolveOwner: () => 'me' }),
+    )
+    const text = (result.content as Array<{ text: string }>)[0].text
+    expect(text).toBe(['Your tabs:', '[3] https://my.example/'].join('\n'))
+    expect(text).not.toContain("User's tabs:")
+    expect(text).not.toContain("Other agents' tabs:")
+  })
+
+  test('renders only "User\'s tabs:" when the caller owns nothing and no other agents claim anything', () => {
+    const result = annotateTabsListWithOwnership(
+      {
+        content: [{ type: 'text', text: 'x' }],
+        structuredContent: {
+          pages: [{ page: 1, url: 'https://u.example/', title: 'Op' }],
+        },
+      },
+      makeDeps(),
+    )
+    const text = (result.content as Array<{ text: string }>)[0].text
+    expect(text).toContain("User's tabs:")
+    expect(text).not.toContain('Your tabs:')
+    expect(text).not.toContain("Other agents' tabs:")
+  })
+
+  test('empty pages list renders the legacy "(no open pages)" cue', () => {
+    const result = annotateTabsListWithOwnership(
+      {
+        content: [{ type: 'text', text: 'x' }],
+        structuredContent: { pages: [] },
+      },
+      makeDeps(),
+    )
+    const text = (result.content as Array<{ text: string }>)[0].text
+    expect(text).toBe('(no open pages)')
+  })
+
+  test('missing structuredContent is treated as an empty pages list', () => {
+    const result = annotateTabsListWithOwnership(
+      { content: [{ type: 'text', text: 'x' }] },
+      makeDeps(),
+    )
+    const text = (result.content as Array<{ text: string }>)[0].text
+    expect(text).toBe('(no open pages)')
+  })
+
+  test('structuredContent.pages retains ordering from the underlying tool', () => {
+    // Pages arrive in a specific order from ctx.session.pages.list();
+    // the annotator must not reorder within `structuredContent`
+    // (only the text render groups by bucket).
+    const result = annotateTabsListWithOwnership(
+      {
+        content: [{ type: 'text', text: 'x' }],
+        structuredContent: {
+          pages: [
+            { page: 9, url: 'https://o.example/' },
+            { page: 3, url: 'https://my.example/' },
+            { page: 1, url: 'https://u.example/' },
+          ],
+        },
+      },
+      makeDeps({
+        resolveOwner: (id) => (id === 3 ? 'me' : id === 9 ? 'other' : null),
+        labelForAgentId: (id) => (id === 'other' ? 'cursor' : null),
+      }),
+    )
+    const sc = result.structuredContent as {
+      pages: Array<{ page: number; ownership: string }>
+    }
+    expect(sc.pages.map((p) => p.page)).toEqual([9, 3, 1])
+    expect(sc.pages.map((p) => p.ownership)).toEqual([
+      'other-agent',
+      'mine',
+      'user',
+    ])
+  })
+
+  test('foreign owner without a label omits the ", owned by ..." suffix', () => {
+    const result = annotateTabsListWithOwnership(
+      {
+        content: [{ type: 'text', text: 'x' }],
+        structuredContent: {
+          pages: [{ page: 9, url: 'https://o.example/' }],
+        },
+      },
+      makeDeps({
+        resolveOwner: () => 'ghost',
+        labelForAgentId: () => null,
+      }),
+    )
+    const text = (result.content as Array<{ text: string }>)[0].text
+    expect(text).toContain("Other agents' tabs:")
+    expect(text).toContain('[9] https://o.example/')
+    expect(text).not.toContain('owned by')
+  })
+
+  test('always clears isError to false on the annotated result', () => {
+    const result = annotateTabsListWithOwnership(
+      {
+        content: [{ type: 'text', text: 'x' }],
+        structuredContent: { pages: [] },
+        isError: true,
+      },
+      makeDeps(),
+    )
+    expect(result.isError).toBe(false)
+  })
+})

--- a/packages/browseros-agent/packages/browser-mcp/src/mcp-prompt.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/mcp-prompt.ts
@@ -1,7 +1,7 @@
 export const BROWSER_MCP_INSTRUCTIONS = `BrowserOS browser automation.
 
 Observe -> Act -> Verify:
-- Start with tabs action="list" to find page ids when needed.
+- Start with tabs action="list" to find page ids when needed. The list is grouped by ownership (your tabs / user's tabs / other agents' tabs); you may only modify your own tabs.
 - Use snapshot before interacting; it returns refs like [ref=e12].
 - Use refs with act for click, fill, hover, select, press, scroll, and coordinate actions.
 - Use navigate for url/back/forward/reload; it returns a fresh snapshot because refs are invalidated.

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/tabs.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/tabs.ts
@@ -4,7 +4,7 @@ import { defineTool, errorResult, textResult } from './framework'
 export const tabs = defineTool({
   name: 'tabs',
   description:
-    'Manage browser tabs: list open pages (with their page ids), show the active page, open a new page, or close one. Use the returned page id with snapshot/act/navigate.',
+    "Manage browser tabs. `list` returns every open page grouped by ownership: `Your tabs` (pages you opened via `tabs new`), `User's tabs` (pages the operator opened), and `Other agents' tabs` (pages another AI agent opened). You can act freely on your own tabs. Page-targeted tools (snapshot, act, navigate, close, etc.) reject dispatches on pages you do not own with an error asking you to call `tabs new`. `active` shows the current front page; `new` opens a fresh page; `close` closes one of yours.",
   input: z.object({
     action: z.enum(['list', 'active', 'new', 'close']).default('list'),
     url: z


### PR DESCRIPTION
## Summary

Replaces the flat filter that hides every non-owned tab from a `tabs list` response with a grouped view that keeps every open page and tags each one with its owner. Agents now see:

```
Your tabs:                                (owner === caller)
[3] https://news.ycombinator.com/news (Hacker News)

User's tabs:                              (no agent owner recorded)
[1] https://docs.google.com/document/... (Draft doc)

Other agents' tabs:                       (owner is another agent)
[7] https://linear.app/... (Ticket, owned by codex-mcp-client)
```

The **cross-agent page guard is unchanged**. Every page-targeted tool (snapshot, act, navigate, evaluate, close, ...) still hard-rejects a dispatch on a page the caller does not own with the same error message. This PR is purely a visibility improvement, not an action-scope change.

## Motivation

The current filter hides operator tabs entirely, so an LLM sees `(no open pages)` even when the user already has several tabs open. It then dispatches `tabs new` and duplicates a page the user is already looking at. With tri-bucket visibility the agent can offer to help with a tab that already exists (\"want me to help with the Gmail tab you have open?\") without opening a duplicate; the guard on modifications keeps user and other-agent tabs safe from accidental hijack.

## Changes

### `agent-tabs.ts`, reverse ownership lookup

Adds `resolveOwner(pageId): agentId | null` backed by a new `Map<pageId, agentId>` maintained alongside the existing per-agent `Set<pageId>`. Both indices stay coherent across `markOpened` / `markClosed` / `forgetAgent` / `clear`. `owners.get(pageId) === agentId` guards on removal so the defensive two-agent-same-pageId collision does not blow away the wrong entry.

### New `apps/claw-server/src/mcp/tabs-ownership.ts`

Pure functions with injected deps:

* `classify(page, deps): AnnotatedPage` returns the correct bucket for a single page.
* `annotateTabsListWithOwnership(result, deps): R` reshapes a successful `tabs list` result: `structuredContent.pages` gets `{ ownership, ownerAgentId, ownerLabel }` appended per entry (ordering preserved); `content[0].text` groups by bucket with fixed section order (Your / User's / Other agents') and empty-bucket-header omission. A truly empty pages list still renders `(no open pages)`.
* `buildOwnershipDeps(callerIdentity, agentTabs, identityService)` snapshots the identity service at call time so the caller sees a stable ownerLabel even if a peer session ends mid-dispatch.

### `register.ts`

One-line swap of `filterTabsListToAgent` for `annotateTabsListWithOwnership` inside the existing `action === 'list'` branch at line ~636. `filterTabsListToAgent` deleted (no downstream imports; grep confirmed).

### `browser-mcp` LLM surface

* `tabs` tool description explains the grouped shape and stays honest about the guard (\"Page-targeted tools reject dispatches on pages you do not own\").
* `mcp-prompt.ts` gets one line under the tools list pointing at the grouping.

## What did NOT change

* **Cross-agent page guard.** Every page-targeted tool still hard-rejects a foreign dispatch. Agent sees other tabs but cannot act on them.
* `tabs active` response shape.
* Audit-log schema. No new columns.
* Tool handler bodies. Only the `description` string moves.
* The tab-group tracker, tab-group operations service, tab-activity registry.

## Test plan

- [ ] `bun install && bun run typecheck` clean in `apps/claw-server` and `packages/browser-mcp`.
- [ ] `bun test` in `apps/claw-server` (370 pass expected, up from 351).
- [ ] `bun test` in `packages/browser-mcp` (24 pass).
- [ ] Smoke: start BrowserClaw, connect two Codex CLI sessions.
  - Session A opens a page. Session B's \`tabs list\` shows it under \"Other agents' tabs\" with the correct owner label.
  - Operator opens a Gmail tab directly. Both sessions' \`tabs list\` show it under \"User's tabs\".
  - Session A calls \`snapshot\` on session B's page: verify the hard-reject error still fires (unchanged behaviour).
  - Session A calls \`tabs close\` on session B's page: verify the hard-reject error still fires.
- [ ] \`tabs list\` on a fresh session with no operator tabs and nothing opened yet still renders \`(no open pages)\`.

## Follow-ups (out of scope for this PR)

* If the softer \"act unless asked\" behaviour is later requested, it lands in a standalone PR that touches only the guard + description. This one does not lay any pipe for it.
* \`tabs active\` ownership label. Same \`classify\` helper handles the single-page shape; not shipped today because the operator did not ask for it.
* Follow-up PR to refactor the register.ts dispatch handler cognitive complexity (already at 157 on \`main\`; unchanged by this diff).