### PR TITLE
chore(bos_build): ship bun claw server; rust path as commented yaml alternative

### DIFF
--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -148,10 +148,8 @@ jobs:
           bun scripts/build/server.ts --target=darwin-arm64 --ci
           bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
           bun scripts/build/claw-onboard.ts --ci
-          "$agent_root/scripts/build/claw-server-rust-local.sh" \
-            --target darwin-arm64 \
-            --agent-root "$agent_root" \
-            --browseros-root "$browseros_root"
+          # Rust alternative: run scripts/build/claw-server-rust-local.sh here
+          # and flip copy_resources.yaml/download_resources.yaml.
 
           cd "$browseros_root"
           AGENT_ROOT="$agent_root" BROWSEROS_ROOT="$browseros_root" uv run python - <<'PY'

--- a/packages/browseros/bos_build/config/copy_resources.yaml
+++ b/packages/browseros/bos_build/config/copy_resources.yaml
@@ -183,107 +183,110 @@ copy_operations:
     os: ["windows"]
     arch: ["x64"]
 
-  # BrowserOS Claw Server resources - switch variants by swapping which block is commented.
-  - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
-    source: "resources/binaries/browseros_claw_server_rust/darwin-arm64/resources"
+  # BrowserOS Claw Server resources - Bun ships by default.
+  # Rust alternative: comment the Bun blocks below and uncomment the matching
+  # Rust blocks to ship claw-server-rust; also flip download_resources.yaml and
+  # nightly-browserclaw.yml.
+  - name: "BrowserOS Claw Server Resources - macOS ARM64"
+    source: "resources/binaries/browseros_claw_server/darwin-arm64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
-    renames:
-      - from: "bin/browseros-claw-server-rs"
-        to: "bin/browseros-claw-server"
     type: "directory"
     product: "browserclaw"
     os: ["macos"]
     arch: ["arm64"]
 
-  - name: "BrowserOS Claw Rust Server Resources - macOS x64"
-    source: "resources/binaries/browseros_claw_server_rust/darwin-x64/resources"
+  # - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
+  #   source: "resources/binaries/browseros_claw_server_rust/darwin-arm64/resources"
+  #   destination: "chrome/browser/browseros/claw_server/resources"
+  #   clear_destination: true
+  #   renames:
+  #     - from: "bin/browseros-claw-server-rs"
+  #       to: "bin/browseros-claw-server"
+  #   type: "directory"
+  #   product: "browserclaw"
+  #   os: ["macos"]
+  #   arch: ["arm64"]
+
+  - name: "BrowserOS Claw Server Resources - macOS x64"
+    source: "resources/binaries/browseros_claw_server/darwin-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
-    renames:
-      - from: "bin/browseros-claw-server-rs"
-        to: "bin/browseros-claw-server"
     type: "directory"
     product: "browserclaw"
     os: ["macos"]
     arch: ["x64"]
 
-  - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
-    source: "resources/binaries/browseros_claw_server_rust/linux-arm64/resources"
+  # - name: "BrowserOS Claw Rust Server Resources - macOS x64"
+  #   source: "resources/binaries/browseros_claw_server_rust/darwin-x64/resources"
+  #   destination: "chrome/browser/browseros/claw_server/resources"
+  #   clear_destination: true
+  #   renames:
+  #     - from: "bin/browseros-claw-server-rs"
+  #       to: "bin/browseros-claw-server"
+  #   type: "directory"
+  #   product: "browserclaw"
+  #   os: ["macos"]
+  #   arch: ["x64"]
+
+  - name: "BrowserOS Claw Server Resources - Linux ARM64"
+    source: "resources/binaries/browseros_claw_server/linux-arm64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
-    renames:
-      - from: "bin/browseros-claw-server-rs"
-        to: "bin/browseros-claw-server"
     type: "directory"
     product: "browserclaw"
     os: ["linux"]
     arch: ["arm64"]
 
