### PR TITLE
fix: reduce macOS keychain prompts during Chrome import

### DIFF
--- a/packages/browseros/bos_build/features.yaml
+++ b/packages/browseros/bos_build/features.yaml
@@ -467,3 +467,11 @@ features:
       - chrome/installer/setup/setup_main.cc
       - chrome/installer/util/util_constants.cc
       - chrome/installer/util/util_constants.h
+
+  keychain-prompts:
+    description: "fix: reduce macOS keychain prompts during Chrome import"
+    files:
+      - components/os_crypt/common/BUILD.gn
+      - components/os_crypt/common/keychain_password_mac_unittest.mm
+      - ui/webui/resources/tools/generate_grd.gni
+      - ui/webui/resources/tools/generate_grd.py

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/BUILD.gn b/chrome/browser/browseros/onboarding/BUILD.gn
 new file mode 100644
-index 0000000000000..1f3f115cb5fd5
+index 0000000000000..a83a34e3f4a8e
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/BUILD.gn
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,62 @@
 +# Copyright 2026 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -27,6 +27,7 @@ index 0000000000000..1f3f115cb5fd5
 +  out_grd = "$target_gen_dir/resources.grd"
 +  input_files = _browseros_onboarding_resource_files
 +  input_files_base_dir = rebase_path("resources", "//")
