### PR TITLE
fix(bpatch): stop treating annotate commits as drift

### DIFF
--- a/packages/browseros/tools/bpatch/src/cli/apply.rs
+++ b/packages/browseros/tools/bpatch/src/cli/apply.rs
@@ -147,7 +147,7 @@ pub struct ApplyConflictFile {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ApplyDriftSource {
-    /// Drift is committed on top of the applied tree.
+    /// Drift is committed on top of the bpatch-authored drift anchor.
     Committed,
     /// Drift is in the index or worktree.
     Uncommitted,

--- a/packages/browseros/tools/bpatch/src/cli/apply.rs
+++ b/packages/browseros/tools/bpatch/src/cli/apply.rs
@@ -307,7 +307,7 @@ pub fn render_human(report: &ApplyReport) -> String {
         ApplyReport::Drift { files, .. } => {
             let mut out = String::new();
             out.push_str(&format!(
-                "drift: working tree differs from applied state in {} {}:\n",
+                "drift: working tree differs from its bpatch baseline in {} {}:\n",
                 files.len(),
                 files_label(files.len())
             ));

--- a/packages/browseros/tools/bpatch/src/cli/diff.rs
+++ b/packages/browseros/tools/bpatch/src/cli/diff.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use serde::Serialize;
 
-use crate::engine::apply::build_apply_target_tree;
+use crate::engine::apply::build_apply_target_trees;
 use crate::engine::progress;
 use crate::engine::state::{StateContext, resolve, unassigned_feature_name};
 use crate::git::GitAdapter;
@@ -79,7 +79,7 @@ pub fn run(ctx: &StateContext) -> Result<DiffReport> {
     let state = resolve(ctx)?;
     let store = Store::load(&ctx.store_dir)?;
     let checkout = GitAdapter::new(&ctx.checkout);
-    let target_tree = build_apply_target_tree(
+    let target = build_apply_target_trees(
         &checkout,
         &ctx.store_dir,
         &store,
@@ -87,7 +87,7 @@ pub fn run(ctx: &StateContext) -> Result<DiffReport> {
         &mut progress::noop(),
     )?;
     let entries = checkout
-        .diff_tree_name_status(&state.head_tree, &target_tree)?
+        .diff_tree_name_status(&state.head_tree, &target.checkout_tree)?
         .into_iter()
         .filter(|entry| {
             entry

--- a/packages/browseros/tools/bpatch/src/cli/diff.rs
+++ b/packages/browseros/tools/bpatch/src/cli/diff.rs
@@ -1,10 +1,13 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde::Serialize;
 
+use crate::engine::apply::build_apply_target_tree;
+use crate::engine::progress;
 use crate::engine::state::{StateContext, resolve, unassigned_feature_name};
+use crate::git::GitAdapter;
 use crate::store::{FeatureMatch, Store};
 
 /// Serializable diff report for the next apply.
@@ -75,22 +78,16 @@ pub struct RebuildScope {
 pub fn run(ctx: &StateContext) -> Result<DiffReport> {
     let state = resolve(ctx)?;
     let store = Store::load(&ctx.store_dir)?;
-    let patches = store
-        .patches()
-        .values()
-        .filter(|patch| store.stores_path(&patch.path))
-        .map(|patch| ctx.store_dir.join(&patch.path))
-        .collect::<Vec<_>>();
-    let target_tree = crate::git::GitAdapter::new(&ctx.checkout)
-        .build_tree_from_patches(&state.base.sha, &patches)
-        .context("building target tree from store patches")?;
-    let applied_tree = state
-        .applied
-        .as_ref()
-        .map(|applied| applied.tree.as_str())
-        .unwrap_or(&state.base.sha);
-    let entries = crate::git::GitAdapter::new(&ctx.checkout)
-        .diff_tree_name_status(applied_tree, &target_tree)?
+    let checkout = GitAdapter::new(&ctx.checkout);
+    let target_tree = build_apply_target_tree(
+        &checkout,
+        &ctx.store_dir,
+        &store,
+        &state,
+        &mut progress::noop(),
+    )?;
+    let entries = checkout
+        .diff_tree_name_status(&state.head_tree, &target_tree)?
         .into_iter()
         .filter(|entry| {
             entry

--- a/packages/browseros/tools/bpatch/src/cli/feature.rs
+++ b/packages/browseros/tools/bpatch/src/cli/feature.rs
@@ -324,7 +324,9 @@ fn last_sequences(ctx: &StateContext) -> Result<BTreeMap<String, usize>> {
     let mut sequences = BTreeMap::new();
     let range = format!("{}..HEAD", state.base.sha);
     for commit in git.first_parent_commits(Some(&range), None)? {
-        if parse_apply_trailers(&git.commit_trailers(&commit)?)?.is_none() {
+        if parse_apply_trailers(&git.commit_trailers(&commit)?)?
+            .is_none_or(|trailers| trailers.state_only)
+        {
             continue;
         }
         if let Some((feature, seq)) = subject_sequence(&git.commit_subject(&commit)?) {

--- a/packages/browseros/tools/bpatch/src/cli/status.rs
+++ b/packages/browseros/tools/bpatch/src/cli/status.rs
@@ -29,7 +29,7 @@ pub struct StatusReport {
     pub applied_store_rev: Option<String>,
     /// Short applied store revision, when present.
     pub applied_store_short_rev: Option<String>,
-    /// Raw store target tree cache or recovered tree, when present.
+    /// Materialized checkout tree cache or recovered tree, when present.
     pub applied_tree: Option<String>,
     /// Number of apply-authored feature commits since base.
     pub feature_commits: usize,

--- a/packages/browseros/tools/bpatch/src/cli/status.rs
+++ b/packages/browseros/tools/bpatch/src/cli/status.rs
@@ -29,7 +29,7 @@ pub struct StatusReport {
     pub applied_store_rev: Option<String>,
     /// Short applied store revision, when present.
     pub applied_store_short_rev: Option<String>,
-    /// Applied tree cache or recovered tree, when present.
+    /// Raw store target tree cache or recovered tree, when present.
     pub applied_tree: Option<String>,
     /// Number of apply-authored feature commits since base.
     pub feature_commits: usize,

--- a/packages/browseros/tools/bpatch/src/cli/status.rs
+++ b/packages/browseros/tools/bpatch/src/cli/status.rs
@@ -35,7 +35,7 @@ pub struct StatusReport {
     pub feature_commits: usize,
     /// Subject of the newest apply-authored feature commit.
     pub last_feature_commit: Option<String>,
-    /// Drift entries relative to the applied tree.
+    /// Drift entries relative to the newest bpatch-authored commit tree.
     pub drift: Vec<StatusDriftFile>,
     /// Active conflict session, when one is in progress.
     pub conflict_session: Option<StatusConflictSession>,
@@ -47,7 +47,7 @@ pub struct StatusReport {
 pub enum StatusResult {
     /// Checkout has no drift.
     Clean,
-    /// Checkout differs from its applied tree.
+    /// Checkout differs from its bpatch-authored drift anchor.
     Drift,
 }
 
@@ -79,7 +79,7 @@ pub struct StatusConflictSession {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StatusDriftSource {
-    /// Drift is committed on top of the applied tree.
+    /// Drift is committed on top of the bpatch-authored drift anchor.
     Committed,
     /// Drift is in the index or worktree.
     Uncommitted,

--- a/packages/browseros/tools/bpatch/src/engine/apply.rs
+++ b/packages/browseros/tools/bpatch/src/engine/apply.rs
@@ -6,8 +6,8 @@ use anyhow::{Context, Result, anyhow, bail};
 
 use crate::engine::progress::ProgressEvent;
 use crate::engine::state::{
-    DriftFile, DriftSource, StateContext, format_annotate_trailers, format_apply_trailers,
-    parse_bpatch_authored_base, unassigned_feature_name,
+    DriftFile, DriftSource, ResolvedState, StateContext, format_annotate_trailers,
+    format_apply_trailers, parse_bpatch_authored_base, unassigned_feature_name,
 };
 use crate::git::{GitAdapter, TreeDiffEntry};
 use crate::process::Git;
@@ -174,25 +174,7 @@ pub fn apply(
     }
 
     let checkout = GitAdapter::new(&ctx.checkout);
-    let store_target_tree =
-        build_target_tree(&checkout, &ctx.store_dir, &store, &state.base.sha, progress)
-            .context("building target tree from store patches")?;
-    let applied_tree = state
-        .applied
-        .as_ref()
-        .map(|applied| applied.tree.as_str())
-        .unwrap_or(&state.base.sha);
-    let store_delta = checkout
-        .diff_tree_name_status(applied_tree, &store_target_tree)?
-        .into_iter()
-        .filter(|entry| stores_entry(&store, entry))
-        .collect::<Vec<_>>();
-    let target_tree = build_tree_from_source_entries(
-        &checkout,
-        &state.head_tree,
-        &store_target_tree,
-        &store_delta,
-    )?;
+    let target_tree = build_apply_target_tree(&checkout, &ctx.store_dir, &store, &state, progress)?;
 
     checkout.refresh_index()?;
     let has_uncommitted_drift = state
@@ -448,7 +430,31 @@ fn pull_store(store_dir: &Path, progress: &mut dyn FnMut(ProgressEvent<'_>)) -> 
     Ok(())
 }
 
-fn build_target_tree(
+/// Builds the exact overlaid tree that apply would materialize for resolved state.
+pub(crate) fn build_apply_target_tree(
+    git: &GitAdapter,
+    store_dir: &Path,
+    store: &Store,
+    state: &ResolvedState,
+    progress: &mut dyn FnMut(ProgressEvent<'_>),
+) -> Result<String> {
+    let store_target_tree =
+        build_store_target_tree(git, store_dir, store, &state.base.sha, progress)
+            .context("building target tree from store patches")?;
+    let applied_tree = state
+        .applied
+        .as_ref()
+        .map(|applied| applied.tree.as_str())
+        .unwrap_or(&state.base.sha);
+    let store_delta = git
+        .diff_tree_name_status(applied_tree, &store_target_tree)?
+        .into_iter()
+        .filter(|entry| stores_entry(store, entry))
+        .collect::<Vec<_>>();
+    build_tree_from_source_entries(git, &state.head_tree, &store_target_tree, &store_delta)
+}
+
+fn build_store_target_tree(
     git: &GitAdapter,
     store_dir: &Path,
     store: &Store,

--- a/packages/browseros/tools/bpatch/src/engine/apply.rs
+++ b/packages/browseros/tools/bpatch/src/engine/apply.rs
@@ -61,7 +61,7 @@ pub struct AppliedApply {
     pub files_changed: usize,
     /// Store-managed file count loaded from the store.
     pub store_managed_files: usize,
-    /// Final target tree carried by the batch's last commit.
+    /// Final checkout tree materialized by this apply.
     pub target_tree: String,
     /// Feature commits authored by this run.
     pub commits: Vec<AuthoredCommit>,
@@ -108,8 +108,11 @@ pub struct AuthorCommitsInput<'a> {
 /// Trailer style for commit-tree authored bpatch commits.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CommitTrailerMode<'a> {
-    /// Apply commits record the store revision and final target tree.
-    Apply { store_rev: &'a str },
+    /// Apply commits record the store revision and raw store target tree.
+    Apply {
+        store_rev: &'a str,
+        store_tree: &'a str,
+    },
     /// Annotate commits record only the base plus an annotation marker.
     Annotate,
 }
@@ -154,6 +157,11 @@ struct CommitGroup {
     files: Vec<TreeDiffEntry>,
 }
 
+pub(crate) struct ApplyTargetTrees {
+    pub checkout_tree: String,
+    pub store_tree: String,
+}
+
 /// Runs same-base convergence against the current store.
 pub fn apply(
     ctx: &StateContext,
@@ -174,7 +182,7 @@ pub fn apply(
     }
 
     let checkout = GitAdapter::new(&ctx.checkout);
-    let target_tree = build_apply_target_tree(&checkout, &ctx.store_dir, &store, &state, progress)?;
+    let target = build_apply_target_trees(&checkout, &ctx.store_dir, &store, &state, progress)?;
 
     checkout.refresh_index()?;
     let has_uncommitted_drift = state
@@ -182,11 +190,11 @@ pub fn apply(
         .files()
         .iter()
         .any(|file| matches!(file.source, DriftSource::Uncommitted));
-    if state.head_tree == target_tree && !has_uncommitted_drift {
+    if state.head_tree == target.checkout_tree && !has_uncommitted_drift {
         return Ok(ApplyOutcome::Converged(ConvergedApply {
             store_rev: state.store.head_rev,
             store_short_rev: state.store.short_head_rev,
-            target_tree,
+            target_tree: target.checkout_tree,
         }));
     }
 
@@ -196,7 +204,7 @@ pub fn apply(
         }));
     }
 
-    let delta = checkout.diff_tree_name_status(&state.head_tree, &target_tree)?;
+    let delta = checkout.diff_tree_name_status(&state.head_tree, &target.checkout_tree)?;
     let collisions = untracked_add_collisions(&checkout, &delta)?;
     if !collisions.is_empty() {
         return Ok(ApplyOutcome::Drift(DriftApply { files: collisions }));
@@ -208,9 +216,10 @@ pub fn apply(
             store: &store,
             base: &state.base.sha,
             applied_tree: &state.head_tree,
-            target_tree: &target_tree,
+            target_tree: &target.checkout_tree,
             trailers: CommitTrailerMode::Apply {
                 store_rev: &state.store.head_rev,
+                store_tree: &target.store_tree,
             },
             subject_mode: SubjectMode::FeatureName,
             parent_commit: &state.head_rev,
@@ -224,11 +233,11 @@ pub fn apply(
         total: Some(delta.len()),
     });
     checkout
-        .materialize_tree_delta(&state.head_tree, &target_tree)
+        .materialize_tree_delta(&state.head_tree, &target.checkout_tree)
         .with_context(|| {
             format!(
-                "materializing target tree failed; recover with `git read-tree -m -u {} {target_tree}`",
-                state.head_tree
+                "materializing target tree failed; recover with `git read-tree -m -u {} {}`",
+                state.head_tree, target.checkout_tree
             )
         })?;
     progress(ProgressEvent::End {
@@ -238,7 +247,7 @@ pub fn apply(
         &ctx.checkout,
         &state.head_rev,
         &chain.final_sha,
-        &target_tree,
+        &target.checkout_tree,
     )?;
 
     Ok(ApplyOutcome::Applied(AppliedApply {
@@ -253,7 +262,7 @@ pub fn apply(
             .keys()
             .filter(|path| store.stores_path(path))
             .count(),
-        target_tree,
+        target_tree: target.checkout_tree,
         commits: chain.commits,
     }))
 }
@@ -304,7 +313,10 @@ pub fn author_feature_commits(
         let index_info = index_info_for_group(&git, input.target_tree, &group.files)?;
         indexed.run_with_stdin(&["update-index", "--index-info"], index_info.as_bytes())?;
         let next_tree = indexed.run_str(&["write-tree"])?;
-        let tree_trailer = (index == last_index).then_some(input.target_tree);
+        let tree_trailer = match input.trailers {
+            CommitTrailerMode::Apply { store_tree, .. } if index == last_index => Some(store_tree),
+            _ => None,
+        };
         let message = commit_message(&group.subject, input.trailers, input.base, tree_trailer);
         let sha = git.process().run_with_stdin(
             &["commit-tree", &next_tree, "-p", &parent],
@@ -430,14 +442,14 @@ fn pull_store(store_dir: &Path, progress: &mut dyn FnMut(ProgressEvent<'_>)) -> 
     Ok(())
 }
 
-/// Builds the exact overlaid tree that apply would materialize for resolved state.
-pub(crate) fn build_apply_target_tree(
+/// Builds the raw store tree and exact overlaid checkout tree for an apply plan.
+pub(crate) fn build_apply_target_trees(
     git: &GitAdapter,
     store_dir: &Path,
     store: &Store,
     state: &ResolvedState,
     progress: &mut dyn FnMut(ProgressEvent<'_>),
-) -> Result<String> {
+) -> Result<ApplyTargetTrees> {
     let store_target_tree =
         build_store_target_tree(git, store_dir, store, &state.base.sha, progress)
             .context("building target tree from store patches")?;
@@ -451,7 +463,12 @@ pub(crate) fn build_apply_target_tree(
         .into_iter()
         .filter(|entry| stores_entry(store, entry))
         .collect::<Vec<_>>();
-    build_tree_from_source_entries(git, &state.head_tree, &store_target_tree, &store_delta)
+    let checkout_tree =
+        build_tree_from_source_entries(git, &state.head_tree, &store_target_tree, &store_delta)?;
+    Ok(ApplyTargetTrees {
+        checkout_tree,
+        store_tree: store_target_tree,
+    })
 }
 
 fn build_store_target_tree(
@@ -681,7 +698,7 @@ fn commit_message(
     message.push_str(subject);
     message.push_str("\n\n");
     match trailers {
-        CommitTrailerMode::Apply { store_rev } => {
+        CommitTrailerMode::Apply { store_rev, .. } => {
             message.push_str(&format_apply_trailers(store_rev, base, tree));
         }
         CommitTrailerMode::Annotate => {

--- a/packages/browseros/tools/bpatch/src/engine/apply.rs
+++ b/packages/browseros/tools/bpatch/src/engine/apply.rs
@@ -57,7 +57,7 @@ pub struct AppliedApply {
     pub base_display: String,
     /// Applied store revision before this run, when any.
     pub previous_store_short_rev: Option<String>,
-    /// Files changed between the applied tree and target tree.
+    /// Files changed between the current checkout and target tree.
     pub files_changed: usize,
     /// Store-managed file count loaded from the store.
     pub store_managed_files: usize,
@@ -108,11 +108,8 @@ pub struct AuthorCommitsInput<'a> {
 /// Trailer style for commit-tree authored bpatch commits.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CommitTrailerMode<'a> {
-    /// Apply commits record the store revision and raw store target tree.
-    Apply {
-        store_rev: &'a str,
-        store_tree: &'a str,
-    },
+    /// Apply commits record the store revision and materialized checkout tree.
+    Apply { store_rev: &'a str },
     /// Annotate commits record only the base plus an annotation marker.
     Annotate,
 }
@@ -159,7 +156,12 @@ struct CommitGroup {
 
 pub(crate) struct ApplyTargetTrees {
     pub checkout_tree: String,
-    pub store_tree: String,
+    pub store_delta: Vec<TreeDiffEntry>,
+}
+
+struct StoreRevisionSnapshot {
+    _temp: tempfile::TempDir,
+    dir: PathBuf,
 }
 
 /// Runs same-base convergence against the current store.
@@ -190,7 +192,14 @@ pub fn apply(
         .files()
         .iter()
         .any(|file| matches!(file.source, DriftSource::Uncommitted));
-    if state.head_tree == target.checkout_tree && !has_uncommitted_drift {
+    let checkout_matches_target = state.head_tree == target.checkout_tree;
+    let applied_checkout_matches_head = state.applied.as_ref().is_some_and(|applied| {
+        applied.store_rev == state.store.head_rev && applied.tree == state.head_tree
+    });
+    if checkout_matches_target
+        && (target.store_delta.is_empty() || applied_checkout_matches_head)
+        && !has_uncommitted_drift
+    {
         return Ok(ApplyOutcome::Converged(ConvergedApply {
             store_rev: state.store.head_rev,
             store_short_rev: state.store.short_head_rev,
@@ -198,7 +207,7 @@ pub fn apply(
         }));
     }
 
-    if !state.drift.is_clean() {
+    if !state.drift.is_clean() && (!checkout_matches_target || has_uncommitted_drift) {
         return Ok(ApplyOutcome::Drift(DriftApply {
             files: state.drift.files().to_vec(),
         }));
@@ -209,6 +218,11 @@ pub fn apply(
     if !collisions.is_empty() {
         return Ok(ApplyOutcome::Drift(DriftApply { files: collisions }));
     }
+    let commit_delta = if delta.is_empty() {
+        &target.store_delta
+    } else {
+        &delta
+    };
 
     let chain = author_feature_commits(
         AuthorCommitsInput {
@@ -219,11 +233,10 @@ pub fn apply(
             target_tree: &target.checkout_tree,
             trailers: CommitTrailerMode::Apply {
                 store_rev: &state.store.head_rev,
-                store_tree: &target.store_tree,
             },
             subject_mode: SubjectMode::FeatureName,
             parent_commit: &state.head_rev,
-            delta: &delta,
+            delta: commit_delta,
         },
         progress,
     )?;
@@ -313,10 +326,7 @@ pub fn author_feature_commits(
         let index_info = index_info_for_group(&git, input.target_tree, &group.files)?;
         indexed.run_with_stdin(&["update-index", "--index-info"], index_info.as_bytes())?;
         let next_tree = indexed.run_str(&["write-tree"])?;
-        let tree_trailer = match input.trailers {
-            CommitTrailerMode::Apply { store_tree, .. } if index == last_index => Some(store_tree),
-            _ => None,
-        };
+        let tree_trailer = (index == last_index).then_some(input.target_tree);
         let message = commit_message(&group.subject, input.trailers, input.base, tree_trailer);
         let sha = git.process().run_with_stdin(
             &["commit-tree", &next_tree, "-p", &parent],
@@ -453,13 +463,36 @@ pub(crate) fn build_apply_target_trees(
     let store_target_tree =
         build_store_target_tree(git, store_dir, store, &state.base.sha, progress)
             .context("building target tree from store patches")?;
-    let applied_tree = state
+    let applied_matches_store_worktree = state
         .applied
         .as_ref()
-        .map(|applied| applied.tree.as_str())
-        .unwrap_or(&state.base.sha);
+        .is_some_and(|applied| applied.store_rev == state.store.head_rev)
+        && Git::new(store_dir)
+            .run(&["status", "--porcelain", "-z", "--", "."])?
+            .is_empty();
+    let applied_store_tree = match &state.applied {
+        Some(_) if applied_matches_store_worktree => store_target_tree.clone(),
+        Some(applied) => {
+            let snapshot = materialize_store_revision(store_dir, &applied.store_rev)?;
+            let applied_store = Store::load(&snapshot.dir).with_context(|| {
+                format!(
+                    "loading store revision {} from {}",
+                    applied.store_rev,
+                    snapshot.dir.display()
+                )
+            })?;
+            if applied_store.metadata().base_commit != applied.base {
+                // Base-bump continue records the pre-repin store revision with its resolved new-base tree.
+                applied.tree.clone()
+            } else {
+                build_store_target_tree(git, &snapshot.dir, &applied_store, &applied.base, progress)
+                    .context("building previous target tree from applied store revision")?
+            }
+        }
+        None => state.base.sha.clone(),
+    };
     let store_delta = git
-        .diff_tree_name_status(applied_tree, &store_target_tree)?
+        .diff_tree_name_status(&applied_store_tree, &store_target_tree)?
         .into_iter()
         .filter(|entry| stores_entry(store, entry))
         .collect::<Vec<_>>();
@@ -467,8 +500,55 @@ pub(crate) fn build_apply_target_trees(
         build_tree_from_source_entries(git, &state.head_tree, &store_target_tree, &store_delta)?;
     Ok(ApplyTargetTrees {
         checkout_tree,
-        store_tree: store_target_tree,
+        store_delta,
     })
+}
+
+/// Materializes one historical store subtree without changing the store worktree.
+fn materialize_store_revision(store_dir: &Path, revision: &str) -> Result<StoreRevisionSnapshot> {
+    let store_dir = fs::canonicalize(store_dir)
+        .with_context(|| format!("resolving store path {}", store_dir.display()))?;
+    let store_git = Git::new(&store_dir);
+    let repo_root = fs::canonicalize(store_git.run_str(&["rev-parse", "--show-toplevel"])?)
+        .context("resolving store repository root")?;
+    let repo_git = Git::new(&repo_root);
+    let store_prefix = store_dir.strip_prefix(&repo_root).with_context(|| {
+        format!(
+            "store path {} is outside repository {}",
+            store_dir.display(),
+            repo_root.display()
+        )
+    })?;
+    let paths = if store_prefix.as_os_str().is_empty() {
+        repo_git.run(&["ls-tree", "-r", "-z", "--name-only", revision])?
+    } else {
+        repo_git.run(&[
+            "ls-tree",
+            "-r",
+            "-z",
+            "--name-only",
+            revision,
+            "--",
+            path_arg(store_prefix)?,
+        ])?
+    };
+    if paths.is_empty() {
+        bail!(
+            "store revision {revision} has no files under {}",
+            store_prefix.display()
+        );
+    }
+
+    let temp = tempfile::tempdir().context("creating historical store snapshot")?;
+    let indexed = repo_git.with_env("GIT_INDEX_FILE", temp.path().join("index").into_os_string());
+    indexed.run(&["read-tree", revision])?;
+    let prefix = format!("--prefix={}/", path_arg(temp.path())?.trim_end_matches('/'));
+    indexed.run_with_stdin(
+        &["checkout-index", "--force", "--stdin", "-z", &prefix],
+        &paths,
+    )?;
+    let dir = temp.path().join(store_prefix);
+    Ok(StoreRevisionSnapshot { _temp: temp, dir })
 }
 
 fn build_store_target_tree(
@@ -698,7 +778,7 @@ fn commit_message(
     message.push_str(subject);
     message.push_str("\n\n");
     match trailers {
-        CommitTrailerMode::Apply { store_rev, .. } => {
+        CommitTrailerMode::Apply { store_rev } => {
             message.push_str(&format_apply_trailers(store_rev, base, tree));
         }
         CommitTrailerMode::Annotate => {

--- a/packages/browseros/tools/bpatch/src/engine/apply.rs
+++ b/packages/browseros/tools/bpatch/src/engine/apply.rs
@@ -6,9 +6,9 @@ use anyhow::{Context, Result, anyhow, bail};
 
 use crate::engine::progress::ProgressEvent;
 use crate::engine::state::{
-    DriftFile, DriftSource, ResolvedState, StateContext, format_annotate_trailers,
-    format_apply_trailers, format_state_apply_trailers, parse_bpatch_authored_base,
-    unassigned_feature_name,
+    BpatchCommitKind, DriftFile, DriftSource, ResolvedState, StateContext,
+    format_annotate_trailers, format_apply_trailers, format_state_apply_trailers,
+    parse_bpatch_authored_base, unassigned_feature_name,
 };
 use crate::git::{GitAdapter, TreeDiffEntry};
 use crate::process::Git;
@@ -207,7 +207,10 @@ pub fn apply(
     let committed_drift_is_store_delta =
         committed_drift_covered_by_store_delta(state.drift.files(), &target.store_delta);
     let target_is_safe = state.drift.is_clean()
-        || (checkout_matches_target && !has_uncommitted_drift && committed_drift_is_store_delta);
+        || (state.drift_anchor_kind == Some(BpatchCommitKind::Apply)
+            && checkout_matches_target
+            && !has_uncommitted_drift
+            && committed_drift_is_store_delta);
     if checkout_matches_target
         && !store_revision_changed
         && (target.store_delta.is_empty() || applied_checkout_matches_head)

--- a/packages/browseros/tools/bpatch/src/engine/apply.rs
+++ b/packages/browseros/tools/bpatch/src/engine/apply.rs
@@ -7,7 +7,8 @@ use anyhow::{Context, Result, anyhow, bail};
 use crate::engine::progress::ProgressEvent;
 use crate::engine::state::{
     DriftFile, DriftSource, ResolvedState, StateContext, format_annotate_trailers,
-    format_apply_trailers, parse_bpatch_authored_base, unassigned_feature_name,
+    format_apply_trailers, format_state_apply_trailers, parse_bpatch_authored_base,
+    unassigned_feature_name,
 };
 use crate::git::{GitAdapter, TreeDiffEntry};
 use crate::process::Git;
@@ -164,6 +165,9 @@ struct StoreRevisionSnapshot {
     dir: PathBuf,
 }
 
+const STATE_COMMIT_SUBJECT: &str = "chore: advance bpatch store state";
+const STATE_COMMIT_FEATURE: &str = "(state)";
+
 /// Runs same-base convergence against the current store.
 pub fn apply(
     ctx: &StateContext,
@@ -193,12 +197,21 @@ pub fn apply(
         .iter()
         .any(|file| matches!(file.source, DriftSource::Uncommitted));
     let checkout_matches_target = state.head_tree == target.checkout_tree;
+    let store_revision_changed = state
+        .applied
+        .as_ref()
+        .is_some_and(|applied| applied.store_rev != state.store.head_rev);
     let applied_checkout_matches_head = state.applied.as_ref().is_some_and(|applied| {
         applied.store_rev == state.store.head_rev && applied.tree == state.head_tree
     });
+    let committed_drift_is_store_delta =
+        committed_drift_covered_by_store_delta(state.drift.files(), &target.store_delta);
+    let target_is_safe = state.drift.is_clean()
+        || (checkout_matches_target && !has_uncommitted_drift && committed_drift_is_store_delta);
     if checkout_matches_target
+        && !store_revision_changed
         && (target.store_delta.is_empty() || applied_checkout_matches_head)
-        && !has_uncommitted_drift
+        && target_is_safe
     {
         return Ok(ApplyOutcome::Converged(ConvergedApply {
             store_rev: state.store.head_rev,
@@ -207,7 +220,7 @@ pub fn apply(
         }));
     }
 
-    if !state.drift.is_clean() && (!checkout_matches_target || has_uncommitted_drift) {
+    if !target_is_safe {
         return Ok(ApplyOutcome::Drift(DriftApply {
             files: state.drift.files().to_vec(),
         }));
@@ -224,22 +237,33 @@ pub fn apply(
         &delta
     };
 
-    let chain = author_feature_commits(
-        AuthorCommitsInput {
-            checkout: &ctx.checkout,
-            store: &store,
-            base: &state.base.sha,
-            applied_tree: &state.head_tree,
-            target_tree: &target.checkout_tree,
-            trailers: CommitTrailerMode::Apply {
-                store_rev: &state.store.head_rev,
+    let chain = if target.store_delta.is_empty() && store_revision_changed {
+        author_state_commit(
+            &checkout,
+            &state.head_rev,
+            &state.head_tree,
+            &state.store.head_rev,
+            &state.base.sha,
+            progress,
+        )?
+    } else {
+        author_feature_commits(
+            AuthorCommitsInput {
+                checkout: &ctx.checkout,
+                store: &store,
+                base: &state.base.sha,
+                applied_tree: &state.head_tree,
+                target_tree: &target.checkout_tree,
+                trailers: CommitTrailerMode::Apply {
+                    store_rev: &state.store.head_rev,
+                },
+                subject_mode: SubjectMode::FeatureName,
+                parent_commit: &state.head_rev,
+                delta: commit_delta,
             },
-            subject_mode: SubjectMode::FeatureName,
-            parent_commit: &state.head_rev,
-            delta: commit_delta,
-        },
-        progress,
-    )?;
+            progress,
+        )?
+    };
 
     progress(ProgressEvent::Start {
         phase: "materialize",
@@ -278,6 +302,67 @@ pub fn apply(
         target_tree: target.checkout_tree,
         commits: chain.commits,
     }))
+}
+
+fn committed_drift_covered_by_store_delta(
+    drift: &[DriftFile],
+    store_delta: &[TreeDiffEntry],
+) -> bool {
+    let mut changed_paths = BTreeSet::new();
+    for entry in store_delta {
+        changed_paths.insert(entry.path.as_path());
+        if let Some(old_path) = entry.old_path.as_deref() {
+            changed_paths.insert(old_path);
+        }
+    }
+    drift
+        .iter()
+        .filter(|file| matches!(file.source, DriftSource::Committed))
+        .all(|file| changed_paths.contains(file.path.as_path()))
+}
+
+/// Authors an unchanged-tree commit when only the store revision advanced.
+fn author_state_commit(
+    git: &GitAdapter,
+    parent_commit: &str,
+    tree: &str,
+    store_rev: &str,
+    base: &str,
+    progress: &mut dyn FnMut(ProgressEvent<'_>),
+) -> Result<AuthoredCommitChain> {
+    progress(ProgressEvent::Start {
+        phase: "commit",
+        total: Some(1),
+    });
+    let mut message = String::from(STATE_COMMIT_SUBJECT);
+    message.push_str("\n\n");
+    message.push_str(&format_state_apply_trailers(store_rev, base, tree));
+    let sha = git.process().run_with_stdin(
+        &["commit-tree", tree, "-p", parent_commit],
+        message.as_bytes(),
+    )?;
+    let sha = String::from_utf8(sha)
+        .context("commit-tree output was not UTF-8")?
+        .trim()
+        .to_string();
+    let short_sha = git.short_rev(&sha)?;
+    progress(ProgressEvent::Tick {
+        phase: "commit",
+        done: 1,
+        total: Some(1),
+        item: Some(STATE_COMMIT_FEATURE),
+    });
+    progress(ProgressEvent::End { phase: "commit" });
+    Ok(AuthoredCommitChain {
+        commits: vec![AuthoredCommit {
+            feature: STATE_COMMIT_FEATURE.to_string(),
+            seq: 0,
+            sha: sha.clone(),
+            short_sha,
+            subject: STATE_COMMIT_SUBJECT.to_string(),
+        }],
+        final_sha: sha,
+    })
 }
 
 /// Authors grouped feature commits with commit-tree without moving refs.

--- a/packages/browseros/tools/bpatch/src/engine/conflict.rs
+++ b/packages/browseros/tools/bpatch/src/engine/conflict.rs
@@ -287,7 +287,6 @@ pub fn continue_session(
             target_tree: &final_tree,
             trailers: CommitTrailerMode::Apply {
                 store_rev: &session.store_rev,
-                store_tree: &final_tree,
             },
             subject_mode: SubjectMode::FeatureName,
             parent_commit: &session.parent_head,

--- a/packages/browseros/tools/bpatch/src/engine/conflict.rs
+++ b/packages/browseros/tools/bpatch/src/engine/conflict.rs
@@ -287,6 +287,7 @@ pub fn continue_session(
             target_tree: &final_tree,
             trailers: CommitTrailerMode::Apply {
                 store_rev: &session.store_rev,
+                store_tree: &final_tree,
             },
             subject_mode: SubjectMode::FeatureName,
             parent_commit: &session.parent_head,

--- a/packages/browseros/tools/bpatch/src/engine/state.rs
+++ b/packages/browseros/tools/bpatch/src/engine/state.rs
@@ -10,7 +10,7 @@ use crate::store::Store;
 pub const TRAILER_STORE_REV: &str = "Bpatch-Store-Rev";
 /// Trailer key carrying the chromium base commit used for convergence.
 pub const TRAILER_BASE: &str = "Bpatch-Base";
-/// Trailer key carrying the cached applied tree.
+/// Trailer key carrying the cached raw store target tree.
 pub const TRAILER_TREE: &str = "Bpatch-Tree";
 /// Trailer key marking commits authored by `bpatch annotate`.
 pub const TRAILER_ANNOTATED: &str = "Bpatch-Annotated";
@@ -44,7 +44,7 @@ pub struct ApplyTrailers {
     pub store_rev: String,
     /// Chromium base commit used to compute the applied tree.
     pub base: String,
-    /// Cached applied tree, when the commit still carries it.
+    /// Cached raw store target tree, when the commit still carries it.
     pub tree: Option<String>,
 }
 
@@ -113,7 +113,7 @@ pub struct AppliedState {
     pub short_store_rev: String,
     /// Base revision recorded in the trailer commit.
     pub base: String,
-    /// Applied tree resolved from the trailer cache or recovery fallback.
+    /// Raw store target tree resolved from the trailer cache or recovery fallback.
     pub tree: String,
     /// Count of apply-authored feature commits since the base.
     pub feature_commit_count: usize,

--- a/packages/browseros/tools/bpatch/src/engine/state.rs
+++ b/packages/browseros/tools/bpatch/src/engine/state.rs
@@ -14,6 +14,8 @@ pub const TRAILER_BASE: &str = "Bpatch-Base";
 pub const TRAILER_TREE: &str = "Bpatch-Tree";
 /// Trailer key marking commits authored by `bpatch annotate`.
 pub const TRAILER_ANNOTATED: &str = "Bpatch-Annotated";
+/// Trailer key marking apply commits that only advance store bookkeeping.
+pub const TRAILER_STATE_ONLY: &str = "Bpatch-State-Only";
 
 const HISTORY_LIMIT: usize = 512;
 const UNASSIGNED_FEATURE: &str = "(unassigned)";
@@ -46,6 +48,8 @@ pub struct ApplyTrailers {
     pub base: String,
     /// Cached materialized checkout tree, when the commit still carries it.
     pub tree: Option<String>,
+    /// Whether the commit advances store state without changing managed files.
+    pub state_only: bool,
 }
 
 /// Parsed bpatch annotate trailers from a commit.
@@ -229,6 +233,7 @@ pub fn resolve(ctx: &StateContext) -> Result<ResolvedState> {
     let head_tree = checkout.tree_id("HEAD")?;
     let store_head = store_repo.head_rev()?;
     let latest_apply = find_latest_apply_commit(&checkout)?;
+    let latest_feature_subject = find_latest_feature_subject(&checkout)?;
     let latest_bpatch = find_latest_bpatch_commit(&checkout)?;
     let latest_bpatch_tree = latest_bpatch
         .as_ref()
@@ -255,7 +260,7 @@ pub fn resolve(ctx: &StateContext) -> Result<ResolvedState> {
                 store_rev: entry.trailers.store_rev,
                 commit: entry.commit,
                 tree,
-                last_subject: entry.subject,
+                last_subject: latest_feature_subject.unwrap_or(entry.subject),
             })
         })
         .transpose()?;
@@ -293,11 +298,13 @@ pub fn parse_apply_trailers(trailers: &[Trailer]) -> Result<Option<ApplyTrailers
     let mut store_rev = None;
     let mut base = None;
     let mut tree = None;
+    let mut state_only = false;
     for trailer in trailers {
         match trailer.key.as_str() {
             TRAILER_STORE_REV => store_rev = Some(trailer.value.clone()),
             TRAILER_BASE => base = Some(trailer.value.clone()),
             TRAILER_TREE => tree = Some(trailer.value.clone()),
+            TRAILER_STATE_ONLY => state_only = trailer.value.eq_ignore_ascii_case("true"),
             _ => {}
         }
     }
@@ -311,6 +318,7 @@ pub fn parse_apply_trailers(trailers: &[Trailer]) -> Result<Option<ApplyTrailers
         store_rev,
         base,
         tree,
+        state_only,
     }))
 }
 
@@ -361,6 +369,14 @@ pub fn format_apply_trailers(store_rev: &str, base: &str, tree: Option<&str>) ->
     out
 }
 
+/// Formats apply trailers for a commit that only advances store bookkeeping.
+pub fn format_state_apply_trailers(store_rev: &str, base: &str, tree: &str) -> String {
+    let mut out = format_apply_trailers(store_rev, base, Some(tree));
+    out.push_str(TRAILER_STATE_ONLY);
+    out.push_str(": true\n");
+    out
+}
+
 /// Formats the trailer block for commits created by `bpatch annotate`.
 pub fn format_annotate_trailers(base: &str) -> String {
     let mut out = String::new();
@@ -405,11 +421,24 @@ fn find_latest_bpatch_commit(git: &GitAdapter) -> Result<Option<BpatchTrailerCom
     Ok(None)
 }
 
+fn find_latest_feature_subject(git: &GitAdapter) -> Result<Option<String>> {
+    for commit in git.first_parent_commits(None, Some(HISTORY_LIMIT))? {
+        if parse_apply_trailers(&git.commit_trailers(&commit)?)?
+            .is_some_and(|trailers| !trailers.state_only)
+        {
+            return Ok(Some(git.commit_subject(&commit)?));
+        }
+    }
+    Ok(None)
+}
+
 fn feature_commit_count(git: &GitAdapter, base: &str) -> Result<usize> {
     let range = format!("{base}..HEAD");
     let mut count = 0;
     for commit in git.first_parent_commits(Some(&range), None)? {
-        if parse_apply_trailers(&git.commit_trailers(&commit)?)?.is_some() {
+        if parse_apply_trailers(&git.commit_trailers(&commit)?)?
+            .is_some_and(|trailers| !trailers.state_only)
+        {
             count += 1;
         }
     }

--- a/packages/browseros/tools/bpatch/src/engine/state.rs
+++ b/packages/browseros/tools/bpatch/src/engine/state.rs
@@ -72,7 +72,7 @@ pub struct ResolvedState {
     pub store: StoreRepoState,
     /// Last apply-authored state, if this checkout has one.
     pub applied: Option<AppliedState>,
-    /// Drift from the applied tree.
+    /// Drift from the newest bpatch-authored commit tree.
     pub drift: DriftState,
 }
 
@@ -103,7 +103,7 @@ pub struct StoreRepoState {
 /// Last apply-authored state discovered in checkout history.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AppliedState {
-    /// Commit carrying the newest bpatch trailers.
+    /// Commit carrying the newest apply trailers.
     pub commit: String,
     /// Short form of the trailer commit.
     pub short_commit: String,
@@ -121,7 +121,7 @@ pub struct AppliedState {
     pub last_subject: String,
 }
 
-/// Drift state relative to the applied tree.
+/// Drift state relative to the newest bpatch-authored commit tree.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DriftState {
     /// No committed or tracked uncommitted drift was found.
@@ -164,7 +164,7 @@ pub struct DriftFile {
 /// Source class for a drift entry.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DriftSource {
-    /// HEAD contains commits after the applied tree.
+    /// HEAD contains commits after the bpatch-authored drift anchor.
     Committed,
     /// The index or worktree differs from HEAD.
     Uncommitted,
@@ -214,8 +214,10 @@ struct TrailerCommit {
     subject: String,
 }
 
-struct BaseTrailerCommit {
+struct BpatchTrailerCommit {
+    commit: String,
     base: String,
+    subject: String,
 }
 
 /// Resolves trailer state, store freshness, base display, and checkout drift.
@@ -226,16 +228,15 @@ pub fn resolve(ctx: &StateContext) -> Result<ResolvedState> {
     let head_rev = checkout.head_rev()?;
     let head_tree = checkout.tree_id("HEAD")?;
     let store_head = store_repo.head_rev()?;
-    let latest = find_latest_apply_commit(&checkout)?;
-    let latest_base = if latest.is_some() {
-        None
-    } else {
-        find_latest_base_commit(&checkout)?
-    };
-    let base_sha = latest
+    let latest_apply = find_latest_apply_commit(&checkout)?;
+    let latest_bpatch = find_latest_bpatch_commit(&checkout)?;
+    let latest_bpatch_tree = latest_bpatch
         .as_ref()
-        .map(|entry| entry.trailers.base.clone())
-        .or_else(|| latest_base.as_ref().map(|entry| entry.base.clone()))
+        .map(|entry| checkout.tree_id(&entry.commit))
+        .transpose()?;
+    let base_sha = latest_bpatch
+        .as_ref()
+        .map(|entry| entry.base.clone())
         .unwrap_or_else(|| head_rev.clone());
     let base = BaseState {
         short_sha: checkout.short_rev(&base_sha)?,
@@ -243,7 +244,7 @@ pub fn resolve(ctx: &StateContext) -> Result<ResolvedState> {
         sha: base_sha.clone(),
     };
 
-    let applied = latest
+    let applied = latest_apply
         .map(|entry| {
             let tree = applied_tree(&checkout, &ctx.store_dir, &store_head, &entry)?;
             Ok::<_, anyhow::Error>(AppliedState {
@@ -268,14 +269,12 @@ pub fn resolve(ctx: &StateContext) -> Result<ResolvedState> {
             .transpose()?,
         head_rev: store_head,
     };
-    let applied_tree = applied
+    let (drift_tree, drift_subject) = latest_bpatch
         .as_ref()
-        .map(|applied| applied.tree.as_str())
-        .unwrap_or(&base.sha);
-    let last_subject = applied
-        .as_ref()
-        .map(|applied| applied.last_subject.as_str());
-    let drift = detect_drift(&checkout, &store_model, applied_tree, last_subject)?;
+        .zip(latest_bpatch_tree.as_deref())
+        .map(|(entry, tree)| (tree, entry.subject.as_str()))
+        .unwrap_or((base.sha.as_str(), "base state"));
+    let drift = detect_drift(&checkout, &store_model, drift_tree, drift_subject)?;
 
     Ok(ResolvedState {
         checkout: ctx.checkout.clone(),
@@ -393,10 +392,14 @@ fn find_latest_apply_commit(git: &GitAdapter) -> Result<Option<TrailerCommit>> {
     Ok(None)
 }
 
-fn find_latest_base_commit(git: &GitAdapter) -> Result<Option<BaseTrailerCommit>> {
+fn find_latest_bpatch_commit(git: &GitAdapter) -> Result<Option<BpatchTrailerCommit>> {
     for commit in git.first_parent_commits(None, Some(HISTORY_LIMIT))? {
         if let Some(base) = parse_bpatch_authored_base(&git.commit_trailers(&commit)?)? {
-            return Ok(Some(BaseTrailerCommit { base }));
+            return Ok(Some(BpatchTrailerCommit {
+                subject: git.commit_subject(&commit)?,
+                commit,
+                base,
+            }));
         }
     }
     Ok(None)
@@ -427,6 +430,7 @@ fn applied_tree(
         let patches = store
             .patches()
             .values()
+            .filter(|patch| store.stores_path(&patch.path))
             .map(|patch| store_dir.join(&patch.path))
             .collect::<Vec<_>>();
         return Ok(git.build_tree_from_patches(&entry.trailers.base, &patches)?);
@@ -440,14 +444,13 @@ fn applied_tree(
 fn detect_drift(
     git: &GitAdapter,
     store: &Store,
-    applied_tree: &str,
-    last_apply_subject: Option<&str>,
+    baseline_tree: &str,
+    baseline_subject: &str,
 ) -> Result<DriftState> {
     let mut files = Vec::new();
-    let subject = last_apply_subject.unwrap_or("applied state");
-    for entry in git.diff_tree_name_status(applied_tree, "HEAD^{tree}")? {
+    for entry in git.diff_tree_name_status(baseline_tree, "HEAD^{tree}")? {
         if stores_path(store, &entry.path) {
-            files.push(committed_drift(entry, subject));
+            files.push(committed_drift(entry, baseline_subject));
         }
     }
 

--- a/packages/browseros/tools/bpatch/src/engine/state.rs
+++ b/packages/browseros/tools/bpatch/src/engine/state.rs
@@ -10,7 +10,7 @@ use crate::store::Store;
 pub const TRAILER_STORE_REV: &str = "Bpatch-Store-Rev";
 /// Trailer key carrying the chromium base commit used for convergence.
 pub const TRAILER_BASE: &str = "Bpatch-Base";
-/// Trailer key carrying the cached raw store target tree.
+/// Trailer key carrying the cached materialized checkout tree.
 pub const TRAILER_TREE: &str = "Bpatch-Tree";
 /// Trailer key marking commits authored by `bpatch annotate`.
 pub const TRAILER_ANNOTATED: &str = "Bpatch-Annotated";
@@ -42,9 +42,9 @@ impl StateContext {
 pub struct ApplyTrailers {
     /// Store repository commit applied to the checkout.
     pub store_rev: String,
-    /// Chromium base commit used to compute the applied tree.
+    /// Chromium base commit used to compute the applied checkout tree.
     pub base: String,
-    /// Cached raw store target tree, when the commit still carries it.
+    /// Cached materialized checkout tree, when the commit still carries it.
     pub tree: Option<String>,
 }
 
@@ -113,7 +113,7 @@ pub struct AppliedState {
     pub short_store_rev: String,
     /// Base revision recorded in the trailer commit.
     pub base: String,
-    /// Raw store target tree resolved from the trailer cache or recovery fallback.
+    /// Materialized checkout tree resolved from the trailer or recovery fallback.
     pub tree: String,
     /// Count of apply-authored feature commits since the base.
     pub feature_commit_count: usize,
@@ -126,7 +126,7 @@ pub struct AppliedState {
 pub enum DriftState {
     /// No committed or tracked uncommitted drift was found.
     Clean,
-    /// One or more files differ from the applied tree.
+    /// One or more files differ from the bpatch-authored drift anchor.
     Drifted {
         /// Drift entries grouped by source class.
         files: Vec<DriftFile>,
@@ -148,7 +148,7 @@ impl DriftState {
     }
 }
 
-/// One file that differs from the applied tree.
+/// One file that differs from the bpatch-authored drift anchor.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DriftFile {
     /// Repository-relative file path.

--- a/packages/browseros/tools/bpatch/src/engine/state.rs
+++ b/packages/browseros/tools/bpatch/src/engine/state.rs
@@ -59,6 +59,15 @@ pub struct AnnotateTrailers {
     pub base: String,
 }
 
+/// Trailer kind of the commit used as the committed-drift anchor.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BpatchCommitKind {
+    /// Commit authored by `bpatch apply`.
+    Apply,
+    /// Commit authored by `bpatch annotate`.
+    Annotate,
+}
+
 /// Resolved checkout state derived from history and the store repo.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ResolvedState {
@@ -76,6 +85,8 @@ pub struct ResolvedState {
     pub store: StoreRepoState,
     /// Last apply-authored state, if this checkout has one.
     pub applied: Option<AppliedState>,
+    /// Kind of the newest bpatch-authored commit, when any.
+    pub drift_anchor_kind: Option<BpatchCommitKind>,
     /// Drift from the newest bpatch-authored commit tree.
     pub drift: DriftState,
 }
@@ -222,6 +233,7 @@ struct BpatchTrailerCommit {
     commit: String,
     base: String,
     subject: String,
+    kind: BpatchCommitKind,
 }
 
 /// Resolves trailer state, store freshness, base display, and checkout drift.
@@ -289,6 +301,7 @@ pub fn resolve(ctx: &StateContext) -> Result<ResolvedState> {
         base,
         store,
         applied,
+        drift_anchor_kind: latest_bpatch.as_ref().map(|entry| entry.kind),
         drift,
     })
 }
@@ -410,13 +423,20 @@ fn find_latest_apply_commit(git: &GitAdapter) -> Result<Option<TrailerCommit>> {
 
 fn find_latest_bpatch_commit(git: &GitAdapter) -> Result<Option<BpatchTrailerCommit>> {
     for commit in git.first_parent_commits(None, Some(HISTORY_LIMIT))? {
-        if let Some(base) = parse_bpatch_authored_base(&git.commit_trailers(&commit)?)? {
-            return Ok(Some(BpatchTrailerCommit {
-                subject: git.commit_subject(&commit)?,
-                commit,
-                base,
-            }));
-        }
+        let trailers = git.commit_trailers(&commit)?;
+        let (base, kind) = if let Some(apply) = parse_apply_trailers(&trailers)? {
+            (apply.base, BpatchCommitKind::Apply)
+        } else if let Some(annotate) = parse_annotate_trailers(&trailers)? {
+            (annotate.base, BpatchCommitKind::Annotate)
+        } else {
+            continue;
+        };
+        return Ok(Some(BpatchTrailerCommit {
+            subject: git.commit_subject(&commit)?,
+            commit,
+            base,
+            kind,
+        }));
     }
     Ok(None)
 }

--- a/packages/browseros/tools/bpatch/tests/apply.rs
+++ b/packages/browseros/tools/bpatch/tests/apply.rs
@@ -15,7 +15,6 @@ use bpatch::engine::state::{
     self, StateContext, TRAILER_ANNOTATED, TRAILER_BASE, TRAILER_STORE_REV, TRAILER_TREE,
 };
 use bpatch::process::Git;
-use bpatch::store::Store;
 use fixtures::FixtureRepo;
 use serde_json::Value;
 
@@ -245,6 +244,53 @@ fn second_apply_is_idempotent_and_does_not_rewrite_index_or_worktree() -> Result
 }
 
 #[test]
+fn dirty_store_patch_applies_once_and_then_converges() -> Result<()> {
+    let scenario = applied_rev1_scenario()?;
+    scenario
+        .checkout
+        .write_file("chrome/browser/ui/llmchat/panel.cc", "dirty store panel\n")?;
+    scenario.checkout.git().run(&["add", "-A"])?;
+    let patch = scenario.checkout.git().run(&[
+        "diff",
+        "--binary",
+        "--cached",
+        &scenario.base,
+        "--",
+        "chrome/browser/ui/llmchat/panel.cc",
+    ])?;
+    scenario
+        .store
+        .write_file("chromium_patches/chrome/browser/ui/llmchat/panel.cc", patch)?;
+    scenario
+        .checkout
+        .git()
+        .run(&["reset", "--hard", &scenario.rev1_commit])?;
+
+    let first = run_apply(&scenario.store_dir, &scenario.checkout, false);
+    match first {
+        ApplyReport::Applied { files_changed, .. } => assert_eq!(files_changed, 1),
+        other => panic!("expected dirty store apply, got {other:?}"),
+    }
+    assert_eq!(
+        scenario
+            .checkout
+            .read_file("chrome/browser/ui/llmchat/panel.cc")?,
+        "dirty store panel\n"
+    );
+    let applied_head = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
+
+    assert!(matches!(
+        run_apply(&scenario.store_dir, &scenario.checkout, false),
+        ApplyReport::Converged { .. }
+    ));
+    assert_eq!(
+        scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?,
+        applied_head
+    );
+    Ok(())
+}
+
+#[test]
 fn annotate_then_apply_writes_pending_store_delta_and_converges() -> Result<()> {
     let scenario = annotated_store_delta_scenario()?;
 
@@ -290,27 +336,12 @@ fn annotate_then_apply_writes_pending_store_delta_and_converges() -> Result<()> 
     );
     let applied_head = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
     assert_ne!(applied_head, scenario.annotate_commit);
-    let store = Store::load(&scenario.store_dir)?;
-    let patches = store
-        .patches()
-        .values()
-        .filter(|patch| store.stores_path(&patch.path))
-        .map(|patch| scenario.store_dir.join(&patch.path))
-        .collect::<Vec<_>>();
-    let expected_store_tree = scenario
-        .checkout
-        .git_adapter()
-        .build_tree_from_patches(&scenario.base, &patches)?;
-    assert_ne!(
-        expected_store_tree,
-        scenario.checkout.git_adapter().tree_id("HEAD")?
-    );
     assert_apply_trailers(
         &scenario.checkout.git_adapter(),
         "HEAD",
         &scenario.store.git().run_str(&["rev-parse", "HEAD"])?,
         &scenario.base,
-        Some(expected_store_tree.as_str()),
+        Some(scenario.checkout.git_adapter().tree_id("HEAD")?.as_str()),
     )?;
 
     let second = run_apply(&scenario.store_dir, &scenario.checkout, false);
@@ -318,6 +349,99 @@ fn annotate_then_apply_writes_pending_store_delta_and_converges() -> Result<()> 
     assert_eq!(
         scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?,
         applied_head
+    );
+    scenario
+        .checkout
+        .write_file("chrome/BUILD.gn", "later store build\n")?;
+    scenario.checkout.git().run(&["add", "-A"])?;
+    let later_store_rev = commit_store_from_index(
+        &scenario.store,
+        &scenario.checkout,
+        &scenario.base,
+        &["chrome/BUILD.gn"],
+        "store later build",
+    )?;
+    scenario
+        .checkout
+        .git()
+        .run(&["reset", "--hard", &applied_head])?;
+
+    let third = run_apply(&scenario.store_dir, &scenario.checkout, false);
+    match third {
+        ApplyReport::Applied {
+            files_changed,
+            commits,
+            ..
+        } => {
+            assert_eq!(files_changed, 1);
+            assert_eq!(commits.len(), 1);
+            assert_eq!(commits[0].feature, "bootstrap");
+        }
+        other => panic!("expected later store apply, got {other:?}"),
+    }
+    assert_eq!(
+        scenario
+            .checkout
+            .read_file("chrome/browser/ui/llmchat/generated_bundle.js")?,
+        "annotated only\n"
+    );
+    assert_apply_trailers(
+        &scenario.checkout.git_adapter(),
+        "HEAD",
+        &later_store_rev,
+        &scenario.base,
+        Some(scenario.checkout.git_adapter().tree_id("HEAD")?.as_str()),
+    )?;
+    let later_head = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
+    assert!(matches!(
+        run_apply(&scenario.store_dir, &scenario.checkout, false),
+        ApplyReport::Converged { .. }
+    ));
+    assert_eq!(
+        scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?,
+        later_head
+    );
+    Ok(())
+}
+
+#[test]
+fn legacy_materialized_tree_trailer_preserves_unpatched_feature_paths() -> Result<()> {
+    let checkout = FixtureRepo::new()?;
+    let base = write_base_checkout(&checkout)?;
+    let store = FixtureRepo::new()?;
+    let store_dir = seed_store(&store, &base)?;
+
+    checkout.write_file("chrome/browser/ui/llmchat/panel.cc", "applied panel\n")?;
+    checkout.write_file(
+        "chrome/browser/ui/llmchat/generated_bundle.js",
+        "preserved generated content\n",
+    )?;
+    checkout.git().run(&["add", "-A"])?;
+    let materialized_tree = checkout.git().run_str(&["write-tree"])?;
+    let store_rev = commit_store_from_index(
+        &store,
+        &checkout,
+        &base,
+        &["chrome/browser/ui/llmchat/panel.cc"],
+        "store applied",
+    )?;
+    checkout.commit_with_trailers(
+        "feat: llmchat",
+        &[
+            (TRAILER_STORE_REV, store_rev.as_str()),
+            (TRAILER_BASE, base.as_str()),
+            (TRAILER_TREE, materialized_tree.as_str()),
+        ],
+    )?;
+    let head_before = checkout.git().run_str(&["rev-parse", "HEAD"])?;
+
+    let report = run_apply(&store_dir, &checkout, false);
+
+    assert!(matches!(report, ApplyReport::Converged { .. }));
+    assert_eq!(checkout.git().run_str(&["rev-parse", "HEAD"])?, head_before);
+    assert_eq!(
+        checkout.read_file("chrome/browser/ui/llmchat/generated_bundle.js")?,
+        "preserved generated content\n"
     );
     Ok(())
 }
@@ -678,7 +802,7 @@ fn pull_fast_forwards_store_before_applying_and_json_uses_sim_fields() -> Result
 }
 
 #[test]
-fn hand_committed_target_tree_reports_converged_before_drift() -> Result<()> {
+fn hand_committed_target_tree_records_advanced_store_state() -> Result<()> {
     let scenario = applied_rev1_scenario()?;
     write_checkout_rev2(&scenario.checkout, false)?;
     let rev2_store = commit_store_from_index(
@@ -697,10 +821,12 @@ fn hand_committed_target_tree_reports_converged_before_drift() -> Result<()> {
     let report = run_apply(&scenario.store_dir, &scenario.checkout, false);
 
     match report {
-        ApplyReport::Converged {
+        ApplyReport::Applied {
             store_rev,
             files_changed,
+            commits,
             exit,
+            ..
         } => {
             assert_eq!(
                 store_rev,
@@ -710,13 +836,28 @@ fn hand_committed_target_tree_reports_converged_before_drift() -> Result<()> {
                     .run_str(&["rev-parse", "--short", &rev2_store])?
             );
             assert_eq!(files_changed, 0);
+            assert_eq!(commits.len(), 1);
+            assert_eq!(commits[0].feature, "llmchat");
             assert_eq!(exit, 0);
         }
-        other => panic!("expected converged report, got {other:?}"),
+        other => panic!("expected applied bookkeeping report, got {other:?}"),
     }
+    let applied_head = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
+    assert_ne!(applied_head, head_before);
+    assert_apply_trailers(
+        &scenario.checkout.git_adapter(),
+        "HEAD",
+        &rev2_store,
+        &scenario.base,
+        Some(scenario.checkout.git_adapter().tree_id("HEAD")?.as_str()),
+    )?;
+    assert!(matches!(
+        run_apply(&scenario.store_dir, &scenario.checkout, false),
+        ApplyReport::Converged { .. }
+    ));
     assert_eq!(
         scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?,
-        head_before
+        applied_head
     );
     Ok(())
 }

--- a/packages/browseros/tools/bpatch/tests/apply.rs
+++ b/packages/browseros/tools/bpatch/tests/apply.rs
@@ -12,7 +12,8 @@ use bpatch::engine::apply::ApplyOptions;
 use bpatch::engine::lock::CheckoutLock;
 use bpatch::engine::progress;
 use bpatch::engine::state::{
-    self, StateContext, TRAILER_ANNOTATED, TRAILER_BASE, TRAILER_STORE_REV, TRAILER_TREE,
+    self, StateContext, TRAILER_ANNOTATED, TRAILER_BASE, TRAILER_STATE_ONLY, TRAILER_STORE_REV,
+    TRAILER_TREE,
 };
 use bpatch::process::Git;
 use fixtures::FixtureRepo;
@@ -862,6 +863,105 @@ fn hand_committed_target_tree_records_advanced_store_state() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn hand_committed_target_with_unrelated_managed_drift_refuses_apply() -> Result<()> {
+    let scenario = applied_rev1_scenario()?;
+    write_checkout_rev2(&scenario.checkout, false)?;
+    commit_store_from_index(
+        &scenario.store,
+        &scenario.checkout,
+        &scenario.base,
+        &[
+            "chrome/browser/ui/llmchat/panel.cc",
+            "chrome/browser/ui/llmchat/resize_util.cc",
+        ],
+        "store rev2",
+    )?;
+    scenario
+        .checkout
+        .write_file("chrome/BUILD.gn", "unrelated committed drift\n")?;
+    scenario.checkout.commit("hand applied target plus drift")?;
+    let head_before = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
+
+    let report = run_apply(&scenario.store_dir, &scenario.checkout, false);
+
+    match report {
+        ApplyReport::Drift { files, exit } => {
+            assert_eq!(exit, 3);
+            assert!(
+                files
+                    .iter()
+                    .any(|file| file.path == Path::new("chrome/BUILD.gn"))
+            );
+        }
+        other => panic!("expected unrelated drift refusal, got {other:?}"),
+    }
+    assert_eq!(
+        scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?,
+        head_before
+    );
+    Ok(())
+}
+
+#[test]
+fn store_revision_without_managed_delta_records_state_once() -> Result<()> {
+    let scenario = applied_rev1_scenario()?;
+    let feature_head = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
+    scenario
+        .store
+        .write_file("docs/store-note.txt", "metadata-only store change\n")?;
+    let store_rev = scenario.store.commit("store metadata only")?;
+
+    let report = run_apply(&scenario.store_dir, &scenario.checkout, false);
+
+    match report {
+        ApplyReport::Applied {
+            files_changed,
+            commits,
+            exit,
+            ..
+        } => {
+            assert_eq!(files_changed, 0);
+            assert_eq!(commits.len(), 1);
+            assert_eq!(commits[0].feature, "(state)");
+            assert_eq!(commits[0].seq, 0);
+            assert_eq!(exit, 0);
+        }
+        other => panic!("expected state-only apply, got {other:?}"),
+    }
+    let state_head = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
+    assert_ne!(state_head, feature_head);
+    let git = scenario.checkout.git_adapter();
+    let trailers = state::parse_apply_trailers(&git.commit_trailers("HEAD")?)?
+        .expect("state-only apply trailers");
+    assert_eq!(trailers.store_rev, store_rev);
+    assert!(trailers.state_only);
+    assert!(
+        git.commit_trailers("HEAD")?
+            .iter()
+            .any(|trailer| trailer.key == TRAILER_STATE_ONLY && trailer.value == "true")
+    );
+
+    let resolved = state::resolve(&StateContext::new(
+        scenario.checkout.path(),
+        &scenario.store_dir,
+    ))?;
+    let applied = resolved.applied.expect("applied state");
+    assert_eq!(resolved.store.revs_ahead, Some(0));
+    assert_eq!(applied.feature_commit_count, 1);
+    assert_eq!(applied.last_subject, "feat: llmchat");
+
+    assert!(matches!(
+        run_apply(&scenario.store_dir, &scenario.checkout, false),
+        ApplyReport::Converged { .. }
+    ));
+    assert_eq!(
+        scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?,
+        state_head
+    );
+    Ok(())
+}
+
 fn run_apply(store_dir: &Path, checkout: &FixtureRepo, pull: bool) -> ApplyReport {
     let mut progress = progress::noop();
     cli_apply::run(
@@ -1035,6 +1135,7 @@ fn assert_apply_trailers(
     assert_eq!(trailers.store_rev, store_rev);
     assert_eq!(trailers.base, base);
     assert_eq!(trailers.tree.as_deref(), tree);
+    assert!(!trailers.state_only);
     Ok(())
 }
 

--- a/packages/browseros/tools/bpatch/tests/apply.rs
+++ b/packages/browseros/tools/bpatch/tests/apply.rs
@@ -480,6 +480,34 @@ fn hand_commit_after_annotate_still_refuses_apply() -> Result<()> {
 }
 
 #[test]
+fn hand_committed_exact_store_delta_after_annotate_still_refuses_apply() -> Result<()> {
+    let scenario = annotated_store_delta_scenario()?;
+    write_checkout_rev2(&scenario.checkout, false)?;
+    scenario.checkout.commit("hand applied exact store delta")?;
+    let head_before = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
+
+    let report = run_apply(&scenario.store_dir, &scenario.checkout, false);
+
+    match report {
+        ApplyReport::Drift { files, exit } => {
+            assert_eq!(exit, 3);
+            assert_eq!(files.len(), 2);
+            assert!(
+                files
+                    .iter()
+                    .all(|file| file.annotation == "modified since feat: llmchat from bos_build")
+            );
+        }
+        other => panic!("expected exact store delta drift refusal, got {other:?}"),
+    }
+    assert_eq!(
+        scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?,
+        head_before
+    );
+    Ok(())
+}
+
+#[test]
 fn uncommitted_managed_edit_after_annotate_still_refuses_apply() -> Result<()> {
     let scenario = annotated_store_delta_scenario()?;
     scenario

--- a/packages/browseros/tools/bpatch/tests/apply.rs
+++ b/packages/browseros/tools/bpatch/tests/apply.rs
@@ -15,6 +15,7 @@ use bpatch::engine::state::{
     self, StateContext, TRAILER_ANNOTATED, TRAILER_BASE, TRAILER_STORE_REV, TRAILER_TREE,
 };
 use bpatch::process::Git;
+use bpatch::store::Store;
 use fixtures::FixtureRepo;
 use serde_json::Value;
 
@@ -278,17 +279,38 @@ fn annotate_then_apply_writes_pending_store_delta_and_converges() -> Result<()> 
     assert_eq!(
         scenario
             .checkout
+            .read_file("chrome/browser/ui/llmchat/generated_bundle.js")?,
+        "annotated only\n"
+    );
+    assert_eq!(
+        scenario
+            .checkout
             .read_file("chrome/browser/ui/llmchat/resize_util.cc")?,
         "resize\n"
     );
     let applied_head = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
     assert_ne!(applied_head, scenario.annotate_commit);
+    let store = Store::load(&scenario.store_dir)?;
+    let patches = store
+        .patches()
+        .values()
+        .filter(|patch| store.stores_path(&patch.path))
+        .map(|patch| scenario.store_dir.join(&patch.path))
+        .collect::<Vec<_>>();
+    let expected_store_tree = scenario
+        .checkout
+        .git_adapter()
+        .build_tree_from_patches(&scenario.base, &patches)?;
+    assert_ne!(
+        expected_store_tree,
+        scenario.checkout.git_adapter().tree_id("HEAD")?
+    );
     assert_apply_trailers(
         &scenario.checkout.git_adapter(),
         "HEAD",
         &scenario.store.git().run_str(&["rev-parse", "HEAD"])?,
         &scenario.base,
-        Some(scenario.checkout.git_adapter().tree_id("HEAD")?.as_str()),
+        Some(expected_store_tree.as_str()),
     )?;
 
     let second = run_apply(&scenario.store_dir, &scenario.checkout, false);
@@ -753,6 +775,10 @@ fn annotated_store_delta_scenario() -> Result<AnnotateScenario> {
 
     checkout.write_file("chrome/browser/ui/llmchat/panel.cc", "annotated panel\n")?;
     checkout.write_file("chrome/browser/ui/llmchat/panel.h", "annotated header\n")?;
+    checkout.write_file(
+        "chrome/browser/ui/llmchat/generated_bundle.js",
+        "annotated only\n",
+    )?;
     checkout.git().run(&["add", "-A"])?;
     commit_store_from_index(
         &store,

--- a/packages/browseros/tools/bpatch/tests/apply.rs
+++ b/packages/browseros/tools/bpatch/tests/apply.rs
@@ -11,7 +11,9 @@ use bpatch::cli::apply::{self as cli_apply, ApplyReport};
 use bpatch::engine::apply::ApplyOptions;
 use bpatch::engine::lock::CheckoutLock;
 use bpatch::engine::progress;
-use bpatch::engine::state::{self, StateContext, TRAILER_BASE, TRAILER_STORE_REV, TRAILER_TREE};
+use bpatch::engine::state::{
+    self, StateContext, TRAILER_ANNOTATED, TRAILER_BASE, TRAILER_STORE_REV, TRAILER_TREE,
+};
 use bpatch::process::Git;
 use fixtures::FixtureRepo;
 use serde_json::Value;
@@ -22,6 +24,14 @@ struct ApplyScenario {
     store_dir: PathBuf,
     base: String,
     rev1_commit: String,
+}
+
+struct AnnotateScenario {
+    checkout: FixtureRepo,
+    store: FixtureRepo,
+    store_dir: PathBuf,
+    base: String,
+    annotate_commit: String,
 }
 
 #[test]
@@ -229,6 +239,126 @@ fn second_apply_is_idempotent_and_does_not_rewrite_index_or_worktree() -> Result
     assert_eq!(
         fs::read(scenario.checkout.path().join(".git/index"))?,
         index
+    );
+    Ok(())
+}
+
+#[test]
+fn annotate_then_apply_writes_pending_store_delta_and_converges() -> Result<()> {
+    let scenario = annotated_store_delta_scenario()?;
+
+    let first = run_apply(&scenario.store_dir, &scenario.checkout, false);
+
+    match first {
+        ApplyReport::Applied {
+            previous_store_rev,
+            files_changed,
+            commits,
+            ..
+        } => {
+            assert!(previous_store_rev.is_none());
+            assert_eq!(files_changed, 2);
+            assert_eq!(commits.len(), 1);
+            assert_eq!(commits[0].feature, "llmchat");
+        }
+        other => panic!("expected applied report, got {other:?}"),
+    }
+    assert_eq!(
+        scenario
+            .checkout
+            .read_file("chrome/browser/ui/llmchat/panel.cc")?,
+        "current panel\n"
+    );
+    assert_eq!(
+        scenario
+            .checkout
+            .read_file("chrome/browser/ui/llmchat/panel.h")?,
+        "annotated header\n"
+    );
+    assert_eq!(
+        scenario
+            .checkout
+            .read_file("chrome/browser/ui/llmchat/resize_util.cc")?,
+        "resize\n"
+    );
+    let applied_head = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
+    assert_ne!(applied_head, scenario.annotate_commit);
+    assert_apply_trailers(
+        &scenario.checkout.git_adapter(),
+        "HEAD",
+        &scenario.store.git().run_str(&["rev-parse", "HEAD"])?,
+        &scenario.base,
+        Some(scenario.checkout.git_adapter().tree_id("HEAD")?.as_str()),
+    )?;
+
+    let second = run_apply(&scenario.store_dir, &scenario.checkout, false);
+    assert!(matches!(second, ApplyReport::Converged { .. }));
+    assert_eq!(
+        scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?,
+        applied_head
+    );
+    Ok(())
+}
+
+#[test]
+fn hand_commit_after_annotate_still_refuses_apply() -> Result<()> {
+    let scenario = annotated_store_delta_scenario()?;
+    scenario
+        .checkout
+        .write_file("chrome/browser/ui/llmchat/panel.cc", "manual commit\n")?;
+    scenario.checkout.commit("manual edit")?;
+    let head_before = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
+
+    let report = run_apply(&scenario.store_dir, &scenario.checkout, false);
+
+    match &report {
+        ApplyReport::Drift { files, exit } => {
+            assert_eq!(*exit, 3);
+            assert_eq!(files.len(), 1);
+            assert_eq!(
+                files[0].annotation,
+                "modified since feat: llmchat from bos_build"
+            );
+        }
+        other => panic!("expected drift report, got {other:?}"),
+    }
+    let human = cli_apply::render_human(&report);
+    assert!(!human.contains("differs from applied state"));
+    assert!(human.contains("modified since feat: llmchat from bos_build"));
+    assert_eq!(
+        scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?,
+        head_before
+    );
+    Ok(())
+}
+
+#[test]
+fn uncommitted_managed_edit_after_annotate_still_refuses_apply() -> Result<()> {
+    let scenario = annotated_store_delta_scenario()?;
+    scenario
+        .checkout
+        .write_file("chrome/browser/ui/llmchat/panel.cc", "uncommitted edit\n")?;
+    let head_before = scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?;
+
+    let report = run_apply(&scenario.store_dir, &scenario.checkout, false);
+
+    match report {
+        ApplyReport::Drift { files, exit } => {
+            assert_eq!(exit, 3);
+            assert_eq!(files.len(), 1);
+            assert_eq!(files[0].annotation, "modified, uncommitted");
+        }
+        other => panic!("expected drift report, got {other:?}"),
+    }
+    assert_eq!(
+        scenario.checkout.git().run_str(&["rev-parse", "HEAD"])?,
+        head_before
+    );
+    assert_eq!(
+        scenario
+            .checkout
+            .read_file("chrome/browser/ui/llmchat/panel.cc")?,
+        "uncommitted edit\n"
     );
     Ok(())
 }
@@ -612,6 +742,52 @@ fn applied_rev1_scenario() -> Result<ApplyScenario> {
         store_dir,
         base,
         rev1_commit,
+    })
+}
+
+fn annotated_store_delta_scenario() -> Result<AnnotateScenario> {
+    let checkout = FixtureRepo::new()?;
+    let base = write_base_checkout(&checkout)?;
+    let store = FixtureRepo::new()?;
+    let store_dir = seed_store(&store, &base)?;
+
+    checkout.write_file("chrome/browser/ui/llmchat/panel.cc", "annotated panel\n")?;
+    checkout.write_file("chrome/browser/ui/llmchat/panel.h", "annotated header\n")?;
+    checkout.git().run(&["add", "-A"])?;
+    commit_store_from_index(
+        &store,
+        &checkout,
+        &base,
+        &[
+            "chrome/browser/ui/llmchat/panel.cc",
+            "chrome/browser/ui/llmchat/panel.h",
+        ],
+        "store annotated state",
+    )?;
+    let annotate_commit = checkout.commit_with_trailers(
+        "feat: llmchat from bos_build",
+        &[(TRAILER_BASE, base.as_str()), (TRAILER_ANNOTATED, "true")],
+    )?;
+
+    write_checkout_rev2(&checkout, false)?;
+    commit_store_from_index(
+        &store,
+        &checkout,
+        &base,
+        &[
+            "chrome/browser/ui/llmchat/panel.cc",
+            "chrome/browser/ui/llmchat/resize_util.cc",
+        ],
+        "store current",
+    )?;
+    checkout.git().run(&["reset", "--hard", &annotate_commit])?;
+
+    Ok(AnnotateScenario {
+        checkout,
+        store,
+        store_dir,
+        base,
+        annotate_commit,
     })
 }
 

--- a/packages/browseros/tools/bpatch/tests/simulations.rs
+++ b/packages/browseros/tools/bpatch/tests/simulations.rs
@@ -362,7 +362,7 @@ fn sim4_drift_refusal_prints_annotations_and_remedies() -> Result<()> {
     assert_eq!(out.code, 3);
     assert!(
         out.stdout
-            .contains("drift: working tree differs from applied state in 2 files:")
+            .contains("drift: working tree differs from its bpatch baseline in 2 files:")
     );
     assert!(out.stdout.contains("chrome/browser/ui/llmchat/panel.cc"));
     assert!(out.stdout.contains("(modified since feat: llmchat)"));

--- a/packages/browseros/tools/bpatch/tests/simulations.rs
+++ b/packages/browseros/tools/bpatch/tests/simulations.rs
@@ -486,7 +486,12 @@ fn sim5_agent_base_bump_conflict_continue_repin_round_trips_store() -> Result<()
         Some(&scenario.store_dir),
         strs(&["apply", "--json"]),
     )?;
-    assert_eq!(parse_json(&converged.stdout)?["result"], "converged");
+    assert_eq!(
+        parse_json(&converged.stdout)?["result"],
+        "converged",
+        "{}",
+        converged.stdout
+    );
     Ok(())
 }
 

--- a/packages/browseros/tools/bpatch/tests/status.rs
+++ b/packages/browseros/tools/bpatch/tests/status.rs
@@ -326,6 +326,52 @@ fn diff_groups_by_feature_and_reports_rebuild_scope() -> Result<()> {
 }
 
 #[test]
+fn diff_after_annotate_reports_only_head_to_apply_target() -> Result<()> {
+    let checkout = FixtureRepo::new()?;
+    let base = write_base_checkout(&checkout)?;
+    let store = FixtureRepo::new()?;
+    let store_dir = seed_store(&store, &base)?;
+
+    checkout.write_file("chrome/browser/ui/llmchat/panel.cc", "annotated panel\n")?;
+    checkout.write_file("chrome/browser/ui/llmchat/features.gni", "annotated gni\n")?;
+    checkout.git().run(&["add", "-A"])?;
+    commit_store_from_index(
+        &store,
+        &checkout,
+        &base,
+        &[
+            "chrome/browser/ui/llmchat/panel.cc",
+            "chrome/browser/ui/llmchat/features.gni",
+        ],
+        "store annotated state",
+    )?;
+    let annotate_commit = checkout.commit_with_trailers(
+        "feat: llmchat from bos_build",
+        &[(TRAILER_BASE, base.as_str()), (TRAILER_ANNOTATED, "true")],
+    )?;
+
+    checkout.write_file("chrome/browser/ui/llmchat/panel.cc", "store current\n")?;
+    checkout.git().run(&["add", "-A"])?;
+    commit_store_from_index(
+        &store,
+        &checkout,
+        &base,
+        &["chrome/browser/ui/llmchat/panel.cc"],
+        "store current",
+    )?;
+    checkout.git().run(&["reset", "--hard", &annotate_commit])?;
+
+    let report = diff::run(&StateContext::new(checkout.path(), &store_dir))?;
+    assert_eq!(report.files_changed, 1);
+    assert_eq!(report.groups.len(), 1);
+    assert_eq!(
+        report.groups[0].files[0].path,
+        PathBuf::from("chrome/browser/ui/llmchat/panel.cc")
+    );
+    Ok(())
+}
+
+#[test]
 fn amending_latest_feature_commit_to_drop_trailers_does_not_wedge_state() -> Result<()> {
     let scenario = applied_scenario(true)?;
     scenario

--- a/packages/browseros/tools/bpatch/tests/status.rs
+++ b/packages/browseros/tools/bpatch/tests/status.rs
@@ -6,7 +6,9 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use bpatch::cli::{diff, status};
 use bpatch::engine::conflict::{self, ConflictFile, ConflictSession};
-use bpatch::engine::state::{self, StateContext, TRAILER_BASE, TRAILER_STORE_REV, TRAILER_TREE};
+use bpatch::engine::state::{
+    self, StateContext, TRAILER_ANNOTATED, TRAILER_BASE, TRAILER_STORE_REV, TRAILER_TREE,
+};
 use fixtures::FixtureRepo;
 use serde_json::Value;
 
@@ -115,6 +117,132 @@ fn drift_reports_clean_committed_and_uncommitted_paths() -> Result<()> {
     assert!(human.contains("(modified since feat: llmchat)"));
     assert!(human.contains("chrome/BUILD.gn"));
     assert!(human.contains("(modified, uncommitted)"));
+    Ok(())
+}
+
+#[test]
+fn annotate_commit_is_clean_and_anchors_later_committed_drift() -> Result<()> {
+    let checkout = FixtureRepo::new()?;
+    let base = write_base_checkout(&checkout)?;
+    let store = FixtureRepo::new()?;
+    let store_dir = seed_store(&store, &base)?;
+    store.commit("seed store")?;
+
+    checkout.write_file("chrome/browser/ui/llmchat/panel.cc", "annotated\n")?;
+    checkout.commit_with_trailers(
+        "feat: llmchat from bos_build",
+        &[(TRAILER_BASE, base.as_str()), (TRAILER_ANNOTATED, "true")],
+    )?;
+
+    let ctx = StateContext::new(checkout.path(), &store_dir);
+    let annotated = status::run(&ctx)?;
+    assert!(annotated.applied_store_rev.is_none());
+    assert!(annotated.drift.is_empty());
+
+    checkout.write_file("chrome/browser/ui/llmchat/panel.cc", "manual commit\n")?;
+    checkout.commit("manual edit")?;
+
+    let drifted = status::run(&ctx)?;
+    assert_eq!(drifted.drift.len(), 1);
+    assert_eq!(
+        drifted.drift[0].annotation,
+        "modified since feat: llmchat from bos_build"
+    );
+    Ok(())
+}
+
+#[test]
+fn annotate_after_apply_replaces_only_the_drift_anchor() -> Result<()> {
+    let scenario = applied_scenario(true)?;
+    scenario.checkout.write_file(
+        "chrome/browser/ui/llmchat/panel.cc",
+        "annotated after apply\n",
+    )?;
+    scenario.checkout.commit_with_trailers(
+        "feat: llmchat from newer bos_build",
+        &[
+            (TRAILER_BASE, scenario.base.as_str()),
+            (TRAILER_ANNOTATED, "true"),
+        ],
+    )?;
+
+    let resolved = state::resolve(&StateContext::new(
+        scenario.checkout.path(),
+        &scenario.store_dir,
+    ))?;
+    let applied = resolved.applied.expect("older applied state");
+    assert_eq!(applied.store_rev, scenario.store_rev);
+    assert_eq!(applied.commit, scenario.apply_commit);
+    assert!(resolved.drift.is_clean());
+    Ok(())
+}
+
+#[test]
+fn missing_tree_recompute_ignores_store_false_patches() -> Result<()> {
+    let checkout = FixtureRepo::new()?;
+    checkout.write_file(
+        "chrome/VERSION",
+        "MAJOR=148\nMINOR=0\nBUILD=7204\nPATCH=1\n",
+    )?;
+    checkout.write_file("chrome/browser/ui/llmchat/panel.cc", "base\n")?;
+    checkout.write_file(
+        "chrome/browser/browseros/server/resources/bundle.js",
+        "base resource\n",
+    )?;
+    let base = checkout.commit("Chromium 148.0.7204.1")?;
+    let store = FixtureRepo::new()?;
+    let store_dir = seed_store(&store, &base)?;
+    store.write_file(
+        "chromium_patches/.features.yaml",
+        r#"version: "1.0"
+features:
+  llmchat:
+    description: "feat: llmchat"
+    files:
+      - chrome/browser/ui/llmchat/
+  build-resources:
+    description: "resource: bos_build outputs"
+    store: false
+    files:
+      - chrome/browser/browseros/server/resources/
+"#,
+    )?;
+
+    checkout.write_file("chrome/browser/ui/llmchat/panel.cc", "applied\n")?;
+    checkout.write_file(
+        "chrome/browser/browseros/server/resources/bundle.js",
+        "store-only resource\n",
+    )?;
+    checkout.git().run(&["add", "-A"])?;
+    let store_rev = commit_store_from_index(
+        &store,
+        &checkout,
+        &base,
+        &[
+            "chrome/browser/ui/llmchat/panel.cc",
+            "chrome/browser/browseros/server/resources/bundle.js",
+        ],
+        "store with ignored resource patch",
+    )?;
+    checkout.git().run(&[
+        "checkout",
+        &base,
+        "--",
+        "chrome/browser/browseros/server/resources/bundle.js",
+    ])?;
+    checkout.git().run(&["add", "-A"])?;
+    let expected_tree = checkout.git().run_str(&["write-tree"])?;
+    checkout.commit_with_trailers(
+        "feat: llmchat",
+        &[
+            (TRAILER_STORE_REV, store_rev.as_str()),
+            (TRAILER_BASE, base.as_str()),
+        ],
+    )?;
+
+    let resolved = state::resolve(&StateContext::new(checkout.path(), &store_dir))?;
+    assert_eq!(resolved.applied.expect("applied state").tree, expected_tree);
+    assert!(resolved.drift.is_clean());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- anchor committed drift at the newest bpatch-authored apply or annotate commit while keeping applied-store bookkeeping apply-only
- make `bpatch diff` share the exact HEAD-overlay target used by apply, including `store: false` filtering
- preserve legacy `Bpatch-Tree` semantics and harden zero-file, metadata-only, and real-drift convergence paths

## Design
State resolution tracks separate apply and drift anchors. Apply reconstructs the prior raw store target from the recorded store revision, overlays only the real store delta onto HEAD, and records explicit state-only transitions when only store metadata advances. Exact-target bookkeeping is restricted to apply-authored anchors, so hand commits after annotate remain drift.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --locked` (81 tests)
- [x] `make install`
- [x] ch4 smoke: annotate-authored history is clean; the original six-file store delta applied; immediate repeat converged
- [x] ch4 final read-only check: clean with no drift; newer store revision left unapplied