-  - name: "BrowserOS Claw Rust Server Resources - Linux x64"
-    source: "resources/binaries/browseros_claw_server_rust/linux-x64/resources"
+  # - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
+  #   source: "resources/binaries/browseros_claw_server_rust/linux-arm64/resources"
+  #   destination: "chrome/browser/browseros/claw_server/resources"
+  #   clear_destination: true
+  #   renames:
+  #     - from: "bin/browseros-claw-server-rs"
+  #       to: "bin/browseros-claw-server"
+  #   type: "directory"
+  #   product: "browserclaw"
+  #   os: ["linux"]
+  #   arch: ["arm64"]
+
+  - name: "BrowserOS Claw Server Resources - Linux x64"
+    source: "resources/binaries/browseros_claw_server/linux-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
-    renames:
-      - from: "bin/browseros-claw-server-rs"
-        to: "bin/browseros-claw-server"
     type: "directory"
     product: "browserclaw"
     os: ["linux"]
     arch: ["x64"]
 
-  - name: "BrowserOS Claw Rust Server Resources - Windows x64"
-    source: "resources/binaries/browseros_claw_server_rust/windows-x64/resources"
+  # - name: "BrowserOS Claw Rust Server Resources - Linux x64"
+  #   source: "resources/binaries/browseros_claw_server_rust/linux-x64/resources"
+  #   destination: "chrome/browser/browseros/claw_server/resources"
+  #   clear_destination: true
+  #   renames:
+  #     - from: "bin/browseros-claw-server-rs"
+  #       to: "bin/browseros-claw-server"
+  #   type: "directory"
+  #   product: "browserclaw"
+  #   os: ["linux"]
+  #   arch: ["x64"]
+
+  - name: "BrowserOS Claw Server Resources - Windows x64"
+    source: "resources/binaries/browseros_claw_server/windows-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
-    renames:
-      - from: "bin/browseros-claw-server-rs.exe"
-        to: "bin/browseros-claw-server.exe"
     type: "directory"
     product: "browserclaw"
     os: ["windows"]
     arch: ["x64"]
 
-  # - name: "BrowserOS Claw Server Resources - macOS ARM64"
-  #   source: "resources/binaries/browseros_claw_server/darwin-arm64/resources"
+  # - name: "BrowserOS Claw Rust Server Resources - Windows x64"
+  #   source: "resources/binaries/browseros_claw_server_rust/windows-x64/resources"
   #   destination: "chrome/browser/browseros/claw_server/resources"
   #   clear_destination: true
-  #   type: "directory"
-  #   product: "browserclaw"
-  #   os: ["macos"]
-  #   arch: ["arm64"]
-  #
-  # - name: "BrowserOS Claw Server Resources - macOS x64"
-  #   source: "resources/binaries/browseros_claw_server/darwin-x64/resources"
-  #   destination: "chrome/browser/browseros/claw_server/resources"
-  #   clear_destination: true
-  #   type: "directory"
-  #   product: "browserclaw"
-  #   os: ["macos"]
-  #   arch: ["x64"]
-  #
-  # - name: "BrowserOS Claw Server Resources - Linux ARM64"
-  #   source: "resources/binaries/browseros_claw_server/linux-arm64/resources"
-  #   destination: "chrome/browser/browseros/claw_server/resources"
-  #   clear_destination: true
-  #   type: "directory"
-  #   product: "browserclaw"
-  #   os: ["linux"]
-  #   arch: ["arm64"]
-  #
-  # - name: "BrowserOS Claw Server Resources - Linux x64"
-  #   source: "resources/binaries/browseros_claw_server/linux-x64/resources"
-  #   destination: "chrome/browser/browseros/claw_server/resources"
-  #   clear_destination: true
-  #   type: "directory"
-  #   product: "browserclaw"
-  #   os: ["linux"]
-  #   arch: ["x64"]
-  #
-  # - name: "BrowserOS Claw Server Resources - Windows x64"
-  #   source: "resources/binaries/browseros_claw_server/windows-x64/resources"
-  #   destination: "chrome/browser/browseros/claw_server/resources"
-  #   clear_destination: true
+  #   renames:
+  #     - from: "bin/browseros-claw-server-rs.exe"
+  #       to: "bin/browseros-claw-server.exe"
   #   type: "directory"
   #   product: "browserclaw"
   #   os: ["windows"]