++  ignore_missing_input_files = true
 +}
 +
 +grit("resources") {

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding.cc b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
 new file mode 100644
-index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
+index 0000000000000..7c79662ac3a21
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
-@@ -0,0 +1,728 @@
+@@ -0,0 +1,599 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -14,16 +14,13 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +
 +#include <memory>
 +#include <optional>
-+#include <set>
 +#include <string>
 +#include <string_view>
 +#include <utility>
-+#include <vector>
 +
 +#include "base/functional/bind.h"
 +#include "base/functional/callback.h"
 +#include "base/location.h"
-+#include "base/memory/weak_ptr.h"
 +#include "base/notreached.h"
 +#include "base/strings/stringprintf.h"
 +#include "base/strings/utf_string_conversions.h"
@@ -154,7 +151,6 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +
 + private:
 +  enum class ImportSourceResultStatus {
-+    kPending,
 +    kImporting,
 +    kSucceeded,
 +    kFailed,
@@ -167,17 +163,10 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +    bool has_selected_items = false;
 +  };
 +
-+  struct ImportQueueEntry {
-+    user_data_importer::SourceProfile source_profile;
-+    std::string source_id;
-+    std::string display_name;
-+    uint16_t imported_items = user_data_importer::NONE;
-+  };
-+
 +  struct ImportSourceResult {
 +    std::string source_id;
 +    std::string display_name;
-+    ImportSourceResultStatus status = ImportSourceResultStatus::kPending;
++    ImportSourceResultStatus status;
 +  };
 +
 +  void RegisterMessages() override {
@@ -223,7 +212,7 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +  }
 +
 +  void HandleRefreshSources(const base::ListValue& args) {
-+    if (IsImportQueueRunning()) {
++    if (IsImportRunning()) {
 +      SendFailure("importing", "import_in_progress",
 +                  "An import is already in progress.");
 +      return;
@@ -235,7 +224,7 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +  }
 +
 +  void HandleStartImport(const base::ListValue& args) {
-+    if (IsImportQueueRunning()) {
++    if (IsImportRunning()) {
 +      SendFailure("importing", "import_in_progress",
 +                  "An import is already in progress.");
 +      return;
@@ -255,47 +244,43 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +      return;
 +    }
 +
-+    std::vector<ImportRequestSelection> selections;
-+    if (!BuildImportSelections(args, &selections)) {
++    ImportRequestSelection selection;
++    if (!BuildImportSelection(args, &selection)) {
 +      SendFailure("invalid_source", "Selected import source is not valid.");
 +      return;
 +    }
 +
-+    std::vector<ImportQueueEntry> import_queue;
-+    std::vector<ImportSourceResult> import_results;
-+    bool has_supported_items = false;
-+    for (const ImportRequestSelection& selection : selections) {
-+      const user_data_importer::SourceProfile& source_profile =
-+          importer_list_->GetSourceProfileAt(selection.source_index);
-+      uint16_t imported_items =
-+          GetEffectiveImportItems(source_profile, selection);
-+      has_supported_items = has_supported_items || imported_items != 0;
++    const user_data_importer::SourceProfile& source_profile =
++        importer_list_->GetSourceProfileAt(selection.source_index);
++    imported_items_ = GetEffectiveImportItems(source_profile, selection);
 +
-+      std::string display_name = GetDisplayName(source_profile);
-+      import_queue.push_back(
-+          {source_profile, selection.source_id, display_name, imported_items});
-+      import_results.push_back({selection.source_id, display_name,
-+                                ImportSourceResultStatus::kPending});
-+    }
-+
-+    if (!has_supported_items) {
++    if (!imported_items_) {
 +      SendFailure("no_supported_items",
 +                  "Selected source has no supported import items.");
 +      return;
 +    }
 +
-+    import_queue_ = std::move(import_queue);
-+    import_results_ = std::move(import_results);
-+    import_queue_index_ = 0;
-+    StartNextImport();
++    std::string display_name = GetDisplayName(source_profile);
++    import_result_ = ImportSourceResult{selection.source_id, display_name,
++                                        ImportSourceResultStatus::kImporting};
++    current_item_ = user_data_importer::NONE;
++    completed_items_ = user_data_importer::NONE;
++    import_did_succeed_ = false;
++
++    if (importer_host_) {
++      importer_host_->set_observer(nullptr);
++      importer_host_ = nullptr;
++    }
++    importer_host_ = new ExternalProcessImporterHost();
++    importer_host_->set_observer(this);
++    Profile* profile = Profile::FromWebUI(web_ui());
++    SendState("importing");
++    importer_host_->StartImportSettings(source_profile, profile,
++                                        imported_items_,
++                                        new ProfileWriter(profile));
 +  }
 +
 +  void HandleComplete(const base::ListValue& args) {
-+    if (completion_handled_) {
-+      return;
-+    }
-+    completion_handled_ = true;
-+
 +    SendState("completed");
 +
 +    if (completion_callback_) {
@@ -336,26 +321,14 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +    return false;
 +  }
 +
-+  bool BuildImportSelections(
-+      const base::ListValue& args,
-+      std::vector<ImportRequestSelection>* selections) const {
++  bool BuildImportSelection(const base::ListValue& args,
++                            ImportRequestSelection* selection) const {
 +    if (!args.empty() && args[0].is_dict()) {
 +      const base::DictValue& request = args[0].GetDict();
 +      if (request.contains("selections")) {
-+        const base::ListValue* requested_selections =
-+            request.FindList("selections");
-+        if (!requested_selections) {
-+          return false;
-+        }
-+        return BuildImportSelectionsFromList(*requested_selections, selections);
-+      }
-+
-+      ImportRequestSelection selection;
-+      if (!BuildImportSelectionFromDict(request, &selection)) {
 +        return false;
 +      }
-+      selections->push_back(std::move(selection));
-+      return true;
++      return BuildImportSelectionFromDict(request, selection);
 +    }
 +
 +    std::optional<int> browser_index = args.empty() ? 0 : args[0].GetIfInt();
@@ -366,35 +339,10 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +      return false;
 +    }
 +
-+    selections->push_back(
-+        {*browser_index, SourceIdForIndex(static_cast<size_t>(*browser_index)),
-+         user_data_importer::NONE, false});
-+    return true;
-+  }
-+
-+  bool BuildImportSelectionsFromList(
-+      const base::ListValue& requested_selections,
-+      std::vector<ImportRequestSelection>* selections) const {
-+    if (requested_selections.empty()) {
-+      return false;
-+    }
-+
-+    std::set<std::string> source_ids;
-+    for (const base::Value& selection_value : requested_selections) {
-+      if (!selection_value.is_dict()) {
-+        return false;
-+      }
-+
-+      ImportRequestSelection selection;
-+      if (!BuildImportSelectionFromDict(selection_value.GetDict(),
-+                                        &selection)) {
-+        return false;
-+      }
-+      if (!source_ids.insert(selection.source_id).second) {
-+        return false;
-+      }
-+      selections->push_back(std::move(selection));
-+    }
++    selection->source_index = *browser_index;
++    selection->source_id = SourceIdForIndex(static_cast<size_t>(*browser_index));
++    selection->selected_items = user_data_importer::NONE;
++    selection->has_selected_items = false;
 +    return true;
 +  }
 +
@@ -450,12 +398,16 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +      std::string browser_name =
 +          base::UTF16ToUTF8(source_profile.importer_name);
 +      std::string profile_name = base::UTF16ToUTF8(source_profile.profile);
++      std::string account_name =
++          base::UTF16ToUTF8(source_profile.account_name);
 +
 +      base::DictValue source;
 +      source.Set("id", SourceIdForIndex(i));
 +      source.Set("displayName", GetDisplayName(source_profile));
 +      source.Set("browserName", browser_name);
 +      source.Set("profileName", profile_name);
++      source.Set("accountName", account_name);
++      source.Set("isManaged", source_profile.is_managed);
 +      source.Set("supportedItems", ImportItemsFromMask(services));
 +      source.Set("recommendedItems", ImportItemsFromMask(services));
 +      sources.Append(std::move(source));
@@ -466,8 +418,6 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +  const char* ImportSourceResultStatusToString(
 +      ImportSourceResultStatus status) const {
 +    switch (status) {
-+      case ImportSourceResultStatus::kPending:
-+        return "pending";
 +      case ImportSourceResultStatus::kImporting:
 +        return "importing";
 +      case ImportSourceResultStatus::kSucceeded:
@@ -480,12 +430,12 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +
 +  base::ListValue BuildResults() const {
 +    base::ListValue results;
-+    for (const ImportSourceResult& result : import_results_) {
++    if (import_result_) {
 +      base::DictValue result_value;
-+      result_value.Set("sourceId", result.source_id);
-+      result_value.Set("displayName", result.display_name);
-+      result_value.Set("status",
-+                       ImportSourceResultStatusToString(result.status));
++      result_value.Set("sourceId", import_result_->source_id);
++      result_value.Set("displayName", import_result_->display_name);
++      result_value.Set(
++          "status", ImportSourceResultStatusToString(import_result_->status));
 +      results.Append(std::move(result_value));
 +    }
 +    return results;
@@ -497,11 +447,10 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +    progress.Set("totalItems",
 +                 static_cast<int>(ImportItemsFromMask(imported_items_).size()));
 +    progress.Set("completedSources", GetCompletedSourceCount());
-+    progress.Set("totalSources", static_cast<int>(import_results_.size()));
-+    if (has_current_source_) {
-+      const ImportQueueEntry& entry = import_queue_[current_source_index_];
-+      progress.Set("currentSourceId", entry.source_id);
-+      progress.Set("currentSourceName", entry.display_name);
++    progress.Set("totalSources", import_result_ ? 1 : 0);
++    if (IsImportRunning()) {
++      progress.Set("currentSourceId", import_result_->source_id);
++      progress.Set("currentSourceName", import_result_->display_name);
 +    }
 +    const char* current_item = ImportItemToString(current_item_);
 +    if (current_item) {
@@ -516,10 +465,10 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +      state.Set("apiVersion", kBrowserOSOnboardingApiVersion);
 +      state.Set("status", std::string(status));
 +      state.Set("sources", BuildSources());
-+      if (!import_results_.empty()) {
++      if (import_result_) {
 +        state.Set("results", BuildResults());
 +      }
-+      if (imported_items_ || !import_results_.empty()) {
++      if (imported_items_ || import_result_) {
 +        state.Set("progress", BuildProgress());
 +      }
 +      CallJavascriptFunction("browserosOnboarding.receiveState", state);
@@ -538,10 +487,10 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +      state.Set("apiVersion", kBrowserOSOnboardingApiVersion);
 +      state.Set("status", std::string(status));
 +      state.Set("sources", BuildSources());
-+      if (!import_results_.empty()) {
++      if (import_result_) {
 +        state.Set("results", BuildResults());
 +      }
-+      if (imported_items_ || !import_results_.empty()) {
++      if (imported_items_ || import_result_) {
 +        state.Set("progress", BuildProgress());
 +      }
 +      base::DictValue error;
@@ -571,111 +520,38 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +      importer_host_->set_observer(nullptr);
 +      importer_host_ = nullptr;
 +    }
-+    if (import_results_.empty()) {
++    if (!import_result_) {
 +      return;
 +    }
 +
 +    current_item_ = user_data_importer::NONE;
-+    if (import_queue_index_ < import_results_.size()) {
-+      import_results_[import_queue_index_].status =
-+          import_did_succeed_ ? ImportSourceResultStatus::kSucceeded
-+                              : ImportSourceResultStatus::kFailed;
-+      ++import_queue_index_;
-+    }
-+
-+    if (IsImportQueueTerminal()) {
-+      has_current_source_ = false;
-+      SendState(GetTerminalImportStatus());
-+      return;
-+    }
-+
-+    SendState("importing");
-+    PostStartNextImport();
++    import_result_->status = import_did_succeed_
++                                 ? ImportSourceResultStatus::kSucceeded
++                                 : ImportSourceResultStatus::kFailed;
++    SendState(GetTerminalImportStatus());
 +  }
 +
-+  void StartNextImport() {
-+    if (import_queue_index_ >= import_queue_.size()) {
-+      has_current_source_ = false;
-+      SendState(GetTerminalImportStatus());
-+      return;
-+    }
-+
-+    current_source_index_ = import_queue_index_;
-+    has_current_source_ = true;
-+    current_item_ = user_data_importer::NONE;
-+    completed_items_ = user_data_importer::NONE;
-+    imported_items_ = import_queue_[import_queue_index_].imported_items;
-+    import_did_succeed_ = false;
-+
-+    if (!imported_items_) {
-+      import_results_[import_queue_index_].status =
-+          ImportSourceResultStatus::kFailed;
-+      ++import_queue_index_;
-+      bool is_terminal = IsImportQueueTerminal();
-+      if (is_terminal) {
-+        has_current_source_ = false;
-+      }
-+      SendState(is_terminal ? GetTerminalImportStatus() : "importing");
-+      if (!is_terminal) {
-+        PostStartNextImport();
-+      }
-+      return;
-+    }
-+
-+    import_results_[import_queue_index_].status =
-+        ImportSourceResultStatus::kImporting;
-+    if (importer_host_) {
-+      importer_host_->set_observer(nullptr);
-+      importer_host_ = nullptr;
-+    }
-+    importer_host_ = new ExternalProcessImporterHost();
-+    importer_host_->set_observer(this);
-+    Profile* profile = Profile::FromWebUI(web_ui());
-+    SendState("importing");
-+    importer_host_->StartImportSettings(
-+        import_queue_[import_queue_index_].source_profile, profile,
-+        imported_items_, new ProfileWriter(profile));
-+  }
-+
-+  void PostStartNextImport() {
-+    // The host deletes itself after ImportEnded(), so the next host starts
-+    // later.
-+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-+        FROM_HERE, base::BindOnce(&BrowserOSOnboardingHandler::StartNextImport,
-+                                  weak_factory_.GetWeakPtr()));
-+  }
-+
-+  bool IsImportQueueRunning() const {
-+    return !import_results_.empty() && !IsImportQueueTerminal();
-+  }
-+
-+  bool IsImportQueueTerminal() const {
-+    if (import_results_.empty()) {
-+      return false;
-+    }
-+    return GetCompletedSourceCount() ==
-+           static_cast<int>(import_results_.size());
++  bool IsImportRunning() const {
++    return import_result_ &&
++           import_result_->status == ImportSourceResultStatus::kImporting;
 +  }
 +
 +  int GetCompletedSourceCount() const {
-+    int count = 0;
-+    for (const ImportSourceResult& result : import_results_) {
-+      if (result.status == ImportSourceResultStatus::kSucceeded ||
-+          result.status == ImportSourceResultStatus::kFailed) {
-+        ++count;
-+      }
++    if (!import_result_) {
++      return 0;
 +    }
-+    return count;
++    return (import_result_->status == ImportSourceResultStatus::kSucceeded ||
++            import_result_->status == ImportSourceResultStatus::kFailed)
++               ? 1
++               : 0;
 +  }
 +
 +  int GetSucceededSourceCount() const {
-+    int count = 0;
-+    for (const ImportSourceResult& result : import_results_) {
-+      if (result.status == ImportSourceResultStatus::kSucceeded) {
-+        ++count;
-+      }
++    if (!import_result_) {
++      return 0;
 +    }
-+    return count;
++    return import_result_->status == ImportSourceResultStatus::kSucceeded ? 1
++                                                                          : 0;
 +  }
 +
 +  const char* GetTerminalImportStatus() const {
@@ -683,33 +559,22 @@ index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 +  }
 +
 +  void ResetImportState() {
-+    weak_factory_.InvalidateWeakPtrs();
 +    current_item_ = user_data_importer::NONE;
 +    completed_items_ = user_data_importer::NONE;
 +    imported_items_ = user_data_importer::NONE;
 +    import_did_succeed_ = false;
-+    import_queue_.clear();
-+    import_results_.clear();
-+    import_queue_index_ = 0;
-+    current_source_index_ = 0;
-+    has_current_source_ = false;
++    import_result_.reset();
 +  }
 +
 +  std::unique_ptr<ImporterList> importer_list_;
 +  raw_ptr<ExternalProcessImporterHost> importer_host_ = nullptr;
 +  base::RepeatingClosure completion_callback_;
-+  std::vector<ImportQueueEntry> import_queue_;
-+  std::vector<ImportSourceResult> import_results_;
++  std::optional<ImportSourceResult> import_result_;
 +  user_data_importer::ImportItem current_item_ = user_data_importer::NONE;
 +  uint16_t completed_items_ = user_data_importer::NONE;
 +  uint16_t imported_items_ = user_data_importer::NONE;
-+  size_t import_queue_index_ = 0;
-+  size_t current_source_index_ = 0;
 +  bool importer_list_loaded_ = false;
 +  bool import_did_succeed_ = false;
-+  bool has_current_source_ = false;
-+  bool completion_handled_ = false;
-+  base::WeakPtrFactory<BrowserOSOnboardingHandler> weak_factory_{this};
 +};
 +
 +BrowserOSOnboardingUIConfig::BrowserOSOnboardingUIConfig()

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts b/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
 new file mode 100644
-index 0000000000000..83a1cb5ea28c7
+index 0000000000000..2bf836fe76daa
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
-@@ -0,0 +1,99 @@
+@@ -0,0 +1,94 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -31,6 +31,8 @@ index 0000000000000..83a1cb5ea28c7
 +  displayName: string;
 +  browserName: string;
 +  profileName: string;
++  accountName: string;
++  isManaged: boolean;
 +  supportedItems: BrowserOSImportItem[];
 +  recommendedItems: BrowserOSImportItem[];
 +}
@@ -50,13 +52,8 @@ index 0000000000000..83a1cb5ea28c7
 +  message: string;
 +}
 +
-+export interface BrowserOSImportSelection {
-+  sourceId: string;
-+  items?: BrowserOSImportItem[];
-+}
-+
 +export type BrowserOSImportSourceResultStatus =
-+    'pending'|'importing'|'succeeded'|'failed';
++    'importing'|'succeeded'|'failed';
 +
 +export interface BrowserOSImportSourceResult {
 +  sourceId: string;
@@ -70,22 +67,20 @@ index 0000000000000..83a1cb5ea28c7
 +  sources: BrowserOSImportSource[];
 +  progress?: BrowserOSImportProgress;
 +  error?: BrowserOSOnboardingError;
-+  /** Multi-source imports can end succeeded with failed per-source results. */
++  /** Single-source imports report one per-source result. */
 +  results?: BrowserOSImportSourceResult[];
 +}
 +
 +/**
-+ * Starts one source or an ordered multi-source import queue.
++ * Starts one source import.
 + *
 + * Must be sent directly from the visible Import action. The browser process
 + * rejects hidden or non-interactive startImport messages because importing
 + * cookies/passwords can trigger the macOS Chrome Safe Storage keychain prompt.
 + */
 +export interface BrowserOSStartImportRequest {
-+  sourceId?: string;
++  sourceId: string;
 +  items?: BrowserOSImportItem[];
-+  /** When present, selections takes precedence over sourceId/items. */
-+  selections?: BrowserOSImportSelection[];
 +}
 +
 +export interface BrowserOSOnboardingClient {

--- a/packages/browseros/chromium_patches/chrome/browser/importer/importer_list.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/importer/importer_list.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/importer/importer_list.cc b/chrome/browser/importer/importer_list.cc
-index 62546b572bab8..80a7ec69346ec 100644
+index 62546b572bab8..df99dae8f9719 100644
 --- a/chrome/browser/importer/importer_list.cc
 +++ b/chrome/browser/importer/importer_list.cc
 @@ -6,10 +6,15 @@
@@ -26,12 +26,35 @@ index 62546b572bab8..80a7ec69346ec 100644
  
  #if BUILDFLAG(IS_MAC)
  #include "base/apple/foundation_util.h"
-@@ -29,6 +35,203 @@
+@@ -29,6 +35,235 @@
  
  namespace {
  
 +// Forward declaration for platform-specific Chrome user data folder getter
 +base::FilePath GetChromeUserDataFolder();
++
++constexpr char kChromeNoHostedDomainFound[] = "NO_HOSTED_DOMAIN";
++
++std::string GetChromeAccountName(const base::DictValue& profile) {
++  const std::string* user_name = profile.FindString("user_name");
++  if (user_name && !user_name->empty()) {
++    return *user_name;
++  }
++
++  const std::string* gaia_name = profile.FindString("gaia_name");
++  return gaia_name ? *gaia_name : std::string();
++}
++
++bool IsManagedChromeProfile(const base::DictValue& profile) {
++  const std::string* hosted_domain = profile.FindString("hosted_domain");
++  if (hosted_domain && !hosted_domain->empty() &&
++      *hosted_domain != kChromeNoHostedDomainFound) {
++    return true;
++  }
++
++  const std::string* managed_user_id = profile.FindString("managed_user_id");
++  return managed_user_id && !managed_user_id->empty();
++}
 +
 +// Chrome importer helper functions (cross-platform)
 +bool HasExtensionsToImport(const base::FilePath& preferences_path) {
@@ -161,6 +184,8 @@ index 62546b572bab8..80a7ec69346ec 100644
 +            base::DictValue entry;
 +            entry.Set("id", value.first);
 +            entry.Set("name", *name);
++            entry.Set("account_name", GetChromeAccountName(*profile));
++            entry.Set("is_managed", IsManagedChromeProfile(*profile));
 +            profiles.Append(std::move(entry));
 +          }
 +        }
@@ -173,6 +198,8 @@ index 62546b572bab8..80a7ec69346ec 100644
 +    base::DictValue entry;
 +    entry.Set("id", "Default");
 +    entry.Set("name", "Default");
++    entry.Set("account_name", "");
++    entry.Set("is_managed", false);
 +    profiles.Append(std::move(entry));
 +  }
 +
@@ -199,6 +226,7 @@ index 62546b572bab8..80a7ec69346ec 100644
 +
 +    const std::string* profile_id = dict->FindString("id");
 +    const std::string* name = dict->FindString("name");
++    const std::string* account_name = dict->FindString("account_name");
 +
 +    if (!profile_id || !name)
 +      continue;
@@ -223,6 +251,10 @@ index 62546b572bab8..80a7ec69346ec 100644
 +    chrome.importer_type = user_data_importer::TYPE_CHROME;
 +    chrome.services_supported = services;
 +    chrome.source_path = profile_folder;
++    if (account_name) {
++      chrome.account_name = base::UTF8ToUTF16(*account_name);
++    }
++    chrome.is_managed = dict->FindBool("is_managed").value_or(false);
 +    profiles->push_back(chrome);
 +  }
 +}
@@ -230,7 +262,7 @@ index 62546b572bab8..80a7ec69346ec 100644
  #if BUILDFLAG(IS_WIN)
  void DetectIEProfiles(
      std::vector<user_data_importer::SourceProfile>* profiles) {
-@@ -71,6 +274,21 @@ void DetectBuiltinWindowsProfiles(
+@@ -71,6 +306,21 @@ void DetectBuiltinWindowsProfiles(
  
  #endif  // BUILDFLAG(IS_WIN)
  
@@ -252,7 +284,7 @@ index 62546b572bab8..80a7ec69346ec 100644
  #if BUILDFLAG(IS_MAC)
  void DetectSafariProfiles(
      std::vector<user_data_importer::SourceProfile>* profiles) {
-@@ -88,8 +306,30 @@ void DetectSafariProfiles(
+@@ -88,8 +338,30 @@ void DetectSafariProfiles(
    safari.services_supported = items;
    profiles->push_back(safari);
  }
@@ -283,7 +315,7 @@ index 62546b572bab8..80a7ec69346ec 100644
  // |locale|: The application locale used for lookups in Firefox's
  // locale-specific search engines feature (see firefox_importer.cc for
  // details).
-@@ -170,8 +410,10 @@ std::vector<user_data_importer::SourceProfile> DetectSourceProfilesWorker(
+@@ -170,8 +442,10 @@ std::vector<user_data_importer::SourceProfile> DetectSourceProfilesWorker(
  #if BUILDFLAG(IS_WIN)
    if (shell_integration::IsFirefoxDefaultBrowser()) {
      DetectFirefoxProfiles(locale, &profiles);
@@ -294,7 +326,7 @@ index 62546b572bab8..80a7ec69346ec 100644
      DetectBuiltinWindowsProfiles(&profiles);
      DetectFirefoxProfiles(locale, &profiles);
    }
-@@ -179,11 +421,15 @@ std::vector<user_data_importer::SourceProfile> DetectSourceProfilesWorker(
+@@ -179,11 +453,15 @@ std::vector<user_data_importer::SourceProfile> DetectSourceProfilesWorker(
    if (shell_integration::IsFirefoxDefaultBrowser()) {
      DetectFirefoxProfiles(locale, &profiles);
      DetectSafariProfiles(&profiles);

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_cookie_importer.cc
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_cookie_importer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_cookie_importer.cc b/chrome/utility/importer/browseros/chrome_cookie_importer.cc
 new file mode 100644
-index 0000000000000..44937aaa83494
+index 0000000000000..21b17a08e1a8e
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_cookie_importer.cc
-@@ -0,0 +1,300 @@
+@@ -0,0 +1,295 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome cookie importer implementation
 +
@@ -152,8 +152,14 @@ index 0000000000000..44937aaa83494
 +}  // namespace
 +
 +std::vector<ImportedCookieEntry> ImportChromeCookies(
-+    const base::FilePath& profile_path) {
++    const base::FilePath& profile_path,
++    const std::string& encryption_key) {
 +  std::vector<ImportedCookieEntry> cookies;
++  if (encryption_key.empty()) {
++    LOG(WARNING) << "browseros: Chrome encryption key unavailable; "
++                 << "skipping cookie import";
++    return cookies;
++  }
 +
 +  // Path to Cookies database
 +  base::FilePath cookies_path = profile_path.AppendASCII(kCookiesFilename);
@@ -209,17 +215,6 @@ index 0000000000000..44937aaa83494
 +    sql::Statement statement(db.GetUniqueStatement(kQuery));
 +    if (!statement.is_valid()) {
 +      LOG(WARNING) << "browseros: Failed to prepare query";
-+      DeleteDatabaseTemp(temp_db_path);
-+      return cookies;
-+    }
-+
-+    // Extract encryption key only once the selected Cookies database is known
-+    // to exist and have the schema we import.
-+    KeyExtractionResult key_result;
-+    std::string encryption_key = ExtractChromeKey(profile_path, &key_result);
-+    if (encryption_key.empty()) {
-+      LOG(WARNING) << "browseros: Failed to extract encryption key, "
-+                   << "result: " << static_cast<int>(key_result);
 +      DeleteDatabaseTemp(temp_db_path);
 +      return cookies;
 +    }

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_cookie_importer.h
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_cookie_importer.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_cookie_importer.h b/chrome/utility/importer/browseros/chrome_cookie_importer.h
 new file mode 100644
-index 0000000000000..edfd9f068250b
+index 0000000000000..b706ed9dfa177
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_cookie_importer.h
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,53 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome cookie importer interface
 +
@@ -51,7 +51,8 @@ index 0000000000000..edfd9f068250b
 +// profile_path should point to the Chrome profile directory containing
 +// the "Cookies" database file.
 +std::vector<ImportedCookieEntry> ImportChromeCookies(
-+    const base::FilePath& profile_path);
++    const base::FilePath& profile_path,
++    const std::string& encryption_key);
 +
 +}  // namespace browseros_importer
 +

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_importer.cc
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_importer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_importer.cc b/chrome/utility/importer/browseros/chrome_importer.cc
 new file mode 100644
-index 0000000000000..ecb17e09bdaf8
+index 0000000000000..3674707cab113
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_importer.cc
-@@ -0,0 +1,209 @@
+@@ -0,0 +1,225 @@
 +// Copyright 2023 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -16,6 +16,7 @@ index 0000000000000..ecb17e09bdaf8
 +#include "chrome/utility/importer/browseros/chrome_autofill_importer.h"
 +#include "chrome/utility/importer/browseros/chrome_bookmarks_importer.h"
 +#include "chrome/utility/importer/browseros/chrome_cookie_importer.h"
++#include "chrome/utility/importer/browseros/chrome_decryptor.h"
 +#include "chrome/utility/importer/browseros/chrome_extensions_importer.h"
 +#include "chrome/utility/importer/browseros/chrome_history_importer.h"
 +#include "chrome/utility/importer/browseros/chrome_password_importer.h"
@@ -33,8 +34,20 @@ index 0000000000000..ecb17e09bdaf8
 +  bridge_ = bridge;
 +  source_path_ = source_profile.source_path;
 +  source_profile_name_ = source_profile.profile;
++  chrome_encryption_key_.clear();
 +
 +  bridge_->NotifyStarted();
++
++  if ((items & (user_data_importer::PASSWORDS | user_data_importer::COOKIES)) &&
++      !cancelled()) {
++    browseros_importer::KeyExtractionResult key_result;
++    chrome_encryption_key_ =
++        browseros_importer::ExtractChromeKey(source_path_, &key_result);
++    if (chrome_encryption_key_.empty()) {
++      LOG(WARNING) << "browseros: Failed to extract Chrome encryption key, "
++                   << "result: " << static_cast<int>(key_result);
++    }
++  }
 +
 +  if ((items & user_data_importer::HISTORY) && !cancelled()) {
 +    bridge_->NotifyItemStarted(user_data_importer::HISTORY);
@@ -73,6 +86,7 @@ index 0000000000000..ecb17e09bdaf8
 +  }
 +
 +  bridge_->NotifyEnded();
++  chrome_encryption_key_.clear();
 +}
 +
 +void ChromeImporter::ImportHistory() {
@@ -130,7 +144,8 @@ index 0000000000000..ecb17e09bdaf8
 +  LOG(INFO) << "browseros: Starting password import";
 +
 +  std::vector<user_data_importer::ImportedPasswordForm> passwords =
-+      browseros_importer::ImportChromePasswords(source_path_);
++      browseros_importer::ImportChromePasswords(source_path_,
++                                                chrome_encryption_key_);
 +
 +  if (passwords.empty()) {
 +    LOG(INFO) << "browseros: No passwords to import";
@@ -153,7 +168,8 @@ index 0000000000000..ecb17e09bdaf8
 +  LOG(INFO) << "browseros: Starting cookie import";
 +
 +  std::vector<browseros_importer::ImportedCookieEntry> cookies =
-+      browseros_importer::ImportChromeCookies(source_path_);
++      browseros_importer::ImportChromeCookies(source_path_,
++                                              chrome_encryption_key_);
 +
 +  if (cookies.empty()) {
 +    LOG(INFO) << "browseros: No cookies to import";

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_importer.h
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_importer.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_importer.h b/chrome/utility/importer/browseros/chrome_importer.h
 new file mode 100644
-index 0000000000000..b6b0ab5e6952e
+index 0000000000000..5b45173f702b7
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_importer.h
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,48 @@
 +// Copyright 2023 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -48,6 +48,7 @@ index 0000000000000..b6b0ab5e6952e
 +
 +  base::FilePath source_path_;
 +  std::u16string source_profile_name_;
++  std::string chrome_encryption_key_;
 +};
 +
 +#endif  // CHROME_UTILITY_IMPORTER_BROWSEROS_CHROME_IMPORTER_H_

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_password_importer.cc
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_password_importer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_password_importer.cc b/chrome/utility/importer/browseros/chrome_password_importer.cc
 new file mode 100644
-index 0000000000000..00528908da168
+index 0000000000000..3aaeb073d7554
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_password_importer.cc
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,143 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome password importer implementation
 +
@@ -30,8 +30,14 @@ index 0000000000000..00528908da168
 +}  // namespace
 +
 +std::vector<user_data_importer::ImportedPasswordForm> ImportChromePasswords(
-+    const base::FilePath& profile_path) {
++    const base::FilePath& profile_path,
++    const std::string& encryption_key) {
 +  std::vector<user_data_importer::ImportedPasswordForm> passwords;
++  if (encryption_key.empty()) {
++    LOG(WARNING) << "browseros: Chrome encryption key unavailable; "
++                 << "skipping password import";
++    return passwords;
++  }
 +
 +  // Path to Login Data database
 +  base::FilePath login_data_path = profile_path.AppendASCII(kLoginDataFilename);
@@ -69,17 +75,6 @@ index 0000000000000..00528908da168
 +    sql::Statement statement(db.GetUniqueStatement(kQuery));
 +    if (!statement.is_valid()) {
 +      LOG(WARNING) << "browseros: Failed to prepare query";
-+      DeleteDatabaseTemp(temp_db_path);
-+      return passwords;
-+    }
-+
-+    // Extract encryption key only once the selected Login Data database is
-+    // known to exist and have the schema we import.
-+    KeyExtractionResult key_result;
-+    std::string encryption_key = ExtractChromeKey(profile_path, &key_result);
-+    if (encryption_key.empty()) {
-+      LOG(WARNING) << "browseros: Failed to extract encryption key, "
-+                   << "result: " << static_cast<int>(key_result);
 +      DeleteDatabaseTemp(temp_db_path);
 +      return passwords;
 +    }

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_password_importer.h
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_password_importer.h
@@ -1,15 +1,16 @@
 diff --git a/chrome/utility/importer/browseros/chrome_password_importer.h b/chrome/utility/importer/browseros/chrome_password_importer.h
 new file mode 100644
-index 0000000000000..e0cb4ec631e39
+index 0000000000000..7111af4e124b5
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_password_importer.h
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,25 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome password importer interface
 +
 +#ifndef CHROME_UTILITY_IMPORTER_BROWSEROS_CHROME_PASSWORD_IMPORTER_H_
 +#define CHROME_UTILITY_IMPORTER_BROWSEROS_CHROME_PASSWORD_IMPORTER_H_
 +
++#include <string>
 +#include <vector>
 +
 +#include "base/files/file_path.h"
@@ -22,7 +23,8 @@ index 0000000000000..e0cb4ec631e39
 +// Returns a vector of ImportedPasswordForm structs.
 +// On failure, returns an empty vector.
 +std::vector<user_data_importer::ImportedPasswordForm> ImportChromePasswords(
-+    const base::FilePath& profile_path);
++    const base::FilePath& profile_path,
++    const std::string& encryption_key);
 +
 +}  // namespace browseros_importer
 +

--- a/packages/browseros/chromium_patches/components/os_crypt/common/BUILD.gn
+++ b/packages/browseros/chromium_patches/components/os_crypt/common/BUILD.gn
@@ -1,0 +1,41 @@
+diff --git a/components/os_crypt/common/BUILD.gn b/components/os_crypt/common/BUILD.gn
+index eb5c136381779..f47dd4a811905 100644
+--- a/components/os_crypt/common/BUILD.gn
++++ b/components/os_crypt/common/BUILD.gn
+@@ -2,12 +2,20 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/buildflag_header.gni")
++import("//chrome/browser/browseros/buildflags.gni")
++
+ source_set("switches") {
+   sources = [
+     "os_crypt_switches.h",
+   ]
+ }
+ 
++buildflag_header("browseros_product_buildflags") {
++  header = "browseros_product_buildflags.h"
++  flags = [ "BROWSEROS_PRODUCT_BROWSERCLAW=$browseros_product_browserclaw" ]
++}
++
+ if (is_apple) {
+   source_set("keychain_password_mac") {
+     sources = [
+@@ -15,6 +23,7 @@ if (is_apple) {
+       "keychain_password_mac.mm",
+     ]
+     deps = [
++      ":browseros_product_buildflags",
+       "//base",
+       "//build:branding_buildflags",
+       "//crypto",
+@@ -28,6 +37,7 @@ source_set("unit_tests") {
+     sources = [ "keychain_password_mac_unittest.mm" ]
+     deps = [
+       ":keychain_password_mac",
++      ":browseros_product_buildflags",
+       "//base",
+       "//crypto:mock_apple_keychain",
+       "//testing/gmock",

--- a/packages/browseros/chromium_patches/components/os_crypt/common/keychain_password_mac.mm
+++ b/packages/browseros/chromium_patches/components/os_crypt/common/keychain_password_mac.mm
@@ -1,16 +1,28 @@
 diff --git a/components/os_crypt/common/keychain_password_mac.mm b/components/os_crypt/common/keychain_password_mac.mm
-index f240dc22ee391..9d2da65a7198c 100644
+index f240dc22ee391..805f7e3f37a5b 100644
 --- a/components/os_crypt/common/keychain_password_mac.mm
 +++ b/components/os_crypt/common/keychain_password_mac.mm
-@@ -38,8 +38,9 @@
+@@ -18,6 +18,7 @@
+ #include "base/strings/string_view_util.h"
+ #include "base/types/expected.h"
+ #include "build/branding_buildflags.h"
++#include "components/os_crypt/common/browseros_product_buildflags.h"
+ #include "crypto/apple/keychain_v2.h"
+ #include "third_party/abseil-cpp/absl/cleanup/cleanup.h"
+ 
+@@ -38,8 +39,13 @@
  const char kDefaultServiceName[] = "Chrome Safe Storage";
  const char kDefaultAccountName[] = "Chrome";
  #else
 -const char kDefaultServiceName[] = "Chromium Safe Storage";
 -const char kDefaultAccountName[] = "Chromium";
-+// BrowserOS: custom keychain service name
++#if BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW)
++const char kDefaultServiceName[] = "BrowserClaw Safe Storage";
++const char kDefaultAccountName[] = "BrowserClaw";
++#else
 +const char kDefaultServiceName[] = "BrowserOS Safe Storage";
 +const char kDefaultAccountName[] = "BrowserOS";
++#endif
  #endif
  
  // These values are persisted to logs. Entries should not be renumbered and

--- a/packages/browseros/chromium_patches/components/os_crypt/common/keychain_password_mac_unittest.mm
+++ b/packages/browseros/chromium_patches/components/os_crypt/common/keychain_password_mac_unittest.mm
@@ -1,0 +1,31 @@
+diff --git a/components/os_crypt/common/keychain_password_mac_unittest.mm b/components/os_crypt/common/keychain_password_mac_unittest.mm
+index 8c5817204161d..64d5477a5e1dc 100644
+--- a/components/os_crypt/common/keychain_password_mac_unittest.mm
++++ b/components/os_crypt/common/keychain_password_mac_unittest.mm
+@@ -5,6 +5,8 @@
+ #include "components/os_crypt/common/keychain_password_mac.h"
+ 
+ #include "build/build_config.h"
++#include "build/branding_buildflags.h"
++#include "components/os_crypt/common/browseros_product_buildflags.h"
+ #include "crypto/apple/fake_keychain_v2.h"
+ #include "crypto/apple/scoped_fake_keychain_v2.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+@@ -96,4 +98,17 @@
+   EXPECT_NE(password1, password2);
+ }
+ 
++TEST(KeychainPasswordTest, DefaultKeychainNamesMatchBuildProduct) {
++#if BUILDFLAG(GOOGLE_CHROME_BRANDING)
++  EXPECT_EQ("Chrome Safe Storage", KeychainPassword::GetServiceName());
++  EXPECT_EQ("Chrome", KeychainPassword::GetAccountName());
++#elif BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW)
++  EXPECT_EQ("BrowserClaw Safe Storage", KeychainPassword::GetServiceName());
++  EXPECT_EQ("BrowserClaw", KeychainPassword::GetAccountName());
++#else
++  EXPECT_EQ("BrowserOS Safe Storage", KeychainPassword::GetServiceName());
++  EXPECT_EQ("BrowserOS", KeychainPassword::GetAccountName());
++#endif
++}
++
+ }  // namespace

--- a/packages/browseros/chromium_patches/components/user_data_importer/common/importer_data_types.h
+++ b/packages/browseros/chromium_patches/components/user_data_importer/common/importer_data_types.h
@@ -1,5 +1,5 @@
 diff --git a/components/user_data_importer/common/importer_data_types.h b/components/user_data_importer/common/importer_data_types.h
-index 3cac91f8d5838..8d5937f653020 100644
+index 3cac91f8d5838..356b6b01d4b03 100644
 --- a/components/user_data_importer/common/importer_data_types.h
 +++ b/components/user_data_importer/common/importer_data_types.h
 @@ -24,12 +24,13 @@ enum ImportItem {
@@ -18,7 +18,18 @@ index 3cac91f8d5838..8d5937f653020 100644
  };
  
  // Information about a profile needed by an importer to do import work.
-@@ -111,6 +112,7 @@ enum VisitSource {
+@@ -47,6 +48,10 @@ struct SourceProfile {
+   // thread on the browser process. This is only used by the Firefox importer.
+   std::string locale;
+   std::u16string profile;
++  // Browser-side display metadata. These fields are not sent to the utility
++  // process.
++  std::u16string account_name;
++  bool is_managed = false;
+ };
+ 
+ // Contains information needed for importing search engine urls.
+@@ -111,6 +116,7 @@ enum VisitSource {
    VISIT_SOURCE_FIREFOX_IMPORTED = 1,
    VISIT_SOURCE_IE_IMPORTED = 2,
    VISIT_SOURCE_SAFARI_IMPORTED = 3,

--- a/packages/browseros/chromium_patches/ui/webui/resources/tools/generate_grd.gni
+++ b/packages/browseros/chromium_patches/ui/webui/resources/tools/generate_grd.gni
@@ -1,0 +1,16 @@
+diff --git a/ui/webui/resources/tools/generate_grd.gni b/ui/webui/resources/tools/generate_grd.gni
+index 8a8a5d6d66815..d85a6419bff3f 100644
+--- a/ui/webui/resources/tools/generate_grd.gni
++++ b/ui/webui/resources/tools/generate_grd.gni
+@@ -51,6 +51,11 @@ template("generate_grd") {
+                 invoker.input_files_base_dir,
+                 "--input-files",
+               ] + invoker.input_files
++
++      if (defined(invoker.ignore_missing_input_files) &&
++          invoker.ignore_missing_input_files) {
++        args += [ "--ignore-missing-input-files" ]
++      }
+     }
+ 
+     if (defined(invoker.output_files_base_dir)) {

--- a/packages/browseros/chromium_patches/ui/webui/resources/tools/generate_grd.py
+++ b/packages/browseros/chromium_patches/ui/webui/resources/tools/generate_grd.py
@@ -1,0 +1,38 @@
+diff --git a/ui/webui/resources/tools/generate_grd.py b/ui/webui/resources/tools/generate_grd.py
+index 63dfeef208af5..7b858b941c51c 100644
+--- a/ui/webui/resources/tools/generate_grd.py
++++ b/ui/webui/resources/tools/generate_grd.py
+@@ -37,6 +37,10 @@
+ #   input_files_base_dir:
+ #     The base directory for the paths in |input_files|. |input_files| and
+ #     |input_files_base_dir| must either both be provided or both be omitted.
++#
++#   ignore_missing_input_files:
++#     If set, files from |input_files| that do not exist under
++#     |input_files_base_dir| are skipped.
+ 
+ import argparse
+ import json
+@@ -112,6 +116,7 @@ def main(argv):
+   parser.add_argument('--root-gen-dir', required=True)
+   parser.add_argument('--input-files', nargs="*")
+   parser.add_argument('--input-files-base-dir')
++  parser.add_argument('--ignore-missing-input-files', action='store_true')
+   parser.add_argument('--output-files-base-dir', default='grit')
+   parser.add_argument('--grdp-files', nargs="*")
+   parser.add_argument('--resource-path-rewrites', nargs="*")
+@@ -157,6 +162,14 @@ def main(argv):
+             f'Error: input_file {filename} found outside of ' + \
+             'input_files_base_dir'
+ 
++        if args.ignore_missing_input_files:
++          real_base_dir = os.path.join(_CWD, '..', '..',
++                                       args.input_files_base_dir)
++          if args.input_files_base_dir.startswith(args.root_gen_dir + '/'):
++            real_base_dir = os.path.join(_CWD, args.input_files_base_dir)
++          if not os.path.exists(os.path.join(real_base_dir, filename)):
++            continue
++
+         filepath = os.path.join(base_dir, filename).replace('\\', '/')
+         grd_file.write(_generate_include_row(
+             args.grd_prefix, filename, filepath,


### PR DESCRIPTION
## Summary
- product-brand macOS os_crypt keychain identity so BrowserClaw uses its own Safe Storage item
- share one extracted Chrome key across password and cookie importers
- collapse onboarding import bridge to one source/profile per import action
- expose Chrome account/managed identity metadata for onboarding display
- keep packaged onboarding icon paths while tolerating absent files during GRD generation

## Verification
- `autoninja -C out/Default_arm64 chrome` in `/Users/shadowfax/ch-1` on rebased `task/keychain-prompts` at `ad561b9c5b138`
- `bpatch feature lint`
- `verify-patches.sh --chromium-src /Users/shadowfax/ch-1 --worktree /Users/shadowfax/worktrees/main/feat-keychain-prompts-patches --tip ad561b9c5b138`

## Notes
- Direct local autoninja required managed BrowserOS resources to be populated first (`download_resources`, `resources`, `sparkle_setup`) because the direct command bypasses the packaging/setup pipeline.
