### PR TITLE
fix: prefer BrowserClaw app for claw dev tools

### DIFF
--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
@@ -41,12 +41,25 @@ function setConnectionsProbePending() {
 }
 
 mock.module('@/modules/api/connections.hooks', () => ({
-  useBrowserosConnections: () =>
-    connectionsHookState()[connectionsHookResultKey] ?? {
-      data: undefined,
-      isPending: true,
-      isError: false,
-    },
+  useBrowserosConnections: Object.assign(
+    () =>
+      connectionsHookState()[connectionsHookResultKey] ?? {
+        data: undefined,
+        isPending: true,
+        isError: false,
+      },
+    { getKey: () => ['cockpit', 'connections'] },
+  ),
+  useConnectBrowseros: () => ({
+    isPending: false,
+    variables: undefined,
+    mutateAsync: async () => ({ installed: true }),
+  }),
+  useDisconnectBrowseros: () => ({
+    isPending: false,
+    variables: undefined,
+    mutateAsync: async () => ({ installed: false }),
+  }),
 }))
 
 const { Cockpit } = await import('./Cockpit')

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
@@ -26,9 +26,33 @@ mock.module('@/modules/api/audit.hooks', () => ({
   useTaskScreenshotBaseUrl: () => null,
 }))
 
+const connectionsHookResultKey = '__browserclawConnectionsHookResult'
+
+function connectionsHookState() {
+  return globalThis as Record<string, unknown>
+}
+
+function setConnectionsProbePending() {
+  connectionsHookState()[connectionsHookResultKey] = {
+    data: undefined,
+    isPending: true,
+    isError: false,
+  }
+}
+
+mock.module('@/modules/api/connections.hooks', () => ({
+  useBrowserosConnections: () =>
+    connectionsHookState()[connectionsHookResultKey] ?? {
+      data: undefined,
+      isPending: true,
+      isError: false,
+    },
+}))
+
 const { Cockpit } = await import('./Cockpit')
 
 function renderApp(): string {
+  setConnectionsProbePending()
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
@@ -46,7 +70,6 @@ describe('Cockpit (v2)', () => {
     const html = renderApp()
     expect(html).toContain('working on')
     expect(html).toContain('Recent activity')
-    // No agents in the stub data means RunningGrid returns null.
     expect(html).not.toContain('Running now')
   })
 

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
@@ -5,66 +5,83 @@
  * harnesses.
  */
 
-import { describe, expect, it, mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router'
 
-mock.module('@/modules/api/connections.hooks', () => ({
-  useBrowserosConnections: Object.assign(
-    () => ({
+const mcpBrowserosConnections = [
+  {
+    harness: 'Claude Code',
+    installed: false,
+    agentId: 'claude-code',
+    message: '',
+  },
+  {
+    harness: 'Cursor',
+    installed: true,
+    agentId: 'cursor',
+    configPath: '/tmp/cursor.json',
+    message: 'Configured in Cursor.',
+  },
+  {
+    harness: 'Codex',
+    installed: false,
+    agentId: 'codex',
+    message: '',
+  },
+  {
+    harness: 'OpenCode',
+    installed: false,
+    agentId: 'opencode',
+    message: '',
+  },
+  {
+    harness: 'Antigravity',
+    installed: false,
+    agentId: 'antigravity',
+    message: '',
+  },
+  {
+    harness: 'VS Code',
+    installed: false,
+    agentId: 'vscode',
+    message: '',
+  },
+  {
+    harness: 'Zed',
+    installed: false,
+    agentId: 'zed',
+    message: '',
+  },
+]
+
+const connectionsHookResultKey = '__browserclawConnectionsHookResult'
+
+function connectionsHookState() {
+  return globalThis as Record<string, unknown>
+}
+
+function setConnectionsHookResult(result: unknown) {
+  connectionsHookState()[connectionsHookResultKey] = result
+}
+
+function getConnectionsHookResult() {
+  return (
+    connectionsHookState()[connectionsHookResultKey] ?? {
       data: {
-        connections: [
-          {
-            harness: 'Claude Code',
-            installed: false,
-            agentId: 'claude-code',
-            message: '',
-          },
-          {
-            harness: 'Cursor',
-            installed: true,
-            agentId: 'cursor',
-            configPath: '/tmp/cursor.json',
-            message: 'Configured in Cursor.',
-          },
-          {
-            harness: 'Codex',
-            installed: false,
-            agentId: 'codex',
-            message: '',
-          },
-          {
-            harness: 'OpenCode',
-            installed: false,
-            agentId: 'opencode',
-            message: '',
-          },
-          {
-            harness: 'Antigravity',
-            installed: false,
-            agentId: 'antigravity',
-            message: '',
-          },
-          {
-            harness: 'VS Code',
-            installed: false,
-            agentId: 'vscode',
-            message: '',
-          },
-          {
-            harness: 'Zed',
-            installed: false,
-            agentId: 'zed',
-            message: '',
-          },
-        ],
+        connections: mcpBrowserosConnections,
       },
       isPending: false,
       isError: false,
-    }),
-    { getKey: () => ['cockpit', 'connections'] },
-  ),
+    }
+  )
+}
+
+mock.module('@/modules/api/connections.hooks', () => ({
+  useBrowserosConnections: Object.assign(() => getConnectionsHookResult(), {
+    getKey: () => ['cockpit', 'connections'],
+  }),
   useConnectBrowseros: () => ({
     isPending: false,
     variables: undefined,
@@ -76,6 +93,24 @@ mock.module('@/modules/api/connections.hooks', () => ({
     mutateAsync: async () => ({ installed: false }),
   }),
 }))
+
+beforeEach(() => {
+  setConnectionsHookResult({
+    data: {
+      connections: mcpBrowserosConnections,
+    },
+    isPending: false,
+    isError: false,
+  })
+})
+
+afterEach(() => {
+  setConnectionsHookResult({
+    data: undefined,
+    isPending: true,
+    isError: false,
+  })
+})
 
 const { Mcp } = await import('./Mcp')
 const { HeroCard } = await import('./HeroCard')
@@ -127,7 +162,6 @@ describe('Mcp (editorial)', () => {
   it('renders the Connected-agents header with the count chip', () => {
     const html = renderApp()
     expect(html).toContain('Connected agents')
-    // 7 supported harnesses, 1 connected (Cursor).
     expect(html).toContain('1 of 7 connected')
   })
 
@@ -140,7 +174,6 @@ describe('Mcp (editorial)', () => {
     expect(html).toContain('Antigravity')
     expect(html).toContain('VS Code')
     expect(html).toContain('Zed')
-    // Retired harnesses do not appear.
     expect(html).not.toContain('Claude Desktop')
     expect(html).not.toContain('Hermes')
     expect(html).not.toContain('Gemini CLI')
@@ -149,10 +182,7 @@ describe('Mcp (editorial)', () => {
 
   it('renders editorial state voices (silent success, mono uppercase action text)', () => {
     const html = renderApp()
-    // Connect action link renders in mono uppercase (single word).
     expect(html).toMatch(/>\s*connect\s*/)
-    // Connected state renders inline `connected` label + disconnect
-    // link.
     expect(html).toMatch(/>\s*connected\s*/)
     expect(html).toMatch(/>\s*disconnect\s*/)
   })

--- a/packages/browseros-agent/tools/dev/browser/args.go
+++ b/packages/browseros-agent/tools/dev/browser/args.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"browseros-dev/proc"
@@ -19,17 +20,57 @@ type ArgsConfig struct {
 const (
 	ProductBrowserOS   = "browseros"
 	ProductBrowserClaw = "browserclaw"
+
+	BrowserOSBinaryPath   = "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS"
+	BrowserClawBinaryPath = "/Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw"
 )
+
+type BinaryResolution struct {
+	Product       string
+	Path          string
+	PreferredPath string
+	Fallback      bool
+}
+
+// ResolveBinary chooses the Chromium app binary for a product with an injectable existence check.
+func ResolveBinary(product string, exists func(string) bool) BinaryResolution {
+	product = normalizeProduct(product)
+	resolution := BinaryResolution{
+		Product:       product,
+		Path:          BrowserOSBinaryPath,
+		PreferredPath: BrowserOSBinaryPath,
+	}
+	if product != ProductBrowserClaw {
+		return resolution
+	}
+
+	resolution.PreferredPath = BrowserClawBinaryPath
+	if exists != nil && exists(BrowserClawBinaryPath) {
+		resolution.Path = BrowserClawBinaryPath
+		return resolution
+	}
+	resolution.Fallback = true
+	return resolution
+}
+
+// ResolveInstalledBinary resolves the product binary against the local macOS app bundle paths.
+func ResolveInstalledBinary(product string) BinaryResolution {
+	return ResolveBinary(product, binaryExists)
+}
 
 // BuildArgs returns the BrowserOS Chromium command for non-WXT dev/test launches.
 func BuildArgs(cfg ArgsConfig) []string {
-	binary := "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS"
+	return buildArgs(cfg, ResolveInstalledBinary)
+}
+
+func buildArgs(cfg ArgsConfig, resolveBinary func(string) BinaryResolution) []string {
 	product := cfg.Product
 	if product == "" {
 		product = ProductBrowserOS
 	}
+	resolution := resolveBinary(product)
 
-	args := []string{binary}
+	args := []string{resolution.Path}
 
 	if cfg.LoadDevExtensions {
 		args = append(args, "--no-first-run", "--no-default-browser-check")
@@ -67,4 +108,16 @@ func BuildArgs(cfg ArgsConfig) []string {
 	}
 
 	return args
+}
+
+func normalizeProduct(product string) string {
+	if product == "" {
+		return ProductBrowserOS
+	}
+	return product
+}
+
+func binaryExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/packages/browseros-agent/tools/dev/browser/args_test.go
+++ b/packages/browseros-agent/tools/dev/browser/args_test.go
@@ -21,15 +21,81 @@ func TestBuildArgsUsesDevDockIcon(t *testing.T) {
 }
 
 func TestBuildArgsUsesProductFlag(t *testing.T) {
-	args := BuildArgs(ArgsConfig{
+	args := buildArgs(ArgsConfig{
 		Root:              "/repo/packages/browseros-agent",
 		Ports:             proc.Ports{CDP: 9005, Server: 9105, Extension: 9305},
 		UserDataDir:       "/tmp/browseros-dev",
 		LoadDevExtensions: true,
 		Product:           ProductBrowserClaw,
+	}, func(product string) BinaryResolution {
+		return BinaryResolution{Product: product, Path: BrowserClawBinaryPath, PreferredPath: BrowserClawBinaryPath}
 	})
 	joined := strings.Join(args, "\n")
+	if args[0] != BrowserClawBinaryPath {
+		t.Fatalf("got binary %q want %q", args[0], BrowserClawBinaryPath)
+	}
 	if !strings.Contains(joined, "--browseros-product=browserclaw") {
 		t.Fatalf("missing BrowserClaw product arg in\n%s", joined)
+	}
+}
+
+func TestResolveBinary(t *testing.T) {
+	tests := []struct {
+		name          string
+		product       string
+		existingPaths map[string]bool
+		wantProduct   string
+		wantPath      string
+		wantPreferred string
+		wantFallback  bool
+	}{
+		{
+			name:          "default product uses BrowserOS",
+			wantProduct:   ProductBrowserOS,
+			wantPath:      BrowserOSBinaryPath,
+			wantPreferred: BrowserOSBinaryPath,
+		},
+		{
+			name:          "BrowserOS product ignores BrowserClaw install",
+			product:       ProductBrowserOS,
+			existingPaths: map[string]bool{BrowserClawBinaryPath: true},
+			wantProduct:   ProductBrowserOS,
+			wantPath:      BrowserOSBinaryPath,
+			wantPreferred: BrowserOSBinaryPath,
+		},
+		{
+			name:          "BrowserClaw product uses BrowserClaw when installed",
+			product:       ProductBrowserClaw,
+			existingPaths: map[string]bool{BrowserClawBinaryPath: true},
+			wantProduct:   ProductBrowserClaw,
+			wantPath:      BrowserClawBinaryPath,
+			wantPreferred: BrowserClawBinaryPath,
+		},
+		{
+			name:          "BrowserClaw product falls back to BrowserOS when absent",
+			product:       ProductBrowserClaw,
+			wantProduct:   ProductBrowserClaw,
+			wantPath:      BrowserOSBinaryPath,
+			wantPreferred: BrowserClawBinaryPath,
+			wantFallback:  true,
+		},
+		{
+			name:          "unknown product keeps product flag but uses BrowserOS",
+			product:       "custom",
+			wantProduct:   "custom",
+			wantPath:      BrowserOSBinaryPath,
+			wantPreferred: BrowserOSBinaryPath,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveBinary(tt.product, func(path string) bool {
+				return tt.existingPaths[path]
+			})
+			if got.Product != tt.wantProduct || got.Path != tt.wantPath || got.PreferredPath != tt.wantPreferred || got.Fallback != tt.wantFallback {
+				t.Fatalf("ResolveBinary got %#v", got)
+			}
+		})
 	}
 }

--- a/packages/browseros-agent/tools/dev/cmd/watch.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch.go
@@ -158,7 +158,12 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	proc.LogMsg(proc.TagInfo, proc.DimColor.Sprint("Press Ctrl+C to stop, double Ctrl+C to force kill"))
 	fmt.Println()
 
-	env := buildWatchEnv(p, userDataDir, watchClaw)
+	clawBinary := browser.BinaryResolution{}
+	if watchClaw {
+		clawBinary = browser.ResolveInstalledBinary(browser.ProductBrowserClaw)
+		logClawBrowserBinary(clawBinary)
+	}
+	env := buildWatchEnvWithBinaryResolution(p, userDataDir, watchClaw, clawBinary)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -235,12 +240,20 @@ func resolveWatchDefaultPorts(root string, claw bool) (proc.Ports, error) {
 
 // buildWatchEnv forwards the selected product into WXT's Chromium launcher config.
 func buildWatchEnv(p proc.Ports, userDataDir string, claw bool) []string {
+	return buildWatchEnvWithBinaryResolution(p, userDataDir, claw, browser.BinaryResolution{})
+}
+
+func buildWatchEnvWithBinaryResolution(p proc.Ports, userDataDir string, claw bool, binaryResolution browser.BinaryResolution) []string {
 	env := proc.BuildEnv(p, "development")
 	env = append(env,
 		fmt.Sprintf("BROWSEROS_USER_DATA_DIR=%s", userDataDir),
 		fmt.Sprintf("BROWSEROS_PRODUCT=%s", watchProduct(claw)),
 	)
 	if claw {
+		if binaryResolution.Path == "" {
+			binaryResolution = browser.ResolveInstalledBinary(browser.ProductBrowserClaw)
+		}
+		env = append(env, fmt.Sprintf("BROWSEROS_BINARY=%s", binaryResolution.Path))
 		env = buildClawWatchEnv(env, p)
 	}
 	return env
@@ -260,6 +273,14 @@ func buildClawWatchEnv(env []string, p proc.Ports) []string {
 		fmt.Sprintf("BROWSEROS_CLAW_CDP_PORT=%d", p.CDP),
 		fmt.Sprintf("VITE_BROWSEROS_CLAW_API_URL=%s", apiURL),
 	)
+}
+
+func logClawBrowserBinary(resolution browser.BinaryResolution) {
+	if resolution.Fallback {
+		proc.LogMsgf(proc.TagInfo, "BrowserClaw app not found at %s; using %s", browser.BrowserClawBinaryPath, resolution.Path)
+		return
+	}
+	proc.LogMsgf(proc.TagInfo, "Browser app: %s", resolution.Path)
 }
 
 // startBrowserOSWatch supervises the BrowserOS agent extension plus server dev pair.

--- a/packages/browseros-agent/tools/dev/cmd/watch_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"browseros-dev/browser"
 	"browseros-dev/proc"
 )
 
@@ -122,14 +123,19 @@ func TestBuildWatchEnvSelectsBrowserOSProduct(t *testing.T) {
 }
 
 func TestBuildWatchEnvSelectsBrowserClawProduct(t *testing.T) {
-	env := buildWatchEnv(proc.Ports{
+	env := buildWatchEnvWithBinaryResolution(proc.Ports{
 		CDP:       9012,
 		Server:    9123,
 		Extension: 9321,
-	}, "/tmp/browseros-dev", true)
+	}, "/tmp/browseros-dev", true, browser.BinaryResolution{
+		Product:       browser.ProductBrowserClaw,
+		Path:          browser.BrowserClawBinaryPath,
+		PreferredPath: browser.BrowserClawBinaryPath,
+	})
 
 	for _, want := range []string{
 		"BROWSEROS_PRODUCT=browserclaw",
+		"BROWSEROS_BINARY=/Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw",
 		"BROWSEROS_CLAW_CDP_PORT=9012",
 		"VITE_BROWSEROS_CLAW_API_URL=http://127.0.0.1:9123",
 	} {
@@ -157,6 +163,22 @@ func TestBuildClawWatchEnvIncludesSelectedPorts(t *testing.T) {
 	}
 	if hasEnvEntry(env, "CLAW_SERVER_PORT=9123") {
 		t.Fatalf("claw server port should be passed through sidecar config, got %#v", env)
+	}
+}
+
+func TestBuildWatchEnvUsesFallbackBrowserBinaryForClaw(t *testing.T) {
+	env := buildWatchEnvWithBinaryResolution(proc.Ports{
+		CDP:    9012,
+		Server: 9123,
+	}, "/tmp/browseros-dev", true, browser.BinaryResolution{
+		Product:       browser.ProductBrowserClaw,
+		Path:          browser.BrowserOSBinaryPath,
+		PreferredPath: browser.BrowserClawBinaryPath,
+		Fallback:      true,
+	})
+
+	if !hasEnvEntry(env, "BROWSEROS_BINARY=/Applications/BrowserOS.app/Contents/MacOS/BrowserOS") {
+		t.Fatalf("expected fallback browser binary env, got %#v", env)
 	}
 }
 

--- a/packages/browseros-agent/tools/dev/proc/process.go
+++ b/packages/browseros-agent/tools/dev/proc/process.go
@@ -411,7 +411,7 @@ func isDevBrowserProcess(command string) bool {
 }
 
 func isBrowserProcessForUserDataDir(command string, userDataDirs []string, includeDevTempProfiles bool) bool {
-	if !strings.Contains(command, "BrowserOS.app/Contents/MacOS/BrowserOS") {
+	if !isBrowserAppCommand(command) {
 		return false
 	}
 	for _, dir := range userDataDirs {
@@ -425,6 +425,11 @@ func isBrowserProcessForUserDataDir(command string, userDataDirs []string, inclu
 	return includeDevTempProfiles &&
 		(strings.Contains(command, "browseros-dev-") ||
 			strings.Contains(command, "browseros-test-"))
+}
+
+func isBrowserAppCommand(command string) bool {
+	return strings.Contains(command, "BrowserOS.app/Contents/MacOS/BrowserOS") ||
+		strings.Contains(command, "BrowserClaw.app/Contents/MacOS/BrowserClaw")
 }
 
 func watchRunPaths(baseDir string, identity WatchRunIdentity) watchRunPathsResult {

--- a/packages/browseros-agent/tools/dev/proc/process_test.go
+++ b/packages/browseros-agent/tools/dev/proc/process_test.go
@@ -56,9 +56,9 @@ func TestWatchRunPathsStableAndSharedAcrossPortChanges(t *testing.T) {
 func TestBrowserProfilePIDsFromPSSelectsOnlyDevAndTestProfiles(t *testing.T) {
 	output := `
   111  111 /Applications/BrowserOS.app/Contents/MacOS/BrowserOS --user-data-dir=/tmp/browseros-dev
-  222  222 /Applications/BrowserOS.app/Contents/MacOS/BrowserOS --user-data-dir=/tmp/browseros-dev-abcd
-  333  333 /Applications/BrowserOS.app/Contents/MacOS/BrowserOS --user-data-dir=/var/folders/x/browseros-test-abcd
-  444  444 /Applications/BrowserOS.app/Contents/MacOS/BrowserOS --user-data-dir=/Users/me/Library/Application Support/BrowserOS
+  222  222 /Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw --user-data-dir=/tmp/browseros-dev-abcd
+  333  333 /Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw --user-data-dir=/var/folders/x/browseros-test-abcd
+  444  444 /Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw --user-data-dir=/Users/me/Library/Application Support/BrowserOS
   555  555 rg browseros-test-
 `
 

--- a/packages/browseros-agent/tools/dogfood/README.md
+++ b/packages/browseros-agent/tools/dogfood/README.md
@@ -13,7 +13,7 @@ High level:
 - It imports your normal BrowserOS profile into a target-specific dogfood profile.
 - It keeps BrowserOS and BrowserClaw state separate from your normal app state and from each other.
 - For BrowserOS, it builds the local extension, starts the local server, and launches the installed BrowserOS app with the alpha Dock icon against them.
-- For BrowserClaw, it starts the BrowserClaw WXT app and standalone Claw server against the installed BrowserOS app.
+- For BrowserClaw, it starts the BrowserClaw WXT app and standalone Claw server against the installed BrowserClaw app, falling back to BrowserOS when BrowserClaw is not installed.
 - It does not auto-pull on `start`; you choose when to update the checkout.
 
 ## Requirements
@@ -21,7 +21,7 @@ High level:
 - macOS.
 - Go.
 - Bun.
-- BrowserOS installed at `/Applications/BrowserOS.app`.
+- BrowserOS installed at `/Applications/BrowserOS.app`; BrowserClaw optionally installed at `/Applications/BrowserClaw.app`.
 - A separate BrowserOS monorepo checkout for alpha dogfood.
 
 ## Install
@@ -54,7 +54,7 @@ browseros-dogfood --claw init
 
 - `Repo path`: the full path to the root BrowserOS git repo clone.
 - `Branch`: the branch dogfood should track. It defaults to the selected repo's current branch, or `main`.
-- `BrowserOS binary`: defaults to `/Applications/BrowserOS.app/Contents/MacOS/BrowserOS`.
+- `BrowserOS binary`: defaults to `/Applications/BrowserOS.app/Contents/MacOS/BrowserOS`; Claw start resolves to BrowserClaw at launch time when available.
 - `Source profile`: your main installed BrowserOS profile.
 
 Use a separate clone for the repo path. This clone is what `browseros-dogfood` uses to run alpha dogfood builds, so ideally it is not the same checkout you use for actual dev work. Give the full root repo path, for example `/Users/you/code/browseros-alpha`.

--- a/packages/browseros-agent/tools/dogfood/browser/args_test.go
+++ b/packages/browseros-agent/tools/dogfood/browser/args_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBuildArgs(t *testing.T) {
 	args := BuildArgs(ArgsConfig{
-		Binary:      "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS",
+		Binary:      config.DefaultBrowserOSAppPath,
 		AgentRoot:   "/repo/packages/browseros-agent",
 		UserDataDir: "/tmp/browseros-dogfood",
 		ProfileDir:  "Default",

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -186,6 +186,9 @@ func buildAndStartBrowserOSEnvironment(ctx context.Context, cfg config.Config, a
 	if err := prepareBrowserOSEnvironment(&cfg, agentRoot, opts); err != nil {
 		return nil, err
 	}
+	if err := resolveStartBrowserApp(&cfg); err != nil {
+		return nil, err
+	}
 	reportProgress(opts, "building agent")
 	if err := pipeline.Build(ctx, agentRoot, opts.Runner); err != nil {
 		return nil, err
@@ -196,6 +199,9 @@ func buildAndStartBrowserOSEnvironment(ctx context.Context, cfg config.Config, a
 func buildAndStartClawEnvironment(ctx context.Context, cfg config.Config, agentRoot string, opts environmentOptions) (*environment, error) {
 	reportProgress(opts, "preparing profile")
 	if err := prepareClawEnvironment(&cfg, opts); err != nil {
+		return nil, err
+	}
+	if err := resolveStartBrowserApp(&cfg); err != nil {
 		return nil, err
 	}
 	reportProgress(opts, "preparing Claw apps")
@@ -462,6 +468,39 @@ func clawRuntimeEnv(base []string, cfg config.Config) []string {
 func exists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+func resolveStartBrowserApp(cfg *config.Config) error {
+	resolution := resolveConfiguredBrowserApp(cfg, browserAppExecutableExists)
+	if err := validateBrowserAppExecutable(resolution.Path); err != nil {
+		return err
+	}
+	if resolution.Fallback {
+		proc.LogMsg(proc.TagInfo, proc.WarnColor.Sprintf("Browser app unavailable at %s; using %s", resolution.MissingPath, resolution.Path))
+	}
+	return nil
+}
+
+func resolveConfiguredBrowserApp(cfg *config.Config, exists func(string) bool) config.BrowserAppResolution {
+	resolution := config.ResolveBrowserAppPath(cfg.Target, cfg.BrowserOSAppPath, exists)
+	cfg.BrowserOSAppPath = resolution.Path
+	return resolution
+}
+
+func browserAppExecutableExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir() && info.Mode()&0111 != 0
+}
+
+func validateBrowserAppExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("browseros_app_path: %w", err)
+	}
+	if info.IsDir() || info.Mode()&0111 == 0 {
+		return fmt.Errorf("browseros_app_path is not an executable file: %s", path)
+	}
+	return nil
 }
 
 func printSummary(cfg config.Config, agentRoot string) {

--- a/packages/browseros-agent/tools/dogfood/cmd/start_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start_test.go
@@ -52,7 +52,7 @@ func TestClawRuntimeEnvWiresBrowserAndAPISettings(t *testing.T) {
 		"BROWSEROS_CLAW_CDP_PORT=1",
 		"VITE_BROWSEROS_CLAW_API_URL=http://wrong",
 	}, config.Config{
-		BrowserOSAppPath: "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS",
+		BrowserOSAppPath: config.DefaultBrowserClawAppPath,
 		DevUserDataDir:   "/tmp/claw-profile",
 		BrowserOSDir:     "/tmp/claw-state",
 		Ports:            config.Ports{CDP: 49337, Server: 9200},
@@ -62,7 +62,7 @@ func TestClawRuntimeEnvWiresBrowserAndAPISettings(t *testing.T) {
 	assertEnvContains(t, got, "NODE_ENV=development")
 	assertEnvContains(t, got, "BROWSERCLAW_DIR=/tmp/claw-state")
 	assertEnvMissingPrefix(t, got, "BROWSEROS_DIR=")
-	assertEnvContains(t, got, "BROWSEROS_BINARY=/Applications/BrowserOS.app/Contents/MacOS/BrowserOS")
+	assertEnvContains(t, got, "BROWSEROS_BINARY=/Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw")
 	assertEnvContains(t, got, "BROWSEROS_USER_DATA_DIR=/tmp/claw-profile")
 	assertEnvContains(t, got, "BROWSEROS_CLAW_CDP_PORT=49337")
 	assertEnvContains(t, got, "BROWSEROS_SERVER_PORT=9200")
@@ -107,6 +107,42 @@ func TestServerRuntimeEnvOverridesInheritedBrowserOSDir(t *testing.T) {
 		t.Fatalf("inherited BrowserOS dir was not overridden: %#v", got)
 	}
 	assertEnvContains(t, got, "BROWSEROS_DIR=/tmp/browseros-dogfood")
+}
+
+func TestResolveConfiguredBrowserAppUsesClawDefaultAtStart(t *testing.T) {
+	cfg := config.Config{
+		Target:           config.TargetClaw,
+		BrowserOSAppPath: config.DefaultBrowserOSAppPath,
+	}
+
+	resolution := resolveConfiguredBrowserApp(&cfg, func(path string) bool {
+		return path == config.DefaultBrowserClawAppPath
+	})
+
+	if cfg.BrowserOSAppPath != config.DefaultBrowserClawAppPath {
+		t.Fatalf("resolved app path got %q", cfg.BrowserOSAppPath)
+	}
+	if resolution.Fallback {
+		t.Fatalf("did not expect fallback: %#v", resolution)
+	}
+}
+
+func TestResolveConfiguredBrowserAppFallsBackWhenCustomPathIsMissing(t *testing.T) {
+	cfg := config.Config{
+		Target:           config.TargetClaw,
+		BrowserOSAppPath: "/missing/custom-browser",
+	}
+
+	resolution := resolveConfiguredBrowserApp(&cfg, func(path string) bool {
+		return path == config.DefaultBrowserClawAppPath
+	})
+
+	if cfg.BrowserOSAppPath != config.DefaultBrowserClawAppPath {
+		t.Fatalf("resolved app path got %q", cfg.BrowserOSAppPath)
+	}
+	if !resolution.Fallback || resolution.MissingPath != "/missing/custom-browser" {
+		t.Fatalf("unexpected fallback resolution: %#v", resolution)
+	}
 }
 
 func assertEnvContains(t *testing.T, env []string, want string) {

--- a/packages/browseros-agent/tools/dogfood/config/config.go
+++ b/packages/browseros-agent/tools/dogfood/config/config.go
@@ -66,8 +66,21 @@ type fileConfig struct {
 	ProductionEnv     ProductionEnv           `yaml:"production_env"`
 }
 
-const LogDirName = "logs"
-const DefaultBranch = "main"
+const (
+	LogDirName = "logs"
+
+	DefaultBranch = "main"
+
+	DefaultBrowserOSAppPath   = "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS"
+	DefaultBrowserClawAppPath = "/Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw"
+)
+
+type BrowserAppResolution struct {
+	Path          string
+	PreferredPath string
+	MissingPath   string
+	Fallback      bool
+}
 
 func Path() (string, error) {
 	home, err := os.UserHomeDir()
@@ -86,7 +99,7 @@ func DefaultConfigDir(home string) string {
 
 func Defaults(home string) Config {
 	cfg := Config{
-		BrowserOSAppPath:  "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS",
+		BrowserOSAppPath:  DefaultBrowserOSAppPath,
 		SourceUserDataDir: filepath.Join(home, "Library/Application Support/BrowserOS"),
 		SourceProfileDir:  "Default",
 		Branch:            DefaultBranch,
@@ -95,6 +108,46 @@ func Defaults(home string) Config {
 	}
 	_ = cfg.ApplyTarget(TargetBrowserOS)
 	return cfg
+}
+
+// ResolveBrowserAppPath chooses the app binary for a target without freezing discovered defaults into config.
+func ResolveBrowserAppPath(target Target, configuredPath string, exists func(string) bool) BrowserAppResolution {
+	configuredPath = strings.TrimSpace(configuredPath)
+	if configuredPath == "" {
+		configuredPath = DefaultBrowserOSAppPath
+	}
+	if isCustomBrowserAppPath(configuredPath) {
+		if target != TargetClaw {
+			return BrowserAppResolution{Path: configuredPath, PreferredPath: configuredPath}
+		}
+		if exists == nil || exists(configuredPath) {
+			return BrowserAppResolution{Path: configuredPath, PreferredPath: configuredPath}
+		}
+		return BrowserAppResolution{
+			Path:          fallbackBrowserAppPath(target, exists),
+			PreferredPath: configuredPath,
+			MissingPath:   configuredPath,
+			Fallback:      true,
+		}
+	}
+	if target == TargetClaw {
+		if exists != nil && exists(DefaultBrowserClawAppPath) {
+			return BrowserAppResolution{
+				Path:          DefaultBrowserClawAppPath,
+				PreferredPath: DefaultBrowserClawAppPath,
+			}
+		}
+		return BrowserAppResolution{
+			Path:          DefaultBrowserOSAppPath,
+			PreferredPath: DefaultBrowserClawAppPath,
+			MissingPath:   DefaultBrowserClawAppPath,
+			Fallback:      true,
+		}
+	}
+	return BrowserAppResolution{
+		Path:          DefaultBrowserOSAppPath,
+		PreferredPath: DefaultBrowserOSAppPath,
+	}
 }
 
 // DefaultTargets returns isolated BrowserOS and BrowserClaw runtime settings.
@@ -287,9 +340,6 @@ func (c Config) Validate() error {
 	if c.RepoPath == "" {
 		return fmt.Errorf("repo_path is required")
 	}
-	if c.BrowserOSAppPath == "" {
-		return fmt.Errorf("browseros_app_path is required")
-	}
 	if c.SourceUserDataDir == "" || c.SourceProfileDir == "" {
 		return fmt.Errorf("source_user_data_dir and source_profile_dir are required")
 	}
@@ -305,12 +355,28 @@ func (c Config) Validate() error {
 	if err := validateRepo(c.AgentRoot()); err != nil {
 		return err
 	}
-	if info, err := os.Stat(c.BrowserOSAppPath); err != nil {
-		return fmt.Errorf("browseros_app_path: %w", err)
-	} else if info.IsDir() || info.Mode()&0111 == 0 {
-		return fmt.Errorf("browseros_app_path is not an executable file: %s", c.BrowserOSAppPath)
+	if c.Target != TargetClaw {
+		if c.BrowserOSAppPath == "" {
+			return fmt.Errorf("browseros_app_path is required")
+		}
+		if info, err := os.Stat(c.BrowserOSAppPath); err != nil {
+			return fmt.Errorf("browseros_app_path: %w", err)
+		} else if info.IsDir() || info.Mode()&0111 == 0 {
+			return fmt.Errorf("browseros_app_path is not an executable file: %s", c.BrowserOSAppPath)
+		}
 	}
 	return nil
+}
+
+func isCustomBrowserAppPath(path string) bool {
+	return path != "" && path != DefaultBrowserOSAppPath
+}
+
+func fallbackBrowserAppPath(target Target, exists func(string) bool) string {
+	if target == TargetClaw && exists != nil && exists(DefaultBrowserClawAppPath) {
+		return DefaultBrowserClawAppPath
+	}
+	return DefaultBrowserOSAppPath
 }
 
 func validateRepo(agentRoot string) error {

--- a/packages/browseros-agent/tools/dogfood/config/config_test.go
+++ b/packages/browseros-agent/tools/dogfood/config/config_test.go
@@ -11,7 +11,7 @@ func TestDefaults(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 	cfg := Defaults(home)
 
-	if cfg.BrowserOSAppPath != "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS" {
+	if cfg.BrowserOSAppPath != DefaultBrowserOSAppPath {
 		t.Fatalf("unexpected browser path: %s", cfg.BrowserOSAppPath)
 	}
 	if cfg.SourceUserDataDir != filepath.Join(home, "Library/Application Support/BrowserOS") {
@@ -82,7 +82,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	path := filepath.Join(dir, "config.yaml")
 	cfg := Config{
 		RepoPath:          "/repo",
-		BrowserOSAppPath:  "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS",
+		BrowserOSAppPath:  DefaultBrowserOSAppPath,
 		SourceUserDataDir: "/source",
 		SourceProfileDir:  "Profile 25",
 		DevUserDataDir:    "/dev",
@@ -212,6 +212,91 @@ func TestResolvePreservesSelectedTarget(t *testing.T) {
 	}
 	if cfg.DevUserDataDir != filepath.Join(home, ".config/browseros-dogfood/claw/profile") {
 		t.Fatalf("dev profile got %q", cfg.DevUserDataDir)
+	}
+}
+
+func TestResolveBrowserAppPath(t *testing.T) {
+	customPath := filepath.Join(t.TempDir(), "CustomBrowser")
+	tests := []struct {
+		name          string
+		target        Target
+		configured    string
+		existingPaths map[string]bool
+		want          BrowserAppResolution
+	}{
+		{
+			name:          "BrowserOS default uses BrowserOS even when BrowserClaw exists",
+			target:        TargetBrowserOS,
+			configured:    DefaultBrowserOSAppPath,
+			existingPaths: map[string]bool{DefaultBrowserClawAppPath: true},
+			want: BrowserAppResolution{
+				Path:          DefaultBrowserOSAppPath,
+				PreferredPath: DefaultBrowserOSAppPath,
+			},
+		},
+		{
+			name:          "Claw default uses BrowserClaw when installed",
+			target:        TargetClaw,
+			configured:    DefaultBrowserOSAppPath,
+			existingPaths: map[string]bool{DefaultBrowserClawAppPath: true},
+			want: BrowserAppResolution{
+				Path:          DefaultBrowserClawAppPath,
+				PreferredPath: DefaultBrowserClawAppPath,
+			},
+		},
+		{
+			name:   "Claw default falls back to BrowserOS when BrowserClaw is absent",
+			target: TargetClaw,
+			want: BrowserAppResolution{
+				Path:          DefaultBrowserOSAppPath,
+				PreferredPath: DefaultBrowserClawAppPath,
+				MissingPath:   DefaultBrowserClawAppPath,
+				Fallback:      true,
+			},
+		},
+		{
+			name:          "custom configured path wins when available",
+			target:        TargetClaw,
+			configured:    customPath,
+			existingPaths: map[string]bool{customPath: true, DefaultBrowserClawAppPath: true},
+			want: BrowserAppResolution{
+				Path:          customPath,
+				PreferredPath: customPath,
+			},
+		},
+		{
+			name:          "BrowserOS custom path remains strict",
+			target:        TargetBrowserOS,
+			configured:    customPath,
+			existingPaths: map[string]bool{DefaultBrowserOSAppPath: true},
+			want: BrowserAppResolution{
+				Path:          customPath,
+				PreferredPath: customPath,
+			},
+		},
+		{
+			name:          "missing custom path falls back to target default",
+			target:        TargetClaw,
+			configured:    customPath,
+			existingPaths: map[string]bool{DefaultBrowserClawAppPath: true},
+			want: BrowserAppResolution{
+				Path:          DefaultBrowserClawAppPath,
+				PreferredPath: customPath,
+				MissingPath:   customPath,
+				Fallback:      true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveBrowserAppPath(tt.target, tt.configured, func(path string) bool {
+				return tt.existingPaths[path]
+			})
+			if got != tt.want {
+				t.Fatalf("ResolveBrowserAppPath got %#v want %#v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- add product-aware BrowserClaw/BrowserOS binary resolution to `browseros-dev`, including Claw WXT watch env wiring via `BROWSEROS_BINARY`
- resolve `browseros-dogfood` app binaries at start time so the Claw target picks BrowserClaw when installed and falls back to BrowserOS without freezing config
- teach dev process cleanup to recognize BrowserClaw app processes and fix Claw app test mock isolation uncovered by the root suite

## Resolution matrix

### tools/dev (`browseros-dev`)
| Product | BrowserClaw.app present | Binary |
| --- | --- | --- |
| `browseros` | yes/no | `/Applications/BrowserOS.app/Contents/MacOS/BrowserOS` |
| `browserclaw` | yes | `/Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw` |
| `browserclaw` | no | `/Applications/BrowserOS.app/Contents/MacOS/BrowserOS` |

### tools/dogfood (`browseros-dogfood start`)
| Target/config | BrowserClaw.app present | Binary |
| --- | --- | --- |
| `browseros` default/unset | yes/no | `/Applications/BrowserOS.app/Contents/MacOS/BrowserOS` |
| `claw` default/unset | yes | `/Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw` |
| `claw` default/unset | no | `/Applications/BrowserOS.app/Contents/MacOS/BrowserOS` |
| `claw` explicit custom path exists | yes/no | explicit custom path |
| `claw` explicit custom path missing | yes | `/Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw` |
| `claw` explicit custom path missing | no | `/Applications/BrowserOS.app/Contents/MacOS/BrowserOS` |

## Verification
- `gofmt -l .` in `packages/browseros-agent/tools/dev`
- `gofmt -l .` in `packages/browseros-agent/tools/dogfood`
- `go test ./...` in `packages/browseros-agent/tools/dev`
- `go test ./...` in `packages/browseros-agent/tools/dogfood`
- `go vet ./...` in `packages/browseros-agent/tools/dev`
- `go vet ./...` in `packages/browseros-agent/tools/dogfood`
- `bun run check` in `packages/browseros-agent`
- `bun run test` in `packages/browseros-agent`
