### PR TITLE
feat(agent-mcp-manager): refresh from upstream 50ec1c8 (0.0.4-rc.3 → 0.0.4-rc.4)

### DIFF
--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -300,7 +300,7 @@
     },
     "packages/agent-mcp-manager": {
       "name": "@browseros/agent-mcp-manager",
-      "version": "0.0.4-rc.3",
+      "version": "0.0.4-rc.4",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "jsonc-parser": "^3.3.1",

--- a/packages/browseros-agent/packages/agent-mcp-manager/PROVENANCE.md
+++ b/packages/browseros-agent/packages/agent-mcp-manager/PROVENANCE.md
@@ -2,11 +2,11 @@
 
 Inlined snapshot of `agent-mcp-manager` from https://github.com/DaniAkash/agent-toolkit.
 
-- Upstream commit: `fedf865d597619571e79e29758df2c20bc4a2a03`
+- Upstream commit: `50ec1c8556015987c89f79d6855fec464b5aaea6`
 - Upstream branch: `feat/mcp-manager-v0.0.4-fp`
 - Upstream PR: https://github.com/DaniAkash/agent-toolkit/pull/64
-- Upstream version at snapshot: `0.0.4-rc.3`
-- Inlined on: 2026-07-10
+- Upstream version at snapshot: `0.0.4-rc.4`
+- Inlined on: 2026-07-10 (refresh from `fedf865d59...`)
 
 ## Why inlined
 

--- a/packages/browseros-agent/packages/agent-mcp-manager/package.json
+++ b/packages/browseros-agent/packages/agent-mcp-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/agent-mcp-manager",
-  "version": "0.0.4-rc.3",
+  "version": "0.0.4-rc.4",
   "description": "Programmatic add/link/unlink for MCP servers across AI coding agents. Inlined snapshot of agent-mcp-manager from DaniAkash/agent-toolkit.",
   "license": "MIT",
   "author": "Dani Akash",

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/client-configs.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/client-configs.ts
@@ -75,7 +75,12 @@ export const claudeCode: ClientConfig = {
     project: ['stdio'],
   },
   stdio: { topLevelKey: 'mcpServers' },
-  http: { supportsOAuth: true },
+  http: {
+    tagKey: 'type',
+    tagValue: 'http',
+    sseTagValue: 'sse',
+    supportsOAuth: true,
+  },
   project: {
     stdio: { topLevelKey: 'mcpServers', tagKey: 'type', tagValue: 'stdio' },
   },
@@ -83,8 +88,8 @@ export const claudeCode: ClientConfig = {
     firstParty: 'https://docs.claude.com/en/docs/claude-code/mcp',
     smithery: SMITHERY_URL,
     notes:
-      'Project scope (.mcp.json) requires an explicit type: stdio tag; ~/.claude.json accepts entries without a tag. System scope writes stdio and http both without a type tag (Claude Code parses both), matching the shape v0.0.3 shipped.',
-    verified: VERIFIED,
+      'HTTP and SSE entries in ~/.claude.json require an explicit `type` field ("http", "sse", or "ws") or Claude Code emits a "url but no type" parse warning and skips the entry on launch. Stdio entries are accepted with or without a type tag. Project scope (.mcp.json) writes an explicit type: stdio tag per Claude Code project-scope docs.',
+    verified: '2026-07-10',
   },
 }
 

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/types.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/types.ts
@@ -87,9 +87,17 @@ export interface HttpShape {
   /**
    * Value written under `tagKey` for http entries. Known values:
    * 'http', 'streamableHttp' (Cline), 'streamable-http' (Kiro),
-   * 'remote' (OpenCode).
+   * 'remote' (OpenCode). Applied to both `http` and `sse` transports
+   * unless `sseTagValue` is set.
    */
   tagValue?: string
+  /**
+   * Value written under `tagKey` for SSE entries specifically. Use when
+   * the client accepts both http and sse and distinguishes them by tag
+   * value: Claude Code writes `type: "http"` for http and `type: "sse"`
+   * for sse. When unset, SSE entries use `tagValue` (the shared value).
+   */
+  sseTagValue?: string
   /** Static fields merged into every http entry. */
   injects?: Record<string, unknown>
   /**

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/shape.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/emitters/shape.ts
@@ -111,11 +111,16 @@ function buildHttpEntry(
   if (spec.headers && Object.keys(spec.headers).length > 0) {
     base[headerField] = spec.headers
   }
-  // HTTP tag value is either a fixed shape.tagValue (Cline, Kiro, etc.)
-  // or nothing (no tag written). We do NOT emit spec.transport as the
-  // tag value here: clients that accept both sse and http use the same
-  // static tag ('http') per Smithery + first-party docs research.
-  return finaliseEntry(base, shape.injects, shape.tagKey, shape.tagValue)
+  // Tag value resolution: `sseTagValue` overrides `tagValue` for sse
+  // entries when set. Used by clients like Claude Code that write
+  // `type: "http"` for http entries and `type: "sse"` for sse entries.
+  // Clients that use the same tag value regardless (Cursor, VS Code,
+  // Gemini, ...) keep `tagValue: 'http'` and omit `sseTagValue`.
+  const tagValue =
+    spec.transport === 'sse' && shape.sseTagValue !== undefined
+      ? shape.sseTagValue
+      : shape.tagValue
+  return finaliseEntry(base, shape.injects, shape.tagKey, tagValue)
 }
 
 function finaliseEntry(

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/index.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/index.ts
@@ -76,4 +76,4 @@ export type {
   ServerManifest,
 } from './types'
 
-export const VERSION = '0.0.4-rc.3'
+export const VERSION = '0.0.4-rc.4'

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/catalog.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/catalog.test.ts
@@ -86,4 +86,14 @@ describe('populated catalog', () => {
     expect(cc.project?.stdio.tagKey).toBe('type')
     expect(cc.project?.stdio.tagValue).toBe('stdio')
   })
+
+  test('claude-code system HTTP shape writes type: "http" and type: "sse" per transport', () => {
+    // Regression: Claude Code emits a parse warning for HTTP entries
+    // that lack an explicit `type` field. Without this shape, the
+    // library wrote entries Claude Code silently rejected on launch.
+    const cc = CATALOG_BY_ID['claude-code']
+    expect(cc.http?.tagKey).toBe('type')
+    expect(cc.http?.tagValue).toBe('http')
+    expect(cc.http?.sseTagValue).toBe('sse')
+  })
 })

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/emitters.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/emitters.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
+  claudeCode,
   claudeDesktop,
   cline,
   codex,
+  cursor,
   goose,
   opencode,
   vscode,
@@ -175,5 +177,46 @@ describe('getEmitter: project-scope override', () => {
     const out = getEmitter(vscode, 'project').add('', 'gh', STDIO_SPEC)
     const parsed = JSON.parse(out)
     expect(parsed.servers.gh.type).toBe('stdio')
+  })
+})
+
+describe('getEmitter: per-transport tag values (Claude Code HTTP + SSE)', () => {
+  // Regression: Claude Code's ~/.claude.json parser rejects HTTP
+  // entries that lack an explicit `type` field. Before rc.4 we wrote
+  // no tag on system-scope HTTP entries and Claude Code silently
+  // skipped them at launch. See the sseTagValue field on HttpShape.
+
+  const SSE_SPEC: McpServerSpec = {
+    transport: 'sse',
+    url: 'https://example.com/sse',
+  }
+
+  test('claude-code system HTTP entry gets type: "http"', () => {
+    const out = getEmitter(claudeCode).add('', 'browserclaw', HTTP_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.mcpServers.browserclaw.type).toBe('http')
+    expect(parsed.mcpServers.browserclaw.url).toBe('https://example.com/mcp')
+  })
+
+  test('claude-code system SSE entry gets type: "sse"', () => {
+    const out = getEmitter(claudeCode).add('', 'events', SSE_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.mcpServers.events.type).toBe('sse')
+    expect(parsed.mcpServers.events.url).toBe('https://example.com/sse')
+  })
+
+  test('claude-code system stdio entry has no type tag (parser accepts it)', () => {
+    const out = getEmitter(claudeCode).add('', 'gh', STDIO_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.mcpServers.gh.type).toBeUndefined()
+    expect(parsed.mcpServers.gh.command).toBe('gh-mcp')
+  })
+
+  test('cursor HTTP (uses shared tagValue) still writes type: "http" for SSE too', () => {
+    // Regression guard: clients without sseTagValue keep the historical
+    // behavior of using the shared tagValue for both transports.
+    const out = getEmitter(cursor).add('', 'events', SSE_SPEC)
+    const parsed = JSON.parse(out)
+    expect(parsed.mcpServers.events.type).toBe('http')
   })
 })


### PR DESCRIPTION
## Summary

Refreshes the inlined `@browseros/agent-mcp-manager` snapshot to pull the one commit that has landed on [`DaniAkash/agent-toolkit#64`](https://github.com/DaniAkash/agent-toolkit/pull/64) since the initial inline (#1771).

Upstream delta:

- `50ec1c8556015987c89f79d6855fec464b5aaea6` — `fix(mcp-manager)!: claude-code system HTTP now writes explicit type field`

## Why this matters for BrowserOS

Commit `00818c13c` ("Revert `fix(claw-server): write Claude Code HTTP transport type`") had earlier attempted this fix at the claw-server layer. Claude Code's config parser needs an explicit `type` field on HTTP transport entries; emitting that from the shared manager benefits every consumer of the manager, not just claw-server. Landing it at the library layer is where the fix belongs.

## Behaviour change

**None for consumers.** Public API is unchanged - `bind`, `link`, `disconnect`, `list`, `resolveAgentSurface`, `resolveAgentMcpConfigPath`, and the error hierarchy are byte-identical to rc.3 at their entry points. Only the on-disk shape of Claude Code system-HTTP entries changes, and that's the intended fix.

No claw-server call sites need updating.

## What changed

**Source refresh** (from upstream):

| File | Delta |
|---|---|
| `src/_catalog/client-configs.ts` | +8 / -3 |
| `src/_catalog/types.ts` | +8 / -2 |
| `src/emitters/shape.ts` | +10 / -5 |
| `src/index.ts` | `VERSION` const bump |
| `test/unit/catalog.test.ts` | +10 (new tests for the fix) |
| `test/unit/emitters.test.ts` | +43 (new tests for the fix) |

**Metadata:**

- `package.json` — version `0.0.4-rc.3` → `0.0.4-rc.4`
- `PROVENANCE.md` — upstream SHA now `50ec1c8556...`, version `0.0.4-rc.4`, dated as a refresh from `fedf865d59...`
- `bun.lock` — regenerated; single-line delta reflecting the workspace-package version bump

**Two upstream import-reflow-only diffs** (`src/planner/types.ts`, `test/unit/manifest.test.ts`) were reverted by BrowserOS's Biome pre-commit hook to the workspace's single-line-import house style. No semantic change either way.

## What is deliberately NOT changed

- Same two BrowserOS-conventions adaptations as the initial inline: source-first `exports` in `package.json`, and extensionless relative imports in `src/` and `test/` (re-applied to the new tree).
- `apps/server` still depends on npm `agent-mcp-manager@0.0.3`. Zero relevance to this PR.

## Test plan

- [x] `bun install` clean; lockfile delta limited to the workspace-package version bump.
- [x] `bun run --filter '@browseros/agent-mcp-manager' typecheck` clean.
- [x] `bun run --filter '@browseros/claw-server' typecheck` clean.
- [x] `bun run --filter '@browseros/server' typecheck` clean (proves the unrelated npm consumer is unaffected).
- [x] Inlined package tests: **140/140 pass** (up from 135; upstream added 5 tests for the new type-field behaviour).
- [x] Claw-server tests: **383/383 pass**.
- [x] `bun run build:claw-server:test` produces `browseros-claw-server-darwin-arm64` successfully.
- [ ] Sideload the new claw-server binary and link a Claude Code HTTP entry end to end; confirm the on-disk config now carries the explicit `type` field.