### PR TITLE
fix(patches): disable onboarding for BrowserOS

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/BUILD.gn b/chrome/browser/browseros/onboarding/BUILD.gn
 new file mode 100644
-index 0000000000000..a83a34e3f4a8e
+index 0000000000000000000000000000000000000000..4b3ae75acf7793612ff587b86d45645b580a8a3a
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/BUILD.gn
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,63 @@
 +# Copyright 2026 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -55,6 +55,7 @@ index 0000000000000..a83a34e3f4a8e
 +    "//base",
 +    "//chrome/browser:browser_process",
 +    "//chrome/browser/browseros/core:prefs",
++    "//chrome/browser/browseros/core:product",
 +    "//chrome/browser/importer",
 +    "//chrome/browser/importer:impl",
 +    "//chrome/browser/profiles:profile",

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
 new file mode 100644
-index 0000000000000..48d0532711afc
+index 0000000000000000000000000000000000000000..3ed691ccd8724e630b36e6d02150d7e9c1a059b3
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
-@@ -0,0 +1,51 @@
+@@ -0,0 +1,56 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -12,6 +12,7 @@ index 0000000000000..48d0532711afc
 +
 +#include "chrome/browser/browser_process.h"
 +#include "chrome/browser/browseros/core/browseros_prefs.h"
++#include "chrome/browser/browseros/core/browseros_product.h"
 +#include "chrome/browser/profiles/profile.h"
 +#include "chrome/common/chrome_constants.h"
 +#include "chrome/common/pref_names.h"
@@ -20,6 +21,10 @@ index 0000000000000..48d0532711afc
 +namespace browseros::onboarding {
 +
 +bool ShouldShow(Profile* profile) {
++  if (browseros::IsBrowserOSProduct()) {
++    return false;
++  }
++
 +  if (!profile || !profile->IsRegularProfile() || profile->IsOffTheRecord()) {
 +    return false;
 +  }

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
@@ -1,6 +1,6 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
 new file mode 100644
-index 0000000000000..5504cfea7ebd9
+index 0000000000000000000000000000000000000000..305109fa7ffe0451e6ab64e2b0fc83c5ee47c3d5
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
 @@ -0,0 +1,28 @@
@@ -15,7 +15,7 @@ index 0000000000000..5504cfea7ebd9
 +
 +namespace browseros::onboarding {
 +
-+// Returns whether BrowserOS onboarding should interrupt startup for `profile`.
++// Returns whether onboarding should interrupt startup for `profile`.
 +bool ShouldShow(Profile* profile);
 +
 +// Marks the BrowserOS onboarding popup complete for `profile`.


### PR DESCRIPTION
## Summary
- disable the custom onboarding startup gate for the BrowserOS product
- preserve the existing BrowserClaw profile and completion-pref checks
- update the three cumulative onboarding patches in the canonical patch store

## Design
`ShouldShow()` now returns early when the selected product is BrowserOS. BrowserClaw continues through the existing eligibility checks, and the onboarding target declares its direct dependency on the product helper. All changed patch files remain owned by the existing `onboarding-import` feature.

## Test plan
- [x] `autoninja -C out/Default_browseros_arm64 chrome` (`40.30s Build Succeeded`)
- [x] `verify-patches.sh` against Chromium tip `de4ce5a0ca956` (`3/3 MATCH`, `3/3 APPLIES`)
- [x] `git diff --check`