### PR TITLE
docs(bos_build): rewrite README as an operator entry point

### DIFF
--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -1,173 +1,333 @@
-# bos_build — BrowserOS Chromium build system
+# bos_build
 
-One engine, many products, many hosts. Every axis of variation —
-product, platform, arch, host type — is data, not a copied config file.
+The build and release system for BrowserOS and BrowserClaw. One Python CLI
+(`browseros`) turns a Chromium checkout into signed, packaged browsers, then
+ships them.
 
-## Layout
+Run everything from `packages/browseros`:
 
-Three toolsets — BUILD (`steps/` on the `core/` engine), RELEASE
-(`release/`), DEV (`patchkit/`) — over shared plumbing (`lib/`) and
-product data (`products/`):
+```bash
+cd packages/browseros
+uv sync                 # once
+cp .env.example .env    # once, then fill in what you need
+uv run browseros --help
+```
+
+Every `browseros …` command below is really `uv run browseros …`. Drop the
+prefix if you have the venv activated.
+
+## Read this first
+
+**`browseros build` builds a binary. It does not release a product.**
+
+A local build produces one browser, one product, one platform, one arch. A
+*release* is a GitHub workflow dispatch that builds every platform, uploads to
+R2, stages update feeds, and drafts a GitHub release. A human then promotes it
+live.
+
+| I want to… | Do this |
+| --- | --- |
+| Build on my machine | `browseros build --preset debug` |
+| See exactly what a build will run | `browseros build --preset release --show-plan` |
+| Release BrowserOS or BrowserClaw | `gh workflow run release-browseros.yml` |
+| Make a staged release live | `browseros release publish`, then `browseros release appcast --publish` |
+| Release an extension CRX | `gh workflow run release-extensions.yml` |
+| Grab today's signed mac build | Download the `nightly-browseros` / `nightly-browserclaw` prerelease |
+| Check the patch stack | `browseros dev doctor` |
+
+## Mental model
+
+A build is composed, not configured:
+
+```
+preset + product + platform + arch + switches  ->  ordered list of steps
+```
+
+- **preset** — `release` or `debug`. Owns the shape of the pipeline.
+- **product** — `browseros` or `browserclaw`. One file each,
+  `products/<id>/product.py`.
+- **platform** — taken from the host: macOS, Windows, Linux.
+- **arch** — `arm64`, `x64`, or `universal` (macOS only; expands into three
+  sequential runs).
+- **switches** — flat toggles: `clean`, `provision`, `download`, `sign`,
+  `upload`. Resolved CLI > profile > preset default.
+  (`bundle_local_extensions` is a switch too, but profile-only — there is no
+  CLI flag for it.)
+
+Composition lives in one pure function, `plan()` in `core/planner.py`. Nothing
+else decides step order. Steps self-register with `@step(...)` and declare the
+env vars they need, so a missing secret fails in preflight — not three hours
+into a compile.
+
+Two switches people mix up:
+
+- `--provision` controls the **Chromium checkout** (`none`, `full`, `shallow`).
+- `--download` controls whether **server and onboarding resource bundles** are
+  pulled from R2. It has nothing to do with Chromium.
+
+### Layout
+
+Three toolsets — BUILD (`steps/` on the `core/` engine), RELEASE (`release/`),
+DEV (`patchkit/`) — over shared plumbing (`lib/`) and product data
+(`products/`):
 
 ```
 bos_build/
   browseros.py  entry — the `browseros` Typer app (also `python -m bos_build`)
-  cli/          thin Typer wrappers (build, source, product, dev, release, ota)
+  cli/          thin Typer wrappers (build, source, product, dev, release, ext, ota)
   core/         engine: context, step registry, planner, runner, pipeline,
-                resolver, events, product descriptor model — zero domain
-                knowledge
-  lib/          cross-cutting plumbing: env, utils, logger, paths, notify,
-                sparkle, versions, r2 client, test fixtures
+                resolver, events, product descriptor model — zero domain knowledge
+  lib/          plumbing: env, utils, logger, paths, notify, sparkle, versions, r2
   products/     one package per product: define() call + server bundles
-  steps/        BUILD toolset — pipeline steps registered via @step
-                (source, setup, resources, patches, extensions, compile,
-                sign, package, storage)
-  release/      RELEASE toolset — list, publish, download, github, appcast;
-                release/ota/ ships server OTA updates
-  patchkit/     DEV toolset — the Python patch surface: dev extract,
-                non-interactive batch-apply, .features.yaml IO, and the
-                read-only patch-stack doctor (interactive apply/sync
-                lives in the Rust tool: tools/bpatch, `bpatch`)
-  profiles/     saved switch sets (flat yaml; a local profile may opt into
-                an explicit modules: list — shipped profiles never do)
-  config/       data: gn flags, resource yamls, appcast templates, offset
+  steps/        BUILD — pipeline steps registered via @step (source, setup,
+                resources, patches, extensions, compile, sign, package, storage)
+  release/      RELEASE — list, publish, download, github, appcast;
+                release/extensions/ packs CRXs, release/feeds/ publishes update
+                feeds, release/ota/ ships server OTA updates
+  patchkit/     DEV — non-interactive patch surface: extract, batch-apply,
+                .features.yaml IO, read-only patch-stack doctor
+  profiles/     saved switch sets (flat yaml)
+  config/       data: gn flags, resource yamls, appcast templates, build offset
+  docs/         the deeper operator docs linked below
 ```
 
