### PR TITLE
fix: clean browseros-agent check

### DIFF
--- a/packages/browseros-agent/.fallowrc.json
+++ b/packages/browseros-agent/.fallowrc.json
@@ -42,6 +42,7 @@
     "**/.output/**",
     "**/coverage/**",
     "**/tmp/**",
+    ".scripts/**",
     "apps/app/schema/**",
     "apps/cli/**",
     "apps/app/assets/**",

--- a/packages/browseros-agent/apps/app/codegen.ts
+++ b/packages/browseros-agent/apps/app/codegen.ts
@@ -42,7 +42,6 @@ const config: CodegenConfig = {
         scalars: {
           Cursor: 'string',
           Datetime: 'string',
-          // biome-ignore lint/suspicious/noExplicitAny: matches previous behaviour
           JSON: 'any',
         },
       },

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.test.ts
@@ -32,6 +32,12 @@ function dispatch(
   }
 }
 
+function expectDefined<T>(value: T | undefined): T {
+  expect(value).toBeDefined()
+  if (value === undefined) throw new Error('Expected value to be defined')
+  return value
+}
+
 describe('groupDispatchesByTab', () => {
   it('returns an empty array for zero dispatches', () => {
     expect(groupDispatchesByTab([], [])).toEqual([])
@@ -41,11 +47,12 @@ describe('groupDispatchesByTab', () => {
     const rows = [dispatch(1, null), dispatch(2, null), dispatch(3, null)]
     const groups = groupDispatchesByTab(rows, [])
     expect(groups).toHaveLength(1)
-    expect(groups[0]!.id).toBe('session')
-    expect(groups[0]!.label).toBe('Session')
-    expect(groups[0]!.pageId).toBeNull()
-    expect(groups[0]!.dispatchCount).toBe(3)
-    expect(groups[0]!.dispatches.map((d) => d.id)).toEqual([1, 2, 3])
+    const session = expectDefined(groups[0])
+    expect(session.id).toBe('session')
+    expect(session.label).toBe('Session')
+    expect(session.pageId).toBeNull()
+    expect(session.dispatchCount).toBe(3)
+    expect(session.dispatches.map((d) => d.id)).toEqual([1, 2, 3])
   })
 
   it('single pageId + zero null dispatches yields Session + one page tab', () => {
@@ -55,10 +62,12 @@ describe('groupDispatchesByTab', () => {
     ]
     const groups = groupDispatchesByTab(rows, [])
     expect(groups).toHaveLength(2)
-    expect(groups[0]!.id).toBe('session')
-    expect(groups[0]!.dispatchCount).toBe(2)
-    expect(groups[1]!.id).toBe('page-7')
-    expect(groups[1]!.label).toBe('Tab 1')
+    const session = expectDefined(groups[0])
+    const page = expectDefined(groups[1])
+    expect(session.id).toBe('session')
+    expect(session.dispatchCount).toBe(2)
+    expect(page.id).toBe('page-7')
+    expect(page.label).toBe('Tab 1')
   })
 
   it('page tabs are labelled sequentially by first-appearance order (Tab 1, Tab 2, ...) not by raw pageId', () => {
@@ -86,7 +95,7 @@ describe('groupDispatchesByTab', () => {
       dispatch(5, 3),
     ]
     const groups = groupDispatchesByTab(rows, [])
-    const session = groups.find((g) => g.id === 'session')!
+    const session = expectDefined(groups.find((g) => g.id === 'session'))
     expect(session.dispatchCount).toBe(5)
     expect(session.dispatches.map((d) => d.id)).toEqual([1, 2, 3, 4, 5])
   })
@@ -100,7 +109,7 @@ describe('groupDispatchesByTab', () => {
       dispatch(5, 7),
     ]
     const groups = groupDispatchesByTab(rows, [1, 3, 5])
-    const session = groups.find((g) => g.id === 'session')!
+    const session = expectDefined(groups.find((g) => g.id === 'session'))
     expect(session.screenshotDispatchIds).toEqual([1, 3, 5])
   })
 
@@ -113,9 +122,8 @@ describe('groupDispatchesByTab', () => {
       dispatch(5, null),
     ]
     const groups = groupDispatchesByTab(rows, [])
-    expect(
-      groups.find((g) => g.id === 'page-5')!.dispatches.map((d) => d.id),
-    ).toEqual([1, 3, 4])
+    const page = expectDefined(groups.find((g) => g.id === 'page-5'))
+    expect(page.dispatches.map((d) => d.id)).toEqual([1, 3, 4])
   })
 
   it('per-page displayUrl uses the LAST non-null url observed in that group', () => {
@@ -125,14 +133,18 @@ describe('groupDispatchesByTab', () => {
       dispatch(3, 7, { url: 'https://latest.example/', title: 'Latest' }),
       dispatch(4, 7, { url: null, title: null }),
     ]
-    const g = groupDispatchesByTab(rows, []).find((x) => x.id === 'page-7')!
+    const g = expectDefined(
+      groupDispatchesByTab(rows, []).find((x) => x.id === 'page-7'),
+    )
     expect(g.displayUrl).toBe('https://latest.example/')
     expect(g.displayTitle).toBe('Latest')
   })
 
   it('per-page displayUrl is null when every url in the group is null', () => {
     const rows = [dispatch(1, 9), dispatch(2, 9)]
-    const g = groupDispatchesByTab(rows, []).find((x) => x.id === 'page-9')!
+    const g = expectDefined(
+      groupDispatchesByTab(rows, []).find((x) => x.id === 'page-9'),
+    )
     expect(g.displayUrl).toBeNull()
     expect(g.displayTitle).toBeNull()
   })
@@ -149,7 +161,9 @@ describe('groupDispatchesByTab', () => {
       dispatch(2, 7, { url: 'https://new.example/', title: null }),
       dispatch(3, 7, { url: 'https://new.example/', title: 'New title' }),
     ]
-    const g = groupDispatchesByTab(rows, []).find((x) => x.id === 'page-7')!
+    const g = expectDefined(
+      groupDispatchesByTab(rows, []).find((x) => x.id === 'page-7'),
+    )
     expect(g.displayUrl).toBe('https://new.example/')
     expect(g.displayTitle).toBe('New title')
   })
@@ -161,7 +175,9 @@ describe('groupDispatchesByTab', () => {
       dispatch(1, 3, { url: null, title: 'Only title' }),
       dispatch(2, 3, { url: 'https://only-url.example/', title: null }),
     ]
-    const g = groupDispatchesByTab(rows, []).find((x) => x.id === 'page-3')!
+    const g = expectDefined(
+      groupDispatchesByTab(rows, []).find((x) => x.id === 'page-3'),
+    )
     expect(g.displayUrl).toBe('https://only-url.example/')
     expect(g.displayTitle).toBe('Only title')
   })
@@ -174,14 +190,11 @@ describe('groupDispatchesByTab', () => {
       dispatch(4, 7),
       dispatch(5, 7),
     ]
-    // Assume screenshots exist for ids 1, 3, 5 (mixed groups).
     const groups = groupDispatchesByTab(rows, [1, 3, 5])
-    expect(
-      groups.find((g) => g.id === 'page-3')!.screenshotDispatchIds,
-    ).toEqual([3])
-    expect(
-      groups.find((g) => g.id === 'page-7')!.screenshotDispatchIds,
-    ).toEqual([5])
+    const page3 = expectDefined(groups.find((g) => g.id === 'page-3'))
+    const page7 = expectDefined(groups.find((g) => g.id === 'page-7'))
+    expect(page3.screenshotDispatchIds).toEqual([3])
+    expect(page7.screenshotDispatchIds).toEqual([5])
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.ts
@@ -33,52 +33,28 @@ export interface TabGroup {
   screenshotDispatchIds: number[]
 }
 
-/**
- * Groups a task's dispatch stream into a leftmost "Session"
- * overview bucket plus one bucket per distinct `pageId`.
- *
- * The Session bucket is the task-level overview: it contains
- * EVERY dispatch and EVERY screenshot, so the operator can see
- * the whole task at a glance without picking a specific tab.
- * Each per-page bucket contains only the dispatches + screenshots
- * scoped to that tab.
- *
- * Page tabs are labelled sequentially (`Tab 1`, `Tab 2`, ...) in
- * chronological order of first appearance. The underlying BrowserOS
- * pageId is intentionally not surfaced in the label: it is stable
- * across the extension's lifetime and can range into the hundreds,
- * which reads as noise.
- *
- * Complexity: O(N) over dispatches, one pass. Callers should
- * memoise per task-detail response.
- */
+/** Groups task dispatches into a session overview and first-seen page buckets for task detail. */
 export function groupDispatchesByTab(
   dispatches: ToolDispatchRow[],
   allScreenshotIds: readonly number[],
 ): TabGroup[] {
   const screenshotSet = new Set(allScreenshotIds)
   const buckets = new Map<number, ToolDispatchRow[]>()
-  // Preserve first-seen order for the sequential Tab numbering
-  // (agents typically open tabs in chronological order, so this
-  // matches the operator's mental narrative better than sorting
-  // by raw pageId).
-  const pageOrder: number[] = []
+  const pageBuckets: Array<[number, ToolDispatchRow[]]> = []
   for (const d of dispatches) {
     if (d.pageId === null) continue
     const arr = buckets.get(d.pageId)
     if (arr) {
       arr.push(d)
     } else {
-      buckets.set(d.pageId, [d])
-      pageOrder.push(d.pageId)
+      const rows = [d]
+      buckets.set(d.pageId, rows)
+      pageBuckets.push([d.pageId, rows])
     }
   }
 
   const groups: TabGroup[] = []
 
-  // Session overview: EVERY dispatch and EVERY screenshot. This is
-  // the default view when the operator opens the task and does not
-  // yet know which tab they want to drill into.
   if (dispatches.length > 0) {
     groups.push({
       id: 'session',
@@ -94,17 +70,8 @@ export function groupDispatchesByTab(
     })
   }
 
-  // Per-page buckets, numbered by first-appearance order.
-  pageOrder.forEach((pageId, idx) => {
-    const rows = buckets.get(pageId)!
-    // Prefer a dispatch that carries url + title TOGETHER so the
-    // tab header shows a consistent (url, title) pair from a
-    // single moment in time. If no such paired dispatch exists in
-    // this tab, fall back to the last individual non-null values
-    // independently. The edge case: mid-navigation dispatches may
-    // have a url but null title (or vice versa); without this
-    // guard the header could show a stale title alongside a fresh
-    // url.
+  pageBuckets.forEach(([pageId, rows], idx) => {
+    // Prefer a paired title/url snapshot to avoid showing a stale title beside a fresh URL.
     const reversed = [...rows].reverse()
     const lastPaired = reversed.find((d) => d.url !== null && d.title !== null)
     const lastWithUrl = lastPaired ?? reversed.find((d) => d.url !== null)
@@ -126,13 +93,7 @@ export function groupDispatchesByTab(
   return groups
 }
 
-/**
- * Picks which tab should be selected first. Prefers the Session
- * overview so the operator sees the task-wide screenshot strip
- * and timeline on entry; page tabs are drill-downs. Falls back to
- * the first available id when Session is absent (e.g. an empty
- * task).
- */
+/** Selects the session overview when available so task detail opens at the task-wide timeline. */
 export function pickDefaultTabId(groups: TabGroup[]): string | undefined {
   const session = groups.find((g) => g.id === 'session')
   return session?.id ?? groups[0]?.id

--- a/packages/browseros-agent/biome.json
+++ b/packages/browseros-agent/biome.json
@@ -7,7 +7,12 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!**/apps/eval/src/dashboard/index.html", "!**/*.svg"]
+    "includes": [
+      "**",
+      "!.scripts",
+      "!**/apps/eval/src/dashboard/index.html",
+      "!**/*.svg"
+    ]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Ignore local `.scripts` scratch files in BrowserOS agent checks via Biome `files.includes` pattern `!.scripts`.
- Ignore local `.scripts` scratch files in Fallow via `.fallowrc.json` `ignorePatterns` pattern `.scripts/**`, using the Context7-confirmed Fallow config key.
- Remove the stale Biome suppression in `apps/app/codegen.ts`.
- Remove task-detail helper/test non-null assertions without weakening assertions.

## Verification
- `bun run check` from `packages/browseros-agent`
- `bun test apps/claw-app/screens/task-detail/task-detail.helpers.test.ts` from `packages/browseros-agent`
