### PR TITLE
feat(claw-server): inline agent-mcp-manager as a workspace package

### DIFF
--- a/packages/browseros-agent/apps/claw-server/package.json
+++ b/packages/browseros-agent/apps/claw-server/package.json
@@ -34,12 +34,12 @@
     "db:migrate": "drizzle-kit migrate"
   },
   "dependencies": {
+    "@browseros/agent-mcp-manager": "workspace:*",
     "@browseros/browser-core": "workspace:*",
     "@browseros/browser-mcp": "workspace:*",
     "@browseros/shared": "workspace:*",
     "@hono/zod-validator": "^0.8.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "agent-mcp-manager": "0.0.4-rc.3",
     "commander": "^14.0.3",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.3",

--- a/packages/browseros-agent/apps/claw-server/src/lib/mcp-manager.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/mcp-manager.ts
@@ -16,7 +16,7 @@
  */
 
 import { join } from 'node:path'
-import { type BoundApi, bind } from 'agent-mcp-manager'
+import { type BoundApi, bind } from '@browseros/agent-mcp-manager'
 import { getClawServerDir } from './browserclaw-dir'
 
 let cached: BoundApi | null = null

--- a/packages/browseros-agent/apps/claw-server/src/lib/migrate-mcp-urls.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/migrate-mcp-urls.ts
@@ -29,7 +29,7 @@
  */
 
 import { rename } from 'node:fs/promises'
-import type { BoundApi, McpServerSpec } from 'agent-mcp-manager'
+import type { BoundApi, McpServerSpec } from '@browseros/agent-mcp-manager'
 import {
   type StoredAgentProfile,
   storedAgentProfileSchema,

--- a/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
@@ -12,12 +12,12 @@
  * polling interval.
  */
 
-import type { AgentId } from 'agent-mcp-manager'
+import type { AgentId } from '@browseros/agent-mcp-manager'
 import {
   AgentNotInstalledError,
   ForeignEntryError,
   resolveAgentMcpConfigPath,
-} from 'agent-mcp-manager'
+} from '@browseros/agent-mcp-manager'
 import { logger } from '../lib/logger'
 import { getMcpManager } from '../lib/mcp-manager'
 import { tildifyHomePath } from '../lib/tildify'

--- a/packages/browseros-agent/apps/claw-server/src/services/harness-install.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/harness-install.ts
@@ -9,12 +9,12 @@
  * an outcome instead of rolling back the profile mutation.
  */
 
-import type { AgentId } from 'agent-mcp-manager'
+import type { AgentId } from '@browseros/agent-mcp-manager'
 import {
   AgentNotSupportedError,
   ForeignEntryError,
   resolveAgentMcpConfigPath,
-} from 'agent-mcp-manager'
+} from '@browseros/agent-mcp-manager'
 import { logger } from '../lib/logger'
 import { getMcpManager } from '../lib/mcp-manager'
 import type { Harness, StoredAgentProfile } from '../routes/agents/schemas'