-## How a build is composed
+## Build locally
 
-Pipeline shapes live in `core/planner.py` as one pure function:
-
-```
-plan(preset, platform, arch, switches) -> [step names]
-```
-
-- **Presets** (`release`, `debug`) encode step composition, including
-  platform variance (sparkle vs winsparkle, mini_installer on unsigned
-  Windows) — once, in code, golden-tested against the YAML matrix this
-  replaced.
-- **Switches** are flat toggles: `product`, `arch`, `clean`,
-  `provision` (none/full/shallow), `download`, `sign`, `upload`.
-  Resolution: CLI > profile file > preset default.
-- **Steps** self-register with `@step(name, phase, platforms,
-  env, optional)`. Required env vars derive from the selected steps and
-  are preflighted before anything runs; within-phase order is the
-  import order in `steps/__init__.py`.
+Always start by looking at the plan. It needs no Chromium checkout:
 
 ```bash
-# Local signed release build
+browseros build --preset release --show-plan
+```
+
+It prints the composed steps and every env var they require, marked set or
+missing.
+
+```bash
+# Fast iteration.
+browseros build --preset debug --chromium-src ~/chromium/src
+
+# Signed local release build, macOS arm64.
 browseros build --preset release --product browserclaw --arch arm64
 
-# What nightly CI runs (profile = saved switches)
-browseros build --profile nightly-ci --arch x64
+# Release-shaped Windows build against a checkout you already have (one line —
+# a Windows path and a shell line-continuation both want the backslash).
+browseros build --preset release --provision none --clean --product browserclaw --arch x64 --sign --upload --chromium-src C:\src\chromium-3\src
 
-# Power users: explicit steps
-browseros build --modules clean,compile,sign_macos --product browseros
-```
-
-### Seeing and tweaking a plan
-
-The composed plan is always a projection of `plan()` — generated, never
-hand-copied, so it can't drift:
-
-```bash
-# Print the composed steps + required env vars and exit
-# (works without a chromium checkout)
-browseros build --preset release --show-plan
-
-# Comment out steps, as an operation: subtract from the composed plan
-browseros build --preset release --skip upload,series_patches
-
-# Resume the tail after a failure without recompiling
+# Resume after a failure, without recompiling.
 browseros build --preset release --from sign_macos
 
-# One-off GN overrides while iterating (appended last, so they win)
-browseros build --preset debug --gn-arg symbol_level=2 --gn-arg dcheck_always_on=true
+# Subtract steps from the composed plan.
+browseros build --preset release --skip upload,series_patches
 ```
 