--- a/packages/browseros/bos_build/config/download_resources.yaml
+++ b/packages/browseros/bos_build/config/download_resources.yaml
@@ -71,7 +71,9 @@ download_operations:
     os: ["windows"]
     arch: ["x64"]
 
-  # BrowserOS Claw Server resource bundles - Platform & Architecture specific
+  # BrowserOS Claw Server resource bundles - Platform & Architecture specific.
+  # Bun ships by default. Rust alternative: uncomment the Rust blocks below and
+  # flip copy_resources.yaml plus nightly-browserclaw.yml to ship claw-server-rust.
   - name: "BrowserOS Claw Server Resources - macOS ARM64"
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip"
     destination: "resources/binaries/browseros_claw_server/darwin-arm64"
@@ -107,41 +109,41 @@ download_operations:
     os: ["windows"]
     arch: ["x64"]
 
-  # BrowserOS Claw Rust Server resource bundles - Platform & Architecture specific
-  - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
-    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip"
-    destination: "resources/binaries/browseros_claw_server_rust/darwin-arm64"
-    download_type: "artifact_zip"
-    os: ["macos"]
-    arch: ["arm64"]
+  # Rust alternative resource bundles - uncomment only when shipping claw-server-rust.
+  # - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
+  #   r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip"
+  #   destination: "resources/binaries/browseros_claw_server_rust/darwin-arm64"
+  #   download_type: "artifact_zip"
+  #   os: ["macos"]
+  #   arch: ["arm64"]
 
-  - name: "BrowserOS Claw Rust Server Resources - macOS x64"
-    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-x64.zip"
-    destination: "resources/binaries/browseros_claw_server_rust/darwin-x64"
-    download_type: "artifact_zip"
-    os: ["macos"]
-    arch: ["x64"]
+  # - name: "BrowserOS Claw Rust Server Resources - macOS x64"
+  #   r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-x64.zip"
+  #   destination: "resources/binaries/browseros_claw_server_rust/darwin-x64"
+  #   download_type: "artifact_zip"
+  #   os: ["macos"]
+  #   arch: ["x64"]
 
-  - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
-    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-arm64.zip"
-    destination: "resources/binaries/browseros_claw_server_rust/linux-arm64"
-    download_type: "artifact_zip"
-    os: ["linux"]
-    arch: ["arm64"]
+  # - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
+  #   r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-arm64.zip"
+  #   destination: "resources/binaries/browseros_claw_server_rust/linux-arm64"
+  #   download_type: "artifact_zip"
+  #   os: ["linux"]
+  #   arch: ["arm64"]
 
-  - name: "BrowserOS Claw Rust Server Resources - Linux x64"
-    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-x64.zip"
-    destination: "resources/binaries/browseros_claw_server_rust/linux-x64"
-    download_type: "artifact_zip"
-    os: ["linux"]
-    arch: ["x64"]
+  # - name: "BrowserOS Claw Rust Server Resources - Linux x64"
+  #   r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-x64.zip"
+  #   destination: "resources/binaries/browseros_claw_server_rust/linux-x64"
+  #   download_type: "artifact_zip"
+  #   os: ["linux"]
+  #   arch: ["x64"]
 
-  - name: "BrowserOS Claw Rust Server Resources - Windows x64"
-    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-windows-x64.zip"
-    destination: "resources/binaries/browseros_claw_server_rust/windows-x64"
-    download_type: "artifact_zip"
-    os: ["windows"]
-    arch: ["x64"]
+  # - name: "BrowserOS Claw Rust Server Resources - Windows x64"
+  #   r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-windows-x64.zip"
+  #   destination: "resources/binaries/browseros_claw_server_rust/windows-x64"
+  #   download_type: "artifact_zip"
+  #   os: ["windows"]
+  #   arch: ["x64"]
 
   # BrowserOS Claw onboarding static resources - platform-independent, feeds
   # the onboarding grit pak built for every product (no os/arch/product gate)

