### PR TITLE
fix(ci): import os in claw nightly staging heredoc

### DIFF
--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -155,6 +155,7 @@ jobs:
 
           cd "$browseros_root"
           AGENT_ROOT="$agent_root" BROWSEROS_ROOT="$browseros_root" uv run python - <<'PY'
+          import os
           import shutil
           from pathlib import Path
 


### PR DESCRIPTION
Run 28916953704 (post tag-fetch fix) failed in 'Stage BrowserClaw nightly resources': the extraction heredoc reads `os.environ` without `import os`. nightly-browseros.yml's heredocs audited — imports present there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)