-- `--skip` (and a `skip:` list in profiles) subtracts **after**
-  composition — it never re-triggers composition rules. CLI `--skip`
-  and profile `skip:` union. Unknown step names fail loudly; a valid
-  step absent from this plan is a no-op, so a saved `skip:` keeps
-  working as presets evolve — subtraction from the canonical plan,
-  never a copy of it.
-- `--from` resumes the composed (post-skip) run timeline at a step:
-  earlier runs are dropped, the first run containing the step is
-  sliced, later runs stay whole. A failed universal merge resumes with
-  just `--arch universal --from merge_universal` — no recompiles.
-  CLI-only: resume is a one-off, so there is no `from:` profile key.
-- `--gn-arg key=value` (repeatable, any mode) appends GN overrides
-  **after** the flags file and product args — last write wins, so
-  `configure` honors them without edits to committed `config/gn/*.gn`
-  files. Values are verbatim GN: bools/ints bare, strings with embedded
-  quotes (`--gn-arg 'target_cpu="arm64"'`). CLI-only by design — a
-  profile wanting different flags should use a different flags file.
-  Only `configure` writes args.gn: a plan that skips it (e.g.
-  `--from compile`) reuses the existing file untouched, including any
-  overrides a previous invocation wrote there.
+Profiles are saved switch sets in `profiles/`:
 
-### Modules profiles — "you own this list now"
+| Profile | Used by | What it sets |
+| --- | --- | --- |
+| `release-ci` | `build-browseros.yml`, the reusable Linux/Windows release lane | `preset: release`, `clean: false`, `provision: none` — the workflow provisions and caches Chromium itself |
+| `nightly-ci` | unsigned cloud nightlies | the same, plus `sign: false`, `upload: false` |
+| `nightly-macos` | the two signed mac nightlies | `preset: release`, `download: false`, `bundle_local_extensions: true` — build servers and extensions from the working tree |
 
-For the rare run that genuinely wants an arbitrary sequence, a profile
-may carry `modules:` as an explicit opt-in — a local, commentable file
-that bypasses the planner entirely:
+`release-macos.yml` uses no profile. It runs `--preset release` straight against
+the persistent checkout on the self-hosted Mac.
 
-```yaml
-# my-tail.yaml (local only — never shipped)
-modules: [compile, sign_macos, package_macos]
-build_type: release   # only valid with modules:; defaults to debug
-arch: arm64           # single arch only
-```
+Deeper flag semantics — `--skip`, `--from`, `--gn-arg`, `modules:` profiles,
+ephemeral runners — live in [`docs/build-cli.md`](docs/build-cli.md).
 
-Planner-owned keys (`preset`, `clean`, `provision`, `download`, `sign`,
-`upload`, `skip`) and the `--skip`/`--from` flags are rejected alongside
-`modules:` — you own the list, edit it directly. Shipped profiles stay
-switch-based (drift-tested).
+## Release a browser
 
-## Remote / ephemeral runners
+Dispatch-only, one product per run. No tag trigger, no schedule: a release can
+never accidentally take WarpBuild or the Mac builder out from under a nightly.
 
-A fresh machine needs nothing outside this package:
+The browser version comes from
+`packages/browseros/resources/BROWSEROS_VERSION`. You do not pass it.
 
 ```bash
-uv sync
-uv run browseros source ensure --root "$CHROMIUM_ROOT" --step checkout
-uv run browseros build --modules clean --chromium-src "$CHROMIUM_ROOT/src" -t release
-uv run browseros source ensure --root "$CHROMIUM_ROOT" --step sync
-uv run browseros build --profile nightly-ci --chromium-src "$CHROMIUM_ROOT/src"
+gh workflow run release-browseros.yml \
+  -f platforms=all \
+  -f include_servers=true \
+  -f sign_windows=true \
+  -f macos_arch=arm64 \
+  -f upload_to_r2=true \
+  -f extensions=alpha \
+  -f extensions_version=<agent-extension-version> \
+  -f github_release_draft=true
 ```
 
-(checkout/sync are split because `clean` must run between them — it
-deletes hook-managed toolchains that sync restores. `browseros source
-cache restore|save` handles the R2 checkout cache on runners without
-WarpCache.)
+`release-browserclaw.yml` takes the same inputs; its `extensions_version` is the
+BrowserClaw extension version. Dispatch by filename, never by the grouped
+`Release:` display name.
 
-## Products
-
-A product is one file: `products/<id>/product.py` with a
-`ProductDescriptor.define()` call (~5 irreducible inputs, ~40 fields
-derived by convention, keyword overrides for deviations) plus its
-server bundle definitions. Verify with:
+Every input has a default, so a bare `gh workflow run release-browseros.yml`
+builds all platforms with servers, signed Windows, arm64 mac, alpha extensions,
+and a draft release. Narrow it when you don't want all of that:
 
 ```bash
-browseros product doctor          # identity uniqueness + branding assets
+gh workflow run release-browseros.yml -f platforms=linux -f extensions=skip
+gh workflow run release-browserclaw.yml -f platforms=macos -f macos_arch=universal -f extensions=skip
 ```
 