--- a/packages/browseros/bos_build/docs/nightly-macos-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-macos-ci.md
@@ -54,15 +54,21 @@ packages/browseros/resources/binaries/browseros_claw_onboard
 ```
 
 BrowserClaw stages the shared BrowserOS server bundle, the product-independent
-onboarding bundle, and both Claw server variants. The workflow always builds the
-TypeScript/Bun bundle:
+onboarding bundle, and the TypeScript/Bun Claw server bundle:
 
 ```bash
 bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
 ```
 
 and extracts it into
-`resources/binaries/browseros_claw_server/darwin-arm64`. It also runs:
+`resources/binaries/browseros_claw_server/darwin-arm64`. The normal resources
+step then copies this root into Chromium; the bundled binary is already named
+`browseros-claw-server`.
+
+The Rust alternative remains available as a manual comment flip. To ship Rust,
+run this helper in `.github/workflows/nightly-browserclaw.yml` before the Python
+staging heredoc and flip the commented Rust blocks in
+`copy_resources.yaml`/`download_resources.yaml`:
 
 ```bash
 packages/browseros-agent/scripts/build/claw-server-rust-local.sh \
@@ -71,18 +77,10 @@ packages/browseros-agent/scripts/build/claw-server-rust-local.sh \
   --browseros-root packages/browseros
 ```
 
-That helper builds the Rust server natively with Cargo and stages:
-
-```text
-packages/browseros/resources/binaries/browseros_claw_server_rust/darwin-arm64/
-  artifact-metadata.json
-  resources/bin/browseros-claw-server-rs
-```
-
-The normal resources step then copies this root into Chromium and renames
-`browseros-claw-server-rs` to the runtime name `browseros-claw-server`.
-Switching the embedded variant is a `copy_resources.yaml` comment swap; the
-Rust block is active by default.
+That helper builds the Rust server natively with Cargo and stages
+`resources/binaries/browseros_claw_server_rust/darwin-arm64`; the commented copy
+block renames `browseros-claw-server-rs` to the runtime name
+`browseros-claw-server`.
 
 ## Bundled Extensions
 
@@ -108,9 +106,10 @@ uv run browseros build --preset release --product <product> --arch <arch> \
   --chromium-src "$CHROMIUM_SRC"
 ```
 
-For BrowserClaw, `download_resources` fetches both Claw server bundles. Rust
-resources come from `claw-server-rust/prod-resources/latest/`, and the
-TypeScript/Bun resources come from `claw-server/prod-resources/latest/`.
+For BrowserClaw, `download_resources` fetches the active TypeScript/Bun Claw
+server bundle from `claw-server/prod-resources/latest/`. Rust resources come
+from `claw-server-rust/prod-resources/latest/` only when the commented Rust
+download/copy blocks are flipped intentionally.
 
 Release runs default to rebuilding the current version files without bumping
 them:
@@ -175,7 +174,8 @@ The Mac Mini must already have:
 - Build repo clone, for example `/Users/<user>/code/browseros-release`
 - Chromium checkout, for example `/Users/<user>/code/chromium-release/src`
 - `uv`, `gh`, `bun`, depot_tools, Xcode Command Line Tools, and signing/notarization tooling
-- Homebrew Cargo available on PATH for the BrowserClaw Rust nightly
+- Homebrew Cargo available on PATH only when manually flipping BrowserClaw
+  nightlies to the Rust server
 - Chrome installed for local CRX packing
 - `packages/browseros/.env` with signing, notarization, R2, Slack, and extension PEM values
 - `MACOS_KEYCHAIN_PASSWORD` in `.env` so the build can unlock the keychain

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -80,27 +80,26 @@ Server resources do not use that version. `release-server.yml` resolves
 `claw-server-rust/vX.Y.Z`.
 
 The Rust Claw server lane publishes to a distinct CDN/R2 prefix:
