### PR TITLE
fix(windows): sign chrome.exe before installer packaging

### DIFF
--- a/packages/browseros/bos_build/core/planner.py
+++ b/packages/browseros/bos_build/core/planner.py
@@ -228,6 +228,8 @@ def _plan_release(switches: Switches, platform: str) -> List[str]:
 def _plan_debug(switches: Switches, platform: str) -> List[str]:
     steps: List[str] = []
     steps.extend(_provision_steps(switches))
+    if platform == "windows":
+        steps.append("winsparkle_setup")
     if switches.download:
         steps.append("download_resources")
     steps.extend(
@@ -242,6 +244,8 @@ def _plan_debug(switches: Switches, platform: str) -> List[str]:
     )
     if platform == "macos" and switches.sign:
         steps.append("sign_macos")
+    if platform == "windows":
+        steps.append("mini_installer")
     steps.append(f"package_{platform}")
     if switches.upload:
         steps.append("upload")

--- a/packages/browseros/bos_build/core/planner_test.py
+++ b/packages/browseros/bos_build/core/planner_test.py
@@ -242,6 +242,24 @@ class DebugGoldenTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "not supported for debug"):
             plan_runs(Switches(preset="debug", architectures=("universal",)), "macos")
 
+    def test_debug_windows_builds_installer_before_packaging(self):
+        self.assertEqual(
+            plan(Switches(preset="debug"), "x64", "windows"),
+            [
+                "git_setup",
+                "winsparkle_setup",
+                "download_resources",
+                "resources",
+                "chromium_replace",
+                "string_replaces",
+                "patches",
+                "configure",
+                "compile",
+                "mini_installer",
+                "package_windows",
+            ],
+        )
+
     def test_debug_rejection_wins_over_platform(self):
         with self.assertRaisesRegex(ValueError, "not supported for debug"):
             plan_runs(Switches(preset="debug", architectures=("universal",)), "linux")

--- a/packages/browseros/bos_build/steps/compile/standard.py
+++ b/packages/browseros/bos_build/steps/compile/standard.py
@@ -130,12 +130,13 @@ class CompileModule(Step):
         )
 
         app_path = ctx.get_chromium_app_path()
-        new_path = ctx.get_app_path()
+        built_app_path = app_path
+        if not IS_WINDOWS():
+            built_app_path = ctx.get_app_path()
+            if app_path.exists() and not built_app_path.exists():
+                shutil.move(str(app_path), str(built_app_path))
 
-        if app_path.exists() and not new_path.exists():
-            shutil.move(str(app_path), str(new_path))
-
-        ctx.artifact_registry.add("built_app", new_path)
+        ctx.artifact_registry.add("built_app", built_app_path)
 
         log_success("Build complete!")
 

--- a/packages/browseros/bos_build/steps/compile/standard_test.py
+++ b/packages/browseros/bos_build/steps/compile/standard_test.py
@@ -3,12 +3,13 @@
 
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from typing import cast
 from unittest import mock
 
 from . import standard
-from ...core.context import Context
+from ...core.context import ArtifactRegistry, Context
 
 
 class ComputeNinjaJobsTest(unittest.TestCase):
@@ -143,6 +144,68 @@ class CompileModuleExecuteTest(unittest.TestCase):
             ["autoninja", "-C", "out/Default_x64", "chrome", "chromedriver"],
         )
         self.assertEqual(run_cmd.call_args.kwargs["cwd"], ctx.chromium_src)