-## Patch stack
+`extensions_version` is required whenever `extensions` is `alpha` or `prod` —
+CRX versions are independent of the browser version.
 
-`chromium_patches/.features.yaml` maps each feature to its patches. The
-dev doctor keeps that map honest — read-only,
-so it can run in CI and before a chromium bump:
+### What CI does, and where it stops
+
+A BrowserClaw run can produce TypeScript claw-server resources, Rust
+claw-server resources, browser builds for three platforms, the BrowserClaw
+extension CRX, staged update feeds, and draft GitHub release assets.
+
+It **stages**. It does not promote:
+
+- Versioned artifacts land in R2 under the version, not under `download/`.
+- Update feeds are rendered as a dry run and uploaded as one Actions artifact,
+  `staged-update-feeds-<product>-<version>`.
+- The GitHub release is a draft.
+- The Actions summary prints the exact promote commands to run.
+
+Going live is a human decision. That is on purpose.
+
+## Promote a release to live
+
+Inspect, then promote. Feed commands are dry runs unless you pass `--publish`.
+A publish backs up the live feed to `feeds-history/` first and refuses a version
+downgrade (`--allow-downgrade` overrides).
 
 ```bash
-browseros dev doctor                            # .features.yaml ↔ patches on disk
+cd packages/browseros
+
+# 1. See what CI staged.
+browseros release list --version <version> --product browseros
+browseros release feeds status
+
+# 2. Copy versioned R2 objects to the live download/ aliases.
+browseros release publish --version <version> --product browseros
+
+# 3. Diff the appcast, then publish it.
+browseros release appcast --version <version> --product browseros
+browseros release appcast --version <version> --product browseros --publish
+```
+
+Swap in `--product browserclaw` for the other product. If you need to recreate
+the draft GitHub release by hand, that is
+`browseros release github create --version <version> --draft --product <id>`.
+Server OTA promotion is separate, and also manual.
+
+Lane-by-lane detail, required secrets, runner cost, and troubleshooting:
+[`docs/release-ci.md`](docs/release-ci.md).
+
+## Release extensions
+
+Four extensions ship as signed CRXs: `agent`, `controller`, `bugreporter`,
+`browserclaw`. `agent` and `browserclaw` build from this repo; the other two are
+cloned from external repos. All four version independently of the browser.
+
+The usual path is the workflow:
+
+```bash
+gh workflow run release-extensions.yml \
+  -f version=0.0.118 \
+  -f extension=agent \
+  -f channel=alpha \
+  -f publish_manifest=false   # dry run; true writes the feeds
+```
+
+The per-product release orchestrators call this same workflow with
+`publish_manifest=false`, so a browser release uploads the CRX but never touches
+live manifests.
+
+Locally there are two commands, and the difference matters:
+
+```bash
+# Build, pack, sign, upload the CRX, then regenerate the feeds.
+browseros ext release --version 0.0.118 --name agent
+browseros ext release --version 0.0.118 --name agent --publish-manifest
+
+# Feeds only, no CRX build. Pin versions; anything unset carries over from live.
+browseros release extensions --channel alpha --set agent=0.0.118
+browseros release extensions --channel alpha --set browserclaw=0.1.4 --publish
+```
+
+`release extensions` regenerates the update manifest, `extensions.json`, and the
+bundled manifest together, so they cannot drift apart.
+
+## Servers and nightlies
+
+Server bundles version independently of the browser, each from its own package
+file:
+
+| Bundle | Version source | Workflow | Tag |
+| --- | --- | --- | --- |
+| BrowserOS agent server | `packages/browseros-agent/apps/server/package.json` | `release-server.yml` | `agent-server/v*` |
+| BrowserClaw server (Bun) | `.../apps/claw-server/package.json` | `release-claw-server.yml` | `claw-server/v*` |
+| BrowserClaw server (Rust) | `.../apps/claw-server-rust/Cargo.toml` | `release-claw-server-rust.yml` | `claw-server-rust/v*` |
+
+BrowserClaw browser builds download the Bun server today. The Rust blocks in
+`config/download_resources.yaml` and `config/copy_resources.yaml` sit beside the
+Bun ones, commented out.
+
+Two signed macOS nightlies run on the self-hosted Mac and publish rolling
+prereleases anyone can download: `nightly-browseros` (04:00 UTC) and
+`nightly-browserclaw` (06:30 UTC). Nightlies build servers and extensions from
+the checked-out tree; releases consume published R2 bundles. That contrast is
+the point — a nightly tests today's integration, a release ships what R2 already
+holds. See [`docs/nightly-macos-ci.md`](docs/nightly-macos-ci.md).
+
+## Patches and products
+
+```bash
+browseros dev doctor                            # .features.yaml <-> patches on disk
 browseros dev doctor --against ~/chromium/src   # + which patches fail, by feature
 browseros dev doctor --feature llm-chat --json  # filtered / machine-readable
+
+browseros product list                          # registered products
+browseros product doctor                        # identity uniqueness + branding assets
 ```
 
