### PR TITLE
chore: update claw docs link

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.test.tsx
@@ -26,7 +26,7 @@ describe('SidebarHelp', () => {
 
   it('pins Docs and onboarding to their exact targets', () => {
     expect(helpItems.map((item) => [item.name, item.url])).toEqual([
-      ['Docs', 'https://docs.browseros.com/'],
+      ['Docs', 'https://docs.browseros.com/browserclaw'],
       ['Revisit Onboarding', 'chrome://browseros-onboarding'],
     ])
   })

--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.tsx
@@ -18,7 +18,11 @@ interface HelpItem {
 }
 
 export const helpItems: HelpItem[] = [
-  { name: 'Docs', url: 'https://docs.browseros.com/', icon: BookOpen },
+  {
+    name: 'Docs',
+    url: 'https://docs.browseros.com/browserclaw',
+    icon: BookOpen,
+  },
   {
     name: 'Revisit Onboarding',
     url: 'chrome://browseros-onboarding',


### PR DESCRIPTION
## Summary
- Point the claw-app sidebar Docs item at the BrowserClaw docs page.
- Update the sidebar exact-target test for the new docs URL.

## Validation
- bunx biome check components/sidebar/SidebarHelp.tsx components/sidebar/SidebarHelp.test.tsx
- bun run --cwd packages/browseros-agent/apps/claw-app test components/sidebar/SidebarHelp.test.tsx
- bun run --cwd packages/browseros-agent/apps/claw-app build:dev