### PR TITLE
fix(bpatch): capture bos_build resources

### DIFF
--- a/packages/browseros/bos_build/features.yaml
+++ b/packages/browseros/bos_build/features.yaml
@@ -3,22 +3,6 @@ features:
   # ── LAYER 1: CORE & BRANDING ──────────────────────────────
   # Foundation patches applied first. Shared files (3+ features)
   # live here so later features don't duplicate them.
-  #
-  #
-build-resources:
-  description: "feat: build resources"
-  files:
-    - chrome/BROWSEROS_VERSION
-    - chrome/VERSION
-    - chrome/app/chromium_strings.grd
-    - chrome/app/settings_chromium_strings.grdp
-    - chrome/app/theme/chromium/
-    - chrome/app/theme/
-    - chrome/browser/browseros/claw_server/resources/
-    - chrome/browser/browseros/server/resources/
-    - chrome/browser/browseros/onboarding/resources/
-    - chrome/enterprise_companion/branding.gni
-    - chrome/updater/branding.gni
 
   browseros-core:
     description: "chore: browseros core infrastructure"

--- a/packages/browseros/chromium_patches/.features.yaml
+++ b/packages/browseros/chromium_patches/.features.yaml
@@ -1,5 +1,24 @@
 version: "1.0"
 features:
+  # ── LAYER 0: BUILD-OWNED OUTPUTS ─────────────────────────
+
+  build-resources:
+    store: false
+    description: "resource: bos_build outputs"
+    files:
+      - chrome/BROWSEROS_VERSION
+      - chrome/VERSION
+      - chrome/app/chromium_strings.grd
+      - chrome/app/settings_chromium_strings.grdp
+      - chrome/app/theme/chromium/
+      - chrome/app/theme/default_100_percent/chromium/
+      - chrome/app/theme/default_200_percent/chromium/
+      - chrome/browser/browseros/claw_server/resources/
+      - chrome/browser/browseros/server/resources/
+      - chrome/browser/browseros/onboarding/resources/
+      - chrome/enterprise_companion/branding.gni
+      - chrome/updater/branding.gni
+
   # ── LAYER 1: CORE & BRANDING ──────────────────────────────
   # Foundation patches applied first. Shared files (3+ features)
   # live here so later features don't duplicate them.