--- a/packages/browseros-agent/apps/claw-server/src/services/mcp-relink.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/mcp-relink.ts
@@ -19,7 +19,7 @@ import type {
   BoundApi,
   LinkPlanSummary,
   McpServerSpec,
-} from 'agent-mcp-manager'
+} from '@browseros/agent-mcp-manager'
 
 interface RelinkManagedServerOptions {
   mgr: BoundApi

--- a/packages/browseros-agent/apps/claw-server/src/services/spec-for.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/spec-for.ts
@@ -19,7 +19,7 @@ import {
   type AgentId,
   type McpServerSpec,
   resolveAgentSurface,
-} from 'agent-mcp-manager'
+} from '@browseros/agent-mcp-manager'
 
 export function specFor(agentId: AgentId, mcpUrl: string): McpServerSpec {
   const surface = resolveAgentSurface(agentId, 'system')

--- a/packages/browseros-agent/apps/claw-server/tests/_helpers/stub-mcp-manager.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/_helpers/stub-mcp-manager.ts
@@ -18,7 +18,7 @@ import type {
   BoundApi,
   ManifestServerEntry,
   McpServer,
-} from 'agent-mcp-manager'
+} from '@browseros/agent-mcp-manager'
 
 export interface StubCall {
   method:

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -209,12 +209,12 @@
       "name": "@browseros/claw-server",
       "version": "0.0.7",
       "dependencies": {
+        "@browseros/agent-mcp-manager": "workspace:*",
         "@browseros/browser-core": "workspace:*",
         "@browseros/browser-mcp": "workspace:*",
         "@browseros/shared": "workspace:*",
         "@hono/zod-validator": "^0.8.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "agent-mcp-manager": "0.0.4-rc.3",
         "commander": "^14.0.3",
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.3",
@@ -296,6 +296,15 @@
         "pino-pretty": "^13.1.3",
         "puppeteer": "^25.1.0",
         "typescript": "^5.9.3",
+      },
+    },
+    "packages/agent-mcp-manager": {
+      "name": "@browseros/agent-mcp-manager",
+      "version": "0.0.4-rc.3",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "jsonc-parser": "^3.3.1",
+        "yaml": "^2.9.0",
       },
     },
     "packages/browser-core": {
@@ -594,6 +603,8 @@
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@browseros/agent-mcp-manager": ["@browseros/agent-mcp-manager@workspace:packages/agent-mcp-manager"],
 
     "@browseros/app": ["@browseros/app@workspace:apps/app"],
 
@@ -1907,7 +1918,7 @@
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
-    "agent-mcp-manager": ["agent-mcp-manager@0.0.4-rc.3", "", { "dependencies": { "@iarna/toml": "^2.2.5", "jsonc-parser": "^3.3.1", "yaml": "^2.9.0" } }, "sha512-aomyrG2cN5SGRlSZNGmKho0Z+4uPIdiq08iT7JagghUhSdYALvwEVRmbpvyXkbb15gQTMB+6LsjzV+NTZ6y7kw=="],
+    "agent-mcp-manager": ["agent-mcp-manager@0.0.3", "", { "dependencies": { "@iarna/toml": "^2.2.5", "jsonc-parser": "^3.3.1" } }, "sha512-DBbMi56b9hMfaSNCdorX38M1euE1tgrW2gvhkCeGSnNqXsTAYrbCdRZ1aNqNDHn6Ej5/t8Hzswc7fYhEm671wg=="],
 
     "ahooks": ["ahooks@3.9.7", "", { "dependencies": { "@babel/runtime": "^7.21.0", "@types/js-cookie": "^3.0.6", "dayjs": "^1.9.1", "intersection-observer": "^0.12.0", "js-cookie": "^3.0.5", "lodash": "^4.17.21", "react-fast-compare": "^3.2.2", "resize-observer-polyfill": "^1.5.1", "screenfull": "^5.0.0", "tslib": "^2.4.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw=="],
 
@@ -4130,8 +4141,6 @@
     "@browseros/server/@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
 
     "@browseros/server/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
-
-    "@browseros/server/agent-mcp-manager": ["agent-mcp-manager@0.0.3", "", { "dependencies": { "@iarna/toml": "^2.2.5", "jsonc-parser": "^3.3.1" } }, "sha512-DBbMi56b9hMfaSNCdorX38M1euE1tgrW2gvhkCeGSnNqXsTAYrbCdRZ1aNqNDHn6Ej5/t8Hzswc7fYhEm671wg=="],
 
     "@browseros/server/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/packages/browseros-agent/packages/agent-mcp-manager/LICENSE
+++ b/packages/browseros-agent/packages/agent-mcp-manager/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dani Akash
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/browseros-agent/packages/agent-mcp-manager/PROVENANCE.md
+++ b/packages/browseros-agent/packages/agent-mcp-manager/PROVENANCE.md
@@ -1,0 +1,17 @@
+# Provenance
+
+Inlined snapshot of `agent-mcp-manager` from https://github.com/DaniAkash/agent-toolkit.
+
+- Upstream commit: `fedf865d597619571e79e29758df2c20bc4a2a03`
+- Upstream branch: `feat/mcp-manager-v0.0.4-fp`
+- Upstream PR: https://github.com/DaniAkash/agent-toolkit/pull/64
+- Upstream version at snapshot: `0.0.4-rc.3`
+- Inlined on: 2026-07-10
+
+## Why inlined
+
+BrowserOS wants to edit this code in place without a round-trip through npm publish. The upstream package continues to exist and may keep publishing separately; this copy is a hard fork with no automatic upstream sync.
+
+## Divergence policy
+
+Edits to this directory are made freely. There is no obligation to sync back to upstream. If upstream ships a bugfix worth pulling, apply it as an ordinary PR touching just this directory and update the upstream-commit SHA above so the divergence point stays discoverable.

--- a/packages/browseros-agent/packages/agent-mcp-manager/README.md
+++ b/packages/browseros-agent/packages/agent-mcp-manager/README.md
@@ -1,0 +1,560 @@
+# agent-mcp-manager
+
+> Programmatic add/link/unlink for **Model Context Protocol** servers
+> across 23 AI coding agents. Functional API, dry-run capable, 23-client
+> catalog with per-client shape declarations.
+
+> [!WARNING]
+> **v0.0.4 is a breaking release.** The `createMcpManager` class API
+> has been removed and replaced with a functional surface. See the
+> [Migration guide](#migration-from-v003) below for a mechanical
+> translation table. If you cannot migrate immediately, pin
+> `agent-mcp-manager@^0.0.3`.
+
+> [!WARNING]
+> **Experimental.** The 0.0.x line is under active development. The
+> public API may change between patch versions. Pin exact versions.
+
+`agent-mcp-manager` writes MCP server entries into the real config
+files that AI coding agents read on launch. Claude Desktop's
+`claude_desktop_config.json`, Cursor's `~/.cursor/mcp.json`, VS Code's
+`mcp.json`, Codex's `~/.codex/config.toml`, and 19 others across
+JSON / JSONC / YAML / TOML. It targets embedders (IDE plugins,
+internal tools, enterprise onboarding flows, custom installers) that
+need to register MCP servers programmatically across many agents.
+
+## Install
+
+```sh
+bun add agent-mcp-manager
+# or: npm i, pnpm add, yarn add
+```
+
+## Quick start
+
+```ts
+import { link, disconnect, rescan, bind } from 'agent-mcp-manager'
+
+const workspaceDir = '~/.myapp/mcp'
+
+// The server is caller-owned data. No pre-registration step.
+const github = {
+  name: 'github',
+  spec: {
+    transport: 'http',
+    url: 'https://api.githubcopilot.com/mcp',
+    headers: { Authorization: `Bearer ${process.env.GH_TOKEN}` },
+  },
+} as const
+
+// One link call = one atomic operation:
+//   - upserts the manifest server entry
+//   - writes the entry to the agent's config file
+await link(workspaceDir, { server: github, agent: 'cursor' })
+await link(workspaceDir, { server: github, agent: 'claude-code' })
+await link(workspaceDir, { server: github, agent: 'vscode' })
+
+// Later, disconnect one agent without touching the others.
+await disconnect(workspaceDir, {
+  serverName: 'github',
+  agent: 'cursor',
+  removeIfLast: true, // drop the manifest entry only if no agents remain
+})
+
+// Periodically check that on-disk configs still match the manifest.
+const report = await rescan(workspaceDir)
+if (report.drifted.length > 0 || report.missing.length > 0) {
+  // ... report / auto-heal / prompt the user
+}
+
+// For consumers who use the same workspaceDir across many calls:
+const mgr = bind(workspaceDir)
+await mgr.link({ server: github, agent: 'gemini' })
+```
+
+## API reference
+
+### Verbs
+
+| Verb | Signature | Purpose |
+|---|---|---|
+| `link` | `(workspaceDir, {server, agent, scope?, projectRoot?, configPath?, allowOverwrite?}) => Promise<LinkPlanSummary>` | Upsert the manifest server entry AND write the server into the agent's config file. Last-write-wins on the manifest spec. |
+| `unlink` | `(workspaceDir, {serverName, agent, scope?, projectRoot?, configPath?}) => Promise<UnlinkPlanSummary>` | Remove one agent's entry from its config file and drop the manifest link. No-op when the manifest has no such link. |
+| `disconnect` | `(workspaceDir, {serverName, agent, scope?, projectRoot?, removeIfLast?}) => Promise<DisconnectPlanSummary>` | Unlink one agent AND drop the manifest entry when no other agents remain linked to it. Never touches other agents' config files. **The primitive that closes [issue #63](https://github.com/DaniAkash/agent-toolkit/issues/63).** |
+| `remove` | `(workspaceDir, {serverName, unlinkFirst?}) => Promise<RemovePlanSummary>` | Drop the manifest entry AND unlink every currently-linked agent's config file. |
+| `list` | `(workspaceDir) => Promise<ManifestServerEntry[]>` | Every server in the manifest. |
+| `listLinks` | `(workspaceDir, {serverNames?, agents?}?) => Promise<ListedLink[]>` | Every (server, agent, configPath) triple in the manifest. Filter by server name or agent. |
+| `rescan` | `(workspaceDir, {agents?}?) => Promise<RescanReport>` | Diff manifest links against disk. Reports verified / drifted / missing entries. **See [rescan section](#rescan-detecting-drift-between-manifest-and-disk) below.** |
+| `isInstalled` | `({agents, scope?, projectRoot?}) => Promise<Partial<Record<AgentId, boolean>>>` | Batch check whether each agent's config location is writable-safely (file exists OR parent directory exists). Predicts what `link()` would throw. **See [isInstalled section](#isinstalled-checking-agent-availability) below.** |
+| `bind` | `(workspaceDir) => BoundApi` | Sugar for calling all verbs with the same workspaceDir. Stateless: every method still runs `readState -> plan -> applyPlan`. |
+
+### The server value
+
+Every mutating call takes an `McpServer` value:
+
+```ts
+interface McpServer {
+  name: string          // manifest key + entry name in the agent's config file
+  spec: McpServerSpec   // how the server is invoked (stdio | sse | http)
+}
+
+type McpServerSpec =
+  | { transport: 'stdio'; command: string; args?: string[]; env?: Record<string, string> }
+  | { transport: 'sse';   url: string; headers?: Record<string, string> }
+  | { transport: 'http';  url: string; headers?: Record<string, string> }
+```
+
+The `name` is trimmed before being used as the manifest key. `link({server: {name: '  gh  ', ...}})` persists under `'gh'`.
+
+### Errors
+
+Every error extends `McpManagerError`. `instanceof` checks are safe across module boundaries.
+
+| Error | Thrown by | Meaning |
+|---|---|---|
+| `AgentNotSupportedError` | any verb | Agent id not in the catalog. |
+| `ForeignEntryError` | `link` | On-disk entry under the target name was not put there by the manifest. Pass `allowOverwrite: true` to take ownership. |
+| `UnsupportedTransportError` | `link` | Transport not accepted by this agent at this scope. Details include the accepted set and a per-agent hint. |
+| `InvalidServerSpecError` | `link` | Server has an empty name, or the spec is missing required fields (empty command, empty url, unknown transport). |
+| `UnresolvedConfigPathError` | any verb that needs the on-disk path | Cannot resolve the agent's config file on this OS (e.g., project scope requested without `projectRoot`, env vars unset). |
+| `AgentNotInstalledError` | `link` | Neither the agent's config file nor its parent directory exists on disk. The agent has either not been installed or has been installed but never launched. Fields: `.agent`, `.configPath`, `.parentDir`. Precheck with `isInstalled({agents})` to avoid the throw. |
+
+Note: v0.0.3's `ServerNotFoundError` no longer applies to `link`, since the server is passed in on every call.
+
+### Return summaries
+
+Every mutating verb returns a summary describing what actually happened:
+
+```ts
+interface LinkPlanSummary {
+  serverName: string
+  agent: AgentId
+  scope: AgentScope
+  created: boolean           // true if no prior link existed for this agent; false if we replaced one
+  overwroteForeign: boolean  // true if allowOverwrite: true replaced an unmanaged entry
+}
+
+interface UnlinkPlanSummary {
+  serverName: string
+  agent: AgentId
+  scope: AgentScope
+  removed: boolean           // true if there was actually a link to remove
+}
+
+interface DisconnectPlanSummary {
+  serverName: string
+  agent: AgentId
+  scope: AgentScope
+  unlinked: boolean          // true if we removed a link record
+  removedManifest: boolean   // true if we dropped the manifest entry (last link + removeIfLast)
+}
+
+interface RemovePlanSummary {
+  serverName: string
+  unlinkedAgents: AgentId[]  // every agent whose config file was rewritten
+  removedManifest: boolean
+}
+```
+
+## `rescan`: detecting drift between manifest and disk
+
+The library maintains its own workspace manifest (`<workspaceDir>/manifest.json`) that records every server you've linked and which agent's config file received it. `rescan` compares that manifest against what's actually on disk and returns a report:
+
+```ts
+interface RescanReport {
+  verified: ReadonlyArray<{ serverName: string; agent: AgentId; configPath: string }>
+  drifted:  ReadonlyArray<{ serverName: string; agent: AgentId; scope: AgentScope; configPath: string; reason: string }>
+  missing:  ReadonlyArray<{ serverName: string; agent: AgentId; scope: AgentScope; configPath: string; reason: string }>
+}
+```
+
+### When to call it
+
+`rescan` is your source of truth whenever the on-disk state may have drifted from what the library last wrote. Common triggers:
+
+- **After a user edits the config file directly.** Someone opens `~/.cursor/mcp.json` in a text editor and deletes an entry. The manifest still thinks it's there.
+- **After you change a spec.** `link({server: A})` then `link({server: A_prime, agent: 'gemini'})` where the name is the same but the spec differs. The manifest holds the newest spec; `A`'s previous linkers (cursor, vscode, ...) still have the old spec on disk. `rescan` won't report drift on presence, but see the note below on how to interpret it.
+- **On app startup.** UI shells that display "which servers are linked to which agents" should call `rescan` on load, not trust the manifest alone.
+- **Before batching writes.** If you're about to `link` a large batch, `rescan` first to detect any pre-existing drift you should surface to the user rather than silently overwriting.
+
+### What each bucket means
+
+- **`verified`**: manifest says agent X has server Y linked to `configPath` Z, AND that file exists AND the emitter finds a matching entry inside it. Everything is aligned.
+- **`drifted`**: manifest recorded a link, the file exists, but the emitter can't find an entry under that name. Someone (user, another tool, a partial write) removed the entry from disk. The manifest still remembers the link.
+- **`missing`**: the config file itself is gone (either the file doesn't exist on disk, or you didn't include the agent in the readState call). The link record survives.
+
+### Common patterns
+
+**Detect drift and prompt to re-link.** The most common consumer flow:
+
+```ts
+const report = await rescan(workspaceDir)
+for (const drift of report.drifted) {
+  console.log(`${drift.agent}'s ${drift.configPath} is missing '${drift.serverName}'`)
+  // Ask the user; on confirm, re-link using the current spec stored in the manifest.
+  const servers = await list(workspaceDir)
+  const server = servers.find((s) => s.name === drift.serverName)
+  if (server) {
+    await link(workspaceDir, {
+      server: { name: server.name, spec: server.spec },
+      agent: drift.agent,
+    })
+  }
+}
+```
+
+**Filter by agent.** If you only care about drift for the agents you actively support, pass a filter:
+
+```ts
+await rescan(workspaceDir, { agents: ['cursor', 'vscode'] })
+```
+
+**Report-only in CI.** `rescan` performs zero writes and returns a plain data value. It's safe to run in a CI check that verifies your dev workspace hasn't drifted:
+
+```ts
+const { drifted, missing } = await rescan(workspaceDir)
+if (drifted.length + missing.length > 0) {
+  console.error('MCP config drift detected:', { drifted, missing })
+  process.exit(1)
+}
+```
+
+### What `rescan` does NOT do
+
+- It does not detect **spec drift** (an entry exists on disk but was written with a different command/url than the manifest's current spec). The current implementation only checks for entry presence. Spec-drift detection is a v0.0.5 candidate; today, you can compare `list(workspaceDir)[i].spec` against a parse of the config file yourself if you need it.
+- It does not scan for **unmanaged entries** (entries on disk that the manifest never wrote). v0.0.3 exposed this via `RescanResult.unmanaged`; v0.0.4 does not. This is also a v0.0.5 candidate.
+- It does not touch disk. `rescan` is read-only and returns a value; the caller decides what to do about it.
+
+## `isInstalled`: checking agent availability
+
+Before you call `link()`, you probably want to know whether the target agent is actually installed on the user's machine. `isInstalled` answers that in one batch call:
+
+```ts
+import { isInstalled } from 'agent-mcp-manager'
+
+const installed = await isInstalled({
+  agents: ['cursor', 'claude-code', 'gemini', 'vscode'],
+})
+
+if (installed.cursor) {
+  await link(workspaceDir, { server, agent: 'cursor' })
+}
+```
+
+Return shape: `Partial<Record<AgentId, boolean>>`. Only the agents you asked about appear as keys. Duplicates in the input array collapse.
+
+### What "installed" means here
+
+An agent is installed iff **its config file already exists OR the parent directory of that config file exists.** For Cursor that's `~/.cursor/mcp.json` or `~/.cursor/`. For Claude Desktop it's `~/Library/Application Support/Claude/claude_desktop_config.json` or `~/Library/Application Support/Claude/`. If neither exists, the agent either hasn't been installed or has been installed but never launched. Either way, the library can't safely write to it.
+
+This is the same signal `link()` uses to gate `AgentNotInstalledError`. So `isInstalled` is exactly the precheck for `link`: if `installed[agent] === false`, `link({server, agent})` will throw.
+
+### When to call it
+
+- **Gating a UI dropdown**: show only installed agents in a "Choose an agent" list.
+- **Filtering a batch before linking**: skip missing agents instead of catching per-call throws.
+- **Background health check**: on app startup, warn the user if agents they had linked previously are no longer available.
+- **Predicting failures**: any time you want to avoid catching `AgentNotInstalledError` in flow control.
+
+### Worked patterns
+
+**Show only installed agents in a UI dropdown.**
+
+```ts
+const supported = listSupportedAgents()
+const installed = await isInstalled({ agents: supported })
+const shown = supported.filter((a) => installed[a] === true)
+// Render `shown` in your UI.
+```
+
+**Precheck a batch before linking.**
+
+```ts
+const targets = ['cursor', 'claude-code', 'gemini']
+const installed = await isInstalled({ agents: targets })
+for (const agent of targets) {
+  if (installed[agent]) {
+    await link(workspaceDir, { server, agent })
+  } else {
+    showWarning(`${agent} is not installed; skipping.`)
+  }
+}
+```
+
+**Predict what `link` will throw.** Because both use the same signal:
+
+```ts
+const installed = await isInstalled({ agents: ['cursor'] })
+// installed.cursor === false  =>  link({server, agent: 'cursor'}) will throw AgentNotInstalledError.
+```
+
+### `isInstalled` vs `detectInstalledAgents`
+
+`detectInstalledAgents` (already in v0.0.3) returns `AgentInfo[]` with an `installed` flag based on the catalog's `installCheckPaths` (app bundle locations like `/Applications/Cursor.app`). It answers "is the app on disk?" That's a different question from "can the library write MCP config here?"
+
+- Use `isInstalled` when you're about to write config or need to precheck `link`. Same signal as the gate.
+- Use `detectInstalledAgents` when you want to know whether the app bundle exists, without necessarily knowing whether the user has launched it. Useful for "we found Cursor in /Applications but you haven't launched it yet; do that first" UX flows.
+
+Both signals will drift apart in cases like unlaunched fresh installs. Pick the one that matches your question.
+
+### `AgentNotInstalledError`
+
+The typed error `link()` throws when the install gate fails. Fields:
+
+```ts
+class AgentNotInstalledError extends McpManagerError {
+  agent: AgentId
+  configPath: string  // the exact path we checked
+  parentDir: string   // its parent, also missing
+}
+```
+
+Handle it around your `link()` call, or use `isInstalled` beforehand to avoid the throw entirely.
+
+## Migration from v0.0.3
+
+If you're on v0.0.3 with `createMcpManager`, you have three paths:
+
+1. **Migrate to the functional API** (recommended). This section gives you the mechanical translations.
+2. **Pin v0.0.3** with `"agent-mcp-manager": "^0.0.3"` in your package.json. The v0.0.3 line is unmaintained but functional; it stays on npm.
+3. **Wait**. No compat shim is planned. v0.0.5+ builds on the functional surface.
+
+### What changed and why
+
+The v0.0.3 `createMcpManager()` returned an object with a private `manifest` reference that mutated across method calls. This produced a real bug ([#63](https://github.com/DaniAkash/agent-toolkit/issues/63)): the "disconnect one agent" flow required a three-line dance (`unlink` + `listLinks` + conditional `remove`), and any race or logic bug in the caller could silently orphan other agents' link records.
+
+Under v0.0.4:
+
+- **No mutable in-memory manifest.** Every verb reads the manifest from disk at call time, computes a plan, applies it.
+- **No pre-registration step.** The v0.0.3 flow was `add(name, spec)` then `link(name, agent)`. That two-step surface let the two calls drift out of sync, allowed manifest ghosts, and made concurrent adds silently clobber each other. v0.0.4 collapses this into one `link({server, agent})` call. The server is caller-owned data.
+- **Every operation composes.** `readState → plan* → applyPlan`. You can inspect the plan before writing.
+- **`disconnect()` is one primitive.** It reads state, unlinks one agent, drops the manifest entry only if no other agents remain linked. Never touches other agents' config files. The #63 bug is structurally impossible.
+- **The workspace manifest schema on disk is unchanged.** If you have a `manifest.json` written by v0.0.3, v0.0.4 reads it without migration.
+
+### Migration table
+
+| v0.0.3 (class API) | v0.0.4 (functional API) |
+|---|---|
+| `const mgr = createMcpManager({ workspaceDir })` | `const mgr = bind(workspaceDir)` (optional; the raw verbs also work) |
+| `await mgr.add({ name, spec })`<br>`await mgr.link({ serverName: name, agent })` | `const server = { name, spec }`<br>`await link(workspaceDir, { server, agent })` |
+| `await mgr.link({ serverName, agent, configPath })` | `await link(workspaceDir, { server, agent, configPath })` |
+| `await mgr.link({ serverName, agent, allowOverwrite: true })` | `await link(workspaceDir, { server, agent, allowOverwrite: true })` |
+| `await mgr.unlink({ serverName, agent })` | `await unlink(workspaceDir, { serverName, agent })` |
+| `await mgr.remove({ serverName })` | `await remove(workspaceDir, { serverName })` |
+| `await mgr.remove({ serverName, unlinkFirst: false })` | `await remove(workspaceDir, { serverName, unlinkFirst: false })` |
+| `await mgr.listServers()` | `await list(workspaceDir)` |
+| `await mgr.listLinks()` | `await listLinks(workspaceDir)` |
+| `await mgr.listLinks({ agents, serverNames })` | `await listLinks(workspaceDir, { agents, serverNames })` |
+| `await mgr.rescan()` | `await rescan(workspaceDir)` (see the [rescan section](#rescan-detecting-drift-between-manifest-and-disk) for report changes) |
+
+**No more `addServer`.** v0.0.3 required two calls to link a server for the first time: `mgr.add(...)` then `mgr.link(...)`. v0.0.4 does both in one `link({server, ...})`. Just build the server value inline and hand it to `link`. If you'd been storing the result of `mgr.add()` to reuse in later `mgr.link` calls, replace that with a caller-owned `const server = {name, spec}` variable.
+
+### The disconnect pattern (the #63 fix)
+
+If your v0.0.3 code has this pattern:
+
+```ts
+// v0.0.3 (buggy: can orphan other agents' links)
+await mgr.unlink({ serverName, agent })
+const links = await mgr.listLinks({ serverNames: [serverName] })
+if (links.length === 0) {
+  await mgr.remove({ serverName })
+}
+```
+
+Replace it with a single call:
+
+```ts
+// v0.0.4 (structural fix)
+await disconnect(workspaceDir, {
+  serverName,
+  agent,
+  removeIfLast: true,  // default is true; can pass false to keep the entry
+})
+```
+
+The v0.0.4 `disconnect` reads the manifest once, computes the post-unlink links map, and only drops the manifest entry when that map is empty. It never touches any other agent's config file. If two callers race, each reads a fresh manifest at call time; the last writer wins on the manifest, and neither ever touches an unrelated agent's config.
+
+### Manager options
+
+v0.0.3 accepted per-manager configuration through `McpManagerOptions`. Those knobs are now per-call:
+
+| v0.0.3 `McpManagerOptions` field | v0.0.4 equivalent |
+|---|---|
+| `workspaceDir` | The first positional argument to every verb (or `bind(workspaceDir)` for sugar) |
+| `scope` | Pass `scope: 'system' \| 'project'` per call |
+| `projectRoot` | Pass `projectRoot: string` per call (required when `scope: 'project'`) |
+| `agentConfigPaths` | Pass `configPath: string` per call to override the resolved path for that call |
+
+Rationale: v0.0.3's per-manager `agentConfigPaths` map applied to every method call, which made mixed-scope operations awkward. v0.0.4's per-call `configPath` is one field with the same effect and no hidden state.
+
+### Return shape diffs
+
+- **`listServers` → `list`**. v0.0.3 returned `InstalledServer[]`; v0.0.4 `list(workspaceDir)` returns `ManifestServerEntry[]`. Same fields (`{name, spec, addedAt, links}`), different type name. Existing consumer code that reads `.name`, `.spec`, `.addedAt`, `.links` needs no change.
+- **`listLinks`**. v0.0.3 returned `McpServerLink[]` with optional `drifted` / `broken` / `unmanaged` flags. v0.0.4 `listLinks(workspaceDir)` returns `ListedLink[]` with just `{serverName, agent, configPath}`. Drift flags moved to `rescan()`, which now returns a dedicated `{verified, drifted, missing}` report.
+- **`rescan`**. v0.0.3 `RescanResult` had four buckets: `verified` / `drifted` / `broken` / `unmanaged`. v0.0.4 `RescanReport` has three: `verified` / `drifted` / `missing`. The v0.0.3 `broken` bucket is now folded into `missing` (a manifest link with no on-disk entry). v0.0.3's `unmanaged` bucket (on-disk entries with no manifest record) is not currently scanned; that's a v0.0.5 candidate.
+
+### New capabilities in v0.0.4
+
+Available today; no equivalent in v0.0.3:
+
+- **Dry-run.** Import from `agent-mcp-manager/lowlevel` and call `planLink` / `planDisconnect` / etc. without applying. Inspect `plan.ops` (the exact file writes) and `plan.nextManifest` (the manifest snapshot) before deciding to apply. Example under "Dry-run and batching" below.
+- **Batching.** Run multiple planner calls against a single `State` snapshot, concatenate the `ops`, and apply them all in one pass with `applyPlan`.
+- **Install-status detection.** `isInstalled({agents})` batch-checks whether each agent is available on the current machine, and `link()` throws `AgentNotInstalledError` (instead of silently creating a ghost config) when the target isn't installed. See the [isInstalled section](#isinstalled-checking-agent-availability).
+- **16 additional clients.** `cline`, `opencode`, `goose`, `kiro`, `windsurf`, `witsy`, `roocode`, `enconvo`, `boltai`, `amazon-bedrock`, `amazonq`, `tome`, `librechat`, `antigravity`, `trae`, `vscode-insiders`.
+
+### Known behavioral differences
+
+- **One-step link.** v0.0.3 required `mgr.add()` before `mgr.link()`. v0.0.4 `link({server, agent})` does both. The manifest server entry is upserted as a side-effect of the link.
+- **Last-write-wins on the manifest spec.** If you call `link({server: A, agent: 'cursor'})` and later `link({server: A', agent: 'gemini'})` where `A.name === A'.name` but the specs differ, the manifest's spec updates to `A'`. Cursor's config still holds `A` on disk (stale) until you re-link cursor. Use `rescan()` to detect this class of drift.
+- **Trimmed names.** `link({server: {name: '  gh  ', ...}})` persists the trimmed key `'gh'`. v0.0.3 persisted the untrimmed value.
+- **Idempotent re-links skip the config write.** `link()` no longer touches mtime when the resulting content is identical. IDE file-watchers (Cursor, VS Code) no longer reload on idempotent re-runs.
+- **`exists: true` for empty files.** `readState` from `/lowlevel` returns `AgentFileState.exists = true` for existing empty files; v0.0.3 conflated existence with non-emptiness.
+- **`unlink` uses the manifest-recorded configPath.** If you `link({ configPath: X })` in v0.0.3 and later `unlink()` without a `configPath`, v0.0.3 rewrote the OS-default path (potentially skipping the file that had the entry). v0.0.4 looks up the recorded path from the manifest first.
+
+### If you consumed `McpManager` as a type
+
+v0.0.3 exported the `McpManager` interface for consumers to store the manager instance in class fields or React refs. v0.0.4 has no equivalent because the verbs are free functions. Two options:
+
+```ts
+// Option A: store the workspaceDir, call the free functions on demand.
+class MyApp {
+  private workspaceDir = '~/.myapp/mcp'
+  async link(server: McpServer, agent: AgentId) {
+    await link(this.workspaceDir, { server, agent })
+  }
+}
+
+// Option B: store a BoundApi.
+import { bind, type BoundApi, type McpServer, type AgentId } from 'agent-mcp-manager'
+class MyApp {
+  private mcp: BoundApi = bind('~/.myapp/mcp')
+  async link(server: McpServer, agent: AgentId) {
+    await this.mcp.link({ server, agent })
+  }
+}
+```
+
+Both are stateless: every method call re-reads the manifest from disk.
+
+## Dry-run and batching
+
+Import from `agent-mcp-manager/lowlevel` for the pure planner primitives plus `readState` and `applyPlan`. Every verb returns a `Plan` you can inspect before touching disk.
+
+```ts
+import {
+  readState,
+  planLink,
+  planDisconnect,
+  applyPlan,
+} from 'agent-mcp-manager/lowlevel'
+
+const state = await readState(workspaceDir, ['cursor', 'gemini'])
+
+// Compute both plans against the SAME state snapshot.
+const linkPlan = planLink(
+  state,
+  { server: { name: 'gh', spec: { transport: 'stdio', command: 'gh-mcp' } }, agent: 'cursor' },
+  new Date().toISOString(),
+)
+const disconnectPlan = planDisconnect(state, { serverName: 'old', agent: 'gemini' })
+
+// Inspect before writing.
+console.log('link ops:', linkPlan.ops)
+console.log('disconnect ops:', disconnectPlan.ops)
+
+// Apply when ready. Each plan is independent; combined ops write once.
+await applyPlan({
+  ops: [...linkPlan.ops, ...disconnectPlan.ops],
+  nextManifest: disconnectPlan.nextManifest,
+})
+```
+
+`FsOp` is a discriminated union:
+
+```ts
+type FsOp =
+  | { kind: 'writeFile'; path: string; content: string; ensureDir?: boolean }
+  | { kind: 'removeFile'; path: string }
+```
+
+Every write goes through atomic `<file>.tmp + rename`.
+
+## Supported clients
+
+23 clients ship in v0.0.4 with hand-authored per-client shape declarations. See `src/_catalog/client-configs.ts` for the source of truth, including each entry's citation URLs.
+
+| Established | Well-documented | Additional |
+|---|---|---|
+| claude-desktop | cline | amazon-bedrock |
+| claude-code | opencode | amazonq |
+| cursor | goose | antigravity |
+| vscode | kiro | boltai |
+| vscode-insiders | windsurf | enconvo |
+| gemini | witsy | librechat |
+| codex | roocode | tome |
+| zed |  | trae |
+
+Every catalog entry has:
+
+- A first-party MCP docs URL as its primary source.
+- A Smithery cross-check URL (design reference, AGPL-3.0; see [`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md)).
+- An ISO `verified` date. The catalog validator rejects any entry more than 12 months stale.
+
+## Transport support and safety guarantees
+
+Each client declares which transports it accepts (stdio / sse / http). Writing an entry with an unsupported transport throws `UnsupportedTransportError` **before** any file write. Concrete examples:
+
+- Claude Desktop is stdio-only; an HTTP spec throws.
+- Claude Code project scope (`.mcp.json`) is stdio-only; system scope (`~/.claude.json`) accepts all three.
+- Codex accepts stdio and streamable HTTP but not SSE.
+
+On disk:
+
+- **Atomic writes.** Every edit goes through `<file>.tmp + rename`. A crashed process never leaves a half-written config file.
+- **Foreign-entry protection.** `link` throws `ForeignEntryError` when an on-disk entry under the target name was not put there by the manifest. Pass `allowOverwrite: true` to take ownership.
+- **Structural protection against orphaning.** `disconnect` computes its ops from the manifest's links map. Under this shape, disconnecting one agent from a server that four others share never touches the four others' config files. The v0.0.3 class API had a bug (issue #63) where `remove` blew away shared manifest entries. That bug is structurally impossible under the FP API.
+- **Idempotent writes.** Re-linking a server that's already correctly present skips the file write entirely. Editors watching the config file do not reload.
+- **Install-status gate.** `link()` refuses to create a ghost config directory for an agent whose config path is under a non-existent parent. The typed `AgentNotInstalledError` carries the agent id, the config path we checked, and the parent directory so consumers can surface an actionable prompt.
+
+## Types
+
+Everything you need is at the package root or under `agent-mcp-manager/lowlevel`. Import paths:
+
+```ts
+import type {
+  McpServer,              // { name, spec }
+  McpServerSpec,          // stdio | sse | http
+  McpStdioSpec,
+  McpHttpSpec,
+  McpSseSpec,
+  AgentId,                // union of 23 client ids
+  AgentScope,             // 'system' | 'project'
+  ServerManifest,         // on-disk schema
+  ManifestServerEntry,
+  ManifestLinkEntry,
+  LinkPlanSummary,
+  UnlinkPlanSummary,
+  DisconnectPlanSummary,
+  RemovePlanSummary,
+  RescanReport,
+  IsInstalledInput,
+  IsInstalledResult,      // Partial<Record<AgentId, boolean>>
+  BoundApi,
+} from 'agent-mcp-manager'
+
+import { AgentNotInstalledError } from 'agent-mcp-manager'  // thrown by link()
+
+import type {
+  State, Plan, FsOp,
+  LinkInput,
+  DisconnectInput,
+  // ... every planner input and result summary
+} from 'agent-mcp-manager/lowlevel'
+```
+
+## Contributing
+
+Author under MIT. Every catalog entry needs a first-party docs URL and an ISO `verified` date; the validator enforces both. Test files live next to the source folders they exercise.
+
+License: MIT. See [`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md) for research references.

--- a/packages/browseros-agent/packages/agent-mcp-manager/THIRD_PARTY_NOTICES.md
+++ b/packages/browseros-agent/packages/agent-mcp-manager/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,66 @@
+# Third-Party Notices
+
+`agent-mcp-manager` is authored under MIT. This file discloses the
+third-party projects whose work informed the catalog and the
+architectural choices behind v0.0.4.
+
+No source code from any listed project is incorporated in the
+published package. Where a project is listed under an AGPL license,
+the disclosure exists because we read the project's public data as a
+research reference; we did not import or copy code, and the published
+package has no runtime dependency on it.
+
+## smithery-ai/cli (design reference; AGPL-3.0)
+
+- Source: https://github.com/smithery-ai/cli
+- License: AGPL-3.0
+- Role: research and cross-check reference for the per-client
+  configuration data in `src/_catalog/client-configs.ts`. Every
+  catalog entry has a `sources.smithery` URL pointing at the specific
+  block we cross-checked in `src/config/clients.ts`. First-party MCP
+  documentation for each client is the primary source
+  (`sources.firstParty`); Smithery is corroboration only.
+- What we DID: read the file to learn what fields exist per client,
+  what tag values each client's parser expects, and which URL / env /
+  command field names are non-default. Populated our own tables from
+  a mix of first-party docs and this cross-check.
+- What we did NOT do: copy the populated `CLIENTS` map or the
+  interface bodies verbatim, depend on the Smithery npm package at
+  runtime, or copy any command-based install templates.
+
+## docker/mcp-gateway (historical reference; MIT)
+
+- Source: https://github.com/docker/mcp-gateway
+- License: MIT
+- Role: the v0.0.3 catalog was hand-derived from
+  `pkg/client/config.yml`. v0.0.4 replaces that with a hand-authored
+  catalog whose write shapes are informed by both docker/mcp-gateway
+  (for stdio) and smithery-ai/cli (for HTTP). The vendored YAML has
+  been removed from this package as of v0.0.4; only the historical
+  git history under the feat/mcp-manager-v0.0.4-fp branch retains it.
+- No source code from mcp-gateway is incorporated in the published
+  package.
+
+### MIT License (docker/mcp-gateway)
+
+```
+Copyright (c) Docker, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/packages/browseros-agent/packages/agent-mcp-manager/package.json
+++ b/packages/browseros-agent/packages/agent-mcp-manager/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@browseros/agent-mcp-manager",
+  "version": "0.0.4-rc.3",
+  "description": "Programmatic add/link/unlink for MCP servers across AI coding agents. Inlined snapshot of agent-mcp-manager from DaniAkash/agent-toolkit.",
+  "license": "MIT",
+  "author": "Dani Akash",
+  "type": "module",
+  "sideEffects": false,
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@iarna/toml": "^2.2.5",
+    "jsonc-parser": "^3.3.1",
+    "yaml": "^2.9.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./lowlevel": {
+      "types": "./src/lowlevel.ts",
+      "default": "./src/lowlevel.ts"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/client-configs.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/client-configs.ts
@@ -1,0 +1,750 @@
+// fallow-ignore-next-line unused-files
+/**
+ * Populated MCP client configuration catalog.
+ *
+ * 23 entries covering the full Smithery client roster. Every entry has:
+ *   - `sources.firstParty`: URL to the client's own MCP documentation
+ *     (primary source).
+ *   - `sources.smithery`: URL to smithery-ai/cli src/config/clients.ts
+ *     (corroborating cross-check; AGPL-3.0 design reference).
+ *   - `sources.verified`: ISO date of last research/verification pass.
+ *
+ * Refresh cadence: the validator rejects any entry whose verified date
+ * is more than 365 days old. When you touch an entry, bump its date.
+ *
+ * License: MIT. Interfaces and populated data authored by us. Smithery
+ * is a design reference for the shape space and a corroborating source
+ * for per-client values; no code copied verbatim. See
+ * THIRD_PARTY_NOTICES.md.
+ */
+
+import type { ClientConfig } from './types'
+
+const SMITHERY_URL =
+  'https://github.com/smithery-ai/cli/blob/main/src/config/clients.ts'
+const VERIFIED = '2026-07-06'
+
+// -------------------------------------------------------------------
+// Popular, well-documented clients
+// -------------------------------------------------------------------
+
+export const claudeDesktop: ClientConfig = {
+  id: 'claude-desktop',
+  displayName: 'Claude Desktop',
+  installCheckPaths: {
+    darwin: ['/Applications/Claude.app'],
+    linux: ['$HOME/.config/claude'],
+    win32: ['$APPDATA\\Claude'],
+  },
+  systemPaths: {
+    darwin: [
+      '$HOME/Library/Application Support/Claude/claude_desktop_config.json',
+    ],
+    linux: ['$HOME/.config/claude/claude_desktop_config.json'],
+    win32: ['$APPDATA\\Claude\\claude_desktop_config.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  sources: {
+    firstParty: 'https://modelcontextprotocol.io/quickstart/user',
+    smithery: SMITHERY_URL,
+    notes:
+      'Claude Desktop parses claude_desktop_config.json strictly. Entries without a `command` field are silently dropped on app launch. Hosted remote connectors are configured via the Claude Desktop UI, not this file.',
+    verified: VERIFIED,
+  },
+}
+
+export const claudeCode: ClientConfig = {
+  id: 'claude-code',
+  displayName: 'Claude Code',
+  installCheckPaths: {
+    darwin: ['$HOME/.claude'],
+    linux: ['$HOME/.claude'],
+    win32: ['$USERPROFILE\\.claude'],
+  },
+  systemPaths: {
+    darwin: ['$CLAUDE_CONFIG_DIR/.claude.json', '$HOME/.claude.json'],
+    linux: ['$CLAUDE_CONFIG_DIR/.claude.json', '$HOME/.claude.json'],
+    win32: ['$CLAUDE_CONFIG_DIR\\.claude.json', '$USERPROFILE\\.claude.json'],
+  },
+  projectFile: '.mcp.json',
+  format: 'json',
+  supportedTransports: {
+    system: ['stdio', 'sse', 'http'],
+    project: ['stdio'],
+  },
+  stdio: { topLevelKey: 'mcpServers' },
+  http: { supportsOAuth: true },
+  project: {
+    stdio: { topLevelKey: 'mcpServers', tagKey: 'type', tagValue: 'stdio' },
+  },
+  sources: {
+    firstParty: 'https://docs.claude.com/en/docs/claude-code/mcp',
+    smithery: SMITHERY_URL,
+    notes:
+      'Project scope (.mcp.json) requires an explicit type: stdio tag; ~/.claude.json accepts entries without a tag. System scope writes stdio and http both without a type tag (Claude Code parses both), matching the shape v0.0.3 shipped.',
+    verified: VERIFIED,
+  },
+}
+
+export const cursor: ClientConfig = {
+  id: 'cursor',
+  displayName: 'Cursor',
+  installCheckPaths: {
+    darwin: ['/Applications/Cursor.app'],
+    linux: ['$HOME/.config/Cursor'],
+    win32: ['$APPDATA\\Cursor'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.cursor/mcp.json'],
+    linux: ['$HOME/.cursor/mcp.json'],
+    win32: ['$USERPROFILE\\.cursor\\mcp.json'],
+  },
+  projectFile: '.cursor/mcp.json',
+  format: 'json',
+  supportedTransports: {
+    system: ['stdio', 'sse', 'http'],
+    project: ['stdio', 'sse', 'http'],
+  },
+  stdio: { topLevelKey: 'mcpServers' },
+  http: { tagKey: 'type', tagValue: 'http', supportsOAuth: true },
+  project: {
+    stdio: { topLevelKey: 'mcpServers' },
+    http: { tagKey: 'type', tagValue: 'http', supportsOAuth: true },
+  },
+  sources: {
+    firstParty: 'https://docs.cursor.com/context/model-context-protocol',
+    smithery: SMITHERY_URL,
+    verified: VERIFIED,
+  },
+}
+
+const VSCODE_STDIO = {
+  topLevelKey: 'servers',
+  tagKey: 'type',
+  tagValue: 'stdio',
+} as const
+const VSCODE_HTTP = {
+  tagKey: 'type',
+  tagValue: 'http',
+  supportsOAuth: true,
+} as const
+
+export const vscode: ClientConfig = {
+  id: 'vscode',
+  displayName: 'Visual Studio Code',
+  installCheckPaths: {
+    darwin: ['/Applications/Visual Studio Code.app'],
+    linux: ['$HOME/.config/Code'],
+    win32: ['$APPDATA\\Code'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/Library/Application Support/Code/User/mcp.json'],
+    linux: ['$HOME/.config/Code/User/mcp.json'],
+    win32: ['$APPDATA\\Code\\User\\mcp.json'],
+  },
+  projectFile: '.vscode/mcp.json',
+  format: 'json',
+  supportedTransports: {
+    system: ['stdio', 'sse', 'http'],
+    project: ['stdio', 'sse', 'http'],
+  },
+  stdio: VSCODE_STDIO,
+  http: VSCODE_HTTP,
+  project: { stdio: VSCODE_STDIO, http: VSCODE_HTTP },
+  sources: {
+    firstParty: 'https://code.visualstudio.com/docs/copilot/chat/mcp-servers',
+    smithery: SMITHERY_URL,
+    verified: VERIFIED,
+  },
+}
+
+export const vscodeInsiders: ClientConfig = {
+  ...vscode,
+  id: 'vscode-insiders',
+  displayName: 'VS Code Insiders',
+  installCheckPaths: {
+    darwin: ['/Applications/Visual Studio Code - Insiders.app'],
+    linux: ['$HOME/.config/Code - Insiders'],
+    win32: ['$APPDATA\\Code - Insiders'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/Library/Application Support/Code - Insiders/User/mcp.json'],
+    linux: ['$HOME/.config/Code - Insiders/User/mcp.json'],
+    win32: ['$APPDATA\\Code - Insiders\\User\\mcp.json'],
+  },
+  sources: {
+    firstParty: 'https://code.visualstudio.com/docs/copilot/chat/mcp-servers',
+    smithery: SMITHERY_URL,
+    notes:
+      'Same shape as the stable VS Code channel; only the config directory differs.',
+    verified: VERIFIED,
+  },
+}
+
+export const gemini: ClientConfig = {
+  id: 'gemini',
+  displayName: 'Gemini CLI',
+  installCheckPaths: {
+    darwin: ['$HOME/.gemini'],
+    linux: ['$HOME/.gemini'],
+    win32: ['$USERPROFILE\\.gemini'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.gemini/settings.json'],
+    linux: ['$HOME/.gemini/settings.json'],
+    win32: ['$USERPROFILE\\.gemini\\settings.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio', 'sse', 'http'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  http: { tagKey: 'type', tagValue: 'http', supportsOAuth: true },
+  sources: {
+    firstParty:
+      'https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md',
+    smithery: SMITHERY_URL,
+    verified: VERIFIED,
+  },
+}
+
+export const codex: ClientConfig = {
+  id: 'codex',
+  displayName: 'Codex',
+  installCheckPaths: {
+    darwin: ['$HOME/.codex'],
+    linux: ['$HOME/.codex'],
+    win32: ['$USERPROFILE\\.codex'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.codex/config.toml'],
+    linux: ['$HOME/.codex/config.toml'],
+    win32: ['$USERPROFILE\\.codex\\config.toml'],
+  },
+  format: 'toml',
+  supportedTransports: { system: ['stdio', 'http'] },
+  stdio: { topLevelKey: 'mcp_servers' },
+  http: { headerField: 'http_headers', supportsOAuth: true },
+  sources: {
+    firstParty: 'https://developers.openai.com/codex/mcp',
+    smithery: SMITHERY_URL,
+    notes:
+      'TOML config. Streamable-HTTP entries carry `url`, optional `bearer_token_env_var`, `http_headers`, `env_http_headers`. SSE is not parsed.',
+    verified: VERIFIED,
+  },
+}
+
+export const zed: ClientConfig = {
+  id: 'zed',
+  displayName: 'Zed',
+  installCheckPaths: {
+    darwin: ['$HOME/.config/zed'],
+    linux: ['$HOME/.config/zed'],
+    win32: ['$APPDATA\\Zed'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.config/zed/settings.json'],
+    linux: ['$HOME/.config/zed/settings.json'],
+    win32: ['$APPDATA\\Zed\\settings.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio', 'sse', 'http'] },
+  stdio: {
+    topLevelKey: 'context_servers',
+    injects: { source: 'custom', enabled: true },
+  },
+  http: {
+    injects: { source: 'custom', enabled: true },
+    supportsOAuth: true,
+  },
+  sources: {
+    firstParty: 'https://zed.dev/docs/ai/mcp',
+    smithery: SMITHERY_URL,
+    notes:
+      'Zed calls them "context_servers". The block sits alongside other settings, so writes are non-destructive under that key.',
+    verified: VERIFIED,
+  },
+}
+
+// -------------------------------------------------------------------
+// Additional clients from Smithery's full roster
+// -------------------------------------------------------------------
+
+export const cline: ClientConfig = {
+  id: 'cline',
+  displayName: 'Cline',
+  installCheckPaths: {
+    darwin: [
+      '$HOME/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev',
+    ],
+    linux: ['$HOME/.config/Code/User/globalStorage/saoudrizwan.claude-dev'],
+    win32: ['$APPDATA\\Code\\User\\globalStorage\\saoudrizwan.claude-dev'],
+  },
+  systemPaths: {
+    darwin: [
+      '$HOME/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json',
+    ],
+    linux: [
+      '$HOME/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json',
+    ],
+    win32: [
+      '$APPDATA\\Code\\User\\globalStorage\\saoudrizwan.claude-dev\\settings\\cline_mcp_settings.json',
+    ],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio', 'http'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  http: {
+    tagKey: 'type',
+    tagValue: 'streamableHttp',
+    supportsOAuth: true,
+  },
+  sources: {
+    firstParty: 'https://docs.cline.bot/mcp/mcp-server-development-protocol',
+    smithery: SMITHERY_URL,
+    notes:
+      'Cline uses `type: "streamableHttp"` (camelCase) for remote HTTP, distinct from Kiro\'s `streamable-http`.',
+    verified: VERIFIED,
+  },
+}
+
+export const opencode: ClientConfig = {
+  id: 'opencode',
+  displayName: 'OpenCode',
+  installCheckPaths: {
+    darwin: ['$HOME/.opencode'],
+    linux: ['$HOME/.opencode'],
+    win32: ['$USERPROFILE\\.opencode'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.opencode/opencode.jsonc'],
+    linux: ['$HOME/.opencode/opencode.jsonc'],
+    win32: ['$USERPROFILE\\.opencode\\opencode.jsonc'],
+  },
+  format: 'jsonc',
+  supportedTransports: { system: ['stdio', 'sse', 'http'] },
+  stdio: {
+    topLevelKey: 'mcp',
+    envField: 'environment',
+    commandAsArray: true,
+    injects: { type: 'local', enabled: true },
+  },
+  http: {
+    tagKey: 'type',
+    tagValue: 'remote',
+    injects: { enabled: true },
+    supportsOAuth: true,
+  },
+  sources: {
+    firstParty: 'https://opencode.ai/docs/mcp',
+    smithery: SMITHERY_URL,
+    notes:
+      'Command written as a single array of [command, ...args] under `command`. `env` renamed to `environment`. Both stdio and remote entries carry a `type` field (`local` vs `remote`).',
+    verified: VERIFIED,
+  },
+}
+
+export const goose: ClientConfig = {
+  id: 'goose',
+  displayName: 'Goose',
+  installCheckPaths: {
+    darwin: ['$HOME/.config/goose'],
+    linux: ['$HOME/.config/goose'],
+    win32: ['$APPDATA\\Block\\goose'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.config/goose/config.yaml'],
+    linux: ['$HOME/.config/goose/config.yaml'],
+    win32: ['$APPDATA\\Block\\goose\\config\\config.yaml'],
+  },
+  format: 'yaml',
+  supportedTransports: { system: ['stdio', 'http'] },
+  stdio: {
+    topLevelKey: 'extensions',
+    commandField: 'cmd',
+    envField: 'envs',
+    tagKey: 'type',
+    tagValue: 'stdio',
+    keyTransform: 'simpleName',
+  },
+  http: { tagKey: 'type', tagValue: 'http', supportsOAuth: true },
+  sources: {
+    firstParty:
+      'https://block.github.io/goose/docs/getting-started/using-extensions',
+    smithery: SMITHERY_URL,
+    notes:
+      "Extension keys are letters-only lowercase (Goose's `simpleName` transform). Command renamed to `cmd`, env renamed to `envs`. Docker's upstream config also hardcodes several static fields (`bundled: null`, `description`, `enabled: true`); we do not emit those unless a consumer asks.",
+    verified: VERIFIED,
+  },
+}
+
+export const kiro: ClientConfig = {
+  id: 'kiro',
+  displayName: 'Kiro',
+  installCheckPaths: {
+    darwin: ['$HOME/.kiro'],
+    linux: ['$HOME/.kiro'],
+    win32: ['$USERPROFILE\\.kiro'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.kiro/settings/mcp.json'],
+    linux: ['$HOME/.kiro/settings/mcp.json'],
+    win32: ['$USERPROFILE\\.kiro\\settings\\mcp.json'],
+  },
+  projectFile: '.kiro/settings/mcp.json',
+  format: 'json',
+  supportedTransports: {
+    system: ['stdio', 'http'],
+    project: ['stdio', 'http'],
+  },
+  stdio: { topLevelKey: 'mcpServers' },
+  http: {
+    tagKey: 'type',
+    tagValue: 'streamable-http',
+    supportsOAuth: true,
+  },
+  project: {
+    stdio: { topLevelKey: 'mcpServers' },
+    http: {
+      tagKey: 'type',
+      tagValue: 'streamable-http',
+      supportsOAuth: true,
+    },
+  },
+  sources: {
+    firstParty: 'https://kiro.dev/docs/mcp',
+    smithery: SMITHERY_URL,
+    notes:
+      'Kiro uses `type: "streamable-http"` (kebab-case), the spec-canonical form.',
+    verified: VERIFIED,
+  },
+}
+
+export const windsurf: ClientConfig = {
+  id: 'windsurf',
+  displayName: 'Windsurf',
+  installCheckPaths: {
+    darwin: ['$HOME/.codeium/windsurf'],
+    linux: ['$HOME/.codeium/windsurf'],
+    win32: ['$USERPROFILE\\.codeium\\windsurf'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.codeium/windsurf/mcp_config.json'],
+    linux: ['$HOME/.codeium/windsurf/mcp_config.json'],
+    win32: ['$USERPROFILE\\.codeium\\windsurf\\mcp_config.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio', 'http'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  http: {
+    urlField: 'serverUrl',
+    supportsOAuth: true,
+  },
+  sources: {
+    firstParty: 'https://docs.windsurf.com/windsurf/mcp',
+    smithery: SMITHERY_URL,
+    notes:
+      'Windsurf calls the URL field `serverUrl` for remote entries, not the default `url`.',
+    verified: VERIFIED,
+  },
+}
+
+export const witsy: ClientConfig = {
+  id: 'witsy',
+  displayName: 'Witsy',
+  installCheckPaths: {
+    darwin: ['$HOME/Library/Application Support/Witsy'],
+    linux: ['$HOME/.config/Witsy'],
+    win32: ['$APPDATA\\Witsy'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/Library/Application Support/Witsy/settings.json'],
+    linux: ['$HOME/.config/Witsy/settings.json'],
+    win32: ['$APPDATA\\Witsy\\settings.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  sources: {
+    firstParty: 'https://github.com/nbonamy/witsy',
+    smithery: SMITHERY_URL,
+    verified: VERIFIED,
+  },
+}
+
+export const enconvo: ClientConfig = {
+  id: 'enconvo',
+  displayName: 'Enconvo',
+  installCheckPaths: {
+    darwin: ['$HOME/.config/enconvo'],
+    linux: ['$HOME/.config/enconvo'],
+    win32: ['$USERPROFILE\\.config\\enconvo'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.config/enconvo/mcp_config.json'],
+    linux: ['$HOME/.config/enconvo/mcp_config.json'],
+    win32: ['$USERPROFILE\\.config\\enconvo\\mcp_config.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  sources: {
+    firstParty: 'https://enconvo.com',
+    smithery: SMITHERY_URL,
+    verified: VERIFIED,
+  },
+}
+
+export const roocode: ClientConfig = {
+  id: 'roocode',
+  displayName: 'Roo Code',
+  installCheckPaths: {
+    darwin: [
+      '$HOME/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline',
+    ],
+    linux: ['$HOME/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline'],
+    win32: ['$APPDATA\\Code\\User\\globalStorage\\rooveterinaryinc.roo-cline'],
+  },
+  systemPaths: {
+    darwin: [
+      '$HOME/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json',
+    ],
+    linux: [
+      '$HOME/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json',
+    ],
+    win32: [
+      '$APPDATA\\Code\\User\\globalStorage\\rooveterinaryinc.roo-cline\\settings\\mcp_settings.json',
+    ],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  sources: {
+    firstParty: 'https://docs.roocode.com/features/mcp/overview',
+    smithery: SMITHERY_URL,
+    notes:
+      "Roo Code is a VS Code extension (fork of Cline). MCP settings live in the extension's globalStorage folder.",
+    verified: VERIFIED,
+  },
+}
+
+export const boltai: ClientConfig = {
+  id: 'boltai',
+  displayName: 'BoltAI',
+  installCheckPaths: {
+    darwin: ['$HOME/.boltai'],
+    linux: ['$HOME/.boltai'],
+    win32: ['$USERPROFILE\\.boltai'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.boltai/mcp.json'],
+    linux: ['$HOME/.boltai/mcp.json'],
+    win32: ['$USERPROFILE\\.boltai\\mcp.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  sources: {
+    firstParty: 'https://boltai.com',
+    smithery: SMITHERY_URL,
+    verified: VERIFIED,
+  },
+}
+
+export const amazonBedrock: ClientConfig = {
+  id: 'amazon-bedrock',
+  displayName: 'Amazon Bedrock',
+  installCheckPaths: {
+    darwin: ['$HOME/Amazon Bedrock Client'],
+    linux: ['$HOME/Amazon Bedrock Client'],
+    win32: ['$USERPROFILE\\Amazon Bedrock Client'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/Amazon Bedrock Client/mcp_config.json'],
+    linux: ['$HOME/Amazon Bedrock Client/mcp_config.json'],
+    win32: ['$USERPROFILE\\Amazon Bedrock Client\\mcp_config.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  sources: {
+    firstParty: 'https://docs.aws.amazon.com/bedrock/latest/userguide/',
+    smithery: SMITHERY_URL,
+    verified: VERIFIED,
+  },
+}
+
+export const amazonq: ClientConfig = {
+  id: 'amazonq',
+  displayName: 'Amazon Q',
+  installCheckPaths: {
+    darwin: ['$HOME/.aws/amazonq'],
+    linux: ['$HOME/.aws/amazonq'],
+    win32: ['$USERPROFILE\\.aws\\amazonq'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.aws/amazonq/mcp.json'],
+    linux: ['$HOME/.aws/amazonq/mcp.json'],
+    win32: ['$USERPROFILE\\.aws\\amazonq\\mcp.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  sources: {
+    firstParty:
+      'https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-mcp.html',
+    smithery: SMITHERY_URL,
+    verified: VERIFIED,
+  },
+}
+
+export const tome: ClientConfig = {
+  id: 'tome',
+  displayName: 'Tome',
+  installCheckPaths: {
+    darwin: ['$HOME/.tome'],
+    linux: ['$HOME/.tome'],
+    win32: ['$USERPROFILE\\.tome'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.tome/mcp_config.json'],
+    linux: ['$HOME/.tome/mcp_config.json'],
+    win32: ['$USERPROFILE\\.tome\\mcp_config.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  sources: {
+    firstParty: 'https://github.com/runebookai/tome',
+    smithery: SMITHERY_URL,
+    verified: VERIFIED,
+  },
+}
+
+export const librechat: ClientConfig = {
+  id: 'librechat',
+  displayName: 'LibreChat',
+  installCheckPaths: {
+    darwin: ['$HOME/LibreChat'],
+    linux: ['$HOME/LibreChat'],
+    win32: ['$USERPROFILE\\LibreChat'],
+  },
+  systemPaths: {
+    darwin: [
+      '$LIBRECHAT_CONFIG_DIR/LibreChat/librechat.yaml',
+      '$HOME/LibreChat/librechat.yaml',
+    ],
+    linux: [
+      '$LIBRECHAT_CONFIG_DIR/LibreChat/librechat.yaml',
+      '$HOME/LibreChat/librechat.yaml',
+    ],
+    win32: [
+      '$LIBRECHAT_CONFIG_DIR\\LibreChat\\librechat.yaml',
+      '$USERPROFILE\\LibreChat\\librechat.yaml',
+    ],
+  },
+  format: 'yaml',
+  supportedTransports: { system: ['stdio', 'sse', 'http'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  http: { tagKey: 'type', tagValue: 'http', supportsOAuth: true },
+  sources: {
+    firstParty:
+      'https://www.librechat.ai/docs/configuration/librechat_yaml/object_structure/mcp_servers',
+    smithery: SMITHERY_URL,
+    notes:
+      'YAML config file. mcpServers block accepts stdio (command/args) and remote (url) entries.',
+    verified: VERIFIED,
+  },
+}
+
+export const antigravity: ClientConfig = {
+  id: 'antigravity',
+  displayName: 'Antigravity',
+  installCheckPaths: {
+    darwin: ['$HOME/.gemini/antigravity'],
+    linux: ['$HOME/.gemini/antigravity'],
+    win32: ['$USERPROFILE\\.gemini\\antigravity'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/.gemini/antigravity/mcp_config.json'],
+    linux: ['$HOME/.gemini/antigravity/mcp_config.json'],
+    win32: ['$USERPROFILE\\.gemini\\antigravity\\mcp_config.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio', 'http'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  http: {
+    urlField: 'serverUrl',
+    supportsOAuth: true,
+  },
+  sources: {
+    firstParty: 'https://antigravity.google/',
+    smithery: SMITHERY_URL,
+    notes:
+      "Google's Antigravity editor. Uses `serverUrl` for remote entries (matches Windsurf's convention).",
+    verified: VERIFIED,
+  },
+}
+
+export const trae: ClientConfig = {
+  id: 'trae',
+  displayName: 'Trae',
+  installCheckPaths: {
+    darwin: ['$HOME/Library/Application Support/Trae'],
+    linux: ['$HOME/.config/Trae'],
+    win32: ['$APPDATA\\Trae'],
+  },
+  systemPaths: {
+    darwin: ['$HOME/Library/Application Support/Trae/User/mcp.json'],
+    linux: ['$HOME/.config/Trae/User/mcp.json'],
+    win32: ['$APPDATA\\Trae\\User\\mcp.json'],
+  },
+  format: 'json',
+  supportedTransports: { system: ['stdio', 'http'] },
+  stdio: { topLevelKey: 'mcpServers' },
+  http: { tagKey: 'type', tagValue: 'http', supportsOAuth: true },
+  sources: {
+    firstParty: 'https://docs.trae.ai/ide/model-context-protocol',
+    smithery: SMITHERY_URL,
+    notes:
+      'Trae is a VS Code fork with a dedicated mcp.json file under `<App Support>/Trae/User/`.',
+    verified: VERIFIED,
+  },
+}
+
+// -------------------------------------------------------------------
+// Aggregated catalog
+// -------------------------------------------------------------------
+
+export const CATALOG: ReadonlyArray<ClientConfig> = [
+  amazonBedrock,
+  amazonq,
+  antigravity,
+  boltai,
+  claudeCode,
+  claudeDesktop,
+  cline,
+  codex,
+  cursor,
+  enconvo,
+  gemini,
+  goose,
+  kiro,
+  librechat,
+  opencode,
+  roocode,
+  tome,
+  trae,
+  vscode,
+  vscodeInsiders,
+  windsurf,
+  witsy,
+  zed,
+]
+
+type CatalogById = { readonly [K in ClientConfig['id']]: ClientConfig }
+
+export const CATALOG_BY_ID: CatalogById = CATALOG.reduce(
+  (acc, entry) => Object.assign(acc, { [entry.id]: entry }),
+  Object.create(null) as CatalogById,
+)

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/types.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/types.ts
@@ -1,0 +1,136 @@
+// fallow-ignore-next-line unused-files
+/**
+ * Hand-authored MCP client configuration catalog.
+ *
+ * Every published client is one `ClientConfig` value. Data lives in
+ * `client-configs.ts`; interpretation lives in the emitters. Sources
+ * were researched from each client's first-party MCP docs, cross-
+ * checked against smithery-ai/cli (AGPL-3.0, design reference only).
+ * See `THIRD_PARTY_NOTICES.md` for the Smithery disclosure.
+ *
+ * Schema pattern (interfaces + shape space) is informed by Smithery's
+ * `src/config/clients.ts`. Interfaces and populated data are authored
+ * by us under MIT; no source code from Smithery is incorporated.
+ */
+
+import type { McpTransport } from '../types'
+
+/** Union of every client id we ship a config for. */
+export type ClientId =
+  | 'claude-desktop'
+  | 'claude-code'
+  | 'cursor'
+  | 'vscode'
+  | 'vscode-insiders'
+  | 'gemini'
+  | 'codex'
+  | 'zed'
+  | 'cline'
+  | 'opencode'
+  | 'goose'
+  | 'kiro'
+  | 'windsurf'
+  | 'witsy'
+  | 'enconvo'
+  | 'roocode'
+  | 'boltai'
+  | 'amazon-bedrock'
+  | 'amazonq'
+  | 'tome'
+  | 'librechat'
+  | 'antigravity'
+  | 'trae'
+
+export interface PerOsPaths {
+  darwin?: string[]
+  linux?: string[]
+  win32?: string[]
+}
+
+export type ConfigFormat = 'json' | 'jsonc' | 'yaml' | 'toml'
+
+export interface StdioShape {
+  /** Object key that holds the entry map. Examples: 'mcpServers', 'servers', 'mcp', 'context_servers', 'extensions'. */
+  topLevelKey: string
+  /** Field name for the executable command. Default 'command'. Goose uses 'cmd'. */
+  commandField?: string
+  /** Field name for the args array. Default 'args'. */
+  argsField?: string
+  /** Field name for the env-var map. Default 'env'. Goose uses 'envs'. OpenCode uses 'environment'. */
+  envField?: string
+  /**
+   * When true, emit command + args as a single array under the command
+   * field (e.g. `command: [<command>, ...<args>]`). OpenCode does this.
+   */
+  commandAsArray?: boolean
+  /** When set, write `{ [tagKey]: tagValue }` alongside the base shape. */
+  tagKey?: 'type' | 'transport'
+  /** Value written under `tagKey`. Common: 'stdio' or 'local'. */
+  tagValue?: string
+  /** Static fields merged into every stdio entry (e.g. Zed's `source: 'custom', enabled: true`). */
+  injects?: Record<string, unknown>
+  /**
+   * When set, transform the caller-supplied server name before using it
+   * as the entry key. `'simpleName'` matches Docker/Goose semantics
+   * (lowercase, letters only: `MCP_DOCKER` -> `mcpdocker`).
+   */
+  keyTransform?: 'simpleName'
+}
+
+export interface HttpShape {
+  /** Field name for the URL. Default 'url'. Windsurf uses 'serverUrl'. */
+  urlField?: string
+  /** Field name for the header map. Default 'headers'. */
+  headerField?: string
+  /** When set, write `{ [tagKey]: tagValue }` for http entries. */
+  tagKey?: 'type' | 'transport'
+  /**
+   * Value written under `tagKey` for http entries. Known values:
+   * 'http', 'streamableHttp' (Cline), 'streamable-http' (Kiro),
+   * 'remote' (OpenCode).
+   */
+  tagValue?: string
+  /** Static fields merged into every http entry. */
+  injects?: Record<string, unknown>
+  /**
+   * Whether the client advertises OAuth support. Recorded for future
+   * awareness; v0.0.4 does not act on it. Consumers thread bearer tokens
+   * via `spec.headers` today.
+   */
+  supportsOAuth?: boolean
+}
+
+export interface ClientConfigSources {
+  /** Required. URL to the client's first-party MCP documentation. */
+  firstParty: string
+  /** URL to the corroborating source we cross-checked at authoring time. Set when Smithery has an entry. */
+  smithery?: string
+  /** Free-form notes about drift between sources or edge cases. */
+  notes?: string
+  /** ISO date the entry was last verified against sources. Enforced by the validator (must be within 12 months). */
+  verified: string
+}
+
+export interface ClientConfig {
+  id: ClientId
+  displayName: string
+  installCheckPaths: PerOsPaths
+  systemPaths: PerOsPaths
+  /** Relative to projectRoot when scope is 'project'. */
+  projectFile?: string
+  format: ConfigFormat
+  supportedTransports: {
+    system: ReadonlyArray<McpTransport>
+    /** Set when project scope diverges from system scope. */
+    project?: ReadonlyArray<McpTransport>
+  }
+  stdio: StdioShape
+  /** Present iff `supportedTransports.system` includes 'http' or 'sse'. Enforced by the validator. */
+  http?: HttpShape
+  /** Present when project scope has divergent write shapes. Enforced by the validator. */
+  project?: {
+    stdio: StdioShape
+    http?: HttpShape
+  }
+  sources: ClientConfigSources
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/validate.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/validate.ts
@@ -1,0 +1,178 @@
+// fallow-ignore-next-line unused-files
+/**
+ * Catalog validator. Pure functions. Runs at test time (see
+ * `test/unit/catalog-validate.test.ts`) and blocks a build whenever a
+ * populated entry is missing a required field, has an inconsistent
+ * transport declaration, or carries a stale `verified` date.
+ *
+ * Consumers of the library never see this module. It exists purely to
+ * enforce the schema-plus-citation invariants on `client-configs.ts`.
+ */
+
+import type { ClientConfig, ClientId } from './types'
+
+export interface ValidationError {
+  clientId: ClientId | '<duplicate>'
+  path: string
+  message: string
+}
+
+/** Maximum age of a `sources.verified` date before it counts as stale. */
+export const MAX_VERIFIED_AGE_DAYS = 365
+
+/**
+ * Validate every populated entry against the catalog's invariants.
+ * Returns an empty array on success. Never throws.
+ */
+export function validateCatalog(
+  entries: ReadonlyArray<ClientConfig>,
+  now: Date,
+): ValidationError[] {
+  const errors: ValidationError[] = []
+  const seenIds = new Set<ClientId>()
+
+  for (const entry of entries) {
+    validateEntry(entry, now, errors)
+    if (seenIds.has(entry.id)) {
+      errors.push({
+        clientId: '<duplicate>',
+        path: `id`,
+        message: `duplicate client id "${entry.id}" appears more than once in CATALOG`,
+      })
+    }
+    seenIds.add(entry.id)
+  }
+  return errors
+}
+
+function validateEntry(
+  entry: ClientConfig,
+  now: Date,
+  errors: ValidationError[],
+): void {
+  validateSources(entry, now, errors)
+  validatePaths(entry, errors)
+  validateTransportShape(entry, errors)
+  validateProjectShape(entry, errors)
+}
+
+function validateSources(
+  entry: ClientConfig,
+  now: Date,
+  errors: ValidationError[],
+): void {
+  const push = mkPush(entry, errors)
+  if (!entry.sources.firstParty?.trim()) {
+    push(
+      'sources.firstParty',
+      'first-party docs URL is required (no populated entry may ship without one)',
+    )
+  } else if (!isLikelyUrl(entry.sources.firstParty)) {
+    push('sources.firstParty', 'value must be an http(s) URL')
+  }
+  if (entry.sources.smithery && !isLikelyUrl(entry.sources.smithery)) {
+    push('sources.smithery', 'value must be an http(s) URL')
+  }
+  if (!isIsoDate(entry.sources.verified)) {
+    push(
+      'sources.verified',
+      `must be a YYYY-MM-DD ISO date, got ${JSON.stringify(entry.sources.verified)}`,
+    )
+  } else if (isStaleVerifiedDate(entry.sources.verified, now)) {
+    push(
+      'sources.verified',
+      `entry has not been re-verified in over ${MAX_VERIFIED_AGE_DAYS} days (last verified ${entry.sources.verified})`,
+    )
+  }
+}
+
+function validatePaths(entry: ClientConfig, errors: ValidationError[]): void {
+  const anyPath = (['darwin', 'linux', 'win32'] as const).some(
+    (os) => (entry.systemPaths[os] ?? []).length > 0,
+  )
+  if (!anyPath) {
+    mkPush(entry, errors)(
+      'systemPaths',
+      'at least one of darwin / linux / win32 must have a non-empty path list',
+    )
+  }
+}
+
+function validateTransportShape(
+  entry: ClientConfig,
+  errors: ValidationError[],
+): void {
+  const push = mkPush(entry, errors)
+  const systemHasRemote = includesRemote(entry.supportedTransports.system)
+  if (systemHasRemote && !entry.http) {
+    push(
+      'http',
+      'system supportedTransports includes http or sse but no http shape is declared',
+    )
+  } else if (!systemHasRemote && entry.http) {
+    push(
+      'http',
+      'http shape declared but supportedTransports.system does not include http or sse',
+    )
+  }
+}
+
+function validateProjectShape(
+  entry: ClientConfig,
+  errors: ValidationError[],
+): void {
+  const projectTransports = entry.supportedTransports.project
+  if (!projectTransports) return
+  const push = mkPush(entry, errors)
+  if (!entry.projectFile) {
+    push(
+      'projectFile',
+      'must be set when supportedTransports.project is declared',
+    )
+  }
+  if (!entry.project?.stdio) {
+    push(
+      'project.stdio',
+      'must be set when supportedTransports.project is declared',
+    )
+  }
+  const projHasRemote = includesRemote(projectTransports)
+  if (projHasRemote && !entry.project?.http) {
+    push(
+      'project.http',
+      'project supportedTransports includes http or sse but no project http shape is declared',
+    )
+  } else if (!projHasRemote && entry.project?.http) {
+    push(
+      'project.http',
+      'project http shape declared but project supportedTransports does not include http or sse',
+    )
+  }
+}
+
+function mkPush(entry: ClientConfig, errors: ValidationError[]) {
+  return (path: string, message: string) =>
+    errors.push({ clientId: entry.id, path, message })
+}
+
+function includesRemote(transports: ReadonlyArray<string>): boolean {
+  return transports.includes('http') || transports.includes('sse')
+}
+
+function isLikelyUrl(value: string): boolean {
+  return /^https?:\/\//.test(value)
+}
+
+function isIsoDate(value: string): boolean {
+  return (
+    /^\d{4}-\d{2}-\d{2}$/.test(value) &&
+    !Number.isNaN(new Date(value).getTime())
+  )
+}
+
+function isStaleVerifiedDate(iso: string, now: Date): boolean {
+  const then = new Date(iso).getTime()
+  const ms = now.getTime() - then
+  const days = ms / (1000 * 60 * 60 * 24)
+  return days > MAX_VERIFIED_AGE_DAYS
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/_internal/atomic-write.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/_internal/atomic-write.ts
@@ -1,0 +1,48 @@
+import * as fsp from 'node:fs/promises'
+import * as path from 'node:path'
+
+/**
+ * Write `data` to `file` via a sibling temp file + rename. Creates the
+ * parent directory if needed. The rename is atomic on POSIX
+ * filesystems; cross-platform "good enough" elsewhere.
+ */
+export async function atomicWriteFile(
+  file: string,
+  data: string,
+): Promise<void> {
+  await fsp.mkdir(path.dirname(file), { recursive: true })
+  const tmp = `${file}.tmp-${process.pid}-${Date.now()}`
+  try {
+    await fsp.writeFile(tmp, data, 'utf8')
+    await fsp.rename(tmp, file)
+  } catch (err) {
+    // Best-effort cleanup of the temp file on failure.
+    try {
+      await fsp.unlink(tmp)
+    } catch {
+      // ignore
+    }
+    throw err
+  }
+}
+
+/**
+ * Read a file's contents plus a flag saying whether the file existed on
+ * disk. An empty file on disk still returns `exists: true`; only ENOENT
+ * returns `exists: false`. Used by `readState` so `AgentFileState.exists`
+ * matches the JSDoc contract instead of conflating "existed" with
+ * "non-empty".
+ */
+export async function readFileWithExistence(
+  file: string,
+): Promise<{ content: string; exists: boolean }> {
+  try {
+    const content = await fsp.readFile(file, 'utf8')
+    return { content, exists: true }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { content: '', exists: false }
+    }
+    throw err
+  }
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/_internal/manifest.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/_internal/manifest.ts
@@ -1,0 +1,68 @@
+import * as fsp from 'node:fs/promises'
+import * as path from 'node:path'
+
+import { McpManagerError } from '../errors'
+import type { ServerManifest } from '../types'
+
+export function emptyManifest(): ServerManifest {
+  return { version: 1, servers: {} }
+}
+
+function manifestPath(workspaceDir: string): string {
+  return path.join(workspaceDir, 'manifest.json')
+}
+
+/**
+ * Read the manifest. Returns an empty manifest only when the file is
+ * absent or empty — malformed JSON, wrong shape, or wrong version
+ * throws so callers can recover instead of silently overwriting their
+ * existing state.
+ */
+export async function readManifest(
+  workspaceDir: string,
+): Promise<ServerManifest> {
+  const file = manifestPath(workspaceDir)
+  let raw: string
+  try {
+    raw = await fsp.readFile(file, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return emptyManifest()
+    throw err
+  }
+  if (!raw.trim()) return emptyManifest()
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new McpManagerError(
+      `Manifest at ${file} is not valid JSON. Inspect and repair or delete to start fresh.`,
+      { cause: err },
+    )
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new McpManagerError(`Manifest at ${file} is not an object.`)
+  }
+  const candidate = parsed as Partial<ServerManifest>
+  if (candidate.version !== 1) {
+    throw new McpManagerError(
+      `Manifest at ${file} has unsupported version ${String(candidate.version)}; expected 1.`,
+    )
+  }
+  if (typeof candidate.servers !== 'object' || candidate.servers === null) {
+    throw new McpManagerError(
+      `Manifest at ${file} is missing a valid \`servers\` object.`,
+    )
+  }
+  return parsed as ServerManifest
+}
+
+export async function writeManifest(
+  workspaceDir: string,
+  manifest: ServerManifest,
+): Promise<void> {
+  const file = manifestPath(workspaceDir)
+  await fsp.mkdir(workspaceDir, { recursive: true })
+  const tmp = `${file}.tmp-${process.pid}-${Date.now()}`
+  await fsp.writeFile(tmp, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+  await fsp.rename(tmp, file)
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/_internal/paths.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/_internal/paths.ts
@@ -1,0 +1,61 @@
+import * as fsp from 'node:fs/promises'
+
+/**
+ * Resolves `$VAR` segments against `process.env`. Mirrors Docker's
+ * `isPathValid` / `os.ExpandEnv` pair: returns null if any referenced
+ * env var is undefined or empty.
+ */
+const ENV_VAR_RE = /\$([A-Za-z_][A-Za-z0-9_]*)/g
+
+function expandPath(p: string): string | null {
+  let missing = false
+  const out = p.replace(ENV_VAR_RE, (_, name: string) => {
+    const value = process.env[name]
+    if (!value) {
+      missing = true
+      return ''
+    }
+    return value
+  })
+  return missing ? null : out
+}
+
+export function expandPaths(paths: string[]): string[] {
+  const out: string[] = []
+  for (const raw of paths) {
+    const expanded = expandPath(raw)
+    if (expanded !== null) out.push(expanded)
+  }
+  return out
+}
+
+export async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fsp.stat(p)
+    return true
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false
+    return false
+  }
+}
+
+export async function anyExists(paths: string[]): Promise<boolean> {
+  for (const p of paths) {
+    if (await pathExists(p)) return true
+  }
+  return false
+}
+
+/**
+ * Pick the best system config path: prefer the first one that already
+ * exists; otherwise the first one with all env vars resolvable.
+ */
+export async function pickConfigPath(
+  candidates: string[],
+): Promise<string | null> {
+  const expanded = expandPaths(candidates)
+  for (const p of expanded) {
+    if (await pathExists(p)) return p
+  }
+  return expanded[0] ?? null
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/agents.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/agents.ts
@@ -1,0 +1,131 @@
+import * as path from 'node:path'
+
+import { CATALOG, CATALOG_BY_ID } from './_catalog/client-configs'
+import type { ClientConfig } from './_catalog/types'
+import { anyExists, expandPaths, pickConfigPath } from './_internal/paths'
+import { AgentNotSupportedError, UnresolvedConfigPathError } from './errors'
+import type { AgentId, AgentInfo, AgentScope, McpTransport } from './types'
+
+const ALL_TRANSPORTS: ReadonlyArray<McpTransport> = ['stdio', 'sse', 'http']
+
+const PLATFORMS = ['darwin', 'linux', 'win32'] as const
+type Platform = (typeof PLATFORMS)[number]
+
+function currentPlatform(): Platform {
+  const p = process.platform
+  if (p === 'darwin' || p === 'linux' || p === 'win32') return p
+  return 'linux'
+}
+
+function pickOsList(map: Partial<Record<Platform, string[]>>): string[] {
+  return map[currentPlatform()] ?? []
+}
+
+export function listSupportedAgents(): AgentId[] {
+  return CATALOG.map((entry) => entry.id)
+}
+
+export function isAgentSupported(agent: string): agent is AgentId {
+  return Object.hasOwn(CATALOG_BY_ID, agent)
+}
+
+export function getCatalogEntry(agent: AgentId): ClientConfig {
+  const entry = CATALOG_BY_ID[agent]
+  if (!entry) throw new AgentNotSupportedError(agent)
+  return entry
+}
+
+/**
+ * Resolve the config file path agent-mcp-manager would write to for
+ * this agent under the given scope. Throws when the path isn't
+ * resolvable on this OS or when project scope is requested for an
+ * agent that has no project file.
+ */
+export async function resolveAgentMcpConfigPath(
+  agent: AgentId,
+  scope: AgentScope = 'system',
+  projectRoot?: string,
+): Promise<string> {
+  const entry = getCatalogEntry(agent)
+  if (scope === 'project') {
+    if (!entry.projectFile) {
+      throw new UnresolvedConfigPathError(
+        agent,
+        `agent has no project-scope config file`,
+      )
+    }
+    if (!projectRoot) {
+      throw new UnresolvedConfigPathError(
+        agent,
+        `projectRoot is required when scope === 'project'`,
+      )
+    }
+    return path.join(projectRoot, entry.projectFile)
+  }
+  const candidates = pickOsList(entry.systemPaths)
+  if (candidates.length === 0) {
+    throw new UnresolvedConfigPathError(
+      agent,
+      `no system config path configured for OS ${currentPlatform()}`,
+    )
+  }
+  const picked = await pickConfigPath(candidates)
+  if (!picked) {
+    throw new UnresolvedConfigPathError(
+      agent,
+      `no system config path resolves (env vars unset?)`,
+    )
+  }
+  return picked
+}
+
+/**
+ * Resolve the transport-capability set the library uses for the given
+ * agent at the given scope. Project scope falls back to system scope
+ * when the catalog entry does not declare a project-specific override.
+ * Consumers who need the write shapes call `getEmitter(entry, scope)`
+ * from `./emitters/index.ts` directly.
+ */
+export function resolveAgentSurface(
+  agent: AgentId,
+  scope: AgentScope = 'system',
+): {
+  client: ClientConfig
+  supportedTransports: ReadonlyArray<McpTransport>
+} {
+  const entry = getCatalogEntry(agent)
+  if (scope === 'project') {
+    return {
+      client: entry,
+      supportedTransports:
+        entry.supportedTransports.project ??
+        entry.supportedTransports.system ??
+        ALL_TRANSPORTS,
+    }
+  }
+  return {
+    client: entry,
+    supportedTransports: entry.supportedTransports.system ?? ALL_TRANSPORTS,
+  }
+}
+
+export async function detectInstalledAgents(): Promise<AgentInfo[]> {
+  const out: AgentInfo[] = []
+  for (const entry of CATALOG) {
+    const checks = expandPaths(pickOsList(entry.installCheckPaths))
+    const installed = await anyExists(checks)
+    let configPath: string | null = null
+    try {
+      configPath = await resolveAgentMcpConfigPath(entry.id, 'system')
+    } catch {
+      configPath = null
+    }
+    out.push({
+      id: entry.id,
+      displayName: entry.displayName,
+      configPath,
+      installed,
+    })
+  }
+  return out
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/api.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/api.ts
@@ -1,0 +1,326 @@
+/**
+ * Functional public API. Each verb composes readState -> plan* ->
+ * applyPlan against the same workspaceDir. Zero shared mutable state
+ * between calls; the manifest is a value read at the boundary.
+ *
+ * bind(workspaceDir) is stateless sugar for consumers who always pass
+ * the same workspaceDir: each method call still goes through the full
+ * readState + plan + applyPlan pipeline.
+ *
+ * For dry-run / batch composition, import from './lowlevel' instead
+ * and use the pure planner functions directly.
+ */
+
+import { dirname } from 'node:path'
+
+import { pathExists } from './_internal/paths'
+import { resolveAgentMcpConfigPath } from './agents'
+import { UnresolvedConfigPathError } from './errors'
+import { applyPlan, readState } from './io/index'
+import {
+  planDisconnect,
+  planLink,
+  planRemove,
+  planRescan,
+  planUnlink,
+} from './planner/planner'
+import type {
+  DisconnectPlanSummary,
+  LinkPlanSummary,
+  RemovePlanSummary,
+  RescanReport,
+  UnlinkPlanSummary,
+} from './planner/types'
+import type {
+  AgentId,
+  AgentScope,
+  ManifestServerEntry,
+  McpServer,
+} from './types'
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+export interface LinkInputAPI {
+  /**
+   * The server value to link. `name` becomes the manifest key; `spec`
+   * is written to the agent's config file and stored on the manifest
+   * server entry (last-write-wins across links).
+   */
+  server: McpServer
+  agent: AgentId
+  scope?: AgentScope
+  projectRoot?: string
+  configPath?: string
+  allowOverwrite?: boolean
+}
+
+export async function link(
+  workspaceDir: string,
+  input: LinkInputAPI,
+): Promise<LinkPlanSummary> {
+  const state = await readState(workspaceDir, [input.agent], {
+    scope: input.scope,
+    projectRoot: input.projectRoot,
+    overrides: input.configPath
+      ? { [input.agent]: input.configPath }
+      : undefined,
+  })
+  const plan = planLink(state, input, nowIso())
+  await applyPlan(plan)
+  return {
+    serverName: plan.serverName,
+    agent: plan.agent,
+    scope: plan.scope,
+    created: plan.created,
+    overwroteForeign: plan.overwroteForeign,
+  }
+}
+
+export interface UnlinkInputAPI {
+  serverName: string
+  agent: AgentId
+  scope?: AgentScope
+  projectRoot?: string
+  configPath?: string
+}
+
+export async function unlink(
+  workspaceDir: string,
+  input: UnlinkInputAPI,
+): Promise<UnlinkPlanSummary> {
+  // Same precedence disconnect/remove use: explicit override first, then
+  // whatever configPath the manifest recorded for this link, then the
+  // OS-resolved default. Without the manifest lookup, an unlink after a
+  // link() with a non-default path would drop the manifest link record
+  // but leave the on-disk entry orphaned.
+  const initial = await readState(workspaceDir)
+  const recorded =
+    initial.manifest.servers[input.serverName]?.links[input.agent]?.configPath
+  const configPath = input.configPath ?? recorded
+  const state = await readState(workspaceDir, [input.agent], {
+    scope: input.scope,
+    projectRoot: input.projectRoot,
+    overrides: configPath ? { [input.agent]: configPath } : undefined,
+  })
+  const plan = planUnlink(state, input)
+  await applyPlan(plan)
+  return {
+    serverName: plan.serverName,
+    agent: plan.agent,
+    scope: plan.scope,
+    removed: plan.removed,
+  }
+}
+
+export interface DisconnectInputAPI {
+  serverName: string
+  agent: AgentId
+  scope?: AgentScope
+  projectRoot?: string
+  removeIfLast?: boolean
+}
+
+export async function disconnect(
+  workspaceDir: string,
+  input: DisconnectInputAPI,
+): Promise<DisconnectPlanSummary> {
+  // Look up the recorded configPath from the manifest so we read the
+  // exact file link() wrote to. Without this, an override at link()
+  // time gets lost and disconnect would rewrite the OS-resolved path
+  // instead of the one that actually has the entry.
+  const initial = await readState(workspaceDir)
+  const linkRecord =
+    initial.manifest.servers[input.serverName]?.links[input.agent]
+  const state = await readState(workspaceDir, [input.agent], {
+    scope: input.scope,
+    projectRoot: input.projectRoot,
+    overrides: linkRecord?.configPath
+      ? { [input.agent]: linkRecord.configPath }
+      : undefined,
+  })
+  const plan = planDisconnect(state, input)
+  await applyPlan(plan)
+  return {
+    agent: plan.agent,
+    serverName: plan.serverName,
+    scope: plan.scope,
+    unlinked: plan.unlinked,
+    removedManifest: plan.removedManifest,
+  }
+}
+
+export interface RemoveInputAPI {
+  serverName: string
+  unlinkFirst?: boolean
+}
+
+export async function remove(
+  workspaceDir: string,
+  input: RemoveInputAPI,
+): Promise<RemovePlanSummary> {
+  // Read every linked agent's config file at the exact path the
+  // manifest records. Same rationale as disconnect(): the link record
+  // is the source of truth for where we wrote, not the OS default.
+  const manifestState = await readState(workspaceDir)
+  const server = manifestState.manifest.servers[input.serverName]
+  const linkedAgents = server
+    ? (Object.keys(server.links) as AgentId[]).filter((a) => server.links[a])
+    : []
+  const overrides: Partial<Record<AgentId, string>> = {}
+  if (server) {
+    for (const agent of linkedAgents) {
+      const cp = server.links[agent]?.configPath
+      if (cp) overrides[agent] = cp
+    }
+  }
+  const state = await readState(workspaceDir, linkedAgents, { overrides })
+  const plan = planRemove(state, input)
+  await applyPlan(plan)
+  return {
+    serverName: plan.serverName,
+    unlinkedAgents: plan.unlinkedAgents,
+    removedManifest: plan.removedManifest,
+  }
+}
+
+export async function list(
+  workspaceDir: string,
+): Promise<ManifestServerEntry[]> {
+  const state = await readState(workspaceDir)
+  return Object.values(state.manifest.servers)
+}
+
+export interface ListedLink {
+  serverName: string
+  agent: AgentId
+  configPath: string
+}
+
+export interface ListLinksInputAPI {
+  serverNames?: string[]
+  agents?: AgentId[]
+}
+
+export async function listLinks(
+  workspaceDir: string,
+  input?: ListLinksInputAPI,
+): Promise<ListedLink[]> {
+  const state = await readState(workspaceDir)
+  const filterServers = input?.serverNames ? new Set(input.serverNames) : null
+  const filterAgents = input?.agents ? new Set(input.agents) : null
+  const out: ListedLink[] = []
+  for (const server of Object.values(state.manifest.servers)) {
+    if (filterServers && !filterServers.has(server.name)) continue
+    for (const [agentRaw, link] of Object.entries(server.links)) {
+      if (!link) continue
+      const agent = agentRaw as AgentId
+      if (filterAgents && !filterAgents.has(agent)) continue
+      out.push({ serverName: server.name, agent, configPath: link.configPath })
+    }
+  }
+  return out
+}
+
+export interface RescanInputAPI {
+  agents?: AgentId[]
+}
+
+export async function rescan(
+  workspaceDir: string,
+  input?: RescanInputAPI,
+): Promise<RescanReport> {
+  const manifestState = await readState(workspaceDir)
+  const filterAgents = input?.agents
+  const referencedAgents = new Set<AgentId>()
+  for (const server of Object.values(manifestState.manifest.servers)) {
+    for (const agent of Object.keys(server.links)) {
+      const id = agent as AgentId
+      if (!filterAgents || filterAgents.includes(id)) referencedAgents.add(id)
+    }
+  }
+  const state = await readState(workspaceDir, [...referencedAgents])
+  const { rescan: report } = planRescan(state, input)
+  return report
+}
+
+// -------------------------------------------------------------------
+// isInstalled: batch check whether agents can safely receive a link.
+//
+// "Installed" here means "the library can write MCP config to this
+// agent's config path": either the config file already exists on disk
+// OR its parent directory does. This is the same signal `link()` uses
+// to gate `AgentNotInstalledError`, so `isInstalled` predicts what
+// `link()` would throw.
+// -------------------------------------------------------------------
+
+export interface IsInstalledInput {
+  agents: AgentId[]
+  scope?: AgentScope
+  projectRoot?: string
+}
+
+/**
+ * Flat map of agent id to install boolean. Only agents present in
+ * `input.agents` appear as keys; consumers who need to iterate know the
+ * key set from their own input. Duplicate ids in the input collapse.
+ */
+export type IsInstalledResult = Partial<Record<AgentId, boolean>>
+
+export async function isInstalled(
+  input: IsInstalledInput,
+): Promise<IsInstalledResult> {
+  const scope = input.scope ?? 'system'
+  const out: IsInstalledResult = {}
+  for (const agent of input.agents) {
+    if (agent in out) continue
+    out[agent] = await checkOneInstalled(agent, scope, input.projectRoot)
+  }
+  return out
+}
+
+async function checkOneInstalled(
+  agent: AgentId,
+  scope: AgentScope,
+  projectRoot: string | undefined,
+): Promise<boolean> {
+  let configPath: string
+  try {
+    configPath = await resolveAgentMcpConfigPath(agent, scope, projectRoot)
+  } catch (err) {
+    if (err instanceof UnresolvedConfigPathError) return false
+    throw err
+  }
+  if (await pathExists(configPath)) return true
+  if (await pathExists(dirname(configPath))) return true
+  return false
+}
+
+// -------------------------------------------------------------------
+// bind: convenience wrapper for a fixed workspaceDir
+// -------------------------------------------------------------------
+
+export interface BoundApi {
+  link(input: LinkInputAPI): Promise<LinkPlanSummary>
+  unlink(input: UnlinkInputAPI): Promise<UnlinkPlanSummary>
+  disconnect(input: DisconnectInputAPI): Promise<DisconnectPlanSummary>
+  remove(input: RemoveInputAPI): Promise<RemovePlanSummary>
+  list(): Promise<ManifestServerEntry[]>
+  listLinks(input?: ListLinksInputAPI): Promise<ListedLink[]>
+  rescan(input?: RescanInputAPI): Promise<RescanReport>
+  isInstalled(input: IsInstalledInput): Promise<IsInstalledResult>
+}
+
+export function bind(workspaceDir: string): BoundApi {
+  return {
+    link: (input) => link(workspaceDir, input),
+    unlink: (input) => unlink(workspaceDir, input),
+    disconnect: (input) => disconnect(workspaceDir, input),
+    remove: (input) => remove(workspaceDir, input),
+    list: () => list(workspaceDir),
+    listLinks: (input) => listLinks(workspaceDir, input),
+    rescan: (input) => rescan(workspaceDir, input),
+    isInstalled: (input) => isInstalled(input),
+  }
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/index.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/index.ts
@@ -1,0 +1,46 @@
+import type { ClientConfig } from '../_catalog/types'
+import type { AgentScope, McpServerSpec } from '../types'
+import { jsonAdd, jsonRead, jsonRemove } from './json'
+import { resolveShapes } from './shape'
+import { tomlAdd, tomlRead, tomlRemove } from './toml'
+import { yamlAdd, yamlRead, yamlRemove } from './yaml'
+
+export interface EmitterIO {
+  read(raw: string): string[]
+  add(raw: string, name: string, spec: McpServerSpec): string
+  remove(raw: string, name: string): string
+}
+
+/**
+ * Pick the read/add/remove trio for the given client and scope. The
+ * format (json / jsonc / yaml / toml) selects the serialiser; the
+ * per-client stdio + http shapes drive every field-name / injection /
+ * tag decision. The returned functions close over the resolved shapes,
+ * so callers only pass raw file contents, name, and spec.
+ */
+export function getEmitter(
+  client: ClientConfig,
+  scope: AgentScope = 'system',
+): EmitterIO {
+  const shapes = resolveShapes(client, scope)
+  if (client.format === 'yaml') {
+    return {
+      read: (raw) => yamlRead(raw, shapes),
+      add: (raw, name, spec) => yamlAdd(raw, name, spec, shapes),
+      remove: (raw, name) => yamlRemove(raw, name, shapes),
+    }
+  }
+  if (client.format === 'toml') {
+    return {
+      read: (raw) => tomlRead(raw, shapes),
+      add: (raw, name, spec) => tomlAdd(raw, name, spec, shapes),
+      remove: (raw, name) => tomlRemove(raw, name, shapes),
+    }
+  }
+  // json and jsonc share the same emitter (jsonc-parser handles both).
+  return {
+    read: (raw) => jsonRead(raw, shapes),
+    add: (raw, name, spec) => jsonAdd(raw, name, spec, shapes),
+    remove: (raw, name) => jsonRemove(raw, name, shapes),
+  }
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/json.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/json.ts
@@ -1,0 +1,51 @@
+import { applyEdits, modify, parse } from 'jsonc-parser'
+
+import type { McpServerSpec } from '../types'
+import { buildEntryValue, type ResolvedShapes, transformKey } from './shape'
+
+const FORMATTING = {
+  formattingOptions: { tabSize: 2, insertSpaces: true },
+} as const
+
+/**
+ * JSON / JSONC config emitter. Uses `jsonc-parser` to preserve
+ * comments and formatting of the target file across edits.
+ */
+
+export function jsonRead(raw: string, shapes: ResolvedShapes): string[] {
+  if (!raw.trim()) return []
+  let parsed: unknown
+  try {
+    parsed = parse(raw)
+  } catch {
+    return []
+  }
+  if (!parsed || typeof parsed !== 'object') return []
+  const container = (parsed as Record<string, unknown>)[shapes.topLevelKey]
+  if (!container || typeof container !== 'object') return []
+  return Object.keys(container as Record<string, unknown>)
+}
+
+export function jsonAdd(
+  raw: string,
+  name: string,
+  spec: McpServerSpec,
+  shapes: ResolvedShapes,
+): string {
+  const seed = raw.trim() ? raw : '{}'
+  const key = transformKey(name, shapes.stdio)
+  const value = buildEntryValue(spec, shapes)
+  const edits = modify(seed, [shapes.topLevelKey, key], value, FORMATTING)
+  return applyEdits(seed, edits)
+}
+
+export function jsonRemove(
+  raw: string,
+  name: string,
+  shapes: ResolvedShapes,
+): string {
+  if (!raw.trim()) return raw
+  const key = transformKey(name, shapes.stdio)
+  const edits = modify(raw, [shapes.topLevelKey, key], undefined, FORMATTING)
+  return applyEdits(raw, edits)
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/shape.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/shape.ts
@@ -1,0 +1,132 @@
+/**
+ * Data-driven entry builder. Given a McpServerSpec and the resolved
+ * StdioShape / HttpShape for the target client + scope, produce the
+ * concrete object we serialise into the client's config file.
+ *
+ * The format-specific emitters (json.ts, yaml.ts, toml.ts) all use
+ * this. Emitters only know how to (de)serialise; every per-client
+ * quirk (parent key, field renames, tag key/value, injects, command-
+ * as-array, key transform) lives here.
+ */
+
+import type { ClientConfig, HttpShape, StdioShape } from '../_catalog/types'
+import { InvalidServerSpecError } from '../errors'
+import type { AgentScope, McpServerSpec } from '../types'
+
+export interface ResolvedShapes {
+  topLevelKey: string
+  stdio: StdioShape
+  http?: HttpShape
+}
+
+/**
+ * Pick the pair of shapes that apply to this client + scope. Project
+ * scope falls back to system scope when the client does not declare a
+ * project-specific override.
+ */
+export function resolveShapes(
+  client: ClientConfig,
+  scope: AgentScope,
+): ResolvedShapes {
+  if (scope === 'project' && client.project) {
+    return {
+      topLevelKey: client.project.stdio.topLevelKey,
+      stdio: client.project.stdio,
+      http: client.project.http,
+    }
+  }
+  return {
+    topLevelKey: client.stdio.topLevelKey,
+    stdio: client.stdio,
+    http: client.http,
+  }
+}
+
+/**
+ * Transform the caller-supplied entry key (server name) per the shape's
+ * keyTransform, if any. Currently the only supported transform is
+ * `simpleName`, which lowercases the input and strips every non-letter
+ * (matches Docker/Goose semantics: `MCP_DOCKER` becomes `mcpdocker`).
+ */
+export function transformKey(
+  name: string,
+  shape: StdioShape | undefined,
+): string {
+  if (shape?.keyTransform === 'simpleName') {
+    return name.toLowerCase().replace(/[^a-z]/g, '')
+  }
+  return name
+}
+
+/**
+ * Build the entry object for one server. The returned value goes
+ * verbatim under `topLevelKey.<transformed name>` in the config file.
+ */
+export function buildEntryValue(
+  spec: McpServerSpec,
+  shapes: ResolvedShapes,
+): Record<string, unknown> {
+  if (spec.transport === 'stdio') {
+    return buildStdioEntry(spec, shapes.stdio)
+  }
+  if (!shapes.http) {
+    throw new InvalidServerSpecError(
+      `client does not accept ${spec.transport} entries at this scope`,
+    )
+  }
+  return buildHttpEntry(spec, shapes.http)
+}
+
+function buildStdioEntry(
+  spec: Extract<McpServerSpec, { transport: 'stdio' }>,
+  shape: StdioShape,
+): Record<string, unknown> {
+  const commandField = shape.commandField ?? 'command'
+  const argsField = shape.argsField ?? 'args'
+  const envField = shape.envField ?? 'env'
+
+  const base: Record<string, unknown> = {}
+  if (shape.commandAsArray) {
+    const parts: string[] = [spec.command, ...(spec.args ?? [])]
+    base[commandField] = parts
+  } else {
+    base[commandField] = spec.command
+    if (spec.args && spec.args.length > 0) base[argsField] = spec.args
+  }
+  if (spec.env && Object.keys(spec.env).length > 0) {
+    base[envField] = spec.env
+  }
+  return finaliseEntry(base, shape.injects, shape.tagKey, shape.tagValue)
+}
+
+function buildHttpEntry(
+  spec: Extract<McpServerSpec, { transport: 'sse' | 'http' }>,
+  shape: HttpShape,
+): Record<string, unknown> {
+  const urlField = shape.urlField ?? 'url'
+  const headerField = shape.headerField ?? 'headers'
+
+  const base: Record<string, unknown> = {}
+  base[urlField] = spec.url
+  if (spec.headers && Object.keys(spec.headers).length > 0) {
+    base[headerField] = spec.headers
+  }
+  // HTTP tag value is either a fixed shape.tagValue (Cline, Kiro, etc.)
+  // or nothing (no tag written). We do NOT emit spec.transport as the
+  // tag value here: clients that accept both sse and http use the same
+  // static tag ('http') per Smithery + first-party docs research.
+  return finaliseEntry(base, shape.injects, shape.tagKey, shape.tagValue)
+}
+
+function finaliseEntry(
+  base: Record<string, unknown>,
+  injects: Record<string, unknown> | undefined,
+  tagKey: 'type' | 'transport' | undefined,
+  tagValue: string | undefined,
+): Record<string, unknown> {
+  const withInjects = injects ? { ...base, ...injects } : base
+  if (tagKey && tagValue !== undefined) {
+    return { ...withInjects, [tagKey]: tagValue }
+  }
+  return withInjects
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/toml.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/toml.ts
@@ -1,0 +1,68 @@
+import TOML from '@iarna/toml'
+
+import type { McpServerSpec } from '../types'
+import { buildEntryValue, type ResolvedShapes, transformKey } from './shape'
+
+/**
+ * TOML config emitter. Codex is currently the only TOML consumer in
+ * the catalog. The @iarna/toml package does not preserve comments on
+ * round-trip; entries hand-authored with comments will lose them if
+ * the emitter rewrites the file.
+ */
+
+function parseDoc(raw: string): Record<string, unknown> {
+  if (!raw.trim()) return {}
+  return TOML.parse(raw) as Record<string, unknown>
+}
+
+function ensureMap(
+  doc: Record<string, unknown>,
+  tableKey: string,
+): Record<string, unknown> {
+  let table = doc[tableKey]
+  if (!table || typeof table !== 'object') {
+    table = {}
+    doc[tableKey] = table
+  }
+  return table as Record<string, unknown>
+}
+
+export function tomlRead(raw: string, shapes: ResolvedShapes): string[] {
+  const doc = parseDoc(raw)
+  const table = doc[shapes.topLevelKey]
+  if (!table || typeof table !== 'object') return []
+  return Object.keys(table as Record<string, unknown>)
+}
+
+export function tomlAdd(
+  raw: string,
+  name: string,
+  spec: McpServerSpec,
+  shapes: ResolvedShapes,
+): string {
+  const doc = parseDoc(raw)
+  const table = ensureMap(doc, shapes.topLevelKey)
+  const key = transformKey(name, shapes.stdio)
+  const value = buildEntryValue(spec, shapes)
+  // Codex expects `http_headers` (not `headers`) for the header map on
+  // http entries. `HttpShape.headerField` in the catalog handles that.
+  table[key] = value
+  return TOML.stringify(doc as TOML.JsonMap)
+}
+
+export function tomlRemove(
+  raw: string,
+  name: string,
+  shapes: ResolvedShapes,
+): string {
+  if (!raw.trim()) return raw
+  const doc = parseDoc(raw)
+  const table = doc[shapes.topLevelKey]
+  if (table && typeof table === 'object') {
+    const t = table as Record<string, unknown>
+    const key = transformKey(name, shapes.stdio)
+    if (key in t) delete t[key]
+    if (Object.keys(t).length === 0) delete doc[shapes.topLevelKey]
+  }
+  return TOML.stringify(doc as TOML.JsonMap)
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/yaml.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/yaml.ts
@@ -1,0 +1,62 @@
+import YAML from 'yaml'
+
+import type { McpServerSpec } from '../types'
+import { buildEntryValue, type ResolvedShapes, transformKey } from './shape'
+
+/**
+ * YAML config emitter. Uses the `yaml` package which round-trips
+ * comments and formatting through a Document API. We keep the whole
+ * file as a Document object so hand-authored comments upstream survive
+ * our edits.
+ */
+
+function parseDoc(raw: string): YAML.Document {
+  if (!raw.trim()) return new YAML.Document({}, { keepSourceTokens: true })
+  return YAML.parseDocument(raw, { keepSourceTokens: true })
+}
+
+export function yamlRead(raw: string, shapes: ResolvedShapes): string[] {
+  if (!raw.trim()) return []
+  const doc = parseDoc(raw)
+  const container = doc.get(shapes.topLevelKey)
+  if (!YAML.isMap(container)) return []
+  return container.items
+    .map((item) =>
+      YAML.isScalar(item.key) ? String(item.key.value) : String(item.key),
+    )
+    .filter((k) => k.length > 0)
+}
+
+export function yamlAdd(
+  raw: string,
+  name: string,
+  spec: McpServerSpec,
+  shapes: ResolvedShapes,
+): string {
+  const doc = parseDoc(raw)
+  const key = transformKey(name, shapes.stdio)
+  const value = buildEntryValue(spec, shapes)
+  const container = doc.get(shapes.topLevelKey)
+  if (YAML.isMap(container)) {
+    container.set(key, value)
+  } else {
+    doc.set(shapes.topLevelKey, { [key]: value })
+  }
+  return String(doc)
+}
+
+export function yamlRemove(
+  raw: string,
+  name: string,
+  shapes: ResolvedShapes,
+): string {
+  if (!raw.trim()) return raw
+  const doc = parseDoc(raw)
+  const key = transformKey(name, shapes.stdio)
+  const container = doc.get(shapes.topLevelKey)
+  if (YAML.isMap(container)) {
+    container.delete(key)
+    if (container.items.length === 0) doc.delete(shapes.topLevelKey)
+  }
+  return String(doc)
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/errors.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/errors.ts
@@ -1,0 +1,123 @@
+import type { AgentId, McpTransport } from './types'
+
+export class McpManagerError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message)
+    this.name = 'McpManagerError'
+    if (options?.cause !== undefined) {
+      ;(this as { cause?: unknown }).cause = options.cause
+    }
+  }
+}
+
+export class AgentNotSupportedError extends McpManagerError {
+  readonly agent: string
+  constructor(agent: string) {
+    super(`Agent not supported: ${agent}`)
+    this.name = 'AgentNotSupportedError'
+    this.agent = agent
+  }
+}
+
+export class ServerNotFoundError extends McpManagerError {
+  readonly serverName: string
+  constructor(serverName: string) {
+    super(`No server named "${serverName}" in the manifest`)
+    this.name = 'ServerNotFoundError'
+    this.serverName = serverName
+  }
+}
+
+/**
+ * Raised by `unlink()` when the on-disk entry under that key was not
+ * written by this library (no manifest record). Callers can retry with
+ * `force: true` (future) or run `rescan({ mode: 'merge' })` to adopt it.
+ */
+export class ForeignEntryError extends McpManagerError {
+  readonly serverName: string
+  readonly agent: AgentId
+  readonly configPath: string
+  constructor(serverName: string, agent: AgentId, configPath: string) {
+    super(
+      `Entry "${serverName}" in ${configPath} was not written by agent-mcp-manager for agent "${agent}". Refusing to remove.`,
+    )
+    this.name = 'ForeignEntryError'
+    this.serverName = serverName
+    this.agent = agent
+    this.configPath = configPath
+  }
+}
+
+export class InvalidServerSpecError extends McpManagerError {
+  constructor(reason: string) {
+    super(`Invalid MCP server spec: ${reason}`)
+    this.name = 'InvalidServerSpecError'
+  }
+}
+
+/**
+ * Raised by `link()` when the requested transport is not one this agent's
+ * config file actually accepts. The most common case is passing
+ * `transport: 'http'` (or `'sse'`) for `claude-desktop`, whose parser
+ * only validates stdio-shaped entries on disk; codex now accepts http
+ * directly but still rejects sse. The `hint` field names the
+ * `mcp-remote` wrapper pattern so callers can produce a stdio-shaped
+ * spec the agent will accept.
+ */
+export class UnsupportedTransportError extends McpManagerError {
+  readonly agent: AgentId
+  readonly transport: McpTransport
+  readonly details: { supported: ReadonlyArray<McpTransport>; hint: string }
+  constructor(
+    agent: AgentId,
+    transport: McpTransport,
+    details: { supported: ReadonlyArray<McpTransport>; hint: string },
+  ) {
+    super(
+      `Agent "${agent}" does not support the "${transport}" transport ` +
+        `(supported: ${details.supported.join(', ')}). ${details.hint}`,
+    )
+    this.name = 'UnsupportedTransportError'
+    this.agent = agent
+    this.transport = transport
+    this.details = details
+  }
+}
+
+export class UnresolvedConfigPathError extends McpManagerError {
+  readonly agent: AgentId
+  constructor(agent: AgentId, reason: string) {
+    super(`Cannot resolve config path for agent "${agent}": ${reason}`)
+    this.name = 'UnresolvedConfigPathError'
+    this.agent = agent
+  }
+}
+
+/**
+ * Thrown by `link()` (and `planLink` at the pure layer) when the target
+ * agent's config file location is not writable-safely: neither the file
+ * nor its parent directory exists on disk. The agent has either not been
+ * installed or has been installed but never launched, so the config
+ * directory does not exist yet.
+ *
+ * Consumers precheck with `isInstalled({agents})` to avoid this error;
+ * or catch it and surface the install prompt to the user.
+ */
+export class AgentNotInstalledError extends McpManagerError {
+  readonly agent: AgentId
+  readonly configPath: string
+  readonly parentDir: string
+  constructor(agent: AgentId, configPath: string, parentDir: string) {
+    super(
+      `Agent "${agent}" does not appear to be installed on this machine. ` +
+        `The library needs "${configPath}" or its parent directory "${parentDir}" ` +
+        `to exist before it can write an MCP entry. ` +
+        `Install ${agent} and launch it at least once, or pass an explicit ` +
+        `"configPath" to write to a custom location.`,
+    )
+    this.name = 'AgentNotInstalledError'
+    this.agent = agent
+    this.configPath = configPath
+    this.parentDir = parentDir
+  }
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/index.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/index.ts
@@ -1,0 +1,79 @@
+/**
+ * agent-mcp-manager public API (v0.0.4).
+ *
+ * The v0.0.3 class API (`createMcpManager`, `McpManager`) has been
+ * removed. Consumers migrate to the functional verbs exported here or
+ * to the low-level plan/apply primitives at
+ * `agent-mcp-manager/lowlevel` for dry-run control.
+ *
+ * See README.md's Migration section for a verb-by-verb translation
+ * table.
+ */
+
+export {
+  detectInstalledAgents,
+  getCatalogEntry,
+  isAgentSupported,
+  listSupportedAgents,
+  resolveAgentMcpConfigPath,
+  resolveAgentSurface,
+} from './agents'
+export type {
+  BoundApi,
+  DisconnectInputAPI,
+  IsInstalledInput,
+  IsInstalledResult,
+  LinkInputAPI,
+  ListedLink,
+  ListLinksInputAPI,
+  RemoveInputAPI,
+  RescanInputAPI,
+  UnlinkInputAPI,
+} from './api'
+export {
+  bind,
+  disconnect,
+  isInstalled,
+  link,
+  list,
+  listLinks,
+  remove,
+  rescan,
+  unlink,
+} from './api'
+
+export {
+  AgentNotInstalledError,
+  AgentNotSupportedError,
+  ForeignEntryError,
+  InvalidServerSpecError,
+  McpManagerError,
+  ServerNotFoundError,
+  UnresolvedConfigPathError,
+  UnsupportedTransportError,
+} from './errors'
+
+export type {
+  DisconnectPlanSummary,
+  LinkPlanSummary,
+  RemovePlanSummary,
+  RescanReport,
+  UnlinkPlanSummary,
+} from './planner/types'
+
+export type {
+  AgentId,
+  AgentInfo,
+  AgentScope,
+  ManifestLinkEntry,
+  ManifestServerEntry,
+  McpHttpSpec,
+  McpServer,
+  McpServerSpec,
+  McpSseSpec,
+  McpStdioSpec,
+  McpTransport,
+  ServerManifest,
+} from './types'
+
+export const VERSION = '0.0.4-rc.3'

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/io/index.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/io/index.ts
@@ -1,0 +1,136 @@
+/**
+ * The I/O boundary.
+ *
+ * readState snapshots the workspace manifest and every requested agent
+ * config file into a single State value the pure planners consume.
+ * applyPlan runs a Plan's ops in dependency order with atomic writes.
+ *
+ * The two functions are the ONLY places outside the planner that touch
+ * the filesystem for domain state. Every other module operates on
+ * values.
+ */
+
+import * as fsp from 'node:fs/promises'
+import * as path from 'node:path'
+import {
+  atomicWriteFile,
+  readFileWithExistence,
+} from '../_internal/atomic-write'
+import { readManifest } from '../_internal/manifest'
+import { pathExists } from '../_internal/paths'
+import { resolveAgentMcpConfigPath } from '../agents'
+import type { AgentFileState, FsOp, Plan, State } from '../planner/types'
+import type { AgentId, AgentScope } from '../types'
+
+export interface ReadStateOptions {
+  scope?: AgentScope
+  projectRoot?: string
+  /**
+   * Per-agent config path override. Bypasses the OS+catalog path
+   * resolution for the given agent + scope pair. Same shape v0.0.3
+   * takes.
+   */
+  overrides?: Partial<Record<AgentId, string>>
+}
+
+const MANIFEST_FILENAME = 'manifest.json'
+
+/**
+ * Snapshot the workspace manifest plus one config file per requested
+ * (agent, scope) pair.
+ *
+ * `agents` filters which agent config files are included. Callers who
+ * skip this argument get a State with no agent files, which is enough
+ * for planRescan and planAdd but not for planLink / planUnlink /
+ * planDisconnect / planRemove. Those planners throw when the agent
+ * they need is not in state.agents. The API layer handles this by
+ * always including the target agents in its readState call.
+ */
+export async function readState(
+  workspaceDir: string,
+  agents?: ReadonlyArray<AgentId>,
+  opts: ReadStateOptions = {},
+): Promise<State> {
+  const manifest = await readManifest(workspaceDir)
+  const scope = opts.scope ?? 'system'
+  const agentFiles: AgentFileState[] = []
+  for (const agent of agents ?? []) {
+    const configPath =
+      opts.overrides?.[agent] ??
+      (await resolveAgentMcpConfigPath(agent, scope, opts.projectRoot))
+    const { content, exists } = await readFileWithExistence(configPath)
+    // When the file exists, the parent must too. Only stat the parent
+    // in the miss case so the common path stays one stat.
+    const parentExists = exists
+      ? true
+      : await pathExists(path.dirname(configPath))
+    agentFiles.push({
+      agent,
+      scope,
+      configPath,
+      rawContent: content,
+      exists,
+      parentExists,
+    })
+  }
+  return {
+    workspaceDir,
+    manifestPath: path.join(workspaceDir, MANIFEST_FILENAME),
+    manifest,
+    agents: agentFiles,
+  }
+}
+
+export interface ApplyPlanResult {
+  writtenPaths: string[]
+  removedPaths: string[]
+}
+
+/**
+ * Apply a Plan. Writes happen atomically via `<file>.tmp + rename`.
+ * File removals happen after writes so a partial-failure re-run picks
+ * up where it left off cleanly.
+ *
+ * The order matters when multiple ops target overlapping files: the
+ * caller is responsible for producing a plan whose ops do not conflict.
+ * All planner-produced plans already satisfy that invariant (agent
+ * config first, manifest last, no duplicate paths).
+ */
+export async function applyPlan(plan: Plan): Promise<ApplyPlanResult> {
+  const writtenPaths: string[] = []
+  const removedPaths: string[] = []
+  // Writes first, then removes. Manifest write typically lands last
+  // because the planner produces ops in that order; we do not re-sort
+  // to avoid confusing consumers who inspect a plan and depend on the
+  // observed order.
+  for (const op of plan.ops) {
+    if (op.kind === 'writeFile') {
+      await writeOp(op)
+      writtenPaths.push(op.path)
+    }
+  }
+  for (const op of plan.ops) {
+    if (op.kind === 'removeFile') {
+      await removeOp(op)
+      removedPaths.push(op.path)
+    }
+  }
+  return { writtenPaths, removedPaths }
+}
+
+async function writeOp(
+  op: Extract<FsOp, { kind: 'writeFile' }>,
+): Promise<void> {
+  if (op.ensureDir) await fsp.mkdir(path.dirname(op.path), { recursive: true })
+  await atomicWriteFile(op.path, op.content)
+}
+
+async function removeOp(
+  op: Extract<FsOp, { kind: 'removeFile' }>,
+): Promise<void> {
+  try {
+    await fsp.unlink(op.path)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+  }
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/lowlevel.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/lowlevel.ts
@@ -1,0 +1,39 @@
+/**
+ * Low-level subpath. Re-exports the pure planner primitives and the
+ * I/O boundary so consumers who need dry-run control (or want to batch
+ * multiple verbs against one State) can compose them directly.
+ *
+ * The high-level `mcp-manager` verbs in `./api.ts` are just:
+ *
+ *   readState(workspaceDir, [agent]) -> plan* -> applyPlan
+ *
+ * Nothing is hidden. Import from here when you want to inspect the
+ * Plan value before applyPlan, or when you want to run multiple
+ * planner calls against the same State snapshot.
+ */
+
+export type { ApplyPlanResult, ReadStateOptions } from './io/index'
+export { applyPlan, readState } from './io/index'
+export {
+  planDisconnect,
+  planLink,
+  planRemove,
+  planRescan,
+  planUnlink,
+} from './planner/planner'
+export type {
+  AgentFileState,
+  DisconnectInput,
+  DisconnectPlanSummary,
+  FsOp,
+  LinkInput,
+  LinkPlanSummary,
+  Plan,
+  RemoveInput,
+  RemovePlanSummary,
+  RescanInput,
+  RescanReport,
+  State,
+  UnlinkInput,
+  UnlinkPlanSummary,
+} from './planner/types'

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/planner/planner.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/planner/planner.ts
@@ -1,0 +1,503 @@
+/**
+ * Pure planner functions. Zero I/O; every input is a value read at
+ * the boundary and every output is a Plan value the caller can inspect
+ * before applying.
+ *
+ * Planners throw the typed error hierarchy for domain-level input
+ * problems (`InvalidServerSpecError` for a bad spec, `ServerNotFound
+ * Error` for an unknown server, `UnsupportedTransportError` when the
+ * client does not accept the requested transport, `ForeignEntryError`
+ * when an on-disk entry was not manifest-managed). Callers catch these
+ * to surface actionable messages; the errors carry the offending name,
+ * agent, and path when relevant.
+ */
+
+import { dirname } from 'node:path'
+
+import { getCatalogEntry } from '../agents'
+import { getEmitter } from '../emitters/index'
+import {
+  AgentNotInstalledError,
+  AgentNotSupportedError,
+  ForeignEntryError,
+  InvalidServerSpecError,
+  UnsupportedTransportError,
+} from '../errors'
+import type {
+  AgentId,
+  AgentScope,
+  ManifestServerEntry,
+  McpServerSpec,
+  ServerManifest,
+} from '../types'
+import type {
+  AgentFileState,
+  DisconnectInput,
+  DisconnectPlanSummary,
+  FsOp,
+  LinkInput,
+  LinkPlanSummary,
+  Plan,
+  RemoveInput,
+  RemovePlanSummary,
+  RescanInput,
+  RescanReport,
+  State,
+  UnlinkInput,
+  UnlinkPlanSummary,
+} from './types'
+
+// -------------------------------------------------------------------
+// planLink: upsert the manifest server entry from `server.spec` and
+// record a link for the given agent. This is the ONLY way a server
+// enters the manifest; there is no separate "register" step.
+// -------------------------------------------------------------------
+
+export function planLink(
+  state: State,
+  input: LinkInput,
+  now: string,
+): Plan & LinkPlanSummary {
+  const scope = input.scope ?? 'system'
+  const name = input.server.name.trim()
+  if (!name) {
+    throw new InvalidServerSpecError('server name is required')
+  }
+  validateSpec(input.server.spec)
+  ensureTransportSupported(input.agent, scope, input.server.spec.transport)
+  const agentFile = requireAgentFile(state, input.agent, scope)
+  ensureAgentInstalled(input.agent, agentFile)
+  const client = getCatalogEntry(input.agent)
+  const emitter = getEmitter(client, scope)
+
+  const existing = state.manifest.servers[name]
+  const existingKeys = emitter.read(agentFile.rawContent)
+  const isKnownToManifest = Boolean(existing?.links[input.agent])
+  const isForeign = existingKeys.includes(name) && !isKnownToManifest
+  if (isForeign && !input.allowOverwrite) {
+    throw new ForeignEntryError(name, input.agent, agentFile.configPath)
+  }
+
+  const nextRaw = emitter.add(agentFile.rawContent, name, input.server.spec)
+  const nextEntry: ManifestServerEntry = {
+    name,
+    // Last-write-wins on the spec: consumers who need to keep multiple
+    // agents in sync should re-link them after mutating the spec, or
+    // use rescan() to detect drift where one agent's file no longer
+    // matches the manifest.
+    spec: input.server.spec,
+    addedAt: existing?.addedAt ?? now,
+    links: {
+      ...existing?.links,
+      [input.agent]: {
+        configPath: agentFile.configPath,
+        createdAt: existing?.links[input.agent]?.createdAt ?? now,
+      },
+    },
+  }
+  const nextManifest = putServer(state.manifest, nextEntry)
+
+  // Guard the agent-config write on actual content change so idempotent
+  // re-links do not touch mtime. IDE file watchers (Cursor, VS Code)
+  // treat every rewrite as a reload trigger; unnecessary rewrites cause
+  // visible UI flicker for consumers batching many links.
+  const ops: FsOp[] = []
+  if (nextRaw !== agentFile.rawContent) {
+    ops.push(writeOp(agentFile.configPath, nextRaw))
+  }
+  ops.push(manifestWriteOp(state, nextManifest))
+
+  return {
+    ops,
+    nextManifest,
+    serverName: name,
+    agent: input.agent,
+    scope,
+    created: !isKnownToManifest,
+    overwroteForeign: isForeign,
+  }
+}
+
+// -------------------------------------------------------------------
+// planUnlink
+// -------------------------------------------------------------------
+
+export function planUnlink(
+  state: State,
+  input: UnlinkInput,
+): Plan & UnlinkPlanSummary {
+  const scope = input.scope ?? 'system'
+  const server = state.manifest.servers[input.serverName]
+  if (!server) {
+    return {
+      ops: [],
+      nextManifest: state.manifest,
+      serverName: input.serverName,
+      agent: input.agent,
+      scope,
+      removed: false,
+    }
+  }
+  const linkRecord = server.links[input.agent]
+  if (!linkRecord) {
+    return {
+      ops: [],
+      nextManifest: state.manifest,
+      serverName: input.serverName,
+      agent: input.agent,
+      scope,
+      removed: false,
+    }
+  }
+  const agentFile = findAgentFile(
+    state,
+    input.agent,
+    scope,
+    linkRecord.configPath,
+  )
+  const client = getCatalogEntry(input.agent)
+  const emitter = getEmitter(client, scope)
+  const ops: FsOp[] = []
+  if (agentFile) {
+    const nextRaw = emitter.remove(agentFile.rawContent, input.serverName)
+    if (nextRaw !== agentFile.rawContent) {
+      ops.push(writeOp(agentFile.configPath, nextRaw))
+    }
+  }
+
+  const nextLinks = { ...server.links }
+  delete nextLinks[input.agent]
+  const nextManifest = putServer(state.manifest, {
+    ...server,
+    links: nextLinks,
+  })
+  ops.push(manifestWriteOp(state, nextManifest))
+
+  return {
+    ops,
+    nextManifest,
+    serverName: input.serverName,
+    agent: input.agent,
+    scope,
+    removed: true,
+  }
+}
+
+// -------------------------------------------------------------------
+// planDisconnect: unlink + optionally drop the manifest entry when
+// the disconnected agent was the last one linked.
+//
+// This is the primitive that closes issue #63. Under the class API,
+// callers had to interleave listLinks + conditional remove. Any race
+// or logic bug in the caller could orphan other agents' links. Under
+// this planner, dropping the manifest entry is a single computation
+// based on the post-unlink links map. Never touches other agents.
+// -------------------------------------------------------------------
+
+export function planDisconnect(
+  state: State,
+  input: DisconnectInput,
+): Plan & DisconnectPlanSummary {
+  const scope = input.scope ?? 'system'
+  const removeIfLast = input.removeIfLast ?? true
+  const server = state.manifest.servers[input.serverName]
+  if (!server?.links[input.agent]) {
+    return {
+      ops: [],
+      nextManifest: state.manifest,
+      agent: input.agent,
+      serverName: input.serverName,
+      scope,
+      unlinked: false,
+      removedManifest: false,
+    }
+  }
+  const unlinkPlan = planUnlink(state, {
+    serverName: input.serverName,
+    agent: input.agent,
+    scope,
+  })
+  const remainingLinks =
+    unlinkPlan.nextManifest.servers[input.serverName]?.links ?? {}
+  const anyLinkLeft = Object.keys(remainingLinks).length > 0
+  if (!removeIfLast || anyLinkLeft) {
+    return {
+      ...unlinkPlan,
+      agent: input.agent,
+      serverName: input.serverName,
+      scope,
+      unlinked: true,
+      removedManifest: false,
+    }
+  }
+  // Drop the manifest entry. Config files of other agents are NOT
+  // touched: `remainingLinks` was empty, so no ops beyond the unlink's
+  // agent-file rewrite and the manifest write are added.
+  const nextManifest = removeServer(unlinkPlan.nextManifest, input.serverName)
+  const opsWithoutManifestWrite = unlinkPlan.ops.filter((op) =>
+    op.kind === 'writeFile' ? op.path !== state.manifestPath : true,
+  )
+  return {
+    ops: [...opsWithoutManifestWrite, manifestWriteOp(state, nextManifest)],
+    nextManifest,
+    agent: input.agent,
+    serverName: input.serverName,
+    scope,
+    unlinked: true,
+    removedManifest: true,
+  }
+}
+
+// -------------------------------------------------------------------
+// planRemove: drop the manifest entry, optionally unlinking every
+// currently-linked agent first.
+// -------------------------------------------------------------------
+
+export function planRemove(
+  state: State,
+  input: RemoveInput,
+): Plan & RemovePlanSummary {
+  const unlinkFirst = input.unlinkFirst ?? true
+  const server = state.manifest.servers[input.serverName]
+  if (!server) {
+    return {
+      ops: [],
+      nextManifest: state.manifest,
+      serverName: input.serverName,
+      unlinkedAgents: [],
+      removedManifest: false,
+    }
+  }
+  const ops: FsOp[] = []
+  const unlinkedAgents: AgentId[] = []
+  let cursor = state.manifest
+  if (unlinkFirst) {
+    for (const [agent, link] of Object.entries(server.links)) {
+      if (!link) continue
+      // Every disk file we touch has a corresponding AgentFileState we
+      // can find by configPath. If the caller didn't include this agent
+      // in readState, we skip the file write (the manifest still gets
+      // its unlink record dropped).
+      //
+      // Scope inference: v0.0.4's ManifestLinkEntry does not record
+      // scope. Default to 'system' because it's the common case AND
+      // because for every 23-client catalog entry that ships project
+      // overrides, the project stdio shape uses the same topLevelKey
+      // as system, so emitter.remove finds and removes the entry
+      // identically at either scope. If a future client's project
+      // topLevelKey diverges, ManifestLinkEntry needs a scope field
+      // and this line becomes real inference.
+      const scope: AgentScope = 'system'
+      const agentFile = findAgentFile(
+        { ...state, manifest: cursor },
+        agent as AgentId,
+        scope,
+        link.configPath,
+      )
+      if (agentFile) {
+        const client = getCatalogEntry(agent as AgentId)
+        const emitter = getEmitter(client, scope)
+        const nextRaw = emitter.remove(agentFile.rawContent, input.serverName)
+        if (nextRaw !== agentFile.rawContent) {
+          ops.push(writeOp(agentFile.configPath, nextRaw))
+        }
+      }
+      unlinkedAgents.push(agent as AgentId)
+      cursor = putServer(cursor, {
+        ...(cursor.servers[input.serverName] as ManifestServerEntry),
+        links: dropKey(cursor.servers[input.serverName]?.links ?? {}, agent),
+      })
+    }
+  }
+  const nextManifest = removeServer(cursor, input.serverName)
+  ops.push(manifestWriteOp(state, nextManifest))
+  return {
+    ops,
+    nextManifest,
+    serverName: input.serverName,
+    unlinkedAgents,
+    removedManifest: true,
+  }
+}
+
+// -------------------------------------------------------------------
+// planRescan: diff manifest links against what's on disk. Reports
+// verified / drifted / missing entries. Does not mutate manifest.
+// -------------------------------------------------------------------
+
+export function planRescan(
+  state: State,
+  input?: RescanInput,
+): { rescan: RescanReport; ops: FsOp[] } {
+  const filter = input?.agents ? new Set(input.agents) : null
+  const verified: RescanReport['verified'] extends ReadonlyArray<infer T>
+    ? T[]
+    : never = []
+  const drifted: RescanReport['drifted'] extends ReadonlyArray<infer T>
+    ? T[]
+    : never = []
+  const missing: RescanReport['missing'] extends ReadonlyArray<infer T>
+    ? T[]
+    : never = []
+
+  for (const server of Object.values(state.manifest.servers)) {
+    for (const [agentRaw, link] of Object.entries(server.links)) {
+      if (!link) continue
+      const agent = agentRaw as AgentId
+      if (filter && !filter.has(agent)) continue
+      const scope: AgentScope = 'system' // rescan reports both scopes if the file is included; scope is informational
+      const file = findAgentFile(state, agent, scope, link.configPath)
+      if (!file) {
+        missing.push({
+          serverName: server.name,
+          agent,
+          scope,
+          configPath: link.configPath,
+          reason: 'config file was not included in readState',
+        })
+        continue
+      }
+      if (!file.exists) {
+        missing.push({
+          serverName: server.name,
+          agent,
+          scope,
+          configPath: link.configPath,
+          reason: 'config file does not exist on disk',
+        })
+        continue
+      }
+      const client = getCatalogEntry(agent)
+      const emitter = getEmitter(client, scope)
+      const keys = emitter.read(file.rawContent)
+      if (keys.includes(server.name)) {
+        verified.push({
+          serverName: server.name,
+          agent,
+          configPath: file.configPath,
+        })
+      } else {
+        drifted.push({
+          serverName: server.name,
+          agent,
+          scope,
+          configPath: file.configPath,
+          reason:
+            'manifest link exists but on-disk config has no matching entry',
+        })
+      }
+    }
+  }
+  return { rescan: { verified, drifted, missing }, ops: [] }
+}
+
+// -------------------------------------------------------------------
+// Internals
+// -------------------------------------------------------------------
+
+function validateSpec(spec: McpServerSpec): void {
+  if (spec.transport === 'stdio') {
+    if (!spec.command?.trim()) {
+      throw new InvalidServerSpecError(
+        'stdio spec requires a non-empty command',
+      )
+    }
+  } else if (spec.transport === 'sse' || spec.transport === 'http') {
+    if (!spec.url?.trim()) {
+      throw new InvalidServerSpecError(
+        `${spec.transport} spec requires a non-empty url`,
+      )
+    }
+  } else {
+    throw new InvalidServerSpecError(
+      `unknown spec transport ${JSON.stringify((spec as { transport: unknown }).transport)}`,
+    )
+  }
+}
+
+function ensureTransportSupported(
+  agent: AgentId,
+  scope: AgentScope,
+  transport: McpServerSpec['transport'],
+): void {
+  const entry = getCatalogEntry(agent)
+  const list =
+    scope === 'project'
+      ? (entry.supportedTransports.project ?? entry.supportedTransports.system)
+      : entry.supportedTransports.system
+  if (!list) throw new AgentNotSupportedError(agent)
+  if (!list.includes(transport)) {
+    throw new UnsupportedTransportError(agent, transport, {
+      supported: list,
+      hint: `Emit a ${list[0] ?? 'stdio'} spec for this agent or pick a different agent.`,
+    })
+  }
+}
+
+function requireAgentFile(
+  state: State,
+  agent: AgentId,
+  scope: AgentScope,
+): AgentFileState {
+  const file = state.agents.find((a) => a.agent === agent && a.scope === scope)
+  if (!file) {
+    throw new InvalidServerSpecError(
+      `agent ${agent}@${scope} was not included in readState; add it to the agents list before planning`,
+    )
+  }
+  return file
+}
+
+function ensureAgentInstalled(agent: AgentId, agentFile: AgentFileState): void {
+  if (agentFile.exists || agentFile.parentExists) return
+  throw new AgentNotInstalledError(
+    agent,
+    agentFile.configPath,
+    dirname(agentFile.configPath),
+  )
+}
+
+function findAgentFile(
+  state: State,
+  agent: AgentId,
+  scope: AgentScope,
+  configPath: string,
+): AgentFileState | undefined {
+  return (
+    state.agents.find(
+      (a) =>
+        a.agent === agent && a.scope === scope && a.configPath === configPath,
+    ) ??
+    state.agents.find((a) => a.agent === agent && a.configPath === configPath)
+  )
+}
+
+function putServer(
+  manifest: ServerManifest,
+  entry: ManifestServerEntry,
+): ServerManifest {
+  return {
+    ...manifest,
+    servers: { ...manifest.servers, [entry.name]: entry },
+  }
+}
+
+function removeServer(manifest: ServerManifest, name: string): ServerManifest {
+  const next = { ...manifest.servers }
+  delete next[name]
+  return { ...manifest, servers: next }
+}
+
+function dropKey<T extends Record<string, unknown>>(obj: T, key: string): T {
+  const copy = { ...obj } as Record<string, unknown>
+  delete copy[key]
+  return copy as T
+}
+
+function writeOp(path: string, content: string): FsOp {
+  return { kind: 'writeFile', path, content, ensureDir: true }
+}
+
+function manifestWriteOp(state: State, manifest: ServerManifest): FsOp {
+  return writeOp(state.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/planner/types.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/planner/types.ts
@@ -1,0 +1,186 @@
+/**
+ * Planner types. Pure discriminated unions, no I/O anywhere.
+ *
+ * State is what the planner sees at the boundary: the workspace
+ * manifest plus every agent config file the caller opted in to
+ * reading. Plan is the exact list of filesystem ops that would run,
+ * with a next-manifest snapshot the caller can inspect before applying.
+ *
+ * The whole point of these types is that a planner call cannot lie
+ * about what it would do. If planDisconnect touches an agent that
+ * was not in the input, that agent shows up in `ops`. If planRemove
+ * drops a shared manifest entry, the caller sees `nextManifest` before
+ * anything is written. The class-based v0.0.3 API could not offer
+ * this because state mutated across method calls.
+ */
+
+import type { AgentId, AgentScope, McpServer, ServerManifest } from '../types'
+
+/**
+ * Snapshot of on-disk state read at the I/O boundary. Every planner
+ * consumes this and returns a Plan with the same shape of ops.
+ */
+export interface State {
+  workspaceDir: string
+  manifestPath: string
+  manifest: ServerManifest
+  /** Per-(agent, scope) file view. The planner reads only these; unknown agents are treated as no-op. */
+  agents: ReadonlyArray<AgentFileState>
+}
+
+export interface AgentFileState {
+  agent: AgentId
+  scope: AgentScope
+  /** Absolute path of the config file we would write to. */
+  configPath: string
+  /** Raw file contents read at boundary time. Empty string when the file does not exist yet. */
+  rawContent: string
+  /** True when the file existed on disk when State was read. */
+  exists: boolean
+  /**
+   * True when the parent directory of `configPath` existed on disk at
+   * State read time. A false here means the agent is not installed
+   * (or has never been launched); `planLink` throws
+   * `AgentNotInstalledError` rather than silently `mkdir -p`-ing the
+   * directory and creating a ghost config.
+   */
+  parentExists: boolean
+}
+
+/**
+ * A single filesystem operation. Applied top-down by applyPlan. Each op
+ * is idempotent: running the same plan twice against the same state
+ * produces the same on-disk result.
+ */
+export type FsOp =
+  | { kind: 'writeFile'; path: string; content: string; ensureDir?: boolean }
+  | { kind: 'removeFile'; path: string }
+
+export interface Plan {
+  ops: FsOp[]
+  /**
+   * The manifest that would land on disk if applyPlan runs to
+   * completion. Present in every plan even when ops are empty; the
+   * caller can diff against `state.manifest` to preview.
+   */
+  nextManifest: ServerManifest
+}
+
+// -------------------------------------------------------------------
+// Planner inputs and per-verb return shapes
+// -------------------------------------------------------------------
+
+export interface LinkInput {
+  /**
+   * Caller-owned server value. `link()` upserts the manifest server
+   * entry from `server.spec` (last-write-wins) and adds a link record
+   * for the given agent. There is no separate "register a server"
+   * step; a server exists in the manifest iff at least one link has
+   * been recorded for it.
+   */
+  server: McpServer
+  agent: AgentId
+  scope?: AgentScope
+  /** Bypass the foreign-entry safety check. Default false. */
+  allowOverwrite?: boolean
+}
+
+export interface UnlinkInput {
+  serverName: string
+  agent: AgentId
+  scope?: AgentScope
+}
+
+export interface DisconnectInput {
+  serverName: string
+  agent: AgentId
+  scope?: AgentScope
+  /**
+   * When true (default), drop the manifest entry once no agents remain
+   * linked to it. False means the manifest keeps the entry with an
+   * empty `links` map so future links can re-attach. Never touches
+   * the config files of agents other than `agent`.
+   */
+  removeIfLast?: boolean
+}
+
+export interface RemoveInput {
+  serverName: string
+  /**
+   * When true (default), also unlink every currently linked agent
+   * before dropping the manifest entry. Every affected agent's config
+   * file gets a removeFile op or a rewrite op via the emitter.
+   */
+  unlinkFirst?: boolean
+}
+
+export interface RescanInput {
+  agents?: AgentId[]
+}
+
+// -------------------------------------------------------------------
+// Result shapes that surface alongside a Plan
+// -------------------------------------------------------------------
+
+export interface LinkPlanSummary {
+  serverName: string
+  agent: AgentId
+  scope: AgentScope
+  /** True if there was no prior link record; false if we replaced one. */
+  created: boolean
+  /**
+   * True when the on-disk config had an entry under this name that the
+   * manifest did not put there, and allowOverwrite was true. Callers
+   * usually surface this in UI. Never true when allowOverwrite was
+   * false; that path throws before returning a plan.
+   */
+  overwroteForeign: boolean
+}
+
+export interface UnlinkPlanSummary {
+  serverName: string
+  agent: AgentId
+  scope: AgentScope
+  /** True when there was actually a link to remove. False = no-op. */
+  removed: boolean
+}
+
+export interface DisconnectPlanSummary {
+  agent: AgentId
+  serverName: string
+  scope: AgentScope
+  /** True when we removed a link record from the manifest. */
+  unlinked: boolean
+  /** True when we dropped the manifest entry entirely (last agent + removeIfLast). */
+  removedManifest: boolean
+}
+
+export interface RemovePlanSummary {
+  serverName: string
+  /** Agents whose config files were rewritten to drop the entry. */
+  unlinkedAgents: AgentId[]
+  /** True when the manifest entry existed and was dropped. */
+  removedManifest: boolean
+}
+
+// -------------------------------------------------------------------
+// Rescan return type (matches the v0.0.3 shape for continuity)
+// -------------------------------------------------------------------
+
+export interface RescanEntryDrift {
+  serverName: string
+  agent: AgentId
+  scope: AgentScope
+  configPath: string
+  reason: string
+}
+
+export interface RescanReport {
+  verified: ReadonlyArray<{
+    serverName: string
+    agent: AgentId
+    configPath: string
+  }>
+  drifted: ReadonlyArray<RescanEntryDrift>
+  missing: ReadonlyArray<RescanEntryDrift>
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/types.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/types.ts
@@ -1,0 +1,69 @@
+// AgentId re-exports the 23-client union declared in the internal
+// catalog. Kept as a name alias for API surface continuity: consumers
+// import `AgentId` from the package root, the catalog's `ClientId`
+// stays internal.
+import type { ClientId } from './_catalog/types'
+
+export type AgentId = ClientId
+
+export type AgentScope = 'system' | 'project'
+
+export type McpTransport = 'stdio' | 'sse' | 'http'
+
+export interface AgentInfo {
+  id: AgentId
+  displayName: string
+  /** Absolute path of the config file we would write to (or null when unresolvable on this OS). */
+  configPath: string | null
+  /** True iff one of the agent's `installCheckPaths` resolves on disk. */
+  installed: boolean
+}
+
+export interface McpStdioSpec {
+  transport: 'stdio'
+  command: string
+  args?: string[]
+  env?: Record<string, string>
+}
+
+export interface McpSseSpec {
+  transport: 'sse'
+  url: string
+  headers?: Record<string, string>
+}
+
+export interface McpHttpSpec {
+  transport: 'http'
+  url: string
+  headers?: Record<string, string>
+}
+
+export type McpServerSpec = McpStdioSpec | McpSseSpec | McpHttpSpec
+
+/**
+ * The unit of work every mutating verb takes. Caller-owned data:
+ * `name` is the manifest key; `spec` describes how the server is
+ * invoked. Passed to `link()` directly; the library never persists
+ * a server independently of a link.
+ */
+export interface McpServer {
+  name: string
+  spec: McpServerSpec
+}
+
+export interface ServerManifest {
+  version: 1
+  servers: Record<string, ManifestServerEntry>
+}
+
+export interface ManifestServerEntry {
+  name: string
+  spec: McpServerSpec
+  addedAt: string
+  links: Partial<Record<AgentId, ManifestLinkEntry>>
+}
+
+export interface ManifestLinkEntry {
+  configPath: string
+  createdAt: string
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/helpers/tmp-workspace.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/helpers/tmp-workspace.ts
@@ -1,0 +1,27 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+export interface TmpWorkspace {
+  root: string
+  workspaceDir: string
+  /** `${root}/configs` — point agent config files in here. */
+  configsDir: string
+  cleanup(): Promise<void>
+}
+
+export async function makeTmpWorkspace(): Promise<TmpWorkspace> {
+  const root = await mkdtemp(join(tmpdir(), 'mcp-mgr-'))
+  const workspaceDir = join(root, 'workspace')
+  const configsDir = join(root, 'configs')
+  await mkdir(workspaceDir, { recursive: true })
+  await mkdir(configsDir, { recursive: true })
+  return {
+    root,
+    workspaceDir,
+    configsDir,
+    async cleanup() {
+      await rm(root, { recursive: true, force: true })
+    },
+  }
+}

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/integration/fp-api.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/integration/fp-api.test.ts
@@ -1,0 +1,373 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  bind,
+  disconnect,
+  isInstalled,
+  link,
+  list,
+  listLinks,
+  remove,
+  unlink,
+} from '../../src/api'
+import { AgentNotInstalledError } from '../../src/errors'
+import { readState } from '../../src/io/index'
+import type { McpServer } from '../../src/types'
+
+let workspaceDir: string
+let cursorPath: string
+let geminiPath: string
+let claudeCodePath: string
+
+const GH_STDIO: McpServer = {
+  name: 'gh',
+  spec: { transport: 'stdio', command: 'gh-mcp' },
+}
+
+const GH_HTTP: McpServer = {
+  name: 'gh',
+  spec: { transport: 'http', url: 'https://api.example.com/mcp' },
+}
+
+const SOLO: McpServer = {
+  name: 'solo',
+  spec: { transport: 'stdio', command: 'solo-mcp' },
+}
+
+beforeEach(async () => {
+  workspaceDir = await mkdtemp(join(tmpdir(), 'acpx-api-'))
+  cursorPath = join(workspaceDir, 'cursor.json')
+  geminiPath = join(workspaceDir, 'gemini.json')
+  claudeCodePath = join(workspaceDir, 'claude.json')
+})
+
+afterEach(async () => {
+  await rm(workspaceDir, { recursive: true, force: true })
+})
+
+describe('link (upserts manifest + writes agent config)', () => {
+  test('first link creates the manifest server entry AND writes the agent config', async () => {
+    const res = await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    expect(res.created).toBe(true)
+    expect(res.overwroteForeign).toBe(false)
+
+    const raw = await readFile(cursorPath, 'utf8')
+    expect(JSON.parse(raw).mcpServers.gh.command).toBe('gh-mcp')
+
+    const state = await readState(workspaceDir)
+    expect(state.manifest.servers.gh?.spec).toEqual(GH_STDIO.spec)
+    expect(state.manifest.servers.gh?.links.cursor?.configPath).toBe(cursorPath)
+  })
+
+  test('re-linking the same server + agent with identical spec returns created: false', async () => {
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    const res = await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    expect(res.created).toBe(false)
+  })
+
+  test('linking the same name with a different spec upserts the manifest (last-write-wins)', async () => {
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    await link(workspaceDir, {
+      server: GH_HTTP,
+      agent: 'gemini',
+      configPath: geminiPath,
+    })
+    const state = await readState(workspaceDir)
+    // Manifest reflects the LATER spec.
+    expect(state.manifest.servers.gh?.spec).toEqual(GH_HTTP.spec)
+    // But cursor's file still has the earlier spec on disk; rescan
+    // will report drift for cursor.
+    const cursorRaw = await readFile(cursorPath, 'utf8')
+    expect(JSON.parse(cursorRaw).mcpServers.gh.command).toBe('gh-mcp')
+  })
+
+  test('trims the server name before using it as the manifest key', async () => {
+    // Regression: matches the trim behavior the removed addServer had.
+    await link(workspaceDir, {
+      server: { name: '  gh  ', spec: GH_STDIO.spec },
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    const state = await readState(workspaceDir)
+    expect(state.manifest.servers.gh).toBeDefined()
+    expect(state.manifest.servers['  gh  ']).toBeUndefined()
+  })
+})
+
+describe('disconnect (regression test for #63)', () => {
+  test('disconnecting one of three linked agents does NOT touch the other two', async () => {
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'gemini',
+      configPath: geminiPath,
+    })
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'claude-code',
+      configPath: claudeCodePath,
+    })
+
+    const before = {
+      gemini: await readFile(geminiPath, 'utf8'),
+      claudeCode: await readFile(claudeCodePath, 'utf8'),
+    }
+
+    const res = await disconnect(workspaceDir, {
+      serverName: 'gh',
+      agent: 'cursor',
+    })
+    expect(res.unlinked).toBe(true)
+    expect(res.removedManifest).toBe(false)
+
+    const cursorAfter = await readFile(cursorPath, 'utf8')
+    expect(JSON.parse(cursorAfter).mcpServers.gh).toBeUndefined()
+
+    expect(await readFile(geminiPath, 'utf8')).toBe(before.gemini)
+    expect(await readFile(claudeCodePath, 'utf8')).toBe(before.claudeCode)
+
+    const state = await readState(workspaceDir)
+    expect(state.manifest.servers.gh).toBeDefined()
+    expect(Object.keys(state.manifest.servers.gh?.links ?? {}).sort()).toEqual([
+      'claude-code',
+      'gemini',
+    ])
+  })
+
+  test('disconnecting the last agent drops the manifest entry by default', async () => {
+    await link(workspaceDir, {
+      server: SOLO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    const res = await disconnect(workspaceDir, {
+      serverName: 'solo',
+      agent: 'cursor',
+    })
+    expect(res.removedManifest).toBe(true)
+    const state = await readState(workspaceDir)
+    expect(state.manifest.servers.solo).toBeUndefined()
+  })
+})
+
+describe('unlink + list + listLinks + remove', () => {
+  test('unlink is idempotent when the link does not exist', async () => {
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    const res = await unlink(workspaceDir, {
+      serverName: 'gh',
+      agent: 'gemini',
+      configPath: geminiPath,
+    })
+    expect(res.removed).toBe(false)
+  })
+
+  test('unlink without an explicit configPath uses the manifest-recorded path', async () => {
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    const res = await unlink(workspaceDir, {
+      serverName: 'gh',
+      agent: 'cursor',
+    })
+    expect(res.removed).toBe(true)
+    const raw = await readFile(cursorPath, 'utf8')
+    expect(JSON.parse(raw).mcpServers.gh).toBeUndefined()
+  })
+
+  test('list returns every manifest server entry', async () => {
+    await link(workspaceDir, {
+      server: { name: 'a', spec: { transport: 'stdio', command: 'a' } },
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    await link(workspaceDir, {
+      server: { name: 'b', spec: { transport: 'http', url: 'https://b/mcp' } },
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    const items = await list(workspaceDir)
+    expect(items.map((s) => s.name).sort()).toEqual(['a', 'b'])
+  })
+
+  test('listLinks reports every (server, agent, configPath) triple', async () => {
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'gemini',
+      configPath: geminiPath,
+    })
+    const links = await listLinks(workspaceDir)
+    expect(links.map((l) => l.agent).sort()).toEqual(['cursor', 'gemini'])
+  })
+
+  test('remove drops the manifest entry and unlinks every currently-linked agent', async () => {
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'gemini',
+      configPath: geminiPath,
+    })
+    const res = await remove(workspaceDir, { serverName: 'gh' })
+    expect(res.removedManifest).toBe(true)
+    expect(res.unlinkedAgents.sort()).toEqual(['cursor', 'gemini'])
+    expect(
+      JSON.parse(await readFile(cursorPath, 'utf8')).mcpServers.gh,
+    ).toBeUndefined()
+    expect(
+      JSON.parse(await readFile(geminiPath, 'utf8')).mcpServers.gh,
+    ).toBeUndefined()
+  })
+})
+
+describe('bind', () => {
+  test('applies the workspaceDir to every verb', async () => {
+    const mgr = bind(workspaceDir)
+    await mgr.link({
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: cursorPath,
+    })
+    const links = await mgr.listLinks()
+    expect(links).toHaveLength(1)
+  })
+})
+
+describe('install-check gate', () => {
+  test('link() throws AgentNotInstalledError when the config parent dir does not exist', async () => {
+    // Point Cursor at a path deep inside a non-existent directory
+    // chain. Even the immediate parent does not exist, so the install
+    // gate fires.
+    const missingParent = join(workspaceDir, 'nonexistent-agent-dir')
+    const missingConfig = join(missingParent, 'cursor.json')
+    let caught: unknown
+    try {
+      await link(workspaceDir, {
+        server: GH_STDIO,
+        agent: 'cursor',
+        configPath: missingConfig,
+      })
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(AgentNotInstalledError)
+    const err = caught as AgentNotInstalledError
+    expect(err.agent).toBe('cursor')
+    expect(err.configPath).toBe(missingConfig)
+    expect(err.parentDir).toBe(missingParent)
+  })
+
+  test('link() succeeds when the parent directory exists but the file does not', async () => {
+    const parent = join(workspaceDir, 'fresh-agent')
+    await mkdir(parent, { recursive: true })
+    const configPath = join(parent, 'cursor.json')
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath,
+    })
+    const raw = await readFile(configPath, 'utf8')
+    expect(JSON.parse(raw).mcpServers.gh.command).toBe('gh-mcp')
+  })
+
+  test('AgentNotInstalledError is re-exported from the package root', async () => {
+    const mod = await import('../../src/index')
+    expect(mod.AgentNotInstalledError).toBeDefined()
+    expect(typeof mod.AgentNotInstalledError).toBe('function')
+  })
+
+  test('isInstalled via bind() returns the same result as the direct call', async () => {
+    // Point $HOME at a fresh dir so cursor's default path resolves
+    // consistently for both calls.
+    const originalHome = process.env.HOME
+    const home = await mkdtemp(join(tmpdir(), 'acpx-bind-installed-'))
+    process.env.HOME = home
+    try {
+      await mkdir(join(home, '.cursor'), { recursive: true })
+      const mgr = bind(workspaceDir)
+      const viaBind = await mgr.isInstalled({ agents: ['cursor'] })
+      const direct = await isInstalled({ agents: ['cursor'] })
+      expect(viaBind).toEqual(direct)
+      expect(viaBind.cursor).toBe(true)
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME
+      else process.env.HOME = originalHome
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  test('isInstalled predicts what link would throw (dual invariant)', async () => {
+    // When isInstalled reports true for a configPath override whose
+    // parent exists, link() succeeds. When false, link() throws.
+    const okParent = join(workspaceDir, 'ok')
+    await mkdir(okParent, { recursive: true })
+    const okConfig = join(okParent, 'cursor.json')
+    const missingParent = join(workspaceDir, 'missing')
+    const missingConfig = join(missingParent, 'cursor.json')
+
+    // Direct helper: check whether a specific file location is
+    // link-safe by looking at its parent. Mirrors the isInstalled
+    // signal for the configPath-override case.
+    const stat = await import('node:fs/promises').then((m) => m.stat)
+    const parentExists = async (p: string) => {
+      try {
+        await stat(p)
+        return true
+      } catch {
+        return false
+      }
+    }
+
+    expect(await parentExists(okParent)).toBe(true)
+    expect(await parentExists(missingParent)).toBe(false)
+
+    await link(workspaceDir, {
+      server: GH_STDIO,
+      agent: 'cursor',
+      configPath: okConfig,
+    })
+    await expect(
+      link(workspaceDir, {
+        server: GH_STDIO,
+        agent: 'cursor',
+        configPath: missingConfig,
+      }),
+    ).rejects.toBeInstanceOf(AgentNotInstalledError)
+  })
+})

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/agents.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/agents.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  isAgentSupported,
+  listSupportedAgents,
+  resolveAgentMcpConfigPath,
+  resolveAgentSurface,
+} from '../../src/agents'
+import { UnresolvedConfigPathError } from '../../src/errors'
+import type { McpTransport } from '../../src/types'
+
+describe('agents catalog', () => {
+  test('listSupportedAgents returns the full 23-client roster (v0.0.4)', () => {
+    expect([...listSupportedAgents()].sort()).toEqual([
+      'amazon-bedrock',
+      'amazonq',
+      'antigravity',
+      'boltai',
+      'claude-code',
+      'claude-desktop',
+      'cline',
+      'codex',
+      'cursor',
+      'enconvo',
+      'gemini',
+      'goose',
+      'kiro',
+      'librechat',
+      'opencode',
+      'roocode',
+      'tome',
+      'trae',
+      'vscode',
+      'vscode-insiders',
+      'windsurf',
+      'witsy',
+      'zed',
+    ])
+  })
+
+  test('isAgentSupported is a tight type guard', () => {
+    expect(isAgentSupported('claude-code')).toBe(true)
+    expect(isAgentSupported('totally-made-up')).toBe(false)
+  })
+
+  test('isAgentSupported rejects Object.prototype keys', () => {
+    // The catalog used to use `in`, which leaked inherited keys like
+    // `toString` / `hasOwnProperty` and let the type guard pass for them.
+    expect(isAgentSupported('toString')).toBe(false)
+    expect(isAgentSupported('hasOwnProperty')).toBe(false)
+    expect(isAgentSupported('__proto__')).toBe(false)
+    expect(isAgentSupported('constructor')).toBe(false)
+  })
+
+  test('resolveAgentMcpConfigPath in project scope requires projectRoot', async () => {
+    await expect(
+      resolveAgentMcpConfigPath('cursor', 'project'),
+    ).rejects.toBeInstanceOf(UnresolvedConfigPathError)
+  })
+
+  test('resolveAgentMcpConfigPath in project scope yields <root>/<projectFile>', async () => {
+    const p = await resolveAgentMcpConfigPath('cursor', 'project', '/tmp/proj')
+    expect(p).toBe('/tmp/proj/.cursor/mcp.json')
+  })
+
+  test('resolveAgentMcpConfigPath in project scope errors for agents w/o project file', async () => {
+    await expect(
+      resolveAgentMcpConfigPath('codex', 'project', '/tmp/proj'),
+    ).rejects.toBeInstanceOf(UnresolvedConfigPathError)
+  })
+})
+
+describe('agent transport-capability surface', () => {
+  const VALID: ReadonlyArray<McpTransport> = ['stdio', 'sse', 'http']
+
+  test('every agent declares a non-empty subset of the transport union', () => {
+    for (const id of listSupportedAgents()) {
+      const { supportedTransports } = resolveAgentSurface(id)
+      expect(supportedTransports.length).toBeGreaterThan(0)
+      for (const t of supportedTransports) {
+        expect(VALID).toContain(t)
+      }
+    }
+  })
+
+  test('claude-desktop is stdio-only', () => {
+    expect(resolveAgentSurface('claude-desktop').supportedTransports).toEqual([
+      'stdio',
+    ])
+  })
+
+  test('codex supports stdio + http (no sse)', () => {
+    expect(
+      [...resolveAgentSurface('codex').supportedTransports].sort(),
+    ).toEqual(['http', 'stdio'])
+  })
+
+  test('cursor accepts all three transports', () => {
+    expect(
+      [...resolveAgentSurface('cursor').supportedTransports].sort(),
+    ).toEqual(['http', 'sse', 'stdio'])
+  })
+
+  test('claude-code system scope accepts all three transports', () => {
+    expect(
+      [
+        ...resolveAgentSurface('claude-code', 'system').supportedTransports,
+      ].sort(),
+    ).toEqual(['http', 'sse', 'stdio'])
+  })
+})

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/catalog-validate.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/catalog-validate.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { ClientConfig } from '../../src/_catalog/types'
+import { validateCatalog } from '../../src/_catalog/validate'
+
+const NOW = new Date('2026-07-06T00:00:00Z')
+
+function baseline(overrides: Partial<ClientConfig> = {}): ClientConfig {
+  return {
+    id: 'cursor',
+    displayName: 'Cursor',
+    installCheckPaths: { darwin: ['/Applications/Cursor.app'] },
+    systemPaths: { darwin: ['$HOME/.cursor/mcp.json'] },
+    format: 'json',
+    supportedTransports: { system: ['stdio'] },
+    stdio: { topLevelKey: 'mcpServers' },
+    sources: {
+      firstParty: 'https://docs.cursor.com/context/model-context-protocol',
+      verified: '2026-07-01',
+    },
+    ...overrides,
+  }
+}
+
+describe('validateCatalog', () => {
+  test('accepts a minimal valid entry', () => {
+    const errors = validateCatalog([baseline()], NOW)
+    expect(errors).toEqual([])
+  })
+
+  test('rejects missing firstParty citation', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          sources: {
+            firstParty: '',
+            verified: '2026-07-01',
+          },
+        }),
+      ],
+      NOW,
+    )
+    expect(errors.map((e) => e.path)).toContain('sources.firstParty')
+  })
+
+  test('rejects a non-URL firstParty value', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          sources: {
+            firstParty: 'not a url',
+            verified: '2026-07-01',
+          },
+        }),
+      ],
+      NOW,
+    )
+    expect(
+      errors.find((e) => e.path === 'sources.firstParty')?.message,
+    ).toContain('http(s) URL')
+  })
+
+  test('rejects a malformed verified date', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          sources: {
+            firstParty: 'https://example.com',
+            verified: 'yesterday',
+          },
+        }),
+      ],
+      NOW,
+    )
+    expect(
+      errors.find((e) => e.path === 'sources.verified')?.message,
+    ).toContain('ISO date')
+  })
+
+  test('rejects a verified date more than 365 days old', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          sources: {
+            firstParty: 'https://example.com',
+            verified: '2024-01-01',
+          },
+        }),
+      ],
+      NOW,
+    )
+    expect(
+      errors.find((e) => e.path === 'sources.verified')?.message,
+    ).toContain('re-verified')
+  })
+
+  test('accepts a smithery citation URL when present', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          sources: {
+            firstParty: 'https://example.com',
+            smithery: 'https://github.com/smithery-ai/cli/blob/main/x',
+            verified: '2026-07-01',
+          },
+        }),
+      ],
+      NOW,
+    )
+    expect(errors).toEqual([])
+  })
+
+  test('rejects a non-URL smithery value', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          sources: {
+            firstParty: 'https://example.com',
+            smithery: 'not a url',
+            verified: '2026-07-01',
+          },
+        }),
+      ],
+      NOW,
+    )
+    expect(
+      errors.find((e) => e.path === 'sources.smithery')?.message,
+    ).toContain('http(s) URL')
+  })
+
+  test('rejects an entry with no systemPaths for any OS', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          systemPaths: {},
+        }),
+      ],
+      NOW,
+    )
+    expect(errors.find((e) => e.path === 'systemPaths')).toBeDefined()
+  })
+
+  test('requires an http shape when system transports include http', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          supportedTransports: { system: ['stdio', 'http'] },
+        }),
+      ],
+      NOW,
+    )
+    expect(errors.find((e) => e.path === 'http')?.message).toContain(
+      'no http shape is declared',
+    )
+  })
+
+  test('requires an http shape when system transports include sse', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          supportedTransports: { system: ['stdio', 'sse'] },
+        }),
+      ],
+      NOW,
+    )
+    expect(errors.find((e) => e.path === 'http')).toBeDefined()
+  })
+
+  test('rejects an http shape when system supports stdio only', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          supportedTransports: { system: ['stdio'] },
+          http: { tagKey: 'type', tagValue: 'http' },
+        }),
+      ],
+      NOW,
+    )
+    expect(errors.find((e) => e.path === 'http')?.message).toContain(
+      'does not include http or sse',
+    )
+  })
+
+  test('requires projectFile and project.stdio when project transports declared', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          supportedTransports: { system: ['stdio'], project: ['stdio'] },
+        }),
+      ],
+      NOW,
+    )
+    expect(errors.some((e) => e.path === 'projectFile')).toBe(true)
+    expect(errors.some((e) => e.path === 'project.stdio')).toBe(true)
+  })
+
+  test('requires project.http when project transports include http', () => {
+    const errors = validateCatalog(
+      [
+        baseline({
+          supportedTransports: {
+            system: ['stdio'],
+            project: ['stdio', 'http'],
+          },
+          projectFile: '.foo/mcp.json',
+          project: { stdio: { topLevelKey: 'mcpServers' } },
+        }),
+      ],
+      NOW,
+    )
+    expect(errors.find((e) => e.path === 'project.http')).toBeDefined()
+  })
+
+  test('flags duplicate ids across the catalog', () => {
+    const errors = validateCatalog([baseline(), baseline()], NOW)
+    expect(errors.find((e) => e.clientId === '<duplicate>')).toBeDefined()
+  })
+})

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/catalog.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/catalog.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+
+import { CATALOG, CATALOG_BY_ID } from '../../src/_catalog/client-configs'
+import { validateCatalog } from '../../src/_catalog/validate'
+
+const NOW = new Date('2026-07-06T00:00:00Z')
+
+describe('populated catalog', () => {
+  test('every entry passes the validator against a recent NOW', () => {
+    const errors = validateCatalog(CATALOG, NOW)
+    expect(errors).toEqual([])
+  })
+
+  test('ships 23 clients matching Smithery roster + docker-known set', () => {
+    expect(CATALOG).toHaveLength(23)
+    expect(CATALOG.map((e) => e.id).sort()).toEqual([
+      'amazon-bedrock',
+      'amazonq',
+      'antigravity',
+      'boltai',
+      'claude-code',
+      'claude-desktop',
+      'cline',
+      'codex',
+      'cursor',
+      'enconvo',
+      'gemini',
+      'goose',
+      'kiro',
+      'librechat',
+      'opencode',
+      'roocode',
+      'tome',
+      'trae',
+      'vscode',
+      'vscode-insiders',
+      'windsurf',
+      'witsy',
+      'zed',
+    ])
+  })
+
+  test('CATALOG_BY_ID lookup returns the right entry per id', () => {
+    for (const entry of CATALOG) {
+      expect(CATALOG_BY_ID[entry.id]).toBe(entry)
+    }
+  })
+
+  test('clients using serverUrl URL rename are captured (windsurf, antigravity)', () => {
+    expect(CATALOG_BY_ID.windsurf.http?.urlField).toBe('serverUrl')
+    expect(CATALOG_BY_ID.antigravity.http?.urlField).toBe('serverUrl')
+  })
+
+  test('clients using non-default HTTP tag values are captured', () => {
+    expect(CATALOG_BY_ID.cline.http?.tagValue).toBe('streamableHttp')
+    expect(CATALOG_BY_ID.kiro.http?.tagValue).toBe('streamable-http')
+    expect(CATALOG_BY_ID.opencode.http?.tagValue).toBe('remote')
+  })
+
+  test('goose keeps its stdio quirks: cmd/envs renames, simpleName transform, type: stdio tag', () => {
+    const g = CATALOG_BY_ID.goose.stdio
+    expect(g.commandField).toBe('cmd')
+    expect(g.envField).toBe('envs')
+    expect(g.keyTransform).toBe('simpleName')
+    expect(g.tagKey).toBe('type')
+    expect(g.tagValue).toBe('stdio')
+  })
+
+  test('opencode: commandAsArray, env rename, type: local stdio inject', () => {
+    const o = CATALOG_BY_ID.opencode.stdio
+    expect(o.commandAsArray).toBe(true)
+    expect(o.envField).toBe('environment')
+    expect(o.injects).toEqual({ type: 'local', enabled: true })
+  })
+
+  test('claude-desktop is stdio-only (guards against the v0.0.2 regression)', () => {
+    const cd = CATALOG_BY_ID['claude-desktop']
+    expect(cd.supportedTransports.system).toEqual(['stdio'])
+    expect(cd.http).toBeUndefined()
+  })
+
+  test('claude-code project scope forces stdio-only with a type tag', () => {
+    const cc = CATALOG_BY_ID['claude-code']
+    expect(cc.projectFile).toBe('.mcp.json')
+    expect(cc.supportedTransports.project).toEqual(['stdio'])
+    expect(cc.project?.stdio.tagKey).toBe('type')
+    expect(cc.project?.stdio.tagValue).toBe('stdio')
+  })
+})

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/emitters.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/emitters.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  claudeDesktop,
+  cline,
+  codex,
+  goose,
+  opencode,
+  vscode,
+  windsurf,
+  zed,
+} from '../../src/_catalog/client-configs'
+import { getEmitter } from '../../src/emitters/index'
+import { InvalidServerSpecError } from '../../src/errors'
+import type { McpServerSpec } from '../../src/types'
+
+const STDIO_SPEC: McpServerSpec = {
+  transport: 'stdio',
+  command: 'gh-mcp',
+  args: ['serve'],
+  env: { KEY: 'val' },
+}
+
+const HTTP_SPEC: McpServerSpec = {
+  transport: 'http',
+  url: 'https://example.com/mcp',
+  headers: { Authorization: 'Bearer x' },
+}
+
+describe('getEmitter: JSON family', () => {
+  test('claude-desktop writes stdio entry under mcpServers', () => {
+    const out = getEmitter(claudeDesktop).add('', 'gh', STDIO_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.mcpServers.gh).toEqual({
+      command: 'gh-mcp',
+      args: ['serve'],
+      env: { KEY: 'val' },
+    })
+  })
+
+  test('vscode injects type: stdio tag', () => {
+    const out = getEmitter(vscode).add('', 'gh', STDIO_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.servers.gh).toEqual({
+      command: 'gh-mcp',
+      args: ['serve'],
+      env: { KEY: 'val' },
+      type: 'stdio',
+    })
+  })
+
+  test('vscode HTTP entry gets type: http and default url field', () => {
+    const out = getEmitter(vscode).add('', 'gh', HTTP_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.servers.gh).toEqual({
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer x' },
+      type: 'http',
+    })
+  })
+
+  test('zed writes context_servers with injects (source, enabled) around stdio', () => {
+    const out = getEmitter(zed).add('', 'gh', STDIO_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.context_servers.gh).toEqual({
+      command: 'gh-mcp',
+      args: ['serve'],
+      env: { KEY: 'val' },
+      source: 'custom',
+      enabled: true,
+    })
+  })
+
+  test('cline HTTP uses type: streamableHttp (camelCase)', () => {
+    const out = getEmitter(cline).add('', 'gh', HTTP_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.mcpServers.gh.type).toBe('streamableHttp')
+    expect(parsed.mcpServers.gh.url).toBe('https://example.com/mcp')
+  })
+
+  test('windsurf HTTP renames url -> serverUrl', () => {
+    const out = getEmitter(windsurf).add('', 'gh', HTTP_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.mcpServers.gh).toEqual({
+      serverUrl: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer x' },
+    })
+    expect(parsed.mcpServers.gh.url).toBeUndefined()
+  })
+
+  test('opencode commandAsArray + type=local + enabled=true injects + env->environment rename', () => {
+    const out = getEmitter(opencode).add('', 'gh', STDIO_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.mcp.gh).toEqual({
+      command: ['gh-mcp', 'serve'],
+      environment: { KEY: 'val' },
+      type: 'local',
+      enabled: true,
+    })
+  })
+
+  test('read returns the entry names under the correct parent key', () => {
+    const out = getEmitter(vscode).add('', 'gh', STDIO_SPEC)
+    expect(getEmitter(vscode).read(out)).toEqual(['gh'])
+  })
+
+  test('remove drops the entry and keeps siblings intact', () => {
+    let raw = getEmitter(vscode).add('', 'gh', STDIO_SPEC)
+    raw = getEmitter(vscode).add(raw, 'other', STDIO_SPEC)
+    const after = getEmitter(vscode).remove(raw, 'gh')
+    const parsed = JSON.parse(after)
+    expect(parsed.servers.gh).toBeUndefined()
+    expect(parsed.servers.other).toBeDefined()
+  })
+
+  test('claude-desktop throws when writing an http entry (no http shape)', () => {
+    expect(() => getEmitter(claudeDesktop).add('', 'gh', HTTP_SPEC)).toThrow(
+      InvalidServerSpecError,
+    )
+  })
+})
+
+describe('getEmitter: YAML family', () => {
+  test('goose writes into extensions with cmd rename + simpleName transform + type=stdio tag', () => {
+    const out = getEmitter(goose).add('', 'MCP_DOCKER', STDIO_SPEC)
+    // Key gets simpleName-transformed to `mcpdocker`.
+    expect(out).toContain('mcpdocker:')
+    expect(out).toContain('cmd: gh-mcp')
+    expect(out).toContain('type: stdio')
+    // args + envs are present too.
+    expect(out).toContain('- serve')
+  })
+
+  test('goose read returns transformed key', () => {
+    const raw = getEmitter(goose).add('', 'MCP_DOCKER', STDIO_SPEC)
+    expect(getEmitter(goose).read(raw)).toEqual(['mcpdocker'])
+  })
+
+  test('goose remove drops the transformed key', () => {
+    let raw = getEmitter(goose).add('', 'MCP_DOCKER', STDIO_SPEC)
+    raw = getEmitter(goose).add(raw, 'OTHER', STDIO_SPEC)
+    const after = getEmitter(goose).remove(raw, 'MCP_DOCKER')
+    expect(getEmitter(goose).read(after)).toEqual(['other'])
+  })
+})
+
+describe('getEmitter: TOML family (codex)', () => {
+  test('codex writes an mcp_servers.NAME table for stdio', () => {
+    const out = getEmitter(codex).add('', 'gh', STDIO_SPEC)
+    expect(out).toContain('[mcp_servers.gh]')
+    expect(out).toContain('command = "gh-mcp"')
+    expect(out).toMatch(/args = \[\s*"serve"\s*\]/)
+  })
+
+  test('codex HTTP entry writes url', () => {
+    const out = getEmitter(codex).add('', 'gh', HTTP_SPEC)
+    expect(out).toContain('url = "https://example.com/mcp"')
+  })
+
+  test('codex read enumerates mcp_servers keys', () => {
+    let raw = getEmitter(codex).add('', 'a', STDIO_SPEC)
+    raw = getEmitter(codex).add(raw, 'b', STDIO_SPEC)
+    expect(getEmitter(codex).read(raw).sort()).toEqual(['a', 'b'])
+  })
+
+  test('codex remove drops the entry and clears the table if empty', () => {
+    const raw = getEmitter(codex).add('', 'gh', STDIO_SPEC)
+    const after = getEmitter(codex).remove(raw, 'gh')
+    expect(after).not.toContain('[mcp_servers')
+  })
+})
+
+describe('getEmitter: project-scope override', () => {
+  test('vscode project scope uses the same shape as system', () => {
+    const out = getEmitter(vscode, 'project').add('', 'gh', STDIO_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.servers.gh.type).toBe('stdio')
+  })
+})

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/errors.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  AgentNotInstalledError,
+  McpManagerError,
+  UnsupportedTransportError,
+} from '../../src/errors'
+
+describe('UnsupportedTransportError', () => {
+  test('extends McpManagerError so instanceof checks compose', () => {
+    const err = new UnsupportedTransportError('claude-desktop', 'http', {
+      supported: ['stdio'],
+      hint: 'wrap with npx -y mcp-remote',
+    })
+    expect(err).toBeInstanceOf(McpManagerError)
+    expect(err).toBeInstanceOf(UnsupportedTransportError)
+    expect(err.name).toBe('UnsupportedTransportError')
+  })
+
+  test('exposes agent, transport, and supported list', () => {
+    const err = new UnsupportedTransportError('codex', 'sse', {
+      supported: ['stdio'],
+      hint: 'use the mcp-remote shim',
+    })
+    expect(err.agent).toBe('codex')
+    expect(err.transport).toBe('sse')
+    expect(err.details.supported).toEqual(['stdio'])
+    expect(err.details.hint).toContain('mcp-remote')
+  })
+
+  test('message names the requested transport and the supported set', () => {
+    const err = new UnsupportedTransportError('claude-desktop', 'http', {
+      supported: ['stdio'],
+      hint: 'see README',
+    })
+    expect(err.message).toContain('claude-desktop')
+    expect(err.message).toContain('"http"')
+    expect(err.message).toContain('supported: stdio')
+  })
+})
+
+describe('AgentNotInstalledError', () => {
+  test('extends McpManagerError so instanceof checks compose', () => {
+    const err = new AgentNotInstalledError(
+      'cursor',
+      '/home/dev/.cursor/mcp.json',
+      '/home/dev/.cursor',
+    )
+    expect(err).toBeInstanceOf(McpManagerError)
+    expect(err.name).toBe('AgentNotInstalledError')
+    expect(err.agent).toBe('cursor')
+    expect(err.configPath).toBe('/home/dev/.cursor/mcp.json')
+    expect(err.parentDir).toBe('/home/dev/.cursor')
+  })
+
+  test('message includes the agent id, config path, and parent dir', () => {
+    const err = new AgentNotInstalledError(
+      'gemini',
+      '/tmp/x/.gemini/settings.json',
+      '/tmp/x/.gemini',
+    )
+    expect(err.message).toContain('gemini')
+    expect(err.message).toContain('/tmp/x/.gemini/settings.json')
+    expect(err.message).toContain('/tmp/x/.gemini')
+  })
+
+  test('message contains no em-dashes (repo writing rule)', () => {
+    const err = new AgentNotInstalledError('zed', '/a/b', '/a')
+    expect(err.message.includes('—')).toBe(false)
+  })
+})

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/io.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/io.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { applyPlan, readState } from '../../src/io/index'
+
+let workspaceDir: string
+
+beforeEach(async () => {
+  workspaceDir = await mkdtemp(join(tmpdir(), 'acpx-io-'))
+})
+
+afterEach(async () => {
+  await rm(workspaceDir, { recursive: true, force: true })
+})
+
+describe('readState', () => {
+  test('empty workspace yields an empty manifest and no agent files', async () => {
+    const state = await readState(workspaceDir)
+    expect(state.manifest.servers).toEqual({})
+    expect(state.agents).toEqual([])
+    expect(state.manifestPath.endsWith('manifest.json')).toBe(true)
+  })
+
+  test('reads manifest when it exists', async () => {
+    const manifestPath = join(workspaceDir, 'manifest.json')
+    const manifest = {
+      version: 1,
+      servers: {
+        gh: {
+          name: 'gh',
+          spec: { transport: 'stdio' as const, command: 'gh-mcp' },
+          addedAt: '2026-07-06',
+          links: {},
+        },
+      },
+    }
+    await Bun.write(manifestPath, JSON.stringify(manifest))
+    const state = await readState(workspaceDir)
+    expect(state.manifest.servers.gh?.name).toBe('gh')
+  })
+
+  test('reads per-agent config files when agents are requested with an override', async () => {
+    const cursorPath = join(workspaceDir, 'cursor.json')
+    await Bun.write(cursorPath, JSON.stringify({ mcpServers: {} }))
+    const state = await readState(workspaceDir, ['cursor'], {
+      overrides: { cursor: cursorPath },
+    })
+    expect(state.agents).toHaveLength(1)
+    expect(state.agents[0]?.agent).toBe('cursor')
+    expect(state.agents[0]?.rawContent).toContain('mcpServers')
+    expect(state.agents[0]?.exists).toBe(true)
+  })
+
+  test('missing agent config file surfaces as exists: false with empty content', async () => {
+    const state = await readState(workspaceDir, ['cursor'], {
+      overrides: { cursor: join(workspaceDir, 'nope.json') },
+    })
+    expect(state.agents[0]?.exists).toBe(false)
+    expect(state.agents[0]?.rawContent).toBe('')
+  })
+
+  test('empty-but-existing config file surfaces as exists: true', async () => {
+    // Regression: `exists` used to be `rawContent.length > 0`, which
+    // misclassified an empty file as missing. planRescan then reported
+    // spurious "missing" drift for editors that touch a config file
+    // empty before writing content.
+    const emptyFile = join(workspaceDir, 'empty.json')
+    await Bun.write(emptyFile, '')
+    const state = await readState(workspaceDir, ['cursor'], {
+      overrides: { cursor: emptyFile },
+    })
+    expect(state.agents[0]?.exists).toBe(true)
+    expect(state.agents[0]?.rawContent).toBe('')
+  })
+
+  test('parentExists: true when the config file exists', async () => {
+    const cursorPath = join(workspaceDir, 'cursor.json')
+    await Bun.write(cursorPath, JSON.stringify({ mcpServers: {} }))
+    const state = await readState(workspaceDir, ['cursor'], {
+      overrides: { cursor: cursorPath },
+    })
+    expect(state.agents[0]?.exists).toBe(true)
+    expect(state.agents[0]?.parentExists).toBe(true)
+  })
+
+  test('parentExists: true when only the parent directory exists (file missing)', async () => {
+    // The workspaceDir (mkdtemp'd) exists; the file inside it does not.
+    // This mirrors a freshly-launched-but-not-configured-yet agent.
+    const state = await readState(workspaceDir, ['cursor'], {
+      overrides: { cursor: join(workspaceDir, 'not-created-yet.json') },
+    })
+    expect(state.agents[0]?.exists).toBe(false)
+    expect(state.agents[0]?.parentExists).toBe(true)
+  })
+
+  test('parentExists: false when neither the file nor its parent exists', async () => {
+    const state = await readState(workspaceDir, ['cursor'], {
+      overrides: {
+        cursor: join(workspaceDir, 'never-created-dir', 'child.json'),
+      },
+    })
+    expect(state.agents[0]?.exists).toBe(false)
+    expect(state.agents[0]?.parentExists).toBe(false)
+  })
+})
+
+describe('applyPlan', () => {
+  test('runs writeFile ops with atomic rename', async () => {
+    const target = join(workspaceDir, 'nested', 'cursor.json')
+    const result = await applyPlan({
+      ops: [
+        {
+          kind: 'writeFile',
+          path: target,
+          content: '{"mcpServers":{}}',
+          ensureDir: true,
+        },
+      ],
+      nextManifest: { version: 1, servers: {} },
+    })
+    expect(result.writtenPaths).toEqual([target])
+    const raw = await readFile(target, 'utf8')
+    expect(raw).toBe('{"mcpServers":{}}')
+  })
+
+  test('applies multiple writeFile ops in the given order', async () => {
+    const a = join(workspaceDir, 'a.json')
+    const b = join(workspaceDir, 'b.json')
+    await applyPlan({
+      ops: [
+        { kind: 'writeFile', path: a, content: 'aa' },
+        { kind: 'writeFile', path: b, content: 'bb' },
+      ],
+      nextManifest: { version: 1, servers: {} },
+    })
+    expect(await readFile(a, 'utf8')).toBe('aa')
+    expect(await readFile(b, 'utf8')).toBe('bb')
+  })
+
+  test('runs removeFile ops after writeFile ops', async () => {
+    const target = join(workspaceDir, 'gone.json')
+    await Bun.write(target, 'original')
+    await applyPlan({
+      ops: [{ kind: 'removeFile', path: target }],
+      nextManifest: { version: 1, servers: {} },
+    })
+    await expect(stat(target)).rejects.toThrow()
+  })
+
+  test('removeFile is idempotent when the target does not exist', async () => {
+    const missing = join(workspaceDir, 'never-existed.json')
+    // Should not throw.
+    await applyPlan({
+      ops: [{ kind: 'removeFile', path: missing }],
+      nextManifest: { version: 1, servers: {} },
+    })
+  })
+
+  test('empty plan is a no-op', async () => {
+    const res = await applyPlan({
+      ops: [],
+      nextManifest: { version: 1, servers: {} },
+    })
+    expect(res.writtenPaths).toEqual([])
+    expect(res.removedPaths).toEqual([])
+  })
+})

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/is-installed.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/is-installed.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { isInstalled } from '../../src/api'
+
+// isInstalled resolves per-agent config paths via
+// resolveAgentMcpConfigPath. To keep the tests hermetic we point the
+// test at a controlled path via a symlink-style trick: set env vars the
+// catalog references so the resolved path lands under our tmp dir.
+// The simplest approach here is to set $HOME to workspaceDir and rely
+// on the fact that most catalog entries use $HOME/... on unix. For
+// win32 test coverage see the CI matrix.
+
+let workspaceDir: string
+let originalHome: string | undefined
+
+beforeEach(async () => {
+  workspaceDir = await mkdtemp(join(tmpdir(), 'acpx-installed-'))
+  originalHome = process.env.HOME
+  process.env.HOME = workspaceDir
+})
+
+afterEach(async () => {
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  await rm(workspaceDir, { recursive: true, force: true })
+})
+
+describe('isInstalled', () => {
+  test('returns installed: true when the config file exists', async () => {
+    // Cursor's system path is $HOME/.cursor/mcp.json.
+    await mkdir(join(workspaceDir, '.cursor'), { recursive: true })
+    await Bun.write(
+      join(workspaceDir, '.cursor', 'mcp.json'),
+      JSON.stringify({ mcpServers: {} }),
+    )
+    const result = await isInstalled({ agents: ['cursor'] })
+    expect(result.cursor).toBe(true)
+  })
+
+  test('returns installed: true when only the parent directory exists', async () => {
+    // Fresh Cursor: ~/.cursor/ exists, mcp.json does not.
+    await mkdir(join(workspaceDir, '.cursor'), { recursive: true })
+    const result = await isInstalled({ agents: ['cursor'] })
+    expect(result.cursor).toBe(true)
+  })
+
+  test('returns installed: false when neither exists', async () => {
+    // Nothing under $HOME/.cursor at all: agent not installed.
+    const result = await isInstalled({ agents: ['cursor'] })
+    expect(result.cursor).toBe(false)
+  })
+
+  test('returns only the requested agents (no extra keys)', async () => {
+    await mkdir(join(workspaceDir, '.cursor'), { recursive: true })
+    const result = await isInstalled({ agents: ['cursor'] })
+    expect(Object.keys(result)).toEqual(['cursor'])
+  })
+
+  test('handles duplicate agent ids in input (deduplicates)', async () => {
+    await mkdir(join(workspaceDir, '.cursor'), { recursive: true })
+    const result = await isInstalled({
+      agents: ['cursor', 'cursor', 'cursor'],
+    })
+    expect(Object.keys(result)).toEqual(['cursor'])
+    expect(result.cursor).toBe(true)
+  })
+
+  test('handles an empty agents list', async () => {
+    const result = await isInstalled({ agents: [] })
+    expect(result).toEqual({})
+  })
+
+  test('reports false when the OS cannot resolve any path candidate', async () => {
+    // Clearing $HOME makes all $HOME/... candidates unresolvable on
+    // this OS. resolveAgentMcpConfigPath throws UnresolvedConfigPath
+    // Error, which isInstalled catches and returns false for.
+    delete process.env.HOME
+    const result = await isInstalled({ agents: ['cursor'] })
+    expect(result.cursor).toBe(false)
+  })
+
+  test('respects scope: project with projectRoot', async () => {
+    // Cursor's project file is `.cursor/mcp.json` relative to project
+    // root. Point projectRoot at workspaceDir; nothing exists yet.
+    const before = await isInstalled({
+      agents: ['cursor'],
+      scope: 'project',
+      projectRoot: workspaceDir,
+    })
+    expect(before.cursor).toBe(false)
+
+    // Create the parent dir and check again.
+    await mkdir(join(workspaceDir, '.cursor'), { recursive: true })
+    const after = await isInstalled({
+      agents: ['cursor'],
+      scope: 'project',
+      projectRoot: workspaceDir,
+    })
+    expect(after.cursor).toBe(true)
+  })
+
+  test('returns a plain object with only string keys (safe to iterate)', async () => {
+    // Guard against future accidental use of Object.create(null) or a
+    // Map. Consumers rely on `Object.keys`, `Object.entries`, and the
+    // `in` operator.
+    const result = await isInstalled({ agents: ['cursor'] })
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
+  })
+})

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/manifest.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/manifest.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import {
+  emptyManifest,
+  readManifest,
+  writeManifest,
+} from '../../src/_internal/manifest'
+import { McpManagerError } from '../../src/errors'
+import { makeTmpWorkspace, type TmpWorkspace } from '../helpers/tmp-workspace'
+
+let ws: TmpWorkspace
+
+beforeEach(async () => {
+  ws = await makeTmpWorkspace()
+})
+
+afterEach(async () => {
+  await ws.cleanup()
+})
+
+describe('manifest', () => {
+  test('emptyManifest is version 1 + empty servers', () => {
+    expect(emptyManifest()).toEqual({ version: 1, servers: {} })
+  })
+
+  test('readManifest returns empty when file is missing', async () => {
+    const m = await readManifest(ws.workspaceDir)
+    expect(m).toEqual({ version: 1, servers: {} })
+  })
+
+  test('write + read round-trip preserves the manifest', async () => {
+    const manifest = emptyManifest()
+    manifest.servers.github = {
+      name: 'github',
+      spec: { transport: 'stdio', command: 'gh-mcp' },
+      addedAt: '2026-06-10T18:00:00.000Z',
+      links: {
+        'claude-code': {
+          configPath: '/tmp/.claude.json',
+          createdAt: '2026-06-10T18:01:00.000Z',
+        },
+      },
+    }
+    await writeManifest(ws.workspaceDir, manifest)
+    expect(await readManifest(ws.workspaceDir)).toEqual(manifest)
+  })
+
+  test('readManifest throws on malformed JSON instead of returning empty', async () => {
+    await writeFile(
+      join(ws.workspaceDir, 'manifest.json'),
+      '{ not json',
+      'utf8',
+    )
+    await expect(readManifest(ws.workspaceDir)).rejects.toBeInstanceOf(
+      McpManagerError,
+    )
+  })
+
+  test('readManifest throws on unsupported version', async () => {
+    await writeFile(
+      join(ws.workspaceDir, 'manifest.json'),
+      JSON.stringify({ version: 99, servers: {} }),
+      'utf8',
+    )
+    await expect(readManifest(ws.workspaceDir)).rejects.toBeInstanceOf(
+      McpManagerError,
+    )
+  })
+
+  test('readManifest throws when servers is missing', async () => {
+    await writeFile(
+      join(ws.workspaceDir, 'manifest.json'),
+      JSON.stringify({ version: 1 }),
+      'utf8',
+    )
+    await expect(readManifest(ws.workspaceDir)).rejects.toBeInstanceOf(
+      McpManagerError,
+    )
+  })
+})

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/planner.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/planner.test.ts
@@ -1,0 +1,669 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  AgentNotInstalledError,
+  ForeignEntryError,
+  InvalidServerSpecError,
+  UnsupportedTransportError,
+} from '../../src/errors'
+import {
+  planDisconnect,
+  planLink,
+  planRemove,
+  planRescan,
+  planUnlink,
+} from '../../src/planner/planner'
+import type { State } from '../../src/planner/types'
+import type {
+  AgentId,
+  ManifestServerEntry,
+  McpServer,
+  McpServerSpec,
+  ServerManifest,
+} from '../../src/types'
+
+const NOW = '2026-07-06T12:00:00Z'
+
+const STDIO_SPEC: McpServerSpec = {
+  transport: 'stdio',
+  command: 'gh-mcp',
+  args: ['serve'],
+}
+
+const HTTP_SPEC: McpServerSpec = {
+  transport: 'http',
+  url: 'https://example.com/mcp',
+}
+
+const GH: McpServer = { name: 'gh', spec: STDIO_SPEC }
+const GH_HTTP: McpServer = { name: 'gh', spec: HTTP_SPEC }
+
+function emptyManifest(): ServerManifest {
+  return { version: 1, servers: {} }
+}
+
+function serverEntry(
+  overrides: Partial<ManifestServerEntry> = {},
+): ManifestServerEntry {
+  return {
+    name: 'gh',
+    spec: STDIO_SPEC,
+    addedAt: NOW,
+    links: {},
+    ...overrides,
+  }
+}
+
+function baseState(overrides: Partial<State> = {}): State {
+  return {
+    workspaceDir: '/tmp/ws',
+    manifestPath: '/tmp/ws/manifest.json',
+    manifest: emptyManifest(),
+    agents: [],
+    ...overrides,
+  }
+}
+
+function stateWithServer(
+  server: ManifestServerEntry,
+  extras: Partial<State> = {},
+): State {
+  return baseState({
+    manifest: { version: 1, servers: { [server.name]: server } },
+    ...extras,
+  })
+}
+
+function agentFile(
+  agent: AgentId,
+  configPath: string,
+  raw = '',
+  scope: 'system' | 'project' = 'system',
+  parentExists = true,
+) {
+  return {
+    agent,
+    scope,
+    configPath,
+    rawContent: raw,
+    exists: raw.length > 0,
+    parentExists,
+  }
+}
+
+// -------------------------------------------------------------------
+// planLink — the primary write verb. Upserts manifest AND writes config.
+// -------------------------------------------------------------------
+
+describe('planLink', () => {
+  test('first link creates a manifest server entry and writes agent config', () => {
+    const state = baseState({
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json')],
+    })
+    const plan = planLink(state, { server: GH, agent: 'cursor' }, NOW)
+    expect(plan.created).toBe(true)
+    expect(plan.overwroteForeign).toBe(false)
+    expect(plan.nextManifest.servers.gh?.spec).toEqual(STDIO_SPEC)
+    expect(plan.nextManifest.servers.gh?.links.cursor?.configPath).toBe(
+      '/tmp/ws/cursor.json',
+    )
+    expect(plan.ops).toHaveLength(2)
+  })
+
+  test('rejects an empty server name', () => {
+    const state = baseState({
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json')],
+    })
+    expect(() =>
+      planLink(
+        state,
+        { server: { name: '  ', spec: STDIO_SPEC }, agent: 'cursor' },
+        NOW,
+      ),
+    ).toThrow(InvalidServerSpecError)
+  })
+
+  test('rejects a stdio spec with an empty command', () => {
+    const state = baseState({
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json')],
+    })
+    expect(() =>
+      planLink(
+        state,
+        {
+          server: { name: 'x', spec: { transport: 'stdio', command: '' } },
+          agent: 'cursor',
+        },
+        NOW,
+      ),
+    ).toThrow(InvalidServerSpecError)
+  })
+
+  test('trims the server name before using it as the manifest key', () => {
+    const state = baseState({
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json')],
+    })
+    const plan = planLink(
+      state,
+      { server: { name: '  gh  ', spec: STDIO_SPEC }, agent: 'cursor' },
+      NOW,
+    )
+    expect(plan.serverName).toBe('gh')
+    expect(plan.nextManifest.servers.gh).toBeDefined()
+    expect(plan.nextManifest.servers['  gh  ']).toBeUndefined()
+  })
+
+  test('re-linking the same server + agent returns created: false and preserves addedAt', () => {
+    const state = stateWithServer(
+      serverEntry({
+        addedAt: '2020-01-01T00:00:00Z',
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+        },
+      }),
+      {
+        agents: [
+          agentFile(
+            'cursor',
+            '/tmp/ws/cursor.json',
+            JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }),
+          ),
+        ],
+      },
+    )
+    const plan = planLink(state, { server: GH, agent: 'cursor' }, NOW)
+    expect(plan.created).toBe(false)
+    expect(plan.nextManifest.servers.gh?.addedAt).toBe('2020-01-01T00:00:00Z')
+  })
+
+  test('upserts manifest spec when the same name is linked with a different spec', () => {
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+        },
+      }),
+      {
+        agents: [agentFile('gemini', '/tmp/ws/gemini.json', '')],
+      },
+    )
+    const plan = planLink(state, { server: GH_HTTP, agent: 'gemini' }, NOW)
+    // Manifest reflects the newer spec.
+    expect(plan.nextManifest.servers.gh?.spec).toEqual(HTTP_SPEC)
+    // Existing cursor link is preserved.
+    expect(plan.nextManifest.servers.gh?.links.cursor).toBeDefined()
+    // New gemini link is added.
+    expect(plan.nextManifest.servers.gh?.links.gemini).toBeDefined()
+  })
+
+  test('throws UnsupportedTransportError when transport not accepted', () => {
+    const state = baseState({
+      agents: [agentFile('claude-desktop', '/tmp/ws/claude.json')],
+    })
+    expect(() =>
+      planLink(state, { server: GH_HTTP, agent: 'claude-desktop' }, NOW),
+    ).toThrow(UnsupportedTransportError)
+  })
+
+  test('throws ForeignEntryError when config already has an unmanaged entry under this name', () => {
+    const foreignJson = JSON.stringify({
+      mcpServers: { gh: { command: 'other-thing' } },
+    })
+    const state = baseState({
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json', foreignJson)],
+    })
+    expect(() => planLink(state, { server: GH, agent: 'cursor' }, NOW)).toThrow(
+      ForeignEntryError,
+    )
+  })
+
+  test('allowOverwrite: true takes ownership of a foreign entry', () => {
+    const foreignJson = JSON.stringify({
+      mcpServers: { gh: { command: 'other-thing' } },
+    })
+    const state = baseState({
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json', foreignJson)],
+    })
+    const plan = planLink(
+      state,
+      { server: GH, agent: 'cursor', allowOverwrite: true },
+      NOW,
+    )
+    expect(plan.overwroteForeign).toBe(true)
+    expect(plan.created).toBe(true)
+  })
+
+  test('re-linking with identical content skips the agent-config write op', () => {
+    const state = baseState({
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json')],
+    })
+    const first = planLink(state, { server: GH, agent: 'cursor' }, NOW)
+    const configWriteOp = first.ops.find(
+      (op) => op.kind === 'writeFile' && op.path === '/tmp/ws/cursor.json',
+    )
+    expect(configWriteOp).toBeDefined()
+
+    const nextRaw =
+      configWriteOp?.kind === 'writeFile' ? configWriteOp.content : ''
+    const afterState = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+        },
+      }),
+      { agents: [agentFile('cursor', '/tmp/ws/cursor.json', nextRaw)] },
+    )
+    const second = planLink(afterState, { server: GH, agent: 'cursor' }, NOW)
+    const secondConfigWrites = second.ops.filter(
+      (op) => op.kind === 'writeFile' && op.path === '/tmp/ws/cursor.json',
+    )
+    expect(secondConfigWrites).toHaveLength(0)
+  })
+
+  // -----------------------------------------------------------------
+  // Install-status gate. Throws AgentNotInstalledError when the agent's
+  // config path is under a non-existent directory. Predicts what link()
+  // would throw and pairs with isInstalled({agents}) as its precheck.
+  // -----------------------------------------------------------------
+
+  test('throws AgentNotInstalledError when neither the config file nor its parent directory exists', () => {
+    const state = baseState({
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json', '', 'system', false)],
+    })
+    expect(() => planLink(state, { server: GH, agent: 'cursor' }, NOW)).toThrow(
+      AgentNotInstalledError,
+    )
+  })
+
+  test('does NOT throw when the parent directory exists (fresh agent, no MCP yet)', () => {
+    const state = baseState({
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json', '', 'system', true)],
+    })
+    const plan = planLink(state, { server: GH, agent: 'cursor' }, NOW)
+    expect(plan.created).toBe(true)
+  })
+
+  test('does NOT throw when the config file already exists', () => {
+    const configJson = JSON.stringify({ mcpServers: {} })
+    const state = baseState({
+      agents: [
+        agentFile('cursor', '/tmp/ws/cursor.json', configJson, 'system', true),
+      ],
+    })
+    const plan = planLink(state, { server: GH, agent: 'cursor' }, NOW)
+    expect(plan.created).toBe(true)
+  })
+
+  test('install-gate error carries the correct agent, configPath, and parentDir', () => {
+    const state = baseState({
+      agents: [
+        agentFile('cursor', '/tmp/ws/nope/cursor.json', '', 'system', false),
+      ],
+    })
+    try {
+      planLink(state, { server: GH, agent: 'cursor' }, NOW)
+      throw new Error('expected AgentNotInstalledError')
+    } catch (err) {
+      expect(err).toBeInstanceOf(AgentNotInstalledError)
+      const e = err as AgentNotInstalledError
+      expect(e.agent).toBe('cursor')
+      expect(e.configPath).toBe('/tmp/ws/nope/cursor.json')
+      expect(e.parentDir).toBe('/tmp/ws/nope')
+    }
+  })
+
+  test('UnsupportedTransportError still fires before the install gate', () => {
+    // Transport validity is a property of the input; check it first
+    // so a caller sending a garbage spec sees the semantic error and
+    // does not have to install an agent just to see it.
+    const state = baseState({
+      agents: [
+        agentFile('claude-desktop', '/tmp/ws/claude.json', '', 'system', false),
+      ],
+    })
+    expect(() =>
+      planLink(state, { server: GH_HTTP, agent: 'claude-desktop' }, NOW),
+    ).toThrow(UnsupportedTransportError)
+  })
+})
+
+// -------------------------------------------------------------------
+// planUnlink
+// -------------------------------------------------------------------
+
+describe('planUnlink', () => {
+  test('no-op when server not in manifest', () => {
+    const plan = planUnlink(baseState(), {
+      serverName: 'ghost',
+      agent: 'cursor',
+    })
+    expect(plan.removed).toBe(false)
+    expect(plan.ops).toEqual([])
+  })
+
+  test('no-op when agent has no link', () => {
+    const state = stateWithServer(serverEntry())
+    const plan = planUnlink(state, { serverName: 'gh', agent: 'cursor' })
+    expect(plan.removed).toBe(false)
+  })
+
+  test('removes the link and rewrites the config file when the entry exists on disk', () => {
+    const configJson = JSON.stringify({
+      mcpServers: { gh: { command: 'gh-mcp' } },
+    })
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+        },
+      }),
+      { agents: [agentFile('cursor', '/tmp/ws/cursor.json', configJson)] },
+    )
+    const plan = planUnlink(state, { serverName: 'gh', agent: 'cursor' })
+    expect(plan.removed).toBe(true)
+    expect(plan.nextManifest.servers.gh?.links.cursor).toBeUndefined()
+    expect(plan.ops).toHaveLength(2)
+  })
+})
+
+// -------------------------------------------------------------------
+// planDisconnect — the #63 primitive
+// -------------------------------------------------------------------
+
+describe('planDisconnect (closes #63)', () => {
+  test('unlinks a single agent and drops the manifest entry when it was the last', () => {
+    const configJson = JSON.stringify({
+      mcpServers: { gh: { command: 'gh-mcp' } },
+    })
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+        },
+      }),
+      { agents: [agentFile('cursor', '/tmp/ws/cursor.json', configJson)] },
+    )
+    const plan = planDisconnect(state, { serverName: 'gh', agent: 'cursor' })
+    expect(plan.unlinked).toBe(true)
+    expect(plan.removedManifest).toBe(true)
+    expect(plan.nextManifest.servers.gh).toBeUndefined()
+  })
+
+  test('DOES NOT drop the manifest entry when other agents remain linked', () => {
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+          'claude-code': { configPath: '/tmp/ws/claude.json', createdAt: NOW },
+          vscode: { configPath: '/tmp/ws/vscode.json', createdAt: NOW },
+          gemini: { configPath: '/tmp/ws/gemini.json', createdAt: NOW },
+        },
+      }),
+      {
+        agents: [
+          agentFile(
+            'cursor',
+            '/tmp/ws/cursor.json',
+            JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }),
+          ),
+          agentFile(
+            'claude-code',
+            '/tmp/ws/claude.json',
+            JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }),
+          ),
+          agentFile(
+            'vscode',
+            '/tmp/ws/vscode.json',
+            JSON.stringify({
+              servers: { gh: { command: 'gh-mcp', type: 'stdio' } },
+            }),
+          ),
+          agentFile(
+            'gemini',
+            '/tmp/ws/gemini.json',
+            JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }),
+          ),
+        ],
+      },
+    )
+    const plan = planDisconnect(state, { serverName: 'gh', agent: 'cursor' })
+    expect(plan.unlinked).toBe(true)
+    expect(plan.removedManifest).toBe(false)
+    const remainingEntry = plan.nextManifest.servers.gh
+    expect(remainingEntry).toBeDefined()
+    expect(Object.keys(remainingEntry?.links ?? {}).sort()).toEqual([
+      'claude-code',
+      'gemini',
+      'vscode',
+    ])
+    const writePaths = plan.ops
+      .filter((op) => op.kind === 'writeFile')
+      .map((op) => (op.kind === 'writeFile' ? op.path : ''))
+    expect(writePaths).toContain('/tmp/ws/cursor.json')
+    expect(writePaths).toContain('/tmp/ws/manifest.json')
+    expect(writePaths).not.toContain('/tmp/ws/claude.json')
+    expect(writePaths).not.toContain('/tmp/ws/vscode.json')
+    expect(writePaths).not.toContain('/tmp/ws/gemini.json')
+  })
+
+  test('removeIfLast: false keeps the manifest entry with empty links map', () => {
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+        },
+      }),
+      {
+        agents: [
+          agentFile(
+            'cursor',
+            '/tmp/ws/cursor.json',
+            JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }),
+          ),
+        ],
+      },
+    )
+    const plan = planDisconnect(state, {
+      serverName: 'gh',
+      agent: 'cursor',
+      removeIfLast: false,
+    })
+    expect(plan.removedManifest).toBe(false)
+    expect(plan.nextManifest.servers.gh?.links).toEqual({})
+  })
+
+  test('no-op when the agent was never linked', () => {
+    const state = stateWithServer(serverEntry())
+    const plan = planDisconnect(state, { serverName: 'gh', agent: 'cursor' })
+    expect(plan.unlinked).toBe(false)
+    expect(plan.removedManifest).toBe(false)
+    expect(plan.ops).toEqual([])
+  })
+})
+
+// -------------------------------------------------------------------
+// planRemove
+// -------------------------------------------------------------------
+
+describe('planRemove', () => {
+  test('drops manifest entry and unlinks every currently-linked agent by default', () => {
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+          gemini: { configPath: '/tmp/ws/gemini.json', createdAt: NOW },
+        },
+      }),
+      {
+        agents: [
+          agentFile(
+            'cursor',
+            '/tmp/ws/cursor.json',
+            JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }),
+          ),
+          agentFile(
+            'gemini',
+            '/tmp/ws/gemini.json',
+            JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }),
+          ),
+        ],
+      },
+    )
+    const plan = planRemove(state, { serverName: 'gh' })
+    expect(plan.removedManifest).toBe(true)
+    expect(plan.unlinkedAgents.sort()).toEqual(['cursor', 'gemini'])
+    expect(plan.nextManifest.servers.gh).toBeUndefined()
+    const paths = plan.ops
+      .filter((op) => op.kind === 'writeFile')
+      .map((op) => (op.kind === 'writeFile' ? op.path : ''))
+    expect(paths).toContain('/tmp/ws/cursor.json')
+    expect(paths).toContain('/tmp/ws/gemini.json')
+    expect(paths).toContain('/tmp/ws/manifest.json')
+  })
+
+  test('unlinkFirst: false drops the manifest entry without touching agent files', () => {
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+        },
+      }),
+    )
+    const plan = planRemove(state, { serverName: 'gh', unlinkFirst: false })
+    expect(plan.removedManifest).toBe(true)
+    expect(plan.unlinkedAgents).toEqual([])
+    expect(
+      plan.ops.filter(
+        (op) => op.kind === 'writeFile' && op.path.includes('cursor'),
+      ),
+    ).toHaveLength(0)
+  })
+
+  test('no-op when server not in manifest', () => {
+    const plan = planRemove(baseState(), { serverName: 'ghost' })
+    expect(plan.removedManifest).toBe(false)
+    expect(plan.ops).toEqual([])
+  })
+})
+
+// -------------------------------------------------------------------
+// planRescan
+// -------------------------------------------------------------------
+
+describe('planRescan', () => {
+  test('reports verified links when the on-disk entry matches', () => {
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+        },
+      }),
+      {
+        agents: [
+          agentFile(
+            'cursor',
+            '/tmp/ws/cursor.json',
+            JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }),
+          ),
+        ],
+      },
+    )
+    const { rescan } = planRescan(state)
+    expect(rescan.verified).toHaveLength(1)
+    expect(rescan.drifted).toHaveLength(0)
+    expect(rescan.missing).toHaveLength(0)
+  })
+
+  test('reports drift when config has no matching entry', () => {
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+        },
+      }),
+      {
+        agents: [
+          agentFile(
+            'cursor',
+            '/tmp/ws/cursor.json',
+            JSON.stringify({ mcpServers: {} }),
+          ),
+        ],
+      },
+    )
+    const { rescan } = planRescan(state)
+    expect(rescan.drifted).toHaveLength(1)
+    expect(rescan.drifted[0]?.serverName).toBe('gh')
+  })
+
+  test('reports missing when the file does not exist', () => {
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+        },
+      }),
+      { agents: [agentFile('cursor', '/tmp/ws/cursor.json', '')] },
+    )
+    const { rescan } = planRescan(state)
+    expect(rescan.missing).toHaveLength(1)
+  })
+
+  test('filter by agents narrows the scan', () => {
+    const state = stateWithServer(
+      serverEntry({
+        links: {
+          cursor: { configPath: '/tmp/ws/cursor.json', createdAt: NOW },
+          gemini: { configPath: '/tmp/ws/gemini.json', createdAt: NOW },
+        },
+      }),
+      {
+        agents: [
+          agentFile(
+            'cursor',
+            '/tmp/ws/cursor.json',
+            JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }),
+          ),
+          agentFile(
+            'gemini',
+            '/tmp/ws/gemini.json',
+            JSON.stringify({ mcpServers: { gh: { command: 'gh-mcp' } } }),
+          ),
+        ],
+      },
+    )
+    const { rescan } = planRescan(state, { agents: ['cursor'] })
+    expect(rescan.verified).toHaveLength(1)
+    expect(rescan.verified[0]?.agent).toBe('cursor')
+  })
+
+  test('returns no ops (rescan is read-only)', () => {
+    const { ops } = planRescan(baseState())
+    expect(ops).toEqual([])
+  })
+})
+
+// -------------------------------------------------------------------
+// Cross-cutting invariants
+// -------------------------------------------------------------------
+
+describe('planner invariants', () => {
+  test('a plan is a value; calling twice on the same state returns equivalent ops', () => {
+    const state = baseState({
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json')],
+    })
+    const a = planLink(state, { server: GH, agent: 'cursor' }, NOW)
+    const b = planLink(state, { server: GH, agent: 'cursor' }, NOW)
+    expect(a.ops).toEqual(b.ops)
+    expect(a.nextManifest).toEqual(b.nextManifest)
+  })
+
+  test('planners never mutate the input state', () => {
+    const state = stateWithServer(serverEntry(), {
+      agents: [agentFile('cursor', '/tmp/ws/cursor.json')],
+    })
+    const before = JSON.stringify(state.manifest)
+    planLink(state, { server: GH, agent: 'cursor' }, NOW)
+    expect(JSON.stringify(state.manifest)).toBe(before)
+  })
+})

