### PR TITLE
fix(ota): use product bundle for Windows signing

### DIFF
--- a/packages/browseros/bos_build/products/server_binaries.py
+++ b/packages/browseros/bos_build/products/server_binaries.py
@@ -79,12 +79,11 @@ def macos_sign_spec_for(binary_path: Path) -> Optional[SignSpec]:
     return None
 
 
-def expected_windows_binary_paths(server_bin_dir: Path) -> List[Path]:
-    """Resolve the browseros server's Windows binaries under resources/bin."""
-    bundles = server_bundles_for_product("browseros")
-    return [
-        server_bin_dir / rel for bundle in bundles for rel in bundle.windows_binaries
-    ]
+def expected_windows_binary_paths(
+    server_bin_dir: Path, bundle: ServerBundle
+) -> List[Path]:
+    """Resolve a server bundle's Windows binaries under resources/bin."""
+    return [server_bin_dir / rel for rel in bundle.windows_binaries]
 
 
 def expected_windows_bundle_binary_paths(

--- a/packages/browseros/bos_build/products/server_binaries_test.py
+++ b/packages/browseros/bos_build/products/server_binaries_test.py
@@ -170,12 +170,19 @@ class WindowsServerBinariesTest(unittest.TestCase):
                 f"{rel} outside expected layout",
             )
 
-    def test_expected_windows_binary_paths_joins_root(self):
+    def test_expected_windows_binary_paths_resolves_browseros_descriptor(self):
         root = Path("/tmp/fake/resources/bin")
-        resolved = expected_windows_binary_paths(root)
-        self.assertEqual(len(resolved), len(WINDOWS_SERVER_BINARIES))
-        for rel, abs_path in zip(WINDOWS_SERVER_BINARIES, resolved):
-            self.assertEqual(abs_path, root / rel)
+        self.assertEqual(
+            expected_windows_binary_paths(root, BROWSEROS_SERVER_BUNDLE),
+            [root / "browseros_server.exe"],
+        )
+
+    def test_expected_windows_binary_paths_resolves_browserclaw_descriptor(self):
+        root = Path("/tmp/fake/resources/bin")
+        self.assertEqual(
+            expected_windows_binary_paths(root, BROWSEROS_CLAW_SERVER_BUNDLE),
+            [root / "browseros-claw-server.exe"],
+        )
 
     def test_expected_windows_bundle_binary_paths_includes_claw(self):
         build_output_dir = Path("/tmp/out/Default")

--- a/packages/browseros/bos_build/release/ota/feeds_alignment_test.py
+++ b/packages/browseros/bos_build/release/ota/feeds_alignment_test.py
@@ -6,11 +6,14 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
+from unittest import mock
 
 from ...core.context import Context
 from ...core.step import ValidationError
+from ...products.browserclaw.product import BROWSERCLAW_SERVER_BUNDLE
 from ..feeds.render import ExistingAppcast, SignedArtifact, render_server_appcast
 from ..feeds.spec import server_feed
+from . import server as ota_server
 from .common import get_appcast_path, merge_base_appcast, promote_appcast_content
 from .server import ServerOTAModule
 
@@ -65,6 +68,20 @@ class BundleDerivationTest(unittest.TestCase):
             module.zip_filename("darwin_arm64"),
             "browserclaw_server_0.0.9_darwin_arm64.zip",
         )
+
+    def test_browserclaw_windows_signing_receives_claw_bundle(self):
+        module = ServerOTAModule(
+            version="0.0.9", channel="alpha", product_id="browserclaw"
+        )
+        resources = Path("/tmp/staged/resources")
+        ctx = cast(Context, SimpleNamespace(env=object()))
+
+        with mock.patch.object(
+            ota_server, "sign_server_bundle_windows", return_value=True
+        ) as signer:
+            self.assertTrue(module._sign_bundle(resources, {"os": "windows"}, ctx))
+
+        signer.assert_called_once_with(resources, ctx.env, BROWSERCLAW_SERVER_BUNDLE)
 
     def test_appcast_staging_paths_per_bundle(self):
         self.assertEqual(get_appcast_path("alpha").name, "appcast-server.alpha.xml")

--- a/packages/browseros/bos_build/release/ota/server.py
+++ b/packages/browseros/bos_build/release/ota/server.py
@@ -281,7 +281,7 @@ class ServerOTAModule(Step):
             )
 
         if os_type == "windows":
-            return sign_server_bundle_windows(staging_resources, ctx.env)
+            return sign_server_bundle_windows(staging_resources, ctx.env, self.bundle)
 
         log_info("No code signing for Linux binaries")
         return True

--- a/packages/browseros/bos_build/release/ota/sign_binary.py
+++ b/packages/browseros/bos_build/release/ota/sign_binary.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 
 from ...lib.env import EnvConfig
 from ...products.server_binaries import (
+    ServerBundle,
     expected_windows_binary_paths,
     macos_sign_spec_for,
 )
