### PR TITLE
fix(docs): break /browserclaw redirect loop, use Mintlify no-slash canonical

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -97,8 +97,7 @@
     { "source": "/features/llm-chat-hub", "destination": "/" },
     { "source": "/features/workflows", "destination": "/features/scheduled-tasks" },
     { "source": "/features/qwen-code-oauth", "destination": "/features/bring-your-own-llm" },
-    { "source": "/browserclaw", "destination": "/browserclaw/" },
-    { "source": "/features/browserclaw", "destination": "/browserclaw/" }
+    { "source": "/features/browserclaw", "destination": "/browserclaw" }
   ],
   "logo": {
     "light": "/logo/logo44.png",

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit-onboarding.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit-onboarding.helpers.test.ts
@@ -74,7 +74,7 @@ describe('cockpit onboarding copy', () => {
     // Should NOT bare-root; readers arriving from the cockpit expect
     // BrowserClaw-specific docs (install / MCP / first-run), not the
     // BrowserOS index. Guard against accidental drift.
-    expect(FOOTER_COPY.docsHref).toBe('https://docs.browseros.com/browserclaw/')
+    expect(FOOTER_COPY.docsHref).toBe('https://docs.browseros.com/browserclaw')
     expect(FOOTER_COPY.docs).toBe('Read the docs')
   })
 

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit-onboarding.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit-onboarding.helpers.ts
@@ -81,6 +81,8 @@ export const FOOTER_COPY = {
   docs: 'Read the docs',
   // Deep-link to the BrowserClaw section instead of the docs root
   // so a first-run reader lands on install / first-run / MCP setup
-  // instead of BrowserOS's general index.
-  docsHref: 'https://docs.browseros.com/browserclaw/',
+  // instead of BrowserOS's general index. Mintlify canonicalises
+  // the URL without a trailing slash, so we use the no-slash form
+  // to avoid triggering a redirect on every click.
+  docsHref: 'https://docs.browseros.com/browserclaw',
 } as const


### PR DESCRIPTION
Live docs.browseros.com/browserclaw was throwing \`ERR_TOO_MANY_REDIRECTS\` after PR #1728 landed. Verified via agent-browser reproduction.

## Cause
The \`/browserclaw -> /browserclaw/\` redirect in \`docs.json\` fights Mintlify's own canonicalisation. Mintlify serves BrowserOS docs pages at their no-trailing-slash form (see the existing \`features/workflows -> features/scheduled-tasks\` entry) and normalises any incoming trailing slash back to no-slash. When we also redirect \`/browserclaw\` to \`/browserclaw/\`, Mintlify canonicalises the landing back to \`/browserclaw\`, our rule fires again, and the browser gives up after N hops.

## Fix
- Drop the self-defeating \`/browserclaw -> /browserclaw/\` rule. Mintlify already routes the bare slug from the folder; no rule needed.
- Change \`/features/browserclaw -> /browserclaw/\` to \`/features/browserclaw -> /browserclaw\` so the destination matches Mintlify's canonical form.
- Flip the claw-app \`FOOTER_COPY.docsHref\` from \`.../browserclaw/\` to \`.../browserclaw\` so the cockpit link lands directly on the canonical URL with no redirect. Snapshot-style test pinned to the new value.

## Note on the branch
This PR replaces the (now-closed) #1729. The prior branch was carrying commits that had already merged as part of #1728's squash, which was showing up as a conflict against main. This branch is cut fresh off \`origin/main\` with just the three-line hotfix on top.

## Test plan
- [ ] After merge + Mintlify redeploy: \`docs.browseros.com/browserclaw\` loads without redirect errors.
- [ ] \`docs.browseros.com/browserclaw/\` (trailing slash) canonicalises to \`/browserclaw\` and loads.
- [ ] \`docs.browseros.com/features/browserclaw\` redirects to \`/browserclaw\` and loads.
- [ ] Cockpit **Read the docs** link lands on \`/browserclaw\` with no interstitial redirect.
- [ ] \`bun test screens/cockpit/cockpit-onboarding.helpers.test.ts\` in \`packages/browseros-agent/apps/claw-app\`: 9 pass / 0 fail.