+
+    def test_windows_keeps_and_registers_chrome_exe(self):
+        with TemporaryDirectory() as tmp:
+            build_output_dir = Path(tmp) / "out" / "Default"
+            build_output_dir.mkdir(parents=True)
+            chrome_path = build_output_dir / "chrome.exe"
+            product_path = build_output_dir / "BrowserOS.exe"
+            chrome_path.write_bytes(b"chrome")
+            registry = ArtifactRegistry()
+            ctx = cast(
+                Context,
+                SimpleNamespace(
+                    out_dir="out/Default",
+                    chromium_src=Path(tmp),
+                    artifact_registry=registry,
+                    get_chromium_app_path=lambda: chrome_path,
+                    get_app_path=lambda: product_path,
+                ),
+            )
+
+            with (
+                mock.patch.object(standard, "IS_WINDOWS", return_value=True),
+                mock.patch.object(standard, "run_command"),
+                mock.patch.object(standard, "autoninja_command", return_value=[]),
+                mock.patch.object(standard.CompileModule, "_create_version_file"),
+            ):
+                standard.CompileModule().execute(ctx)
+
+            self.assertTrue(chrome_path.exists())
+            self.assertFalse(product_path.exists())
+            self.assertEqual(registry.get("built_app"), chrome_path)
+
+    def test_non_windows_keeps_product_rename(self):
+        with TemporaryDirectory() as tmp:
+            build_output_dir = Path(tmp) / "out" / "Default"
+            build_output_dir.mkdir(parents=True)
+            chrome_path = build_output_dir / "chrome"
+            product_path = build_output_dir / "browseros"
+            chrome_path.write_bytes(b"chrome")
+            registry = ArtifactRegistry()
+            ctx = cast(
+                Context,
+                SimpleNamespace(
+                    out_dir="out/Default",
+                    chromium_src=Path(tmp),
+                    artifact_registry=registry,
+                    get_chromium_app_path=lambda: chrome_path,
+                    get_app_path=lambda: product_path,
+                ),
+            )
+
+            with (
+                mock.patch.object(standard, "IS_WINDOWS", return_value=False),
+                mock.patch.object(standard, "run_command"),
+                mock.patch.object(standard, "autoninja_command", return_value=[]),
+                mock.patch.object(standard.CompileModule, "_create_version_file"),
+            ):
+                standard.CompileModule().execute(ctx)
+
+            self.assertFalse(chrome_path.exists())
+            self.assertEqual(product_path.read_bytes(), b"chrome")
+            self.assertEqual(registry.get("built_app"), product_path)
 
 
 class BuildTargetTest(unittest.TestCase):

--- a/packages/browseros/bos_build/steps/package/windows.py
+++ b/packages/browseros/bos_build/steps/package/windows.py
@@ -74,11 +74,30 @@ class WindowsPackageModule(Step):
 
         installer_path = self._create_installer(context)
         zip_path = self._create_portable_zip(context)
+        product_executable_path = self._copy_product_executable(context)
 
         context.artifact_registry.add("installer", installer_path)
         context.artifact_registry.add("installer_zip", zip_path)
+        context.artifact_registry.add("built_app", product_executable_path)
 
         log_success("Windows packages created successfully")
+
+    def _copy_product_executable(self, ctx: Context) -> Path:
+        """Create the product-named executable after installer packaging."""
+        chrome_path = ctx.get_chromium_app_path()
+        product_path = ctx.get_app_path()
+        if not chrome_path.exists():
+            raise RuntimeError(
+                f"Primary browser executable not found after packaging: {chrome_path}"
+            )
+
+        try:
+            shutil.copy2(chrome_path, product_path)
+        except Exception as e:
+            raise RuntimeError(f"Failed to create product executable: {e}") from e
+
+        log_success(f"Product executable created: {product_path.name}")
+        return product_path
 
     def _create_installer(self, ctx: Context) -> Path:
         build_output_dir = join_paths(ctx.chromium_src, ctx.out_dir)
@@ -119,6 +138,8 @@ class WindowsPackageModule(Step):
             return zip_path
         except Exception as e:
             raise RuntimeError(f"Failed to create installer ZIP: {e}")
+
+
 def build_mini_installer(ctx: Context) -> bool:
     """Build the mini_installer target if it doesn't exist"""
     log_info("\n🔨 Checking mini_installer build...")

--- a/packages/browseros/bos_build/steps/package/windows_test.py
+++ b/packages/browseros/bos_build/steps/package/windows_test.py
@@ -10,7 +10,8 @@ from unittest import mock
 
 from . import windows
 from ..compile import standard
-from ...core.context import Context
+from ...core.context import ArtifactRegistry, Context
+from ...core.products import get_product_descriptor
 from ...core.step import ValidationError
 
 
@@ -35,6 +36,88 @@ class BuildMiniInstallerTest(unittest.TestCase):
         )
         # Artifacts were never produced (run_command is mocked), so it reports failure.
         self.assertFalse(result)