-Exit 0 healthy / 1 findings / 2 usage or environment errors. `--against`
-only ever dry-runs (`git apply --check`); the chromium tree is never
-modified. The dry-run is stricter than the build's apply step (which
-falls back to `--ignore-whitespace`/`--3way`), so a doctor failure means
-"needs attention", not necessarily "won't build".
+`dev doctor` is read-only, so it runs in CI and before a Chromium bump.
+`--against` only ever dry-runs `git apply --check`; the Chromium tree is never
+touched. That dry run is stricter than the build's apply step (which falls back
+to `--ignore-whitespace` and `--3way`), so a doctor failure means "needs
+attention", not necessarily "won't build". Exit 0 healthy, 1 findings, 2 usage
+or environment error.
+
+Interactive patch work — `apply`, `extract`, repinning the store to a new
+Chromium base — lives in the Rust tool `bpatch`
+([`tools/bpatch/README.md`](../tools/bpatch/README.md)). `patchkit/` keeps the
+non-interactive Python surface the build steps depend on.
+
+## Where the truth lives
+
+| Thing | Source |
+| --- | --- |
+| Browser version | `packages/browseros/resources/BROWSEROS_VERSION` |
+| Chromium pin | `packages/browseros/CHROMIUM_VERSION`, `BASE_COMMIT` |
+| Pipeline shape | `bos_build/core/planner.py` |
+| Steps and their required env | `bos_build/steps/`, printed by `--show-plan` |
+| Product identity | `bos_build/products/<id>/product.py` |
+| Patch stack map | `packages/browseros/chromium_patches/.features.yaml` |
+| Which server bundle ships | `config/download_resources.yaml`, `config/copy_resources.yaml` |
+| Local secrets | `packages/browseros/.env` (copy `.env.example`) |
+| Repo secrets | synced by `tools/release_secrets/sync.py` |
+
+## Deeper docs
+
+| Doc | Read it when |
+| --- | --- |
+| [`docs/build-cli.md`](docs/build-cli.md) | You need `--skip` / `--from` / `--gn-arg` precedence, `modules:` profiles, or ephemeral-runner setup |
+| [`docs/release-ci.md`](docs/release-ci.md) | You are running a release and want the lane map, secrets matrix, and promote commands |
+| [`docs/warpbuild-ci.md`](docs/warpbuild-ci.md) | A Linux or Windows cloud build is slow, stuck, or expensive |
+| [`docs/nightly-macos-ci.md`](docs/nightly-macos-ci.md) | You are debugging a signed nightly or setting up the Mac builder |
+| [`docs/windows-install-verification.md`](docs/windows-install-verification.md) | You are hand-verifying a Windows installer before shipping |
+
+Team-only context lives in the `.internal-docs/` submodule (private; nothing
+there is needed to build BrowserOS):
+
+- `setup/release-browser.md` — the operator runbook for one browser release,
+  including rollback
+- `setup/release-server.md` — publishing server, claw-server, and onboard bundles
+- `setup/nightlies.md` — the two mac nightlies and the machine behind them
+- `architecture/release-workflows.md` — how the workflows fit together. Older
+  than `docs/release-ci.md`; when they disagree, the workflow files win.
 
 ## Tests
 