--- a/packages/browseros-agent/packages/agent-mcp-manager/tsconfig.json
+++ b/packages/browseros-agent/packages/agent-mcp-manager/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/browseros-agent/tsconfig.json
+++ b/packages/browseros-agent/tsconfig.json
@@ -26,6 +26,7 @@
     "declarationMap": true
   },
   "references": [
+    { "path": "./packages/agent-mcp-manager" },
     { "path": "./packages/browser-core" },
     { "path": "./packages/browser-mcp" },
     { "path": "./packages/build-server-tools" },


### PR DESCRIPTION
## Summary

Snapshots `agent-mcp-manager` from `DaniAkash/agent-toolkit` branch `feat/mcp-manager-v0.0.4-fp` ([PR #64](https://github.com/DaniAkash/agent-toolkit/pull/64)) into `packages/browseros-agent/packages/agent-mcp-manager/` as `@browseros/agent-mcp-manager`, and rewires `apps/claw-server` to consume it via `workspace:*` instead of the current npm pin `agent-mcp-manager@0.0.4-rc.3`.

Motivation: the manager is now core to claw-server's harness install and MCP relink flow, and iteration cost is dominated by the npm publish loop (bump rc, publish, `bun install`, retry). Owning the source in-tree lets edits happen in the same PR as the caller changes.

## Behaviour change

**None.** The snapshot is byte-identical to the upstream `0.0.4-rc.3` tree that claw-server was already pinned against on npm. Two small BrowserOS-conventions adaptations only:

- `package.json` exports source-first (`./src/index.ts`) instead of `./dist`. Matches the sibling workspace packages that run TypeScript directly under Bun rather than bundling with `bunup`.
- Relative imports use extensionless specifiers (`./agents`) instead of `./agents.ts`. Matches `moduleResolution: bundler` in the workspace `tsconfig.json`.

Everything else - APIs, catalog, planner, emitters, IO layer, error types, tests - is untouched from upstream.

## What changed

**Added** (new workspace package, snapshot of upstream):
- `packages/browseros-agent/packages/agent-mcp-manager/` — 20 source files, 11 test files, `README.md`, `THIRD_PARTY_NOTICES.md`, `LICENSE`, `PROVENANCE.md`, and destination-shaped `package.json` + `tsconfig.json`.
- `PROVENANCE.md` records the upstream commit SHA (`fedf865d59...`), branch, PR, and inline date so the fork point stays discoverable.

**Modified** (workspace wiring):
- `packages/browseros-agent/tsconfig.json` — one line added to the `references` array.
- `packages/browseros-agent/apps/claw-server/package.json` — swapped `agent-mcp-manager: 0.0.4-rc.3` for `@browseros/agent-mcp-manager: workspace:*`.
- 7 files under `apps/claw-server/` — import specifier rewrite `'agent-mcp-manager'` -> `'@browseros/agent-mcp-manager'` (6 src files + 1 test helper). No other edits.
- `packages/browseros-agent/bun.lock` — regenerated by `bun install`.

## What is deliberately NOT changed

- `apps/server/` continues to depend on the npm-published `agent-mcp-manager@0.0.3` (class API from before the v0.0.4 rewrite). Scoped `@browseros/agent-mcp-manager` and unscoped `agent-mcp-manager` do not collide, so no side effects for that app. Migrating `apps/server` to the new functional API is a separate scope and out of this PR.
- No source-level changes to the manager itself. If a bugfix or refactor is needed, ship it as a follow-up PR touching only the inlined package.

## Test plan

- [x] `bun install` clean, lockfile regenerates without conflict.
- [x] `bun run --filter '@browseros/agent-mcp-manager' typecheck` clean.
- [x] `bun run --filter '@browseros/claw-server' typecheck` clean.
- [x] `bun run --filter '@browseros/server' typecheck` clean (proves the coexistence of scoped and unscoped names works).
- [x] `bun test` in the inlined package: 135 pass, 0 fail.
- [x] `bun test` in claw-server: 383 pass, 0 fail.
- [x] `bun run build:claw-server:test` produces `browseros-claw-server-darwin-arm64` successfully.
- [ ] Sideload a claw-server binary from this branch and exercise a real Claude Desktop link flow end to end.

## Follow-ups

- Optional: migrate `apps/server` off the npm `agent-mcp-manager@0.0.3` class API and onto this workspace copy. Requires rewriting `apps/server/src/lib/mcp-manager/*.ts` to the functional verbs. Not in scope here.