### PR TITLE
fix(claw-app): keep first-run video playable with reduced motion

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitOnboarding.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitOnboarding.test.tsx
@@ -4,23 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { describe, expect, it, mock } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router'
 import { CockpitOnboarding } from './CockpitOnboarding'
-
-// FirstRunVideo pulls the demo from a GitHub Release URL and would
-// try to hit the network during SSR. Stub it so the surrounding
-// markup can render, then assert the presence of the wrapper.
-mock.module('./FirstRunVideo', () => ({
-  FirstRunVideo: () => (
-    <div
-      data-testid="first-run-video-stub"
-      role="img"
-      aria-label="motion demo"
-    />
-  ),
-}))
 
 function render(state: 'first-run' | 'waiting'): string {
   return renderToStaticMarkup(
@@ -35,7 +22,7 @@ describe('CockpitOnboarding', () => {
     const html = render('first-run')
     expect(html).toContain('You watch. Your agent')
     expect(html).toContain('works.')
-    expect(html).toContain('first-run-video-stub')
+    expect(html).toContain('first-run-demo.mp4')
     expect(html).toContain('Set up MCP endpoint')
     expect(html).toContain('Paste this into Claude Code, Cursor, or Codex.')
     expect(html).toContain(

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { FirstRunVideo } from './FirstRunVideo'
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
+
+afterEach(() => {
+  if (originalWindow) {
+    Object.defineProperty(globalThis, 'window', originalWindow)
+    return
+  }
+  Reflect.deleteProperty(globalThis, 'window')
+})
+
+function renderWithReducedMotion(matches: boolean): string {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      matchMedia: (query: string) =>
+        ({
+          matches,
+          media: query,
+          onchange: null,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+        }) as MediaQueryList,
+    } satisfies Partial<Window>,
+  })
+  return renderToStaticMarkup(<FirstRunVideo />)
+}
+
+describe('FirstRunVideo', () => {
+  it('renders a playable video without autoplay when reduced motion is preferred', () => {
+    const html = renderWithReducedMotion(true)
+
+    expect(html).toContain('<video')
+    expect(html).toContain('first-run-demo.mp4')
+    expect(html).toContain('first-run-demo-poster.png')
+    expect(html).toContain('controls=""')
+    expect(html).not.toContain('autoPlay=""')
+    expect(html).not.toContain('loop=""')
+    expect(html).not.toContain('pointer-events-none')
+    expect(html).not.toContain('<img')
+  })
+
+  it('preserves muted autoplay looping when reduced motion is not preferred', () => {
+    const html = renderWithReducedMotion(false)
+
+    expect(html).toContain('<video')
+    expect(html).toContain('autoPlay=""')
+    expect(html).toContain('muted=""')
+    expect(html).toContain('loop=""')
+    expect(html).toContain('playsInline=""')
+    expect(html).not.toContain('controls=""')
+    expect(html).toContain('pointer-events-none')
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.tsx
@@ -7,7 +7,8 @@
  * native `<video autoplay muted loop playsinline>` that streams from
  * versioned Cloudflare R2 objects through the BrowserOS CDN. Chromium
  * always allows muted autoplay without a user gesture. Reduced-motion
- * readers see the poster PNG rendered from frame 0 of the composition.
+ * readers get the same video with autoplay and looping disabled, plus
+ * native controls so playback starts from an explicit interaction.
  *
  * How the video URL got here
  *
@@ -60,60 +61,69 @@ export function FirstRunVideo() {
   const reducedMotion = usePrefersReducedMotion()
   const ref = useRef<HTMLVideoElement>(null)
   useEffect(() => {
-    if (reducedMotion) return
+    const el = ref.current
+    if (!el) return
+    if (reducedMotion) {
+      el.pause()
+      return
+    }
     // Muted + autoplay is allowed everywhere, but tab throttling or
     // an unlucky race between mount and the first-byte of the video
     // stream can leave the element paused. Kick play() explicitly
     // to close the gap.
-    const el = ref.current
-    if (!el) return
     void el.play().catch(() => {
       // Blocked or errored; the poster stays visible until the
       // reader interacts. Extremely rare in practice.
     })
   }, [reducedMotion])
-  if (reducedMotion) {
-    return (
-      <img
-        src={POSTER_SRC}
-        alt=""
-        aria-hidden
-        className="aspect-video w-full select-none overflow-hidden rounded-2xl border border-border-2 bg-bg-sunken object-contain"
-      />
-    )
-  }
   return (
     <video
       ref={ref}
       src={VIDEO_SRC}
       poster={POSTER_SRC}
       preload="auto"
-      autoPlay
+      autoPlay={!reducedMotion}
       muted
-      loop
+      loop={!reducedMotion}
       playsInline
-      controls={false}
+      controls={reducedMotion}
       disablePictureInPicture
       aria-label="A short motion demo showing how BrowserClaw works: install the MCP, prompt your agent, watch the run land in this cockpit."
-      className="pointer-events-none aspect-video w-full select-none overflow-hidden rounded-2xl border border-border-2 bg-bg-sunken object-contain"
+      className={
+        reducedMotion
+          ? 'aspect-video w-full select-none overflow-hidden rounded-2xl border border-border-2 bg-bg-sunken object-contain'
+          : 'pointer-events-none aspect-video w-full select-none overflow-hidden rounded-2xl border border-border-2 bg-bg-sunken object-contain'
+      }
     />
   )
 }
 
 function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(false)
+  const [reduced, setReduced] = useState(readPrefersReducedMotion)
   useEffect(() => {
-    if (
-      typeof window === 'undefined' ||
-      typeof window.matchMedia !== 'function'
-    ) {
+    if (typeof window === 'undefined') {
       return
     }
-    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const mql = reducedMotionQuery()
+    if (!mql) return
     const update = () => setReduced(mql.matches)
     update()
     mql.addEventListener('change', update)
     return () => mql.removeEventListener('change', update)
   }, [])
   return reduced
+}
+
+function readPrefersReducedMotion(): boolean {
+  return reducedMotionQuery()?.matches ?? false
+}
+
+function reducedMotionQuery(): MediaQueryList | null {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return null
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)')
 }


### PR DESCRIPTION
## Summary
- Render the same CDN-backed first-run `<video>` for reduced-motion users instead of swapping to a static poster image.
- Disable autoplay, looping, and the explicit `play()` kick under reduced motion; enable native controls and pointer interaction so playback is user-initiated.
- Preserve the existing non-reduced path: muted autoplay loop, playsInline, poster, disablePictureInPicture, aria-label, and the explicit play kick.

## Root Cause And Delivery
- Root cause: `FirstRunVideo` returned an `<img>` whenever `(prefers-reduced-motion: reduce)` matched, so users with macOS Reduce Motion enabled never had a video element to play.
- The CDN/delivery chain is not changed here: the component remains pinned to `ASSET_VERSION = '0.2.0'`, using the versioned BrowserOS CDN MP4 and poster URLs.
- I rejected packaging the MP4 into `claw-server` prod resources because CDN delivery was already verified healthy; keeping network delivery preserves the existing versioned R2/CDN asset pipeline and avoids growing local prod resources for a non-delivery bug.

## Verification
- `bun test components/cockpit/FirstRunVideo.test.tsx components/cockpit/CockpitOnboarding.test.tsx` from `packages/browseros-agent/apps/claw-app`
- `bun run check` from `packages/browseros-agent` (exits 0; existing unrelated Biome/Fallow warnings still print)
- `bun run test` from `packages/browseros-agent`

## Manual Verification
- With macOS Reduce Motion ON, run `bun run dev:claw:watch:new`; the first-run cockpit shows the demo with a play affordance, and clicking plays it.
- With macOS Reduce Motion OFF, the first-run demo autoplays as before.
