### PR TITLE
fix(claw-server): write Claude Code HTTP transport type

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/lib/migrate-mcp-urls.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/migrate-mcp-urls.ts
@@ -29,11 +29,12 @@
  */
 
 import { rename } from 'node:fs/promises'
-import type { BoundApi, McpServerSpec } from 'agent-mcp-manager'
+import type { AgentId, BoundApi, McpServerSpec } from 'agent-mcp-manager'
 import {
   type StoredAgentProfile,
   storedAgentProfileSchema,
 } from '../routes/agents/schemas'
+import { tagClaudeCodeHttpEntry } from '../services/mcp-relink'
 import { resolveClawServerPath } from './browserclaw-dir'
 import { logger } from './logger'
 import { getMcpManager } from './mcp-manager'
@@ -136,17 +137,17 @@ async function relinkOne(
   mgr: BoundApi,
   serverName: string,
   nextSpec: McpServerSpec,
-  agent: string,
+  agent: AgentId,
   fromUrl: string,
   toUrl: string,
 ): Promise<boolean> {
   try {
     await mgr.link({
       server: { name: serverName, spec: nextSpec },
-      // biome-ignore lint/suspicious/noExplicitAny: agent is a manifest AgentId key threaded through opaque catalog types
-      agent: agent as any,
+      agent,
       allowOverwrite: true,
     })
+    await tagClaudeCodeHttpEntry(mgr, agent, nextSpec, serverName)
     logger.info('mcpUrl migration: relinked', {
       serverName,
       agent,

--- a/packages/browseros-agent/apps/claw-server/src/services/integrity-scan.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/integrity-scan.ts
@@ -21,6 +21,7 @@
 
 import { logger } from '../lib/logger'
 import { getMcpManager } from '../lib/mcp-manager'
+import { tagClaudeCodeHttpEntry } from './mcp-relink'
 
 export interface IntegrityScanOutcome {
   verified: number
@@ -58,6 +59,7 @@ export async function runIntegrityScan(): Promise<IntegrityScanOutcome> {
         scope: entry.scope,
         allowOverwrite: true,
       })
+      await tagClaudeCodeHttpEntry(mgr, entry.agent, spec, entry.serverName)
       healed++
       logger.info('integrity scan: healed drifted entry', {
         serverName: entry.serverName,

--- a/packages/browseros-agent/apps/claw-server/src/services/mcp-relink.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/mcp-relink.ts
@@ -9,17 +9,19 @@
  * lives in one place. On failure, restores the previous link so a
  * partial write does not orphan the entry.
  *
- * Since agent-mcp-manager 0.0.4 the library emits the Claude Code
- * `type: "http"` transport tag natively at the catalog layer, so
- * the post-write fixup that used to live here retired.
+ * agent-mcp-manager 0.0.4-rc.3 omits Claude Code's required
+ * `type: "http"` transport tag, so the shared add-only repair runs
+ * immediately after the managed write.
  */
 
+import { ensureClaudeCodeHttpTransportTag } from '@browseros/shared/mcp/claude-code-transport-tag'
 import type {
   AgentId,
   BoundApi,
   LinkPlanSummary,
   McpServerSpec,
 } from 'agent-mcp-manager'
+import { logger } from '../lib/logger'
 
 interface RelinkManagedServerOptions {
   mgr: BoundApi
@@ -39,11 +41,13 @@ export async function relinkManagedServer({
 }: RelinkManagedServerOptions): Promise<LinkPlanSummary> {
   const previousSpec = await findExistingSpec(mgr, serverName)
   try {
-    return await mgr.link({
+    const result = await mgr.link({
       server: { name: serverName, spec },
       agent,
       ...(allowOverwrite ? { allowOverwrite } : {}),
     })
+    await tagClaudeCodeHttpEntry(mgr, agent, spec, serverName)
+    return result
   } catch (err) {
     if (previousSpec) {
       try {
@@ -52,6 +56,7 @@ export async function relinkManagedServer({
           agent,
           ...(allowOverwrite ? { allowOverwrite } : {}),
         })
+        await tagClaudeCodeHttpEntry(mgr, agent, previousSpec, serverName)
       } catch (restoreErr) {
         const relinkMessage = err instanceof Error ? err.message : String(err)
         const restoreMessage =
@@ -62,6 +67,43 @@ export async function relinkManagedServer({
       }
     }
     throw err
+  }
+}
+
+async function tagClaudeCodeHttpEntry(
+  mgr: BoundApi,
+  agent: AgentId,
+  spec: McpServerSpec,
+  serverName: string,
+): Promise<void> {
+  if (agent !== 'claude-code' || spec.transport !== 'http') return
+
+  try {
+    const links = await mgr.listLinks({
+      serverNames: [serverName],
+      agents: [agent],
+    })
+    const configPath = links.find(
+      (link) => link.serverName === serverName && link.agent === agent,
+    )?.configPath
+    if (!configPath) {
+      logger.warn('Claude Code MCP link path missing; skipped transport tag', {
+        serverName,
+      })
+      return
+    }
+    await ensureClaudeCodeHttpTransportTag({
+      configPath,
+      serverName,
+      expectedUrl: spec.url,
+      onlyIfMissing: true,
+      logger,
+    })
+  } catch (err) {
+    logger.warn('Failed to locate Claude Code MCP config for transport tag', {
+      serverName,
+      error: err instanceof Error ? err.message : String(err),
+    })
   }
 }
 

--- a/packages/browseros-agent/apps/claw-server/src/services/mcp-relink.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/mcp-relink.ts
@@ -3,11 +3,10 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Choke-point relink for a managed MCP server. Every claw-server
- * write path (Connect button, profile install, profile reconcile,
- * boot URL migration) funnels through here so the transport rule
- * lives in one place. On failure, restores the previous link so a
- * partial write does not orphan the entry.
+ * Choke-point relink for a managed MCP server. Connect and profile
+ * install paths funnel through here; direct boot repair links call
+ * the exported transport-tag helper below. On failure, restores the
+ * previous link so a partial write does not orphan the entry.
  *
  * agent-mcp-manager 0.0.4-rc.3 omits Claude Code's required
  * `type: "http"` transport tag, so the shared add-only repair runs
@@ -70,7 +69,7 @@ export async function relinkManagedServer({
   }
 }
 
-async function tagClaudeCodeHttpEntry(
+export async function tagClaudeCodeHttpEntry(
   mgr: BoundApi,
   agent: AgentId,
   spec: McpServerSpec,

--- a/packages/browseros-agent/apps/claw-server/tests/lib/migrate-mcp-urls.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/migrate-mcp-urls.test.ts
@@ -46,6 +46,66 @@ describe('migrateMcpUrls', () => {
     })
   })
 
+  test('keeps the Claude Code HTTP type when migrating the managed URL', async () => {
+    await withTempBrowserClawDir(async (root) => {
+      const configPath = join(root, '.claude.json')
+      const oldUrl = 'http://127.0.0.1:8080/mcp'
+      const newUrl = 'http://127.0.0.1:9200/mcp'
+      const originalConfig = {
+        theme: 'dark',
+        mcpServers: {
+          context7: { type: 'stdio', command: 'npx' },
+        },
+      }
+      await writeFile(
+        configPath,
+        `${JSON.stringify(originalConfig, null, 2)}\n`,
+        'utf8',
+      )
+
+      const stub = createStubMcpManager()
+      const originalLink = stub.link
+      stub.link = async (input) => {
+        const result = await originalLink({ ...input, configPath })
+        if (input.server.spec.transport !== 'http') {
+          throw new Error('expected an HTTP BrowserClaw spec')
+        }
+        const config = JSON.parse(await readFile(configPath, 'utf8')) as {
+          theme: string
+          mcpServers: Record<string, unknown>
+        }
+        config.mcpServers[input.server.name] = {
+          url: input.server.spec.url,
+        }
+        await writeFile(
+          configPath,
+          `${JSON.stringify(config, null, 2)}\n`,
+          'utf8',
+        )
+        return result
+      }
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: oldUrl },
+        },
+        agent: 'claude-code',
+      })
+      setMcpManagerForTesting(stub)
+      stub.reset()
+
+      await migrateMcpUrls(newUrl)
+
+      expect(JSON.parse(await readFile(configPath, 'utf8'))).toEqual({
+        ...originalConfig,
+        mcpServers: {
+          ...originalConfig.mcpServers,
+          BrowserClaw: { url: newUrl, type: 'http' },
+        },
+      })
+    })
+  })
+
   test('skips a server whose spec URL already matches the target', async () => {
     await withTempBrowserClawDir(async () => {
       const stub = createStubMcpManager()

--- a/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
@@ -18,6 +18,7 @@ import {
   disconnectBrowserosFromHarness,
   listBrowserosConnections,
 } from '../../src/services/browseros-connect'
+import { relinkManagedServer } from '../../src/services/mcp-relink'
 import { createStubMcpManager } from '../_helpers/stub-mcp-manager'
 
 const ORIGINAL_SERVER_PORT = env.serverPort
@@ -140,6 +141,7 @@ describe('connectBrowserosToHarness', () => {
     }
     expect(payload.server.spec.transport).toBe('http')
     expect(payload.server.spec.url).toBe('http://127.0.0.1:9200/mcp')
+    expect(stub.calls.some((call) => call.method === 'listLinks')).toBe(false)
   })
 
   it('falls back to the server bind port when no proxy port is configured', async () => {
@@ -185,32 +187,69 @@ describe('connectBrowserosToHarness', () => {
   })
 
   it('restores the previous BrowserClaw spec when the replacement link throws', async () => {
-    const stub = createStubMcpManager()
-    stub.seedServer({
-      name: 'BrowserClaw',
-      spec: { transport: 'http', url: 'http://127.0.0.1:8080/mcp' },
-    })
-    // First link call throws; the second (restore) succeeds via the
-    // default in-memory link behaviour.
-    let calls = 0
-    const originalLink = stub.link
-    stub.link = async (input) => {
-      calls++
-      if (calls === 1) throw new Error('replacement failed')
-      return originalLink(input)
+    const dir = await mkdtemp(join(tmpdir(), 'browserclaw-restore-'))
+    const configPath = join(dir, '.claude.json')
+    try {
+      const stub = createStubMcpManager()
+      stub.seedServer({
+        name: 'BrowserClaw',
+        spec: { transport: 'http', url: 'http://127.0.0.1:8080/mcp' },
+      })
+      let calls = 0
+      const originalLink = stub.link
+      stub.link = async (input) => {
+        calls++
+        if (calls === 1) throw new Error('replacement failed')
+        const result = await originalLink({ ...input, configPath })
+        if (input.server.spec.transport !== 'http') {
+          throw new Error('expected an HTTP BrowserClaw spec')
+        }
+        await writeFile(
+          configPath,
+          `${JSON.stringify({
+            mcpServers: {
+              BrowserClaw: { url: input.server.spec.url },
+            },
+          })}\n`,
+          'utf8',
+        )
+        return result
+      }
+      setMcpManagerForTesting(stub)
+
+      const result = await connectBrowserosToHarness('Claude Code')
+      expect(result.installed).toBe(false)
+      expect(result.message).toContain('replacement failed')
+      const servers = await stub.list()
+      const bc = servers.find((s) => s.name === 'BrowserClaw')
+      expect(bc?.spec).toMatchObject({
+        transport: 'http',
+        url: 'http://127.0.0.1:8080/mcp',
+      })
+      expect(JSON.parse(await readFile(configPath, 'utf8'))).toEqual({
+        mcpServers: {
+          BrowserClaw: {
+            url: 'http://127.0.0.1:8080/mcp',
+            type: 'http',
+          },
+        },
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
     }
-    setMcpManagerForTesting(stub)
-    const result = await connectBrowserosToHarness('Claude Code')
-    expect(result.installed).toBe(false)
-    expect(result.message).toContain('replacement failed')
-    // The manifest should still hold the previous spec after the
-    // restore. Verify by listing servers.
-    const servers = await stub.list()
-    const bc = servers.find((s) => s.name === 'BrowserClaw')
-    expect(bc?.spec).toMatchObject({
-      transport: 'http',
-      url: 'http://127.0.0.1:8080/mcp',
+  })
+})
+
+describe('relinkManagedServer transport tag guard', () => {
+  it('does not inspect config links for a Claude Code stdio relink', async () => {
+    const stub = createStubMcpManager()
+    await relinkManagedServer({
+      mgr: stub,
+      serverName: 'BrowserClaw',
+      agent: 'claude-code',
+      spec: { transport: 'stdio', command: 'npx', args: ['mcp-remote'] },
     })
+    expect(stub.calls.some((call) => call.method === 'listLinks')).toBe(false)
   })
 })
 

--- a/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
@@ -5,6 +5,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { env } from '../../src/env'
 import {
   resetMcpManagerForTesting,
@@ -53,6 +56,77 @@ describe('connectBrowserosToHarness', () => {
     // rebuild, prior manifest). allowOverwrite skips the library's
     // ForeignEntryError safety net for this specific server name.
     expect(payload.allowOverwrite).toBe(true)
+  })
+
+  it('adds the Claude Code HTTP type without changing other user config', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'browserclaw-claude-code-'))
+    const configPath = join(dir, '.claude.json')
+    try {
+      const originalConfig = {
+        numStartups: 12,
+        mcpServers: {
+          context7: {
+            type: 'stdio',
+            command: 'npx',
+            args: ['-y', '@upstash/context7-mcp'],
+          },
+          granola: {
+            type: 'http',
+            url: 'https://mcp.granola.ai/mcp',
+          },
+        },
+      }
+      await writeFile(
+        configPath,
+        `${JSON.stringify(originalConfig, null, 2)}\n`,
+        'utf8',
+      )
+
+      const stub = createStubMcpManager()
+      const originalLink = stub.link
+      stub.link = async (input) => {
+        const result = await originalLink({ ...input, configPath })
+        if (input.server.spec.transport !== 'http') {
+          throw new Error('expected an HTTP BrowserClaw spec')
+        }
+        const config = JSON.parse(await readFile(configPath, 'utf8')) as {
+          numStartups: number
+          mcpServers: Record<string, unknown>
+        }
+        config.mcpServers[input.server.name] = {
+          url: input.server.spec.url,
+        }
+        await writeFile(
+          configPath,
+          `${JSON.stringify(config, null, 2)}\n`,
+          'utf8',
+        )
+        return result
+      }
+      setMcpManagerForTesting(stub)
+      env.proxyPort = 9000
+
+      await expect(
+        connectBrowserosToHarness('Claude Code'),
+      ).resolves.toMatchObject({ installed: true, agentId: 'claude-code' })
+
+      const first = await readFile(configPath, 'utf8')
+      expect(JSON.parse(first)).toEqual({
+        ...originalConfig,
+        mcpServers: {
+          ...originalConfig.mcpServers,
+          BrowserClaw: {
+            url: 'http://127.0.0.1:9000/mcp',
+            type: 'http',
+          },
+        },
+      })
+
+      await connectBrowserosToHarness('Claude Code')
+      await expect(readFile(configPath, 'utf8')).resolves.toBe(first)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 
   it('writes a direct HTTP spec for Codex (http-capable in the catalog)', async () => {


### PR DESCRIPTION
## Summary

- add the required `type: "http"` field after BrowserClaw links its managed Claude Code endpoint
- keep the existing add-only JSONC merge path, preserving sibling MCP servers and unrelated `~/.claude.json` keys
- cover connect/reconnect, rollback, startup URL migration, and integrity repair paths; leave other harness writers unchanged after checking their schemas

## Design

The MCP manager remains authoritative for linking and metadata. A narrow post-link repair uses the manager-recorded config path and the existing shared JSONC helper to add only the missing transport field when the managed URL matches.

## Test plan

- [x] `bunx bun@1.3.6 test` in `packages/browseros-agent/apps/claw-server` — 386 pass
- [x] `bunx bun@1.3.6 run typecheck` in `packages/browseros-agent/apps/claw-server`
- [x] `bunx bun@1.3.6 run test` at repository root
- [x] Biome check for touched files and `git diff --check origin/main..HEAD`
- [x] Two adversarial review rounds; final review clean

Root lint and dead-code checks completed. The untouched `apps/server` TypeScript process exceeded the local Node heap during the aggregate root `check`; the touched claw-server typecheck passes independently.