### PR TITLE
fix(build): stage bundled extensions in debug plans

### DIFF
--- a/packages/browseros/bos_build/core/planner.py
+++ b/packages/browseros/bos_build/core/planner.py
@@ -235,6 +235,7 @@ def _plan_debug(switches: Switches, platform: str) -> List[str]:
     steps.extend(
         [
             "resources",
+            "bundled_extensions",
             "chromium_replace",
             "string_replaces",
             "patches",

--- a/packages/browseros/bos_build/core/planner_test.py
+++ b/packages/browseros/bos_build/core/planner_test.py
@@ -221,14 +221,15 @@ class CiGoldenTest(unittest.TestCase):
 
 class DebugGoldenTest(unittest.TestCase):
     def test_debug_macos(self):
-        # config/debug.yaml — no clean, no bundled_extensions, no
-        # series_patches, no sparkle_setup, no sign, no upload
+        # config/debug.yaml — no clean, no series_patches, no sparkle_setup,
+        # no sign, no upload
         self.assertEqual(
             plan(Switches(preset="debug"), "arm64", "macos"),
             [
                 "git_setup",
                 "download_resources",
                 "resources",
+                "bundled_extensions",
                 "chromium_replace",
                 "string_replaces",
                 "patches",
@@ -250,6 +251,7 @@ class DebugGoldenTest(unittest.TestCase):
                 "winsparkle_setup",
                 "download_resources",
                 "resources",
+                "bundled_extensions",
                 "chromium_replace",
                 "string_replaces",
                 "patches",
@@ -257,6 +259,23 @@ class DebugGoldenTest(unittest.TestCase):
                 "compile",
                 "mini_installer",
                 "package_windows",
+            ],
+        )
+
+    def test_debug_linux(self):
+        self.assertEqual(
+            plan(Switches(preset="debug"), "x64", "linux"),
+            [
+                "git_setup",
+                "download_resources",
+                "resources",
+                "bundled_extensions",
+                "chromium_replace",
+                "string_replaces",
+                "patches",
+                "configure",
+                "compile",
+                "package_linux",
             ],
         )
 


### PR DESCRIPTION
## Summary

- stage the existing `bundled_extensions` step in every debug platform plan immediately after `resources`
- add explicit macOS, Windows, and Linux debug-plan goldens for the staging boundary
- preserve release/CI ordering and each platform's existing Chromium, installer, and packaging tail

## Design

The debug planner already owns one shared cross-platform core sequence. Adding the registered staging step there applies the existing debug three-extension union and stale-output cleanup uniformly before Chromium preparation, configuration, and compilation, without changing product selection or staging internals.

## Test plan

- [x] `cd packages/browseros && uv run python -m unittest bos_build.core.planner_test bos_build.core.context_test bos_build.steps.extensions.bundled_extensions_test -v` (95 passed)
- [x] `cd packages/browseros && uv run ruff check bos_build`
- [x] `git diff --check`
- [x] context-free adversarial review (clean)
