### PR TITLE
fix(patchkit): skip bpatch-v2 root metadata in patch collection

### DIFF
--- a/packages/browseros/bos_build/patchkit/batch_apply.py
+++ b/packages/browseros/bos_build/patchkit/batch_apply.py
@@ -38,6 +38,11 @@ def reset_file_to_commit(file_path: str, commit: str, chromium_src: Path) -> boo
 # are never applied; the doctor maps them back onto their base path.
 MARKER_SUFFIXES = (".deleted", ".binary", ".rename")
 
+# bpatch-v2 (#1690) keeps its metadata at the patch-tree root; these are not
+# patches. Matched by exact root-relative path so a real chromium yaml patch
+# deeper in the tree still applies.
+METADATA_ROOT_FILES = ("features.yaml", "store.yaml")
+
 
 def find_patch_files(patches_dir: Path) -> List[Path]:
     """Find all valid patch files in a directory.
@@ -58,6 +63,7 @@ def find_patch_files(patches_dir: Path) -> List[Path]:
             if p.is_file()
             and not p.name.endswith(MARKER_SUFFIXES)
             and not p.name.startswith(".")
+            and str(p.relative_to(patches_dir)) not in METADATA_ROOT_FILES
         ]
     )
 

--- a/packages/browseros/bos_build/patchkit/batch_apply_test.py
+++ b/packages/browseros/bos_build/patchkit/batch_apply_test.py
@@ -118,6 +118,21 @@ class BatchApplyTest(unittest.TestCase):
         names = [p.name for p in find_patch_files(self.patches_dir)]
         self.assertEqual(names, ["a.patch"])
 
+    def test_find_patch_files_skips_root_metadata_but_not_nested_yaml(self):
+        # bpatch-v2 metadata at the tree root is not a patch; a chromium
+        # yaml file patched deeper in the tree still is.
+        (self.patches_dir / "features.yaml").write_text("x")
+        (self.patches_dir / "store.yaml").write_text("x")
+        nested = self.patches_dir / "chrome" / "app"
+        nested.mkdir(parents=True)
+        (nested / "features.yaml").write_text("x")
+
+        names = [
+            str(p.relative_to(self.patches_dir))
+            for p in find_patch_files(self.patches_dir)
+        ]
+        self.assertEqual(names, ["chrome/app/features.yaml"])
+
     def test_dry_run_reports_without_modifying_tree(self):
         _make_patch(self.repo, self.patches_dir)
 

--- a/packages/browseros/bos_build/patchkit/doctor.py
+++ b/packages/browseros/bos_build/patchkit/doctor.py
@@ -12,7 +12,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-from .batch_apply import MARKER_SUFFIXES
+from .batch_apply import MARKER_SUFFIXES, METADATA_ROOT_FILES
 from .validation import validate_description, validate_feature_name
 
 # Features whose description carries this prefix list files touched by
@@ -64,6 +64,8 @@ def patch_base_paths(patches_dir: Path) -> Set[str]:
         if not path.is_file() or path.name.startswith("."):
             continue
         rel = path.relative_to(patches_dir).as_posix()
+        if rel in METADATA_ROOT_FILES:
+            continue
         for suffix in MARKER_SUFFIXES:
             if rel.endswith(suffix):
                 rel = rel[: -len(suffix)]


### PR DESCRIPTION
bpatch-v2 (#1690) keeps `features.yaml` + `store.yaml` at the chromium_patches/ root. Two consumers treated them as patches: `batch_apply.find_patch_files` (nightly run 28917080586 failed: 'No valid patches in input') and `doctor.patch_base_paths` (pre-existing RepoTruthTest failure on main: 'patch not claimed by any feature'). Both now skip an exact root-relative METADATA_ROOT_FILES set — a chromium yaml patched deeper in the tree still applies (covered by a new test). 652 tests + ruff green; live `dev doctor`: healthy, 374 patches / 34 features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)