### PR TITLE
chore(ci): macOS universal is the default release arch

### DIFF
--- a/.github/workflows/release-browserclaw.yml
+++ b/.github/workflows/release-browserclaw.yml
@@ -26,7 +26,7 @@ on:
       macos_arch:
         description: "macOS architecture to build"
         type: choice
-        default: arm64
+        default: universal
         options:
           - arm64
           - universal

--- a/.github/workflows/release-browseros.yml
+++ b/.github/workflows/release-browseros.yml
@@ -26,7 +26,7 @@ on:
       macos_arch:
         description: "macOS architecture to build"
         type: choice
-        default: arm64
+        default: universal
         options:
           - arm64
           - universal

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -14,7 +14,7 @@ on:
       arch:
         description: macOS architecture to build
         type: choice
-        default: arm64
+        default: universal
         options:
           - arm64
           - universal
@@ -46,9 +46,9 @@ on:
         type: string
         default: browseros
       arch:
-        description: macOS architecture to build (arm64, universal)
+        description: macOS architecture to build (universal, universal)
         type: string
-        default: arm64
+        default: universal
       bump:
         description: Version bump level (offset-only, offset+build, offset+patch, none)
         type: string
@@ -101,7 +101,7 @@ jobs:
           set -euo pipefail
 
           products="${INPUT_PRODUCTS:-browseros}"
-          arch="${INPUT_ARCH:-arm64}"
+          arch="${INPUT_ARCH:-universal}"
           bump_mode="${INPUT_BUMP:-none}"
           commit_version="${INPUT_COMMIT_VERSION:-false}"
           upload_to_r2="${INPUT_UPLOAD_TO_R2:-true}"

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -126,7 +126,7 @@ gh workflow run release-browseros.yml \
   -f platforms=all \
   -f include_servers=true \
   -f sign_windows=true \
-  -f macos_arch=arm64 \
+  -f macos_arch=universal \
   -f upload_to_r2=true \
   -f extensions=alpha \
   -f extensions_version=<agent-extension-version> \
@@ -136,7 +136,7 @@ gh workflow run release-browserclaw.yml \
   -f platforms=all \
   -f include_servers=true \
   -f sign_windows=true \
-  -f macos_arch=arm64 \
+  -f macos_arch=universal \
   -f upload_to_r2=true \
   -f extensions=alpha \
   -f extensions_version=<browserclaw-extension-version> \
@@ -171,7 +171,7 @@ gh workflow run release-claw-server.yml -f version=0.0.3
 gh workflow run release-claw-server-rust.yml -f version=0.1.0
 gh workflow run release-linux.yml -f products=browseros -f upload_to_r2=true
 gh workflow run release-windows.yml -f products=browserclaw -f sign=false
-gh workflow run release-macos.yml -f products=all -f arch=arm64
+gh workflow run release-macos.yml -f products=all   # arch defaults to universal; pass -f arch=arm64 for a faster single-arch build
 ```
 
 ## Secrets And Variables


### PR DESCRIPTION
Releases should ship universal mac binaries by default — yesterday's release used the old `arm64` default and universal never got built. Flips the defaults in `release-browseros.yml` / `release-browserclaw.yml` (`macos_arch`), `release-macos.yml` (dispatch + workflow_call `arch`, and the shell fallback), and updates the doc examples. Nightlies are self-contained and keep their explicit `--arch arm64` for speed. Universal roughly doubles mac build time — that's the accepted default cost for releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)