### PR TITLE
feat(onboarding-video): wrap cockpit demo in a browser shell

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useRef, useState } from 'react'
 
 const CDN_BASE_URL = 'https://cdn.browseros.com'
-const ASSET_VERSION = '0.1.0'
+const ASSET_VERSION = '0.2.0'
 const ASSET_BASE = `${CDN_BASE_URL}/artifacts/claw/onboarding-video/v${ASSET_VERSION}`
 const VIDEO_SRC = `${ASSET_BASE}/first-run-demo.mp4`
 const POSTER_SRC = `${ASSET_BASE}/first-run-demo-poster.png`

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
@@ -113,7 +113,7 @@ describe('Cockpit (v2)', () => {
     expect(html).toContain('You watch. Your agent')
     expect(html).toContain('Set up MCP endpoint')
     expect(html).toContain(
-      'https://cdn.browseros.com/artifacts/claw/onboarding-video/v0.1.0/first-run-demo.mp4',
+      'https://cdn.browseros.com/artifacts/claw/onboarding-video/v0.2.0/first-run-demo.mp4',
     )
   })
 })

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -338,7 +338,7 @@
     },
     "packages/onboarding-video": {
       "name": "@browseros/onboarding-video",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "react": "^19.1.1",
         "react-dom": "^19.1.1",

--- a/packages/browseros-agent/packages/onboarding-video/package.json
+++ b/packages/browseros-agent/packages/onboarding-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/onboarding-video",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Remotion compositions for BrowserClaw cockpit first-run motion demo. Shared by claw-app (runtime via @remotion/player) and a future offline render pipeline (webm output).",

--- a/packages/browseros-agent/packages/onboarding-video/src/FirstRunDemo.tsx
+++ b/packages/browseros-agent/packages/onboarding-video/src/FirstRunDemo.tsx
@@ -19,9 +19,16 @@ import { ScenePan } from './scenes/ScenePan'
 import { ScenePrompt } from './scenes/ScenePrompt'
 import { SCENES } from './timing'
 
+// Mirrors claw-app's --font-sans. Explicit because the headless
+// render browser falls back to a serif when no family is set.
+const FONT_SANS =
+  '"Schibsted Grotesk Variable", "Schibsted Grotesk", system-ui, sans-serif'
+
 export function FirstRunDemo() {
   return (
-    <AbsoluteFill style={{ background: palette.bgCanvas }}>
+    <AbsoluteFill
+      style={{ background: palette.bgCanvas, fontFamily: FONT_SANS }}
+    >
       <Sequence
         from={SCENES.cockpit.from}
         durationInFrames={SCENES.cockpit.duration}

--- a/packages/browseros-agent/packages/onboarding-video/src/components/CockpitFrame.tsx
+++ b/packages/browseros-agent/packages/onboarding-video/src/components/CockpitFrame.tsx
@@ -6,6 +6,10 @@
  * The BrowserClaw cockpit chrome as it appears inside the demo. A
  * stylised recreation of the actual app: sidebar wordmark, header
  * strip, empty recent-activity table, one live-task row optional.
+ * Wrapped in a minimal Chromium-style browser shell (traffic lights,
+ * tab, URL bar) so readers see the cockpit lives inside their
+ * browser. The URL bar shows the new-tab placeholder because
+ * claw-app ships as the browser's new-tab page.
  * Kept SVG-simple so the render stays under budget and the visual
  * matches the app without a screenshot dependency.
  */
@@ -35,6 +39,15 @@ interface CockpitFrameProps {
 }
 
 const RADIUS = 24
+const TAB_STRIP_HEIGHT = 40
+const TOOLBAR_HEIGHT = 46
+const TAB_STRIP_BG = '#e7ebf1'
+
+/**
+ * Height the browser shell adds above the app surface. Scenes that
+ * pin overlays against sidebar positions offset by this.
+ */
+export const BROWSER_CHROME_HEIGHT = TAB_STRIP_HEIGHT + TOOLBAR_HEIGHT + 1
 
 export function CockpitFrame({
   liveTask,
@@ -47,6 +60,7 @@ export function CockpitFrame({
     <div
       style={{
         display: 'flex',
+        flexDirection: 'column',
         width: '100%',
         height: '100%',
         borderRadius: RADIUS,
@@ -57,12 +71,184 @@ export function CockpitFrame({
         ...style,
       }}
     >
-      <Sidebar
-        highlightNav={highlightNav}
-        highlightIntensity={highlightIntensity}
-      />
-      <MainColumn liveTask={liveTask} showLandingDot={showLandingDot} />
+      <BrowserChrome />
+      <div style={{ flex: 1, minHeight: 0, display: 'flex' }}>
+        <Sidebar
+          highlightNav={highlightNav}
+          highlightIntensity={highlightIntensity}
+        />
+        <MainColumn liveTask={liveTask} showLandingDot={showLandingDot} />
+      </div>
     </div>
+  )
+}
+
+function BrowserChrome() {
+  return (
+    <div>
+      <div
+        style={{
+          height: TAB_STRIP_HEIGHT,
+          background: TAB_STRIP_BG,
+          display: 'flex',
+          alignItems: 'flex-end',
+          padding: '0 14px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            gap: 8,
+            alignSelf: 'center',
+            marginRight: 16,
+          }}
+        >
+          <TrafficLight color="#ff5f56" />
+          <TrafficLight color="#ffbd2e" />
+          <TrafficLight color="#27c93f" />
+        </div>
+        <div
+          style={{
+            height: 32,
+            minWidth: 190,
+            padding: '0 10px 0 12px',
+            borderRadius: '10px 10px 0 0',
+            background: palette.card,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <div
+            style={{
+              width: 16,
+              height: 16,
+              borderRadius: 4,
+              background: palette.accent,
+              color: palette.card,
+              fontSize: 10,
+              fontWeight: 800,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            B
+          </div>
+          <span
+            style={{
+              flex: 1,
+              fontSize: 12,
+              fontWeight: 600,
+              color: palette.ink,
+              letterSpacing: -0.1,
+            }}
+          >
+            BrowserClaw
+          </span>
+          <Glyph d="M5 5l6 6M11 5l-6 6" color={palette.ink3} size={13} />
+        </div>
+        <div style={{ alignSelf: 'center', padding: '0 10px' }}>
+          <Glyph d="M8 3.5v9M3.5 8h9" color={palette.ink3} size={14} />
+        </div>
+      </div>
+      <div
+        style={{
+          height: TOOLBAR_HEIGHT,
+          background: palette.card,
+          borderBottom: `1px solid ${palette.border2}`,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          padding: '0 16px',
+        }}
+      >
+        <Glyph d="M10 3.5 5.5 8l4.5 4.5" color={palette.ink2} />
+        <Glyph d="M6 3.5 10.5 8 6 12.5" color={palette.border2} />
+        <Glyph
+          d="M13 8a5 5 0 1 1-1.46-3.54M13 3.5V6h-2.5"
+          color={palette.ink2}
+        />
+        <div
+          style={{
+            flex: 1,
+            height: 30,
+            borderRadius: 999,
+            background: palette.bgSunken,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '0 14px',
+          }}
+        >
+          <Glyph
+            d="M11 7a4 4 0 1 1-8 0 4 4 0 0 1 8 0M9.9 9.9l2.6 2.6"
+            color={palette.ink3}
+            size={13}
+          />
+          <span style={{ fontSize: 12, color: palette.ink3 }}>
+            Search Google or type a URL
+          </span>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2.5,
+            padding: '0 2px',
+          }}
+        >
+          {['a', 'b', 'c'].map((k) => (
+            <span
+              key={k}
+              style={{
+                width: 3,
+                height: 3,
+                borderRadius: 999,
+                background: palette.ink3,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TrafficLight({ color }: { color: string }) {
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        width: 10,
+        height: 10,
+        borderRadius: 999,
+        background: color,
+      }}
+    />
+  )
+}
+
+function Glyph({
+  d,
+  color,
+  size = 16,
+}: {
+  d: string
+  color: string
+  size?: number
+}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" role="presentation">
+      <path
+        d={d}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.7}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   )
 }
 

--- a/packages/browseros-agent/packages/onboarding-video/src/scenes/SceneInstallMcp.tsx
+++ b/packages/browseros-agent/packages/onboarding-video/src/scenes/SceneInstallMcp.tsx
@@ -14,7 +14,7 @@
  */
 
 import { AbsoluteFill, Easing, interpolate, useCurrentFrame } from 'remotion'
-import { CockpitFrame } from '../components/CockpitFrame'
+import { BROWSER_CHROME_HEIGHT, CockpitFrame } from '../components/CockpitFrame'
 import { SceneLabel } from '../components/SceneLabel'
 import { palette } from '../palette'
 
@@ -89,7 +89,7 @@ function EndpointCard({
       style={{
         position: 'absolute',
         left: 250,
-        top: 140,
+        top: 140 + BROWSER_CHROME_HEIGHT,
         width: 420,
         borderRadius: 16,
         background: palette.card,


### PR DESCRIPTION
## Summary
- Wraps `CockpitFrame` in a minimal Chromium-style browser shell (traffic lights, BrowserClaw tab, URL bar with the new-tab placeholder) so every scene shows the cockpit living inside the browser.
- Pins the composition to claw-app's sans stack — the headless render browser was falling back to a serif.
- Bumps onboarding-video assets to **v0.2.0** (immutable CDN path) and repins `FirstRunVideo` to the v0.2.0 URLs.

## Design
The first-run demo now frames the cockpit inside browser chrome so first-time viewers read it as "your agent's browser," reinforcing the mental model the demo teaches. Font rendering is pinned to the app sans stack because Remotion's headless render browser lacks the referenced fonts and was substituting a serif. Assets ship on an immutable, versioned CDN path rather than being tracked in git; the version bump forces a fresh path so caches never serve a stale render.

## Test plan
- [x] `packages/onboarding-video` typecheck clean (`tsc --noEmit`).
- [x] `apps/claw-app` Cockpit tests pass (4/4).
- [ ] Render v0.2.0 mp4 + poster from HEAD; eyeball the browser shell + fonts in the real output.
- [ ] Confirm both v0.2.0 CDN URLs return 200 after upload.

## Blocked
**v0.2.0 assets are not on R2/CDN yet.** `FirstRunVideo` points at `cdn.browseros.com/artifacts/claw/onboarding-video/v0.2.0/{first-run-demo.mp4,first-run-demo-poster.png}` — both currently **HTTP 404**. Merging as-is ships a broken first-run onboarding video. The commit checklist calls this out ("render + upload to R2 before merging").

To unblock and mark ready:
1. Re-render from the committed source (the local `out/` render is timestamped **11:07**, before this **12:13** commit — likely stale):
   `bun run --cwd packages/onboarding-video render && bun run --cwd packages/onboarding-video render:poster`
2. Upload (immutable path; needs `apps/server/.env.production`): `bun run upload:onboarding-video`
3. Verify both v0.2.0 URLs return 200 → mark PR ready → `/sf-merge`.