### PR TITLE
ci(fallow): enforce claw-app extension/video import isolation

### DIFF
--- a/packages/browseros-agent/.fallowrc.json
+++ b/packages/browseros-agent/.fallowrc.json
@@ -16,7 +16,11 @@
     "scripts/dev/inspect-ui.ts",
     "scripts/patch-windows-exe.ts",
     "apps/eval/scripts/generate-report.ts",
-    "apps/eval/scripts/weekly-report.ts"
+    "apps/eval/scripts/weekly-report.ts",
+    "apps/claw-app/entrypoints/newtab/main.tsx",
+    "apps/claw-app/entrypoints/background.ts",
+    "apps/claw-app/entrypoints/recorder.content.ts",
+    "apps/claw-app/onboarding-video/src/index-render.ts"
   ],
   "ignoreDependencies": [
     "tailwind-scrollbar-hide",
@@ -26,7 +30,9 @@
     "dotenv",
     "picocolors",
     "@browseros/cdp-protocol",
-    "@graphql-typed-document-node/core"
+    "@graphql-typed-document-node/core",
+    "@remotion/bundler",
+    "@remotion/renderer"
   ],
   "ignoreUnresolvedImports": [
     "@/assets/**",
@@ -67,7 +73,35 @@
     "unlisted-dependencies": "warn",
     "circular-dependencies": "warn",
     "unused-class-members": "off",
-    "duplicate-exports": "off"
+    "duplicate-exports": "off",
+    "boundary-violation": "error"
+  },
+  "boundaries": {
+    "zones": [
+      {
+        "name": "claw-app-extension",
+        "patterns": [
+          "apps/claw-app/entrypoints/**",
+          "apps/claw-app/components/**",
+          "apps/claw-app/screens/**",
+          "apps/claw-app/modules/**"
+        ]
+      },
+      {
+        "name": "claw-app-video",
+        "patterns": ["apps/claw-app/onboarding-video/**"]
+      }
+    ],
+    "rules": [
+      {
+        "from": "claw-app-extension",
+        "allow": []
+      },
+      {
+        "from": "claw-app-video",
+        "allow": ["claw-app-extension"]
+      }
+    ]
   },
   "overrides": [
     {


### PR DESCRIPTION
## Summary

PR 2 of the [claw-app-remotion-real-ui epic](https://github.com/browseros-ai/BrowserOS/tree/epic/claw-app-remotion-real-ui). Lands the extension/video isolation invariant BEFORE any scene swap so every subsequent PR in the epic is validated by CI against the boundary.

If a follow-up PR accidentally reaches from the extension zone into the video zone, `bun fallow` in CI catches it before merge, not on a human review pass.

## Changes

All in `packages/browseros-agent/.fallowrc.json`.

### Entry list gets four new roots

Missing today (pre-existing hygiene gap):

- `apps/claw-app/entrypoints/newtab/main.tsx`
- `apps/claw-app/entrypoints/background.ts`
- `apps/claw-app/entrypoints/recorder.content.ts`

Plus the video render entry point:

- `apps/claw-app/onboarding-video/src/index-render.ts`

### `boundary-violation` rule is now `error`

Explicitly declared so fallow enforces it (schema default is error, but the rule must appear in the `rules` block).

### New `boundaries` block

Two zones, two rules:

```jsonc
"boundaries": {
  "zones": [
    { "name": "claw-app-extension", "patterns": [
      "apps/claw-app/entrypoints/**",
      "apps/claw-app/components/**",
      "apps/claw-app/screens/**",
      "apps/claw-app/modules/**"
    ]},
    { "name": "claw-app-video", "patterns": [
      "apps/claw-app/onboarding-video/**"
    ]}
  ],
  "rules": [
    { "from": "claw-app-extension", "allow": [] },
    { "from": "claw-app-video", "allow": ["claw-app-extension"] }
  ]
}
```

Semantics:
- Extension zone may NOT import from any declared zone (i.e., not from video).
- Video zone MAY import from the extension zone. This is the whole point of the epic.
- Anything outside declared zones (`@/lib/*` root utilities, etc.) is untouched.

### Two Remotion CLI deps suppressed

`@remotion/bundler` and `@remotion/renderer` are invoked by `@remotion/cli` at video render time; they are never imported in source. Fallow can't see the runtime linkage, so it flagged both as unused devDependencies. Added to `ignoreDependencies`.

## Verified locally

`bunx fallow list --boundaries`:

```
Boundaries: 2 zones, 2 rules
Zones:
  claw-app-extension   221 files  apps/claw-app/entrypoints/**, apps/claw-app/components/**, apps/claw-app/screens/**, apps/claw-app/modules/**
  claw-app-video       17 files   apps/claw-app/onboarding-video/**
Rules:
  claw-app-extension   (isolated, no imports allowed)
  claw-app-video       → claw-app-extension
```

`bunx fallow dead-code` on the baseline: **0 boundary violations**. Every other issue reported is pre-existing on main (private-type leaks in `components/ai-elements/`, unused deps in `apps/server`, unused files in the ai-elements barrel).

**Deliberate bad-import test**: injected `import '../../onboarding-video/src/FirstRunDemo'` into `apps/claw-app/entrypoints/newtab/main.tsx`. Fallow flagged:

```
● Boundary violations (1)
  apps/claw-app/entrypoints/newtab/main.tsx:1 → apps/claw-app/onboarding-video/src/FirstRunDemo.tsx (claw-app-extension → claw-app-video)
```

Bad import removed after verification.

## Base

`epic/claw-app-remotion-real-ui`. This PR does NOT touch main.

## Test plan
- [x] Config parses: `bunx fallow list --boundaries` succeeds.
- [x] Baseline clean: no boundary violations on the current epic tip.
- [x] Rule fires on a real cross-boundary import.
- [ ] CI `Code Quality / Fallow` job passes on this PR.