-`claw-server-rust/prod-resources/{version,latest}/`. Do not add
-`download_resources.yaml` entries that point at a new Rust server version until
-that workflow has populated the matching R2 objects; the bos_build download
-step fails the whole Chromium build when a configured key is missing.
-
-BrowserClaw browser builds download both claw-server variants:
-Rust from `claw-server-rust/prod-resources/latest/` and TypeScript/Bun from
-`claw-server/prod-resources/latest/`. The embedded variant is selected in
-`packages/browseros/bos_build/config/copy_resources.yaml` by swapping which
-BrowserClaw claw-server block is commented. The Rust block is active by default
-and renames `browseros-claw-server-rs` to the runtime name
-`browseros-claw-server`. BrowserClaw server OTA feeds
-(`appcast-claw-server*.xml`) remain pinned to the TypeScript server bundle
-until a separate feed migration changes them.
+`claw-server-rust/prod-resources/{version,latest}/`. BrowserClaw browser builds
+ship the TypeScript/Bun server by default from `claw-server/prod-resources/latest/`.
+The Rust download entries in
+`packages/browseros/bos_build/config/download_resources.yaml` and the Rust copy
+entries in `packages/browseros/bos_build/config/copy_resources.yaml` are kept as
+commented alternatives. To ship Rust, uncomment the matching Rust blocks,
+comment the Bun blocks, and ensure the Rust workflow has already populated the
+matching R2 objects; the bos_build download step fails the whole Chromium build
+when a configured key is missing. The Rust copy blocks rename
+`browseros-claw-server-rs` to the runtime name `browseros-claw-server`.
+BrowserClaw server OTA feeds (`appcast-claw-server*.xml`) remain pinned to the
+TypeScript/Bun server bundle until a separate feed migration changes them.
 
 `release-macos.yml` follows this release rule too: it does not build server
 resources from the checked-out `packages/browseros-agent` tree. Its browser
 build command leaves downloads enabled, so `download_resources` fetches the
-published BrowserOS server bundle, both BrowserClaw server bundles, and the
-onboarding bundle from R2 using the runner-local `packages/browseros/.env` R2
-credentials.
+published BrowserOS server bundle, the active Bun BrowserClaw server bundle, and
+the onboarding bundle from R2 using the runner-local `packages/browseros/.env`
+R2 credentials. Flip the commented Rust blocks only when intentionally shipping
+the Rust server.
 
 The reusable nesting depth is `release-browseros.yml` or
 `release-browserclaw.yml` -> `release-linux.yml` or `release-windows.yml` ->

--- a/packages/browseros/bos_build/products/browserclaw/product.py
+++ b/packages/browseros/bos_build/products/browserclaw/product.py
@@ -38,6 +38,9 @@ BROWSERCLAW_SERVER_BUNDLE = ServerBundle(
     unsigned_artifact_base_name="browseros-claw-server-resources",
 )
 
