### PR TITLE
chore(bos_build): seed browserclaw appcast staging placeholders

### DIFF
--- a/packages/browseros/bos_build/config/appcast/appcast-claw-server.alpha.xml
+++ b/packages/browseros/bos_build/config/appcast/appcast-claw-server.alpha.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <title>BrowserOS Claw Server (Alpha)</title>
+    <link>https://cdn.browseros.com/appcast-claw-server.alpha.xml</link>
+    <description>BrowserOS Claw Server (Alpha) binary updates</description>
+    <language>en</language>
+
+  </channel>
+</rss>

--- a/packages/browseros/bos_build/config/appcast/appcast-claw-server.xml
+++ b/packages/browseros/bos_build/config/appcast/appcast-claw-server.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <title>BrowserOS Claw Server</title>
+    <link>https://cdn.browseros.com/appcast-claw-server.xml</link>
+    <description>BrowserOS Claw Server binary updates</description>
+    <language>en</language>
+
+  </channel>
+</rss>

--- a/packages/browseros/bos_build/config/appcast/appcast-claw-win-arm64.xml
+++ b/packages/browseros/bos_build/config/appcast/appcast-claw-win-arm64.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
+  xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>BrowserClaw Windows Updates</title>
+    <link>https://cdn.browseros.com/appcast-claw-win-arm64.xml</link>
+    <description>Most recent changes with links to updates.</description>
+    <language>en</language>
+
+  </channel>
+</rss>

--- a/packages/browseros/bos_build/config/appcast/appcast-claw-win.xml
+++ b/packages/browseros/bos_build/config/appcast/appcast-claw-win.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
+  xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>BrowserClaw Windows Updates</title>
+    <link>https://cdn.browseros.com/appcast-claw-win.xml</link>
+    <description>Most recent changes with links to updates.</description>
+    <language>en</language>
+
+  </channel>
+</rss>

--- a/packages/browseros/bos_build/config/appcast/appcast-claw-x86_64.xml
+++ b/packages/browseros/bos_build/config/appcast/appcast-claw-x86_64.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
+  xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>BrowserClaw</title>
+    <link>https://cdn.browseros.com/appcast-claw-x86_64.xml</link>
+    <description>Most recent changes with links to updates.</description>
+    <language>en</language>
+
+  </channel>
+</rss>

--- a/packages/browseros/bos_build/config/appcast/appcast-claw.xml
+++ b/packages/browseros/bos_build/config/appcast/appcast-claw.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
+  xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>BrowserClaw</title>
+    <link>https://cdn.browseros.com/appcast-claw.xml</link>
+    <description>Most recent changes with links to updates.</description>
+    <language>en</language>
+
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary
- add empty BrowserClaw browser appcast staging seeds for macOS and Windows feed keys
- add empty BrowserOS Claw Server prod and alpha appcast staging seeds
- keep seed XML byte-identical to the committed api-worker placeholders

## Verification
- cmp against api-worker copies for all six files
- XML parse plus feed_by_key title/link metadata check
- cd packages/browseros && uv run python -m unittest bos_build.release.feeds.spec_test bos_build.release.feeds.publisher_test bos_build.release.feeds.render_test