### PR TITLE
chore: restore first-run video comments

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.tsx
@@ -2,6 +2,50 @@
  * @license
  * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Renders the ~20-second cockpit first-run motion demo. Ships as a
+ * native `<video autoplay muted loop playsinline>` that streams from
+ * versioned Cloudflare R2 objects through the BrowserOS CDN. Chromium
+ * always allows muted autoplay without a user gesture. Reduced-motion
+ * readers see the poster PNG rendered from frame 0 of the composition.
+ *
+ * How the video URL got here
+ *
+ * The MP4 + poster are NOT tracked in git. The source composition is
+ * versioned in `packages/browseros-agent/packages/onboarding-video/`;
+ * rendered assets are uploaded to versioned R2 keys under
+ * `artifacts/claw/onboarding-video/v<version>/` and served publicly from
+ * `https://cdn.browseros.com`. That indirection keeps the extension
+ * bundle small and the repo history clean.
+ *
+ * To bump the video:
+ *
+ *   1. Edit the composition source in
+ *      `packages/browseros-agent/packages/onboarding-video/`.
+ *
+ *   2. Bump `packages/onboarding-video/package.json` to a new version.
+ *      Never reuse an existing version: the upload script guards against
+ *      overwriting R2 objects, and the versioned CDN URL is the cache
+ *      buster clients see.
+ *
+ *   3. Render locally:
+ *        cd packages/browseros-agent
+ *        bun run --cwd packages/onboarding-video render
+ *        bun run --cwd packages/onboarding-video render:poster
+ *
+ *   4. Upload the rendered MP4 + poster to R2:
+ *        bun run upload:onboarding-video
+ *
+ *      The script reads R2 credentials from process env or
+ *      `apps/server/.env.production`, writes keys below
+ *      `artifacts/claw/onboarding-video/v<version>/`, and prints the
+ *      public CDN URLs. Use `--force` only for an intentional overwrite.
+ *
+ *   5. Update `ASSET_VERSION` below to the uploaded package version.
+ *
+ * Because clients request versioned CDN URLs, a URL bump should come from
+ * a package-version bump plus fresh R2 objects. Overwriting an existing
+ * version can leave clients on the cached old asset.
  */
 
 import { useEffect, useRef, useState } from 'react'
@@ -17,9 +61,16 @@ export function FirstRunVideo() {
   const ref = useRef<HTMLVideoElement>(null)
   useEffect(() => {
     if (reducedMotion) return
+    // Muted + autoplay is allowed everywhere, but tab throttling or
+    // an unlucky race between mount and the first-byte of the video
+    // stream can leave the element paused. Kick play() explicitly
+    // to close the gap.
     const el = ref.current
     if (!el) return
-    void el.play().catch(() => undefined)
+    void el.play().catch(() => {
+      // Blocked or errored; the poster stays visible until the
+      // reader interacts. Extremely rare in practice.
+    })
   }, [reducedMotion])
   if (reducedMotion) {
     return (


### PR DESCRIPTION
## Summary
- Restores the explicit `play()` autoplay rationale comments in `FirstRunVideo`.
- Replaces the stale GitHub Release explanation with the current R2/CDN asset flow.
- Documents the bump path: edit the Remotion source, bump the onboarding-video package version, render, upload with `bun run upload:onboarding-video`, and update `ASSET_VERSION`.

## Design
This is a comment-only restoration in `FirstRunVideo.tsx`. Runtime behavior stays unchanged while the file-level guidance now matches the versioned `cdn.browseros.com/artifacts/claw/onboarding-video/v...` URLs introduced by `29a09454e`.

## Test plan
- [x] `bunx @biomejs/biome check apps/claw-app/components/cockpit/FirstRunVideo.tsx`
- [x] `git diff --check`