### PR TITLE
fix(claw-server-rust): HTTP parity batch (cancel 404 shape, MCP hygiene, failure logs, env overrides, screenshot fallback flag)

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/config.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/config.rs
@@ -216,7 +216,8 @@ fn read_positive_ms(env: &ConfigEnv, key: &str, fallback: u64) -> u64 {
     let Some(raw) = env.get(key) else {
         return fallback;
     };
-    raw.parse::<u64>()
+    raw.trim()
+        .parse::<u64>()
         .ok()
         .filter(|value| *value > 0)
         .unwrap_or(fallback)
@@ -324,6 +325,108 @@ mod tests {
         let dev_cfg = Config::load_with_env_and_default_dev_mode(&dev_config_path, &env, false)?;
         assert!(dev_cfg.dev_mode);
         assert!(dev_cfg.browserclaw_dir.ends_with(".browserclaw-dev"));
+        Ok(())
+    }
+
+    #[test]
+    fn env_ms_overrides_fall_back_on_garbage_and_accept_padded_values() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let config_path = dir.path().join("sidecar.json");
+        fs::write(&config_path, r#"{"ports":{},"directories":{}}"#)?;
+        let home = dir.path().join("home");
+
+        let cases: &[(&str, &str, Duration, Duration)] = &[
+            // (idle raw, sweep raw, expected idle, expected sweep)
+            (
+                "garbage",
+                "-500",
+                Duration::from_millis(300_000),
+                Duration::from_millis(60_000),
+            ),
+            (
+                "0",
+                "500abc",
+                Duration::from_millis(300_000),
+                Duration::from_millis(60_000),
+            ),
+            (
+                " 2500 ",
+                "45000",
+                Duration::from_millis(2500),
+                Duration::from_millis(45_000),
+            ),
+        ];
+        for (idle_raw, sweep_raw, expected_idle, expected_sweep) in cases {
+            let mut vars = BTreeMap::new();
+            vars.insert("CLAW_SESSION_IDLE_MS".to_string(), (*idle_raw).to_string());
+            vars.insert(
+                "CLAW_SESSION_SWEEP_INTERVAL_MS".to_string(),
+                (*sweep_raw).to_string(),
+            );
+            let cfg =
+                Config::load_with_env(&config_path, &ConfigEnv::with_vars(vars, home.clone()))?;
+            assert_eq!(cfg.session_idle, *expected_idle, "idle raw: {idle_raw:?}");
+            assert_eq!(
+                cfg.session_sweep_interval, *expected_sweep,
+                "sweep raw: {sweep_raw:?}"
+            );
+        }
+
+        let cfg = Config::load_with_env(
+            &config_path,
+            &ConfigEnv::with_vars(BTreeMap::new(), home.clone()),
+        )?;
+        assert_eq!(cfg.session_idle, Duration::from_millis(300_000));
+        assert_eq!(cfg.session_sweep_interval, Duration::from_millis(60_000));
+        Ok(())
+    }
+
+    #[test]
+    fn screencast_fallback_flag_disables_only_on_zero_or_false() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let config_path = dir.path().join("sidecar.json");
+        fs::write(&config_path, r#"{"ports":{},"directories":{}}"#)?;
+        let home = dir.path().join("home");
+
+        let cases: &[(Option<&str>, bool)] = &[
+            (None, true),
+            (Some("0"), false),
+            (Some("false"), false),
+            (Some(" FALSE "), false),
+            (Some("1"), true),
+            (Some("off"), true),
+            (Some(""), true),
+        ];
+        for (raw, expected) in cases {
+            let mut vars = BTreeMap::new();
+            if let Some(raw) = raw {
+                vars.insert(
+                    "CLAW_SCREENCAST_SCREENSHOT_FALLBACK".to_string(),
+                    (*raw).to_string(),
+                );
+            }
+            let cfg =
+                Config::load_with_env(&config_path, &ConfigEnv::with_vars(vars, home.clone()))?;
+            assert_eq!(
+                cfg.screencast_screenshot_fallback, *expected,
+                "flag raw: {raw:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn blank_browserclaw_dir_override_is_ignored() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let config_path = dir.path().join("sidecar.json");
+        fs::write(&config_path, r#"{"ports":{},"directories":{}}"#)?;
+        let mut vars = BTreeMap::new();
+        vars.insert("BROWSERCLAW_DIR".to_string(), "   ".to_string());
+        let cfg = Config::load_with_env(
+            &config_path,
+            &ConfigEnv::with_vars(vars, dir.path().join("home")),
+        )?;
+        assert!(cfg.browserclaw_dir.starts_with(dir.path().join("home")));
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/config.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/config.rs
@@ -216,11 +216,19 @@ fn read_positive_ms(env: &ConfigEnv, key: &str, fallback: u64) -> u64 {
     let Some(raw) = env.get(key) else {
         return fallback;
     };
-    raw.trim()
-        .parse::<u64>()
-        .ok()
-        .filter(|value| *value > 0)
-        .unwrap_or(fallback)
+    parse_positive_int_prefix(raw).unwrap_or(fallback)
+}
+
+/// Mirrors the TS server's `Number.parseInt(raw, 10)` env semantics: the
+/// leading integer prefix wins and trailing garbage is ignored ("500ms" is
+/// 500), while digit-less or non-positive values fall back.
+fn parse_positive_int_prefix(raw: &str) -> Option<u64> {
+    let trimmed = raw.trim_start();
+    let unsigned = trimmed.strip_prefix('+').unwrap_or(trimmed);
+    let end = unsigned
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(unsigned.len());
+    unsigned[..end].parse::<u64>().ok().filter(|value| *value > 0)
 }
 
 fn read_bool_default_true(env: &ConfigEnv, key: &str) -> bool {
@@ -345,15 +353,17 @@ mod tests {
             ),
             (
                 "0",
-                "500abc",
+                "0x10",
                 Duration::from_millis(300_000),
                 Duration::from_millis(60_000),
             ),
+            // Number.parseInt parity: integer prefix wins, trailing garbage
+            // ignored, surrounding whitespace tolerated.
             (
                 " 2500 ",
-                "45000",
+                "500ms",
                 Duration::from_millis(2500),
-                Duration::from_millis(45_000),
+                Duration::from_millis(500),
             ),
         ];
         for (idle_raw, sweep_raw, expected_idle, expected_sweep) in cases {

--- a/packages/browseros-agent/apps/claw-server-rust/src/error.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/error.rs
@@ -66,6 +66,22 @@ impl AppError {
     }
 
     #[must_use]
+    pub fn forbidden(message: impl Into<String>) -> Self {
+        Self::Http {
+            status: StatusCode::FORBIDDEN,
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn unsupported_media_type(message: impl Into<String>) -> Self {
+        Self::Http {
+            status: StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
     pub fn unavailable(message: impl Into<String>) -> Self {
         Self::Http {
             status: StatusCode::SERVICE_UNAVAILABLE,

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/hooks.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/hooks.rs
@@ -367,6 +367,11 @@ impl ScreenshotPersister {
         if wrote {
             return;
         }
+        // Fallback capture is an opt-out feature (CLAW_SCREENCAST_SCREENSHOT_FALLBACK);
+        // disabling it must not affect the explicit tool-image branch above.
+        if !state.config.screencast_screenshot_fallback {
+            return;
+        }
         let Some(browser) = &call.browser_session else {
             return;
         };
@@ -704,6 +709,12 @@ mod tests {
     }
 
     async fn test_state() -> anyhow::Result<TestState> {
+        test_state_with_fallback(true).await
+    }
+
+    async fn test_state_with_fallback(
+        screencast_screenshot_fallback: bool,
+    ) -> anyhow::Result<TestState> {
         let dir = tempfile::tempdir()?;
         let root = dir.path().join("browserclaw");
         let config = Arc::new(Config {
@@ -715,7 +726,7 @@ mod tests {
             claw_dir: root,
             session_idle: Duration::from_secs(300),
             session_sweep_interval: Duration::from_secs(60),
-            screencast_screenshot_fallback: true,
+            screencast_screenshot_fallback,
             dev_mode: false,
             auth_token: None,
         });
@@ -895,6 +906,29 @@ mod tests {
             app.state.sessions.owner_of_page(&PageId(4)).await,
             Some(second.agent().ownership_key())
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn persist_writes_explicit_tool_image_when_fallback_disabled() -> anyhow::Result<()> {
+        let app = test_state_with_fallback(false).await?;
+        let session = test_session("s1", "codex-a", "codex");
+        let call = page_call(1);
+        // "anBlZw==" is base64 for "jpeg".
+        let result = ToolResult::image("anBlZw==", "image/jpeg", json!({}));
+
+        ScreenshotPersister::persist(
+            &app.state,
+            &session,
+            &call,
+            &result,
+            AuditRecord { row_id: 7 },
+            output_files(),
+        )
+        .await;
+
+        assert_eq!(app.state.screenshots.read("7").await?, b"jpeg");
+        assert_eq!(app.state.screenshots.read("dispatch").await?, b"jpeg");
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/hooks.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/hooks.rs
@@ -364,7 +364,14 @@ impl ScreenshotPersister {
                 }
             }
         }
+        let page_id = result_page_id(result)
+            .or_else(|| extract_page_id(call.hooks.accepts_page_arg, &call.raw_args));
         if wrote {
+            // A tool-carried image counts as the page's visual anchor, so
+            // later read-only dispatches skip the fallback capture.
+            if let Some(page_id) = page_id {
+                session.mark_first_capture_done(PageId(page_id)).await;
+            }
             return;
         }
         // Fallback capture is an opt-out feature (CLAW_SCREENCAST_SCREENSHOT_FALLBACK);
@@ -375,8 +382,6 @@ impl ScreenshotPersister {
         let Some(browser) = &call.browser_session else {
             return;
         };
-        let page_id = result_page_id(result)
-            .or_else(|| extract_page_id(call.hooks.accepts_page_arg, &call.raw_args));
         let Some(page_id) = page_id else {
             return;
         };
@@ -929,6 +934,10 @@ mod tests {
 
         assert_eq!(app.state.screenshots.read("7").await?, b"jpeg");
         assert_eq!(app.state.screenshots.read("dispatch").await?, b"jpeg");
+        assert!(
+            session.has_first_capture(&PageId(1)).await,
+            "tool-carried image should count as the page's first capture"
+        );
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
@@ -65,33 +65,31 @@ pub fn router(state: AppState) -> Router<AppState> {
 /// against the loopback MCP endpoint always carries `origin` or
 /// `sec-fetch-site`; native MCP clients never do.
 async fn mcp_request_hygiene(req: Request, next: Next) -> Response {
+    // The nested /mcp service shadows the router's `/{*path}` preflight
+    // route, and the TS server's cors layer answers OPTIONS before its
+    // hygiene runs — mirror both so preflight stays 204 here too.
+    if *req.method() == Method::OPTIONS {
+        return StatusCode::NO_CONTENT.into_response();
+    }
     let headers = req.headers();
     if headers.contains_key(header::ORIGIN) || headers.contains_key("sec-fetch-site") {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(json!({ "error": "unsupported request" })),
-        )
-            .into_response();
+        return AppError::forbidden("unsupported request").into_response();
     }
-    let is_write = matches!(
-        *req.method(),
-        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
-    );
-    if is_write {
-        let content_type = headers.get(header::CONTENT_TYPE);
+    let needs_json = match *req.method() {
+        Method::POST | Method::PUT | Method::PATCH => true,
         // rmcp's DELETE /mcp session teardown carries no body and no
         // content-type; the TS server never sees that shape (its clients
         // always send application/json), so exempt only that case.
-        let exempt_bodyless_delete = *req.method() == Method::DELETE && content_type.is_none();
-        let is_json = content_type
+        Method::DELETE => headers.contains_key(header::CONTENT_TYPE),
+        _ => false,
+    };
+    if needs_json {
+        let is_json = headers
+            .get(header::CONTENT_TYPE)
             .and_then(|value| value.to_str().ok())
             .is_some_and(|value| value.to_ascii_lowercase().contains("application/json"));
-        if !is_json && !exempt_bodyless_delete {
-            return (
-                StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                Json(json!({ "error": "unsupported content type" })),
-            )
-                .into_response();
+        if !is_json {
+            return AppError::unsupported_media_type("unsupported content type").into_response();
         }
     }
     next.run(req).await
@@ -107,23 +105,14 @@ pub async fn request_context(req: Request, next: Next) -> Response {
         let mut response = next.run(req).await;
         // One structured line per failed request; sub-400 traffic stays
         // unlogged on purpose (claw-app polls several endpoints).
-        let status = response.status();
-        if status.as_u16() >= 500 {
-            tracing::error!(
-                %method,
-                %path,
-                status = status.as_u16(),
-                duration_ms = start.elapsed().as_millis() as u64,
-                "request failed"
-            );
-        } else if status.as_u16() >= 400 {
-            tracing::warn!(
-                %method,
-                %path,
-                status = status.as_u16(),
-                duration_ms = start.elapsed().as_millis() as u64,
-                "request failed"
-            );
+        let status = response.status().as_u16();
+        if status >= 400 {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            if status >= 500 {
+                tracing::error!(%method, %path, status, duration_ms, "request failed");
+            } else {
+                tracing::warn!(%method, %path, status, duration_ms, "request failed");
+            }
         }
         let headers = response.headers_mut();
         headers.insert(

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
@@ -16,13 +16,13 @@ use axum::{
     body::Body,
     extract::{Path, Query, Request, State},
     http::{HeaderValue, Method, StatusCode, header},
-    middleware::Next,
+    middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, options, post},
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
-use std::str::FromStr;
+use std::{str::FromStr, time::Instant};
 use tracing::{Instrument, info_span};
 use ulid::Ulid;
 
@@ -51,8 +51,50 @@ pub fn router(state: AppState) -> Router<AppState> {
         .route("/audit/replay/{session_id}", get(replay_get))
         .route("/audit/replay/{session_id}/exists", get(replay_exists))
         .route("/replay/tabs", get(replay_tabs))
-        .nest_service("/mcp", streamable_http_service(state))
+        .nest_service(
+            "/mcp",
+            Router::new()
+                .fallback_service(streamable_http_service(state))
+                .layer(middleware::from_fn(mcp_request_hygiene)),
+        )
         .route("/{*path}", options(preflight))
+}
+
+/// Enforces the header conventions native MCP clients follow (parity with
+/// the TS server's mcp-request-hygiene middleware). A browser-page fetch
+/// against the loopback MCP endpoint always carries `origin` or
+/// `sec-fetch-site`; native MCP clients never do.
+async fn mcp_request_hygiene(req: Request, next: Next) -> Response {
+    let headers = req.headers();
+    if headers.contains_key(header::ORIGIN) || headers.contains_key("sec-fetch-site") {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "unsupported request" })),
+        )
+            .into_response();
+    }
+    let is_write = matches!(
+        *req.method(),
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+    );
+    if is_write {
+        let content_type = headers.get(header::CONTENT_TYPE);
+        // rmcp's DELETE /mcp session teardown carries no body and no
+        // content-type; the TS server never sees that shape (its clients
+        // always send application/json), so exempt only that case.
+        let exempt_bodyless_delete = *req.method() == Method::DELETE && content_type.is_none();
+        let is_json = content_type
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.to_ascii_lowercase().contains("application/json"));
+        if !is_json && !exempt_bodyless_delete {
+            return (
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                Json(json!({ "error": "unsupported content type" })),
+            )
+                .into_response();
+        }
+    }
+    next.run(req).await
 }
 
 pub async fn request_context(req: Request, next: Next) -> Response {
@@ -61,7 +103,28 @@ pub async fn request_context(req: Request, next: Next) -> Response {
     let path = req.uri().path().to_string();
     let span = info_span!("http_request", %request_id, %method, %path);
     async move {
+        let start = Instant::now();
         let mut response = next.run(req).await;
+        // One structured line per failed request; sub-400 traffic stays
+        // unlogged on purpose (claw-app polls several endpoints).
+        let status = response.status();
+        if status.as_u16() >= 500 {
+            tracing::error!(
+                %method,
+                %path,
+                status = status.as_u16(),
+                duration_ms = start.elapsed().as_millis() as u64,
+                "request failed"
+            );
+        } else if status.as_u16() >= 400 {
+            tracing::warn!(
+                %method,
+                %path,
+                status = status.as_u16(),
+                duration_ms = start.elapsed().as_millis() as u64,
+                "request failed"
+            );
+        }
         let headers = response.headers_mut();
         headers.insert(
             header::ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -125,12 +188,23 @@ async fn system_url(State(state): State<AppState>) -> Json<Value> {
 async fn agents_cancel(
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
-) -> AppResult<Json<Value>> {
+) -> Response {
     let cancelled = state.sessions.cancel_by_agent(&agent_id).await;
     if cancelled == 0 {
-        return Err(AppError::not_found("no active dispatches for this agent"));
+        // claw-app parses this 404 body as a CancelAgentResult (idle state,
+        // not a failure), so it must keep the TS shape, not `{"error":...}`.
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({
+                "ok": false,
+                "cancelled": 0,
+                "reason": "no active dispatches for this agent",
+            })),
+        )
+            .into_response();
     }
-    Ok(Json(json!({ "ok": true, "cancelled": cancelled })))
+    tracing::info!(%agent_id, cancelled, "cancelled in-flight dispatches for agent");
+    Json(json!({ "ok": true, "cancelled": cancelled })).into_response()
 }
 
 async fn tabs_activity(State(state): State<AppState>) -> AppResult<Json<Value>> {
@@ -339,6 +413,3 @@ fn validate_limit(limit: Option<i64>, cap: i64) -> AppResult<()> {
     }
     Ok(())
 }
-
-#[allow(dead_code)]
-fn _method(_: Method) {}

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -34,6 +34,14 @@ async fn test_app() -> anyhow::Result<TestApp> {
 }
 
 async fn test_app_with_cdp_port(cdp_port: u16, start_browser: bool) -> anyhow::Result<TestApp> {
+    test_app_with_options(cdp_port, start_browser, true).await
+}
+
+async fn test_app_with_options(
+    cdp_port: u16,
+    start_browser: bool,
+    screencast_screenshot_fallback: bool,
+) -> anyhow::Result<TestApp> {
     let dir = tempfile::tempdir()?;
     let root = dir.path().join("browserclaw");
     let config = Arc::new(Config {
@@ -45,7 +53,7 @@ async fn test_app_with_cdp_port(cdp_port: u16, start_browser: bool) -> anyhow::R
         claw_dir: root,
         session_idle: Duration::from_secs(300),
         session_sweep_interval: Duration::from_secs(60),
-        screencast_screenshot_fallback: true,
+        screencast_screenshot_fallback,
         dev_mode: false,
         auth_token: None,
     });
@@ -125,6 +133,15 @@ async fn request_json_with_headers(
     let bytes = to_bytes(response.into_body(), usize::MAX).await?;
     let value = response_body_value(&headers, &bytes)?;
     Ok((status, headers, value))
+}
+
+async fn request_status(router: &Router, method: &str, uri: &str) -> anyhow::Result<StatusCode> {
+    let request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(header::HOST, "localhost")
+        .body(Body::empty())?;
+    Ok(router.clone().oneshot(request).await?.status())
 }
 
 fn response_body_value(headers: &HeaderMap, bytes: &[u8]) -> anyhow::Result<Value> {
@@ -290,6 +307,77 @@ async fn replay_tabs_keeps_first_live_session_per_agent_id() -> anyhow::Result<(
 }
 
 #[tokio::test]
+async fn cancel_with_no_active_dispatches_returns_ts_shaped_404() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, body) =
+        request_json(&app.router, "POST", "/agents/idle-agent/cancel", None).await?;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(
+        body,
+        json!({
+            "ok": false,
+            "cancelled": 0,
+            "reason": "no active dispatches for this agent"
+        })
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_hygiene_rejects_browser_originated_requests() -> anyhow::Result<()> {
+    let app = test_app().await?;
+
+    let (status, _headers, body) = request_json_with_headers(
+        &app.router,
+        "POST",
+        "/mcp",
+        Some(json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}})),
+        &[("origin", "http://evil.example")],
+    )
+    .await?;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body, json!({ "error": "unsupported request" }));
+
+    let (status, _headers, body) = request_json_with_headers(
+        &app.router,
+        "GET",
+        "/mcp",
+        None,
+        &[("sec-fetch-site", "cross-site")],
+    )
+    .await?;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body, json!({ "error": "unsupported request" }));
+
+    // Hygiene applies to /mcp only: the same origin header is fine elsewhere.
+    let (status, _headers, _body) =
+        request_json_with_headers(&app.router, "GET", "/system/health", None, &[(
+            "origin",
+            "http://evil.example",
+        )])
+        .await?;
+    assert_eq!(status, StatusCode::OK);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_hygiene_rejects_non_json_writes() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let request = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header(header::HOST, "localhost")
+        .header(header::CONTENT_TYPE, "text/plain")
+        .body(Body::from("hello"))?;
+    let response = app.router.clone().oneshot(request).await?;
+    assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await?;
+    let body: Value = serde_json::from_slice(&bytes)?;
+    assert_eq!(body, json!({ "error": "unsupported content type" }));
+    Ok(())
+}
+
+#[tokio::test]
 async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
     let app = test_app().await?;
     let initialize = json!({
@@ -315,6 +403,7 @@ async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("missing mcp-session-id"))?
         .to_string();
     send_initialized(&app.router, &session_id).await?;
+    wait_for_session_registration(&app, &session_id).await?;
 
     let list = json!({
         "jsonrpc": "2.0",
@@ -357,7 +446,7 @@ async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
     )
     .await?;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["result"]["isError"], true);
+    assert_eq!(body["result"]["isError"], true, "navigate body: {body:?}");
     assert!(
         body["result"]["content"][0]["text"]
             .as_str()
@@ -452,13 +541,81 @@ async fn mcp_tabs_new_roundtrips_through_mock_cdp() -> anyhow::Result<()> {
 
     let (status, dispatches) = request_json(&app.router, "GET", "/audit/dispatches", None).await?;
     assert_eq!(status, StatusCode::OK);
+    let rows = dispatches["rows"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("rows not array"))?;
     assert!(
-        dispatches["rows"]
-            .as_array()
-            .ok_or_else(|| anyhow::anyhow!("rows not array"))?
-            .iter()
+        rows.iter()
             .any(|row| row["toolName"] == "tabs" && row["dispatchId"].is_string())
     );
+
+    // Fallback screenshots default on: the tabs-new dispatch persisted a frame.
+    let mut screenshot_statuses = Vec::new();
+    for row in rows {
+        let dispatch_id = row["dispatchId"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("dispatchId not string"))?;
+        screenshot_statuses.push(
+            request_status(
+                &app.router,
+                "GET",
+                &format!("/audit/screenshot/{dispatch_id}"),
+            )
+            .await?,
+        );
+    }
+    assert!(
+        screenshot_statuses.contains(&StatusCode::OK),
+        "no dispatch had a persisted screenshot: {screenshot_statuses:?}"
+    );
+    drop(mock);
+    Ok(())
+}
+
+#[tokio::test]
+async fn screencast_fallback_flag_disables_fallback_screenshots() -> anyhow::Result<()> {
+    let mock = MockCdp::start().await?;
+    let app = test_app_with_options(mock.cdp_port, false, false).await?;
+    app.state.browser.connect_once_for_testing().await?;
+    wait_for_cdp_connected(&app.router).await?;
+    let session_id = initialize_mcp(&app).await?;
+
+    let tabs_new = json!({
+        "jsonrpc": "2.0",
+        "id": 30,
+        "method": "tools/call",
+        "params": {
+            "name": "tabs",
+            "arguments": { "action": "new", "url": "https://example.com" }
+        }
+    });
+    let (status, _headers, body) = request_json_with_headers(
+        &app.router,
+        "POST",
+        "/mcp",
+        Some(tabs_new),
+        &[("mcp-session-id", &session_id)],
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["result"]["isError"], false, "tabs_new body: {body:?}");
+
+    let (status, dispatches) = request_json(&app.router, "GET", "/audit/dispatches", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    let rows = dispatches["rows"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("rows not array"))?;
+    assert_eq!(rows.len(), 1);
+    let dispatch_id = rows[0]["dispatchId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("dispatchId not string"))?;
+    let status = request_status(
+        &app.router,
+        "GET",
+        &format!("/audit/screenshot/{dispatch_id}"),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::NOT_FOUND);
     drop(mock);
     Ok(())
 }
@@ -653,14 +810,22 @@ async fn initialize_mcp(app: &TestApp) -> anyhow::Result<String> {
         .map(str::to_string)
         .ok_or_else(|| anyhow::anyhow!("missing mcp-session-id"))?;
     send_initialized(&app.router, &session_id).await?;
+    wait_for_session_registration(app, &session_id).await?;
+    Ok(session_id)
+}
+
+/// The initialized notification is acknowledged with 202 before the
+/// session_started hook finishes registering the session, so a tools/call
+/// fired immediately after can race the registry. Tests wait it out.
+async fn wait_for_session_registration(app: &TestApp, session_id: &str) -> anyhow::Result<()> {
     for _ in 0..50 {
         if app
             .state
             .sessions
-            .contains(&SessionId::new(session_id.clone()))
+            .contains(&SessionId::new(session_id.to_string()))
             .await
         {
-            return Ok(session_id);
+            return Ok(());
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -357,6 +357,18 @@ async fn mcp_hygiene_rejects_browser_originated_requests() -> anyhow::Result<()>
         )])
         .await?;
     assert_eq!(status, StatusCode::OK);
+
+    // CORS preflight stays 204 like every other route (TS cors layer
+    // answers OPTIONS before hygiene runs).
+    let (status, _headers, _body) = request_json_with_headers(
+        &app.router,
+        "OPTIONS",
+        "/mcp",
+        None,
+        &[("origin", "http://evil.example")],
+    )
+    .await?;
+    assert_eq!(status, StatusCode::NO_CONTENT);
     Ok(())
 }
 
@@ -380,30 +392,7 @@ async fn mcp_hygiene_rejects_non_json_writes() -> anyhow::Result<()> {
 #[tokio::test]
 async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
     let app = test_app().await?;
-    let initialize = json!({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "initialize",
-        "params": {
-            "protocolVersion": "2025-06-18",
-            "capabilities": {},
-            "clientInfo": { "name": "Codex", "version": "1.0" }
-        }
-    });
-    let (status, headers, body) =
-        request_json_with_headers(&app.router, "POST", "/mcp", Some(initialize), &[]).await?;
-    assert_eq!(status, StatusCode::OK, "initialize body: {body:?}");
-    assert_eq!(
-        body["result"]["serverInfo"]["name"],
-        "browseros-claw-server"
-    );
-    let session_id = headers
-        .get("mcp-session-id")
-        .and_then(|value| value.to_str().ok())
-        .ok_or_else(|| anyhow::anyhow!("missing mcp-session-id"))?
-        .to_string();
-    send_initialized(&app.router, &session_id).await?;
-    wait_for_session_registration(&app, &session_id).await?;
+    let session_id = initialize_mcp(&app).await?;
 
     let list = json!({
         "jsonrpc": "2.0",
@@ -497,20 +486,11 @@ async fn mcp_tabs_new_roundtrips_through_mock_cdp() -> anyhow::Result<()> {
     wait_for_cdp_connected(&app.router).await?;
     let session_id = initialize_mcp(&app).await?;
 
-    let tabs_new = json!({
-        "jsonrpc": "2.0",
-        "id": 10,
-        "method": "tools/call",
-        "params": {
-            "name": "tabs",
-            "arguments": { "action": "new", "url": "https://example.com" }
-        }
-    });
     let (status, _headers, body) = request_json_with_headers(
         &app.router,
         "POST",
         "/mcp",
-        Some(tabs_new),
+        Some(tabs_new_request(10)),
         &[("mcp-session-id", &session_id)],
     )
     .await?;
@@ -580,20 +560,11 @@ async fn screencast_fallback_flag_disables_fallback_screenshots() -> anyhow::Res
     wait_for_cdp_connected(&app.router).await?;
     let session_id = initialize_mcp(&app).await?;
 
-    let tabs_new = json!({
-        "jsonrpc": "2.0",
-        "id": 30,
-        "method": "tools/call",
-        "params": {
-            "name": "tabs",
-            "arguments": { "action": "new", "url": "https://example.com" }
-        }
-    });
     let (status, _headers, body) = request_json_with_headers(
         &app.router,
         "POST",
         "/mcp",
-        Some(tabs_new),
+        Some(tabs_new_request(30)),
         &[("mcp-session-id", &session_id)],
     )
     .await?;
@@ -635,20 +606,11 @@ async fn cancel_endpoint_aborts_in_flight_dispatch() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("missing test session"))?;
     let agent_id = session.agent().agent_id().as_str().to_string();
 
-    let tabs_new = json!({
-        "jsonrpc": "2.0",
-        "id": 20,
-        "method": "tools/call",
-        "params": {
-            "name": "tabs",
-            "arguments": { "action": "new", "url": "https://example.com" }
-        }
-    });
     let (status, _headers, body) = request_json_with_headers(
         &app.router,
         "POST",
         "/mcp",
-        Some(tabs_new),
+        Some(tabs_new_request(20)),
         &[("mcp-session-id", &session_id)],
     )
     .await?;
@@ -804,6 +766,10 @@ async fn initialize_mcp(app: &TestApp) -> anyhow::Result<String> {
     let (status, headers, body) =
         request_json_with_headers(&app.router, "POST", "/mcp", Some(initialize), &[]).await?;
     assert_eq!(status, StatusCode::OK, "initialize body: {body:?}");
+    assert_eq!(
+        body["result"]["serverInfo"]["name"],
+        "browseros-claw-server"
+    );
     let session_id = headers
         .get("mcp-session-id")
         .and_then(|value| value.to_str().ok())
@@ -812,6 +778,18 @@ async fn initialize_mcp(app: &TestApp) -> anyhow::Result<String> {
     send_initialized(&app.router, &session_id).await?;
     wait_for_session_registration(app, &session_id).await?;
     Ok(session_id)
+}
+
+fn tabs_new_request(id: u64) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": "tabs",
+            "arguments": { "action": "new", "url": "https://example.com" }
+        }
+    })
 }
 
 /// The initialized notification is acknowledged with 202 before the


### PR DESCRIPTION
## Summary
- **Cancel 404 body shape**: `POST /agents/{agent_id}/cancel` with no active dispatches now returns the TS-shaped 404 body `{"ok":false,"cancelled":0,"reason":"no active dispatches for this agent"}` instead of the generic `{"error":...}` — claw-app parses this body as a `CancelAgentResult` without throwing, so `result.ok`/`result.cancelled` were coming back `undefined` against the Rust server.
- **MCP request hygiene middleware** (parity with `routes/mcp/mcp-request-hygiene.ts`), layered on the `/mcp` nest only: any request carrying `origin` or `sec-fetch-site` → 403 `{"error":"unsupported request"}`; POST/PUT/PATCH/DELETE without an `application/json` content-type → 415 `{"error":"unsupported content type"}`. Carve-out: DELETE with **no** content-type header passes, because rmcp's own session-teardown DELETE sends no body/content-type (proven by the existing integration test); native MCP clients always send `application/json` on writes with bodies. OPTIONS answers 204 preflight (the nested service shadows the router's catch-all preflight route; on TS, hono's cors layer answers OPTIONS before hygiene runs).
- **Request failure logging** (parity with `server.ts` `requestFailureLog`): one structured line per response with status ≥ 400 (`warn` 4xx / `error` 5xx) with method, path, status, duration_ms. Sub-400 stays unlogged on purpose — claw-app polls `/tabs/activity` at 1.5s and `/audit/*` at 3s.
- **Env override parity** (vs `src/env.ts`): `CLAW_SESSION_IDLE_MS`, `CLAW_SESSION_SWEEP_INTERVAL_MS`, `CLAW_SCREENCAST_SCREENSHOT_FALLBACK`, and `BROWSERCLAW_DIR` were already honored with identical names/defaults; the ms readers now also mirror `Number.parseInt(raw, 10)` prefix semantics (`"500ms"` → 500, whitespace tolerated, non-positive/digit-less → default). Parsing is unit-tested for all four vars.
- **Screenshot fallback flag honored**: `ScreenshotPersister` (mcp/hooks.rs) now skips the fallback capture when `screencast_screenshot_fallback` is false, while images explicitly returned by a tool are still persisted — matching `services/screenshots.ts`. A tool-carried image also marks the page's first capture (TS branch-1 parity), so later read-only dispatches no longer trigger an extra CDP capture. `services/screencast.rs` untouched.

## VERIFY items (as requested)
- **(a) Unknown `mcp-session-id` on /mcp**: rmcp returns 404 with a **plain-text** body `"Not Found: Session not found"`, while TS returns 404 JSON `{"error":"unknown mcp-session-id","hint":...}`. Not fixed here: rewriting rmcp's response bodies would require buffering middleware over the streaming service — not trivial, and no consumer parses this body (claw-app never calls /mcp; MCP clients only react to the 404 status by re-initializing).
- **(b) GET /system/version**: Rust reports CARGO_PKG values (`claw-server-rust` / `0.1.0`) vs TS package name/version. Confirmed no consumer parses these: claw-app never calls `/system/*`, and tools/dev only polls `/system/health` (grep over both). Left as-is (rust-identified) per the decision.

## Notes / deliberate deltas
- `NODE_ENV` is deliberately not read by the Rust config (pinned by the existing `ignores_node_env_when_sidecar_flag_is_missing` test): the dev-vs-prod state-dir switch (`~/.browserclaw-dev` vs `~/.browserclaw`) comes from the sidecar `flags.devMode` or the build profile. The dev stack runs `cargo run` (debug ⇒ dev dir) with `NODE_ENV=development`, and release binaries run without `NODE_ENV` ⇒ prod dir — behavior matches the TS server in both real flows.
- **Pre-existing race surfaced while stabilizing tests** (out of scope for this PR, worth a follow-up in `crates/browseros-mcp`): `ensure_session_started` (service.rs) sets `lifecycle.started = true` and *then* awaits the `session_started` hook, so a tools/call racing the `notifications/initialized` processing can hit `"mcp session ... is not registered"`. Reproduced on `main` (3/10 runs under test concurrency). Tests now wait for registration via a shared `wait_for_session_registration` helper.
- Bodyless-DELETE carve-out means a content-type-less `DELETE /mcp` gets 202 here where TS would 415 — required to keep rmcp's real teardown flow working; decided in the task.

## Test plan
- [x] `cargo test -p claw-server-rust` — 38 unit + 12 integration tests green (10 consecutive full-suite runs to rule out the flake)
- [x] `cargo clippy -p claw-server-rust --all-targets` — clean under workspace lints (deny unwrap/expect/unsafe)
- [x] New tests: cancel-404 body; hygiene 403 (origin, sec-fetch-site) / 415 (text/plain) / 204 (OPTIONS) / scope (non-/mcp routes unaffected); env ms + bool + dir parsing matrix; explicit-image persist with fallback disabled (unit) + fallback-off ⇒ no audit screenshot, fallback-on ⇒ audit screenshot served (integration, mock CDP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)