### PR TITLE
fix: correct onboarding patch hunk counts

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000000000..e936189f913b130160a04bbca0b871e09dafad54
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
-@@ -0,0 +1,728 @@
+@@ -0,0 +1,734 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000000000..0da2a0e14b2daaabd33a9db1f624308aa09a86af
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,38 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.


### PR DESCRIPTION
## Summary\n- correct BrowserOS onboarding patch hunk headers whose counts were stale after the completion-crash fix\n- prevents bpatch refresh from truncating browseros_onboarding.cc and browseros_onboarding_prefs.cc\n\n## Verification\n- uv run python -m bos_build.cli.dev doctor\n- verified new-file hunk counts match added-line counts\n- verified patch object hashes match index headers\n- Chromium pool build in ch-3 is running with the local equivalent source fixes