### PR TITLE
fix: clear BrowserClaw legacy CommandExecute CLSID

### DIFF
--- a/packages/browseros/bos_build/steps/patches/product_user_data_dir_test.py
+++ b/packages/browseros/bos_build/steps/patches/product_user_data_dir_test.py
@@ -186,7 +186,7 @@ class ProductUserDataDirPatchTest(unittest.TestCase):
                 'L"{0EF5669B-7FD7-4138-A91F-E466631ADE97}"',
             ),
             "legacy_command_execute_clsid": (
-                'L"{4472EEED-A982-4070-9C3A-543B16590A82}"',
+                'L""',
                 'L"{AFDDB293-0724-49E5-A4EC-1096BF6C84AF}"',
             ),
         }
@@ -225,7 +225,6 @@ class ProductUserDataDirPatchTest(unittest.TestCase):
         browserclaw, browseros = _product_identity_branches(install_modes)
         guid_fields = (
             "active_setup_guid",
-            "legacy_command_execute_clsid",
             "toast_activator_clsid",
             "elevator_clsid",
             "tracing_service_clsid",

--- a/packages/browseros/chromium_patches/chrome/install_static/chromium_install_modes.h
+++ b/packages/browseros/chromium_patches/chrome/install_static/chromium_install_modes.h
@@ -1,5 +1,5 @@
 diff --git a/chrome/install_static/chromium_install_modes.h b/chrome/install_static/chromium_install_modes.h
-index ee62888f89705a08a95f130505ebfafb246f4bc2..d8ad4b44254610d6ceb28a824ce6d89c7a9398d9 100644
+index ee62888f89705a08a95f130505ebfafb246f4bc2..a0835e7f66dd12edeed11c672368f2d6e4de92a8 100644
 --- a/chrome/install_static/chromium_install_modes.h
 +++ b/chrome/install_static/chromium_install_modes.h
 @@ -10,6 +10,7 @@
@@ -46,7 +46,7 @@ index ee62888f89705a08a95f130505ebfafb246f4bc2..d8ad4b44254610d6ceb28a824ce6d89c
 +    .pdf_prog_id_prefix = L"BClawPDF",
 +    .pdf_prog_id_description = L"BrowserClaw PDF Document",
 +    .active_setup_guid = L"{E9E65674-914E-4A29-83A9-A98D407446EC}",
-+    .legacy_command_execute_clsid = L"{4472EEED-A982-4070-9C3A-543B16590A82}",
++    .legacy_command_execute_clsid = L"",
 +    .toast_activator_clsid = {0xD0A19C03,
 +                              0xEE25,
 +                              0x463B,


### PR DESCRIPTION
## Summary
- set BrowserClaw legacy CommandExecute cleanup identity to the empty string because BrowserClaw never shipped that DelegateExecute handler
- preserve BrowserOS's shipped cleanup CLSID and update the patch contract test to exclude the empty BrowserClaw field from GUID parsing

## Design
Keep Windows install identity compile-time selected through `BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW)`. This is the narrow Approach C correction: only the historical cleanup identity changes; shared implemented interfaces and unrelated product identity remain untouched.

## Test plan
- [x] `sfmux pool build -- autoninja -C out/Default_browseros_arm64 chrome`
- [x] `uv run python -m unittest bos_build.steps.patches.product_user_data_dir_test -v`
- [x] `uv run browseros dev doctor`
- [x] `git diff --check`
- [x] extracted patch byte-matches Chromium and applies cleanly to `BASE_COMMIT`