### PR TITLE
docs(browserclaw): position BrowserClaw as a standalone product, stub install

### DIFF
--- a/docs/browserclaw/how-it-works.mdx
+++ b/docs/browserclaw/how-it-works.mdx
@@ -48,7 +48,7 @@ You can scrub the whole session in [audit and replay](/browserclaw/audit-and-rep
 
 ## Where the data lives
 
-Everything sits on your disk, under the BrowserOS user data directory. No cloud. No sync. No telemetry from BrowserClaw itself.
+Everything sits on your disk, inside BrowserClaw's own local data directory. No cloud. No sync. No telemetry from BrowserClaw itself.
 
 Your MCP client (Claude Code, Cursor, and so on) still sends your prompt to its own vendor: that is between you and that vendor. BrowserClaw does not intermediate that leg.
 
@@ -58,7 +58,7 @@ See [Privacy and data](/browserclaw/privacy) for the full breakdown.
 
 <CardGroup cols={2}>
   <Card title="Install BrowserClaw" icon="download" href="/browserclaw/install">
-    Get it running in under two minutes.
+    Download links and setup steps.
   </Card>
   <Card title="Your first run" icon="play" href="/browserclaw/first-run">
     A walkthrough from install to a first activity row.

--- a/docs/browserclaw/index.mdx
+++ b/docs/browserclaw/index.mdx
@@ -30,20 +30,14 @@ BrowserClaw is a free, open-source browser your AI agents drive using your logge
 
 Developers running Claude Code, Cursor, Codex, VS Code, Zed, OpenCode, or Antigravity in agentic mode. You want the agent to act on the web (log in somewhere, extract data, book a thing, test a flow) without giving it your own tabs and cookies. You want to see what it did after the fact.
 
-## What it is not
-
-- Not a chat app. The chat lives in your MCP client.
-- Not a scraper. It runs a real browser with your consent, not a scale scraper.
-- Not a bot farm. One BrowserClaw, one machine, your data.
-
 ## Quick start
 
 <Steps>
   <Step title="Install BrowserClaw">
-    Download it from [browseros.com](https://browseros.com). BrowserClaw ships as part of BrowserOS.
+    Download BrowserClaw for your operating system.
 
     <Card title="Install guide" icon="download" href="/browserclaw/install">
-      macOS, Windows, and Linux download links plus verification.
+      macOS, Windows, and Linux downloads.
     </Card>
   </Step>
   <Step title="Connect your agent">

--- a/docs/browserclaw/install.mdx
+++ b/docs/browserclaw/install.mdx
@@ -3,89 +3,12 @@ title: "Install BrowserClaw"
 description: "Download and install BrowserClaw on macOS, Windows, or Linux."
 ---
 
-BrowserClaw ships as part of BrowserOS. If you already run BrowserOS, you already have BrowserClaw. Skip ahead to [Your first run](/browserclaw/first-run).
+<Note>
+This page is landing in a follow-up release. Track the [BrowserClaw docs rollout](https://github.com/browseros-ai/BrowserOS/issues) for progress.
+</Note>
 
-## Do I already have it
+Coming soon.
 
-Open a new tab. If you see a dashboard headed "You watch. Your agent works.", you have BrowserClaw. Continue to [Your first run](/browserclaw/first-run).
-
-If a normal new-tab page loads, install BrowserOS below.
-
-## Download
-
-<Tabs>
-  <Tab title="macOS">
-    Download the latest BrowserOS installer from [browseros.com](https://browseros.com). Universal binary for Apple Silicon and Intel.
-
-    <Steps>
-      <Step title="Open the downloaded .dmg">
-        Drag BrowserOS into your Applications folder.
-      </Step>
-      <Step title="Launch BrowserOS">
-        macOS will ask you to confirm the first launch of a downloaded app. Click **Open**.
-      </Step>
-    </Steps>
-  </Tab>
-  <Tab title="Windows">
-    Download the latest BrowserOS installer from [browseros.com](https://browseros.com).
-
-    <Steps>
-      <Step title="Run the installer">
-        Double-click the downloaded `.exe`. Follow the wizard.
-      </Step>
-      <Step title="Launch BrowserOS">
-        BrowserOS opens after the install completes.
-      </Step>
-    </Steps>
-  </Tab>
-  <Tab title="Linux">
-    Download the latest BrowserOS build for your distribution from [browseros.com](https://browseros.com). Debian and RPM packages are available; AppImage as an alternative.
-
-    <Steps>
-      <Step title="Install the package">
-        `sudo dpkg -i browseros_<version>_amd64.deb` on Debian and Ubuntu, or `sudo rpm -i browseros-<version>.rpm` on Fedora and RHEL.
-      </Step>
-      <Step title="Launch BrowserOS">
-        From your app launcher, or run `browseros` from the terminal.
-      </Step>
-    </Steps>
-  </Tab>
-</Tabs>
-
-## Import from Chrome
-
-Bring your bookmarks, passwords, and history from Chrome so your agent inherits the same logins you already have.
-
-<Steps>
-  <Step title="Open the import page">
-    Go to `chrome://settings/importData` in BrowserOS.
-  </Step>
-  <Step title="Pick Chrome and click Import">
-    Select **Google Chrome** and click **Import**. Choose **Always allow** if macOS asks.
-  </Step>
-</Steps>
-
-<Tip>
-Chrome's `importData` page brings in bookmarks, passwords, browsing history, and extensions in one click.
-</Tip>
-
-## Update from an older BrowserOS
-
-Already on an older BrowserOS? BrowserClaw came with a recent update. See the [update guide](/update/index) for how to catch up on your platform.
-
-## Verify install
-
-Open a new tab. You should see the BrowserClaw cockpit with a "You watch. Your agent works." headline and a short motion demo below it. That is the surface you will drive your agents from.
-
-If a normal new-tab page loads, restart BrowserOS. If it still does not appear, see [Troubleshooting](/browserclaw/troubleshooting).
-
-## Next
-
-<CardGroup cols={2}>
-  <Card title="Your first run" icon="play" href="/browserclaw/first-run">
-    Connect your agent and run your first prompt.
-  </Card>
-  <Card title="How it works" icon="lightbulb" href="/browserclaw/how-it-works">
-    The mental model behind the two-actor design.
-  </Card>
-</CardGroup>
+<Card title="Your first run" icon="arrow-right" href="/browserclaw/first-run">
+  Continue with what is shipped today.
+</Card>


### PR DESCRIPTION
Three copy corrections on the shipped BrowserClaw pages so the docs stop implying BrowserClaw is bundled with BrowserOS.

## Changes

### 1. \`browserclaw/index.mdx\`
- Retire the **What it is not** section. It was reactive framing that answered questions readers were never actually asking, and it forced the page below the fold before any concrete value landed.
- Quick-start step 1 no longer claims BrowserClaw ships as part of BrowserOS. It is a standalone product. New copy just says \"Download BrowserClaw for your operating system.\" and links to the install page.

### 2. \`browserclaw/how-it-works.mdx\`
- **Where the data lives** no longer says data sits under the BrowserOS user data directory. BrowserClaw runs its own local data directory. Same privacy promise, correct scoping.
- Retired the \"Get it running in under two minutes.\" claim on the install card (that framing depended on the shipped install page, which is being stubbed below).

### 3. \`browserclaw/install.mdx\`
- Everything on that page (\"Do I already have it\", Download tabs pointing at BrowserOS installers, \"Update from an older BrowserOS\", \"Verify install\" via BrowserOS) was built on the same wrong assumption. Rather than patch every line, replaced the whole page with the standard **Coming soon** stub that matches the other pending pages. Real content lands in a follow-up once the standalone install story is nailed down.

## Verified

- No other shipped page (\`first-run.mdx\`, MCP hub, 20 stubs) makes the same claim.
- No em-dashes across the changed files.
- All internal links in the changed files still resolve.

## Test plan
- [ ] Once merged + Mintlify redeploys:
  - \`docs.browseros.com/browserclaw\` no longer shows the retired \"What it is not\" section and step 1 no longer mentions BrowserOS shipping BrowserClaw.
  - \`docs.browseros.com/browserclaw/install\` shows the Coming soon stub instead of the BrowserOS-tied content.
  - \`docs.browseros.com/browserclaw/how-it-works\` says \"BrowserClaw's own local data directory\" under **Where the data lives**.