### PR TITLE
fix: package BrowserClaw payloads and executable identity

### DIFF
--- a/packages/browseros/bos_build/steps/patches/product_payload_manifest_test.py
+++ b/packages/browseros/bos_build/steps/patches/product_payload_manifest_test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tests for product payload manifest patches."""
+
+import re
+import unittest
+
+from ...lib.paths import get_package_root
+
+
+PATCHES = get_package_root() / "chromium_patches"
+
+
+def _patched_source(relative_path: str) -> str:
+    """Reconstruct the changed source regions from a unified diff."""
+    source_lines: list[str] = []
+    in_hunk = False
+
+    for line in (PATCHES / relative_path).read_text().splitlines():
+        if line.startswith("@@"):
+            in_hunk = True
+            continue
+        if not in_hunk:
+            continue
+        if line.startswith("diff --git "):
+            in_hunk = False
+            continue
+        if line.startswith(("+", " ")):
+            source_lines.append(line[1:])
+
+    return "\n".join(source_lines)
+
+
+def _source_literals(source: str) -> set[str]:
+    return set(re.findall(r'"([^"\n]+\.(?:crx|json))"', source))
+
+
+def _conditional_sources(source: str, condition: str) -> set[str]:
+    match = re.search(
+        rf"if \({re.escape(condition)}\) \{{\n(?P<body>.*?)\n\}}",
+        source,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"missing GN condition: {condition}")
+    return _source_literals(match.group("body"))
+
+
+class ProductPayloadManifestPatchTest(unittest.TestCase):
+    def test_windows_manifest_carries_both_server_layouts(self) -> None:
+        manifest = _patched_source("chrome/installer/mini_installer/chrome.release")
+        browseros_block = "\n".join(
+            (
+                "BrowserOSServer\\default\\resources\\*.*: %(VersionDir)s\\BrowserOSServer\\default\\resources\\",
+                "BrowserOSServer\\default\\resources\\bin\\*.*: %(VersionDir)s\\BrowserOSServer\\default\\resources\\bin\\",
+                "BrowserOSServer\\default\\resources\\bin\\third_party\\*.*: %(VersionDir)s\\BrowserOSServer\\default\\resources\\bin\\third_party\\",
+                "BrowserOSServer\\default\\resources\\db\\migrations\\*.*: %(VersionDir)s\\BrowserOSServer\\default\\resources\\db\\migrations\\",
+                "BrowserOSServer\\default\\resources\\db\\migrations\\meta\\*.*: %(VersionDir)s\\BrowserOSServer\\default\\resources\\db\\migrations\\meta\\",
+            )
+        )
+        browserclaw_block = "\n".join(
+            (
+                "BrowserClawServer\\default\\resources\\*.*: %(VersionDir)s\\BrowserClawServer\\default\\resources\\",
+                "BrowserClawServer\\default\\resources\\bin\\*.*: %(VersionDir)s\\BrowserClawServer\\default\\resources\\bin\\",
+                "BrowserClawServer\\default\\resources\\db\\migrations\\*.*: %(VersionDir)s\\BrowserClawServer\\default\\resources\\db\\migrations\\",
+                "BrowserClawServer\\default\\resources\\db\\migrations\\meta\\*.*: %(VersionDir)s\\BrowserClawServer\\default\\resources\\db\\migrations\\meta\\",
+            )
+        )
+
+        self.assertIn(browseros_block, manifest)
+        self.assertIn(browserclaw_block, manifest)
+        self.assertNotIn(
+            "BrowserClawServer\\default\\resources\\bin\\third_party", manifest
+        )
+
+    def test_windows_manifest_carries_bundled_extensions(self) -> None:
+        manifest = _patched_source("chrome/installer/mini_installer/chrome.release")
+
+        self.assertIn(
+            "browseros_extensions\\*.*: %(VersionDir)s\\browseros_extensions\\",
+            manifest.splitlines(),
+        )
+
+    def test_gn_sources_follow_product_matrix(self) -> None:
+        build = _patched_source("chrome/browser/browseros/bundled_extensions/BUILD.gn")
+        assignment = re.search(
+            r"_bundled_extensions_sources = \[(?P<body>.*?)\n\]",
+            build,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(assignment)
+        assert assignment is not None
+
+        manifest = "bundled_extensions.json"
+        agent = "bflpfmnmnokmjhmgnolecpppdbdophmk.crx"
+        bug_reporter = "adlpneommgkgeanpaekgoaolcpncohkf.crx"
+        browserclaw = "pjimfkbpehlcllblajnpfamdfjhhlgkc.crx"
+        base_sources = _source_literals(assignment.group("body"))
+        browseros_sources = _conditional_sources(
+            build,
+            "browseros_allow_runtime_product_override || browseros_product_browseros",
+        )
+        browserclaw_sources = _conditional_sources(
+            build,
+            "browseros_allow_runtime_product_override || browseros_product_browserclaw",
+        )
+
+        self.assertIn('import("//chrome/browser/browseros/buildflags.gni")', build)
+        self.assertEqual(base_sources, {manifest, bug_reporter})
+        self.assertEqual(browseros_sources, {agent})
+        self.assertEqual(browserclaw_sources, {browserclaw})
+        self.assertEqual(
+            base_sources | browseros_sources,
+            {manifest, agent, bug_reporter},
+        )
+        self.assertEqual(
+            base_sources | browserclaw_sources,
+            {manifest, browserclaw, bug_reporter},
+        )
+        self.assertEqual(
+            base_sources | browseros_sources | browserclaw_sources,
+            {manifest, agent, browserclaw, bug_reporter},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/bundled_extensions/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/bundled_extensions/BUILD.gn
@@ -1,12 +1,14 @@
 diff --git a/chrome/browser/browseros/bundled_extensions/BUILD.gn b/chrome/browser/browseros/bundled_extensions/BUILD.gn
 new file mode 100644
-index 0000000000000..3793b4baa5efe
+index 0000000000000000000000000000000000000000..dcc0720c667865f28b40801cd250c5aadcfe60d1
 --- /dev/null
 +++ b/chrome/browser/browseros/bundled_extensions/BUILD.gn
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,42 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
++
++import("//chrome/browser/browseros/buildflags.gni")
 +
 +# Bundled BrowserOS extensions for immediate installation on first run.
 +# These CRX files are installed locally before fetching remote updates.
@@ -19,10 +21,18 @@ index 0000000000000..3793b4baa5efe
 +
 +_bundled_extensions_sources = [
 +  "bundled_extensions.json",
-+  "bflpfmnmnokmjhmgnolecpppdbdophmk.crx",  # Agent
 +  "adlpneommgkgeanpaekgoaolcpncohkf.crx",  # Bug Reporter
-+  "pjimfkbpehlcllblajnpfamdfjhhlgkc.crx",  # BrowserClaw
 +]
++
++if (browseros_allow_runtime_product_override || browseros_product_browseros) {
++  _bundled_extensions_sources +=
++      [ "bflpfmnmnokmjhmgnolecpppdbdophmk.crx" ]  # Agent
++}
++
++if (browseros_allow_runtime_product_override || browseros_product_browserclaw) {
++  _bundled_extensions_sources +=
++      [ "pjimfkbpehlcllblajnpfamdfjhhlgkc.crx" ]  # BrowserClaw
++}
 +
 +if (!is_mac) {
 +  copy("bundled_extensions") {

--- a/packages/browseros/chromium_patches/chrome/common/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/common/BUILD.gn
@@ -1,8 +1,16 @@
 diff --git a/chrome/common/BUILD.gn b/chrome/common/BUILD.gn
-index 1a692fe440945..a82aaabd142a4 100644
+index 1a692fe440945200128c90fc968d5682ae62470f..9506fdc252db035e647facdc0a48f789047cf6f0 100644
 --- a/chrome/common/BUILD.gn
 +++ b/chrome/common/BUILD.gn
-@@ -596,7 +596,10 @@ static_library("constants") {
+@@ -457,6 +457,7 @@ static_library("non_code_constants") {
+     ":buildflags",
+     ":version_header",
+     "//base",
++    "//chrome/browser/browseros:buildflags",
+     "//content/public/common:buildflags",
+   ]
+ 
+@@ -596,7 +597,10 @@ static_library("constants") {
    }
    if (is_linux || is_chromeos) {
      sources += [ "chrome_paths_linux.cc" ]

--- a/packages/browseros/chromium_patches/chrome/common/chrome_constants.cc
+++ b/packages/browseros/chromium_patches/chrome/common/chrome_constants.cc
@@ -1,24 +1,44 @@
 diff --git a/chrome/common/chrome_constants.cc b/chrome/common/chrome_constants.cc
-index 6e30ef11474c4..0a6aaeb85d73b 100644
+index 6e30ef11474c457acf1bca690c6a310afb11d751..a87732bff1ae008949f8d86f70e35c98ba268f55 100644
 --- a/chrome/common/chrome_constants.cc
 +++ b/chrome/common/chrome_constants.cc
-@@ -46,7 +46,7 @@ const base::FilePath::CharType kBrowserProcessExecutableName[] = FPL("chrome");
+@@ -5,6 +5,7 @@
+ #include "chrome/common/chrome_constants.h"
+ 
+ #include "build/build_config.h"
++#include "chrome/browser/browseros/buildflags.h"
+ #include "chrome/common/chrome_version.h"
+ 
+ #define FPL FILE_PATH_LITERAL
+@@ -46,7 +47,12 @@ const base::FilePath::CharType kBrowserProcessExecutableName[] = FPL("chrome");
  const base::FilePath::CharType kHelperProcessExecutableName[] =
      FPL("sandboxed_process");
  #elif BUILDFLAG(IS_POSIX)
 -const base::FilePath::CharType kBrowserProcessExecutableName[] = FPL("chrome");
++#if BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW)
++const base::FilePath::CharType kBrowserProcessExecutableName[] =
++    FPL("browserclaw");
++#else
 +const base::FilePath::CharType kBrowserProcessExecutableName[] = FPL("browseros");
++#endif
  // Helper processes end up with a name of "exe" due to execing via
  // /proc/self/exe.  See bug 22703.
  const base::FilePath::CharType kHelperProcessExecutableName[] = FPL("exe");
-@@ -75,8 +75,8 @@ const base::FilePath::CharType kHelperProcessExecutablePath[] =
+@@ -75,8 +81,15 @@ const base::FilePath::CharType kHelperProcessExecutablePath[] =
  const base::FilePath::CharType kBrowserProcessExecutablePath[] = FPL("chrome");
  const base::FilePath::CharType kHelperProcessExecutablePath[] = FPL("chrome");
  #elif BUILDFLAG(IS_POSIX)
 -const base::FilePath::CharType kBrowserProcessExecutablePath[] = FPL("chrome");
 -const base::FilePath::CharType kHelperProcessExecutablePath[] = FPL("chrome");
++#if BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW)
++const base::FilePath::CharType kBrowserProcessExecutablePath[] =
++    FPL("browserclaw");
++const base::FilePath::CharType kHelperProcessExecutablePath[] =
++    FPL("browserclaw");
++#else
 +const base::FilePath::CharType kBrowserProcessExecutablePath[] = FPL("browseros");
 +const base::FilePath::CharType kHelperProcessExecutablePath[] = FPL("browseros");
++#endif
  #endif  // OS_*
  
  #if BUILDFLAG(IS_MAC)

--- a/packages/browseros/chromium_patches/chrome/installer/mini_installer/chrome.release
+++ b/packages/browseros/chromium_patches/chrome/installer/mini_installer/chrome.release
@@ -1,8 +1,8 @@
 diff --git a/chrome/installer/mini_installer/chrome.release b/chrome/installer/mini_installer/chrome.release
-index 0f331c3e0f2a3..051d499bcfa37 100644
+index 0f331c3e0f2a39813af0a33a162cefaff9324524..56773976378807c144a07ef9725a2261db013ad9 100644
 --- a/chrome/installer/mini_installer/chrome.release
 +++ b/chrome/installer/mini_installer/chrome.release
-@@ -36,6 +36,7 @@ vk_swiftshader.dll: %(VersionDir)s\
+@@ -36,9 +36,11 @@ vk_swiftshader.dll: %(VersionDir)s\
  vk_swiftshader_icd.json: %(VersionDir)s\
  vulkan-1.dll: %(VersionDir)s\
  v8_context_snapshot.bin: %(VersionDir)s\
@@ -10,7 +10,11 @@ index 0f331c3e0f2a3..051d499bcfa37 100644
  #
  # Sub directories living in the version dir
  #
-@@ -63,6 +64,15 @@ PrivacySandboxAttestationsPreloaded\privacy-sandbox-attestations.dat: %(VersionD
++browseros_extensions\*.*: %(VersionDir)s\browseros_extensions\
+ Extensions\*.*: %(VersionDir)s\Extensions\
+ locales\*.pak: %(VersionDir)s\Locales
+ 
+@@ -63,6 +65,23 @@ PrivacySandboxAttestationsPreloaded\privacy-sandbox-attestations.dat: %(VersionD
  MEIPreload\manifest.json: %(VersionDir)s\MEIPreload\
  MEIPreload\preloaded_data.pb: %(VersionDir)s\MEIPreload\
  
@@ -22,6 +26,14 @@ index 0f331c3e0f2a3..051d499bcfa37 100644
 +BrowserOSServer\default\resources\bin\third_party\*.*: %(VersionDir)s\BrowserOSServer\default\resources\bin\third_party\
 +BrowserOSServer\default\resources\db\migrations\*.*: %(VersionDir)s\BrowserOSServer\default\resources\db\migrations\
 +BrowserOSServer\default\resources\db\migrations\meta\*.*: %(VersionDir)s\BrowserOSServer\default\resources\db\migrations\meta\
++
++#
++# BrowserClaw Server
++#
++BrowserClawServer\default\resources\*.*: %(VersionDir)s\BrowserClawServer\default\resources\
++BrowserClawServer\default\resources\bin\*.*: %(VersionDir)s\BrowserClawServer\default\resources\bin\
++BrowserClawServer\default\resources\db\migrations\*.*: %(VersionDir)s\BrowserClawServer\default\resources\db\migrations\
++BrowserClawServer\default\resources\db\migrations\meta\*.*: %(VersionDir)s\BrowserClawServer\default\resources\db\migrations\meta\
 +
  #
  # IWA Key Distribution


### PR DESCRIPTION
## Summary
- package the BrowserClaw server and shared bundled-extension directory in the static Windows installer manifest while preserving the BrowserOS server block
- select BrowserOS, BrowserClaw, or debug CRX inputs from the existing GN product booleans
- compile POSIX executable constants from the baked product buildflag and add static payload-contract coverage

## Design
The Windows manifest declares both server roots because unmatched globs are intentionally skipped; clean product GN output decides which root ships. Bundled extensions retain the shared `browseros_extensions` path, while GN selects agent plus bug reporter for BrowserOS release, Claw plus bug reporter for BrowserClaw release, and all three when runtime product override is enabled. macOS naming remains driven by BRANDING.

## Merge ordering
This Chromium GN matrix must merge before or at the same time as the parallel Python exact-staging PR. If Python stages only the active two CRXs while the old GN file still lists all three, Ninja fails on the missing inactive CRX input.

## Test plan
- [x] `uv run python -m unittest bos_build.steps.patches.product_payload_manifest_test -v`
- [x] `uv run browseros dev doctor` (379 patches, 34 features)
- [x] extracted patches: 4/4 byte-match and 4/4 apply-check
- [x] shared pool build: `autoninja -C out/Default_browseros_arm64 chrome`
- [x] live Windows Claw server ZIP contains `resources/bin`, `resources/db/migrations`, and `resources/db/migrations/meta`, with no `bin/third_party`