### PR TITLE
fix(build): stage exact product extension sets

### DIFF
--- a/packages/browseros/bos_build/core/context.py
+++ b/packages/browseros/bos_build/core/context.py
@@ -298,6 +298,20 @@ class Context:
         base = self.get_chromium_replace_files_dir()
         return [base / "common", base / "products" / self.product.id]
 
+    @property
+    def required_extension_ids(self) -> tuple[tuple[str, str], ...]:
+        """Return bundled-extension requirements for the current build."""
+        if self.build_type != "debug":
+            return self.product.required_extension_ids
+
+        from ..products import PRODUCTS
+
+        required: Dict[str, str] = {}
+        for product in PRODUCTS.values():
+            for extension_id, name in product.required_extension_ids:
+                required.setdefault(extension_id, name)
+        return tuple(required.items())
+
     def get_product_gn_args(self) -> list[str]:
         """Product GN args: release bakes identity; debug keeps the runtime
         product switch working (it needs both server resource sets)."""

--- a/packages/browseros/bos_build/core/context_test.py
+++ b/packages/browseros/bos_build/core/context_test.py
@@ -9,7 +9,13 @@ from unittest import mock
 
 from . import context as context_mod
 from .context import Context
-from .products import ProductDescriptor, get_product_descriptor
+from .products import (
+    BROWSEROS_AGENT_EXTENSION_ID,
+    BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+    BROWSERCLAW_EXTENSION_ID,
+    ProductDescriptor,
+    get_product_descriptor,
+)
 
 
 class GetAppPathTest(unittest.TestCase):
@@ -154,6 +160,47 @@ class GetAppPathTest(unittest.TestCase):
                         "browseros_package_all_server_resources = false",
                     ],
                 )