+
+    def test_unsigned_step_leaves_product_alias_for_packaging(self):
+        for product_id in ("browseros", "browserclaw"):
+            with self.subTest(product=product_id), tempfile.TemporaryDirectory() as tmp:
+                product = get_product_descriptor(product_id)
+                build_output_dir = Path(tmp) / "out" / "Default"
+                build_output_dir.mkdir(parents=True)
+                chrome_path = build_output_dir / "chrome.exe"
+                product_path = build_output_dir / f"{product.app_base_name}.exe"
+                chrome_path.write_bytes(b"chrome")
+                ctx = cast(
+                    Context,
+                    SimpleNamespace(
+                        chromium_src=Path(tmp),
+                        out_dir="out/Default",
+                        get_app_path=lambda: product_path,
+                    ),
+                )
+
+                with mock.patch.object(
+                    windows, "build_mini_installer", return_value=True
+                ):
+                    windows.MiniInstallerModule().execute(ctx)
+
+                self.assertEqual(chrome_path.read_bytes(), b"chrome")
+                self.assertFalse(product_path.exists())
+
+
+class WindowsExecutableFinalizationTest(unittest.TestCase):
+    def test_product_alias_is_copied_after_installer_outputs(self):
+        for product_id in ("browseros", "browserclaw"):
+            with self.subTest(product=product_id), tempfile.TemporaryDirectory() as tmp:
+                product = get_product_descriptor(product_id)
+                root = Path(tmp)
+                build_output_dir = root / "out" / "Default"
+                build_output_dir.mkdir(parents=True)
+                chrome_path = build_output_dir / "chrome.exe"
+                product_path = build_output_dir / f"{product.app_base_name}.exe"
+                chrome_path.write_bytes(b"signed chrome")
+                product_path.write_bytes(b"stale product")
+                registry = ArtifactRegistry()
+                ctx = cast(
+                    Context,
+                    SimpleNamespace(
+                        chromium_src=root,
+                        out_dir="out/Default",
+                        artifact_registry=registry,
+                        get_chromium_app_path=lambda: chrome_path,
+                        get_app_path=lambda: product_path,
+                    ),
+                )
+                order = []
+                installer_path = root / "dist" / "installer.exe"
+                zip_path = root / "dist" / "installer.zip"
+
+                def create_installer(_ctx):
+                    self.assertEqual(product_path.read_bytes(), b"stale product")
+                    order.append("installer")
+                    return installer_path
+
+                def create_zip(_ctx):
+                    self.assertEqual(product_path.read_bytes(), b"stale product")
+                    order.append("zip")
+                    return zip_path
+
+                module = windows.WindowsPackageModule()
+                with (
+                    mock.patch.object(
+                        module, "_create_installer", side_effect=create_installer
+                    ),
+                    mock.patch.object(
+                        module, "_create_portable_zip", side_effect=create_zip
+                    ),
+                ):
+                    module.execute(ctx)
+
+                self.assertEqual(order, ["installer", "zip"])
+                self.assertEqual(chrome_path.read_bytes(), b"signed chrome")
+                self.assertEqual(product_path.read_bytes(), b"signed chrome")
+                self.assertEqual(registry.get("built_app"), product_path)
+                self.assertEqual(registry.get("installer"), installer_path)
+                self.assertEqual(registry.get("installer_zip"), zip_path)
 
 
 class WindowsPackageModuleValidateTest(unittest.TestCase):

--- a/packages/browseros/bos_build/steps/sign/windows.py
+++ b/packages/browseros/bos_build/steps/sign/windows.py
@@ -76,10 +76,10 @@ class WindowsSignModule(Step):
     def _sign_executables(self, build_output_dir: Path, ctx: Context) -> None:
         log_info("\nStep 1/3: Signing executables before packaging...")
         env = ctx.env
-        binaries_to_sign_first = [build_output_dir / "chrome.exe"]
-        binaries_to_sign_first.extend(
-            get_existing_browseros_server_binary_paths(build_output_dir, ctx.product.id)
-        )
+        chrome_path = build_output_dir / "chrome.exe"
+        if not chrome_path.exists():
+            raise RuntimeError(f"Missing primary browser executable: {chrome_path}")
+
         missing = get_missing_required_browseros_server_binary_paths(
             build_output_dir, ctx.product.id
         )
@@ -89,18 +89,14 @@ class WindowsSignModule(Step):
                 + ", ".join(str(path) for path in missing)
             )
 
