### PR TITLE
fix: launch Windows server without a console window

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/BUILD.gn b/chrome/browser/browseros/server/BUILD.gn
 new file mode 100644
-index 0000000000000..aed05041c83b4
+index 0000000000000000000000000000000000000000..5fadaa41de9c2259e4d0cd35a08b758f694ba703
 --- /dev/null
 +++ b/chrome/browser/browseros/server/BUILD.gn
-@@ -0,0 +1,175 @@
+@@ -0,0 +1,183 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -63,11 +63,18 @@ index 0000000000000..aed05041c83b4
 +    "process_controller.h",
 +    "process_controller_impl.cc",
 +    "process_controller_impl.h",
++    "server_process_launcher.h",
 +    "server_state_store.h",
 +    "server_state_store_impl.cc",
 +    "server_state_store_impl.h",
 +    "server_updater.h",
 +  ]
++
++  if (is_win) {
++    sources += [ "server_process_launcher_win.cc" ]
++  } else {
++    sources += [ "server_process_launcher.cc" ]
++  }
 +
 +  deps = [
 +    "//base",
@@ -112,6 +119,7 @@ index 0000000000000..aed05041c83b4
 +    "browseros_server_manager_unittest.cc",
 +    "browseros_server_proxy_unittest.cc",
 +    "browseros_server_utils_unittest.cc",
++    "server_process_launcher_unittest.cc",
 +  ]
 +
 +  deps = [

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/process_controller_impl.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/process_controller_impl.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/process_controller_impl.cc b/chrome/browser/browseros/server/process_controller_impl.cc
 new file mode 100644
-index 0000000000000..4ea850197327e
+index 0000000000000000000000000000000000000000..5e5fcdc251bfc3e352287150f9e43fc7c618b093
 --- /dev/null
 +++ b/chrome/browser/browseros/server/process_controller_impl.cc
-@@ -0,0 +1,172 @@
+@@ -0,0 +1,167 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -15,9 +15,9 @@ index 0000000000000..4ea850197327e
 +#include "base/files/file_util.h"
 +#include "base/json/json_writer.h"
 +#include "base/logging.h"
-+#include "base/process/launch.h"
 +#include "build/build_config.h"
 +#include "chrome/browser/browseros/server/browseros_server_utils.h"
++#include "chrome/browser/browseros/server/server_process_launcher.h"
 +
 +#if BUILDFLAG(IS_POSIX)
 +#include <signal.h>
@@ -99,12 +99,7 @@ index 0000000000000..4ea850197327e
 +  base::CommandLine cmd(actual_exe_path);
 +  cmd.AppendSwitchPath("config", config_path);
 +
-+  base::LaunchOptions options;
-+#if BUILDFLAG(IS_WIN)
-+  options.start_hidden = true;
-+#endif
-+
-+  result.process = base::LaunchProcess(cmd, options);
++  result.process = LaunchServerProcess(cmd);
 +  return result;
 +}
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/server_process_launcher.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/server_process_launcher.cc
@@ -1,0 +1,21 @@
+diff --git a/chrome/browser/browseros/server/server_process_launcher.cc b/chrome/browser/browseros/server/server_process_launcher.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..b834c7d4c52e08ca9e26b2e6a057b26f9c9a89f8
+--- /dev/null
++++ b/chrome/browser/browseros/server/server_process_launcher.cc
+@@ -0,0 +1,15 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/browseros/server/server_process_launcher.h"
++
++#include "base/process/launch.h"
++
++namespace browseros {
++
++base::Process LaunchServerProcess(const base::CommandLine& command_line) {
++  return base::LaunchProcess(command_line, {});
++}
++
++}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/server_process_launcher.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/server_process_launcher.h
@@ -1,0 +1,27 @@
+diff --git a/chrome/browser/browseros/server/server_process_launcher.h b/chrome/browser/browseros/server/server_process_launcher.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..a800642043e169688367367870edd0717e97b71a
+--- /dev/null
++++ b/chrome/browser/browseros/server/server_process_launcher.h
+@@ -0,0 +1,21 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_BROWSEROS_SERVER_SERVER_PROCESS_LAUNCHER_H_
++#define CHROME_BROWSER_BROWSEROS_SERVER_SERVER_PROCESS_LAUNCHER_H_
++
++#include "base/process/process.h"
++
++namespace base {
++class CommandLine;
++}
++
++namespace browseros {
++
++// Launches a managed server with platform-appropriate background semantics.
++base::Process LaunchServerProcess(const base::CommandLine& command_line);
++
++}  // namespace browseros
++
++#endif  // CHROME_BROWSER_BROWSEROS_SERVER_SERVER_PROCESS_LAUNCHER_H_

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/server_process_launcher_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/server_process_launcher_unittest.cc
@@ -1,0 +1,64 @@
+diff --git a/chrome/browser/browseros/server/server_process_launcher_unittest.cc b/chrome/browser/browseros/server/server_process_launcher_unittest.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..1446939a28f483e91db85293ad4021cc36c35a91
+--- /dev/null
++++ b/chrome/browser/browseros/server/server_process_launcher_unittest.cc
+@@ -0,0 +1,58 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/browseros/server/server_process_launcher.h"
++
++#include "build/build_config.h"
++
++#if BUILDFLAG(IS_WIN)
++#include <windows.h>
++#endif
++
++#include "base/test/multiprocess_test.h"
++#include "base/test/test_timeouts.h"
++#include "testing/gtest/include/gtest/gtest.h"
++#include "testing/multiprocess_func_list.h"
++
++namespace browseros {
++namespace {
++
++MULTIPROCESS_TEST_MAIN(ManagedServerChild) {
++  return 0;
++}
++
++#if BUILDFLAG(IS_WIN)
++MULTIPROCESS_TEST_MAIN(ManagedServerNoConsoleChild) {
++  return ::GetConsoleWindow() == nullptr ? 0 : 1;
++}
++#endif
++
++class ServerProcessLauncherTest : public base::MultiProcessTest {};
++
++TEST_F(ServerProcessLauncherTest, ReturnsManagedProcess) {
++  base::Process process =
++      LaunchServerProcess(MakeCmdLine("ManagedServerChild"));
++  ASSERT_TRUE(process.IsValid());
++
++  int exit_code = -1;
++  ASSERT_TRUE(process.WaitForExitWithTimeout(TestTimeouts::action_max_timeout(),
++                                             &exit_code));
++  EXPECT_EQ(0, exit_code);
++}
++
++#if BUILDFLAG(IS_WIN)
++TEST_F(ServerProcessLauncherTest, LaunchesWithoutConsoleWindow) {
++  base::Process process =
++      LaunchServerProcess(MakeCmdLine("ManagedServerNoConsoleChild"));
++  ASSERT_TRUE(process.IsValid());
++
++  int exit_code = -1;
++  ASSERT_TRUE(process.WaitForExitWithTimeout(TestTimeouts::action_max_timeout(),
++                                             &exit_code));
++  EXPECT_EQ(0, exit_code);
++}
++#endif
++
++}  // namespace
++}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/server_process_launcher_win.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/server_process_launcher_win.cc
@@ -1,0 +1,45 @@
+diff --git a/chrome/browser/browseros/server/server_process_launcher_win.cc b/chrome/browser/browseros/server/server_process_launcher_win.cc
+new file mode 100644
+index 0000000000000000000000000000000000000000..69ccd172300d28bbe36817bf526711bb8c9ddb14
+--- /dev/null
++++ b/chrome/browser/browseros/server/server_process_launcher_win.cc
+@@ -0,0 +1,39 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/browseros/server/server_process_launcher.h"
++
++#include <windows.h>
++
++#include <string>
++
++#include "base/command_line.h"
++#include "base/logging.h"
++#include "base/threading/scoped_thread_priority.h"
++#include "base/win/scoped_process_information.h"
++#include "base/win/startup_information.h"
++
++namespace browseros {
++
++base::Process LaunchServerProcess(const base::CommandLine& command_line) {
++  base::win::StartupInformation startup_info;
++  STARTUPINFO* startup_info_ptr = startup_info.startup_info();
++  startup_info_ptr->dwFlags |= STARTF_USESHOWWINDOW;
++  startup_info_ptr->wShowWindow = SW_HIDE;
++
++  PROCESS_INFORMATION raw_process_info = {};
++  std::wstring writable_command_line = command_line.GetCommandLineString();
++  SCOPED_MAY_LOAD_LIBRARY_AT_BACKGROUND_PRIORITY();
++  if (!::CreateProcessW(nullptr, writable_command_line.data(), nullptr, nullptr,
++                        FALSE, CREATE_NO_WINDOW, nullptr, nullptr,
++                        startup_info_ptr, &raw_process_info)) {
++    DPLOG(ERROR) << "browseros: Failed to launch managed server";
++    return base::Process();
++  }
++
++  base::win::ScopedProcessInformation process_info(raw_process_info);
++  return base::Process(process_info.TakeProcessHandle());
++}
++
++}  // namespace browseros


