### PR TITLE
feat(claw-app): upload onboarding video to R2

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.tsx
@@ -2,85 +2,24 @@
  * @license
  * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * Renders the ~20-second cockpit first-run motion demo. Ships as a
- * native `<video autoplay muted loop playsinline>` that streams
- * from a versioned GitHub Release asset. Chromium always allows
- * muted autoplay without a user gesture. Reduced-motion readers see
- * the poster PNG (rendered from frame 0 of the composition).
- *
- * ─── how the video URL got here ────────────────────────────────
- *
- * The MP4 + poster are NOT tracked in git. They live as release
- * artefacts of the source composition, which is versioned in
- * `packages/browseros-agent/packages/onboarding-video/`. That
- * indirection keeps the extension bundle small (~250 KB gz saved)
- * and the repo history clean (no blob per render).
- *
- * To bump the video:
- *
- *   1. Edit the composition source in `packages/onboarding-video/`.
- *
- *   2. Render locally:
- *        cd packages/browseros-agent/packages/onboarding-video
- *        bun run render          # writes out/first-run-demo.mp4
- *        bun run render:poster   # writes out/first-run-demo-poster.png
- *
- *   3. Publish as a new GitHub Release. Never reuse an existing tag
- *      (Chromium caches these URLs aggressively; a new tag is the
- *      only reliable cache-buster):
- *        VERSION=v0.2.0
- *        gh release create onboarding-video/$VERSION \
- *          --repo browseros-ai/BrowserOS \
- *          --target <branch-that-has-the-source> \
- *          --prerelease \
- *          --title "Onboarding video $VERSION (preview)" \
- *          --notes "One-line summary of what changed." \
- *          packages/browseros-agent/packages/onboarding-video/out/first-run-demo.mp4 \
- *          packages/browseros-agent/packages/onboarding-video/out/first-run-demo-poster.png
- *
- *   4. Update the two `RELEASE_*` constants below to point at the
- *      new tag and commit.
- *
- * The GitHub Releases CDN sets
- *   `Cache-Control: public, max-age=31536000, immutable`
- * on release-download URLs, so the browser fetches each URL exactly
- * once per client and reuses the local copy for a year. That is
- * why a URL bump requires cutting a new tag, not overwriting the
- * existing asset in place. Overwriting leaves clients staring at
- * the cached old version until they hard-reload.
- *
- * ─── why not just curl on setup ────────────────────────────────
- *
- * The alternative pattern of `bun run video:fetch` pulling into
- * `public/onboarding/` at setup time was tried and dropped. Fetching
- * at runtime removes an extra build step, keeps the repo bundle
- * lean, and the browser cache does the heavy lifting once the first
- * visitor loads it.
  */
 
 import { useEffect, useRef, useState } from 'react'
 