-        existing_binaries = []
-        for binary in binaries_to_sign_first:
-            if binary.exists():
-                existing_binaries.append(binary)
-                log_info(f"Found binary to sign: {binary.name}")
-            else:
-                log_warning(f"Binary not found: {binary}")
+        binaries_to_sign = [chrome_path]
+        binaries_to_sign.extend(
+            get_existing_browseros_server_binary_paths(build_output_dir, ctx.product.id)
+        )
+        for binary in binaries_to_sign:
+            log_info(f"Found binary to sign: {binary.name}")
 
-        if not existing_binaries:
-            raise RuntimeError("No binaries found to sign")
-
-        if not sign_with_codesigntool(existing_binaries, env):
+        if not sign_with_codesigntool(binaries_to_sign, env):
             raise RuntimeError("Failed to sign executables")
 
     def _build_mini_installer(self, ctx: Context) -> None:

--- a/packages/browseros/bos_build/steps/sign/windows_test.py
+++ b/packages/browseros/bos_build/steps/sign/windows_test.py
@@ -109,6 +109,27 @@ class WindowsSignPathsTest(unittest.TestCase):
                     build_output_dir, self._ctx("browseros")
                 )
 
+    def test_missing_chrome_is_fatal_for_each_product(self):
+        for product_id in ("browseros", "browserclaw"):
+            with self.subTest(product=product_id), TemporaryDirectory() as tmp:
+                build_output_dir = Path(tmp)
+                for binary in get_browseros_server_binary_paths(
+                    build_output_dir, product_id
+                ):
+                    self._write_binary(binary)
+
+                with mock.patch(
+                    "bos_build.steps.sign.windows.sign_with_codesigntool"
+                ) as sign:
+                    with self.assertRaisesRegex(
+                        RuntimeError, "Missing primary browser executable:.*chrome.exe"
+                    ):
+                        WindowsSignModule()._sign_executables(
+                            build_output_dir, self._ctx(product_id)
+                        )
+
+                sign.assert_not_called()
+
     def test_browserclaw_requires_claw_binary(self):
         with TemporaryDirectory() as tmp:
             build_output_dir = Path(tmp)


### PR DESCRIPTION
## Summary

- keep Windows `chrome.exe` at Chromium's canonical path through executable signing and mini-installer construction
- fail signing immediately when the primary browser executable is missing
- copy the signed/built executable to `BrowserOS.exe` or `BrowserClaw.exe` only after Windows installer artifacts are created
- make the Windows debug plan build WinSparkle and the unsigned mini-installer before packaging

This contract applies equally to BrowserOS and BrowserClaw releases. Linux and macOS compile-time rename behavior is unchanged.

## Evidence

- [Windows release run 28836949185](https://github.com/browseros-ai/BrowserOS/actions/runs/28836949185) entered `sign_windows` and logged `Binary not found: ...\chrome.exe`, then proceeded with only the product server executable. This confirms the missing-primary-executable signing boundary on a fresh CI output directory.
- That job subsequently failed on signing-provider authentication before mini-installer construction. It therefore does **not** prove that a released installer shipped an unsigned `chrome.exe`; that artifact-level claim remains unverified.
- The source plan orders Windows release builds as `compile` → `sign_windows` or `mini_installer` → `package_windows`. Before this change, compile moved `chrome.exe` to the product name while signing still required `chrome.exe`.

## Design

Windows compile now registers and preserves `chrome.exe`. The signing step treats it as mandatory, signs it before building the mini-installer, and still signs the outer installer afterward. Both signed and unsigned routes converge on `package_windows`, which creates the installer and ZIP first, then uses `shutil.copy2` to overwrite the exact descriptor-derived product executable path without removing `chrome.exe` from Ninja's output graph.

## Test plan

- [x] missing `chrome.exe` is fatal for BrowserOS and BrowserClaw even when their server binaries exist
- [x] Windows compile preserves/registers `chrome.exe`; non-Windows compile keeps the existing rename
- [x] unsigned mini-installer construction leaves product aliasing to packaging
- [x] packaging creates installer outputs before overwriting `BrowserOS.exe` / `BrowserClaw.exe`, while preserving `chrome.exe`
- [x] Windows debug plan includes WinSparkle setup and mini-installer before package
- [x] `cd packages/browseros && uv run python -m unittest discover -s bos_build -t . -p "*_test.py" -v` (667 passed)
- [x] `cd packages/browseros && uv run ruff check bos_build`