--- a/packages/browseros/bos_build/docs/build-cli.md
+++ b/packages/browseros/bos_build/docs/build-cli.md
@@ -107,9 +107,14 @@ WarpCache, `browseros source cache restore|save` handles the R2 checkout cache.
 
 ## Concurrency
 
-Every build takes a lock on its Chromium checkout, keyed by path. A second build
-against the same checkout fails fast. Pass `--lock-wait` to queue behind it
-instead.
+Every build takes an exclusive lock on its Chromium checkout, keyed by the
+resolved `src` path and held regardless of product. A second build against the
+same checkout fails fast and tells you who holds it. Pass `--lock-wait` to queue
+behind it instead.
+
+Release builds run `git reset`, `git clean`, and patch application in one shared
+checkout, which is why the lock exists. The lock file sits next to the gclient
+root rather than under `src/`, so `git clean` cannot delete it mid-build.
 
 ## Products
 

--- a/packages/browseros/bos_build/docs/build-cli.md
+++ b/packages/browseros/bos_build/docs/build-cli.md
@@ -1,0 +1,123 @@
+# Build CLI Reference
+
+Everything `browseros build` can do beyond the common invocations in
+[`../README.md`](../README.md). Run these from `packages/browseros`.
+
+## Seeing and tweaking a plan
+
+The composed plan is always a projection of `plan()` in `core/planner.py` —
+generated, never hand-copied, so it cannot drift from what actually runs.
+
+```bash
+# Print the composed steps + required env vars and exit
+# (works without a chromium checkout)
+browseros build --preset release --show-plan
+
+# Comment out steps, as an operation: subtract from the composed plan
+browseros build --preset release --skip upload,series_patches
+
+# Resume the tail after a failure without recompiling
+browseros build --preset release --from sign_macos
+
+# One-off GN overrides while iterating (appended last, so they win)
+browseros build --preset debug --gn-arg symbol_level=2 --gn-arg dcheck_always_on=true
+```
+
+### `--skip`
+
+Subtracts **after** composition, so it never re-triggers composition rules —
+skipping `sign_windows` will not add `mini_installer`. CLI `--skip` and a
+profile's `skip:` list union. Unknown step names fail loudly; a valid step
+absent from this plan is a no-op, so a saved `skip:` keeps working as presets
+evolve. It is subtraction from the canonical plan, never a copy of it.
+
+### `--from`
+
+Resumes the composed (post-skip) run timeline at a step. Earlier runs are
+dropped, the first run containing the step is sliced, later runs stay whole. A
+failed universal merge resumes with just
+`--arch universal --from merge_universal` — no recompiles.
+
+CLI-only: a resume is a one-off, so there is no `from:` profile key.
+
+### `--gn-arg`
+
+Repeatable, valid in any mode. Appends GN overrides **after** the flags file and
+the product args, so last write wins and `configure` honors them without editing
+the committed `config/gn/*.gn` files.
+
+Values are verbatim GN: bools and ints bare, strings with embedded quotes
+(`--gn-arg 'target_cpu="arm64"'`). CLI-only by design — a profile that wants
+different flags should use a different flags file.
+
+Only the `configure` step writes `args.gn`. A plan that skips it (for example
+`--from compile`) reuses the existing file untouched, including any overrides a
+previous invocation wrote there.
+
+## Modules profiles — "you own this list now"
+
+For the rare run that genuinely wants an arbitrary sequence, a profile may carry
+`modules:` as an explicit opt-in — a local, commentable file that bypasses the
+planner entirely:
+
+```yaml
+# my-tail.yaml (local only — never shipped)
+modules: [compile, sign_macos, package_macos]
+build_type: release   # only valid with modules:; defaults to debug
+arch: arm64           # single arch only
+```
+
+Planner-owned keys (`preset`, `clean`, `provision`, `download`, `sign`,
+`upload`, `bundle_local_extensions`, `skip`) and the `--skip` / `--from` flags
+are rejected alongside `modules:`. You own the list; edit it directly. Shipped
+profiles stay switch-based, and a golden test keeps them from drifting.
+
+The same escape hatch exists on the command line for one-off runs:
+
+```bash
+browseros build --modules clean,compile,sign_macos --product browseros
+browseros build --list                                # every available step
+```
+
+Phase flags are the middle ground — auto-ordered, no explicit step list:
+
+```bash
+browseros build --setup --build --sign --package
+browseros build --build --sign                        # skip setup
+```
+
+Note that `--prep` does **not** apply `series_patches`. Run
+`browseros build -m series_patches` separately if you need them.
+
+## Remote and ephemeral runners
+
+A fresh machine needs nothing outside this package:
+
+```bash
+uv sync
+uv run browseros source ensure --root "$CHROMIUM_ROOT" --step checkout
+uv run browseros build --modules clean --chromium-src "$CHROMIUM_ROOT/src" -t release
+uv run browseros source ensure --root "$CHROMIUM_ROOT" --step sync
+uv run browseros build --profile nightly-ci --chromium-src "$CHROMIUM_ROOT/src"
+```
+
+Checkout and sync are split because `clean` must run between them: it deletes
+the hook-managed toolchains that sync then restores. On runners without
+WarpCache, `browseros source cache restore|save` handles the R2 checkout cache.
+
+## Concurrency
+
+Every build takes a lock on its Chromium checkout, keyed by path. A second build
+against the same checkout fails fast. Pass `--lock-wait` to queue behind it
+instead.
+
+## Products
+
+A product is one file: `products/<id>/product.py` with a
+`ProductDescriptor.define()` call — about five irreducible inputs, roughly forty
+fields derived by convention, keyword overrides for deviations — plus its server
+bundle definitions. Verify with:
+
+```bash
+browseros product doctor          # identity uniqueness + branding assets
+```


