### PR TITLE
fix(bos_build): argv-safe CodeSignTool invocation with redacted logging

### DIFF
--- a/packages/browseros/bos_build/steps/sign/windows.py
+++ b/packages/browseros/bos_build/steps/sign/windows.py
@@ -170,8 +170,30 @@ def get_missing_required_browseros_server_binary_paths(
 def build_mini_installer(ctx: Context) -> bool:
     """Build the mini_installer.exe"""
     from ..compile import build_target
+
     log_info("Building mini_installer target...")
     return build_target(ctx, "mini_installer")
+
+
+def _codesigntool_command_prefix(codesigntool_path: Path) -> List[str]:
+    if codesigntool_path.suffix.lower() == ".bat":
+        return ["cmd", "/c", str(codesigntool_path)]
+    return [str(codesigntool_path)]
+
+
+def _redact_codesigntool_secrets(text: str, env: EnvConfig) -> str:
+    secrets = [
+        env.esigner_password,
+        env.esigner_totp_secret,
+        env.esigner_credential_id,
+    ]
+    for secret in sorted((secret for secret in secrets if secret), key=len, reverse=True):
+        text = text.replace(secret, "***")
+    return text
+
+
+def _format_redacted_command(cmd: List[str], env: EnvConfig) -> str:
+    return _redact_codesigntool_secrets(" ".join(cmd), env)
 
 
 def sign_with_codesigntool(
@@ -221,13 +243,12 @@ def sign_with_codesigntool(
             temp_output_dir = binary.parent / "signed_temp"
             temp_output_dir.mkdir(exist_ok=True)
 
-            cmd = [
-                str(codesigntool_path),
+            cmd = _codesigntool_command_prefix(codesigntool_path) + [
                 "sign",
                 "-username",
                 env.esigner_username,
                 "-password",
-                f'"{env.esigner_password}"',
+                env.esigner_password,
             ]
 
             if env.esigner_credential_id:
@@ -245,12 +266,11 @@ def sign_with_codesigntool(
                 ]
             )
 
-            cmd_str = " ".join(cmd)
-            log_info(f"Running: {cmd_str}")
+            log_info(f"Running: {_format_redacted_command(cmd, env)}")
 
             result = subprocess.run(
-                cmd_str,
-                shell=True,
+                cmd,
+                shell=False,
                 capture_output=True,
                 text=True,
                 cwd=str(codesigntool_path.parent),
@@ -259,11 +279,11 @@ def sign_with_codesigntool(
             if result.stdout:
                 for line in result.stdout.split("\n"):
                     if line.strip():
-                        log_info(line.strip())
+                        log_info(_redact_codesigntool_secrets(line.strip(), env))
             if result.stderr:
                 for line in result.stderr.split("\n"):
                     if line.strip() and "WARNING" not in line:
-                        log_error(line.strip())
+                        log_error(_redact_codesigntool_secrets(line.strip(), env))
 
             if result.stdout and "Error:" in result.stdout:
                 log_error(
@@ -303,7 +323,8 @@ def sign_with_codesigntool(
                 log_warning(f"Could not verify signature for {binary.name}")
 
         except Exception as e:
-            log_error(f"Failed to sign {binary.name}: {e}")
+            error = _redact_codesigntool_secrets(str(e), env)
+            log_error(f"Failed to sign {binary.name}: {error}")
             all_success = False
 
     return all_success

--- a/packages/browseros/bos_build/steps/sign/windows_test.py
+++ b/packages/browseros/bos_build/steps/sign/windows_test.py
@@ -10,11 +10,14 @@ from unittest import mock
 
 from bos_build.core.context import Context
 from bos_build.core.products import get_product_descriptor
+from bos_build.lib.env import EnvConfig
+from . import windows as windows_module
 from .windows import (
     WindowsSignModule,
     get_browseros_server_binary_paths,
     get_existing_browseros_server_binary_paths,
     get_missing_required_browseros_server_binary_paths,
+    sign_with_codesigntool,
 )
 
 
@@ -128,6 +131,114 @@ class WindowsSignPathsTest(unittest.TestCase):
             Context,
             SimpleNamespace(product=get_product_descriptor(product), env=mock.Mock()),
         )
+
+
+class SignWithCodeSignToolInvocationTest(unittest.TestCase):
+    def test_bat_invocation_uses_argv_list_and_redacted_logs(self):
+        password = 'pa ss%"!^&word'
+        totp_secret = "totp%secret!^&"
+        credential_id = "credential id&123"
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tool_dir = root / "tool dir"
+            tool_dir.mkdir()
+            codesigntool = tool_dir / "CodeSignTool.bat"
+            codesigntool.write_text("@echo off\n")
+
+            binary_dir = root / "bin dir"
+            binary_dir.mkdir()
+            binary = binary_dir / "browser.exe"
+            binary.write_bytes(b"binary")
+
+            env = SimpleNamespace(
+                code_sign_tool_exe=None,
+                code_sign_tool_path=str(tool_dir),
+                esigner_username="signer@example.com",
+                esigner_password=password,
+                esigner_totp_secret=totp_secret,
+                esigner_credential_id=credential_id,
+            )
+            sign_result = SimpleNamespace(
+                stdout=f"signed with {password} and {totp_secret}\n",
+                stderr=f"using {credential_id}\n",
+            )
+            verify_result = SimpleNamespace(stdout="Valid\n", stderr="")
+            info_logs: list[str] = []
+            error_logs: list[str] = []
+
+            with (
+                mock.patch.object(
+                    windows_module.subprocess,
+                    "run",
+                    side_effect=[sign_result, verify_result],
+                ) as run,
+                mock.patch.object(
+                    windows_module, "log_info", side_effect=info_logs.append
+                ),
+                mock.patch.object(
+                    windows_module, "log_success", side_effect=info_logs.append
+                ),
+                mock.patch.object(
+                    windows_module, "log_error", side_effect=error_logs.append
+                ),
+            ):
+                self.assertTrue(sign_with_codesigntool([binary], cast(EnvConfig, env)))
+
+            sign_call = run.call_args_list[0]
+            sign_cmd = sign_call.args[0]
+            self.assertIsInstance(sign_cmd, list)
+            self.assertEqual(sign_cmd[:3], ["cmd", "/c", str(codesigntool)])
+            self.assertEqual(sign_call.kwargs["shell"], False)
+            self.assertEqual(sign_call.kwargs["cwd"], str(tool_dir))
+            self.assertEqual(sign_cmd[sign_cmd.index("-password") + 1], password)
+            self.assertNotIn(f'"{password}"', sign_cmd)
+
+            running_logs = [line for line in info_logs if line.startswith("Running:")]
+            self.assertEqual(len(running_logs), 1)
+            self.assertIn("-password ***", running_logs[0])
+            self.assertIn("-totp_secret ***", running_logs[0])
+            self.assertIn("-credential_id ***", running_logs[0])
+
+            all_logs = "\n".join(info_logs + error_logs)
+            self.assertNotIn(password, all_logs)
+            self.assertNotIn(totp_secret, all_logs)
+            self.assertNotIn(credential_id, all_logs)
+
+    def test_code_sign_tool_exe_runs_directly_as_argv(self):
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            codesigntool = root / "CodeSignTool.sh"
+            codesigntool.write_text("#!/bin/sh\n")
+            binary = root / "browser.exe"
+            binary.write_bytes(b"binary")
+
+            env = SimpleNamespace(
+                code_sign_tool_exe=str(codesigntool),
+                code_sign_tool_path=None,
+                esigner_username="signer@example.com",
+                esigner_password="password",
+                esigner_totp_secret="totp",
+                esigner_credential_id=None,
+            )
+            sign_result = SimpleNamespace(stdout="", stderr="")
+            verify_result = SimpleNamespace(stdout="Valid\n", stderr="")
+
+            with (
+                mock.patch.object(
+                    windows_module.subprocess,
+                    "run",
+                    side_effect=[sign_result, verify_result],
+                ) as run,
+                mock.patch.object(windows_module, "log_info"),
+                mock.patch.object(windows_module, "log_success"),
+                mock.patch.object(windows_module, "log_error"),
+            ):
+                self.assertTrue(sign_with_codesigntool([binary], cast(EnvConfig, env)))
+
+            sign_cmd = run.call_args_list[0].args[0]
+            self.assertEqual(sign_cmd[0], str(codesigntool))
+            self.assertNotEqual(sign_cmd[:3], ["cmd", "/c", str(codesigntool)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Run CodeSignTool with argv lists and shell=False, using cmd /c only for .bat dispatch.
- Remove manual password quote-wrapping and preserve the existing CodeSignTool cwd.
- Redact password, TOTP secret, and credential ID from command/output/error logs.
- Add Windows signing regression tests for .bat argv shape, exact password argv value, direct executable dispatch, and redacted logs.

Verification:
- uv run python -m unittest discover -s bos_build -t . -p '*_test.py'
- uv run ruff check bos_build