+# Rust release/OTA metadata stays defined for release-claw-server-rust.yml.
+# It is not in SERVER_BUNDLES and ships only when the commented YAML blocks are
+# flipped by hand.
 BROWSERCLAW_RUST_SERVER_BUNDLE = ServerBundle(
     id="browserclaw-server-rust",
     name="BrowserOS Claw Server (Rust)",

--- a/packages/browseros/bos_build/products/server_binaries.py
+++ b/packages/browseros/bos_build/products/server_binaries.py
@@ -106,6 +106,6 @@ def expected_windows_bundle_binary_paths(
 
 def _browser_build_server_bundles() -> Tuple[ServerBundle, ...]:
     from .browseros.product import BROWSEROS_SERVER_BUNDLE
-    from .browserclaw.product import BROWSERCLAW_RUST_SERVER_BUNDLE
+    from .browserclaw.product import BROWSERCLAW_SERVER_BUNDLE
 
-    return (BROWSEROS_SERVER_BUNDLE, BROWSERCLAW_RUST_SERVER_BUNDLE)
+    return (BROWSEROS_SERVER_BUNDLE, BROWSERCLAW_SERVER_BUNDLE)

--- a/packages/browseros/bos_build/products/server_binaries_test.py
+++ b/packages/browseros/bos_build/products/server_binaries_test.py
@@ -30,10 +30,10 @@ ENTITLEMENTS_DIR = Path(__file__).resolve().parents[2] / "resources" / "entitlem
 
 
 class MacosServerBinariesTest(unittest.TestCase):
-    def test_server_bundles_use_rust_for_browser_builds(self):
+    def test_server_bundles_use_bun_for_browser_builds(self):
         self.assertEqual(
             all_server_bundles(),
-            (BROWSEROS_SERVER_BUNDLE, BROWSERCLAW_RUST_SERVER_BUNDLE),
+            (BROWSEROS_SERVER_BUNDLE, BROWSEROS_CLAW_SERVER_BUNDLE),
         )
 
     def test_server_bundles_have_separate_resource_roots(self):
@@ -96,7 +96,7 @@ class MacosServerBinariesTest(unittest.TestCase):
         )
         self.assertEqual(
             server_bundles_for_product("browserclaw"),
-            (BROWSERCLAW_RUST_SERVER_BUNDLE,),
+            (BROWSEROS_CLAW_SERVER_BUNDLE,),
         )
 
     def test_server_ota_bundles_stay_pinned_to_typescript_claw(self):

--- a/packages/browseros/bos_build/steps/resources/resources_test.py
+++ b/packages/browseros/bos_build/steps/resources/resources_test.py
@@ -322,7 +322,7 @@ class CopyResourcesTest(unittest.TestCase):
         self.assertFalse(claw_dest.exists())
         self.assertFalse(claw_rust_dest.exists())
 
-    def test_real_config_copies_rust_server_resources_for_browserclaw_by_default(
+    def test_real_config_copies_bun_server_resources_for_browserclaw_by_default(
         self,
     ):
         self.root.write_copy_config(self._real_copy_config())
@@ -358,7 +358,7 @@ class CopyResourcesTest(unittest.TestCase):
         (claw_rust_source / "bin" / "browseros-claw-server-rs").write_text(
             "claw-rust"
         )
-        stale_ts_only_file = (
+        stale_rust_file = (
             self.chromium.src
             / "chrome"
             / "browser"
@@ -366,11 +366,10 @@ class CopyResourcesTest(unittest.TestCase):
             / "claw_server"
             / "resources"
             / "bin"
-            / "third_party"
-            / "bun"
+            / "browseros-claw-server-rs"
         )
-        stale_ts_only_file.parent.mkdir(parents=True)
-        stale_ts_only_file.write_text("stale")
+        stale_rust_file.parent.mkdir(parents=True)
+        stale_rust_file.write_text("stale")
 
         with patch(
             "bos_build.steps.resources.resources.get_platform",
@@ -416,11 +415,11 @@ class CopyResourcesTest(unittest.TestCase):
             / "browseros-claw-server-rs"
         )
         self.assertEqual(browseros_dest.read_text(), "browseros")
-        self.assertEqual(claw_dest.read_text(), "claw-rust")
+        self.assertEqual(claw_dest.read_text(), "claw")
         self.assertFalse(claw_rust_dest.exists())
-        self.assertFalse(stale_ts_only_file.exists())
+        self.assertFalse(stale_rust_file.exists())
 
-    def test_real_config_keeps_typescript_claw_server_switch_block_commented(
+    def test_real_config_keeps_rust_claw_server_switch_block_commented(
         self,
     ):
         config_path = (
@@ -431,22 +430,26 @@ class CopyResourcesTest(unittest.TestCase):
         active_names = [op["name"] for op in config["copy_operations"]]
 
         self.assertIn(
-            "# BrowserOS Claw Server resources - switch variants by swapping which block is commented.",
+            "# BrowserOS Claw Server resources - Bun ships by default.",
             text,
         )
         self.assertIn(
-            '# - name: "BrowserOS Claw Server Resources - macOS ARM64"',
+            "# Rust alternative: comment the Bun blocks below and uncomment the matching",
             text,
         )
         self.assertIn(
-            '#   destination: "chrome/browser/browseros/claw_server/resources"',
+            '# - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"',
             text,
         )
-        self.assertNotIn(
+        self.assertIn(
+            '#     - from: "bin/browseros-claw-server-rs"',
+            text,
+        )
+        self.assertIn(
             "BrowserOS Claw Server Resources - macOS ARM64",
             active_names,
         )
-        self.assertIn(
+        self.assertNotIn(
             "BrowserOS Claw Rust Server Resources - macOS ARM64",
             active_names,
         )

--- a/packages/browseros/bos_build/steps/sign/macos_test.py
+++ b/packages/browseros/bos_build/steps/sign/macos_test.py
@@ -230,7 +230,7 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
         claw_destinations = {
             op["destination"]
             for op in config["copy_operations"]
-            if op["name"].startswith("BrowserOS Claw Rust Server Resources")
+            if op["name"].startswith("BrowserOS Claw Server Resources")
         }
         self.assertEqual(
             claw_destinations,

--- a/packages/browseros/bos_build/steps/storage/download_test.py
+++ b/packages/browseros/bos_build/steps/storage/download_test.py
@@ -215,11 +215,6 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",
                         "resources/binaries/browseros_claw_server/darwin-arm64",
                     ),
-                    (
-                        "BrowserOS Claw Rust Server Resources - macOS ARM64",
-                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
-                        "resources/binaries/browseros_claw_server_rust/darwin-arm64",
-                    ),
                 ],
             ),
             (
@@ -235,11 +230,6 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "BrowserOS Claw Server Resources - macOS x64",
                         "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip",
                         "resources/binaries/browseros_claw_server/darwin-x64",
-                    ),
-                    (
-                        "BrowserOS Claw Rust Server Resources - macOS x64",
-                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-x64.zip",
-                        "resources/binaries/browseros_claw_server_rust/darwin-x64",
                     ),
                 ],
             ),
@@ -257,11 +247,6 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip",
                         "resources/binaries/browseros_claw_server/linux-arm64",
                     ),
-                    (
-                        "BrowserOS Claw Rust Server Resources - Linux ARM64",
-                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-arm64.zip",
-                        "resources/binaries/browseros_claw_server_rust/linux-arm64",
-                    ),
                 ],
             ),
             (
@@ -278,11 +263,6 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip",
                         "resources/binaries/browseros_claw_server/linux-x64",
                     ),
