### PR TITLE
feat(bpatch): add annotate and resource groups

### DIFF
--- a/packages/browseros/tools/bpatch/README.md
+++ b/packages/browseros/tools/bpatch/README.md
@@ -62,6 +62,11 @@ apply: store 8c1f2ab (delta vs applied 55e0d3c: 3 files)
   ✓ 3 files written · 3,161 store-managed files untouched (content + mtime preserved)
   ✓ commit 7ab19c2 "feat: llmchat #2"   [Bpatch-Store-Rev: 8c1f2ab]
 converged. → incremental build will recompile ~1 target dir
+
+$ bpatch annotate
+claimed 41 -> 12 feature commits
+resources 214 -> 1 commit "resource: bos_build outputs"
+next: bpatch extract <annotated-rev-range> to fold feature commits into the store
 ```
 
 The same checkout-scoped commands can target an alias or path from any directory:
@@ -89,9 +94,10 @@ Global flags:
 | `bpatch status` | global flags | `0`, `3`, `1` | Show checkout base, store rev, applied trailers, and drift. |
 | `bpatch diff` | global flags | `0`, `3`, `1` | Show what `apply` would touch, grouped by feature, with rebuild-scope hint. |
 | `bpatch apply` | `--pull`, global flags | `0`, `2`, `3`, `1` | Optionally fast-forward the store repo, then converge the checkout or report conflicts/drift. |
+| `bpatch annotate` | `--rest <NAME>`, `--triage`, global flags | `0`, `2`, `3`, `1` | Commit dirty bos_build output into feature commits, one resource commit for `store:false` groups, and report unclaimed leftovers. |
 | `bpatch extract [SPEC]` | `--feature <FEATURE>`, `--commit`, `--repin`, global flags | `0`, `3`, `1` | Extract `<rev>` or `<rev1>..<rev2>` into the store, or repin existing store patches to the checkout base. |
 | `bpatch feature list` | global flags | `0`, `1` | List features, owned patch counts, and last applied sequence numbers. |
-| `bpatch feature add <NAME> --path <PATH>` | `--description <DESCRIPTION>`, global flags | `0`, `1` | Append a new feature block to `.features.yaml`. |
+| `bpatch feature add <NAME> [PATH...]` | `--path <PATH>`, `--desc <DESCRIPTION>`, `--store=false`, `--from-dirty`, `--commit`, global flags | `0`, `1` | Append paths to `.features.yaml`, or claim currently unclaimed dirty paths into a feature/resource group. |
 | `bpatch alias add <NAME> <PATH>` | global flags | `0`, `1` | Add or update a checkout alias in `~/.config/bpatch/config.toml`. |
 | `bpatch alias list` | global flags | `0`, `1` | List checkout aliases. |
 | `bpatch alias remove <NAME>` | global flags | `0`, `1` | Remove a checkout alias. |
@@ -112,6 +118,38 @@ Global flags:
 | `1` | CLI, git, lock, config, or unexpected error. |
 
 With `--json`, every command emits a single object carrying `result` and `exit`.
+
+## Annotating bos_build Output
+
+`annotate` is for a Chromium checkout dirtied by bos_build's patch/build pipeline. It classifies dirty paths with the same ownership rules as the store:
+
+- paths with patch files or `store: true` feature entries become feature commits;
+- paths owned by `store: false` feature entries become one `resource: bos_build outputs` commit;
+- unclaimed paths are left dirty, reported with `bpatch feature add ...` suggestions, and return exit 3.
+
+```console
+$ bpatch annotate
+claimed 3088 -> 41 feature commits
+resources 214 -> 1 commit "resource: bos_build outputs"
+unclaimed 2 (left in working tree):
+  chrome/browser/browseros/wallet/service.cc                 suggest: bpatch feature add wallet chrome/browser/browseros/wallet/ --desc "feat: wallet"
+exit 3
+
+$ bpatch annotate --rest wip-frame-experiments
+rest 2 -> 1 commit "wip: wip-frame-experiments"
+```
+
+Use `--triage --json` when an agent needs the unclaimed-path plan without opening an editor. Annotate commits carry `Bpatch-Base` and `Bpatch-Annotated`; they intentionally do not claim a store revision. After feature commits are reviewed, fold them back with `bpatch extract <rev-range>`.
+
+Resource groups are seeded from a clean checkout by running the build without applying patches, then claiming the resulting dirty paths:
+
+```console
+$ bos_build build --debug --skip patches
+$ bpatch feature add build-resources --store=false --from-dirty
+scanned 217 dirty paths · collapsed to 9 dirs + 12 files · 214 new, 3 already claimed
+updated feature "build-resources" in .features.yaml
+next: --commit to commit the store repo
+```
 
 ## Troubleshooting
 
@@ -180,6 +218,18 @@ Use `ls -a` to see the store metadata files. They are dot-prefixed so generic pa
 
 `.features.yaml` entries can own exact files or directory prefixes ending in `/`. `extract` matches exact paths first, then prefixes, then reports or creates the nearest feature decision.
 
+Set `store: false` on feature groups for build-owned resources that should be committed by `annotate` but skipped by `extract`, `apply`, `status`, and `diff` store-convergence math:
+
+```yaml
+features:
+  build-resources:
+    description: "resource: bos_build outputs"
+    store: false
+    files:
+      - chrome/BROWSEROS_VERSION
+      - chrome/app/theme/chromium/
+```
+
 ## Cutover Checklist Vs `tools/patch`
 
 The old Go tool stays in the repo until cutover; removing it is a separate effort. `packages/browseros/bos_build/features.yaml` also still exists for `bos_build`'s reader while consolidation is pending.
@@ -189,10 +239,11 @@ The old Go tool stays in the repo until cutover; removing it is a separate effor
 | `status` | `bpatch status` |
 | `diff` | `bpatch diff` |
 | `apply` / checkout catch-up | `bpatch apply` |
+| annotate dirty bos_build output | `bpatch annotate` |
 | store refresh by pulling first | `bpatch apply --pull` |
 | `extract` | `bpatch extract <rev>` or `bpatch extract <rev1>..<rev2>` |
 | feature inventory | `bpatch feature list` |
-| feature creation | `bpatch feature add <name> --path <path> [--description ...]` |
+| feature creation/top-up | `bpatch feature add <name> <path> [--desc ...]` or `bpatch feature add <name> --from-dirty` |
 | checkout aliases | `bpatch alias add <name> <path>`, then `bpatch apply <name>` or `bpatch -C <name> ...` |
 | conflict abort | `bpatch abort` |
 | conflict continue | `bpatch continue` or `bpatch continue --materialize` |

--- a/packages/browseros/tools/bpatch/src/cli/annotate.rs
+++ b/packages/browseros/tools/bpatch/src/cli/annotate.rs
@@ -1,0 +1,508 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::engine::annotate::{self as engine_annotate, AnnotateOptions, AnnotateOutcome};
+use crate::engine::dirty::UnclaimedPath;
+use crate::engine::lock::CheckoutLock;
+use crate::engine::progress::ProgressEvent;
+use crate::engine::state::StateContext;
+use crate::git::GitAdapter;
+use crate::store::{FeatureSuggestion, Store};
+
+/// Serializable annotate command report.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "result", rename_all = "kebab-case")]
+pub enum AnnotateReport {
+    Clean {
+        exit: i32,
+    },
+    Annotated {
+        claimed: usize,
+        resources: usize,
+        rest: usize,
+        commits: Vec<AnnotateCommitReport>,
+        resource_commit: Option<AnnotateCommitReport>,
+        rest_commit: Option<AnnotateCommitReport>,
+        next: String,
+        exit: i32,
+    },
+    Leftovers {
+        claimed: usize,
+        resources: usize,
+        rest: usize,
+        commits: Vec<AnnotateCommitReport>,
+        resource_commit: Option<AnnotateCommitReport>,
+        rest_commit: Option<AnnotateCommitReport>,
+        unclaimed: Vec<UnclaimedReport>,
+        next: String,
+        exit: i32,
+    },
+    Conflicts {
+        files: Vec<ConflictReport>,
+        exit: i32,
+    },
+    Triage {
+        claimed: usize,
+        resources: usize,
+        unclaimed: Vec<UnclaimedReport>,
+        exit: i32,
+    },
+}
+
+/// One commit authored by annotate.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct AnnotateCommitReport {
+    pub subject: String,
+    pub sha: String,
+    pub files: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub feature: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seq: Option<usize>,
+}
+
+/// One path left for feature assignment.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct UnclaimedReport {
+    pub path: PathBuf,
+    pub suggestion: String,
+    pub command: String,
+}
+
+/// One unresolved conflict path.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ConflictReport {
+    pub path: PathBuf,
+    pub status: String,
+}
+
+impl AnnotateReport {
+    /// Returns the process exit code represented by the report.
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::Clean { exit }
+            | Self::Annotated { exit, .. }
+            | Self::Leftovers { exit, .. }
+            | Self::Conflicts { exit, .. }
+            | Self::Triage { exit, .. } => *exit,
+        }
+    }
+}
+
+/// Runs annotate with the checkout lock held by the engine.
+pub fn run(
+    ctx: &StateContext,
+    options: &AnnotateOptions,
+    progress: &mut dyn FnMut(ProgressEvent<'_>),
+) -> Result<AnnotateReport> {
+    Ok(match engine_annotate::annotate(ctx, options, progress)? {
+        AnnotateOutcome::Clean => AnnotateReport::Clean { exit: 0 },
+        AnnotateOutcome::Conflicts { files } => AnnotateReport::Conflicts {
+            files: files
+                .into_iter()
+                .map(|file| ConflictReport {
+                    path: file.path,
+                    status: file.status,
+                })
+                .collect(),
+            exit: 2,
+        },
+        AnnotateOutcome::Annotated(result) => AnnotateReport::Annotated {
+            claimed: result.claimed_files,
+            resources: result.resource_files,
+            rest: result.rest_files,
+            commits: feature_commits(&result.feature_commits),
+            resource_commit: result.resource_commit.as_ref().map(named_commit),
+            rest_commit: result.rest_commit.as_ref().map(named_commit),
+            next: next_extract(),
+            exit: 0,
+        },
+        AnnotateOutcome::Leftovers(result) => AnnotateReport::Leftovers {
+            claimed: result.claimed_files,
+            resources: result.resource_files,
+            rest: result.rest_files,
+            commits: feature_commits(&result.feature_commits),
+            resource_commit: result.resource_commit.as_ref().map(named_commit),
+            rest_commit: result.rest_commit.as_ref().map(named_commit),
+            unclaimed: unclaimed_reports(&result.unclaimed),
+            next: next_extract(),
+            exit: 3,
+        },
+    })
+}
+
+/// Builds a no-mutation triage report for JSON consumers.
+pub fn triage(ctx: &StateContext) -> Result<AnnotateReport> {
+    Ok(match engine_annotate::plan(ctx)? {
+        engine_annotate::AnnotatePlan::Clean => AnnotateReport::Clean { exit: 0 },
+        engine_annotate::AnnotatePlan::Conflicts { files } => AnnotateReport::Conflicts {
+            files: files
+                .into_iter()
+                .map(|file| ConflictReport {
+                    path: file.path,
+                    status: file.status,
+                })
+                .collect(),
+            exit: 2,
+        },
+        engine_annotate::AnnotatePlan::Dirty { plan } => AnnotateReport::Triage {
+            claimed: plan.claimed.len(),
+            resources: plan.resources.len(),
+            unclaimed: unclaimed_reports(&plan.unclaimed),
+            exit: if plan.unclaimed.is_empty() { 0 } else { 3 },
+        },
+    })
+}
+
+/// Runs human triage through $EDITOR, applies saved feature paths, then annotates.
+pub fn triage_editor(
+    ctx: &StateContext,
+    progress: &mut dyn FnMut(ProgressEvent<'_>),
+) -> Result<AnnotateReport> {
+    let plan = engine_annotate::plan(ctx)?;
+    let engine_annotate::AnnotatePlan::Dirty { plan } = plan else {
+        return triage(ctx);
+    };
+    if plan.unclaimed.is_empty() {
+        return run(ctx, &AnnotateOptions::default(), progress);
+    }
+
+    let path = triage_path(&ctx.checkout)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let file = TriageFile {
+        features: triage_features(&plan.unclaimed),
+    };
+    fs::write(&path, serde_yaml::to_string(&file)?)
+        .with_context(|| format!("writing {}", path.display()))?;
+    open_editor(&path)?;
+    let edited =
+        fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let edited: TriageFile =
+        serde_yaml::from_str(&edited).with_context(|| format!("parsing {}", path.display()))?;
+    apply_triage_file(ctx, edited)?;
+    run(ctx, &AnnotateOptions::default(), progress)
+}
+
+/// Renders a human annotate report.
+pub fn render_human(report: &AnnotateReport) -> String {
+    match report {
+        AnnotateReport::Clean { .. } => "annotate: clean — nothing to do.\n".to_string(),
+        AnnotateReport::Conflicts { files, .. } => {
+            let mut out = String::new();
+            out.push_str(&format!(
+                "annotate: refusing conflicted tree ({} {})\n",
+                files.len(),
+                files_label(files.len())
+            ));
+            for file in files {
+                out.push_str(&format!("  {:<4} {}\n", file.status, file.path.display()));
+            }
+            out
+        }
+        AnnotateReport::Annotated {
+            claimed,
+            resources,
+            rest,
+            commits,
+            resource_commit,
+            rest_commit,
+            next,
+            ..
+        } => render_committed(
+            *claimed,
+            *resources,
+            *rest,
+            commits,
+            resource_commit,
+            rest_commit,
+            next,
+        ),
+        AnnotateReport::Leftovers {
+            claimed,
+            resources,
+            rest,
+            commits,
+            resource_commit,
+            rest_commit,
+            unclaimed,
+            next,
+            ..
+        } => {
+            let mut out = render_committed(
+                *claimed,
+                *resources,
+                *rest,
+                commits,
+                resource_commit,
+                rest_commit,
+                next,
+            );
+            out.push_str(&format!(
+                "unclaimed {} (left in working tree):\n",
+                unclaimed.len()
+            ));
+            for path in unclaimed {
+                out.push_str(&format!(
+                    "  {:<56} suggest: {}\n",
+                    path.path.display(),
+                    path.command
+                ));
+            }
+            out.push_str("exit 3\n");
+            out
+        }
+        AnnotateReport::Triage {
+            claimed,
+            resources,
+            unclaimed,
+            ..
+        } => {
+            let mut out = String::new();
+            out.push_str(&format!(
+                "triage: claimed {}, resources {}, unclaimed {}\n",
+                claimed,
+                resources,
+                unclaimed.len()
+            ));
+            for path in unclaimed {
+                out.push_str(&format!(
+                    "  {:<56} suggest: {}\n",
+                    path.path.display(),
+                    path.command
+                ));
+            }
+            out
+        }
+    }
+}
+
+/// Renders a JSON annotate report.
+pub fn render_json(report: &AnnotateReport) -> Result<String> {
+    Ok(serde_json::to_string(report)?)
+}
+
+fn render_committed(
+    claimed: usize,
+    resources: usize,
+    rest: usize,
+    commits: &[AnnotateCommitReport],
+    resource_commit: &Option<AnnotateCommitReport>,
+    rest_commit: &Option<AnnotateCommitReport>,
+    next: &str,
+) -> String {
+    let mut out = String::new();
+    if !commits.is_empty() || claimed > 0 {
+        out.push_str(&format!(
+            "claimed {} -> {} feature {}\n",
+            claimed,
+            commits.len(),
+            commits_label(commits.len())
+        ));
+        for commit in commits {
+            out.push_str(&format!(
+                "  ✓ commit {} \"{}\"\n",
+                commit.sha, commit.subject
+            ));
+        }
+    }
+    if let Some(commit) = resource_commit {
+        out.push_str(&format!(
+            "resources {} -> 1 commit \"{}\"\n",
+            resources, commit.subject
+        ));
+    }
+    if let Some(commit) = rest_commit {
+        out.push_str(&format!(
+            "rest {} -> 1 commit \"{}\"\n",
+            rest, commit.subject
+        ));
+    }
+    if commits.is_empty() && resource_commit.is_none() && rest_commit.is_none() {
+        out.push_str("annotate: no claimable paths committed\n");
+    }
+    out.push_str(next);
+    out.push('\n');
+    out
+}
+
+fn feature_commits(commits: &[crate::engine::apply::AuthoredCommit]) -> Vec<AnnotateCommitReport> {
+    commits
+        .iter()
+        .map(|commit| AnnotateCommitReport {
+            subject: commit.subject.clone(),
+            sha: commit.short_sha.clone(),
+            files: 0,
+            feature: Some(commit.feature.clone()),
+            seq: Some(commit.seq),
+        })
+        .collect()
+}
+
+fn named_commit(commit: &crate::engine::annotate::NamedCommit) -> AnnotateCommitReport {
+    AnnotateCommitReport {
+        subject: commit.subject.clone(),
+        sha: commit.short_sha.clone(),
+        files: commit.files,
+        feature: None,
+        seq: None,
+    }
+}
+
+fn unclaimed_reports(paths: &[UnclaimedPath]) -> Vec<UnclaimedReport> {
+    paths
+        .iter()
+        .map(|path| {
+            let (suggestion, command) = suggestion_command(path);
+            UnclaimedReport {
+                path: path.path.clone(),
+                suggestion,
+                command,
+            }
+        })
+        .collect()
+}
+
+fn suggestion_command(path: &UnclaimedPath) -> (String, String) {
+    let path_text = path.path.to_string_lossy();
+    match &path.suggestion {
+        FeatureSuggestion::ExistingFeature(feature) => (
+            format!("nearest feature \"{feature}\""),
+            format!("bpatch feature add {feature} {}", shell_word(&path_text)),
+        ),
+        FeatureSuggestion::NewFeature(feature) => {
+            let owned_path = parent_dir(&path_text).unwrap_or_else(|| path_text.to_string());
+            (
+                feature.clone(),
+                format!(
+                    "bpatch feature add {feature} {} --desc {}",
+                    shell_word(&owned_path),
+                    shell_word(&format!("feat: {feature}"))
+                ),
+            )
+        }
+    }
+}
+
+fn parent_dir(path: &str) -> Option<String> {
+    path.rsplit_once('/')
+        .map(|(parent, _)| format!("{parent}/"))
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct TriageFile {
+    features: Vec<TriageFeature>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct TriageFeature {
+    name: String,
+    description: String,
+    #[serde(default)]
+    store: Option<bool>,
+    paths: Vec<String>,
+}
+
+fn triage_features(paths: &[UnclaimedPath]) -> Vec<TriageFeature> {
+    let mut grouped = BTreeMap::<String, TriageFeature>::new();
+    for path in paths {
+        let path_text = path.path.to_string_lossy();
+        let (name, description, owned_path) = match &path.suggestion {
+            FeatureSuggestion::ExistingFeature(feature) => (
+                feature.clone(),
+                format!("feat: {feature}"),
+                path_text.to_string(),
+            ),
+            FeatureSuggestion::NewFeature(feature) => (
+                feature.clone(),
+                format!("feat: {feature}"),
+                parent_dir(&path_text).unwrap_or_else(|| path_text.to_string()),
+            ),
+        };
+        grouped
+            .entry(name.clone())
+            .or_insert_with(|| TriageFeature {
+                name,
+                description,
+                store: None,
+                paths: Vec::new(),
+            })
+            .paths
+            .push(owned_path);
+    }
+    grouped.into_values().collect()
+}
+
+fn apply_triage_file(ctx: &StateContext, file: TriageFile) -> Result<()> {
+    let _store_lock = CheckoutLock::acquire_store_repo(&ctx.store_dir)?;
+    let mut store = Store::load(&ctx.store_dir)?;
+    for feature in file.features {
+        if feature.paths.is_empty() {
+            continue;
+        }
+        if store.features().features.contains_key(&feature.name) {
+            store.append_feature_paths(&feature.name, feature.paths)?;
+        } else {
+            store.add_feature_with_store(
+                &feature.name,
+                &feature.description,
+                feature.paths,
+                feature.store.unwrap_or(true),
+            )?;
+        }
+    }
+    store.save()
+}
+
+fn open_editor(path: &Path) -> Result<()> {
+    let editor = env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+    let status = Command::new(&editor)
+        .arg(path)
+        .status()
+        .with_context(|| format!("opening {editor}"))?;
+    if !status.success() {
+        bail!("{editor} exited with {status}");
+    }
+    Ok(())
+}
+
+fn triage_path(checkout: &Path) -> Result<PathBuf> {
+    let git = GitAdapter::new(checkout);
+    let git_dir = PathBuf::from(git.process().run_str(&["rev-parse", "--git-dir"])?);
+    let git_dir = if git_dir.is_absolute() {
+        git_dir
+    } else {
+        checkout.join(git_dir)
+    };
+    Ok(git_dir.join("bpatch/triage.yaml"))
+}
+
+fn shell_word(value: &str) -> String {
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-'))
+    {
+        value.to_string()
+    } else {
+        format!("{value:?}")
+    }
+}
+
+fn next_extract() -> String {
+    "next: bpatch extract <annotated-rev-range> to fold feature commits into the store".to_string()
+}
+
+fn files_label(count: usize) -> &'static str {
+    if count == 1 { "file" } else { "files" }
+}
+
+fn commits_label(count: usize) -> &'static str {
+    if count == 1 { "commit" } else { "commits" }
+}

--- a/packages/browseros/tools/bpatch/src/cli/diff.rs
+++ b/packages/browseros/tools/bpatch/src/cli/diff.rs
@@ -78,6 +78,7 @@ pub fn run(ctx: &StateContext) -> Result<DiffReport> {
     let patches = store
         .patches()
         .values()
+        .filter(|patch| store.stores_path(&patch.path))
         .map(|patch| ctx.store_dir.join(&patch.path))
         .collect::<Vec<_>>();
     let target_tree = crate::git::GitAdapter::new(&ctx.checkout)
@@ -87,9 +88,17 @@ pub fn run(ctx: &StateContext) -> Result<DiffReport> {
         .applied
         .as_ref()
         .map(|applied| applied.tree.as_str())
-        .unwrap_or(&state.head_tree);
+        .unwrap_or(&state.base.sha);
     let entries = crate::git::GitAdapter::new(&ctx.checkout)
-        .diff_tree_name_status(applied_tree, &target_tree)?;
+        .diff_tree_name_status(applied_tree, &target_tree)?
+        .into_iter()
+        .filter(|entry| {
+            entry
+                .path
+                .to_str()
+                .is_none_or(|path| store.stores_path(path))
+        })
+        .collect::<Vec<_>>();
 
     let mut groups = BTreeMap::<String, Vec<DiffFile>>::new();
     let mut build_files_changed = 0;

--- a/packages/browseros/tools/bpatch/src/cli/feature.rs
+++ b/packages/browseros/tools/bpatch/src/cli/feature.rs
@@ -1,12 +1,14 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use serde::Serialize;
 
+use crate::engine::dirty::{classify_dirty, collapse_dirty_paths, scan_dirty};
 use crate::engine::lock::CheckoutLock;
 use crate::engine::state::{StateContext, parse_apply_trailers};
 use crate::git::GitAdapter;
+use crate::process::Git;
 use crate::store::{FEATURES_FILE, FeatureMatch, Store};
 
 /// Serializable feature command report.
@@ -24,13 +26,39 @@ pub enum FeatureReport {
     FeatureAdded {
         /// Feature name.
         name: String,
-        /// Owned path prefix.
-        path: String,
+        /// Owned paths appended or created.
+        paths: Vec<String>,
         /// Description written to .features.yaml.
         description: String,
+        /// Whether paths are stored as Chromium patch files.
+        store: bool,
+        /// Whether this command created a new feature block.
+        created: bool,
+        /// Number of dirty paths newly covered by this command.
+        appended: usize,
+        /// Number of dirty paths already claimed by another feature or patch.
+        skipped: usize,
+        /// Number of collapsed directory entries appended to .features.yaml.
+        collapsed_dirs: usize,
+        /// Number of file entries appended to .features.yaml.
+        collapsed_files: usize,
+        /// Store commit created by --commit.
+        committed: Option<String>,
+        /// Whether paths came from --from-dirty.
+        from_dirty: bool,
         /// Process exit code for this result.
         exit: i32,
     },
+}
+
+/// Feature add behavior selected by the CLI.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FeatureAddOptions {
+    pub paths: Vec<String>,
+    pub description: Option<String>,
+    pub store: bool,
+    pub from_dirty: bool,
+    pub commit: bool,
 }
 
 /// One row in feature list output.
@@ -74,27 +102,135 @@ pub fn list(ctx: &StateContext) -> Result<FeatureReport> {
     Ok(FeatureReport::Features { features, exit: 0 })
 }
 
-/// Appends a feature block to .features.yaml.
+/// Appends explicit paths or unclaimed dirty paths to .features.yaml.
 pub fn add(
+    ctx: &StateContext,
     store_dir: impl Into<PathBuf>,
     name: &str,
-    path: &str,
-    description: Option<&str>,
+    options: FeatureAddOptions,
 ) -> Result<FeatureReport> {
+    if options.paths.is_empty() && !options.from_dirty {
+        bail!("feature add requires a path argument, --path <PATH>, or --from-dirty");
+    }
     let store_dir = store_dir.into();
     let _store_lock = CheckoutLock::acquire_store_repo(&store_dir)?;
-    let description = description
-        .map(ToOwned::to_owned)
+    let description = options
+        .description
         .unwrap_or_else(|| format!("feat: {name}"));
     let mut store = Store::load(&store_dir)?;
-    store.add_feature(name, &description, vec![path.to_string()])?;
-    store.save()?;
+
+    let add_plan = if options.from_dirty {
+        from_dirty_plan(ctx, &store)?
+    } else {
+        explicit_plan(&store, name, options.paths)
+    };
+    let created = !store.features().features.contains_key(name);
+    if !add_plan.paths.is_empty() {
+        if created {
+            store.add_feature_with_store(
+                name,
+                &description,
+                add_plan.paths.clone(),
+                options.store,
+            )?;
+        } else {
+            store.append_feature_paths(name, add_plan.paths.clone())?;
+        }
+        store.save()?;
+    }
+
+    let committed = if options.commit {
+        commit_store_features(&store_dir)?
+    } else {
+        None
+    };
+
     Ok(FeatureReport::FeatureAdded {
         name: name.to_string(),
-        path: path.to_string(),
+        paths: add_plan.paths,
         description,
+        store: options.store,
+        created,
+        appended: add_plan.appended,
+        skipped: add_plan.skipped,
+        collapsed_dirs: add_plan.collapsed_dirs,
+        collapsed_files: add_plan.collapsed_files,
+        committed,
+        from_dirty: options.from_dirty,
         exit: 0,
     })
+}
+
+struct AddPlan {
+    paths: Vec<String>,
+    appended: usize,
+    skipped: usize,
+    collapsed_dirs: usize,
+    collapsed_files: usize,
+}
+
+fn explicit_plan(store: &Store, name: &str, paths: Vec<String>) -> AddPlan {
+    let existing = store
+        .features()
+        .features
+        .get(name)
+        .map(|feature| feature.paths.as_slice())
+        .unwrap_or(&[]);
+    let paths = paths
+        .into_iter()
+        .filter(|path| !existing.iter().any(|existing| existing == path))
+        .collect::<Vec<_>>();
+    AddPlan {
+        appended: paths.len(),
+        skipped: 0,
+        collapsed_dirs: paths.iter().filter(|path| path.ends_with('/')).count(),
+        collapsed_files: paths.iter().filter(|path| !path.ends_with('/')).count(),
+        paths,
+    }
+}
+
+fn from_dirty_plan(ctx: &StateContext, store: &Store) -> Result<AddPlan> {
+    let git = GitAdapter::new(&ctx.checkout);
+    let scan = scan_dirty(&git)?;
+    if !scan.conflicts.is_empty() {
+        bail!("feature add --from-dirty refuses conflicted trees");
+    }
+    let plan = classify_dirty(store, &scan.entries);
+    let candidates = plan
+        .unclaimed
+        .iter()
+        .map(|path| path.path.clone())
+        .collect::<Vec<_>>();
+    let paths = collapse_dirty_paths(&git, &candidates)?;
+    let dirty_count = scan.entries.len();
+    let skipped = dirty_count.saturating_sub(candidates.len());
+    Ok(AddPlan {
+        appended: candidates.len(),
+        skipped,
+        collapsed_dirs: paths.iter().filter(|path| path.ends_with('/')).count(),
+        collapsed_files: paths.iter().filter(|path| !path.ends_with('/')).count(),
+        paths,
+    })
+}
+
+fn commit_store_features(store_dir: &Path) -> Result<Option<String>> {
+    let git = Git::new(store_dir);
+    git.run(&[
+        "add",
+        "-A",
+        "--",
+        FEATURES_FILE,
+        ".store.yaml",
+        "features.yaml",
+        "store.yaml",
+    ])?;
+    let diff = git.output(&["diff", "--cached", "--quiet", "--", FEATURES_FILE])?;
+    if diff.status.success() {
+        return Ok(None);
+    }
+    git.run(&["commit", "-m", "chore(chromium_patches): update features"])
+        .context("committing store feature update")?;
+    Ok(Some(git.run_str(&["rev-parse", "HEAD"])?))
 }
 
 /// Renders a human feature report.
@@ -120,8 +256,46 @@ pub fn render_human(report: &FeatureReport) -> String {
             }
             out
         }
-        FeatureReport::FeatureAdded { name, path, .. } => {
-            format!("created feature \"{name}\" (path: {path}) in {FEATURES_FILE}\n")
+        FeatureReport::FeatureAdded {
+            name,
+            paths,
+            created,
+            appended,
+            skipped,
+            collapsed_dirs,
+            collapsed_files,
+            committed,
+            from_dirty,
+            ..
+        } => {
+            let action = if *created { "created" } else { "updated" };
+            let mut out = String::new();
+            if paths.len() == 1 {
+                out.push_str(&format!(
+                    "{action} feature \"{name}\" (path: {}) in {FEATURES_FILE}\n",
+                    paths[0]
+                ));
+            } else {
+                out.push_str(&format!(
+                    "{action} feature \"{name}\" ({} entries) in {FEATURES_FILE}\n",
+                    paths.len()
+                ));
+            }
+            if *from_dirty && (*appended > 0 || *skipped > 0) {
+                out.push_str(&format!(
+                    "scanned {} dirty {} · collapsed to {} dirs + {} files · {} new, {} already claimed\n",
+                    appended + skipped,
+                    files_label(appended + skipped),
+                    collapsed_dirs,
+                    collapsed_files,
+                    appended,
+                    skipped
+                ));
+            }
+            if *from_dirty && committed.is_none() {
+                out.push_str("next: --commit to commit the store repo\n");
+            }
+            out
         }
     }
 }
@@ -134,6 +308,9 @@ pub fn render_json(report: &FeatureReport) -> Result<String> {
 fn patch_counts(store: &Store) -> BTreeMap<String, usize> {
     let mut counts = BTreeMap::new();
     for path in store.patches().keys() {
+        if !store.stores_path(path) {
+            continue;
+        }
         if let FeatureMatch::Matched { feature, .. } = store.match_path(path) {
             *counts.entry(feature).or_insert(0) += 1;
         }
@@ -167,4 +344,8 @@ fn subject_sequence(subject: &str) -> Option<(String, usize)> {
             .map(|seq| (feature.to_string(), seq));
     }
     Some((rest.to_string(), 1))
+}
+
+fn files_label(count: usize) -> &'static str {
+    if count == 1 { "path" } else { "paths" }
 }

--- a/packages/browseros/tools/bpatch/src/cli/mod.rs
+++ b/packages/browseros/tools/bpatch/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod abort;
 pub mod alias;
+pub mod annotate;
 pub mod apply;
 mod checkout_guard;
 pub mod continue_cmd;
@@ -12,6 +13,7 @@ pub mod status;
 
 use std::collections::BTreeMap;
 use std::env;
+use std::ffi::OsString;
 use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -54,6 +56,7 @@ EXAMPLES:
     bpatch status
     bpatch diff
     bpatch apply
+    bpatch annotate
 
   Extract checkout commits into the store:
     bpatch extract <rev1>..<rev2> --feature <name>
@@ -62,7 +65,7 @@ EXAMPLES:
     bpatch apply -> bpatch continue --materialize -> resolve markers -> bpatch continue -> bpatch extract --repin
 
 EXIT CODES:
-  0  Initialized, converged, applied, extracted, repinned, listed, added, aborted, or completed.
+  0  Initialized, converged, applied, annotated, extracted, repinned, listed, added, aborted, or completed.
   2  Conflicts are pending or conflict files remain unresolved.
   3  Drift/refusal or extract needs a feature decision.
   1  CLI, git, lock, config, or unexpected error.
@@ -118,6 +121,16 @@ pub enum Command {
 "#
     )]
     Apply(ApplyArgs),
+    /// Commit dirty bos_build output into feature/resource commits.
+    #[command(
+        long_about = "Commit a dirty bos_build-patched checkout into feature commits, one resource commit for store:false groups, and optionally one wip commit for leftovers. Exit 3 means unclaimed paths were left in the working tree.",
+        after_long_help = r#"EXAMPLES:
+  bpatch annotate
+  bpatch annotate --rest wip-frame-experiments
+  bpatch annotate --triage --json
+"#
+    )]
+    Annotate(AnnotateArgs),
     /// Extract commits into the store or repin the store base.
     #[command(
         long_about = "Extract <rev> or <rev1>..<rev2> into the store, or repin existing store patches to the checkout base. Use --feature <FEATURE> to route unmatched files, --commit to commit store repo changes, and --repin without a spec for base upgrades.",
@@ -189,6 +202,19 @@ pub struct ApplyArgs {
     pub checkout: Option<String>,
 }
 
+/// Annotate command flags.
+#[derive(Debug, Args)]
+pub struct AnnotateArgs {
+    /// Commit unclaimed leftovers into one `wip: <NAME>` commit.
+    #[arg(long)]
+    pub rest: Option<String>,
+    /// Emit a triage plan instead of committing; JSON mode never opens an editor.
+    #[arg(long)]
+    pub triage: bool,
+    /// Checkout alias or path.
+    pub checkout: Option<String>,
+}
+
 /// Extract command flags.
 #[derive(Debug, Args)]
 pub struct ExtractArgs {
@@ -227,11 +253,12 @@ pub enum FeatureCommand {
 "#
     )]
     List,
-    /// Add a feature path block.
+    /// Add paths to a feature block.
     #[command(
-        long_about = "Append a new feature block to .features.yaml. Provide a feature name and an exact path or directory prefix with --path.",
+        long_about = "Append paths to .features.yaml. Provide explicit paths, or use --from-dirty to claim currently unclaimed dirty paths. Use --store=false for resource groups that annotate commits but extract/apply ignore.",
         after_long_help = r#"EXAMPLE:
-  bpatch feature add wallet --path chrome/browser/browseros/wallet/ --description "Wallet UI"
+  bpatch feature add wallet chrome/browser/browseros/wallet/ --desc "feat: wallet"
+  bpatch feature add build-resources --store=false --from-dirty
 "#
     )]
     Add(FeatureAddArgs),
@@ -242,12 +269,23 @@ pub enum FeatureCommand {
 pub struct FeatureAddArgs {
     /// Feature name.
     pub name: String,
-    /// Path or prefix owned by the feature.
+    /// Path or prefixes owned by the feature.
+    pub paths: Vec<String>,
+    /// Path or prefix owned by the feature. Kept for older scripts.
     #[arg(long)]
-    pub path: String,
+    pub path: Vec<String>,
     /// Feature description.
-    #[arg(long)]
+    #[arg(long, alias = "desc")]
     pub description: Option<String>,
+    /// Claim currently unclaimed dirty checkout paths.
+    #[arg(long)]
+    pub from_dirty: bool,
+    /// Commit the store repo after updating .features.yaml.
+    #[arg(long)]
+    pub commit: bool,
+    /// Hidden normalized spelling for `feature add ... --store=false`.
+    #[arg(id = "feature_store", long = "feature-store", hide = true)]
+    pub feature_store: Option<bool>,
 }
 
 /// Continue command flags.
@@ -265,6 +303,7 @@ impl Command {
         match self {
             Self::Status(args) | Self::Diff(args) | Self::Abort(args) => args.checkout.as_deref(),
             Self::Apply(args) => args.checkout.as_deref(),
+            Self::Annotate(args) => args.checkout.as_deref(),
             Self::Continue(args) => args.checkout.as_deref(),
             Self::Extract(_) | Self::Feature(_) | Self::Alias(_) | Self::Init(_) => None,
         }
@@ -353,6 +392,31 @@ fn run_inner(cli: &Cli) -> Result<i32> {
             )?;
             Ok(report.exit_code())
         }
+        Command::Annotate(args) => {
+            let report = if args.triage {
+                if render::is_interactive(cli.json) {
+                    let mut progress = render::progress_sink(cli.json);
+                    annotate::triage_editor(&state_ctx, &mut progress)?
+                } else {
+                    annotate::triage(&state_ctx)?
+                }
+            } else {
+                let mut progress = render::progress_sink(cli.json);
+                annotate::run(
+                    &state_ctx,
+                    &crate::engine::annotate::AnnotateOptions {
+                        rest: args.rest.clone(),
+                    },
+                    &mut progress,
+                )?
+            };
+            write_output(
+                cli.json,
+                &annotate::render_json(&report)?,
+                &annotate::render_human(&report),
+            )?;
+            Ok(report.exit_code())
+        }
         Command::Extract(args) => run_extract(cli, args, &checkout, &store_dir),
         Command::Feature(args) => run_feature(cli, args, &state_ctx, &store_dir),
         Command::Alias(_) => unreachable!("alias dispatches before checkout/store discovery"),
@@ -383,6 +447,46 @@ fn run_inner(cli: &Cli) -> Result<i32> {
             Ok(report.exit_code())
         }
     }
+}
+
+/// Normalizes feature-add's `--store=false` before clap sees the global store flag.
+pub fn normalize_args(args: impl IntoIterator<Item = OsString>) -> Vec<OsString> {
+    let mut out = Vec::new();
+    let mut saw_feature = false;
+    let mut in_feature_add = false;
+    let mut iter = args.into_iter().peekable();
+    while let Some(arg) = iter.next() {
+        let text = arg.to_string_lossy();
+        if text == "feature" {
+            saw_feature = true;
+            out.push(arg);
+            continue;
+        }
+        if saw_feature && text == "add" {
+            in_feature_add = true;
+            out.push(arg);
+            continue;
+        }
+        if in_feature_add && (text == "--store=false" || text == "--store=true") {
+            out.push(OsString::from(text.replacen(
+                "--store",
+                "--feature-store",
+                1,
+            )));
+            continue;
+        }
+        if in_feature_add
+            && text == "--store"
+            && let Some(next) = iter.peek()
+            && matches!(next.to_string_lossy().as_ref(), "false" | "true")
+        {
+            out.push(OsString::from("--feature-store"));
+            out.push(iter.next().expect("peeked"));
+            continue;
+        }
+        out.push(arg);
+    }
+    out
 }
 
 /// Resolves `-C` or positional checkout selectors into the checkout used by all checkout verbs.
@@ -534,10 +638,16 @@ fn run_feature(
     let report = match &args.command {
         FeatureCommand::List => feature::list(state_ctx)?,
         FeatureCommand::Add(args) => feature::add(
+            state_ctx,
             store_dir,
             &args.name,
-            &args.path,
-            args.description.as_deref(),
+            feature::FeatureAddOptions {
+                paths: args.paths.iter().chain(args.path.iter()).cloned().collect(),
+                description: args.description.clone(),
+                store: args.feature_store.unwrap_or(true),
+                from_dirty: args.from_dirty,
+                commit: args.commit,
+            },
         )?,
     };
     write_output(
@@ -561,7 +671,7 @@ fn extract_policy(args: &ExtractArgs) -> FeatureDecisionPolicy {
 fn needs_checkout_store_guard(command: &Command) -> bool {
     matches!(
         command,
-        Command::Status(_) | Command::Diff(_) | Command::Apply(_)
+        Command::Status(_) | Command::Diff(_) | Command::Apply(_) | Command::Annotate(_)
     )
 }
 

--- a/packages/browseros/tools/bpatch/src/engine/annotate.rs
+++ b/packages/browseros/tools/bpatch/src/engine/annotate.rs
@@ -1,0 +1,234 @@
+use anyhow::{Context, Result};
+
+use crate::engine::apply::{
+    AuthorCommitsInput, AuthoredCommit, CommitTrailerMode, SubjectMode, author_feature_commits,
+};
+use crate::engine::dirty::{
+    ClaimPlan, DirtyEntry, UnclaimedPath, classify_dirty, reset_index_paths_to_head, scan_dirty,
+    tree_from_worktree_paths,
+};
+use crate::engine::lock::CheckoutLock;
+use crate::engine::progress::ProgressEvent;
+use crate::engine::state::{StateContext, format_annotate_trailers};
+use crate::git::{GitAdapter, TreeDiffEntry};
+use crate::store::Store;
+
+/// Options controlling dirty-tree annotation.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AnnotateOptions {
+    pub rest: Option<String>,
+}
+
+/// Result of annotating the current dirty checkout.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AnnotateOutcome {
+    Clean,
+    Conflicts { files: Vec<DirtyEntry> },
+    Annotated(Box<AnnotateResult>),
+    Leftovers(Box<AnnotateResult>),
+}
+
+/// Commits authored by one annotate run plus any leftover paths.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AnnotateResult {
+    pub claimed_files: usize,
+    pub resource_files: usize,
+    pub rest_files: usize,
+    pub feature_commits: Vec<AuthoredCommit>,
+    pub resource_commit: Option<NamedCommit>,
+    pub rest_commit: Option<NamedCommit>,
+    pub unclaimed: Vec<UnclaimedPath>,
+}
+
+/// A non-feature commit authored by annotate.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NamedCommit {
+    pub sha: String,
+    pub short_sha: String,
+    pub subject: String,
+    pub files: usize,
+}
+
+/// Builds an annotate plan without mutating the checkout.
+pub fn plan(ctx: &StateContext) -> Result<AnnotatePlan> {
+    let git = GitAdapter::new(&ctx.checkout);
+    let scan = scan_dirty(&git)?;
+    if !scan.conflicts.is_empty() {
+        return Ok(AnnotatePlan::Conflicts {
+            files: scan.conflicts,
+        });
+    }
+    if scan.entries.is_empty() {
+        return Ok(AnnotatePlan::Clean);
+    }
+    let store = Store::load(&ctx.store_dir)?;
+    Ok(AnnotatePlan::Dirty {
+        plan: classify_dirty(&store, &scan.entries),
+    })
+}
+
+/// Read-only annotate classification used by JSON triage.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AnnotatePlan {
+    Clean,
+    Conflicts { files: Vec<DirtyEntry> },
+    Dirty { plan: ClaimPlan },
+}
+
+/// Converts a dirty checkout into feature/resource/rest commits.
+pub fn annotate(
+    ctx: &StateContext,
+    options: &AnnotateOptions,
+    progress: &mut dyn FnMut(ProgressEvent<'_>),
+) -> Result<AnnotateOutcome> {
+    let _lock = CheckoutLock::acquire(&ctx.checkout)?;
+    let git = GitAdapter::new(&ctx.checkout);
+    let scan = scan_dirty(&git)?;
+    if !scan.conflicts.is_empty() {
+        return Ok(AnnotateOutcome::Conflicts {
+            files: scan.conflicts,
+        });
+    }
+    if scan.entries.is_empty() {
+        return Ok(AnnotateOutcome::Clean);
+    }
+
+    let state = crate::engine::state::resolve(ctx)?;
+    let store = Store::load(&ctx.store_dir)?;
+    let claim_plan = classify_dirty(&store, &scan.entries);
+    let rest_paths = options
+        .rest
+        .as_ref()
+        .map(|_| {
+            claim_plan
+                .unclaimed
+                .iter()
+                .map(|path| path.path.clone())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut committed_paths = Vec::new();
+    let feature_tree = tree_from_worktree_paths(&git, &state.head_tree, &claim_plan.claimed)?;
+    let feature_delta = git.diff_tree_name_status(&state.head_tree, &feature_tree)?;
+    let feature_chain = author_feature_commits(
+        AuthorCommitsInput {
+            checkout: &ctx.checkout,
+            store: &store,
+            base: &state.base.sha,
+            applied_tree: &state.head_tree,
+            target_tree: &feature_tree,
+            trailers: CommitTrailerMode::Annotate,
+            subject_mode: SubjectMode::FeatureDescription,
+            parent_commit: &state.head_rev,
+            delta: &feature_delta,
+        },
+        progress,
+    )?;
+    if !feature_delta.is_empty() {
+        committed_paths.extend(claim_plan.claimed.iter().cloned());
+    }
+
+    let mut parent = feature_chain.final_sha.clone();
+    let resource_tree = tree_from_worktree_paths(&git, &feature_tree, &claim_plan.resources)?;
+    let resource_delta = git.diff_tree_name_status(&feature_tree, &resource_tree)?;
+    let resource_commit = if resource_delta.is_empty() {
+        None
+    } else {
+        let commit = commit_named_tree(
+            &git,
+            &resource_tree,
+            &parent,
+            "resource: bos_build outputs",
+            &state.base.sha,
+            &resource_delta,
+        )?;
+        parent = commit.sha.clone();
+        committed_paths.extend(claim_plan.resources.iter().cloned());
+        Some(commit)
+    };
+
+    let rest_tree = tree_from_worktree_paths(&git, &resource_tree, &rest_paths)?;
+    let rest_delta = git.diff_tree_name_status(&resource_tree, &rest_tree)?;
+    let rest_commit = if rest_delta.is_empty() {
+        None
+    } else {
+        let subject = format!(
+            "wip: {}",
+            options
+                .rest
+                .as_deref()
+                .expect("rest paths require rest name")
+        );
+        let commit = commit_named_tree(
+            &git,
+            &rest_tree,
+            &parent,
+            &subject,
+            &state.base.sha,
+            &rest_delta,
+        )?;
+        parent = commit.sha.clone();
+        committed_paths.extend(rest_paths);
+        Some(commit)
+    };
+
+    if parent != state.head_rev {
+        git.process()
+            .run(&["update-ref", "HEAD", &parent, &state.head_rev])
+            .with_context(|| {
+                format!(
+                    "finalizing annotated HEAD failed; recover with `git update-ref HEAD {parent} {}`",
+                    state.head_rev
+                )
+            })?;
+        reset_index_paths_to_head(&git, &committed_paths)?;
+    }
+
+    let result = AnnotateResult {
+        claimed_files: claim_plan.claimed.len(),
+        resource_files: claim_plan.resources.len(),
+        rest_files: rest_commit.as_ref().map(|commit| commit.files).unwrap_or(0),
+        feature_commits: feature_chain.commits,
+        resource_commit,
+        rest_commit,
+        unclaimed: if options.rest.is_some() {
+            Vec::new()
+        } else {
+            claim_plan.unclaimed
+        },
+    };
+
+    if result.unclaimed.is_empty() {
+        Ok(AnnotateOutcome::Annotated(Box::new(result)))
+    } else {
+        Ok(AnnotateOutcome::Leftovers(Box::new(result)))
+    }
+}
+
+fn commit_named_tree(
+    git: &GitAdapter,
+    tree: &str,
+    parent: &str,
+    subject: &str,
+    base: &str,
+    delta: &[TreeDiffEntry],
+) -> Result<NamedCommit> {
+    let mut message = String::new();
+    message.push_str(subject);
+    message.push_str("\n\n");
+    message.push_str(&format_annotate_trailers(base));
+    let sha = git
+        .process()
+        .run_with_stdin(&["commit-tree", tree, "-p", parent], message.as_bytes())?;
+    let sha = String::from_utf8(sha)
+        .context("commit-tree output was not UTF-8")?
+        .trim()
+        .to_string();
+    Ok(NamedCommit {
+        short_sha: git.short_rev(&sha)?,
+        sha,
+        subject: subject.to_string(),
+        files: delta.len(),
+    })
+}

--- a/packages/browseros/tools/bpatch/src/engine/apply.rs
+++ b/packages/browseros/tools/bpatch/src/engine/apply.rs
@@ -6,8 +6,8 @@ use anyhow::{Context, Result, anyhow, bail};
 
 use crate::engine::progress::ProgressEvent;
 use crate::engine::state::{
-    DriftFile, DriftSource, StateContext, format_apply_trailers, parse_apply_trailers,
-    unassigned_feature_name,
+    DriftFile, DriftSource, StateContext, format_annotate_trailers, format_apply_trailers,
+    parse_bpatch_authored_base, unassigned_feature_name,
 };
 use crate::git::{GitAdapter, TreeDiffEntry};
 use crate::process::Git;
@@ -95,12 +95,32 @@ pub struct AuthorCommitsInput<'a> {
     pub applied_tree: &'a str,
     /// Final tree that the authored commit chain must reach.
     pub target_tree: &'a str,
-    /// Store repository commit to write into trailers.
-    pub store_rev: &'a str,
+    /// Trailer block written to each authored commit.
+    pub trailers: CommitTrailerMode<'a>,
+    /// Subject source used when building feature commit messages.
+    pub subject_mode: SubjectMode,
     /// Parent commit for the first authored feature commit.
     pub parent_commit: &'a str,
     /// Files changed between `applied_tree` and `target_tree`.
     pub delta: &'a [TreeDiffEntry],
+}
+
+/// Trailer style for commit-tree authored bpatch commits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommitTrailerMode<'a> {
+    /// Apply commits record the store revision and final target tree.
+    Apply { store_rev: &'a str },
+    /// Annotate commits record only the base plus an annotation marker.
+    Annotate,
+}
+
+/// Subject source for grouped feature commits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SubjectMode {
+    /// Use the stable `feat: <feature>` subject style.
+    FeatureName,
+    /// Use `.features.yaml` descriptions when present.
+    FeatureDescription,
 }
 
 /// Commit authored for one feature group.
@@ -154,12 +174,33 @@ pub fn apply(
     }
 
     let checkout = GitAdapter::new(&ctx.checkout);
-    let target_tree =
+    let store_target_tree =
         build_target_tree(&checkout, &ctx.store_dir, &store, &state.base.sha, progress)
             .context("building target tree from store patches")?;
+    let applied_tree = state
+        .applied
+        .as_ref()
+        .map(|applied| applied.tree.as_str())
+        .unwrap_or(&state.base.sha);
+    let store_delta = checkout
+        .diff_tree_name_status(applied_tree, &store_target_tree)?
+        .into_iter()
+        .filter(|entry| stores_entry(&store, entry))
+        .collect::<Vec<_>>();
+    let target_tree = build_tree_from_source_entries(
+        &checkout,
+        &state.head_tree,
+        &store_target_tree,
+        &store_delta,
+    )?;
 
     checkout.refresh_index()?;
-    if state.head_tree == target_tree && !checkout.diff_index_has_changes("HEAD")? {
+    let has_uncommitted_drift = state
+        .drift
+        .files()
+        .iter()
+        .any(|file| matches!(file.source, DriftSource::Uncommitted));
+    if state.head_tree == target_tree && !has_uncommitted_drift {
         return Ok(ApplyOutcome::Converged(ConvergedApply {
             store_rev: state.store.head_rev,
             store_short_rev: state.store.short_head_rev,
@@ -173,12 +214,7 @@ pub fn apply(
         }));
     }
 
-    let applied_tree = state
-        .applied
-        .as_ref()
-        .map(|applied| applied.tree.as_str())
-        .unwrap_or(&state.head_tree);
-    let delta = checkout.diff_tree_name_status(applied_tree, &target_tree)?;
+    let delta = checkout.diff_tree_name_status(&state.head_tree, &target_tree)?;
     let collisions = untracked_add_collisions(&checkout, &delta)?;
     if !collisions.is_empty() {
         return Ok(ApplyOutcome::Drift(DriftApply { files: collisions }));
@@ -189,9 +225,12 @@ pub fn apply(
             checkout: &ctx.checkout,
             store: &store,
             base: &state.base.sha,
-            applied_tree,
+            applied_tree: &state.head_tree,
             target_tree: &target_tree,
-            store_rev: &state.store.head_rev,
+            trailers: CommitTrailerMode::Apply {
+                store_rev: &state.store.head_rev,
+            },
+            subject_mode: SubjectMode::FeatureName,
             parent_commit: &state.head_rev,
             delta: &delta,
         },
@@ -203,10 +242,11 @@ pub fn apply(
         total: Some(delta.len()),
     });
     checkout
-        .materialize_tree_delta(applied_tree, &target_tree)
+        .materialize_tree_delta(&state.head_tree, &target_tree)
         .with_context(|| {
             format!(
-                "materializing target tree failed; recover with `git read-tree -m -u {applied_tree} {target_tree}`"
+                "materializing target tree failed; recover with `git read-tree -m -u {} {target_tree}`",
+                state.head_tree
             )
         })?;
     progress(ProgressEvent::End {
@@ -226,7 +266,11 @@ pub fn apply(
         base_display: state.base.display,
         previous_store_short_rev: state.applied.map(|applied| applied.short_store_rev),
         files_changed: delta.len(),
-        store_managed_files: store.patches().len(),
+        store_managed_files: store
+            .patches()
+            .keys()
+            .filter(|path| store.stores_path(path))
+            .count(),
         target_tree,
         commits: chain.commits,
     }))
@@ -251,6 +295,7 @@ pub fn author_feature_commits(
         input.base,
         input.parent_commit,
         input.delta,
+        input.subject_mode,
     )?;
     let git_dir = git_dir(git.process())?;
     let temp = tempfile::Builder::new()
@@ -278,7 +323,7 @@ pub fn author_feature_commits(
         indexed.run_with_stdin(&["update-index", "--index-info"], index_info.as_bytes())?;
         let next_tree = indexed.run_str(&["write-tree"])?;
         let tree_trailer = (index == last_index).then_some(input.target_tree);
-        let message = commit_message(&group.subject, input.store_rev, input.base, tree_trailer);
+        let message = commit_message(&group.subject, input.trailers, input.base, tree_trailer);
         let sha = git.process().run_with_stdin(
             &["commit-tree", &next_tree, "-p", &parent],
             message.as_bytes(),
@@ -423,16 +468,27 @@ fn build_target_tree(
 
     progress(ProgressEvent::Start {
         phase: "tree",
-        total: Some(store.patches().len()),
+        total: Some(
+            store
+                .patches()
+                .keys()
+                .filter(|path| store.stores_path(path))
+                .count(),
+        ),
     });
-    for (index, patch) in store.patches().values().enumerate() {
+    let patches = store
+        .patches()
+        .values()
+        .filter(|patch| store.stores_path(&patch.path))
+        .collect::<Vec<_>>();
+    for (index, patch) in patches.iter().enumerate() {
         let patch_path = store_dir.join(&patch.path);
         let patch_arg = path_arg(&patch_path)?;
         indexed.run(&["apply", "--cached", "--whitespace=nowarn", patch_arg])?;
         progress(ProgressEvent::Tick {
             phase: "tree",
             done: index + 1,
-            total: Some(store.patches().len()),
+            total: Some(patches.len()),
             item: Some(&patch.path),
         });
     }
@@ -441,12 +497,38 @@ fn build_target_tree(
     Ok(tree)
 }
 
+/// Builds a tree by copying selected entries from a source tree onto a base tree.
+pub fn build_tree_from_source_entries(
+    git: &GitAdapter,
+    base_tree: &str,
+    source_tree: &str,
+    entries: &[TreeDiffEntry],
+) -> Result<String> {
+    if entries.is_empty() {
+        return Ok(base_tree.to_string());
+    }
+    let git_dir = git_dir(git.process())?;
+    let temp = tempfile::Builder::new()
+        .prefix("bpatch-overlay-index-")
+        .tempfile_in(git_dir)?;
+    let index_path = temp.into_temp_path();
+    fs::remove_file(&index_path)?;
+    let indexed = git
+        .process()
+        .with_env("GIT_INDEX_FILE", index_path.as_os_str().to_os_string());
+    indexed.run(&["read-tree", base_tree])?;
+    let index_info = index_info_for_group(git, source_tree, entries)?;
+    indexed.run_with_stdin(&["update-index", "--index-info"], index_info.as_bytes())?;
+    indexed.run_str(&["write-tree"])
+}
+
 fn plan_commit_groups(
     git: &GitAdapter,
     store: &Store,
     base: &str,
     parent_commit: &str,
     delta: &[TreeDiffEntry],
+    subject_mode: SubjectMode,
 ) -> Result<Vec<CommitGroup>> {
     let mut grouped = BTreeMap::<String, Vec<TreeDiffEntry>>::new();
     for entry in delta {
@@ -465,7 +547,7 @@ fn plan_commit_groups(
     grouped
         .into_iter()
         .map(|(feature, files)| {
-            let subject_base = subject_base(&feature);
+            let subject_base = subject_base(store, &feature, subject_mode);
             let seq = existing.get(&subject_base).copied().unwrap_or(0) + 1;
             let subject = if seq == 1 {
                 subject_base.clone()
@@ -490,7 +572,7 @@ fn existing_subject_counts(
     let mut counts = BTreeMap::new();
     let range = format!("{base}..{parent_commit}");
     for commit in git.first_parent_commits(Some(&range), None)? {
-        if parse_apply_trailers(&git.commit_trailers(&commit)?)?.is_none() {
+        if parse_bpatch_authored_base(&git.commit_trailers(&commit)?)?.is_none() {
             continue;
         }
         let subject = git.commit_subject(&commit)?;
@@ -501,9 +583,18 @@ fn existing_subject_counts(
     Ok(counts)
 }
 
-fn subject_base(feature: &str) -> String {
+fn subject_base(store: &Store, feature: &str, subject_mode: SubjectMode) -> String {
     if feature == unassigned_feature_name() {
         "chore: unassigned store patches".to_string()
+    } else if subject_mode == SubjectMode::FeatureDescription {
+        store
+            .features()
+            .features
+            .get(feature)
+            .map(|feature| feature.description.trim())
+            .filter(|description| !description.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("feat: {feature}"))
     } else {
         format!("feat: {feature}")
     }
@@ -512,10 +603,7 @@ fn subject_base(feature: &str) -> String {
 fn apply_subject_base(subject: &str) -> Option<String> {
     let without_digits = subject.trim_end_matches(|ch: char| ch.is_ascii_digit());
     let base = without_digits.strip_suffix(" #").unwrap_or(subject);
-    if base.starts_with("feat: ") || base == "chore: unassigned store patches" {
-        return Some(base.to_string());
-    }
-    None
+    (!base.trim().is_empty()).then(|| base.to_string())
 }
 
 fn index_info_for_group(
@@ -577,12 +665,31 @@ fn append_index_info_line(
     Ok(())
 }
 
-fn commit_message(subject: &str, store_rev: &str, base: &str, tree: Option<&str>) -> String {
+fn commit_message(
+    subject: &str,
+    trailers: CommitTrailerMode<'_>,
+    base: &str,
+    tree: Option<&str>,
+) -> String {
     let mut message = String::new();
     message.push_str(subject);
     message.push_str("\n\n");
-    message.push_str(&format_apply_trailers(store_rev, base, tree));
+    match trailers {
+        CommitTrailerMode::Apply { store_rev } => {
+            message.push_str(&format_apply_trailers(store_rev, base, tree));
+        }
+        CommitTrailerMode::Annotate => {
+            message.push_str(&format_annotate_trailers(base));
+        }
+    }
     message
+}
+
+fn stores_entry(store: &Store, entry: &TreeDiffEntry) -> bool {
+    entry
+        .path
+        .to_str()
+        .is_none_or(|path| store.stores_path(path))
 }
 
 fn git_dir(git: &Git) -> Result<PathBuf> {

--- a/packages/browseros/tools/bpatch/src/engine/conflict.rs
+++ b/packages/browseros/tools/bpatch/src/engine/conflict.rs
@@ -7,8 +7,8 @@ use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::engine::apply::{
-    AuthorCommitsInput, AuthoredCommit, author_feature_commits, finalize_head,
-    untracked_add_collisions,
+    AuthorCommitsInput, AuthoredCommit, CommitTrailerMode, SubjectMode, author_feature_commits,
+    finalize_head, untracked_add_collisions,
 };
 use crate::engine::progress::ProgressEvent;
 use crate::engine::state::{DriftFile, DriftSource, StateContext};
@@ -285,7 +285,10 @@ pub fn continue_session(
             base: &session.new_base,
             applied_tree: &new_base_tree,
             target_tree: &final_tree,
-            store_rev: &session.store_rev,
+            trailers: CommitTrailerMode::Apply {
+                store_rev: &session.store_rev,
+            },
+            subject_mode: SubjectMode::FeatureName,
             parent_commit: &session.parent_head,
             delta: &delta,
         },

--- a/packages/browseros/tools/bpatch/src/engine/dirty.rs
+++ b/packages/browseros/tools/bpatch/src/engine/dirty.rs
@@ -1,0 +1,280 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow};
+
+use crate::git::GitAdapter;
+use crate::store::{FEATURES_FILE, FeatureMatch, FeatureSuggestion, STORE_FILE, Store};
+
+/// One path reported by `git status --porcelain -z`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirtyEntry {
+    pub status: String,
+    pub path: PathBuf,
+    pub old_path: Option<PathBuf>,
+}
+
+/// Dirty checkout scan split into ordinary entries and unresolved conflicts.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirtyScan {
+    pub entries: Vec<DirtyEntry>,
+    pub conflicts: Vec<DirtyEntry>,
+}
+
+/// Dirty path populations after applying bpatch ownership rules.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaimPlan {
+    pub claimed: Vec<PathBuf>,
+    pub resources: Vec<PathBuf>,
+    pub unclaimed: Vec<UnclaimedPath>,
+}
+
+/// Dirty path that bpatch cannot assign to a feature or resource group.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnclaimedPath {
+    pub path: PathBuf,
+    pub suggestion: FeatureSuggestion,
+}
+
+/// Scans the checkout's porcelain status without mutating the index.
+pub fn scan_dirty(git: &GitAdapter) -> Result<DirtyScan> {
+    git.refresh_index()?;
+    parse_dirty_status(&git.status_porcelain_z()?)
+}
+
+/// Classifies dirty entries into stored features, store:false resources, and leftovers.
+pub fn classify_dirty(store: &Store, entries: &[DirtyEntry]) -> ClaimPlan {
+    let mut claimed = BTreeSet::new();
+    let mut resources = BTreeSet::new();
+    let mut unclaimed = BTreeMap::new();
+
+    for path in dirty_paths(entries) {
+        let Some(path_str) = path.to_str() else {
+            unclaimed.insert(
+                path.clone(),
+                FeatureSuggestion::NewFeature("feature".to_string()),
+            );
+            continue;
+        };
+        if is_store_metadata_path(path_str) {
+            unclaimed.insert(
+                path.clone(),
+                FeatureSuggestion::NewFeature("metadata".to_string()),
+            );
+            continue;
+        }
+
+        match store.match_path(path_str) {
+            FeatureMatch::Matched { feature, .. } => {
+                let stores_path = store
+                    .features()
+                    .features
+                    .get(&feature)
+                    .is_none_or(|feature| feature.store);
+                if stores_path {
+                    claimed.insert(path);
+                } else {
+                    resources.insert(path);
+                }
+            }
+            FeatureMatch::Unmatched { suggestion } => {
+                if store.patches().contains_key(path_str) {
+                    claimed.insert(path);
+                } else {
+                    unclaimed.insert(path, suggestion);
+                }
+            }
+        }
+    }
+
+    ClaimPlan {
+        claimed: claimed.into_iter().collect(),
+        resources: resources.into_iter().collect(),
+        unclaimed: unclaimed
+            .into_iter()
+            .map(|(path, suggestion)| UnclaimedPath { path, suggestion })
+            .collect(),
+    }
+}
+
+/// Writes a tree that starts at `base_tree` and captures selected worktree paths.
+pub fn tree_from_worktree_paths(
+    git: &GitAdapter,
+    base_tree: &str,
+    paths: &[PathBuf],
+) -> Result<String> {
+    if paths.is_empty() {
+        return Ok(base_tree.to_string());
+    }
+    let git_dir = git_dir(git)?;
+    let temp = tempfile::Builder::new()
+        .prefix("bpatch-dirty-index-")
+        .tempfile_in(git_dir)?;
+    let index_path = temp.into_temp_path();
+    fs::remove_file(&index_path)?;
+    let indexed = git
+        .process()
+        .with_env("GIT_INDEX_FILE", index_path.as_os_str().to_os_string());
+    indexed.run(&["read-tree", base_tree])?;
+    indexed.run_with_stdin(
+        &["add", "-A", "--pathspec-from-file=-", "--pathspec-file-nul"],
+        &pathspec_bytes(paths)?,
+    )?;
+    indexed.run_str(&["write-tree"])
+}
+
+/// Updates the real index for committed paths after HEAD moves.
+pub fn reset_index_paths_to_head(git: &GitAdapter, paths: &[PathBuf]) -> Result<()> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+    git.process().run_with_stdin(
+        &[
+            "reset",
+            "-q",
+            "HEAD",
+            "--pathspec-from-file=-",
+            "--pathspec-file-nul",
+        ],
+        &pathspec_bytes(paths)?,
+    )?;
+    git.refresh_index()?;
+    Ok(())
+}
+
+/// Collapses dirty path claims to directories when every tracked child is dirty.
+pub fn collapse_dirty_paths(git: &GitAdapter, paths: &[PathBuf]) -> Result<Vec<String>> {
+    let dirty = paths
+        .iter()
+        .filter_map(|path| path.to_str().map(ToOwned::to_owned))
+        .collect::<BTreeSet<_>>();
+    let mut dirs = dirty
+        .iter()
+        .filter_map(|path| path.rsplit_once('/').map(|(parent, _)| parent.to_string()))
+        .collect::<BTreeSet<_>>();
+    dirs.retain(|dir| !dir.is_empty());
+    let mut collapsible = BTreeSet::new();
+    for dir in dirs.iter().rev() {
+        let prefix = format!("{dir}/");
+        let dirty_under = dirty
+            .iter()
+            .filter(|path| path.starts_with(&prefix))
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if dirty_under.len() < 2 {
+            continue;
+        }
+        let tracked = tracked_files_under(git, dir)?;
+        if tracked.iter().all(|path| dirty_under.contains(path)) {
+            collapsible.insert(format!("{dir}/"));
+        }
+    }
+
+    let mut out = Vec::new();
+    for path in dirty {
+        let covered = collapsible
+            .iter()
+            .find(|dir| path.starts_with(dir.as_str()))
+            .cloned();
+        if let Some(dir) = covered {
+            if !out.contains(&dir) {
+                out.push(dir);
+            }
+        } else {
+            out.push(path);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn parse_dirty_status(bytes: &[u8]) -> Result<DirtyScan> {
+    let mut parts = bytes.split(|byte| *byte == 0);
+    let mut entries = Vec::new();
+    let mut conflicts = Vec::new();
+    while let Some(record) = parts.next() {
+        if record.is_empty() {
+            break;
+        }
+        let text = std::str::from_utf8(record).context("git status output was not UTF-8")?;
+        if text.len() < 4 {
+            continue;
+        }
+        let status = text[..2].to_string();
+        let path = PathBuf::from(&text[3..]);
+        let old_path = if status.starts_with('R') || status.starts_with('C') {
+            parts.next().map(|old| {
+                std::str::from_utf8(old)
+                    .map(PathBuf::from)
+                    .context("git status rename source was not UTF-8")
+            })
+        } else {
+            None
+        }
+        .transpose()?;
+        let entry = DirtyEntry {
+            status,
+            path,
+            old_path,
+        };
+        if is_conflict_status(&entry.status) {
+            conflicts.push(entry);
+        } else {
+            entries.push(entry);
+        }
+    }
+    Ok(DirtyScan { entries, conflicts })
+}
+
+fn dirty_paths(entries: &[DirtyEntry]) -> Vec<PathBuf> {
+    let mut paths = BTreeSet::new();
+    for entry in entries {
+        paths.insert(entry.path.clone());
+        if let Some(old_path) = &entry.old_path {
+            paths.insert(old_path.clone());
+        }
+    }
+    paths.into_iter().collect()
+}
+
+fn tracked_files_under(git: &GitAdapter, dir: &str) -> Result<BTreeSet<String>> {
+    let out = git.process().run(&["ls-files", "-z", "--", dir])?;
+    out.split(|byte| *byte == 0)
+        .filter(|field| !field.is_empty())
+        .map(|field| String::from_utf8(field.to_vec()).context("git ls-files path was not UTF-8"))
+        .collect::<Result<BTreeSet<_>>>()
+}
+
+fn is_conflict_status(status: &str) -> bool {
+    let bytes = status.as_bytes();
+    bytes.contains(&b'U') || matches!(status, "AA" | "DD")
+}
+
+fn is_store_metadata_path(path: &str) -> bool {
+    matches!(
+        path,
+        FEATURES_FILE | STORE_FILE | "features.yaml" | "store.yaml"
+    )
+}
+
+fn pathspec_bytes(paths: &[PathBuf]) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    for path in paths {
+        let path = path
+            .to_str()
+            .ok_or_else(|| anyhow!("path is not UTF-8: {}", path.display()))?;
+        out.extend_from_slice(path.as_bytes());
+        out.push(0);
+    }
+    Ok(out)
+}
+
+fn git_dir(git: &GitAdapter) -> Result<PathBuf> {
+    let git_dir = PathBuf::from(git.process().run_str(&["rev-parse", "--git-dir"])?);
+    if git_dir.is_absolute() {
+        Ok(git_dir)
+    } else {
+        Ok(git.process().repo().join(git_dir))
+    }
+}

--- a/packages/browseros/tools/bpatch/src/engine/extract.rs
+++ b/packages/browseros/tools/bpatch/src/engine/extract.rs
@@ -185,7 +185,10 @@ pub fn extract(
     }
     progress(ProgressEvent::End { phase: "scan" });
 
-    let candidate_paths = candidates.into_iter().collect::<Vec<_>>();
+    let candidate_paths = candidates
+        .into_iter()
+        .filter(|path| store.stores_path(path))
+        .collect::<Vec<_>>();
     progress(ProgressEvent::Start {
         phase: "diff",
         total: Some(candidate_paths.len()),
@@ -323,7 +326,12 @@ pub fn repin(
     let old_metadata = store.metadata().clone();
     ensure_tree_exists(&git, &state.base.sha)?;
 
-    let paths = store.patches().keys().cloned().collect::<Vec<_>>();
+    let paths = store
+        .patches()
+        .keys()
+        .filter(|path| store.stores_path(path))
+        .cloned()
+        .collect::<Vec<_>>();
     progress(ProgressEvent::Start {
         phase: "repin",
         total: Some(paths.len()),

--- a/packages/browseros/tools/bpatch/src/engine/mod.rs
+++ b/packages/browseros/tools/bpatch/src/engine/mod.rs
@@ -1,5 +1,7 @@
+pub mod annotate;
 pub mod apply;
 pub mod conflict;
+pub mod dirty;
 pub mod extract;
 pub mod lock;
 pub mod progress;

--- a/packages/browseros/tools/bpatch/src/engine/state.rs
+++ b/packages/browseros/tools/bpatch/src/engine/state.rs
@@ -12,6 +12,8 @@ pub const TRAILER_STORE_REV: &str = "Bpatch-Store-Rev";
 pub const TRAILER_BASE: &str = "Bpatch-Base";
 /// Trailer key carrying the cached applied tree.
 pub const TRAILER_TREE: &str = "Bpatch-Tree";
+/// Trailer key marking commits authored by `bpatch annotate`.
+pub const TRAILER_ANNOTATED: &str = "Bpatch-Annotated";
 
 const HISTORY_LIMIT: usize = 512;
 const UNASSIGNED_FEATURE: &str = "(unassigned)";
@@ -44,6 +46,13 @@ pub struct ApplyTrailers {
     pub base: String,
     /// Cached applied tree, when the commit still carries it.
     pub tree: Option<String>,
+}
+
+/// Parsed bpatch annotate trailers from a commit.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AnnotateTrailers {
+    /// Chromium base commit used while grouping dirty checkout changes.
+    pub base: String,
 }
 
 /// Resolved checkout state derived from history and the store repo.
@@ -205,17 +214,28 @@ struct TrailerCommit {
     subject: String,
 }
 
+struct BaseTrailerCommit {
+    base: String,
+}
+
 /// Resolves trailer state, store freshness, base display, and checkout drift.
 pub fn resolve(ctx: &StateContext) -> Result<ResolvedState> {
     let checkout = GitAdapter::new(&ctx.checkout);
     let store_repo = StoreRepo::new(&ctx.store_dir);
+    let store_model = Store::load(&ctx.store_dir)?;
     let head_rev = checkout.head_rev()?;
     let head_tree = checkout.tree_id("HEAD")?;
     let store_head = store_repo.head_rev()?;
     let latest = find_latest_apply_commit(&checkout)?;
+    let latest_base = if latest.is_some() {
+        None
+    } else {
+        find_latest_base_commit(&checkout)?
+    };
     let base_sha = latest
         .as_ref()
         .map(|entry| entry.trailers.base.clone())
+        .or_else(|| latest_base.as_ref().map(|entry| entry.base.clone()))
         .unwrap_or_else(|| head_rev.clone());
     let base = BaseState {
         short_sha: checkout.short_rev(&base_sha)?,
@@ -251,11 +271,11 @@ pub fn resolve(ctx: &StateContext) -> Result<ResolvedState> {
     let applied_tree = applied
         .as_ref()
         .map(|applied| applied.tree.as_str())
-        .unwrap_or(&head_tree);
+        .unwrap_or(&base.sha);
     let last_subject = applied
         .as_ref()
         .map(|applied| applied.last_subject.as_str());
-    let drift = detect_drift(&checkout, applied_tree, last_subject)?;
+    let drift = detect_drift(&checkout, &store_model, applied_tree, last_subject)?;
 
     Ok(ResolvedState {
         checkout: ctx.checkout.clone(),
@@ -295,6 +315,33 @@ pub fn parse_apply_trailers(trailers: &[Trailer]) -> Result<Option<ApplyTrailers
     }))
 }
 
+/// Parses annotate trailers from a git trailer list.
+pub fn parse_annotate_trailers(trailers: &[Trailer]) -> Result<Option<AnnotateTrailers>> {
+    let mut annotated = false;
+    let mut base = None;
+    for trailer in trailers {
+        match trailer.key.as_str() {
+            TRAILER_ANNOTATED => annotated = true,
+            TRAILER_BASE => base = Some(trailer.value.clone()),
+            _ => {}
+        }
+    }
+    if !annotated {
+        return Ok(None);
+    }
+    let base =
+        base.ok_or_else(|| anyhow!("{TRAILER_ANNOTATED} commit is missing {TRAILER_BASE}"))?;
+    Ok(Some(AnnotateTrailers { base }))
+}
+
+/// Returns the Chromium base from any bpatch-authored commit trailer block.
+pub fn parse_bpatch_authored_base(trailers: &[Trailer]) -> Result<Option<String>> {
+    if let Some(apply) = parse_apply_trailers(trailers)? {
+        return Ok(Some(apply.base));
+    }
+    Ok(parse_annotate_trailers(trailers)?.map(|annotate| annotate.base))
+}
+
 /// Formats apply trailers as a commit-message trailer block.
 pub fn format_apply_trailers(store_rev: &str, base: &str, tree: Option<&str>) -> String {
     let mut out = String::new();
@@ -315,6 +362,18 @@ pub fn format_apply_trailers(store_rev: &str, base: &str, tree: Option<&str>) ->
     out
 }
 
+/// Formats the trailer block for commits created by `bpatch annotate`.
+pub fn format_annotate_trailers(base: &str) -> String {
+    let mut out = String::new();
+    out.push_str(TRAILER_BASE);
+    out.push_str(": ");
+    out.push_str(base);
+    out.push('\n');
+    out.push_str(TRAILER_ANNOTATED);
+    out.push_str(": true\n");
+    out
+}
+
 /// Returns the conventional fallback group for unowned paths.
 pub fn unassigned_feature_name() -> &'static str {
     UNASSIGNED_FEATURE
@@ -329,6 +388,15 @@ fn find_latest_apply_commit(git: &GitAdapter) -> Result<Option<TrailerCommit>> {
                 trailers,
                 commit,
             }));
+        }
+    }
+    Ok(None)
+}
+
+fn find_latest_base_commit(git: &GitAdapter) -> Result<Option<BaseTrailerCommit>> {
+    for commit in git.first_parent_commits(None, Some(HISTORY_LIMIT))? {
+        if let Some(base) = parse_bpatch_authored_base(&git.commit_trailers(&commit)?)? {
+            return Ok(Some(BaseTrailerCommit { base }));
         }
     }
     Ok(None)
@@ -371,18 +439,21 @@ fn applied_tree(
 
 fn detect_drift(
     git: &GitAdapter,
+    store: &Store,
     applied_tree: &str,
     last_apply_subject: Option<&str>,
 ) -> Result<DriftState> {
     let mut files = Vec::new();
     let subject = last_apply_subject.unwrap_or("applied state");
     for entry in git.diff_tree_name_status(applied_tree, "HEAD^{tree}")? {
-        files.push(committed_drift(entry, subject));
+        if stores_path(store, &entry.path) {
+            files.push(committed_drift(entry, subject));
+        }
     }
 
     git.refresh_index()?;
     if git.diff_index_has_changes("HEAD")? {
-        files.extend(parse_porcelain_drift(&git.status_porcelain_z()?)?);
+        files.extend(parse_porcelain_drift(store, &git.status_porcelain_z()?)?);
     }
 
     if files.is_empty() {
@@ -390,6 +461,10 @@ fn detect_drift(
     } else {
         Ok(DriftState::Drifted { files })
     }
+}
+
+fn stores_path(store: &Store, path: &Path) -> bool {
+    path.to_str().is_none_or(|path| store.stores_path(path))
 }
 
 fn committed_drift(entry: TreeDiffEntry, subject: &str) -> DriftFile {
@@ -401,7 +476,7 @@ fn committed_drift(entry: TreeDiffEntry, subject: &str) -> DriftFile {
     }
 }
 
-fn parse_porcelain_drift(bytes: &[u8]) -> Result<Vec<DriftFile>> {
+fn parse_porcelain_drift(store: &Store, bytes: &[u8]) -> Result<Vec<DriftFile>> {
     let mut parts = bytes.split(|byte| *byte == 0);
     let mut files = Vec::new();
     let mut seen = BTreeSet::new();
@@ -421,7 +496,7 @@ fn parse_porcelain_drift(bytes: &[u8]) -> Result<Vec<DriftFile>> {
         if status.starts_with('R') || status.starts_with('C') {
             let _old_path = parts.next();
         }
-        if seen.insert(path.to_string()) {
+        if store.stores_path(path) && seen.insert(path.to_string()) {
             files.push(DriftFile {
                 path: PathBuf::from(path),
                 status: status.trim().to_string(),

--- a/packages/browseros/tools/bpatch/src/git.rs
+++ b/packages/browseros/tools/bpatch/src/git.rs
@@ -266,7 +266,7 @@ impl GitAdapter {
 
     /// Returns `git status --porcelain -z` for exact uncommitted paths.
     pub fn status_porcelain_z(&self) -> GitResult<Vec<u8>> {
-        Ok(self.git.run(&["status", "--porcelain", "-z"])?)
+        Ok(self.git.run(&["status", "--porcelain", "-z", "-uall"])?)
     }
 
     /// Builds a tree by applying patches to a base in a temporary index.

--- a/packages/browseros/tools/bpatch/src/main.rs
+++ b/packages/browseros/tools/bpatch/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 
 fn main() {
-    let cli = bpatch::cli::Cli::parse();
+    let cli = bpatch::cli::Cli::parse_from(bpatch::cli::normalize_args(std::env::args_os()));
     std::process::exit(bpatch::cli::run(cli));
 }

--- a/packages/browseros/tools/bpatch/src/store.rs
+++ b/packages/browseros/tools/bpatch/src/store.rs
@@ -122,8 +122,19 @@ impl Store {
         Ok(())
     }
 
-    /// Appends a new feature block while leaving existing .features.yaml bytes intact.
+    /// Appends a new stored feature block while leaving existing .features.yaml bytes intact.
     pub fn add_feature(&mut self, name: &str, description: &str, paths: Vec<String>) -> Result<()> {
+        self.add_feature_with_store(name, description, paths, true)
+    }
+
+    /// Appends a new feature block while preserving the surrounding YAML bytes.
+    pub fn add_feature_with_store(
+        &mut self,
+        name: &str,
+        description: &str,
+        paths: Vec<String>,
+        store: bool,
+    ) -> Result<()> {
         validate_feature_name(name)?;
         if self.features.features.contains_key(name) {
             bail!("feature {name} already exists");
@@ -135,9 +146,35 @@ impl Store {
             validate_feature_path(path)?;
         }
 
-        append_feature_block(&mut self.features_yaml, name, description, &paths)?;
+        append_feature_block(&mut self.features_yaml, name, description, store, &paths)?;
         self.features = parse_features_yaml(&self.features_yaml)?;
         Ok(())
+    }
+
+    /// Appends owned paths to an existing feature without reserializing comments.
+    pub fn append_feature_paths(&mut self, name: &str, paths: Vec<String>) -> Result<usize> {
+        validate_feature_name(name)?;
+        if paths.is_empty() {
+            return Ok(0);
+        }
+        let Some(feature) = self.features.features.get(name) else {
+            bail!("feature {name} does not exist");
+        };
+        let mut existing = feature.paths.iter().cloned().collect::<BTreeSet<_>>();
+        let mut appended = Vec::new();
+        for path in paths {
+            validate_feature_path(&path)?;
+            if existing.insert(path.clone()) {
+                appended.push(path);
+            }
+        }
+        if appended.is_empty() {
+            return Ok(0);
+        }
+
+        append_paths_to_feature_block(&mut self.features_yaml, name, &appended)?;
+        self.features = parse_features_yaml(&self.features_yaml)?;
+        Ok(appended.len())
     }
 
     /// Resolves a chromium path to a feature match or a nearest-path suggestion.
@@ -156,6 +193,26 @@ impl Store {
         }
         FeatureMatch::Unmatched {
             suggestion: self.nearest_suggestion(path),
+        }
+    }
+
+    /// Returns whether path content belongs in the patch store.
+    pub fn stores_path(&self, path: &str) -> bool {
+        match self.match_path(path) {
+            FeatureMatch::Matched { feature, .. } => self
+                .features
+                .features
+                .get(&feature)
+                .is_none_or(|feature| feature.store),
+            FeatureMatch::Unmatched { .. } => true,
+        }
+    }
+
+    /// Returns the parsed feature for a matched path.
+    pub fn matched_feature(&self, path: &str) -> Option<&Feature> {
+        match self.match_path(path) {
+            FeatureMatch::Matched { feature, .. } => self.features.features.get(&feature),
+            FeatureMatch::Unmatched { .. } => None,
         }
     }
 
@@ -255,6 +312,7 @@ pub struct Feature {
     pub name: String,
     pub description: String,
     pub paths: Vec<String>,
+    pub store: bool,
 }
 
 /// One per-file unified diff stored under its chromium-relative path.
@@ -345,6 +403,7 @@ struct FeaturesYaml {
 #[derive(Debug, Deserialize)]
 struct FeatureYaml {
     description: Option<String>,
+    store: Option<bool>,
     files: Option<Vec<String>>,
 }
 
@@ -361,6 +420,7 @@ fn parse_features_yaml(bytes: &[u8]) -> Result<Features> {
             Feature {
                 name,
                 description: feature.description.unwrap_or_default(),
+                store: feature.store.unwrap_or(true),
                 paths,
             },
         );
@@ -575,6 +635,7 @@ fn append_feature_block(
     yaml: &mut Vec<u8>,
     name: &str,
     description: &str,
+    store: bool,
     paths: &[String],
 ) -> Result<()> {
     if yaml.is_empty() {
@@ -592,6 +653,9 @@ fn append_feature_block(
     block.push_str("    description: ");
     block.push_str(&yaml_string(description));
     block.push('\n');
+    if !store {
+        block.push_str("    store: false\n");
+    }
     block.push_str("    files:\n");
     for path in paths {
         block.push_str("      - ");
@@ -599,6 +663,59 @@ fn append_feature_block(
         block.push('\n');
     }
     yaml.extend_from_slice(block.as_bytes());
+    Ok(())
+}
+
+fn append_paths_to_feature_block(yaml: &mut Vec<u8>, name: &str, paths: &[String]) -> Result<()> {
+    let text = std::str::from_utf8(yaml).context(".features.yaml is not UTF-8")?;
+    let lines = text
+        .split_inclusive('\n')
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    let header = format!("  {name}:");
+    let feature_start = lines
+        .iter()
+        .position(|line| line.trim_end() == header)
+        .ok_or_else(|| anyhow!("feature {name} does not exist in .features.yaml bytes"))?;
+    let feature_end = lines
+        .iter()
+        .enumerate()
+        .skip(feature_start + 1)
+        .find_map(|(index, line)| {
+            let trimmed = line.trim_end();
+            (trimmed.starts_with("  ") && !trimmed.starts_with("    ")).then_some(index)
+        })
+        .unwrap_or(lines.len());
+    let files_line = lines[feature_start + 1..feature_end]
+        .iter()
+        .position(|line| line.trim() == "files:")
+        .map(|offset| feature_start + 1 + offset)
+        .ok_or_else(|| anyhow!("feature {name} has no files list in .features.yaml"))?;
+    let insert_at = lines
+        .iter()
+        .enumerate()
+        .take(feature_end)
+        .skip(files_line + 1)
+        .find_map(|(index, line)| {
+            let trimmed = line.trim_start();
+            (!(trimmed.starts_with("- ") || trimmed.starts_with('#') || trimmed.trim().is_empty()))
+                .then_some(index)
+        })
+        .unwrap_or(feature_end);
+
+    let mut next = String::new();
+    for line in &lines[..insert_at] {
+        next.push_str(line);
+    }
+    for path in paths {
+        next.push_str("      - ");
+        next.push_str(&yaml_string(path));
+        next.push('\n');
+    }
+    for line in &lines[insert_at..] {
+        next.push_str(line);
+    }
+    *yaml = next.into_bytes();
     Ok(())
 }
 

--- a/packages/browseros/tools/bpatch/src/store.rs
+++ b/packages/browseros/tools/bpatch/src/store.rs
@@ -208,14 +208,6 @@ impl Store {
         }
     }
 
-    /// Returns the parsed feature for a matched path.
-    pub fn matched_feature(&self, path: &str) -> Option<&Feature> {
-        match self.match_path(path) {
-            FeatureMatch::Matched { feature, .. } => self.features.features.get(&feature),
-            FeatureMatch::Unmatched { .. } => None,
-        }
-    }
-
     fn exact_match(&self, path: &str) -> Option<(String, String)> {
         self.features.features.iter().find_map(|(name, feature)| {
             feature

--- a/packages/browseros/tools/bpatch/tests/simulations.rs
+++ b/packages/browseros/tools/bpatch/tests/simulations.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result};
 use bpatch::engine::lock::CheckoutLock;
-use bpatch::engine::state::{TRAILER_BASE, TRAILER_STORE_REV, TRAILER_TREE};
+use bpatch::engine::state::{TRAILER_ANNOTATED, TRAILER_BASE, TRAILER_STORE_REV, TRAILER_TREE};
 use bpatch::process::Git;
 use bpatch::store::Store;
 use fixtures::FixtureRepo;
@@ -52,6 +52,7 @@ fn top_level_help_teaches_chromium_workflow() -> Result<()> {
     assert!(stdout.contains("bpatch status"));
     assert!(stdout.contains("bpatch diff"));
     assert!(stdout.contains("bpatch apply"));
+    assert!(stdout.contains("bpatch annotate"));
     assert!(stdout.contains("bpatch extract <rev1>..<rev2> --feature <name>"));
     assert!(stdout.contains("bpatch apply -> bpatch continue --materialize"));
     assert!(stdout.contains("EXIT CODES:"));
@@ -536,6 +537,243 @@ fn sim6_needs_feature_json_then_named_feature_extracts() -> Result<()> {
     assert_eq!(json["patches"], 4);
     assert_eq!(json["new_features"][0], "wallet");
     assert_eq!(json["exit"], 0);
+    Ok(())
+}
+
+#[test]
+fn sim7_annotate_commits_claimed_resources_and_leaves_leftovers_then_rest() -> Result<()> {
+    let checkout = FixtureRepo::new()?;
+    let base = write_annotate_base(&checkout)?;
+    let store = FixtureRepo::new()?;
+    let store_dir = seed_annotate_store(&store, &base)?;
+    store.commit("seed annotate store")?;
+
+    checkout.write_file("chrome/browser/browseros/core/service.cc", "core changed\n")?;
+    checkout.plant_untracked("chrome/browser/browseros/core/new_file.cc", "new core\n")?;
+    checkout.write_file("chrome/BROWSEROS_VERSION", "148.0.7204.1-browseros\n")?;
+    checkout.plant_untracked("chrome/app/theme/chromium/logo.png", "logo\n")?;
+    checkout.plant_untracked("chrome/browser/browseros/wallet/service.cc", "wallet\n")?;
+
+    let annotated = run_bpatch(checkout.path(), Some(&store_dir), strs(&["annotate"]))?;
+    assert_eq!(annotated.code, 3, "{}", annotated.stderr);
+    assert!(annotated.stdout.contains("claimed 2 -> 1 feature commit"));
+    assert!(
+        annotated
+            .stdout
+            .contains("resources 2 -> 1 commit \"resource: bos_build outputs\"")
+    );
+    assert!(
+        annotated
+            .stdout
+            .contains("unclaimed 1 (left in working tree):")
+    );
+    assert!(
+        annotated
+            .stdout
+            .contains("chrome/browser/browseros/wallet/service.cc")
+    );
+    assert!(annotated.stdout.contains("bpatch feature add wallet"));
+
+    let subjects = checkout.git().run_str(&["log", "--format=%s", "-2"])?;
+    assert!(
+        subjects
+            .lines()
+            .any(|line| line == "resource: bos_build outputs")
+    );
+    assert!(
+        subjects
+            .lines()
+            .any(|line| line == "chore: browseros core infrastructure")
+    );
+    assert!(
+        checkout
+            .git()
+            .run_str(&[
+                "ls-tree",
+                "-r",
+                "--name-only",
+                "HEAD",
+                "--",
+                "chrome/browser/browseros/core/new_file.cc",
+            ])?
+            .contains("chrome/browser/browseros/core/new_file.cc")
+    );
+
+    let message = checkout.git().run_str(&["log", "-1", "--format=%B"])?;
+    assert!(message.contains(TRAILER_BASE));
+    assert!(message.contains(TRAILER_ANNOTATED));
+    assert!(!message.contains(TRAILER_STORE_REV));
+    let status = checkout.status_porcelain()?;
+    assert!(status.contains("chrome/browser/browseros/wallet"));
+    assert!(!status.contains("chrome/browser/browseros/core/new_file.cc"));
+    assert!(!status.contains("chrome/BROWSEROS_VERSION"));
+
+    let rest = run_bpatch(
+        checkout.path(),
+        Some(&store_dir),
+        strs(&["annotate", "--rest", "wip-frame-experiments"]),
+    )?;
+    assert_eq!(rest.code, 0, "{}", rest.stderr);
+    assert!(
+        rest.stdout
+            .contains("rest 1 -> 1 commit \"wip: wip-frame-experiments\"")
+    );
+    assert_eq!(
+        checkout.git().run_str(&["log", "-1", "--format=%s"])?,
+        "wip: wip-frame-experiments"
+    );
+    assert!(checkout.status_porcelain()?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn sim8_annotate_triage_json_then_feature_add_round_trip() -> Result<()> {
+    let checkout = FixtureRepo::new()?;
+    let base = write_annotate_base(&checkout)?;
+    let store = FixtureRepo::new()?;
+    let store_dir = seed_annotate_store(&store, &base)?;
+    store.commit("seed annotate store")?;
+
+    checkout.plant_untracked("chrome/browser/browseros/wallet/service.cc", "wallet\n")?;
+
+    let triage = run_bpatch(
+        checkout.path(),
+        Some(&store_dir),
+        strs(&["annotate", "--triage", "--json"]),
+    )?;
+    assert_eq!(triage.code, 3, "{}", triage.stderr);
+    let json = parse_json(&triage.stdout)?;
+    assert_eq!(json["result"], "triage");
+    assert_eq!(
+        json["unclaimed"][0]["path"],
+        "chrome/browser/browseros/wallet/service.cc"
+    );
+    assert!(
+        json["unclaimed"][0]["command"]
+            .as_str()
+            .expect("command")
+            .contains("bpatch feature add wallet chrome/browser/browseros/wallet/")
+    );
+
+    let add = run_bpatch(
+        checkout.path(),
+        Some(&store_dir),
+        strs(&[
+            "feature",
+            "add",
+            "wallet",
+            "chrome/browser/browseros/wallet/",
+            "--desc",
+            "feat: wallet",
+            "--json",
+        ]),
+    )?;
+    assert_eq!(add.code, 0, "{}", add.stderr);
+    assert_eq!(parse_json(&add.stdout)?["result"], "feature-added");
+
+    let annotated = run_bpatch(
+        checkout.path(),
+        Some(&store_dir),
+        strs(&["annotate", "--json"]),
+    )?;
+    assert_eq!(annotated.code, 0, "{}", annotated.stderr);
+    let json = parse_json(&annotated.stdout)?;
+    assert_eq!(json["result"], "annotated");
+    assert_eq!(json["claimed"], 1);
+    assert!(checkout.status_porcelain()?.is_empty());
+    Ok(())
+}
+
+#[test]
+fn sim9_store_false_resource_commit_is_clean_for_status_and_diff() -> Result<()> {
+    let checkout = FixtureRepo::new()?;
+    let base = write_annotate_base(&checkout)?;
+    let store = FixtureRepo::new()?;
+    let store_dir = seed_annotate_store(&store, &base)?;
+    store.commit("seed annotate store")?;
+
+    checkout.write_file("chrome/BROWSEROS_VERSION", "resource changed\n")?;
+    let annotated = run_bpatch(
+        checkout.path(),
+        Some(&store_dir),
+        strs(&["annotate", "--json"]),
+    )?;
+    assert_eq!(annotated.code, 0, "{}", annotated.stderr);
+    let json = parse_json(&annotated.stdout)?;
+    assert_eq!(json["result"], "annotated");
+    assert_eq!(json["resources"], 1);
+
+    let status = run_bpatch(
+        checkout.path(),
+        Some(&store_dir),
+        strs(&["status", "--json"]),
+    )?;
+    assert_eq!(status.code, 0, "{}", status.stderr);
+    let json = parse_json(&status.stdout)?;
+    assert_eq!(json["result"], "clean");
+    assert_eq!(json["drift"].as_array().expect("drift").len(), 0);
+
+    let diff = run_bpatch(checkout.path(), Some(&store_dir), strs(&["diff", "--json"]))?;
+    assert_eq!(diff.code, 0, "{}", diff.stderr);
+    let json = parse_json(&diff.stdout)?;
+    assert_eq!(json["result"], "converged");
+    assert_eq!(json["files_changed"], 0);
+    Ok(())
+}
+
+#[test]
+fn sim10_feature_add_from_dirty_collapses_dirs_and_is_idempotent() -> Result<()> {
+    let checkout = FixtureRepo::new()?;
+    let base = write_annotate_base(&checkout)?;
+    let store = FixtureRepo::new()?;
+    let store_dir = seed_capture_store(&store, &base)?;
+    store.commit("seed capture store")?;
+
+    checkout.write_file("chrome/app/theme/chromium/icon16.png", "icon16 changed\n")?;
+    checkout.write_file("chrome/app/theme/chromium/icon32.png", "icon32 changed\n")?;
+    checkout.write_file("chrome/BROWSEROS_VERSION", "resource changed\n")?;
+
+    let add = run_bpatch(
+        checkout.path(),
+        Some(&store_dir),
+        strs(&[
+            "feature",
+            "add",
+            "build-resources",
+            "--store=false",
+            "--from-dirty",
+            "--json",
+        ]),
+    )?;
+    assert_eq!(add.code, 0, "{}", add.stderr);
+    let json = parse_json(&add.stdout)?;
+    assert_eq!(json["result"], "feature-added");
+    assert_eq!(json["store"], false);
+    assert_eq!(json["appended"], 3);
+    assert_eq!(json["skipped"], 0);
+    assert_eq!(json["collapsed_dirs"], 1);
+    assert_eq!(json["collapsed_files"], 1);
+    let features = fs::read_to_string(store_dir.join(".features.yaml"))?;
+    assert!(features.contains("    store: false"));
+    assert!(features.contains("      - \"chrome/app/theme/chromium/\""));
+    assert!(features.contains("      - \"chrome/BROWSEROS_VERSION\""));
+
+    let repeat = run_bpatch(
+        checkout.path(),
+        Some(&store_dir),
+        strs(&[
+            "feature",
+            "add",
+            "build-resources",
+            "--store=false",
+            "--from-dirty",
+            "--json",
+        ]),
+    )?;
+    assert_eq!(repeat.code, 0, "{}", repeat.stderr);
+    let json = parse_json(&repeat.stdout)?;
+    assert_eq!(json["appended"], 0);
+    assert_eq!(json["skipped"], 3);
     Ok(())
 }
 
@@ -1342,6 +1580,57 @@ features:
     description: "chore: bootstrap"
     files:
       - chrome/browser/browseros/BUILD.gn
+"#,
+    )?;
+    Ok(store.path().join("chromium_patches"))
+}
+
+fn write_annotate_base(repo: &FixtureRepo) -> Result<String> {
+    repo.write_file(
+        "chrome/VERSION",
+        "MAJOR=148\nMINOR=0\nBUILD=7204\nPATCH=1\n",
+    )?;
+    repo.write_file("chrome/browser/browseros/core/service.cc", "core base\n")?;
+    repo.write_file("chrome/BROWSEROS_VERSION", "base resource\n")?;
+    repo.write_file("chrome/app/theme/chromium/icon16.png", "icon16 base\n")?;
+    repo.write_file("chrome/app/theme/chromium/icon32.png", "icon32 base\n")?;
+    repo.commit("Chromium 148.0.7204.1")
+}
+
+fn seed_annotate_store(store: &FixtureRepo, base: &str) -> Result<PathBuf> {
+    let store_dir = seed_capture_store(store, base)?;
+    store.write_file(
+        "chromium_patches/.features.yaml",
+        r#"version: "1.0"
+features:
+  browseros-core:
+    description: "chore: browseros core infrastructure"
+    files:
+      - chrome/browser/browseros/core/
+  build-resources:
+    description: "resource: bos_build outputs"
+    store: false
+    files:
+      - chrome/BROWSEROS_VERSION
+      - chrome/app/theme/chromium/
+"#,
+    )?;
+    Ok(store_dir)
+}
+
+fn seed_capture_store(store: &FixtureRepo, base: &str) -> Result<PathBuf> {
+    store.write_file(
+        "chromium_patches/.store.yaml",
+        format!("base_commit: {base}\nbase_version: \"148.0.7204.1\"\n"),
+    )?;
+    store.write_file(
+        "chromium_patches/.features.yaml",
+        r#"version: "1.0"
+features:
+  browseros-core:
+    description: "chore: browseros core infrastructure"
+    files:
+      - chrome/browser/browseros/core/
 "#,
     )?;
     Ok(store.path().join("chromium_patches"))

--- a/packages/browseros/tools/bpatch/tests/store.rs
+++ b/packages/browseros/tools/bpatch/tests/store.rs
@@ -176,6 +176,53 @@ fn adding_feature_appends_without_rewriting_existing_comments() -> Result<()> {
 }
 
 #[test]
+fn feature_store_false_defaults_and_appends_preserve_yaml() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    write_minimal_store(dir.path())?;
+    let original = fs::read(dir.path().join(".features.yaml"))?;
+
+    let mut store = Store::load(dir.path())?;
+    assert!(
+        store
+            .features()
+            .features
+            .get("llmchat")
+            .expect("llmchat")
+            .store
+    );
+    store.add_feature_with_store(
+        "build-resources",
+        "resource: bos_build outputs",
+        vec!["chrome/app/theme/chromium/".to_string()],
+        false,
+    )?;
+    store.append_feature_paths(
+        "build-resources",
+        vec!["chrome/BROWSEROS_VERSION".to_string()],
+    )?;
+    store.save()?;
+
+    let updated = fs::read(dir.path().join(".features.yaml"))?;
+    assert!(updated.starts_with(&original));
+    let text = String::from_utf8(updated)?;
+    assert!(text.contains("  build-resources:"));
+    assert!(text.contains("    store: false"));
+    assert!(text.contains("      - \"chrome/app/theme/chromium/\""));
+    assert!(text.contains("      - \"chrome/BROWSEROS_VERSION\""));
+
+    let reparsed = Store::load(dir.path())?;
+    let feature = reparsed
+        .features()
+        .features
+        .get("build-resources")
+        .expect("build-resources");
+    assert!(!feature.store);
+    assert!(!reparsed.stores_path("chrome/app/theme/chromium/logo.png"));
+    assert!(reparsed.stores_path("chrome/browser/ui/llmchat/panel.cc"));
+    Ok(())
+}
+
+#[test]
 fn non_patch_files_are_ignored_and_preserved_on_save() -> Result<()> {
     let dir = tempfile::tempdir()?;
     write_minimal_store(dir.path())?;


### PR DESCRIPTION
## Summary
- add `bpatch annotate` for dirty bos_build checkouts, with feature commits, one `resource: bos_build outputs` commit for `store:false` groups, `--rest`, `--triage`, and JSON output
- add `store: false` feature schema support and exclude those paths from extract, apply/status/diff convergence, feature patch counts, and resource drift
- add `bpatch feature add <group> --store=false --from-dirty` with dir collapse, idempotent top-ups, positional paths, `--desc`, `--commit`, and JSON reports
- update README/help coverage for annotate and the `bos_build build --debug --skip patches` resource capture flow

## Design mapping
- `bpatch annotate`: implemented in `src/engine/annotate.rs` + `src/cli/annotate.rs`, reusing `author_feature_commits` with annotate trailers and description-based subjects
- `store:false`: implemented in `src/store.rs`, filtered through extract/apply/state/diff/feature list
- `feature add --from-dirty`: implemented through shared dirty classification in `src/engine/dirty.rs` and the feature CLI

## Transcript coverage
- `sim7_annotate_commits_claimed_resources_and_leaves_leftovers_then_rest`: claimed + resources + leftovers, recursive untracked directory claim, `--rest`
- `sim8_annotate_triage_json_then_feature_add_round_trip`: JSON triage plan -> feature add -> annotate clean
- `sim9_store_false_resource_commit_is_clean_for_status_and_diff`: resource commit is ignored by status/diff convergence
- `sim10_feature_add_from_dirty_collapses_dirs_and_is_idempotent`: `--from-dirty` capture, dir collapse, idempotent top-up

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `make test`