### PR TITLE
fix(bos_build): always stage both products' server resources

### DIFF
--- a/packages/browseros/bos_build/config/copy_resources.yaml
+++ b/packages/browseros/bos_build/config/copy_resources.yaml
@@ -192,7 +192,6 @@ copy_operations:
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
     type: "directory"
-    product: "browserclaw"
     os: ["macos"]
     arch: ["arm64"]
 
@@ -204,7 +203,6 @@ copy_operations:
   #     - from: "bin/browseros-claw-server-rs"
   #       to: "bin/browseros-claw-server"
   #   type: "directory"
-  #   product: "browserclaw"
   #   os: ["macos"]
   #   arch: ["arm64"]
 
@@ -213,7 +211,6 @@ copy_operations:
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
     type: "directory"
-    product: "browserclaw"
     os: ["macos"]
     arch: ["x64"]
 
@@ -225,7 +222,6 @@ copy_operations:
   #     - from: "bin/browseros-claw-server-rs"
   #       to: "bin/browseros-claw-server"
   #   type: "directory"
-  #   product: "browserclaw"
   #   os: ["macos"]
   #   arch: ["x64"]
 
@@ -234,7 +230,6 @@ copy_operations:
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
     type: "directory"
-    product: "browserclaw"
     os: ["linux"]
     arch: ["arm64"]
 
@@ -246,7 +241,6 @@ copy_operations:
   #     - from: "bin/browseros-claw-server-rs"
   #       to: "bin/browseros-claw-server"
   #   type: "directory"
-  #   product: "browserclaw"
   #   os: ["linux"]
   #   arch: ["arm64"]
 
@@ -255,7 +249,6 @@ copy_operations:
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
     type: "directory"
-    product: "browserclaw"
     os: ["linux"]
     arch: ["x64"]
 
@@ -267,7 +260,6 @@ copy_operations:
   #     - from: "bin/browseros-claw-server-rs"
   #       to: "bin/browseros-claw-server"
   #   type: "directory"
-  #   product: "browserclaw"
   #   os: ["linux"]
   #   arch: ["x64"]
 
@@ -276,7 +268,6 @@ copy_operations:
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
     type: "directory"
-    product: "browserclaw"
     os: ["windows"]
     arch: ["x64"]
 
@@ -288,7 +279,6 @@ copy_operations:
   #     - from: "bin/browseros-claw-server-rs.exe"
   #       to: "bin/browseros-claw-server.exe"
   #   type: "directory"
-  #   product: "browserclaw"
   #   os: ["windows"]
   #   arch: ["x64"]
 

--- a/packages/browseros/bos_build/steps/resources/resources_test.py
+++ b/packages/browseros/bos_build/steps/resources/resources_test.py
@@ -241,7 +241,7 @@ class CopyResourcesTest(unittest.TestCase):
 
         self.assertFalse((self.chromium.src / "chrome" / "ghost").exists())
 
-    def test_real_config_copies_server_resources_for_browseros_product(self):
+    def test_real_config_copies_both_server_resources_for_browseros_product(self):
         self.root.write_copy_config(self._real_copy_config())
         browseros_source = (
             self.root.root
@@ -319,7 +319,7 @@ class CopyResourcesTest(unittest.TestCase):
             / "browseros-claw-server-rs"
         )
         self.assertEqual(browseros_dest.read_text(), "browseros")
-        self.assertFalse(claw_dest.exists())
+        self.assertEqual(claw_dest.read_text(), "claw")
         self.assertFalse(claw_rust_dest.exists())
 
     def test_real_config_copies_bun_server_resources_for_browserclaw_by_default(
@@ -453,6 +453,21 @@ class CopyResourcesTest(unittest.TestCase):
             "BrowserOS Claw Rust Server Resources - macOS ARM64",
             active_names,
         )
+        self.assertNotIn('#   product: "browserclaw"', text)
+
+    def test_real_config_keeps_active_server_copy_resources_ungated(self):
+        config = self._real_copy_config()
+        server_ops = [
+            op
+            for op in config["copy_operations"]
+            if op["name"].startswith("BrowserOS Server Resources")
+            or op["name"].startswith("BrowserOS Claw Server Resources")
+        ]
+
+        self.assertTrue(server_ops)
+        for op in server_ops:
+            with self.subTest(name=op["name"]):
+                self.assertNotIn("product", op)
 
     def test_real_config_copies_claw_onboard_resources_for_both_products(self):
         # The downloaded onboarding dist must land in the grit resources dir

--- a/packages/browseros/bos_build/steps/storage/download_test.py
+++ b/packages/browseros/bos_build/steps/storage/download_test.py
@@ -378,6 +378,20 @@ class DownloadResourceConfigTest(unittest.TestCase):
             ],
         )
 
+    def test_real_config_keeps_active_server_downloads_ungated(self) -> None:
+        operations = self._real_download_operations()
+        server_ops = [
+            op
+            for op in operations
+            if op["name"].startswith("BrowserOS Server Resources")
+            or op["name"].startswith("BrowserOS Claw Server Resources")
+        ]
+
+        self.assertTrue(server_ops)
+        for op in server_ops:
+            with self.subTest(name=op["name"]):
+                self.assertNotIn("product", op)
+
     def test_real_config_keeps_rust_claw_downloads_commented(self) -> None:
         config_path = (
             Path(__file__).resolve().parents[2] / "config" / "download_resources.yaml"


### PR DESCRIPTION
## Summary
- remove BrowserClaw server resource product gates from active copy config so every browser tree stages both active server resource roots
- keep branding/icon resources product-gated and leave the Rust server blocks as manual commented alternatives
- add regression tests that active server download/copy entries carry no product gate

## Verification
- `uv run python -m unittest discover -s bos_build -t . -p '*_test.py'` (655 tests)
- `uv run ruff check bos_build`
- `git diff --check`
- No workflow files touched, so actionlint was not applicable

## Repro Proof
- Before: the user's BrowserOS arm64 debug build failed scheduling with `chrome/browser/browseros/claw_server/resources` missing and no known rule to make it.
- Resource staging: with R2 env loaded from the release checkout's `.env`, ran `uv run browseros build --modules download_resources,resources --product browseros -t debug --arch arm64 --chromium-src /Users/shadowfax/code/chromium-release/src` from this worktree. It downloaded BrowserOS Server, BrowserOS Claw Server, and BrowserOS Claw Onboarding resources, then copied both `chrome/browser/browseros/server/resources` and `chrome/browser/browseros/claw_server/resources` for product `browseros`.
- Staged binary checks passed afterward: `chrome/browser/browseros/server/resources/bin/browseros_server` and `chrome/browser/browseros/claw_server/resources/bin/browseros-claw-server` both exist in `/Users/shadowfax/code/chromium-release/src`.
- After: generated a temporary `out/Default_devcheck_stage_both` with BrowserOS debug args (`browseros_package_all_server_resources = true`) and ran `autoninja -C out/Default_devcheck_stage_both -n chrome chromedriver`. Dry-run scheduling reached build edge emission (`build start: Ready 7647 Pending 71725`) with no missing-resource rule error. The devcheck out dir was removed afterward.

## Notes
- The Chromium GN wiring keeps release nightlies scoped: release args set `browseros_package_all_server_resources = false`, so release builds package only the selected product's server resources. No nightly workflow changes were needed.
