### PR TITLE
fix(patches): suppress upstream first run

### DIFF
--- a/packages/browseros/chromium_patches/.features.yaml
+++ b/packages/browseros/chromium_patches/.features.yaml
@@ -267,6 +267,7 @@ features:
       - chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
       - chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
       - chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
+      - chrome/browser/ui/startup/BUILD.gn
       - chrome/browser/ui/startup/startup_browser_creator.cc
       - chrome/browser/ui/views/profiles/first_run_flow_controller.cc
       - chrome/browser/ui/views/profiles/first_run_flow_controller.h

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
 new file mode 100644
-index 0000000000000000000000000000000000000000..3ed691ccd8724e630b36e6d02150d7e9c1a059b3
+index 0000000000000000000000000000000000000000..a403ca0c367402c1e47cf1a91f2cdcdc7569a6d6
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,52 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -49,11 +49,7 @@ index 0000000000000000000000000000000000000000..3ed691ccd8724e630b36e6d02150d7e9
 +}
 +
 +void NeutralizeUpstreamFirstRun() {
-+  // `kFirstRunFinished` is a Local State pref read by
-+  // FirstRunService::ShouldOpenFirstRun(). Setting it here means: BrowserOS
-+  // provides its own onboarding as the first-run experience, so Chromium's DICE
-+  // first-run is already finished and must not re-open itself when we launch a
-+  // browser after onboarding.
++  // BrowserOS owns first-run policy whether it skips or replaces onboarding.
 +  if (PrefService* local_state = g_browser_process->local_state()) {
 +    local_state->SetBoolean(::prefs::kFirstRunFinished, true);
 +  }

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..305109fa7ffe0451e6ab64e2b0fc83c5ee47c3d5
+index 0000000000000000000000000000000000000000..0a78fc904746e06fdc2ad0ebf514702fa1aeed3f
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,23 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -21,12 +21,7 @@ index 0000000000000000000000000000000000000000..305109fa7ffe0451e6ab64e2b0fc83c5
 +// Marks the BrowserOS onboarding popup complete for `profile`.
 +void MarkCompleted(Profile* profile);
 +
-+// Tells Chromium's built-in (DICE) first-run that first-run is already finished,
-+// so `FirstRunService::ShouldOpenFirstRun()` stops re-intercepting the browser
-+// launch after BrowserOS onboarding completes. Without this, completing
-+// onboarding deadlocks: every attempt to open a browser window re-enters the
-+// upstream first-run flow (which BrowserOS bypassed on entry) and no window is
-+// ever shown. Call once when BrowserOS takes over first-run.
++// Marks Chromium's DICE first-run finished so BrowserOS can skip or replace it.
 +void NeutralizeUpstreamFirstRun();
 +
 +}  // namespace browseros::onboarding

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/BUILD.gn
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/startup/BUILD.gn b/chrome/browser/ui/startup/BUILD.gn
+index 7d63fa20547b14cf5ee6110060b72ed91c5e880e..df48dfd98e0e019a331f2cdfdc625d43c728a9ee 100644
+--- a/chrome/browser/ui/startup/BUILD.gn
++++ b/chrome/browser/ui/startup/BUILD.gn
+@@ -131,6 +131,7 @@ source_set("impl") {
+     "//chrome/browser:browser_features",
+     "//chrome/browser:browser_process",
+     "//chrome/browser/actor",
++    "//chrome/browser/browseros/core:product",
+     "//chrome/browser/devtools",
+     "//chrome/browser/infobars",
+     "//chrome/browser/profiles",

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_browser_creator.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_browser_creator.cc
@@ -1,16 +1,17 @@
 diff --git a/chrome/browser/ui/startup/startup_browser_creator.cc b/chrome/browser/ui/startup/startup_browser_creator.cc
-index 597bd5bfdcbbf..48e33de23903d 100644
+index 597bd5bfdcbbfbdcb553639ba24ff01d463ee11e..2bf1f18642288671739c60fca75c392582a78a4d 100644
 --- a/chrome/browser/ui/startup/startup_browser_creator.cc
 +++ b/chrome/browser/ui/startup/startup_browser_creator.cc
-@@ -41,6 +41,7 @@
+@@ -41,6 +41,8 @@
  #include "chrome/browser/apps/platform_apps/platform_app_launch.h"
  #include "chrome/browser/browser_features.h"
  #include "chrome/browser/browser_process.h"
++#include "chrome/browser/browseros/core/browseros_product.h"
 +#include "chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h"
  #include "chrome/browser/extensions/startup_helper.h"
  #include "chrome/browser/first_run/first_run.h"
  #include "chrome/browser/lifetime/browser_shutdown.h"
-@@ -474,6 +475,49 @@ void OpenNewWindowForFirstRun(const base::CommandLine& command_line,
+@@ -474,6 +476,49 @@ void OpenNewWindowForFirstRun(const base::CommandLine& command_line,
  }
  #endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)
  
@@ -60,11 +61,15 @@ index 597bd5bfdcbbf..48e33de23903d 100644
  #if BUILDFLAG(IS_CHROMEOS)
  // Returns the app id of the kiosk app associated with the current user session.
  // Returns nullopt for non-kiosk user sessions and for ARCVM kiosk sessions,
-@@ -712,6 +756,22 @@ void StartupBrowserCreator::LaunchBrowser(
+@@ -712,6 +757,26 @@ void StartupBrowserCreator::LaunchBrowser(
        command_line, {profile, StartupProfileMode::kBrowserWindow});
  
    if (!IsSilentLaunchEnabled(command_line, profile)) {
 +#if !BUILDFLAG(IS_CHROMEOS)
++    if (browseros::IsBrowserOSProduct()) {
++      browseros::onboarding::NeutralizeUpstreamFirstRun();
++    }
++
 +    if (!command_line.HasSwitch(switches::kNoFirstRun) &&
 +        browseros::onboarding::ShouldShow(profile)) {
 +      // BrowserOS onboarding is now the first-run experience. Stand down


### PR DESCRIPTION
## Summary
- mark Chromium's DICE first-run finished before BrowserOS reaches the upstream first-run check
- keep `ShouldShow()` side-effect free and preserve BrowserClaw custom onboarding
- register the startup target's direct product dependency in the onboarding patch feature

## Design
BrowserOS now calls `NeutralizeUpstreamFirstRun()` at the visible-launch policy boundary before evaluating custom onboarding or DICE. BrowserClaw retains the existing neutralization immediately before opening its custom onboarding picker.

## Test plan
- [x] `autoninja -C out/Default_browseros_arm64 chrome` (`36.48s Build Succeeded`)
- [x] `verify-patches.sh` against Chromium tip `ec39c9f1eef43` (`4/4 MATCH`, `4/4 APPLIES`)
- [x] `git diff --check`