### PR TITLE
chore(bpatch): improve help screens

### DIFF
--- a/packages/browseros/tools/bpatch/src/cli/mod.rs
+++ b/packages/browseros/tools/bpatch/src/cli/mod.rs
@@ -25,9 +25,41 @@ use crate::store::Store;
 
 /// Top-level bpatch command-line interface.
 #[derive(Debug, Parser)]
-#[command(name = "bpatch", about = "Manage BrowserOS Chromium patches")]
+#[command(
+    name = "bpatch",
+    about = "Manage BrowserOS Chromium patches",
+    after_long_help = r#"GETTING STARTED:
+  Configure the patch store once in ~/.config/bpatch/config.toml:
+    store = "/abs/path/to/chromium_patches"
+
+  Or pass --store /abs/path/to/chromium_patches on any command.
+  Run bpatch from inside a Chromium checkout.
+
+GLOBAL FLAGS:
+  --store <STORE>  Overrides the config file for this invocation.
+  --json           Emits a single JSON object and suppresses progress and prompts.
+
+EXAMPLES:
+  Daily loop:
+    bpatch status
+    bpatch diff
+    bpatch apply
+
+  Extract checkout commits into the store:
+    bpatch extract <rev1>..<rev2> --feature <name>
+
+  Base upgrade:
+    bpatch apply -> bpatch continue --materialize -> resolve markers -> bpatch continue -> bpatch extract --repin
+
+EXIT CODES:
+  0  Converged, applied, extracted, repinned, listed, added, aborted, or completed.
+  2  Conflicts are pending or conflict files remain unresolved.
+  3  Drift/refusal or extract needs a feature decision.
+  1  CLI, git, lock, config, or unexpected error.
+"#
+)]
 pub struct Cli {
-    /// Path to the chromium_patches store directory.
+    /// Override the config file's chromium_patches store directory.
     #[arg(long, global = true)]
     pub store: Option<PathBuf>,
     /// Emit a single JSON object and disable progress and prompts.
@@ -42,18 +74,61 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Show checkout/store state.
+    #[command(
+        long_about = "Show checkout base, store rev, applied trailers, and drift.",
+        after_long_help = r#"EXAMPLE:
+  bpatch status
+"#
+    )]
     Status,
     /// Show what apply would touch.
+    #[command(
+        long_about = "Show what apply would touch, grouped by feature, with a rebuild-scope hint.",
+        after_long_help = r#"EXAMPLE:
+  bpatch diff
+"#
+    )]
     Diff,
     /// Converge the checkout to the store.
+    #[command(
+        long_about = "Optionally fast-forward the store repo with --pull, then converge the checkout to the store. Exit 2 means conflicts are pending; exit 3 means drift or refusal blocked the write.",
+        after_long_help = r#"EXAMPLE:
+  bpatch apply --pull
+"#
+    )]
     Apply(ApplyArgs),
     /// Extract commits into the store or repin the store base.
+    #[command(
+        long_about = "Extract <rev> or <rev1>..<rev2> into the store, or repin existing store patches to the checkout base. Use --feature <FEATURE> to route unmatched files, --commit to commit store repo changes, and --repin without a spec for base upgrades.",
+        after_long_help = r#"EXAMPLE:
+  bpatch extract <rev1>..<rev2> --feature <name>
+"#
+    )]
     Extract(ExtractArgs),
     /// Manage features.yaml entries.
+    #[command(
+        long_about = "Manage features.yaml entries. List the feature inventory or append a new feature block with an owned path.",
+        after_long_help = r#"EXAMPLES:
+  bpatch feature list
+  bpatch feature add wallet --path chrome/browser/browseros/wallet/
+"#
+    )]
     Feature(FeatureArgs),
     /// Abort a conflict session.
+    #[command(
+        long_about = "Remove a pending conflict session. Before continue --materialize, abort only deletes the session file; the worktree has not been touched.",
+        after_long_help = r#"EXAMPLE:
+  bpatch abort
+"#
+    )]
     Abort,
     /// Continue a conflict session.
