### PR TITLE
feat(claw-app): wrap Remotion composition in MemoryRouter + QueryClientProvider

### DIFF
--- a/packages/browseros-agent/apps/claw-app/onboarding-video/src/Root.tsx
+++ b/packages/browseros-agent/apps/claw-app/onboarding-video/src/Root.tsx
@@ -6,13 +6,33 @@
  * Remotion Studio + CLI entry. Registers the FirstRunDemo
  * composition at 1600x900 / 30fps / 20s.
  *
- * Render to WebM (VP9) locally with:
- *   bunx remotion render src/Root.tsx FirstRunDemo out/first-run-demo.mp4
+ * Render to MP4 locally with:
+ *   bun run video:render      (from apps/claw-app)
  *
  * Render a still for the poster with:
- *   bunx remotion still src/Root.tsx FirstRunDemo out/first-run-demo-poster.png --frame 0
+ *   bun run video:poster      (from apps/claw-app)
+ *
+ * The `component` prop wraps `FirstRunDemo` in the same
+ * providers the extension mounts in `entrypoints/newtab/main.tsx`
+ * so that any real component reachable from the composition
+ * (via `@/components/**`) can call react-query hooks or use
+ * react-router primitives without changes:
+ *
+ *   - `<QueryClientProvider>` with a fresh, non-fetching client.
+ *     Later PRs seed specific query keys via
+ *     `queryClient.setQueryData()` to render live-looking cockpit
+ *     data (e.g. the ready-state activity row).
+ *   - `<MemoryRouter>` so `<NavLink>` / `useLocation` render as
+ *     inert anchors instead of throwing. The composition never
+ *     navigates; it just renders whatever the route defaults to.
+ *
+ * Providers must live INSIDE the component the Composition
+ * renders (not around the Composition itself), because Remotion
+ * instantiates that tree fresh on every frame it snapshots.
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router'
 import { Composition } from 'remotion'
 import './index.css'
 import { FirstRunDemo } from './FirstRunDemo'
@@ -21,11 +41,35 @@ import { FPS, TOTAL_FRAMES } from './timing'
 const WIDTH = 1600
 const HEIGHT = 900
 
+// One QueryClient for the whole render process. `retry: false` and
+// infinite stale/gc times mean any consumer hook will either read
+// from a pre-seeded cache entry or return `undefined` synchronously,
+// never triggering a network fetch during render.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: Number.POSITIVE_INFINITY,
+      gcTime: Number.POSITIVE_INFINITY,
+      retry: false,
+    },
+  },
+})
+
+function FirstRunDemoWithProviders() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <FirstRunDemo />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
 export function RemotionRoot() {
   return (
     <Composition
       id="FirstRunDemo"
-      component={FirstRunDemo}
+      component={FirstRunDemoWithProviders}
       durationInFrames={TOTAL_FRAMES}
       fps={FPS}
       width={WIDTH}


### PR DESCRIPTION
## Summary

PR 4 of the [claw-app-remotion-real-ui epic](https://github.com/browseros-ai/BrowserOS/tree/epic/claw-app-remotion-real-ui). Sets up the two React context providers that PRs 5-8 need in order to render real claw-app components (which call \`useTasks\`, \`useLocation\`, and friends) without the components themselves changing.

## Changes

One file: \`apps/claw-app/onboarding-video/src/Root.tsx\`.

- New \`FirstRunDemoWithProviders\` wrapper that mounts \`<QueryClientProvider>\` + \`<MemoryRouter>\` around the existing \`<FirstRunDemo />\`. The \`Composition\` now takes this wrapper as its \`component\`.
- \`QueryClient\` is configured with \`staleTime: Number.POSITIVE_INFINITY\`, \`gcTime: Number.POSITIVE_INFINITY\`, \`retry: false\`. Any hook that reads a NOT-yet-seeded key returns \`undefined\` synchronously; **no network fetch triggers during a render**. Seeding specific keys happens in the PR that swaps SceneActivity to the real \`<RecentActivity>\`.
- Providers live INSIDE the component the Composition renders, not around the Composition descriptor itself. Remotion instantiates the component tree fresh on every frame it snapshots; providers wrapping the Composition descriptor wouldn't reach the frame renderer.
- \`<MemoryRouter>\` (not \`<HashRouter>\` from the extension) because compositions never navigate. \`<NavLink>\` renders as an inert anchor without needing browser URL manipulation.

## What is NOT changed

- No scene file touched.
- No claw-app component imported yet — providers are ready, consumers land in PRs 5-8.
- Rendered MP4 is visually identical to PR 3's output.

## Verified locally

- \`bun install --frozen-lockfile\`: clean.
- \`bun run typecheck\` on claw-app: clean.
- \`bun run video:poster\` + \`bun run video:render\`: succeed. MP4 is 1.7 MB, still-frame byte-comparable to the previous PR's render.
- \`bunx fallow dead-code\`: zero boundary violations.
- \`bunx biome ci .\`: 0 errors, 38 warnings (pre-existing on epic tip, unchanged).

## Base

\`epic/claw-app-remotion-real-ui\`. Does not touch main.

## Test plan
- [x] Typecheck clean.
- [x] Render pipeline works.
- [x] Providers don't crash the composition when no consumer reads from them.
- [x] Boundary invariant preserved.
- [ ] CI \`Code Quality / Biome\` passes.
- [ ] CI test suites pass.