--- a/packages/browseros/tools/bpatch/src/engine/dirty.rs
+++ b/packages/browseros/tools/bpatch/src/engine/dirty.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 
@@ -40,7 +40,12 @@ pub struct UnclaimedPath {
 /// Scans the checkout's porcelain status without mutating the index.
 pub fn scan_dirty(git: &GitAdapter) -> Result<DirtyScan> {
     git.refresh_index()?;
-    parse_dirty_status(&git.status_porcelain_z()?)
+    let mut scan = parse_dirty_status(&git.status_porcelain_z()?)?;
+    scan.entries
+        .retain(|entry| !entry_has_ignored_checkout_state_path(entry));
+    scan.conflicts
+        .retain(|entry| !entry_has_ignored_checkout_state_path(entry));
+    Ok(scan)
 }
 
 /// Classifies dirty entries into stored features, store:false resources, and leftovers.
@@ -256,6 +261,22 @@ fn is_store_metadata_path(path: &str) -> bool {
         path,
         FEATURES_FILE | STORE_FILE | "features.yaml" | "store.yaml"
     )
+}
+
+fn entry_has_ignored_checkout_state_path(entry: &DirtyEntry) -> bool {
+    is_ignored_checkout_state_path(&entry.path)
+        || entry
+            .old_path
+            .as_ref()
+            .is_some_and(|path| is_ignored_checkout_state_path(path))
+}
+
+fn is_ignored_checkout_state_path(path: &Path) -> bool {
+    path.to_str().is_some_and(|path| {
+        path == ".browseros-patch"
+            || path == ".browseros-patch/"
+            || path.starts_with(".browseros-patch/")
+    })
 }
 
 fn pathspec_bytes(paths: &[PathBuf]) -> Result<Vec<u8>> {

--- a/packages/browseros/tools/bpatch/tests/simulations.rs
+++ b/packages/browseros/tools/bpatch/tests/simulations.rs
@@ -693,6 +693,7 @@ fn sim9_store_false_resource_commit_is_clean_for_status_and_diff() -> Result<()>
     store.commit("seed annotate store")?;
 
     checkout.write_file("chrome/BROWSEROS_VERSION", "resource changed\n")?;
+    checkout.plant_untracked(".browseros-patch/state.json", "{}\n")?;
     let annotated = run_bpatch(
         checkout.path(),
         Some(&store_dir),
@@ -718,6 +719,14 @@ fn sim9_store_false_resource_commit_is_clean_for_status_and_diff() -> Result<()>
     let json = parse_json(&diff.stdout)?;
     assert_eq!(json["result"], "converged");
     assert_eq!(json["files_changed"], 0);
+
+    let triage = run_bpatch(
+        checkout.path(),
+        Some(&store_dir),
+        strs(&["annotate", "--triage", "--json"]),
+    )?;
+    assert_eq!(triage.code, 0, "{}", triage.stderr);
+    assert_eq!(parse_json(&triage.stdout)?["result"], "clean");
     Ok(())
 }
 

--- a/packages/browseros/tools/bpatch/tests/store.rs
+++ b/packages/browseros/tools/bpatch/tests/store.rs
@@ -223,6 +223,42 @@ fn feature_store_false_defaults_and_appends_preserve_yaml() -> Result<()> {
 }
 
 #[test]
+fn canonical_store_loads_build_resources_as_unstored() -> Result<()> {
+    let store_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("chromium_patches");
+    let store = Store::load(&store_dir)?;
+    let feature = store
+        .features()
+        .features
+        .get("build-resources")
+        .expect("build-resources");
+    let expected = vec![
+        "chrome/BROWSEROS_VERSION",
+        "chrome/VERSION",
+        "chrome/app/chromium_strings.grd",
+        "chrome/app/settings_chromium_strings.grdp",
+        "chrome/app/theme/chromium/",
+        "chrome/app/theme/default_100_percent/chromium/",
+        "chrome/app/theme/default_200_percent/chromium/",
+        "chrome/browser/browseros/claw_server/resources/",
+        "chrome/browser/browseros/server/resources/",
+        "chrome/browser/browseros/onboarding/resources/",
+        "chrome/enterprise_companion/branding.gni",
+        "chrome/updater/branding.gni",
+    ];
+
+    assert_eq!(feature.description, "resource: bos_build outputs");
+    assert!(!feature.store);
+    assert_eq!(feature.paths, expected);
+    assert!(!store.stores_path("chrome/app/theme/chromium/product_logo.png"));
+    assert!(!store.stores_path("chrome/browser/browseros/server/resources/bin/browseros_server"));
+    assert!(!store.stores_path("chrome/browser/browseros/claw_server/resources/bin/server"));
+    assert!(store.stores_path("chrome/browser/browseros/claw_server/BUILD.gn"));
+    Ok(())
+}
+
+#[test]
 fn non_patch_files_are_ignored_and_preserved_on_save() -> Result<()> {
     let dir = tempfile::tempdir()?;
     write_minimal_store(dir.path())?;

--- a/packages/browseros/tools/patch/internal/patch/patch_test.go
+++ b/packages/browseros/tools/patch/internal/patch/patch_test.go
@@ -81,8 +81,48 @@ rename to chrome/new.cc
 }
 
 func TestPathMatchesSkipsInternalState(t *testing.T) {
-	if PathMatches(".browseros-patch/state.yaml", nil) {
-		t.Fatalf("expected internal state path to be ignored")
+	for _, rel := range []string{
+		".browseros-patch/state.yaml",
+		".features.yaml",
+		".store.yaml",
+		"features.yaml",
+		"store.yaml",
+	} {
+		if PathMatches(rel, nil) {
+			t.Fatalf("expected internal path %s to be ignored", rel)
+		}
+	}
+}
+
+func TestLoadRepoPatchSetSkipsInternalMetadata(t *testing.T) {
+	patchesDir := t.TempDir()
+	for _, rel := range []string{
+		".features.yaml",
+		".store.yaml",
+		"features.yaml",
+		"store.yaml",
+		".browseros-patch/state.yaml",
+	} {
+		writeRepoFile(t, filepath.Join(patchesDir, filepath.FromSlash(rel)), "not a patch\n")
+	}
+	writeRepoFile(
+		t,
+		filepath.Join(patchesDir, "chrome", "foo.cc"),
+		"diff --git a/chrome/foo.cc b/chrome/foo.cc\n"+
+			"index 0000000000000000000000000000000000000000..1111111111111111111111111111111111111111 100644\n"+
+			"--- a/chrome/foo.cc\n"+
+			"+++ b/chrome/foo.cc\n"+
+			"@@ -1 +1 @@\n"+
+			"-old\n"+
+			"+new\n",
+	)
+
+	loaded, err := LoadRepoPatchSet(patchesDir, nil)
+	if err != nil {
+		t.Fatalf("LoadRepoPatchSet: %v", err)
+	}
+	if len(loaded) != 1 || loaded["chrome/foo.cc"].Path != "chrome/foo.cc" {
+		t.Fatalf("expected only chrome/foo.cc, got %+v", loaded)
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/patch/repo.go
+++ b/packages/browseros/tools/patch/internal/patch/repo.go
@@ -23,6 +23,9 @@ func LoadRepoPatchSet(patchesDir string, filters []string) (PatchSet, error) {
 			return err
 		}
 		relPath = NormalizeChromiumPath(relPath)
+		if IsInternalPath(relPath) {
+			return nil
+		}
 		patchFile, err := loadPatchFile(fullPath, relPath)
 		if err != nil {
 			return err

--- a/packages/browseros/tools/patch/internal/patch/types.go
+++ b/packages/browseros/tools/patch/internal/patch/types.go
@@ -69,7 +69,12 @@ func PathMatches(rel string, filters []string) bool {
 
 func IsInternalPath(rel string) bool {
 	candidate := NormalizeChromiumPath(rel)
-	return candidate == ".browseros-patch" || strings.HasPrefix(candidate, ".browseros-patch/")
+	return candidate == ".browseros-patch" ||
+		strings.HasPrefix(candidate, ".browseros-patch/") ||
+		candidate == ".features.yaml" ||
+		candidate == ".store.yaml" ||
+		candidate == "features.yaml" ||
+		candidate == "store.yaml"
 }
 
 func (p FilePatch) IsPureRename() bool {


### PR DESCRIPTION
## Summary
- Add canonical bpatch `build-resources` as a `store: false` group in `packages/browseros/chromium_patches/.features.yaml`.
- Remove the malformed top-level `build-resources` block from `packages/browseros/bos_build/features.yaml`; the twin stays group-free because its Python doctor treats no-patch entries as errors.
- Exclude `.browseros-patch/` from bpatch dirty scans, and teach the legacy Go patch loader to skip hidden bpatch metadata files.

## Final resource group
```yaml
build-resources:
  store: false
  description: "resource: bos_build outputs"
  files:
    - chrome/BROWSEROS_VERSION
    - chrome/VERSION
    - chrome/app/chromium_strings.grd
    - chrome/app/settings_chromium_strings.grdp
    - chrome/app/theme/chromium/
    - chrome/app/theme/default_100_percent/chromium/
    - chrome/app/theme/default_200_percent/chromium/
    - chrome/browser/browseros/claw_server/resources/
    - chrome/browser/browseros/server/resources/
    - chrome/browser/browseros/onboarding/resources/
    - chrome/enterprise_companion/branding.gni
    - chrome/updater/branding.gni
```

## Investigation notes
- `92948487d` has no revert rationale beyond the generated "This reverts commit 44bdc24b9..." body.
- Empirically, `f843407cc` made `bos_build/features.yaml` valid YAML but broke its shape: `features:` loaded as empty and `build-resources` was a top-level key. Python doctor then reported every patch as unclassified.
- `44bdc24b9` added generated outputs as patch files and did not set `store: false`, so bpatch would treat build-owned outputs as patch-backed feature content instead of as resources. That is the behavior this PR avoids.
- Mirroring the no-patch resource group into `bos_build/features.yaml` is not tolerated by the Python doctor: a probe reported `missing-patch` / `empty-dir` findings for resource entries. The resource group is therefore bpatch-only.
- `.browseros-patch/` is checkout-local tool state, not a resource. bpatch now never reports it, matching the legacy Go tool's state-dir behavior.

## Verification
- `cd packages/browseros/tools/bpatch && cargo fmt --all --check`
- `cd packages/browseros/tools/bpatch && cargo clippy --all-targets -- -D warnings`
- `cd packages/browseros/tools/bpatch && cargo test --locked`
- `cd packages/browseros && uv run python -m unittest bos_build.patchkit.features_io_test bos_build.patchkit.doctor_test`
- `cd packages/browseros && uv run ruff check bos_build`
- `cd packages/browseros && uv run browseros dev doctor --json` -> healthy true, features 34, patches 374, errors 0, warnings 0
- `cd packages/browseros/tools/patch && go test ./...`
- legacy Go `browseros-patch feature lint --json` with isolated config -> features 34, patches 375, unclaimed [], duplicates []