+    #[command(
+        long_about = "Use continue --materialize first to write conflict marker files, then resolve markers and run bare continue to finish convergence.",
+        after_long_help = r#"EXAMPLE:
+  bpatch continue --materialize -> resolve markers -> bpatch continue
+"#
+    )]
     Continue(ContinueArgs),
 }
 
@@ -96,8 +171,20 @@ pub struct FeatureArgs {
 #[derive(Debug, Subcommand)]
 pub enum FeatureCommand {
     /// List features, patch counts, and last applied sequence.
+    #[command(
+        long_about = "List features, owned patch counts, and last applied sequence numbers.",
+        after_long_help = r#"EXAMPLE:
+  bpatch feature list
+"#
+    )]
     List,
     /// Add a feature path block.
+    #[command(
+        long_about = "Append a new feature block to features.yaml. Provide a feature name and an exact path or directory prefix with --path.",
+        after_long_help = r#"EXAMPLE:
+  bpatch feature add wallet --path chrome/browser/browseros/wallet/ --description "Wallet UI"
+"#
+    )]
     Add(FeatureAddArgs),
 }
 

--- a/packages/browseros/tools/bpatch/tests/simulations.rs
+++ b/packages/browseros/tools/bpatch/tests/simulations.rs
@@ -28,6 +28,50 @@ struct AppliedScenario {
 }
 
 #[test]
+fn top_level_help_teaches_chromium_workflow() -> Result<()> {
+    let output = Command::new(env!("CARGO_BIN_EXE_bpatch"))
+        .arg("--help")
+        .output()
+        .context("running bpatch --help")?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+
+    assert!(output.status.success(), "{stderr}");
+    assert!(stderr.is_empty());
+    assert!(!stdout.contains('\u{1b}'));
+    assert!(stdout.contains("GETTING STARTED:"));
+    assert!(stdout.contains("store = \"/abs/path/to/chromium_patches\""));
+    assert!(stdout.contains("Run bpatch from inside a Chromium checkout."));
+    assert!(stdout.contains("GLOBAL FLAGS:"));
+    assert!(stdout.contains("--store <STORE>  Overrides the config file"));
+    assert!(stdout.contains("--json           Emits a single JSON object"));
+    assert!(stdout.contains("EXAMPLES:"));
+    assert!(stdout.contains("bpatch status"));
+    assert!(stdout.contains("bpatch diff"));
+    assert!(stdout.contains("bpatch apply"));
+    assert!(stdout.contains("bpatch extract <rev1>..<rev2> --feature <name>"));
+    assert!(stdout.contains("bpatch apply -> bpatch continue --materialize"));
+    assert!(stdout.contains("EXIT CODES:"));
+    assert!(stdout.contains("0  Converged, applied, extracted"));
+    assert!(stdout.contains("2  Conflicts are pending"));
+    assert!(stdout.contains("3  Drift/refusal or extract needs a feature decision."));
+    assert!(stdout.contains("1  CLI, git, lock, config, or unexpected error."));
+
+    let short = Command::new(env!("CARGO_BIN_EXE_bpatch"))
+        .arg("-h")
+        .output()
+        .context("running bpatch -h")?;
+    let short_stdout = String::from_utf8(short.stdout)?;
+    let short_stderr = String::from_utf8(short.stderr)?;
+
+    assert!(short.status.success(), "{short_stderr}");
+    assert!(short_stderr.is_empty());
+    assert!(!short_stdout.contains("GETTING STARTED:"));
+    assert!(!short_stdout.contains("EXIT CODES:"));
+    Ok(())
+}
+
+#[test]
 fn sim1_extract_hack_commit_renders_routing_net_fold_and_next_step() -> Result<()> {
     let checkout = FixtureRepo::new()?;
     let base = write_extract_base(&checkout)?;


### PR DESCRIPTION
## Summary
- add long-form top-level bpatch help with setup, daily loop, extract, base upgrade, global flags, and exit codes
- add long-help examples for bpatch verbs and nested feature commands
- add a simulation-style regression test for top-level --help and compact -h

## Tests
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test