### PR TITLE
fix(onboarding-video): match claw-app type system, not serif fallback

### DIFF
--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -340,6 +340,7 @@
       "name": "@browseros/onboarding-video",
       "version": "0.0.1",
       "dependencies": {
+        "@remotion/google-fonts": "^4.0.400",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "remotion": "^4.0.400",
@@ -1359,6 +1360,8 @@
     "@remotion/compositor-linux-x64-musl": ["@remotion/compositor-linux-x64-musl@4.0.484", "", { "os": "linux", "cpu": "x64" }, "sha512-DnQxv3uh9xa7FBnWsmD93gwCUVaD9qk8cy9O7HyPDykvnCe2ejocNBjKswlr3W4HOcsnkmZQyZ4pvxKYZKwhfQ=="],
 
     "@remotion/compositor-win32-x64-msvc": ["@remotion/compositor-win32-x64-msvc@4.0.484", "", { "os": "win32", "cpu": "x64" }, "sha512-MxTN7uCZ5zD+X7TaaYfAR4ewtH9BZ7Wh5xS+oRJ72XbNHV/d+nULtOG3VdphFo/HhaPRzTYO9i/sZjogE+In/g=="],
+
+    "@remotion/google-fonts": ["@remotion/google-fonts@4.0.484", "", { "dependencies": { "remotion": "4.0.484" } }, "sha512-ZFq0pbchI/BkOuFDYKeuJI9OWHzwE8+7qyOEcK6AXih4ppfip9VKVrLscXptSZpyda2lszHXChAFSTavTJc/VQ=="],
 
     "@remotion/licensing": ["@remotion/licensing@4.0.484", "", {}, "sha512-YtiERD4bC3n5yQtNgEZasdZXqDKjIJssjKDLL+YjGDU3mMcw/93my83UU6jJVCB7TBrIms8DVbCgqt4hhU8kMA=="],
 

--- a/packages/browseros-agent/packages/onboarding-video/package.json
+++ b/packages/browseros-agent/packages/onboarding-video/package.json
@@ -18,6 +18,7 @@
     }
   },
   "dependencies": {
+    "@remotion/google-fonts": "^4.0.400",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "remotion": "^4.0.400"

--- a/packages/browseros-agent/packages/onboarding-video/src/FirstRunDemo.tsx
+++ b/packages/browseros-agent/packages/onboarding-video/src/FirstRunDemo.tsx
@@ -10,6 +10,7 @@
  */
 
 import { AbsoluteFill, Sequence } from 'remotion'
+import { fonts } from './fonts'
 import { palette } from './palette'
 import { SceneActivity } from './scenes/SceneActivity'
 import { SceneCockpit } from './scenes/SceneCockpit'
@@ -21,7 +22,9 @@ import { SCENES } from './timing'
 
 export function FirstRunDemo() {
   return (
-    <AbsoluteFill style={{ background: palette.bgCanvas }}>
+    <AbsoluteFill
+      style={{ background: palette.bgCanvas, fontFamily: fonts.sans }}
+    >
       <Sequence
         from={SCENES.cockpit.from}
         durationInFrames={SCENES.cockpit.duration}

--- a/packages/browseros-agent/packages/onboarding-video/src/components/AgentTerminal.tsx
+++ b/packages/browseros-agent/packages/onboarding-video/src/components/AgentTerminal.tsx
@@ -10,6 +10,7 @@
  */
 
 import type { CSSProperties } from 'react'
+import { fonts } from '../fonts'
 import { palette } from '../palette'
 
 interface AgentTerminalProps {
@@ -64,7 +65,7 @@ export function AgentTerminal({
             marginLeft: 12,
             color: '#8a92a8',
             fontSize: 11,
-            fontFamily: '"JetBrains Mono", monospace',
+            fontFamily: fonts.mono,
           }}
         >
           agent, claude-code
@@ -74,7 +75,7 @@ export function AgentTerminal({
         style={{
           flex: 1,
           padding: '22px 24px',
-          fontFamily: '"JetBrains Mono", monospace',
+          fontFamily: fonts.mono,
           fontSize: 14,
           lineHeight: 1.55,
           color: '#e0e4ee',

--- a/packages/browseros-agent/packages/onboarding-video/src/components/CockpitFrame.tsx
+++ b/packages/browseros-agent/packages/onboarding-video/src/components/CockpitFrame.tsx
@@ -11,6 +11,7 @@
  */
 
 import type { CSSProperties } from 'react'
+import { fonts } from '../fonts'
 import { palette } from '../palette'
 
 interface CockpitFrameProps {
@@ -208,7 +209,7 @@ function MainColumn({
             fontSize: 10,
             color: palette.ink3,
             letterSpacing: 2,
-            fontFamily: '"JetBrains Mono", monospace',
+            fontFamily: fonts.mono,
           }}
         >
           COCKPIT
@@ -258,7 +259,7 @@ function TableHeader() {
         fontSize: 10,
         color: palette.ink3,
         letterSpacing: 1.6,
-        fontFamily: '"JetBrains Mono", monospace',
+        fontFamily: fonts.mono,
         borderBottom: `1px solid ${palette.border2}`,
         paddingBottom: 8,
       }}

--- a/packages/browseros-agent/packages/onboarding-video/src/components/ConnectorPacket.tsx
+++ b/packages/browseros-agent/packages/onboarding-video/src/components/ConnectorPacket.tsx
@@ -11,6 +11,7 @@
  * `opacity` handles the outer fade-out at the end of the scene.
  */
 
+import { fonts } from '../fonts'
 import { palette } from '../palette'
 
 interface ConnectorPacketProps {
@@ -93,7 +94,7 @@ export function ConnectorPacket({
         <text
           x={52}
           y={25}
-          fontFamily='"JetBrains Mono", monospace'
+          fontFamily={fonts.mono}
           fontSize={17}
           fontWeight={800}
           letterSpacing={3}

--- a/packages/browseros-agent/packages/onboarding-video/src/components/SceneLabel.tsx
+++ b/packages/browseros-agent/packages/onboarding-video/src/components/SceneLabel.tsx
@@ -7,6 +7,7 @@
  * "where your work happens" and "you are here" style annotations.
  */
 
+import { fonts } from '../fonts'
 import { palette } from '../palette'
 
 interface SceneLabelProps {
@@ -28,7 +29,7 @@ export function SceneLabel({
         display: 'flex',
         alignItems: 'center',
         gap: 10,
-        fontFamily: '"JetBrains Mono", monospace',
+        fontFamily: fonts.mono,
         fontSize: 12,
         letterSpacing: 2,
         color: palette.ink3,

--- a/packages/browseros-agent/packages/onboarding-video/src/fonts.ts
+++ b/packages/browseros-agent/packages/onboarding-video/src/fonts.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Loads the claw-app type system into the render and exposes each
+ * family as a ready-to-use `fontFamily` stack. `loadFont()` blocks the
+ * render until the font is ready on its own, so importing this module
+ * once from the composition root is all the wiring needed — no manual
+ * `delayRender`/`continueRender`. Fonts are fetched only at render time
+ * (the shipped artefact is a baked MP4), never in the extension runtime.
+ *
+ * Families and fallbacks mirror apps/claw-app/entrypoints/newtab/styles.css:
+ *   --font-sans:  "Schibsted Grotesk Variable", system-ui, sans-serif
+ *   --font-serif: "Newsreader", Georgia, serif   (italic accent only)
+ *   --font-mono:  "JetBrains Mono Variable", ui-monospace, monospace
+ * Google Fonts serves Schibsted Grotesk / JetBrains Mono as the same
+ * typefaces the app self-hosts via fontsource; at the weights used the
+ * rendered output matches.
+ */
+
+import { loadFont as loadMono } from '@remotion/google-fonts/JetBrainsMono'
+import { loadFont as loadSerif } from '@remotion/google-fonts/Newsreader'
+import { loadFont as loadSans } from '@remotion/google-fonts/SchibstedGrotesk'
+
+const { fontFamily: sans } = loadSans('normal', {
+  weights: ['400', '500', '600', '700', '800', '900'],
+  subsets: ['latin'],
+})
+
+// Newsreader is used only for the italic serif accent ("Your agent works.").
+const { fontFamily: serif } = loadSerif('italic', {
+  weights: ['500'],
+  subsets: ['latin'],
+})
+
+const { fontFamily: mono } = loadMono('normal', {
+  weights: ['400', '800'],
+  subsets: ['latin'],
+})
+
+export const fonts = {
+  sans: `"${sans}", system-ui, sans-serif`,
+  serif: `"${serif}", Georgia, serif`,
+  mono: `"${mono}", ui-monospace, monospace`,
+} as const

--- a/packages/browseros-agent/packages/onboarding-video/src/index.ts
+++ b/packages/browseros-agent/packages/onboarding-video/src/index.ts
@@ -5,5 +5,6 @@
  */
 
 export { FirstRunDemo } from './FirstRunDemo'
+export { fonts } from './fonts'
 export { palette } from './palette'
 export { FPS, SCENES, TOTAL_FRAMES } from './timing'

--- a/packages/browseros-agent/packages/onboarding-video/src/scenes/SceneActivity.tsx
+++ b/packages/browseros-agent/packages/onboarding-video/src/scenes/SceneActivity.tsx
@@ -11,6 +11,7 @@
 
 import { AbsoluteFill, Easing, interpolate, useCurrentFrame } from 'remotion'
 import { CockpitFrame } from '../components/CockpitFrame'
+import { fonts } from '../fonts'
 import { palette } from '../palette'
 
 const SETTLE_END = 45
@@ -75,7 +76,7 @@ export function SceneActivity() {
         You watch.{' '}
         <span
           style={{
-            fontFamily: '"Newsreader", serif',
+            fontFamily: fonts.serif,
             fontStyle: 'italic',
             color: palette.accent,
             fontWeight: 500,

--- a/packages/browseros-agent/packages/onboarding-video/src/scenes/SceneInstallMcp.tsx
+++ b/packages/browseros-agent/packages/onboarding-video/src/scenes/SceneInstallMcp.tsx
@@ -16,6 +16,7 @@
 import { AbsoluteFill, Easing, interpolate, useCurrentFrame } from 'remotion'
 import { CockpitFrame } from '../components/CockpitFrame'
 import { SceneLabel } from '../components/SceneLabel'
+import { fonts } from '../fonts'
 import { palette } from '../palette'
 
 const EASE_OUT = Easing.bezier(0.16, 1, 0.3, 1)
@@ -105,7 +106,7 @@ function EndpointCard({
     >
       <div
         style={{
-          fontFamily: '"JetBrains Mono", monospace',
+          fontFamily: fonts.mono,
           fontSize: 10,
           letterSpacing: 1.6,
           color: palette.ink3,
@@ -115,7 +116,7 @@ function EndpointCard({
       </div>
       <div
         style={{
-          fontFamily: '"JetBrains Mono", monospace',
+          fontFamily: fonts.mono,
           fontSize: 13,
           color: palette.ink,
         }}


### PR DESCRIPTION
## Summary
The Remotion first-run demo (`packages/onboarding-video/`) rendered its mock BrowserClaw cockpit in the renderer's **Times-style serif fallback**: the composition referenced font families by name but **loaded no font** and **set no base sans**. This makes the demo match the real claw-app type system.

- Load **Schibsted Grotesk** (sans), **Newsreader** (italic serif accent), and **JetBrains Mono** (labels/terminal) via `@remotion/google-fonts`. `loadFont()` auto-blocks the render until each family is ready — no manual `delayRender` wiring.
- Centralize the three `fontFamily` stacks in **`src/fonts.ts`** (sibling of `palette.ts`), with fallback tails mirroring `apps/claw-app/entrypoints/newtab/styles.css`. Every scene/component now references `fonts.{sans,serif,mono}` — no inline font literals remain.
- Set the sans as the **base `fontFamily` on the composition root** so the whole cockpit chrome (wordmark, headings, sidebar, table) inherits it — that was the largest serif-fallback delta.
- Only the weights/subsets actually used are loaded (sans 400–900, mono 400/800, serif italic 500; `latin` subset).

## Design — why `@remotion/google-fonts` (not fontsource + `@remotion/fonts`)
The shipped artefact is a **pre-rendered MP4** streamed from a GitHub Release (`apps/claw-app/components/cockpit/FirstRunVideo.tsx`); `FirstRunDemo` is imported nowhere in `apps/` — there is no live `@remotion/player` sharing the newtab DOM today. So fonts only need to resolve **at render time on the dev machine**; the baked MP4 carries the type as pixels and end users fetch **no** fonts. That removes the only reason to prefer byte-exact self-hosted woff2, and buys a cleaner change: no committed binaries, no `public/` plumbing, declarative weight/subset control. Google serves the same typefaces the app self-hosts via fontsource; at the weights used the render matches.

## Visual verification (rendered locally, headless Chrome)
Rendered stills at frame 126 (MCP-install beat) and frame 500 (activity beat). Both now match the claw-app type system:
- **Sans (Schibsted Grotesk):** "BrowserClaw", "Recent activity", sidebar `Cockpit/MCP/Audit/Agents`, task rows, "You watch." — grotesque sans, no serif.
- **Mono (JetBrains Mono):** `COCKPIT`, `AGENT/ACTION/STATUS/WHEN`, `MCP ENDPOINT`, `http://127.0.0.1:9200/mcp`, scene labels.
- **Italic serif (Newsreader):** "*Your agent works.*" accent.

_Before_ = every glyph in Times serif fallback (the reported Studio screenshot). _After_ = the two frames above.

## Test plan
- [x] `bun run check` (lint + typecheck + Fallow) — green.
- [x] `bunx remotion still … --frame 126` and `--frame 500` — render exit 0; fonts visually correct.
- [x] `bun run typecheck` in `packages/onboarding-video` — green.

## Follow-up (depends on this merging)
The video must be **re-rendered and re-uploaded** so the shipped MP4/poster pick up the new fonts:
```
cd packages/browseros-agent/packages/onboarding-video
bun run render && bun run render:poster
```
then publish under a **new** `onboarding-video/vX.Y.Z` GitHub Release tag and bump the `RELEASE_TAG` in `FirstRunVideo.tsx` (that file is owned by the in-flight `feat/onboarding-video-r2` branch — coordinate there). Renders are build artefacts and are intentionally **not** committed here.

## Scope
Package-internal only (`packages/onboarding-video/src` + its `package.json` dep). Does **not** touch `FirstRunVideo.tsx` or the root `package.json` (owned by `feat/onboarding-video-r2`). `origin/main` (the `fix: clean browseros-agent check` commit) is merged in.