### PR DESCRIPTION
## What

`packages/browseros/bos_build/README.md` was a build-system architecture note. It explained how the planner composes a pipeline, but said nothing about how to cut a release, promote a staged one, or ship an extension CRX — so an operator had to read `docs/release-ci.md` and the workflow YAML to find out.

Rewritten as the entry point and map:

- **Leads with the thing people get wrong**: `browseros build` produces a binary. A release is a workflow dispatch.
- A "what do I want to do → do this" table up top.
- Mental model: `preset + product + platform + arch + switches -> ordered steps`, plus the `--provision` (Chromium checkout) vs `--download` (server/onboarding bundles from R2) distinction people conflate.
- Local build examples, and the three shipped profiles with who actually uses each.
- Per-product release dispatch (`release-browseros.yml` / `release-browserclaw.yml`), what CI stages and where it deliberately stops.
- Manual promotion: `release list` / `feeds status` / `publish` / `appcast --publish`.
- Extension releases, including the `ext release` (builds a CRX) vs `release extensions` (feeds only) distinction.
- Servers, nightlies, patch stack, a source-of-truth table, and links to `docs/*.md` and the private `.internal-docs/` runbooks.

New `docs/build-cli.md` holds the deep flag semantics moved out of the README (`--skip` / `--from` / `--gn-arg` precedence, `modules:` profiles, ephemeral-runner setup, the checkout lock) so nothing is lost.

## Verification

Docs-only — no code changed. Every claim was checked against the source rather than copied from the old README or the internal docs:

- `--show-plan`, `build --list`, `source ensure/cache`, `dev doctor --feature llm-chat --json`, `product list/doctor`, and every documented `release` / `ext` flag were run or `--help`-checked against the real CLI.
- Every relative markdown link, referenced repo path, and referenced workflow filename resolves (scripted check).
- Profile table verified against `profiles/*.yaml` and the `profile:` inputs in `release-linux.yml` / `release-windows.yml` / `build-browseros.yml`; noted that `release-macos.yml` uses `--preset release` with no profile.
- Extension in-repo vs external-repo split verified against `release/extensions/specs.py`.
- `uv run ruff check bos_build` → clean. `unittest discover` → 658 tests, OK.

Where `.internal-docs/architecture/release-workflows.md` and the current workflow files disagreed, the workflow files won; the README says so explicitly.

## Found while writing, not fixed here

`browseros release github create` declares `--publish` twice — once as the off-switch for `draft` (`"--draft/--publish"`) and once as `publish_to_download` (`"--publish", "-p"`). Its docstring also advertises `--no-draft`, which does not exist. Real bug, but it's code and this PR is docs-only, so the README documents only the unambiguous `--draft` form. Worth a follow-up.