### PR TITLE
fix(patches): mark upstream first-run finished after onboarding

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
@@ -1,18 +1,20 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
 new file mode 100644
-index 0000000000000..0da2a0e14b2daaabd33a9db1f624308aa09a86af
+index 0000000000000..48d0532711afc
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,51 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#include "chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h"
 +
++#include "chrome/browser/browser_process.h"
 +#include "chrome/browser/browseros/core/browseros_prefs.h"
 +#include "chrome/browser/profiles/profile.h"
 +#include "chrome/common/chrome_constants.h"
++#include "chrome/common/pref_names.h"
 +#include "components/prefs/pref_service.h"
 +
 +namespace browseros::onboarding {
@@ -39,6 +41,17 @@ index 0000000000000..0da2a0e14b2daaabd33a9db1f624308aa09a86af
 +  PrefService* prefs = profile->GetPrefs();
 +  prefs->SetBoolean(browseros::prefs::kOnboardingCompleted, true);
 +  prefs->CommitPendingWrite();
++}
++
++void NeutralizeUpstreamFirstRun() {
++  // `kFirstRunFinished` is a Local State pref read by
++  // FirstRunService::ShouldOpenFirstRun(). Setting it here means: BrowserOS
++  // provides its own onboarding as the first-run experience, so Chromium's DICE
++  // first-run is already finished and must not re-open itself when we launch a
++  // browser after onboarding.
++  if (PrefService* local_state = g_browser_process->local_state()) {
++    local_state->SetBoolean(::prefs::kFirstRunFinished, true);
++  }
 +}
 +
 +}  // namespace browseros::onboarding

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
 new file mode 100644
-index 0000000000000..fc0d5b3bfc641
+index 0000000000000..5504cfea7ebd9
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,28 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -20,6 +20,14 @@ index 0000000000000..fc0d5b3bfc641
 +
 +// Marks the BrowserOS onboarding popup complete for `profile`.
 +void MarkCompleted(Profile* profile);
++
++// Tells Chromium's built-in (DICE) first-run that first-run is already finished,
++// so `FirstRunService::ShouldOpenFirstRun()` stops re-intercepting the browser
++// launch after BrowserOS onboarding completes. Without this, completing
++// onboarding deadlocks: every attempt to open a browser window re-enters the
++// upstream first-run flow (which BrowserOS bypassed on entry) and no window is
++// ever shown. Call once when BrowserOS takes over first-run.
++void NeutralizeUpstreamFirstRun();
 +
 +}  // namespace browseros::onboarding
 +

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_browser_creator.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_browser_creator.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/startup/startup_browser_creator.cc b/chrome/browser/ui/startup/startup_browser_creator.cc
-index 597bd5bfdcbbf..846af4e4c9df8 100644
+index 597bd5bfdcbbf..48e33de23903d 100644
 --- a/chrome/browser/ui/startup/startup_browser_creator.cc
 +++ b/chrome/browser/ui/startup/startup_browser_creator.cc
 @@ -41,6 +41,7 @@
@@ -60,13 +60,17 @@ index 597bd5bfdcbbf..846af4e4c9df8 100644
  #if BUILDFLAG(IS_CHROMEOS)
  // Returns the app id of the kiosk app associated with the current user session.
  // Returns nullopt for non-kiosk user sessions and for ARCVM kiosk sessions,
-@@ -712,6 +756,18 @@ void StartupBrowserCreator::LaunchBrowser(
+@@ -712,6 +756,22 @@ void StartupBrowserCreator::LaunchBrowser(
        command_line, {profile, StartupProfileMode::kBrowserWindow});
  
    if (!IsSilentLaunchEnabled(command_line, profile)) {
 +#if !BUILDFLAG(IS_CHROMEOS)
 +    if (!command_line.HasSwitch(switches::kNoFirstRun) &&
 +        browseros::onboarding::ShouldShow(profile)) {
++      // BrowserOS onboarding is now the first-run experience. Stand down
++      // Chromium's DICE first-run so it does not re-intercept the browser
++      // launch when onboarding completes (which would deadlock with no window).
++      browseros::onboarding::NeutralizeUpstreamFirstRun();
 +      ProfilePicker::Show(ProfilePicker::Params::ForFirstRun(
 +          profile->GetPath(),
 +          base::BindOnce(&OpenNewWindowForBrowserOSOnboarding, command_line,


### PR DESCRIPTION
## Summary
- Extracts Chromium commit `9d656efa8ec10` into BrowserOS patch store.
- Adds `NeutralizeUpstreamFirstRun()` to BrowserOS onboarding prefs.
- Calls it before BrowserOS takes over first-run, preventing Chromium first-run from re-intercepting completion.

## Design
BrowserOS shows its own onboarding through `ProfilePicker::Show(ForFirstRun)`, bypassing `FirstRunService`. This patch marks Chromium's upstream first-run pref finished when BrowserOS owns first-run, so completion can open a normal browser window instead of re-entering first-run.

## Test plan
- [x] `/Users/shadowfax/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/code/chromium-1/src --worktree /Users/shadowfax/worktrees/main/feat-onboarding-first-run-patches --tip 9d656efa8ec10 chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h chrome/browser/ui/startup/startup_browser_creator.cc`