-                    (
-                        "BrowserOS Claw Rust Server Resources - Linux x64",
-                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-x64.zip",
-                        "resources/binaries/browseros_claw_server_rust/linux-x64",
-                    ),
                 ],
             ),
             (
@@ -298,11 +278,6 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "BrowserOS Claw Server Resources - Windows x64",
                         "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip",
                         "resources/binaries/browseros_claw_server/windows-x64",
-                    ),
-                    (
-                        "BrowserOS Claw Rust Server Resources - Windows x64",
-                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-windows-x64.zip",
-                        "resources/binaries/browseros_claw_server_rust/windows-x64",
                     ),
                 ],
             ),
@@ -330,8 +305,6 @@ class DownloadResourceConfigTest(unittest.TestCase):
                 "BrowserOS Server Resources - macOS x64",
                 "BrowserOS Claw Server Resources - macOS ARM64",
                 "BrowserOS Claw Server Resources - macOS x64",
-                "BrowserOS Claw Rust Server Resources - macOS ARM64",
-                "BrowserOS Claw Rust Server Resources - macOS x64",
                 "BrowserOS Claw Onboarding Resources",
             ],
             [op["name"] for op in filtered],
@@ -373,7 +346,7 @@ class DownloadResourceConfigTest(unittest.TestCase):
                     ]
                     self.assertEqual([expected], actual)
 
