### PR TITLE
fix: cap release changelog entries

### DIFF
--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -83,18 +83,28 @@ jobs:
       - name: Generate release notes
         env:
           PREVIOUS_TAG: ${{ steps.release.outputs.previous_tag }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
           RELEASE_SHA: ${{ steps.release.outputs.release_sha }}
         run: |
           set -euo pipefail
+          CHANGELOG_FILE="/tmp/release-changelog.md"
+          NOTES_FILE="/tmp/release-notes.md"
 
           if [ -z "$PREVIOUS_TAG" ]; then
-            echo "Initial BrowserClaw Server Rust release." > /tmp/release-notes.md
+            echo "Initial BrowserClaw Server Rust release." > "$CHANGELOG_FILE"
           else
-            git log "$PREVIOUS_TAG..$RELEASE_SHA" --pretty=format:"- %s (%h)" > /tmp/release-notes.md
-            if [ ! -s /tmp/release-notes.md ]; then
-              echo "No commits since $PREVIOUS_TAG." > /tmp/release-notes.md
+            git log "$PREVIOUS_TAG..$RELEASE_SHA" --pretty=format:"- %s (%h)" > "$CHANGELOG_FILE"
+            if [ ! -s "$CHANGELOG_FILE" ]; then
+              echo "No commits since $PREVIOUS_TAG." > "$CHANGELOG_FILE"
             fi
           fi
+
+          node packages/browseros-agent/scripts/release/cap-release-changelog.mjs \
+            --input "$CHANGELOG_FILE" \
+            --output "$NOTES_FILE" \
+            --max-entries 15 \
+            --previous-tag "$PREVIOUS_TAG" \
+            --release-tag "$RELEASE_TAG"
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -96,18 +96,28 @@ jobs:
       - name: Generate release notes
         env:
           PREVIOUS_TAG: ${{ steps.release.outputs.previous_tag }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
           RELEASE_SHA: ${{ steps.release.outputs.release_sha }}
         run: |
           set -euo pipefail
+          CHANGELOG_FILE="/tmp/release-changelog.md"
+          NOTES_FILE="/tmp/release-notes.md"
 
           if [ -z "$PREVIOUS_TAG" ]; then
-            echo "Initial BrowserClaw Server release." > /tmp/release-notes.md
+            echo "Initial BrowserClaw Server release." > "$CHANGELOG_FILE"
           else
-            git log "$PREVIOUS_TAG..$RELEASE_SHA" --pretty=format:"- %s (%h)" > /tmp/release-notes.md
-            if [ ! -s /tmp/release-notes.md ]; then
-              echo "No commits since $PREVIOUS_TAG." > /tmp/release-notes.md
+            git log "$PREVIOUS_TAG..$RELEASE_SHA" --pretty=format:"- %s (%h)" > "$CHANGELOG_FILE"
+            if [ ! -s "$CHANGELOG_FILE" ]; then
+              echo "No commits since $PREVIOUS_TAG." > "$CHANGELOG_FILE"
             fi
           fi
+
+          node packages/browseros-agent/scripts/release/cap-release-changelog.mjs \
+            --input "$CHANGELOG_FILE" \
+            --output "$NOTES_FILE" \
+            --max-entries 15 \
+            --previous-tag "$PREVIOUS_TAG" \
+            --release-tag "$RELEASE_TAG"
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -93,6 +93,7 @@ jobs:
           CLI_PATH="packages/browseros-agent/apps/cli"
           TAG="${{ steps.release.outputs.tag }}"
           CHANGELOG_FILE="/tmp/release-changelog.md"
+          NOTES_FILE="/tmp/release-notes.md"
           PREV_TAG="${{ steps.release.outputs.previous_tag }}"
 
           if [ -z "$PREV_TAG" ]; then
@@ -119,8 +120,14 @@ jobs:
             fi
           fi
 
-          cat "$CHANGELOG_FILE" > /tmp/release-notes.md
-          cat >> /tmp/release-notes.md <<'EOF'
+          node packages/browseros-agent/scripts/release/cap-release-changelog.mjs \
+            --input "$CHANGELOG_FILE" \
+            --output "$NOTES_FILE" \
+            --max-entries 15 \
+            --previous-tag "$PREV_TAG" \
+            --release-tag "$TAG"
+
+          cat >> "$NOTES_FILE" <<'EOF'
 
           ## Install `browseros-cli`
 

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -105,18 +105,28 @@ jobs:
       - name: Generate release notes
         env:
           PREVIOUS_TAG: ${{ steps.release.outputs.previous_tag }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
           RELEASE_SHA: ${{ steps.release.outputs.release_sha }}
         run: |
           set -euo pipefail
+          CHANGELOG_FILE="/tmp/release-changelog.md"
+          NOTES_FILE="/tmp/release-notes.md"
 
           if [ -z "$PREVIOUS_TAG" ]; then
-            echo "Initial BrowserOS Server release." > /tmp/release-notes.md
+            echo "Initial BrowserOS Server release." > "$CHANGELOG_FILE"
           else
-            git log "$PREVIOUS_TAG..$RELEASE_SHA" --pretty=format:"- %s (%h)" > /tmp/release-notes.md
-            if [ ! -s /tmp/release-notes.md ]; then
-              echo "No commits since $PREVIOUS_TAG." > /tmp/release-notes.md
+            git log "$PREVIOUS_TAG..$RELEASE_SHA" --pretty=format:"- %s (%h)" > "$CHANGELOG_FILE"
+            if [ ! -s "$CHANGELOG_FILE" ]; then
+              echo "No commits since $PREVIOUS_TAG." > "$CHANGELOG_FILE"
             fi
           fi
+
+          node packages/browseros-agent/scripts/release/cap-release-changelog.mjs \
+            --input "$CHANGELOG_FILE" \
+            --output "$NOTES_FILE" \
+            --max-entries 15 \
+            --previous-tag "$PREVIOUS_TAG" \
+            --release-tag "$RELEASE_TAG"
 
       - name: Create GitHub release
         env:

--- a/packages/browseros-agent/scripts/build/cli/release-policy.test.ts
+++ b/packages/browseros-agent/scripts/build/cli/release-policy.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import {
   assertIncrementingRelease,
@@ -12,6 +12,30 @@ import {
   parseCliReleaseTag,
   selectPreviousCliReleaseTag,
 } from './release-policy'
+
+const repoRoot = resolve(import.meta.dir, '../../../../..')
+const cliReleaseWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/release-cli.yml'),
+  'utf8',
+)
+
+function cliGenerateReleaseNotesStep(): string {
+  const start = cliReleaseWorkflow.indexOf('- name: Generate release notes')
+  const end = cliReleaseWorkflow.indexOf('- name: Create GitHub release')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return cliReleaseWorkflow.slice(start, end)
+}
+
+function cliCreateGithubReleaseStep(): string {
+  const start = cliReleaseWorkflow.indexOf('- name: Create GitHub release')
+  const end = cliReleaseWorkflow.indexOf(
+    '- name: Verify GitHub release assets are public',
+  )
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return cliReleaseWorkflow.slice(start, end)
+}
 
 describe('parseCliReleaseTag', () => {
   test('parses cli release tags', () => {
@@ -160,6 +184,32 @@ describe('ensureTagReachableFromDefaultBranch', () => {
     } finally {
       rmSync(tmp, { recursive: true, force: true })
     }
+  })
+})
+
+describe('release-cli workflow changelog cap', () => {
+  test('caps only the isolated changelog before appending install instructions', () => {
+    const step = cliGenerateReleaseNotesStep()
+
+    expect(step).toContain('CHANGELOG_FILE="/tmp/release-changelog.md"')
+    expect(step).toContain('NOTES_FILE="/tmp/release-notes.md"')
+    expect(step).toContain(
+      'node packages/browseros-agent/scripts/release/cap-release-changelog.mjs',
+    )
+    expect(step).toContain('--max-entries 15')
+    expect(step).toContain('--previous-tag "$PREV_TAG"')
+    expect(step).toContain('--release-tag "$TAG"')
+    expect(step.indexOf('cap-release-changelog.mjs')).toBeLessThan(
+      step.indexOf('## Install `browseros-cli`'),
+    )
+  })
+
+  test('uses the capped notes file for both create and edit reruns', () => {
+    const createStep = cliCreateGithubReleaseStep()
+
+    expect(
+      createStep.match(/--notes-file \/tmp\/release-notes\.md/g),
+    ).toHaveLength(2)
   })
 })
 

--- a/packages/browseros-agent/scripts/release/cap-release-changelog.mjs
+++ b/packages/browseros-agent/scripts/release/cap-release-changelog.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+export const DEFAULT_MAX_ENTRIES = 15
+
+/** Builds the GitHub compare URL used when a release changelog is truncated. */
+export function buildCompareUrl(options) {
+  const previousTag = options.previousTag ?? ''
+  if (!previousTag) {
+    throw new Error('Cannot build a compare URL without a previous tag')
+  }
+
+  const releaseTag = options.releaseTag ?? ''
+  if (!releaseTag) {
+    throw new Error('Cannot build a compare URL without a release tag')
+  }
+
+  const repositoryUrl = resolveRepositoryUrl(options)
+  if (!repositoryUrl) {
+    throw new Error('Cannot build a compare URL without a repository URL')
+  }
+
+  return `${repositoryUrl}/compare/${encodeURIComponent(previousTag)}...${encodeURIComponent(releaseTag)}`
+}
+
+/** Caps a changelog-only Markdown fragment while leaving non-entry prose intact. */
+export function renderCappedChangelog(content, options = {}) {
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES
+  assertMaxEntries(maxEntries)
+
+  const lines = content.replace(/\r\n/g, '\n').split('\n')
+  if (lines.at(-1) === '') {
+    lines.pop()
+  }
+
+  let entryCount = 0
+  let lastKeptEntryIndex = -1
+  const output = []
+
+  for (const line of lines) {
+    if (isChangelogEntry(line)) {
+      entryCount += 1
+      if (entryCount > maxEntries) {
+        continue
+      }
+      lastKeptEntryIndex = output.length
+    }
+
+    output.push(line)
+  }
+
+  if (entryCount <= maxEntries) {
+    return content
+  }
+
+  const compareUrl = buildCompareUrl(options)
+  output.splice(
+    lastKeptEntryIndex + 1,
+    0,
+    '',
+    `_Showing the latest ${maxEntries} of ${entryCount} changes. [View the full changelog](${compareUrl})._`,
+  )
+
+  return `${output.join('\n')}\n`
+}
+
+function isChangelogEntry(line) {
+  return line.startsWith('- ')
+}
+
+function assertMaxEntries(maxEntries) {
+  if (!Number.isInteger(maxEntries) || maxEntries < 1) {
+    throw new Error(`Expected --max-entries to be a positive integer`)
+  }
+}
+
+function resolveRepositoryUrl(options) {
+  if (options.repositoryUrl) {
+    return normalizeRepositoryUrl(options.repositoryUrl)
+  }
+
+  const serverUrl = options.githubServerUrl ?? process.env.GITHUB_SERVER_URL
+  const repository = options.githubRepository ?? process.env.GITHUB_REPOSITORY
+  if (serverUrl && repository) {
+    return normalizeRepositoryUrl(
+      `${serverUrl.replace(/\/+$/, '')}/${repository.replace(/^\/+|\/+$/g, '')}`,
+    )
+  }
+
+  return detectOriginRepositoryUrl(options.repositoryRoot ?? process.cwd())
+}
+
+function detectOriginRepositoryUrl(repositoryRoot) {
+  try {
+    return normalizeRepositoryUrl(
+      execFileSync('git', ['config', '--get', 'remote.origin.url'], {
+        cwd: repositoryRoot,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim(),
+    )
+  } catch {
+    return ''
+  }
+}
+
+function normalizeRepositoryUrl(repositoryUrl) {
+  const trimmed = repositoryUrl
+    .trim()
+    .replace(/\/+$/, '')
+    .replace(/\.git$/, '')
+  const scpLike = trimmed.match(/^git@([^:]+):(.+)$/)
+  if (scpLike) {
+    return `https://${scpLike[1]}/${scpLike[2].replace(/\.git$/, '')}`
+  }
+
+  const ssh = trimmed.match(/^ssh:\/\/git@([^/]+)\/(.+)$/)
+  if (ssh) {
+    return `https://${ssh[1]}/${ssh[2].replace(/\.git$/, '')}`
+  }
+
+  return trimmed
+}
+
+function parseArgs(args) {
+  const options = {}
+  for (let index = 0; index < args.length; index += 1) {
+    const raw = args[index]
+    if (!raw.startsWith('--')) {
+      throw new Error(`Unexpected argument ${raw}`)
+    }
+
+    const key = raw.slice(2)
+    const value = args[index + 1]
+    if (value === undefined) {
+      throw new Error(`Missing value for --${key}`)
+    }
+
+    options[key] = value
+    index += 1
+  }
+  return options
+}
+
+function requireOption(options, key) {
+  const value = options[key]
+  if (value === undefined || value === '') {
+    throw new Error(`Missing --${key}`)
+  }
+  return value
+}
+
+function toCliOptions(args) {
+  const parsed = parseArgs(args)
+  const maxEntries = parsed['max-entries']
+    ? Number(parsed['max-entries'])
+    : DEFAULT_MAX_ENTRIES
+
+  return {
+    input: requireOption(parsed, 'input'),
+    output: requireOption(parsed, 'output'),
+    maxEntries,
+    previousTag: parsed['previous-tag'] ?? '',
+    releaseTag: parsed['release-tag'] ?? '',
+    repositoryUrl: parsed['repository-url'] ?? '',
+    githubServerUrl: parsed['github-server-url'] ?? '',
+    githubRepository: parsed['github-repository'] ?? '',
+    repositoryRoot: parsed['repository-root'] ?? process.cwd(),
+  }
+}
+
+function main() {
+  const options = toCliOptions(process.argv.slice(2))
+  const content = readFileSync(options.input, 'utf-8')
+  const rendered = renderCappedChangelog(content, options)
+  writeFileSync(options.output, rendered)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`::error::${message}`)
+    process.exit(1)
+  }
+}

--- a/packages/browseros-agent/scripts/release/cap-release-changelog.test.ts
+++ b/packages/browseros-agent/scripts/release/cap-release-changelog.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'bun:test'
+
+import {
+  buildCompareUrl,
+  renderCappedChangelog,
+} from './cap-release-changelog.mjs'
+
+const repositoryUrl = 'https://github.test/browseros-ai/BrowserOS'
+const previousTag = 'claw-server/v0.0.5'
+const releaseTag = 'claw-server/v0.0.6'
+
+function changelogEntries(count: number): string {
+  return Array.from({ length: count }, (_, index) => `- change ${index + 1}`)
+    .join('\n')
+    .concat('\n')
+}
+
+function render(content: string): string {
+  return renderCappedChangelog(content, {
+    maxEntries: 15,
+    previousTag,
+    releaseTag,
+    repositoryUrl,
+  })
+}
+
+function changelistEntries(content: string): string[] {
+  return content.split('\n').filter((line) => line.startsWith('- '))
+}
+
+describe('renderCappedChangelog', () => {
+  it('preserves empty changelogs', () => {
+    expect(render('No notable changes.\n')).toBe('No notable changes.\n')
+  })
+
+  it('preserves a single changelog entry without a compare link', () => {
+    expect(render(changelogEntries(1))).toBe('- change 1\n')
+  })
+
+  it('preserves exactly fifteen changelog entries without a compare link', () => {
+    const content = changelogEntries(15)
+
+    expect(render(content)).toBe(content)
+  })
+
+  it('keeps the newest fifteen entries and appends a compare link', () => {
+    const result = render(changelogEntries(17))
+
+    expect(changelistEntries(result)).toHaveLength(15)
+    expect(result).toContain('- change 1')
+    expect(result).toContain('- change 15')
+    expect(result).not.toContain('- change 16')
+    expect(result).not.toContain('- change 17')
+    expect(result).toContain(
+      '_Showing the latest 15 of 17 changes. [View the full changelog](https://github.test/browseros-ai/BrowserOS/compare/claw-server%2Fv0.0.5...claw-server%2Fv0.0.6)._',
+    )
+  })
+
+  it('places the truncation notice after the retained changelist', () => {
+    const result = render(`## What's Changed\n\n${changelogEntries(16)}`)
+
+    expect(result.indexOf('- change 15')).toBeLessThan(
+      result.indexOf('_Showing the latest 15 of 16 changes.'),
+    )
+    expect(
+      result.indexOf('_Showing the latest 15 of 16 changes.'),
+    ).toBeLessThan(result.length)
+  })
+
+  it('preserves initial release text when no previous tag exists', () => {
+    const content = 'Initial BrowserClaw Server release.\n'
+
+    expect(
+      renderCappedChangelog(content, {
+        maxEntries: 15,
+        previousTag: '',
+        releaseTag,
+        repositoryUrl,
+      }),
+    ).toBe(content)
+  })
+
+  it('does not fabricate a compare URL when truncation needs a previous tag', () => {
+    expect(() =>
+      renderCappedChangelog(changelogEntries(16), {
+        maxEntries: 15,
+        previousTag: '',
+        releaseTag,
+        repositoryUrl,
+      }),
+    ).toThrow('previous tag')
+  })
+})
+
+describe('buildCompareUrl', () => {
+  it('encodes slash-containing release tags', () => {
+    expect(
+      buildCompareUrl({
+        previousTag: 'cli/v0.4.0',
+        releaseTag: 'cli/v0.4.1',
+        repositoryUrl: 'https://github.com/browseros-ai/BrowserOS.git',
+      }),
+    ).toBe(
+      'https://github.com/browseros-ai/BrowserOS/compare/cli%2Fv0.4.0...cli%2Fv0.4.1',
+    )
+  })
+
+  it('can build from GitHub Actions server and repository values', () => {
+    expect(
+      buildCompareUrl({
+        previousTag,
+        releaseTag,
+        githubServerUrl: 'https://github.enterprise.test/',
+        githubRepository: '/browseros-ai/BrowserOS/',
+      }),
+    ).toBe(
+      'https://github.enterprise.test/browseros-ai/BrowserOS/compare/claw-server%2Fv0.0.5...claw-server%2Fv0.0.6',
+    )
+  })
+})

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -10,6 +10,23 @@ const workflow = readFileSync(
 const shellChannelPlaceholder = '$' + '{channel}'
 const shellTargetPlaceholder = '$' + '{target}'
 const shellAssetsPlaceholder = '$' + '{assets[@]}'
+const releaseTagOutput = '$' + '{{ steps.release.outputs.tag }}'
+
+function generateReleaseNotesStep(): string {
+  const start = workflow.indexOf('- name: Generate release notes')
+  const end = workflow.indexOf('- name: Create GitHub release')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return workflow.slice(start, end)
+}
+
+function createGithubReleaseStep(): string {
+  const start = workflow.indexOf('- name: Create GitHub release')
+  const end = workflow.indexOf('  cargo-test:')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return workflow.slice(start, end)
+}
 
 describe('release-claw-server-rust workflow', () => {
   it('uses the Rust claw tag trigger and workflow_call contract', () => {
@@ -93,5 +110,23 @@ describe('release-claw-server-rust workflow', () => {
       `gh release upload "$RELEASE_TAG" "${shellAssetsPlaceholder}" --clobber`,
     )
     expect(workflow).toContain('Expected 5 Rust server resource zips')
+  })
+
+  it('caps generated changelogs before create and edit consume release notes', () => {
+    const step = generateReleaseNotesStep()
+    const createStep = createGithubReleaseStep()
+
+    expect(step).toContain(`RELEASE_TAG: ${releaseTagOutput}`)
+    expect(step).toContain('CHANGELOG_FILE="/tmp/release-changelog.md"')
+    expect(step).toContain('NOTES_FILE="/tmp/release-notes.md"')
+    expect(step).toContain(
+      'node packages/browseros-agent/scripts/release/cap-release-changelog.mjs',
+    )
+    expect(step).toContain('--max-entries 15')
+    expect(step).toContain('--previous-tag "$PREVIOUS_TAG"')
+    expect(step).toContain('--release-tag "$RELEASE_TAG"')
+    expect(
+      createStep.match(/--notes-file \/tmp\/release-notes\.md/g),
+    ).toHaveLength(2)
   })
 })

--- a/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
@@ -14,12 +14,29 @@ const shellVersionPlaceholder = '$' + '{VERSION}'
 const shellTargetPlaceholder = '$' + '{target}'
 const shellServerAssetsPlaceholder = '$' + '{server_assets[@]}'
 const publishOtaIf = '$' + '{{ inputs.publish_ota == true }}'
+const releaseTagOutput = '$' + '{{ steps.release.outputs.tag }}'
 const expectedBumpBranch = `chore-bump-claw-server-v${shellVersionPlaceholder}`
 
 function reflectVersionStep(): string {
   const start = workflow.indexOf('- name: Reflect version on main via PR')
   expect(start).toBeGreaterThanOrEqual(0)
   return workflow.slice(start)
+}
+
+function generateReleaseNotesStep(): string {
+  const start = workflow.indexOf('- name: Generate release notes')
+  const end = workflow.indexOf('- name: Create GitHub release')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return workflow.slice(start, end)
+}
+
+function createGithubReleaseStep(): string {
+  const start = workflow.indexOf('- name: Create GitHub release')
+  const end = workflow.indexOf('  build-publish:')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return workflow.slice(start, end)
 }
 
 describe('release-claw-server workflow', () => {
@@ -73,5 +90,23 @@ describe('release-claw-server workflow', () => {
     expect(step).not.toContain('continue-on-error: true')
     expect(step).toContain('GITHUB_STEP_SUMMARY')
     expect(step).toContain('::error::')
+  })
+
+  it('caps generated changelogs before create and edit consume release notes', () => {
+    const step = generateReleaseNotesStep()
+    const createStep = createGithubReleaseStep()
+
+    expect(step).toContain(`RELEASE_TAG: ${releaseTagOutput}`)
+    expect(step).toContain('CHANGELOG_FILE="/tmp/release-changelog.md"')
+    expect(step).toContain('NOTES_FILE="/tmp/release-notes.md"')
+    expect(step).toContain(
+      'node packages/browseros-agent/scripts/release/cap-release-changelog.mjs',
+    )
+    expect(step).toContain('--max-entries 15')
+    expect(step).toContain('--previous-tag "$PREVIOUS_TAG"')
+    expect(step).toContain('--release-tag "$RELEASE_TAG"')
+    expect(
+      createStep.match(/--notes-file \/tmp\/release-notes\.md/g),
+    ).toHaveLength(2)
   })
 })

--- a/packages/browseros-agent/scripts/release/release-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-server-workflow.test.ts
@@ -12,12 +12,29 @@ const shellVersionPlaceholder = '$' + '{VERSION}'
 const shellTargetPlaceholder = '$' + '{target}'
 const shellAssetsPlaceholder = '$' + '{assets[@]}'
 const publishOtaIf = '$' + '{{ inputs.publish_ota == true }}'
+const releaseTagOutput = '$' + '{{ steps.release.outputs.tag }}'
 const expectedBumpBranch = `chore-bump-server-v${shellVersionPlaceholder}`
 
 function reflectVersionStep(): string {
   const start = workflow.indexOf('- name: Reflect version on main via PR')
   expect(start).toBeGreaterThanOrEqual(0)
   return workflow.slice(start)
+}
+
+function generateReleaseNotesStep(): string {
+  const start = workflow.indexOf('- name: Generate release notes')
+  const end = workflow.indexOf('- name: Create GitHub release')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return workflow.slice(start, end)
+}
+
+function createGithubReleaseStep(): string {
+  const start = workflow.indexOf('- name: Create GitHub release')
+  const end = workflow.indexOf('  build-publish:')
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return workflow.slice(start, end)
 }
 
 describe('release-server workflow', () => {
@@ -81,5 +98,23 @@ describe('release-server workflow', () => {
     expect(workflow).toContain(
       'uv run browseros ota server release --version "$VERSION" --channel alpha --product browseros',
     )
+  })
+
+  it('caps generated changelogs before create and edit consume release notes', () => {
+    const step = generateReleaseNotesStep()
+    const createStep = createGithubReleaseStep()
+
+    expect(step).toContain(`RELEASE_TAG: ${releaseTagOutput}`)
+    expect(step).toContain('CHANGELOG_FILE="/tmp/release-changelog.md"')
+    expect(step).toContain('NOTES_FILE="/tmp/release-notes.md"')
+    expect(step).toContain(
+      'node packages/browseros-agent/scripts/release/cap-release-changelog.mjs',
+    )
+    expect(step).toContain('--max-entries 15')
+    expect(step).toContain('--previous-tag "$PREVIOUS_TAG"')
+    expect(step).toContain('--release-tag "$RELEASE_TAG"')
+    expect(
+      createStep.match(/--notes-file \/tmp\/release-notes\.md/g),
+    ).toHaveLength(2)
   })
 })


### PR DESCRIPTION
## Summary
- add a shared zero-dependency release changelog limiter with GitHub compare links
- wire server, claw-server, claw-server-rust, and CLI release workflows through the limiter before release create/edit
- cover helper behavior and workflow contracts for truncation, initial/empty releases, CLI install notes, and reruns

## Verification
- bun test scripts/release/cap-release-changelog.test.ts scripts/release/release-server-workflow.test.ts scripts/release/release-claw-server-workflow.test.ts scripts/release/release-claw-server-rust-workflow.test.ts scripts/build/cli/release-policy.test.ts
- git diff --check
- bun run check
- node packages/browseros-agent/scripts/release/cap-release-changelog.mjs smoke test with 16 entries
