### PR TITLE
fix(linux): package bundled extensions in appimage and deb

### DIFF
--- a/packages/browseros/bos_build/steps/package/linux.py
+++ b/packages/browseros/bos_build/steps/package/linux.py
@@ -163,8 +163,16 @@ def copy_browser_files(
     Returns:
         True if successful, False otherwise
     """
-    target_dir.mkdir(parents=True, exist_ok=True)
     out_dir = join_paths(ctx.chromium_src, ctx.out_dir)
+    extensions_dir_name = "browseros_extensions"
+    extensions_src = join_paths(out_dir, extensions_dir_name)
+    if not extensions_src.is_dir():
+        raise FileNotFoundError(
+            f"Required bundled extensions directory not found at {extensions_src}; "
+            f"expected {extensions_dir_name} in Chromium output directory {out_dir}"
+        )
+
+    target_dir.mkdir(parents=True, exist_ok=True)
 
     files_to_copy = [
         ctx.BROWSEROS_APP_NAME,
@@ -193,6 +201,13 @@ def copy_browser_files(
             log_info(f"  ✓ Copied {file}")
         else:
             log_warning(f"  ⚠ File not found: {file}")
+
+    shutil.copytree(
+        extensions_src,
+        join_paths(target_dir, extensions_dir_name),
+        dirs_exist_ok=True,
+    )
+    log_info(f"  ✓ Copied {extensions_dir_name}/")
 
     dirs_to_copy = [
         "locales",

--- a/packages/browseros/bos_build/steps/package/linux_test.py
+++ b/packages/browseros/bos_build/steps/package/linux_test.py
@@ -73,6 +73,75 @@ class HostAppImageToolTest(unittest.TestCase):
 
 
 class CopyBrowserFilesTest(unittest.TestCase):
+    def test_copies_required_extensions_beside_browser_for_both_products(
+        self,
+    ) -> None:
+        for product_id in ("browseros", "browserclaw"):
+            with self.subTest(product_id=product_id), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                out_dir = root / "out" / "Release"
+                target_dir = root / "package"
+                extensions_dir = out_dir / "browseros_extensions"
+                extensions_dir.mkdir(parents=True)
+                (out_dir / product_id).write_text("browser")
+                (extensions_dir / "bundled_extensions.json").write_text("{}")
+                (extensions_dir / f"{product_id}.crx").write_text(product_id)
+                resources_dir = out_dir / "resources"
+                resources_dir.mkdir()
+                (resources_dir / "not-packaged.txt").write_text("chromium")
+
+                ctx = cast(
+                    Context,
+                    SimpleNamespace(
+                        chromium_src=root,
+                        out_dir=Path("out") / "Release",
+                        BROWSEROS_APP_NAME=product_id,
+                        product=get_product_descriptor(product_id),
+                    ),
+                )
+
+                with patch("bos_build.steps.package.linux.log_warning"):
+                    self.assertTrue(copy_browser_files(ctx, target_dir))
+
+                self.assertEqual((target_dir / product_id).read_text(), "browser")
+                self.assertEqual(
+                    (
+                        target_dir
+                        / "browseros_extensions"
+                        / f"{product_id}.crx"
+                    ).read_text(),
+                    product_id,
+                )
+                self.assertFalse((target_dir / "resources").exists())
+
+    def test_missing_required_extensions_raises_precise_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out_dir = root / "out" / "Release"
+            target_dir = root / "package"
+            out_dir.mkdir(parents=True)
+            (out_dir / "browseros").write_text("browser")
+            expected_dir = out_dir / "browseros_extensions"
+            ctx = cast(
+                Context,
+                SimpleNamespace(
+                    chromium_src=root,
+                    out_dir=Path("out") / "Release",
+                    BROWSEROS_APP_NAME="browseros",
+                    product=get_product_descriptor("browseros"),
+                ),
+            )
+
+            with self.assertRaises(FileNotFoundError) as raised:
+                copy_browser_files(ctx, target_dir)
+
+            self.assertEqual(
+                str(raised.exception),
+                f"Required bundled extensions directory not found at {expected_dir}; "
+                f"expected browseros_extensions in Chromium output directory {out_dir}",
+            )
+            self.assertFalse(target_dir.exists())
+
     def test_copies_browseros_and_claw_server_roots_when_present(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -80,6 +149,9 @@ class CopyBrowserFilesTest(unittest.TestCase):
             target_dir = root / "package"
             out_dir.mkdir(parents=True)
             (out_dir / "browseros").write_text("browser")
+            extensions_dir = out_dir / "browseros_extensions"
+            extensions_dir.mkdir()
+            (extensions_dir / "bundled_extensions.json").write_text("{}")
 
             for bundle_name in ("BrowserOSServer", "BrowserClawServer"):
                 resources = out_dir / bundle_name / "default" / "resources"
@@ -107,6 +179,15 @@ class CopyBrowserFilesTest(unittest.TestCase):
                     / "marker.txt"
                 ).exists()
             )
+            self.assertTrue(
+                (
+                    target_dir
+                    / "BrowserClawServer"
+                    / "default"
+                    / "resources"
+                    / "marker.txt"
+                ).exists()
+            )
 
     def test_product_context_copies_only_owned_server_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -115,6 +196,9 @@ class CopyBrowserFilesTest(unittest.TestCase):
             target_dir = root / "package"
             out_dir.mkdir(parents=True)
             (out_dir / "browserclaw").write_text("browser")
+            extensions_dir = out_dir / "browseros_extensions"
+            extensions_dir.mkdir()
+            (extensions_dir / "bundled_extensions.json").write_text("{}")
 
             for bundle_name in ("BrowserOSServer", "BrowserClawServer"):
                 resources = out_dir / bundle_name / "default" / "resources"
@@ -147,30 +231,36 @@ class CopyBrowserFilesTest(unittest.TestCase):
 
 
 class LinuxProductMetadataTest(unittest.TestCase):
-    def test_browserclaw_helpers_use_product_package_names(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            ctx = cast(
-                Context,
-                SimpleNamespace(
-                    product=get_product_descriptor("browserclaw"),
-                    BROWSEROS_APP_NAME="browserclaw",
-                    get_browseros_chromium_version=lambda: "137.0.7231.69",
-                ),
-            )
+    def test_helpers_use_product_package_names(self) -> None:
+        for product_id in ("browseros", "browserclaw"):
+            with self.subTest(product_id=product_id), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                product = get_product_descriptor(product_id)
+                ctx = cast(
+                    Context,
+                    SimpleNamespace(
+                        product=product,
+                        BROWSEROS_APP_NAME=product_id,
+                        get_browseros_chromium_version=lambda: "137.0.7231.69",
+                    ),
+                )
 
-            desktop = create_desktop_file(
-                ctx, root / "applications", "/usr/bin/browserclaw"
-            )
-            create_launcher_script(ctx, root / "bin")
-            create_apparmor_profile(ctx, root / "apparmor")
-            create_metainfo_file(ctx, root / "metainfo")
+                desktop = create_desktop_file(
+                    ctx, root / "applications", f"/usr/bin/{product_id}"
+                )
+                create_launcher_script(ctx, root / "bin")
+                create_apparmor_profile(ctx, root / "apparmor")
+                create_metainfo_file(ctx, root / "metainfo")
 
-            self.assertEqual(desktop.name, "browserclaw.desktop")
-            self.assertIn("Name=BrowserClaw", desktop.read_text())
-            self.assertTrue((root / "bin" / "browserclaw").exists())
-            self.assertTrue((root / "apparmor" / "browserclaw").exists())
-            self.assertTrue((root / "metainfo" / "browserclaw.metainfo.xml").exists())
+                desktop_content = desktop.read_text()
+                self.assertEqual(desktop.name, f"{product_id}.desktop")
+                self.assertIn(f"Name={product.display_name}", desktop_content)
+                self.assertIn(f"Icon={product_id}", desktop_content)
+                self.assertTrue((root / "bin" / product_id).exists())
+                self.assertTrue((root / "apparmor" / product_id).exists())
+                self.assertTrue(
+                    (root / "metainfo" / f"{product_id}.metainfo.xml").exists()
+                )
 
     def test_browserclaw_icons_copy_from_product_resource_tree(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- copy the required browseros_extensions output beside Linux browser executables for both products
- fail before staging when the required extension directory is missing
- preserve optional files, active-product server roots, product naming, and the Chromium resources boundary

## Design
The shared copy_browser_files helper preflights the generated out-dir payload and copies it explicitly, separate from the existing optional directory loop. Both AppImage and deb staging already use this helper, so they inherit the same fatal contract without format-specific changes.

## Test plan
- [x] uv run python -m unittest bos_build.steps.package.linux_test -v
- [x] uv run ruff check bos_build
- [x] uv run python -m unittest discover -s bos_build -t . -p "*_test.py" -v
- [x] release-secrets and vendor-upload unittest suites
- [x] browseros build list/show-plan and product doctor smokes
- [x] context-free diff review: clean