+
+    def test_release_required_extensions_follow_active_product(self):
+        expected = {
+            "browseros": (
+                (BROWSEROS_AGENT_EXTENSION_ID, "BrowserOS agent"),
+                (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
+            ),
+            "browserclaw": (
+                (BROWSERCLAW_EXTENSION_ID, "BrowserClaw app"),
+                (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
+            ),
+        }
+
+        for product, required in expected.items():
+            with self.subTest(product=product):
+                ctx = Context(
+                    chromium_src=Path("/nonexistent-src"),
+                    architecture="arm64",
+                    build_type="release",
+                    product=get_product_descriptor(product),
+                )
+
+                self.assertEqual(ctx.required_extension_ids, required)
+
+    def test_debug_required_extensions_are_registered_product_union(self):
+        expected = (
+            (BROWSEROS_AGENT_EXTENSION_ID, "BrowserOS agent"),
+            (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
+            (BROWSERCLAW_EXTENSION_ID, "BrowserClaw app"),
+        )
+
+        for product in ("browseros", "browserclaw"):
+            with self.subTest(product=product):
+                ctx = Context(
+                    chromium_src=Path("/nonexistent-src"),
+                    architecture="arm64",
+                    build_type="debug",
+                    product=get_product_descriptor(product),
+                )
+
+                self.assertEqual(ctx.required_extension_ids, expected)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/core/products.py
+++ b/packages/browseros/bos_build/core/products.py
@@ -17,13 +17,6 @@ BROWSERCLAW_EXTENSION_ID = "pjimfkbpehlcllblajnpfamdfjhhlgkc"
 # Packaged to the CDN but neither bundled nor in the update feeds.
 BROWSEROS_CONTROLLER_EXTENSION_ID = "nlnihljpboknmfagkikhkdblbedophja"
 
-# TODO: nikhil - remove packaging all extensions after chromium fix
-DEFAULT_REQUIRED_EXTENSIONS: Tuple[Tuple[str, str], ...] = (
-    (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
-    (BROWSEROS_AGENT_EXTENSION_ID, "BrowserOS agent"),
-    (BROWSERCLAW_EXTENSION_ID, "BrowserClaw app"),
-)
-
 
 @dataclass(frozen=True)
 class MacProductIdentity:
@@ -139,7 +132,7 @@ class ProductDescriptor:
         homepage_url: str = "https://www.browseros.com/",
         support_url: str = "https://docs.browseros.com/",
         bugtracker_url: str = "https://github.com/browseros-ai/BrowserOS/issues",
-        required_extensions: Tuple[Tuple[str, str], ...] = DEFAULT_REQUIRED_EXTENSIONS,
+        required_extensions: Tuple[Tuple[str, str], ...] = (),
         **overrides,
     ) -> "ProductDescriptor":
         """Build a descriptor from irreducible inputs; derive the rest.

--- a/packages/browseros/bos_build/products/browserclaw/product.py
+++ b/packages/browseros/bos_build/products/browserclaw/product.py
@@ -3,7 +3,11 @@
 
 from pathlib import Path
 
-from ...core.products import ProductDescriptor
+from ...core.products import (
+    BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+    BROWSERCLAW_EXTENSION_ID,
+    ProductDescriptor,
+)
 from ..server_binaries import ServerBundle, SignSpec
 
 BROWSERCLAW_PRODUCT = ProductDescriptor.define(
@@ -12,6 +16,10 @@ BROWSERCLAW_PRODUCT = ProductDescriptor.define(
     windows_installer_guid="{FA2AFFF8-647B-477C-A5D2-905BA8DB9B82}",
     summary="The open source browser for web agents",
     description="BrowserClaw is a Chromium-based browser for agent workflows.",
+    required_extensions=(
+        (BROWSERCLAW_EXTENSION_ID, "BrowserClaw app"),
+        (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
+    ),
 )
 
 BROWSERCLAW_SERVER_BUNDLE = ServerBundle(

--- a/packages/browseros/bos_build/products/browseros/product.py
+++ b/packages/browseros/bos_build/products/browseros/product.py
@@ -3,7 +3,11 @@
 
 from pathlib import Path
 
-from ...core.products import ProductDescriptor
+from ...core.products import (
+    BROWSEROS_AGENT_EXTENSION_ID,
+    BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+    ProductDescriptor,
+)
 from ..server_binaries import ServerBundle, SignSpec
 
 BROWSEROS_PRODUCT = ProductDescriptor.define(
@@ -12,6 +16,10 @@ BROWSEROS_PRODUCT = ProductDescriptor.define(
     windows_installer_guid="{5d8d08af-2df9-4da2-86c1-eac353a0ca32}",
     summary="The open source agentic browser",
     description="BrowserOS is a privacy-focused web browser built on Chromium.",
+    required_extensions=(
+        (BROWSEROS_AGENT_EXTENSION_ID, "BrowserOS agent"),
+        (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
+    ),
 )
 
 BROWSEROS_SERVER_BUNDLE = ServerBundle(

--- a/packages/browseros/bos_build/products/products_test.py
+++ b/packages/browseros/bos_build/products/products_test.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-"""Golden tests: define() must reproduce the original hand-written
-descriptors (copied verbatim from the pre-factory products.py) field
-for field, so the derivation conventions can't silently drift."""
+"""Golden tests for shipped product descriptors and define() conventions."""
 
 import unittest
 
@@ -19,8 +17,7 @@ BROWSEROS_AGENT_EXTENSION_ID = "bflpfmnmnokmjhmgnolecpppdbdophmk"
 BROWSEROS_BUG_REPORTER_EXTENSION_ID = "adlpneommgkgeanpaekgoaolcpncohkf"
 BROWSERCLAW_EXTENSION_ID = "pjimfkbpehlcllblajnpfamdfjhhlgkc"
 
-# Verbatim from the pre-define() products.py (commit d6ff84c0 lineage).
-ORIGINAL_BROWSEROS = ProductDescriptor(
+EXPECTED_BROWSEROS = ProductDescriptor(
     id="browseros",
     gn_product="browseros",
     display_name="BrowserOS",
@@ -39,9 +36,8 @@ ORIGINAL_BROWSEROS = ProductDescriptor(
     description="BrowserOS is a privacy-focused web browser built on Chromium.",
     string_replacements=_replacements("BrowserOS"),
     required_extension_ids=(
-        (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
         (BROWSEROS_AGENT_EXTENSION_ID, "BrowserOS agent"),
-        (BROWSERCLAW_EXTENSION_ID, "BrowserClaw app"),
+        (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
     ),
     server_bundle_ids=("browseros-server",),
     mac=MacProductIdentity(
@@ -69,7 +65,7 @@ ORIGINAL_BROWSEROS = ProductDescriptor(
     ),
 )
 
-ORIGINAL_BROWSERCLAW = ProductDescriptor(
+EXPECTED_BROWSERCLAW = ProductDescriptor(
     id="browserclaw",
     gn_product="browserclaw",
     display_name="BrowserClaw",
@@ -88,9 +84,8 @@ ORIGINAL_BROWSERCLAW = ProductDescriptor(
     description="BrowserClaw is a Chromium-based browser for agent workflows.",
     string_replacements=_replacements("BrowserClaw"),
     required_extension_ids=(
-        (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
-        (BROWSEROS_AGENT_EXTENSION_ID, "BrowserOS agent"),
         (BROWSERCLAW_EXTENSION_ID, "BrowserClaw app"),
+        (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
     ),
     server_bundle_ids=("browserclaw-server",),
     mac=MacProductIdentity(
@@ -120,11 +115,11 @@ ORIGINAL_BROWSERCLAW = ProductDescriptor(
 
 
 class DefineGoldenTest(unittest.TestCase):
-    def test_browseros_matches_original_hand_written_descriptor(self):
-        self.assertEqual(get_product_descriptor("browseros"), ORIGINAL_BROWSEROS)
+    def test_browseros_matches_expected_descriptor(self):
+        self.assertEqual(get_product_descriptor("browseros"), EXPECTED_BROWSEROS)
 
-    def test_browserclaw_matches_original_hand_written_descriptor(self):
-        self.assertEqual(get_product_descriptor("browserclaw"), ORIGINAL_BROWSERCLAW)
+    def test_browserclaw_matches_expected_descriptor(self):
+        self.assertEqual(get_product_descriptor("browserclaw"), EXPECTED_BROWSERCLAW)
 
 
 class DefineBehaviorTest(unittest.TestCase):
@@ -148,6 +143,7 @@ class DefineBehaviorTest(unittest.TestCase):
         self.assertEqual(p.windows.app_user_model_id, "BrowserOS.AcmeFox")
         self.assertEqual(p.server_bundle_ids, ("acmefox-server",))
         self.assertEqual(p.release_prefix, "acmefox")
+        self.assertEqual(p.required_extension_ids, ())
 
     def test_override_wins_over_derivation(self):
         p = self._minimal(artifact_prefix="Acme")

--- a/packages/browseros/bos_build/steps/extensions/bundled_extensions.py
+++ b/packages/browseros/bos_build/steps/extensions/bundled_extensions.py
@@ -9,6 +9,7 @@ while required external extensions continue to download from the CDN manifest.
 
 import json
 import os
+import shutil
 import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
@@ -96,6 +97,7 @@ class BundledExtensionsModule(Step):
         output_dir = self._get_output_dir(ctx)
 
         output_dir.mkdir(parents=True, exist_ok=True)
+        self._clear_generated_outputs(ctx, output_dir)
         log_info(f"  Output: {output_dir}")
 
         extensions = self._fetch_and_parse_manifest(manifest_url)
@@ -126,6 +128,18 @@ class BundledExtensionsModule(Step):
         return (
             ctx.chromium_src / "chrome" / "browser" / "browseros" / "bundled_extensions"
         )
+
+    def _clear_generated_outputs(self, ctx: Context, output_dir: Path) -> None:
+        """Remove generated extension payloads without touching source files."""
+        for crx_path in output_dir.glob("*.crx"):
+            crx_path.unlink()
+        (output_dir / "bundled_extensions.json").unlink(missing_ok=True)
+
+        generated_output_dir = ctx.chromium_src / ctx.out_dir / "browseros_extensions"
+        if generated_output_dir.is_symlink() or generated_output_dir.is_file():
+            generated_output_dir.unlink()
+        elif generated_output_dir.exists():
+            shutil.rmtree(generated_output_dir)
 
     def _fetch_and_parse_manifest(self, url: str) -> List[ExtensionInfo]:
         """Fetch XML manifest and parse extension information"""
@@ -183,27 +197,25 @@ class BundledExtensionsModule(Step):
     def _select_product_extensions(
         self, extensions: List[ExtensionInfo], ctx: Context
     ) -> List[ExtensionInfo]:
-        """Return manifest entries required by the active product."""
+        """Return manifest entries required by the current build."""
         self._validate_required_extensions(extensions, ctx)
-        required_ids = {
-            extension_id for extension_id, _ in ctx.product.required_extension_ids
-        }
+        required_ids = {extension_id for extension_id, _ in ctx.required_extension_ids}
         return [ext for ext in extensions if ext.id in required_ids]
 
     def _validate_required_extensions(
         self, extensions: List[ExtensionInfo], ctx: Context
     ) -> None:
-        """Fail if the release manifest omits a required bundled extension."""
+        """Fail if the manifest omits a required bundled extension."""
         extension_ids = {ext.id for ext in extensions}
         missing = [
             f"{name} ({extension_id})"
-            for extension_id, name in ctx.product.required_extension_ids
+            for extension_id, name in ctx.required_extension_ids
             if extension_id not in extension_ids
         ]
         if missing:
             raise RuntimeError(
-                "Bundled extension manifest missing required entries: "
-                + ", ".join(missing)
+                f"Bundled extension manifest for {ctx.product.display_name} "
+                "missing required entries: " + ", ".join(missing)
             )
 
     def _use_local_bundles(self, ctx: Context) -> bool:
@@ -218,7 +230,7 @@ class BundledExtensionsModule(Step):
         planned: List[BundlePlan] = []
         missing: List[str] = []
 
-        for extension_id, name in ctx.product.required_extension_ids:
+        for extension_id, name in ctx.required_extension_ids:
             spec = local_specs_by_id.get(extension_id)
             if spec is not None:
                 planned.append(LocalBundle(name=name, spec=spec))
@@ -233,8 +245,8 @@ class BundledExtensionsModule(Step):
 
         if missing:
             raise RuntimeError(
-                "Bundled extensions missing required local or manifest entries: "
-                + ", ".join(missing)
+                f"Bundled extensions for {ctx.product.display_name} missing required "
+                "local or manifest entries: " + ", ".join(missing)
             )
         return planned
 
@@ -326,7 +338,7 @@ class BundledExtensionsModule(Step):
         missing = []
         local_specs_by_id = self._local_specs_by_id()
         has_local_required = False
-        for extension_id, name in ctx.product.required_extension_ids:
+        for extension_id, name in ctx.required_extension_ids:
             spec = local_specs_by_id.get(extension_id)
             if spec is None:
                 continue

--- a/packages/browseros/bos_build/steps/extensions/bundled_extensions_test.py
+++ b/packages/browseros/bos_build/steps/extensions/bundled_extensions_test.py
@@ -26,7 +26,6 @@ from bos_build.steps.extensions.bundled_extensions import (
     ManifestBundle,
 )
 
-CLAW_EXTENSION_ID = "pjimfkbpehlcllblajnpfamdfjhhlgkc"
 MODULE = "bos_build.steps.extensions.bundled_extensions"
 
 
@@ -42,8 +41,14 @@ class BundledExtensionsManifestTest(unittest.TestCase):
         )
 
         by_id = {ext.id: ext for ext in extensions}
-        required = get_product_descriptor("browseros").required_extension_ids
-        for extension_id, name in required:
+        required = {
+            extension_id: name
+            for product in ("browseros", "browserclaw")
+            for extension_id, name in get_product_descriptor(
+                product
+            ).required_extension_ids
+        }
+        for extension_id, name in required.items():
             self.assertIn(extension_id, by_id, name)
 
         for ext in extensions:
@@ -54,21 +59,20 @@ class BundledExtensionsManifestTest(unittest.TestCase):
             self.assertTrue(ext.version)
             self.assertIn(f"-{ext.version}.crx", ext.codebase)
 
-    def test_required_ids_cover_agent_bug_reporter_and_claw(self) -> None:
-        # Both products bundle all three until the chromium-side fix lands
-        # (see the required_extension_ids TODO in common/products.py).
-        expected = {
-            "adlpneommgkgeanpaekgoaolcpncohkf": "BrowserOS bug reporter",
-            "bflpfmnmnokmjhmgnolecpppdbdophmk": "BrowserOS agent",
-            CLAW_EXTENSION_ID: "BrowserClaw app",
-        }
+    def test_release_product_required_ids_are_exact(self) -> None:
         self.assertEqual(
-            dict(get_product_descriptor("browseros").required_extension_ids),
-            expected,
+            get_product_descriptor("browseros").required_extension_ids,
+            (
+                (BROWSEROS_AGENT_EXTENSION_ID, "BrowserOS agent"),
+                (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
+            ),
         )
         self.assertEqual(
-            dict(get_product_descriptor("browserclaw").required_extension_ids),
-            expected,
+            get_product_descriptor("browserclaw").required_extension_ids,
+            (
+                (BROWSERCLAW_EXTENSION_ID, "BrowserClaw app"),
+                (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
+            ),
         )
 
     def test_generated_json_maps_claw_id_to_crx(self) -> None:
@@ -77,7 +81,7 @@ class BundledExtensionsManifestTest(unittest.TestCase):
             BundledExtensionsModule()._generate_json(
                 [
                     ExtensionInfo(
-                        id=CLAW_EXTENSION_ID,
+                        id=BROWSERCLAW_EXTENSION_ID,
                         version="0.0.1",
                         codebase=(
                             "https://cdn.browseros.com/extensions/browserclaw-0.0.1.crx"
@@ -90,118 +94,189 @@ class BundledExtensionsManifestTest(unittest.TestCase):
             data = json.loads((output_dir / "bundled_extensions.json").read_text())
 
         self.assertEqual(
-            data[CLAW_EXTENSION_ID],
+            data[BROWSERCLAW_EXTENSION_ID],
             {
-                "external_crx": f"{CLAW_EXTENSION_ID}.crx",
+                "external_crx": f"{BROWSERCLAW_EXTENSION_ID}.crx",
                 "external_version": "0.0.1",
             },
         )
 
-    def test_missing_claw_app_fails_validation(self) -> None:
-        extensions = [
-            ExtensionInfo(
-                id="adlpneommgkgeanpaekgoaolcpncohkf",
-                version="52.0.0.0",
-                codebase="https://cdn.browseros.com/extensions/bugreporter.crx",
-            ),
-            ExtensionInfo(
-                id="bflpfmnmnokmjhmgnolecpppdbdophmk",
-                version="0.0.115.0",
-                codebase="https://cdn.browseros.com/extensions/agent.crx",
-            ),
-        ]
-
-        with self.assertRaisesRegex(
-            RuntimeError,
-            f"BrowserClaw app \\({CLAW_EXTENSION_ID}\\)",
-        ):
-            BundledExtensionsModule()._validate_required_extensions(
-                extensions, self._ctx("browserclaw")
-            )
-
-    def test_browserclaw_selects_all_required_extensions(self) -> None:
-        extensions = [
-            ExtensionInfo(
-                id="adlpneommgkgeanpaekgoaolcpncohkf",
-                version="52.0.0.0",
-                codebase="https://cdn.browseros.com/extensions/bugreporter.crx",
-            ),
-            ExtensionInfo(
-                id="bflpfmnmnokmjhmgnolecpppdbdophmk",
-                version="0.0.115.0",
-                codebase="https://cdn.browseros.com/extensions/agent.crx",
-            ),
-            ExtensionInfo(
-                id=CLAW_EXTENSION_ID,
-                version="0.0.1",
-                codebase="https://cdn.browseros.com/extensions/browserclaw.crx",
-            ),
-        ]
-
-        selected = BundledExtensionsModule()._select_product_extensions(
-            extensions, self._ctx("browserclaw")
+    def test_missing_required_entry_names_product_and_extension(self) -> None:
+        cases = (
+            ("browseros", BROWSEROS_AGENT_EXTENSION_ID, "BrowserOS agent"),
+            ("browserclaw", BROWSERCLAW_EXTENSION_ID, "BrowserClaw app"),
         )
+        for product, missing_id, missing_name in cases:
+            with self.subTest(product=product):
+                extensions = [
+                    ext for ext in self._all_extensions() if ext.id != missing_id
+                ]
+                display_name = get_product_descriptor(product).display_name
 
-        # All three ship for browserclaw too while the packaging TODO stands.
-        self.assertEqual(
-            [ext.id for ext in selected],
-            [
-                "adlpneommgkgeanpaekgoaolcpncohkf",
-                "bflpfmnmnokmjhmgnolecpppdbdophmk",
-                CLAW_EXTENSION_ID,
-            ],
-        )
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    f"{display_name}.*{missing_name} \\({missing_id}\\)",
+                ):
+                    BundledExtensionsModule()._validate_required_extensions(
+                        extensions, self._ctx(product)
+                    )
+
+    def test_release_selection_is_product_exact(self) -> None:
+        expected = {
+            "browseros": {
+                BROWSEROS_AGENT_EXTENSION_ID,
+                BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+            },
+            "browserclaw": {
+                BROWSERCLAW_EXTENSION_ID,
+                BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+            },
+        }
+        for product, required_ids in expected.items():
+            with self.subTest(product=product):
+                selected = BundledExtensionsModule()._select_product_extensions(
+                    self._all_extensions(), self._ctx(product)
+                )
+
+                self.assertEqual({ext.id for ext in selected}, required_ids)
+
+    def test_debug_selection_is_registered_product_union(self) -> None:
+        expected = {
+            BROWSEROS_AGENT_EXTENSION_ID,
+            BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+            BROWSERCLAW_EXTENSION_ID,
+        }
+        for product in ("browseros", "browserclaw"):
+            with self.subTest(product=product):
+                selected = BundledExtensionsModule()._select_product_extensions(
+                    self._all_extensions(), self._ctx(product, build_type="debug")
+                )
+
+                self.assertEqual({ext.id for ext in selected}, expected)
 
     def test_hybrid_mode_builds_in_repo_and_downloads_external_required(self) -> None:
         plan = BundledExtensionsModule()._plan_hybrid_bundles(
-            [
-                ExtensionInfo(
-                    id=BROWSEROS_BUG_REPORTER_EXTENSION_ID,
-                    version="52.0.0.0",
-                    codebase="https://cdn.browseros.com/extensions/bugreporter.crx",
-                ),
-                # Local-buildable IDs may still appear in the manifest; local wins.
-                ExtensionInfo(
-                    id=BROWSEROS_AGENT_EXTENSION_ID,
-                    version="0.0.115.0",
-                    codebase="https://cdn.browseros.com/extensions/agent.crx",
-                ),
-                ExtensionInfo(
-                    id=BROWSERCLAW_EXTENSION_ID,
-                    version="0.0.1",
-                    codebase="https://cdn.browseros.com/extensions/browserclaw.crx",
-                ),
-            ],
+            self._all_extensions(),
             self._ctx("browseros", bundle_local_extensions=True),
         )
 
-        self.assertIsInstance(plan[0], ManifestBundle)
-        self.assertIsInstance(plan[1], LocalBundle)
-        self.assertIsInstance(plan[2], LocalBundle)
+        self.assertIsInstance(plan[0], LocalBundle)
+        self.assertIsInstance(plan[1], ManifestBundle)
+        self.assertEqual(cast(LocalBundle, plan[0]).spec.name, "agent")
         self.assertEqual(
-            cast(ManifestBundle, plan[0]).extension.id,
+            cast(ManifestBundle, plan[1]).extension.id,
             BROWSEROS_BUG_REPORTER_EXTENSION_ID,
         )
-        self.assertEqual(cast(LocalBundle, plan[1]).spec.name, "agent")
-        self.assertEqual(cast(LocalBundle, plan[2]).spec.name, "browserclaw")
+
+    def test_browserclaw_hybrid_mode_builds_claw_not_agent(self) -> None:
+        plan = BundledExtensionsModule()._plan_hybrid_bundles(
+            self._all_extensions(),
+            self._ctx("browserclaw", bundle_local_extensions=True),
+        )
+
+        self.assertIsInstance(plan[0], LocalBundle)
+        self.assertIsInstance(plan[1], ManifestBundle)
+        self.assertEqual(cast(LocalBundle, plan[0]).spec.name, "browserclaw")
+        self.assertEqual(
+            cast(ManifestBundle, plan[1]).extension.id,
+            BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+        )
 
     def test_hybrid_mode_fails_when_external_required_missing(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "BrowserOS bug reporter"):
             BundledExtensionsModule()._plan_hybrid_bundles(
                 [
-                    ExtensionInfo(
-                        id=BROWSEROS_AGENT_EXTENSION_ID,
-                        version="0.0.115.0",
-                        codebase="https://cdn.browseros.com/extensions/agent.crx",
-                    ),
-                    ExtensionInfo(
-                        id=BROWSERCLAW_EXTENSION_ID,
-                        version="0.0.1",
-                        codebase="https://cdn.browseros.com/extensions/browserclaw.crx",
-                    ),
+                    ext
+                    for ext in self._all_extensions()
+                    if ext.id != BROWSEROS_BUG_REPORTER_EXTENSION_ID
                 ],
                 self._ctx("browseros", bundle_local_extensions=True),
             )
+
+    def test_cleanup_removes_only_generated_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src = Path(tmp)
+            ctx = self._ctx("browseros", chromium_src=chromium_src)
+            module = BundledExtensionsModule()
+            source_dir = module._get_output_dir(ctx)
+            source_dir.mkdir(parents=True)
+            preserved = ("BUILD.gn", ".gitignore", "README.md", "saved.crx.backup")
+            for name in preserved:
+                (source_dir / name).write_text(name)
+            for extension_id in (
+                BROWSEROS_AGENT_EXTENSION_ID,
+                BROWSERCLAW_EXTENSION_ID,
+            ):
+                (source_dir / f"{extension_id}.crx").write_text(extension_id)
+            (source_dir / "bundled_extensions.json").write_text("{}")
+
+            active_output = chromium_src / ctx.out_dir / "browseros_extensions"
+            active_output.mkdir(parents=True)
+            (active_output / "stale.crx").write_text("stale")
+            unrelated_output = (
+                chromium_src
+                / "out"
+                / "Default_browserclaw_arm64"
+                / "browseros_extensions"
+            )
+            unrelated_output.mkdir(parents=True)
+            (unrelated_output / "keep.crx").write_text("keep")
+
+            module._clear_generated_outputs(ctx, source_dir)
+
+            self.assertFalse((source_dir / "bundled_extensions.json").exists())
+            self.assertEqual(list(source_dir.glob("*.crx")), [])
+            for name in preserved:
+                self.assertTrue((source_dir / name).is_file(), name)
+            self.assertFalse(active_output.exists())
+            self.assertTrue((unrelated_output / "keep.crx").is_file())
+
+    def test_sequential_staging_leaves_only_latest_product_payload(self) -> None:
+        expected = {
+            "browseros": {
+                BROWSEROS_AGENT_EXTENSION_ID,
+                BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+            },
+            "browserclaw": {
+                BROWSERCLAW_EXTENSION_ID,
+                BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+            },
+        }
+
+        for first, second in (
+            ("browseros", "browserclaw"),
+            ("browserclaw", "browseros"),
+        ):
+            with (
+                self.subTest(first=first, second=second),
+                tempfile.TemporaryDirectory() as tmp,
+            ):
+                chromium_src = Path(tmp)
+                module = BundledExtensionsModule()
+
+                def write_crx(ext: ExtensionInfo, output_dir: Path) -> None:
+                    (output_dir / f"{ext.id}.crx").write_text(ext.id)
+
+                with (
+                    patch.object(
+                        module,
+                        "_fetch_and_parse_manifest",
+                        return_value=self._all_extensions(),
+                    ),
+                    patch.object(module, "_download_extension", side_effect=write_crx),
+                ):
+                    module.execute(self._ctx(first, chromium_src=chromium_src))
+                    module.execute(self._ctx(second, chromium_src=chromium_src))
+
+                source_dir = module._get_output_dir(
+                    self._ctx(second, chromium_src=chromium_src)
+                )
+                staged_ids = {path.stem for path in source_dir.glob("*.crx")}
+                manifest_ids = set(
+                    json.loads((source_dir / "bundled_extensions.json").read_text())
+                )
+                self.assertEqual(staged_ids, expected[second])
+                self.assertEqual(manifest_ids, expected[second])
 
     def test_build_local_extension_uses_spec_recipe_without_version_stamp(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -258,14 +333,22 @@ class BundledExtensionsManifestTest(unittest.TestCase):
                 os.environ,
                 {
                     "BROWSEROS_AGENT_V2_KEY": "agent-pem",
-                    "BROWSERCLAW_KEY": "claw-pem",
                 },
-                clear=False,
+                clear=True,
             ),
             patch(f"{MODULE}.find_chrome_binary", return_value="chrome-bin"),
         ):
             BundledExtensionsModule().preflight(
                 self._ctx("browseros", bundle_local_extensions=True)
+            )
+
+    def test_browserclaw_local_preflight_requires_only_claw_key(self) -> None:
+        with (
+            patch.dict(os.environ, {"BROWSERCLAW_KEY": "claw-pem"}, clear=True),
+            patch(f"{MODULE}.find_chrome_binary", return_value="chrome-bin"),
+        ):
+            BundledExtensionsModule().preflight(
+                self._ctx("browserclaw", bundle_local_extensions=True)
             )
 
     def test_local_mode_preflight_names_missing_local_signing_key(self) -> None:
@@ -288,15 +371,41 @@ class BundledExtensionsManifestTest(unittest.TestCase):
         product: str,
         bundle_local_extensions: bool = False,
         root_dir: Path | None = None,
-    ):
-        return cast(
-            Context,
-            SimpleNamespace(
-                product=get_product_descriptor(product),
-                bundle_local_extensions=bundle_local_extensions,
-                root_dir=root_dir or Path("/repo/packages/browseros"),
-            ),
+        build_type: str = "release",
+        chromium_src: Path | None = None,
+    ) -> Context:
+        return Context(
+            root_dir=root_dir or Path("/repo/packages/browseros"),
+            chromium_src=chromium_src or Path("/chromium"),
+            architecture="arm64",
+            build_type=build_type,
+            chromium_version="1.0.0.0",
+            browseros_build_offset="1",
+            browseros_version_parts=(1, 0, 0, 0),
+            browseros_chromium_version="1.0.0.1",
+            semantic_version="0.0.1",
+            product=get_product_descriptor(product),
+            bundle_local_extensions=bundle_local_extensions,
         )
+
+    def _all_extensions(self) -> list[ExtensionInfo]:
+        return [
+            ExtensionInfo(
+                id=BROWSEROS_AGENT_EXTENSION_ID,
+                version="0.0.115.0",
+                codebase="https://cdn.browseros.com/extensions/agent.crx",
+            ),
+            ExtensionInfo(
+                id=BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+                version="52.0.0.0",
+                codebase="https://cdn.browseros.com/extensions/bugreporter.crx",
+            ),
+            ExtensionInfo(
+                id=BROWSERCLAW_EXTENSION_ID,
+                version="0.0.1",
+                codebase="https://cdn.browseros.com/extensions/browserclaw.crx",
+            ),
+        ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- declare exact BrowserOS and BrowserClaw release extension ownership at each product definition
- derive the runtime-override debug union once in `Context` and use it for downloaded and local/hybrid staging
- remove only generated CRXs/manifests and the active out-dir extension tree before staging, preventing sequential build leakage

## Design

Product descriptors own release requirements, while `Context` turns those into the effective build requirements: the active pair for release and the deduplicated registered-product union for debug. Every staging, validation, hybrid, and local-preflight path consumes that one boundary. Cleanup is deliberately narrow so checked-in staging sources and unrelated output trees survive.

## Merge order

This PR must merge **after** the parallel Chromium GN PR from `task/claw-payload-manifests` / remote extraction branch `feat/claw-payload-manifests-patches` (currently commit `c3656e702099ee2c60d3417e086bfce23f093036`), or in the same release train after that commit. This Python change stages only two CRXs for release; the old GN list names all three as sources and would make Ninja fail on the inactive product's missing input.

## Test plan

- [x] `uv run python -m unittest bos_build.steps.extensions.bundled_extensions_test bos_build.products.products_test bos_build.core.context_test -v`
- [x] `uv run ruff check bos_build`
- [x] `uv run browseros product doctor`
- [x] `uv run python -m unittest discover -s bos_build -t . -p '*_test.py' -v` (668 tests)
- [x] Ruff formatting check for all eight touched Python files