-    def test_real_config_downloads_both_claw_servers_for_browserclaw(
+    def test_real_config_downloads_bun_claw_server_for_browserclaw(
         self,
     ) -> None:
         operations = self._real_download_operations()
@@ -397,17 +370,33 @@ class DownloadResourceConfigTest(unittest.TestCase):
                     "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",
                     "resources/binaries/browseros_claw_server/darwin-arm64",
                 ),
-                (
-                    "BrowserOS Claw Rust Server Resources - macOS ARM64",
-                    "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
-                    "resources/binaries/browseros_claw_server_rust/darwin-arm64",
-                ),
             ],
             [
                 (op["name"], op["r2_key"], op["destination"])
                 for op in filtered
                 if "Server Resources" in op["name"]
             ],
+        )
+
+    def test_real_config_keeps_rust_claw_downloads_commented(self) -> None:
+        config_path = (
+            Path(__file__).resolve().parents[2] / "config" / "download_resources.yaml"
+        )
+        text = config_path.read_text()
+        operations = self._real_download_operations()
+
+        self.assertIn(
+            "# Rust alternative resource bundles - uncomment only when shipping "
+            "claw-server-rust.",
+            text,
+        )
+        self.assertIn(
+            '# - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"',
+            text,
+        )
+        self.assertNotIn(
+            "BrowserOS Claw Rust Server Resources - macOS ARM64",
+            [op["name"] for op in operations],
         )
 
     def _real_download_operations(self) -> list[dict]:


### PR DESCRIPTION
## Summary
- Ship the Bun BrowserClaw server from `browseros_claw_server/<target>/resources` in active copy/download config.
- Keep the Rust copy/download alternatives as whole-line commented YAML blocks with manual flip instructions.
- Stop nightly BrowserClaw staging from building Rust by default, while documenting the Rust flip path.
- Align browser-build server bundle lookup/sign/package guards to the Bun BrowserClaw bundle; keep Rust bundle metadata for the Rust release lane.

## Verification
- `uv run python -m unittest discover -s bos_build -t . -p '*_test.py'`
- `uv run ruff check bos_build`
- `actionlint .github/workflows/nightly-browserclaw.yml`
- `uv run browseros build --show-plan --profile nightly-macos --product browserclaw --arch arm64`
- YAML parse check: active Claw server ops are only the five Bun targets in both `copy_resources.yaml` and `download_resources.yaml`.

## Local copy proof
Built and staged the Bun Claw server because the ignored staging dir was absent in this worktree:

```bash
cd packages/browseros-agent
bun ci
bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
cd ../browseros
uv run python - <<'PY'
from pathlib import Path
from bos_build.steps.storage.download import extract_artifact_zip
# extracted browseros-claw-server-resources-darwin-arm64.zip to:
# resources/binaries/browseros_claw_server/darwin-arm64
PY
```

Then ran only the resource-copy module against the shared Chromium checkout:

```bash
uv run browseros build \
  --modules resources \
  --product browserclaw \
  --arch arm64 \
  --build-type release \
  --chromium-src /Users/shadowfax/code/chromium-release/src
```

Copied binary proof:

```text
/Users/shadowfax/code/chromium-release/src/chrome/browser/browseros/claw_server/resources/bin/browseros-claw-server: Mach-O 64-bit executable arm64
sha256 copied: 031c2d9b9053d3455a99a99724bedcb91af32dcb8ec9e73d9ef8570287126a0d
sha256 staged: 031c2d9b9053d3455a99a99724bedcb91af32dcb8ec9e73d9ef8570287126a0d
strings rust tells: ~/.cargo/registry=0, axum=0, browseros-claw-server-rs=0, claw-server-rust=0, target/release=0
strings bun tells present: bun-lockfile-format-v, __bun, __BUN, JavaScriptCore
```
