### PR TITLE
fix(claw-onboard): sync onboarding api mirror

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/browseros-onboarding-api.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/browseros-onboarding-api.ts
@@ -39,19 +39,36 @@ export interface BrowserOSImportSource {
   displayName: string
   browserName: string
   profileName: string
+  accountName: string
+  isManaged: boolean
   supportedItems: BrowserOSImportItem[]
   recommendedItems: BrowserOSImportItem[]
 }
 
 export interface BrowserOSImportProgress {
   currentItem?: BrowserOSImportItem
+  currentSourceId?: string
+  currentSourceName?: string
   completedItems: BrowserOSImportItem[]
   totalItems: number
+  completedSources?: number
+  totalSources?: number
 }
 
 export interface BrowserOSOnboardingError {
   code: string
   message: string
+}
+
+export type BrowserOSImportSourceResultStatus =
+  | 'importing'
+  | 'succeeded'
+  | 'failed'
+
+export interface BrowserOSImportSourceResult {
+  sourceId: string
+  displayName: string
+  status: BrowserOSImportSourceResultStatus
 }
 
 export interface BrowserOSOnboardingState {
@@ -60,8 +77,11 @@ export interface BrowserOSOnboardingState {
   sources: BrowserOSImportSource[]
   progress?: BrowserOSImportProgress
   error?: BrowserOSOnboardingError
+  /** Single-source imports report one per-source result. */
+  results?: BrowserOSImportSourceResult[]
 }
 
+/** Starts one source import from the visible Import action; Chromium rejects hidden/non-interactive requests for macOS keychain safety. */
 export interface BrowserOSStartImportRequest {
   sourceId: string
   items?: BrowserOSImportItem[]

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/browseros-onboarding-bridge.test.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/browseros-onboarding-bridge.test.ts
@@ -130,5 +130,29 @@ describe('createBrowserOSOnboardingBridge', () => {
     expect(states.at(-1)?.progress?.completedItems).toEqual(
       MOCK_BROWSEROS_IMPORT_SOURCES[0].recommendedItems,
     )
+    expect(states[2]?.progress).toMatchObject({
+      currentSourceId: MOCK_BROWSEROS_IMPORT_SOURCES[0].id,
+      currentSourceName: MOCK_BROWSEROS_IMPORT_SOURCES[0].displayName,
+      completedSources: 0,
+      totalSources: 1,
+    })
+    expect(states[2]?.results).toEqual([
+      {
+        sourceId: MOCK_BROWSEROS_IMPORT_SOURCES[0].id,
+        displayName: MOCK_BROWSEROS_IMPORT_SOURCES[0].displayName,
+        status: 'importing',
+      },
+    ])
+    expect(states.at(-1)?.progress).toMatchObject({
+      completedSources: 1,
+      totalSources: 1,
+    })
+    expect(states.at(-1)?.results).toEqual([
+      {
+        sourceId: MOCK_BROWSEROS_IMPORT_SOURCES[0].id,
+        displayName: MOCK_BROWSEROS_IMPORT_SOURCES[0].displayName,
+        status: 'succeeded',
+      },
+    ])
   })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/browseros-onboarding-bridge.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/browseros-onboarding-bridge.ts
@@ -7,6 +7,8 @@
 import {
   BROWSEROS_ONBOARDING_API_VERSION,
   type BrowserOSImportProgress,
+  type BrowserOSImportSource,
+  type BrowserOSImportSourceResult,
   type BrowserOSOnboardingChrome,
   BrowserOSOnboardingMessage,
   type BrowserOSOnboardingState,
@@ -54,12 +56,14 @@ function getChromeBridge(
 function createState(
   status: BrowserOSOnboardingState['status'],
   progress?: BrowserOSImportProgress,
+  results?: BrowserOSImportSourceResult[],
 ): BrowserOSOnboardingState {
   return {
     apiVersion: BROWSEROS_ONBOARDING_API_VERSION,
     status,
     sources: [...MOCK_BROWSEROS_IMPORT_SOURCES],
     ...(progress ? { progress } : {}),
+    ...(results ? { results } : {}),
   }
 }
 
@@ -82,22 +86,77 @@ function recommendedItemsFor(request: BrowserOSStartImportRequest) {
   )
 }
 
+function mockSourceFor(request: BrowserOSStartImportRequest) {
+  return MOCK_BROWSEROS_IMPORT_SOURCES.find(
+    (source) => source.id === request.sourceId,
+  )
+}
+
+function sourceDisplayNameFor(
+  request: BrowserOSStartImportRequest,
+  source: BrowserOSImportSource | undefined,
+) {
+  return source?.displayName ?? request.sourceId
+}
+
 function emitMockImport(request: BrowserOSStartImportRequest, sync: boolean) {
   const items = recommendedItemsFor(request)
-  const started = createState('importing', {
-    currentItem: items[0],
-    completedItems: [],
-    totalItems: items.length,
-  })
-  const halfway = createState('importing', {
-    currentItem: items[1],
-    completedItems: items.slice(0, 1),
-    totalItems: items.length,
-  })
-  const succeeded = createState('succeeded', {
-    completedItems: items,
-    totalItems: items.length,
-  })
+  const source = mockSourceFor(request)
+  const sourceName = sourceDisplayNameFor(request, source)
+  const started = createState(
+    'importing',
+    {
+      currentItem: items[0],
+      currentSourceId: request.sourceId,
+      currentSourceName: sourceName,
+      completedItems: [],
+      totalItems: items.length,
+      completedSources: 0,
+      totalSources: 1,
+    },
+    [
+      {
+        sourceId: request.sourceId,
+        displayName: sourceName,
+        status: 'importing',
+      },
+    ],
+  )
+  const halfway = createState(
+    'importing',
+    {
+      currentItem: items[1],
+      currentSourceId: request.sourceId,
+      currentSourceName: sourceName,
+      completedItems: items.slice(0, 1),
+      totalItems: items.length,
+      completedSources: 0,
+      totalSources: 1,
+    },
+    [
+      {
+        sourceId: request.sourceId,
+        displayName: sourceName,
+        status: 'importing',
+      },
+    ],
+  )
+  const succeeded = createState(
+    'succeeded',
+    {
+      completedItems: items,
+      totalItems: items.length,
+      completedSources: 1,
+      totalSources: 1,
+    },
+    [
+      {
+        sourceId: request.sourceId,
+        displayName: sourceName,
+        status: 'succeeded',
+      },
+    ],
+  )
 
   emitMockState(started)
   if (sync) {

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/ImportingProgressCard.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/ImportingProgressCard.tsx
@@ -3,6 +3,7 @@ import { RefreshCw } from 'lucide-react'
 interface ImportingProgressCardProps {
   currentItemLabel?: string
   progress: number
+  sourceLabel?: string
   total: number
 }
 
@@ -10,6 +11,7 @@ interface ImportingProgressCardProps {
 export function ImportingProgressCard({
   currentItemLabel,
   progress,
+  sourceLabel,
   total,
 }: ImportingProgressCardProps) {
   const percent = total === 0 ? 0 : Math.min(100, (progress / total) * 100)
@@ -21,6 +23,11 @@ export function ImportingProgressCard({
           Importing {currentItemLabel ?? 'data'}...
         </span>
       </div>
+      {sourceLabel && (
+        <div className="mb-3 font-bold text-[12px] text-ink-2">
+          {sourceLabel}
+        </div>
+      )}
       <div className="mb-2.5 h-2 overflow-hidden rounded-full bg-bg-sunken">
         <div
           className="h-full bg-accent transition-[width] duration-100"

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.test.ts
@@ -27,6 +27,8 @@ describe('MOCK_BROWSEROS_IMPORT_SOURCES fixture', () => {
   it('uses the Chromium contract source shape', () => {
     for (const source of MOCK_BROWSEROS_IMPORT_SOURCES) {
       expect(source.displayName.length).toBeGreaterThan(0)
+      expect(typeof source.accountName).toBe('string')
+      expect(typeof source.isManaged).toBe('boolean')
       expect(source.recommendedItems.length).toBeGreaterThan(0)
       expect(source.supportedItems).toContain(source.recommendedItems[0])
     }

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.ts
@@ -17,6 +17,8 @@ export const MOCK_BROWSEROS_IMPORT_SOURCES: readonly BrowserOSImportSource[] = [
     displayName: 'Google Chrome - Work',
     browserName: 'Google Chrome',
     profileName: 'Work',
+    accountName: 'work@example.com',
+    isManaged: true,
     supportedItems: [
       'history',
       'bookmarks',
@@ -41,6 +43,8 @@ export const MOCK_BROWSEROS_IMPORT_SOURCES: readonly BrowserOSImportSource[] = [
     displayName: 'Google Chrome - Personal',
     browserName: 'Google Chrome',
     profileName: 'Personal',
+    accountName: 'personal@example.com',
+    isManaged: false,
     supportedItems: [
       'history',
       'bookmarks',
@@ -55,6 +59,8 @@ export const MOCK_BROWSEROS_IMPORT_SOURCES: readonly BrowserOSImportSource[] = [
     displayName: 'Microsoft Edge - Default',
     browserName: 'Microsoft Edge',
     profileName: 'Default',
+    accountName: '',
+    isManaged: false,
     supportedItems: ['history', 'bookmarks', 'cookies', 'passwords'],
     recommendedItems: ['history', 'bookmarks', 'cookies'],
   },

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
@@ -190,12 +190,24 @@ describe('ImportStep', () => {
         status: 'importing',
         progress: {
           currentItem: 'cookies',
+          currentSourceId: MOCK_BROWSEROS_IMPORT_SOURCES[0].id,
+          currentSourceName: MOCK_BROWSEROS_IMPORT_SOURCES[0].displayName,
           completedItems: ['history', 'bookmarks'],
           totalItems: 7,
+          completedSources: 0,
+          totalSources: 1,
         },
+        results: [
+          {
+            sourceId: MOCK_BROWSEROS_IMPORT_SOURCES[0].id,
+            displayName: MOCK_BROWSEROS_IMPORT_SOURCES[0].displayName,
+            status: 'importing',
+          },
+        ],
       }),
     )
     expect(html).toContain('Importing Cookies')
+    expect(html).toContain('Google Chrome - Work')
     expect(html).toContain('2 / 7 items')
   })
 
@@ -225,10 +237,19 @@ describe('ImportStep', () => {
         progress: {
           completedItems: MOCK_BROWSEROS_IMPORT_SOURCES[0].recommendedItems,
           totalItems: 7,
+          completedSources: 1,
+          totalSources: 1,
         },
+        results: [
+          {
+            sourceId: MOCK_BROWSEROS_IMPORT_SOURCES[0].id,
+            displayName: MOCK_BROWSEROS_IMPORT_SOURCES[0].displayName,
+            status: 'succeeded',
+          },
+        ],
       }),
     )
-    expect(html).toContain('Imported 7 items from Work')
+    expect(html).toContain('Imported 7 items from Google Chrome - Work')
     expect(html).toContain('History, Bookmarks')
     expect(html).toContain('Continue')
   })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
@@ -59,11 +59,15 @@ export function ImportStep({
 }: ImportStepProps) {
   const selectedSourceId = form.watch('selectedSourceId')
   const selectedSource = selectedSourceById(state.sources, selectedSourceId)
+  const sourceResult = state.results?.[0]
   const checkedItems = selectedSource
     ? sanitizeImportSelection(selectedSource, form.watch('selectedItems'))
     : []
   const sourceName =
-    selectedSource?.profileName || selectedSource?.browserName || 'source'
+    sourceResult?.displayName ||
+    selectedSource?.profileName ||
+    selectedSource?.browserName ||
+    'source'
   const isDetecting = state.status === 'detecting'
   const hasSupportedItems = (selectedSource?.supportedItems.length ?? 0) > 0
   const isPickerValid =
@@ -78,6 +82,7 @@ export function ImportStep({
   const currentItemLabel = state.progress?.currentItem
     ? importItemLabel(state.progress.currentItem)
     : undefined
+  const currentSourceLabel = state.progress?.currentSourceName
   const importedItems = state.progress?.completedItems ?? []
   const importedItemSummary = state.progress
     ? importedItems.length
@@ -202,6 +207,7 @@ export function ImportStep({
         <ImportingProgressCard
           currentItemLabel={currentItemLabel}
           progress={completedItems}
+          sourceLabel={currentSourceLabel}
           total={totalItems}
         />
       )}


### PR DESCRIPTION
## Summary
- sync the claw-onboard vendored onboarding API with the Chromium v1 mirror while preserving the AGPL header and local formatting
- add BrowserOSImportSource accountName/isManaged fields, BrowserOSImportSourceResult + status, state.results, and per-source progress fields
- update bridge mock import states and import-step rendering/tests to exercise per-source progress/results

## Completion flow
- no claw-onboard real-flow navigation change in this PR
- the browser-opening issue is owned by the Chromium FirstRunFlowController completion sequencing and is shipping separately from a Chromium checkout task

## Verification
- bun run --filter @browseros/claw-onboard test
- bun run check
- bun run test

## Notes
- bun run check exits 0 but still prints existing repo-wide Biome/fallow warnings outside this change
