### PR TITLE
fix(ci): force tag updates in persistent-checkout repo sync

### DIFF
--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -104,7 +104,8 @@ jobs:
         run: |
           set -euo pipefail
           cd "$BROWSEROS_REPO"
-          git fetch origin --tags --prune
+          # Rolling nightly release tags move nightly; persistent checkouts must force-update and prune deleted tags.
+          git fetch origin --tags --prune --prune-tags --force
           # Wipe any local edits before switching refs. The builder's working
           # tree can carry stray modifications to tracked files, which would
           # otherwise make the checkout below abort before reset --hard runs.

--- a/.github/workflows/nightly-browseros.yml
+++ b/.github/workflows/nightly-browseros.yml
@@ -131,7 +131,8 @@ jobs:
         run: |
           set -euo pipefail
           cd "$BROWSEROS_REPO"
-          git fetch origin --tags --prune
+          # Rolling nightly release tags move nightly; persistent checkouts must force-update and prune deleted tags.
+          git fetch origin --tags --prune --prune-tags --force
           # Wipe any local edits before switching refs. The builder's working
           # tree can carry stray modifications to tracked files, which would
           # otherwise make the checkout below abort before reset --hard runs.

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -241,7 +241,8 @@ jobs:
         run: |
           set -euo pipefail
           cd "$BROWSEROS_REPO"
-          git fetch origin --tags --prune
+          # Rolling nightly release tags move nightly; persistent checkouts must force-update and prune deleted tags.
+          git fetch origin --tags --prune --prune-tags --force
           # Wipe any local edits before switching refs. The builder's working
           # tree can carry stray modifications to tracked files, which would
           # otherwise make the checkout below abort before reset --hard runs.


### PR DESCRIPTION
## Summary
- force-update and prune tags during persistent mac builder repo sync
- add the same rolling-nightly tag rationale to BrowserOS nightly, BrowserClaw nightly, and macOS release sync steps

## Runner note
The self-hosted mac checkout at `BROWSEROS_REPO_PATH` can keep its stale local `nightly-browserclaw` tag. After this merges, the next sync runs `git fetch origin --tags --prune --prune-tags --force`, so the clobbering tag is updated in place and tags deleted during the release delete+recreate window are pruned. No manual cleanup is required.

## Verification
- `actionlint .github/workflows/nightly-browseros.yml .github/workflows/nightly-browserclaw.yml .github/workflows/release-macos.yml`

No workflow dispatches were run.