### PR DESCRIPTION
## Summary
- route managed server startup through a BrowserOS-owned platform launcher instead of extending Chromium base APIs
- launch the Windows console-subsystem server with `CREATE_NO_WINDOW` while preserving the managed process handle and existing non-Windows behavior
- add multiprocess regression coverage that distinguishes no console from a merely hidden console

## Design
`start_hidden` only supplies `STARTF_USESHOWWINDOW` and `SW_HIDE`; it controls presentation but does not prevent Windows from allocating a console for a console-subsystem executable. The Windows launcher uses `CreateProcessW` with the same command line, inherited environment/current directory, non-inherited handles, and owned process handle as the prior default launch, adding only `CREATE_NO_WINDOW`. `SW_HIDE` remains as compatibility behavior if the packaged executable changes subsystem.

## Test plan
- [x] `autoninja -C out/Default_browseros_arm64 chrome/browser/browseros/server:server chrome/browser/browseros/server:unit_tests`
- [x] `out/Default_browseros_arm64/unit_tests --gtest_filter='ServerProcessLauncherTest.*:BrowserOSServerManagerTest.*'` (20 passed)
- [x] `autoninja -C out/Default_browseros_arm64 chrome`
- [x] extracted patch verification: 6/6 byte-match and 6/6 apply-check

## References
- [Process creation flags](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags)
- [STARTUPINFO](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/ns-processthreadsapi-startupinfow)