-const RELEASE_TAG = 'onboarding-video/v0.1.0'
-const RELEASE_BASE = `https://github.com/browseros-ai/BrowserOS/releases/download/${RELEASE_TAG}`
-const VIDEO_SRC = `${RELEASE_BASE}/first-run-demo.mp4`
-const POSTER_SRC = `${RELEASE_BASE}/first-run-demo-poster.png`
+const CDN_BASE_URL = 'https://cdn.browseros.com'
+const ASSET_VERSION = '0.1.0'
+const ASSET_BASE = `${CDN_BASE_URL}/artifacts/claw/onboarding-video/v${ASSET_VERSION}`
+const VIDEO_SRC = `${ASSET_BASE}/first-run-demo.mp4`
+const POSTER_SRC = `${ASSET_BASE}/first-run-demo-poster.png`
 
 export function FirstRunVideo() {
   const reducedMotion = usePrefersReducedMotion()
   const ref = useRef<HTMLVideoElement>(null)
   useEffect(() => {
     if (reducedMotion) return
-    // Muted + autoplay is allowed everywhere, but tab throttling or
-    // an unlucky race between mount and the first-byte of the video
-    // stream can leave the element paused. Kick play() explicitly
-    // to close the gap.
     const el = ref.current
     if (!el) return
-    void el.play().catch(() => {
-      // Blocked or errored; the poster stays visible until the
-      // reader interacts. Extremely rare in practice.
-    })
+    void el.play().catch(() => undefined)
   }, [reducedMotion])
   if (reducedMotion) {
     return (

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
@@ -1,12 +1,8 @@
-/** Pins the Claw homepage's hero, running grid, and recent activity sections. */
-
 import { describe, expect, it, mock } from 'bun:test'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router'
 
-// Stub the data hook so the test does not need a network mock or
-// real polling. The shape mirrors the v2 CockpitData interface.
 mock.module('./cockpit.data', () => ({
   useCockpitData: () => ({
     agents: [],
@@ -15,8 +11,6 @@ mock.module('./cockpit.data', () => ({
   }),
 }))
 
-// RecentActivity now consumes useTasks directly. Stub it to return an
-// empty page so the empty-state branch renders.
 mock.module('@/modules/api/audit.hooks', () => ({
   useTasks: () => ({
     data: { pages: [{ tasks: [], nextCursor: null }] },
@@ -24,6 +18,12 @@ mock.module('@/modules/api/audit.hooks', () => ({
   }),
   taskScreenshotUrl: (id: number) => `/audit/screenshot/${id}`,
   useTaskScreenshotBaseUrl: () => null,
+}))
+
+mock.module('@/modules/api/connections.hooks', () => ({
+  useBrowserosConnections: () => ({
+    data: { connections: [] },
+  }),
 }))
 
 const { Cockpit } = await import('./Cockpit')
@@ -42,11 +42,12 @@ function renderApp(): string {
 }
 
 describe('Cockpit (v2)', () => {
-  it('renders the hero and activity header (running grid hides when no agents)', () => {
+  it('renders the first-run hero and hides the running grid when no agents exist', () => {
     const html = renderApp()
-    expect(html).toContain('working on')
-    expect(html).toContain('Recent activity')
-    // No agents in the stub data means RunningGrid returns null.
+    expect(html).toContain('You watch. Your agent')
+    expect(html).toContain(
+      'https://cdn.browseros.com/artifacts/claw/onboarding-video/v0.1.0/first-run-demo.mp4',
+    )
     expect(html).not.toContain('Running now')
   })
 
@@ -56,10 +57,13 @@ describe('Cockpit (v2)', () => {
     expect(html).not.toContain('harness . logins . guardrails')
   })
 
-  it('shows only the recent-activity empty state when registry is empty (Running now hides)', () => {
+  it('shows the first-run shell when there are no connections or runs', () => {
     const html = renderApp()
     expect(html).not.toContain('No agents connected')
     expect(html).not.toContain('Running now')
-    expect(html).toContain('No recent activity')
+    expect(html).toContain('Set up MCP endpoint')
+    expect(html).toContain(
+      'Use BrowserClaw. Book me the cheapest morning flight',
+    )
   })
 })

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -338,7 +338,7 @@
     },
     "packages/onboarding-video": {
       "name": "@browseros/onboarding-video",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -52,6 +52,7 @@
     "build:agent:dev": "FORCE_COLOR=1 bun run --filter @browseros/app --elide-lines=0 build:dev",
     "build:agent": "bun run codegen:agent && bun run --filter @browseros/app build",
     "codegen:agent": "bun run --filter @browseros/app codegen",
+    "upload:onboarding-video": "FORCE_COLOR=1 bun scripts/build/upload-onboarding-video.ts",
     "test": "bun run test:all",
     "test:all": "bun run ./scripts/run-test-suite.ts all",
     "test:fixtures": "bun apps/server/tests/__fixtures__/browser-fixtures/serve.ts",

--- a/packages/browseros-agent/packages/onboarding-video/package.json
+++ b/packages/browseros-agent/packages/onboarding-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/onboarding-video",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "description": "Remotion compositions for BrowserClaw cockpit first-run motion demo. Shared by claw-app (runtime via @remotion/player) and a future offline render pipeline (webm output).",

--- a/packages/browseros-agent/scripts/build/upload-onboarding-video.test.ts
+++ b/packages/browseros-agent/scripts/build/upload-onboarding-video.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  buildOnboardingVideoUploadPlan,
+  parseOnboardingVideoUploadArgs,
+  validateOnboardingVideoInputs,
+} from './upload-onboarding-video'
+
+describe('onboarding video upload', () => {
+  let tempRoot: string | null = null
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true })
+      tempRoot = null
+    }
+  })
+
+  test('builds versioned R2 keys and CDN URLs', () => {
+    const rootDir = writeOnboardingVideoRoot('0.1.0')
+    writeRenderOutput(rootDir, 'first-run-demo.mp4')
+    writeRenderOutput(rootDir, 'first-run-demo-poster.png')
+
+    const plan = buildOnboardingVideoUploadPlan(rootDir)
+
+    expect(plan).toEqual({
+      version: '0.1.0',
+      assets: [
+        {
+          filename: 'first-run-demo.mp4',
+          relativePath: 'packages/onboarding-video/out/first-run-demo.mp4',
+          absolutePath: join(
+            rootDir,
+            'packages/onboarding-video/out/first-run-demo.mp4',
+          ),
+          contentType: 'video/mp4',
+          key: 'artifacts/claw/onboarding-video/v0.1.0/first-run-demo.mp4',
+          url: 'https://cdn.browseros.com/artifacts/claw/onboarding-video/v0.1.0/first-run-demo.mp4',
+          renderCommand: 'bun run --cwd packages/onboarding-video render',
+        },
+        {
+          filename: 'first-run-demo-poster.png',
+          relativePath:
+            'packages/onboarding-video/out/first-run-demo-poster.png',
+          absolutePath: join(
+            rootDir,
+            'packages/onboarding-video/out/first-run-demo-poster.png',
+          ),
+          contentType: 'image/png',
+          key: 'artifacts/claw/onboarding-video/v0.1.0/first-run-demo-poster.png',
+          url: 'https://cdn.browseros.com/artifacts/claw/onboarding-video/v0.1.0/first-run-demo-poster.png',
+          renderCommand:
+            'bun run --cwd packages/onboarding-video render:poster',
+        },
+      ],
+    })
+    expect(() => validateOnboardingVideoInputs(plan)).not.toThrow()
+  })
+
+  test('reports missing renders with exact render commands', () => {
+    const rootDir = writeOnboardingVideoRoot('0.1.0')
+    writeRenderOutput(rootDir, 'first-run-demo.mp4')
+    const plan = buildOnboardingVideoUploadPlan(rootDir)
+
+    expect(() => validateOnboardingVideoInputs(plan)).toThrow(
+      [
+        'Missing onboarding video render output:',
+        '- packages/onboarding-video/out/first-run-demo-poster.png',
+        '',
+        'Render the missing assets first:',
+        '  bun run --cwd packages/onboarding-video render:poster',
+      ].join('\n'),
+    )
+  })
+
+  test('parses dry-run and force flags', () => {
+    expect(
+      parseOnboardingVideoUploadArgs(['--', '--dry-run', '--force']),
+    ).toEqual({
+      dryRun: true,
+      force: true,
+    })
+    expect(() => parseOnboardingVideoUploadArgs(['--unknown'])).toThrow(
+      'Unknown option: --unknown',
+    )
+  })
+
+  function writeOnboardingVideoRoot(version: string): string {
+    tempRoot = mkdtempSync(join(tmpdir(), 'onboarding-video-upload-'))
+    const packageDir = join(tempRoot, 'packages/onboarding-video')
+    mkdirSync(packageDir, { recursive: true })
+    writeFileSync(
+      join(packageDir, 'package.json'),
+      `${JSON.stringify({ version })}\n`,
+    )
+    return tempRoot
+  }
+})
+
+function writeRenderOutput(rootDir: string, filename: string): void {
+  const outDir = join(rootDir, 'packages/onboarding-video/out')
+  mkdirSync(outDir, { recursive: true })
+  writeFileSync(join(outDir, filename), 'stub')
+}

--- a/packages/browseros-agent/scripts/build/upload-onboarding-video.ts
+++ b/packages/browseros-agent/scripts/build/upload-onboarding-video.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env bun
+
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { HeadObjectCommand, type S3Client } from '@aws-sdk/client-s3'
+import {
+  createR2Client,
+  joinObjectKey,
+  type R2Config,
+  uploadFileToObject,
+} from '@browseros/build-server-tools'
+import { parse } from 'dotenv'
+
+import { log } from './log'
+
+const CDN_BASE_URL = 'https://cdn.browseros.com'
+const PROD_ENV_PATH = join('apps', 'server', '.env.production')
+const UPLOAD_PREFIX = 'artifacts/claw/onboarding-video'
+const PACKAGE_DIR = join('packages', 'onboarding-video')
+const OUT_DIR = join(PACKAGE_DIR, 'out')
+
+const ONBOARDING_VIDEO_ASSETS = [
+  {
+    filename: 'first-run-demo.mp4',
+    contentType: 'video/mp4',
+    renderCommand: 'bun run --cwd packages/onboarding-video render',
+  },
+  {
+    filename: 'first-run-demo-poster.png',
+    contentType: 'image/png',
+    renderCommand: 'bun run --cwd packages/onboarding-video render:poster',
+  },
+] as const
+
+export interface OnboardingVideoUploadOptions {
+  dryRun?: boolean
+  force?: boolean
+}
+
+export interface OnboardingVideoAssetPlan {
+  filename: string
+  relativePath: string
+  absolutePath: string
+  contentType: string
+  key: string
+  url: string
+  renderCommand: string
+}
+
+export interface OnboardingVideoUploadPlan {
+  version: string
+  assets: OnboardingVideoAssetPlan[]
+}
+
+function resolveRootDir(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+}
+
+function readPackageVersion(rootDir: string): string {
+  const packagePath = join(rootDir, PACKAGE_DIR, 'package.json')
+  const pkg = JSON.parse(readFileSync(packagePath, 'utf-8')) as {
+    version?: string
+  }
+  if (!pkg.version) {
+    throw new Error(`${PACKAGE_DIR}/package.json is missing a version`)
+  }
+  return pkg.version
+}
+
+/** Builds the immutable R2 keys and public CDN URLs for one onboarding-video version. */
+export function buildOnboardingVideoUploadPlan(
+  rootDir: string,
+): OnboardingVideoUploadPlan {
+  const version = readPackageVersion(rootDir)
+  const assets = ONBOARDING_VIDEO_ASSETS.map((asset) => {
+    const relativePath = join(OUT_DIR, asset.filename)
+    const key = joinObjectKey(UPLOAD_PREFIX, `v${version}`, asset.filename)
+    return {
+      filename: asset.filename,
+      relativePath,
+      absolutePath: join(rootDir, relativePath),
+      contentType: asset.contentType,
+      key,
+      url: `${CDN_BASE_URL}/${key}`,
+      renderCommand: asset.renderCommand,
+    }
+  })
+
+  return { version, assets }
+}
+
+export function validateOnboardingVideoInputs(
+  plan: OnboardingVideoUploadPlan,
+): void {
+  const missingAssets = plan.assets.filter(
+    (asset) => !existsSync(asset.absolutePath),
+  )
+  if (missingAssets.length === 0) {
+    return
+  }
+
+  const renderCommands = [
+    ...new Set(missingAssets.map((asset) => asset.renderCommand)),
+  ]
+  throw new Error(
+    [
+      'Missing onboarding video render output:',
+      ...missingAssets.map((asset) => `- ${asset.relativePath}`),
+      '',
+      'Render the missing assets first:',
+      ...renderCommands.map((command) => `  ${command}`),
+    ].join('\n'),
+  )
+}
+
+function pickEnv(name: string, fileEnv: Record<string, string>): string {
+  const value = process.env[name] ?? fileEnv[name]
+  if (!value || value.trim().length === 0) {
+    throw new Error(
+      `Missing required environment variable: ${name} (set it in process env or ${PROD_ENV_PATH})`,
+    )
+  }
+  return value
+}
+
+function loadProdEnv(rootDir: string): Record<string, string> {
+  const prodEnvPath = join(rootDir, PROD_ENV_PATH)
+  if (!existsSync(prodEnvPath)) {
+    return {}
+  }
+  return parse(readFileSync(prodEnvPath, 'utf-8'))
+}
+
+function loadR2Config(rootDir: string): R2Config {
+  const fileEnv = loadProdEnv(rootDir)
+  return {
+    accountId: pickEnv('R2_ACCOUNT_ID', fileEnv),
+    accessKeyId: pickEnv('R2_ACCESS_KEY_ID', fileEnv),
+    secretAccessKey: pickEnv('R2_SECRET_ACCESS_KEY', fileEnv),
+    bucket: pickEnv('R2_BUCKET', fileEnv),
+    downloadPrefix: '',
+    uploadPrefix: UPLOAD_PREFIX,
+  }
+}
+
+export function parseOnboardingVideoUploadArgs(
+  argv: string[],
+): OnboardingVideoUploadOptions {
+  const options: OnboardingVideoUploadOptions = {}
+  for (const arg of argv) {
+    if (arg === '--') {
+      continue
+    }
+    if (arg === '--dry-run') {
+      options.dryRun = true
+    } else if (arg === '--force') {
+      options.force = true
+    } else {
+      throw new Error(`Unknown option: ${arg}`)
+    }
+  }
+  return options
+}
+
+function isMissingObjectError(error: unknown): boolean {
+  const candidate = error as {
+    name?: string
+    $metadata?: { httpStatusCode?: number }
+  }
+  return (
+    candidate.name === 'NotFound' || candidate.$metadata?.httpStatusCode === 404
+  )
+}
+
+async function objectExists(
+  client: S3Client,
+  r2: R2Config,
+  key: string,
+): Promise<boolean> {
+  try {
+    await client.send(
+      new HeadObjectCommand({
+        Bucket: r2.bucket,
+        Key: key,
+      }),
+    )
+    return true
+  } catch (error) {
+    if (isMissingObjectError(error)) {
+      return false
+    }
+    throw error
+  }
+}
+
+async function assertObjectsDoNotExist(
+  client: S3Client,
+  r2: R2Config,
+  plan: OnboardingVideoUploadPlan,
+): Promise<void> {
+  const existingKeys: string[] = []
+  for (const asset of plan.assets) {
+    log.step(`Checking ${asset.key}`)
+    if (await objectExists(client, r2, asset.key)) {
+      existingKeys.push(asset.key)
+    }
+  }
+
+  if (existingKeys.length > 0) {
+    throw new Error(
+      [
+        'R2 object already exists:',
+        ...existingKeys.map((key) => `- ${key}`),
+        '',
+        'Please bump the package version in packages/onboarding-video/package.json, or rerun with --force to overwrite intentionally.',
+      ].join('\n'),
+    )
+  }
+}
+
+function printPlan(plan: OnboardingVideoUploadPlan): void {
+  for (const asset of plan.assets) {
+    log.info(asset.key)
+    log.info(asset.url)
+  }
+}
+
+/** Uploads the rendered first-run demo video assets to immutable R2/CDN keys. */
+export async function runOnboardingVideoUpload(
+  rootDir: string,
+  options: OnboardingVideoUploadOptions = {},
+): Promise<void> {
+  const plan = buildOnboardingVideoUploadPlan(rootDir)
+  validateOnboardingVideoInputs(plan)
+
+  log.header(`BrowserClaw onboarding video v${plan.version}`)
+  printPlan(plan)
+
+  if (options.dryRun) {
+    log.done('Onboarding video upload dry run completed')
+    return
+  }
+
+  const r2 = loadR2Config(rootDir)
+  const client = createR2Client(r2)
+  try {
+    if (options.force) {
+      log.warn('Skipping existing-object guard because --force was supplied')
+    } else {
+      await assertObjectsDoNotExist(client, r2, plan)
+    }
+
+    for (const asset of plan.assets) {
+      log.step(`Uploading ${asset.relativePath}`)
+      await uploadFileToObject(client, r2, asset.key, asset.absolutePath, {
+        contentType: asset.contentType,
+      })
+      log.success(`Uploaded ${asset.key}`)
+      log.info(asset.url)
+    }
+  } finally {
+    client.destroy()
+  }
+
+  log.done('Onboarding video upload completed')
+}
+
+async function main(): Promise<void> {
+  const rootDir = resolveRootDir()
+  const options = parseOnboardingVideoUploadArgs(process.argv.slice(2))
+  await runOnboardingVideoUpload(rootDir, options)
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`\n✗ ${message}\n`)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- Add `bun run upload:onboarding-video` for the Remotion first-run MP4 and poster.
- Upload plan uses immutable R2 keys under `artifacts/claw/onboarding-video/v0.1.0/` and refuses existing keys unless `--force` is supplied.
- Point `FirstRunVideo` at the BrowserOS CDN instead of GitHub Releases.

## R2/CDN asset version
Version: `0.1.0`

Keys:
- `artifacts/claw/onboarding-video/v0.1.0/first-run-demo.mp4`
- `artifacts/claw/onboarding-video/v0.1.0/first-run-demo-poster.png`

CDN URLs:
- `https://cdn.browseros.com/artifacts/claw/onboarding-video/v0.1.0/first-run-demo.mp4`
- `https://cdn.browseros.com/artifacts/claw/onboarding-video/v0.1.0/first-run-demo-poster.png`

## Manual upload
No R2 upload was performed by this agent. To publish after renders are generated:

```sh
bun run --cwd packages/onboarding-video render
bun run --cwd packages/onboarding-video render:poster
bun run upload:onboarding-video
```

Use `bun run upload:onboarding-video --dry-run` to preview keys/URLs. Use `--force` only for an intentional repair overwrite.

## Tests
- `bun test scripts/build/upload-onboarding-video.test.ts`
- `bun run ./scripts/run-bun-test.ts ./scripts/build`
- `bun run upload:onboarding-video` (missing-render path)
- `bun run upload:onboarding-video -- --dry-run` (with temporary stub outputs, removed afterwards)
- `bun run check`
- `bun run test`