@@ -406,15 +407,17 @@ def sign_server_bundle_macos(
     return True
 
 
-def sign_server_bundle_windows(resources_dir: Path, env: EnvConfig) -> bool:
-    """Sign each Windows binary enumerated in ``WINDOWS_SERVER_BINARIES``.
+def sign_server_bundle_windows(
+    resources_dir: Path, env: EnvConfig, bundle: ServerBundle
+) -> bool:
+    """Sign each Windows binary declared by a server bundle.
 
     A missing expected binary is a hard error: publishing an incomplete
     Windows bundle would ship a broken OTA update without a pipeline signal.
     Symmetric with the macOS bundle's unknown-file guard.
     """
     bin_dir = resources_dir / "bin"
-    for path in expected_windows_binary_paths(bin_dir):
+    for path in expected_windows_binary_paths(bin_dir, bundle):
         if not path.exists():
             log_error(f"Windows binary missing (cannot sign): {path}")
             return False

--- a/packages/browseros/bos_build/release/ota/sign_binary.py
+++ b/packages/browseros/bos_build/release/ota/sign_binary.py
@@ -417,10 +417,13 @@ def sign_server_bundle_windows(
     Symmetric with the macOS bundle's unknown-file guard.
     """
     bin_dir = resources_dir / "bin"
-    for path in expected_windows_binary_paths(bin_dir, bundle):
+    paths = expected_windows_binary_paths(bin_dir, bundle)
+    for path in paths:
         if not path.exists():
             log_error(f"Windows binary missing (cannot sign): {path}")
             return False
+
+    for path in paths:
         if not sign_windows_binary(path, env):
             return False
     return True

--- a/packages/browseros/bos_build/release/ota/sign_binary_test.py
+++ b/packages/browseros/bos_build/release/ota/sign_binary_test.py
@@ -4,6 +4,7 @@
 import tempfile
 import subprocess
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -66,6 +67,26 @@ class SignServerBundleWindowsTest(unittest.TestCase):
                 self.assertFalse(
                     sign_binary.sign_server_bundle_windows(
                         resources, EnvConfig(), BROWSERCLAW_SERVER_BUNDLE
+                    )
+                )
+
+            signer.assert_not_called()
+
+    def test_preflights_all_descriptor_binaries_before_signing(self):
+        bundle = replace(
+            BROWSERCLAW_SERVER_BUNDLE,
+            windows_binaries=("browseros-claw-server.exe", "missing.exe"),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            resources = Path(tmp) / "resources"
+            _write_exe(resources / "bin" / "browseros-claw-server.exe")
+
+            with mock.patch.object(
+                sign_binary, "sign_windows_binary", return_value=True
+            ) as signer:
+                self.assertFalse(
+                    sign_binary.sign_server_bundle_windows(
+                        resources, EnvConfig(), bundle
                     )
                 )
 

--- a/packages/browseros/bos_build/release/ota/sign_binary_test.py
+++ b/packages/browseros/bos_build/release/ota/sign_binary_test.py
@@ -10,6 +10,8 @@ from typing import cast
 from unittest import mock
 
 from ...lib.env import EnvConfig
+from ...products.browserclaw.product import BROWSERCLAW_SERVER_BUNDLE
+from ...products.browseros.product import BROWSEROS_SERVER_BUNDLE
 from . import sign_binary
 
 
@@ -23,10 +25,10 @@ def _write_exe(path: Path) -> None:
 
 
 class SignServerBundleWindowsTest(unittest.TestCase):
-    def test_signs_shipped_windows_binaries_without_third_party_cli_tools(self):
+    def _assert_signs_bundle_binary(self, bundle, binary_name):
         with tempfile.TemporaryDirectory() as tmp:
             resources = Path(tmp) / "resources"
-            _write_exe(resources / "bin" / "browseros_server.exe")
+            _write_exe(resources / "bin" / binary_name)
 
             signed = []
 
@@ -38,10 +40,36 @@ class SignServerBundleWindowsTest(unittest.TestCase):
                 sign_binary, "sign_windows_binary", side_effect=fake_sign
             ):
                 self.assertTrue(
-                    sign_binary.sign_server_bundle_windows(resources, EnvConfig())
+                    sign_binary.sign_server_bundle_windows(
+                        resources, EnvConfig(), bundle
+                    )
                 )
 
-            self.assertEqual(signed, ["browseros_server.exe"])
+            self.assertEqual(signed, [binary_name])
+
+    def test_signs_browseros_descriptor_binary(self):
+        self._assert_signs_bundle_binary(
+            BROWSEROS_SERVER_BUNDLE, "browseros_server.exe"
+        )
+
+    def test_signs_browserclaw_descriptor_binary(self):
+        self._assert_signs_bundle_binary(
+            BROWSERCLAW_SERVER_BUNDLE, "browseros-claw-server.exe"
+        )
+
+    def test_fails_when_browserclaw_descriptor_binary_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            resources = Path(tmp) / "resources"
+            _write_exe(resources / "bin" / "browseros_server.exe")
+
+            with mock.patch.object(sign_binary, "sign_windows_binary") as signer:
+                self.assertFalse(
+                    sign_binary.sign_server_bundle_windows(
+                        resources, EnvConfig(), BROWSERCLAW_SERVER_BUNDLE
+                    )
+                )
+
+            signer.assert_not_called()
 
 
 class SignWindowsBinaryLoggingTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- thread the active server product bundle through the Windows OTA signing path
- resolve BrowserClaw's `browseros-claw-server.exe` while preserving BrowserOS's `browseros_server.exe`
- preflight every descriptor-declared executable before invoking CodeSignTool

## Design
`ServerOTAModule` remains the single product-selection boundary and passes its selected `ServerBundle` to the Windows signer. The shared path helper resolves only that descriptor's `windows_binaries`, so product metadata stays the source of truth and no BrowserOS fallback is possible.

## Test plan
- [x] `uv run python -m unittest bos_build.products.server_binaries_test bos_build.release.ota.sign_binary_test bos_build.release.ota.feeds_alignment_test -v`
- [x] `uv run python -m unittest discover -s bos_build -t . -p '*_test.py'` (698 tests)
- [x] `uv run ruff check bos_build`
- [x] `uv run pyright`
