### PR TITLE
feat(claw-server-rust): session naming via MCP elicitation

### DIFF
--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -1497,6 +1497,7 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/packages/browseros-agent/Cargo.toml
+++ b/packages/browseros-agent/Cargo.toml
@@ -18,7 +18,7 @@ tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rmcp = { version = "2.1", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "2.1", features = ["server", "transport-io", "transport-streamable-http-server", "elicitation"] }
 schemars = "1.0"
 axum = "0.8"
 http = "1"

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/session.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/session.rs
@@ -97,6 +97,9 @@ pub struct Session {
     cancel: CancellationToken,
     replay_handle: Mutex<Option<String>>,
     last_activity: Mutex<Instant>,
+    /// User-facing session name gathered via MCP elicitation. In-memory only,
+    /// mirroring the TS identity map's sessionLabel (never persisted to audit).
+    session_label: RwLock<Option<String>>,
 }
 
 impl Session {
@@ -110,6 +113,7 @@ impl Session {
             cancel: CancellationToken::new(),
             replay_handle: Mutex::new(None),
             last_activity: Mutex::new(now),
+            session_label: RwLock::new(None),
         })
     }
 
@@ -145,6 +149,14 @@ impl Session {
 
     pub async fn set_replay_handle(&self, value: Option<String>) {
         *self.replay_handle.lock().await = value;
+    }
+
+    pub async fn session_label(&self) -> Option<String> {
+        self.session_label.read().await.clone()
+    }
+
+    pub async fn set_session_label(&self, label: String) {
+        *self.session_label.write().await = Some(label);
     }
 
     pub fn cancel(&self) {

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/hooks.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/hooks.rs
@@ -1,6 +1,10 @@
 use crate::{
     app::AppState,
     domain::{AgentRef, ClientInfo, DispatchId, Session, SessionId, color_for_slug},
+    mcp::naming::{
+        build_session_group_title, client_prefix_from_slug, desired_group_title,
+        elicit_session_name, peer_elicit_session_name,
+    },
     services::{
         audit::{DispatchResultSummary, RecordToolDispatchInput},
         tab_activity::RecordToolInput,
@@ -15,13 +19,18 @@ use browseros_mcp::{
     BrowserToolDefaults, BrowserToolOptions, McpBeforeToolResult, McpClientInfo, McpHookError,
     McpHookResult, McpHooks, McpSessionClosed, McpSessionStarted, McpToolCall, McpToolTiming,
     OutputFileAccess, ToolCtx, ToolResult, catalog, execute_tool, extract_page_id, result_page_id,
+    output_file::create_browser_output_file_access,
 };
 use futures_util::future::BoxFuture;
-use rmcp::model::ContentBlock;
+use rmcp::{
+    RoleServer,
+    model::ContentBlock,
+    service::{ElicitationMode, Peer},
+};
 use serde_json::{Value, json};
 use std::{collections::BTreeSet, sync::Arc};
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, info_span, warn};
+use tracing::{Instrument, debug, info_span, warn};
 
 const NAVIGATE_BLOCKED_SCHEMES: &[&str] = &["javascript", "file", "data"];
 
@@ -61,6 +70,9 @@ impl ClawMcpHooks {
             agent = %session.agent().agent_id(),
             "mcp session initialized"
         );
+        if let Some(peer) = event.peer {
+            SessionNamer::spawn(self.state.clone(), session, peer);
+        }
         Ok(())
     }
 
@@ -477,6 +489,87 @@ impl TabActivityTracker {
     }
 }
 
+struct SessionNamer;
+
+impl SessionNamer {
+    /// Fire-and-forget session-name elicitation; must never block or fail
+    /// initialize, so every failure path is a log line at most.
+    fn spawn(state: AppState, session: Arc<Session>, peer: Peer<RoleServer>) {
+        if !peer
+            .supported_elicitation_modes()
+            .contains(&ElicitationMode::Form)
+        {
+            return;
+        }
+        tokio::spawn(async move {
+            Self::run(state, session, peer).await;
+        });
+    }
+
+    async fn run(state: AppState, session: Arc<Session>, peer: Peer<RoleServer>) {
+        let prefix = client_prefix_from_slug(session.agent().slug()).to_string();
+        let Some(name) =
+            elicit_session_name(|_attempt| peer_elicit_session_name(&peer, &prefix)).await
+        else {
+            return;
+        };
+        // The idle sweeper may have torn the session down mid-elicitation.
+        if state.sessions.lookup(session.id()).await.is_none() {
+            debug!(session_id = %session.id(), "session closed before naming applied");
+            return;
+        }
+        session.set_session_label(name.clone()).await;
+        let title = build_session_group_title(&prefix, &name);
+        tracing::info!(session_id = %session.id(), title = %title, "mcp session named");
+        Self::retitle_existing_group(&state, &session, &title).await;
+    }
+
+    /// Late-name path: the tab group already exists, so push the new title.
+    /// When no group exists yet, the create path reads the label instead.
+    async fn retitle_existing_group(state: &AppState, session: &Arc<Session>, title: &str) {
+        let Some(group_id) = state
+            .sessions
+            .ownership()
+            .tab_group_ref(&session.agent().ownership_key())
+            .await
+        else {
+            return;
+        };
+        let Some(browser) = state.browser.session().await else {
+            return;
+        };
+        let Some(tab_groups) = catalog().into_iter().find(|tool| tool.name == "tab_groups") else {
+            warn!("tab_groups tool missing from catalog");
+            return;
+        };
+        let tool_ctx = ToolCtx::new(BrowserToolOptions {
+            session: browser,
+            defaults: BrowserToolDefaults::default(),
+            cancel: session.child_token(),
+            output_files: create_browser_output_file_access(),
+        });
+        match execute_tool(
+            &tab_groups,
+            json!({ "action": "update", "groupId": group_id, "title": title }),
+            &tool_ctx,
+        )
+        .await
+        {
+            Ok(result) if !result.is_error => {}
+            Ok(result) => warn!(
+                session_id = %session.id(),
+                error = first_text(&result),
+                "session name tab group retitle returned error"
+            ),
+            Err(err) => warn!(
+                session_id = %session.id(),
+                error = %err,
+                "session name tab group retitle failed"
+            ),
+        }
+    }
+}
+
 struct TabGroupOrchestrator;
 
 impl TabGroupOrchestrator {
@@ -508,13 +601,14 @@ impl TabGroupOrchestrator {
             .tab_group_color(&agent_key)
             .await
             .unwrap_or_else(|| color_for_slug(session.agent().slug()));
+        let creation_title = desired_group_title(session).await;
         let args = if let Some(group_id) = group_id {
             json!({ "action": "create", "groupId": group_id, "pages": [page_id] })
         } else {
             json!({
                 "action": "create",
                 "pages": [page_id],
-                "title": session.agent().slug()
+                "title": creation_title
             })
         };
         let tool_ctx = ToolCtx::new(BrowserToolOptions {
@@ -537,13 +631,18 @@ impl TabGroupOrchestrator {
                         .set_tab_group(agent_key, Some(group_id.clone()), Some(color))
                         .await;
                     if created_new_group {
-                        match execute_tool(
-                            &tab_groups,
-                            json!({ "action": "update", "groupId": group_id, "color": color }),
-                            &tool_ctx,
-                        )
-                        .await
+                        let mut update_args =
+                            json!({ "action": "update", "groupId": group_id, "color": color });
+                        // The naming task may have stored a label while the
+                        // create was in flight; fold the corrected title into
+                        // the color lock so the group never keeps a stale slug.
+                        let desired_title = desired_group_title(session).await;
+                        if desired_title != creation_title
+                            && let Some(update) = update_args.as_object_mut()
                         {
+                            update.insert("title".to_string(), Value::String(desired_title));
+                        }
+                        match execute_tool(&tab_groups, update_args, &tool_ctx).await {
                             Ok(result) if !result.is_error => {}
                             Ok(result) => warn!(
                                 dispatch_id = %call.dispatch_id,

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/hooks.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/hooks.rs
@@ -489,6 +489,30 @@ impl TabActivityTracker {
     }
 }
 
+/// Dispatches one `tab_groups` call through the shared tool framework,
+/// folding tool-missing, transport, and tool-error outcomes into Err(reason).
+async fn dispatch_tab_groups(
+    browser: &Arc<BrowserSession>,
+    cancel: CancellationToken,
+    output_files: OutputFileAccess,
+    args: Value,
+) -> Result<ToolResult, String> {
+    let Some(tab_groups) = catalog().into_iter().find(|tool| tool.name == "tab_groups") else {
+        return Err("tab_groups tool missing from catalog".to_string());
+    };
+    let tool_ctx = ToolCtx::new(BrowserToolOptions {
+        session: browser.clone(),
+        defaults: BrowserToolDefaults::default(),
+        cancel,
+        output_files,
+    });
+    match execute_tool(&tab_groups, args, &tool_ctx).await {
+        Ok(result) if !result.is_error => Ok(result),
+        Ok(result) => Err(first_text(&result)),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
 struct SessionNamer;
 
 impl SessionNamer {
@@ -508,9 +532,16 @@ impl SessionNamer {
 
     async fn run(state: AppState, session: Arc<Session>, peer: Peer<RoleServer>) {
         let prefix = client_prefix_from_slug(session.agent().slug()).to_string();
-        let Some(name) =
-            elicit_session_name(|_attempt| peer_elicit_session_name(&peer, &prefix)).await
-        else {
+        // Session teardown cancels the elicitation so an abandoned prompt
+        // does not park this task (and the peer handle) for the full 120s.
+        let name = tokio::select! {
+            name = elicit_session_name(|| peer_elicit_session_name(&peer, &prefix)) => name,
+            () = session.child_token().cancelled_owned() => {
+                debug!(session_id = %session.id(), "session closed during naming elicitation");
+                return;
+            }
+        };
+        let Some(name) = name else {
             return;
         };
         // The idle sweeper may have torn the session down mid-elicitation.
@@ -538,34 +569,19 @@ impl SessionNamer {
         let Some(browser) = state.browser.session().await else {
             return;
         };
-        let Some(tab_groups) = catalog().into_iter().find(|tool| tool.name == "tab_groups") else {
-            warn!("tab_groups tool missing from catalog");
-            return;
-        };
-        let tool_ctx = ToolCtx::new(BrowserToolOptions {
-            session: browser,
-            defaults: BrowserToolDefaults::default(),
-            cancel: session.child_token(),
-            output_files: create_browser_output_file_access(),
-        });
-        match execute_tool(
-            &tab_groups,
+        if let Err(reason) = dispatch_tab_groups(
+            &browser,
+            session.child_token(),
+            create_browser_output_file_access(),
             json!({ "action": "update", "groupId": group_id, "title": title }),
-            &tool_ctx,
         )
         .await
         {
-            Ok(result) if !result.is_error => {}
-            Ok(result) => warn!(
+            warn!(
                 session_id = %session.id(),
-                error = first_text(&result),
-                "session name tab group retitle returned error"
-            ),
-            Err(err) => warn!(
-                session_id = %session.id(),
-                error = %err,
+                error = %reason,
                 "session name tab group retitle failed"
-            ),
+            );
         }
     }
 }
@@ -589,85 +605,91 @@ impl TabGroupOrchestrator {
         let Some(page_id) = result_page_id(result) else {
             return;
         };
-        let Some(tab_groups) = catalog().into_iter().find(|tool| tool.name == "tab_groups") else {
-            warn!("tab_groups tool missing from catalog");
-            return;
-        };
         let ownership = state.sessions.ownership();
         let agent_key = session.agent().ownership_key();
         let group_id = ownership.tab_group_ref(&agent_key).await;
-        let created_new_group = group_id.is_none();
         let color = ownership
             .tab_group_color(&agent_key)
             .await
             .unwrap_or_else(|| color_for_slug(session.agent().slug()));
-        let creation_title = desired_group_title(session).await;
-        let args = if let Some(group_id) = group_id {
-            json!({ "action": "create", "groupId": group_id, "pages": [page_id] })
+        // creation_title is Some only when this call creates the group.
+        let (args, creation_title) = if let Some(group_id) = group_id {
+            (
+                json!({ "action": "create", "groupId": group_id, "pages": [page_id] }),
+                None,
+            )
         } else {
-            json!({
-                "action": "create",
-                "pages": [page_id],
-                "title": creation_title
-            })
+            let title = desired_group_title(session).await;
+            (
+                json!({ "action": "create", "pages": [page_id], "title": title }),
+                Some(title),
+            )
         };
-        let tool_ctx = ToolCtx::new(BrowserToolOptions {
-            session: browser.clone(),
-            defaults: BrowserToolDefaults::default(),
-            cancel: call.cancel.clone(),
-            output_files,
-        });
-        match execute_tool(&tab_groups, args, &tool_ctx).await {
-            Ok(group_result) if !group_result.is_error => {
-                if let Some(group_id) = group_result
-                    .structured_content
-                    .as_ref()
-                    .and_then(|value| value.get("group"))
-                    .and_then(|value| value.get("groupId"))
-                    .and_then(Value::as_str)
-                    .map(str::to_string)
-                {
-                    ownership
-                        .set_tab_group(agent_key, Some(group_id.clone()), Some(color))
-                        .await;
-                    if created_new_group {
-                        let mut update_args =
-                            json!({ "action": "update", "groupId": group_id, "color": color });
-                        // The naming task may have stored a label while the
-                        // create was in flight; fold the corrected title into
-                        // the color lock so the group never keeps a stale slug.
-                        let desired_title = desired_group_title(session).await;
-                        if desired_title != creation_title
-                            && let Some(update) = update_args.as_object_mut()
-                        {
-                            update.insert("title".to_string(), Value::String(desired_title));
-                        }
-                        match execute_tool(&tab_groups, update_args, &tool_ctx).await {
-                            Ok(result) if !result.is_error => {}
-                            Ok(result) => warn!(
-                                dispatch_id = %call.dispatch_id,
-                                group_color = %color,
-                                error = first_text(&result),
-                                "tab group color lock returned error"
-                            ),
-                            Err(err) => warn!(
-                                error = %err,
-                                dispatch_id = %call.dispatch_id,
-                                group_color = %color,
-                                "tab group color lock failed"
-                            ),
-                        }
-                    }
+        let group_result =
+            match dispatch_tab_groups(browser, call.cancel.clone(), output_files.clone(), args)
+                .await
+            {
+                Ok(result) => result,
+                Err(reason) => {
+                    warn!(
+                        dispatch_id = %call.dispatch_id,
+                        error = %reason,
+                        "tab group orchestration failed"
+                    );
+                    return;
                 }
-            }
-            Ok(group_result) => warn!(
+            };
+        let Some(group_id) = group_result
+            .structured_content
+            .as_ref()
+            .and_then(|value| value.get("group"))
+            .and_then(|value| value.get("groupId"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        else {
+            return;
+        };
+        ownership
+            .set_tab_group(agent_key, Some(group_id.clone()), Some(color))
+            .await;
+        let Some(creation_title) = creation_title else {
+            return;
+        };
+        // Lock the colour separately: `tab_groups create` does not accept a
+        // colour today; update does. A failure leaves the default colour.
+        if let Err(reason) = dispatch_tab_groups(
+            browser,
+            call.cancel.clone(),
+            output_files.clone(),
+            json!({ "action": "update", "groupId": group_id, "color": color }),
+        )
+        .await
+        {
+            warn!(
                 dispatch_id = %call.dispatch_id,
-                error = first_text(&group_result),
-                "tab group orchestration returned error"
-            ),
-            Err(err) => {
-                warn!(error = %err, dispatch_id = %call.dispatch_id, "tab group orchestration failed")
-            }
+                group_color = %color,
+                error = %reason,
+                "tab group color lock failed"
+            );
+        }
+        // Dedicated late-title apply, independent of the color lock: a label
+        // that landed while the create was in flight must not be lost to a
+        // color failure (mirrors the TS applyAgentTabGroupTitle update).
+        let desired_title = desired_group_title(session).await;
+        if desired_title != creation_title
+            && let Err(reason) = dispatch_tab_groups(
+                browser,
+                call.cancel.clone(),
+                output_files,
+                json!({ "action": "update", "groupId": group_id, "title": desired_title }),
+            )
+            .await
+        {
+            warn!(
+                dispatch_id = %call.dispatch_id,
+                error = %reason,
+                "tab group late title apply failed"
+            );
         }
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/mod.rs
@@ -1,4 +1,5 @@
 pub mod hooks;
+pub mod naming;
 
 use crate::{AppState, mcp::hooks::ClawMcpHooks};
 use browseros_mcp::{BrowserMcpService, BrowserMcpServiceOptions, BrowserSessionProvider};

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/naming.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/naming.rs
@@ -95,11 +95,11 @@ pub enum ElicitNameOutcome {
 /// Runs the elicitation retry table and returns the normalized label.
 pub async fn elicit_session_name<F, Fut>(mut elicit: F) -> Option<String>
 where
-    F: FnMut(u32) -> Fut,
+    F: FnMut() -> Fut,
     Fut: Future<Output = ElicitNameOutcome>,
 {
     for attempt in 0..2 {
-        match elicit(attempt).await {
+        match elicit().await {
             ElicitNameOutcome::Accepted(raw) => {
                 let name = normalize_small_name(&raw);
                 return if name.is_empty() { None } else { Some(name) };
@@ -227,7 +227,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn accepted_name_is_normalized() {
-        let name = elicit_session_name(|_| {
+        let name = elicit_session_name(|| {
             std::future::ready(ElicitNameOutcome::Accepted("Invoice Processing".to_string()))
         })
         .await;
@@ -237,7 +237,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn accepted_name_normalizing_to_empty_is_dropped() {
         let mut calls = 0;
-        let name = elicit_session_name(|_| {
+        let name = elicit_session_name(|| {
             calls += 1;
             std::future::ready(ElicitNameOutcome::Accepted("!!!".to_string()))
         })
@@ -249,7 +249,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn timeout_never_retries() {
         let mut calls = 0;
-        let name = elicit_session_name(|_| {
+        let name = elicit_session_name(|| {
             calls += 1;
             std::future::ready(ElicitNameOutcome::TimedOut)
         })
@@ -261,7 +261,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn decline_never_retries() {
         let mut calls = 0;
-        let name = elicit_session_name(|_| {
+        let name = elicit_session_name(|| {
             calls += 1;
             std::future::ready(ElicitNameOutcome::NoName)
         })
@@ -273,9 +273,9 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn transport_failure_retries_once_then_accepts() {
         let mut calls = 0;
-        let name = elicit_session_name(|attempt| {
+        let name = elicit_session_name(|| {
             calls += 1;
-            std::future::ready(if attempt == 0 {
+            std::future::ready(if calls == 1 {
                 ElicitNameOutcome::Failed("no stream yet".to_string())
             } else {
                 ElicitNameOutcome::Accepted("flight search".to_string())
@@ -289,7 +289,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn two_transport_failures_give_up() {
         let mut calls = 0;
-        let name = elicit_session_name(|_| {
+        let name = elicit_session_name(|| {
             calls += 1;
             std::future::ready(ElicitNameOutcome::Failed("still no stream".to_string()))
         })

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/naming.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/naming.rs
@@ -1,0 +1,300 @@
+//! MCP session naming via elicitation, ported from the TS claw-server
+//! (`src/lib/mcp-session/naming.ts` + `src/mcp/session-naming.ts`). The
+//! normalizer, prompt, schema, and retry table must stay in lockstep with
+//! the TS oracle so both servers title tab groups identically.
+
+use crate::domain::Session;
+use rmcp::{
+    RoleServer,
+    model::{ElicitRequestParams, ElicitationAction, ElicitationSchema},
+    service::{Peer, ServiceError},
+};
+use serde_json::Value;
+use std::time::Duration;
+use tracing::debug;
+
+const ELICITATION_TIMEOUT: Duration = Duration::from_secs(120);
+const ELICITATION_RETRY_DELAY: Duration = Duration::from_secs(2);
+const SMALL_NAME_WORD_LIMIT: usize = 3;
+const SMALL_NAME_MAX_LEN: usize = 32;
+const SESSION_NAME_INPUT_MAX_LEN: u32 = 64;
+const NAME_GUIDANCE: &str = "a small lowercase 2-3 word name for what this session is doing";
+
+/// Normalizes a user-provided session label into a short tab-group slug.
+#[must_use]
+pub fn normalize_small_name(raw: &str) -> String {
+    let lowered = raw.to_lowercase();
+    let words = lowered
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|part| !part.is_empty())
+        .take(SMALL_NAME_WORD_LIMIT)
+        .collect::<Vec<_>>();
+    let mut name = words.join("-");
+    name.truncate(SMALL_NAME_MAX_LEN);
+    name.trim_matches('-').to_string()
+}
+
+/// Returns the short client namespace used before the session label.
+#[must_use]
+pub fn client_prefix_from_slug(slug: &str) -> &str {
+    slug.split('-')
+        .find(|part| !part.is_empty())
+        .unwrap_or("agent")
+}
+
+/// Builds the BrowserOS tab-group title for a named MCP session.
+#[must_use]
+pub fn build_session_group_title(prefix: &str, small_name: &str) -> String {
+    format!("{prefix}/{small_name}")
+}
+
+/// Builds the elicitation message with the concrete client prefix.
+#[must_use]
+pub fn build_session_name_prompt(prefix: &str) -> String {
+    format!(
+        "Name this browser session: {NAME_GUIDANCE} (e.g. \"invoice processing\"). Tabs will be grouped as {prefix}/<name>."
+    )
+}
+
+fn session_name_schema() -> ElicitationSchema {
+    ElicitationSchema::builder()
+        .required_string_property("name", |schema| {
+            schema
+                .title("Session name")
+                .description(format!(
+                    "Use {NAME_GUIDANCE}, such as \"invoice processing\"."
+                ))
+                .max_length(SESSION_NAME_INPUT_MAX_LEN)
+        })
+        .build_unchecked()
+}
+
+/// Tab-group title the orchestrator should apply for this session right now.
+pub async fn desired_group_title(session: &Session) -> String {
+    match session.session_label().await {
+        Some(label) => {
+            build_session_group_title(client_prefix_from_slug(session.agent().slug()), &label)
+        }
+        None => session.agent().slug().to_string(),
+    }
+}
+
+/// One elicitation attempt's result, folded into the TS retry table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ElicitNameOutcome {
+    /// Client accepted and returned a raw `name` string.
+    Accepted(String),
+    /// Decline, cancel, or accept without a usable string: stop silently.
+    NoName,
+    /// The 120s window elapsed — the user ignored the prompt; never retry.
+    TimedOut,
+    /// Transport-level failure (eg. no SSE stream yet): retry once after 2s.
+    Failed(String),
+}
+
+/// Runs the elicitation retry table and returns the normalized label.
+pub async fn elicit_session_name<F, Fut>(mut elicit: F) -> Option<String>
+where
+    F: FnMut(u32) -> Fut,
+    Fut: Future<Output = ElicitNameOutcome>,
+{
+    for attempt in 0..2 {
+        match elicit(attempt).await {
+            ElicitNameOutcome::Accepted(raw) => {
+                let name = normalize_small_name(&raw);
+                return if name.is_empty() { None } else { Some(name) };
+            }
+            ElicitNameOutcome::NoName => return None,
+            ElicitNameOutcome::TimedOut => {
+                debug!("mcp session naming elicitation timed out");
+                return None;
+            }
+            ElicitNameOutcome::Failed(reason) => {
+                debug!(error = %reason, "mcp session naming elicitation unavailable");
+                if attempt == 0 {
+                    tokio::time::sleep(ELICITATION_RETRY_DELAY).await;
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Sends one session-name elicitation over the live peer.
+pub async fn peer_elicit_session_name(
+    peer: &Peer<RoleServer>,
+    prefix: &str,
+) -> ElicitNameOutcome {
+    let params = ElicitRequestParams::FormElicitationParams {
+        meta: None,
+        message: build_session_name_prompt(prefix),
+        requested_schema: session_name_schema(),
+    };
+    match peer
+        .create_elicitation_with_timeout(params, Some(ELICITATION_TIMEOUT))
+        .await
+    {
+        Ok(result) => match result.action {
+            ElicitationAction::Accept => result
+                .content
+                .as_ref()
+                .and_then(|content| content.get("name"))
+                .and_then(Value::as_str)
+                .map(|name| ElicitNameOutcome::Accepted(name.to_string()))
+                .unwrap_or(ElicitNameOutcome::NoName),
+            _ => ElicitNameOutcome::NoName,
+        },
+        Err(ServiceError::Timeout { .. }) => ElicitNameOutcome::TimedOut,
+        Err(err) => ElicitNameOutcome::Failed(err.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{AgentId, AgentRef, SessionId};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn desired_group_title_uses_label_when_named() {
+        let session = Session::new(
+            SessionId::new("s1"),
+            AgentRef::Ephemeral {
+                agent_id: AgentId::new("claude-code-abc123"),
+                slug: "claude-code".to_string(),
+                label: "Claude Code".to_string(),
+            },
+            tokio::time::Instant::now(),
+        );
+        assert_eq!(desired_group_title(&session).await, "claude-code");
+        session.set_session_label("flight-search".to_string()).await;
+        assert_eq!(desired_group_title(&session).await, "claude/flight-search");
+    }
+
+    #[test]
+    fn normalize_small_name_matches_ts_vectors() {
+        assert_eq!(normalize_small_name("Invoice Processing!"), "invoice-processing");
+        assert_eq!(normalize_small_name("  LinkedIn   Jobs "), "linkedin-jobs");
+        assert_eq!(normalize_small_name("one two three four five"), "one-two-three");
+        assert_eq!(normalize_small_name("!!!"), "");
+        assert_eq!(normalize_small_name(""), "");
+        assert_eq!(normalize_small_name("日本語"), "");
+        assert_eq!(normalize_small_name(&"x".repeat(60)), "x".repeat(32));
+    }
+
+    #[test]
+    fn client_prefix_matches_ts_vectors() {
+        assert_eq!(client_prefix_from_slug("claude-code"), "claude");
+        assert_eq!(client_prefix_from_slug("cursor"), "cursor");
+        assert_eq!(client_prefix_from_slug(""), "agent");
+    }
+
+    #[test]
+    fn group_title_combines_prefix_and_name() {
+        assert_eq!(
+            build_session_group_title("claude", "invoice-processing"),
+            "claude/invoice-processing"
+        );
+    }
+
+    #[test]
+    fn prompt_names_the_group_namespace() {
+        let prompt = build_session_name_prompt("claude");
+        assert!(prompt.contains("Tabs will be grouped as claude/<name>"));
+        assert!(prompt.starts_with("Name this browser session:"));
+    }
+
+    #[test]
+    fn schema_matches_ts_requested_schema() -> anyhow::Result<()> {
+        let schema = serde_json::to_value(session_name_schema())?;
+        assert_eq!(
+            schema,
+            json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "Session name",
+                        "description": "Use a small lowercase 2-3 word name for what this session is doing, such as \"invoice processing\".",
+                        "maxLength": 64
+                    }
+                },
+                "required": ["name"]
+            })
+        );
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn accepted_name_is_normalized() {
+        let name = elicit_session_name(|_| {
+            std::future::ready(ElicitNameOutcome::Accepted("Invoice Processing".to_string()))
+        })
+        .await;
+        assert_eq!(name.as_deref(), Some("invoice-processing"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn accepted_name_normalizing_to_empty_is_dropped() {
+        let mut calls = 0;
+        let name = elicit_session_name(|_| {
+            calls += 1;
+            std::future::ready(ElicitNameOutcome::Accepted("!!!".to_string()))
+        })
+        .await;
+        assert_eq!(name, None);
+        assert_eq!(calls, 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_never_retries() {
+        let mut calls = 0;
+        let name = elicit_session_name(|_| {
+            calls += 1;
+            std::future::ready(ElicitNameOutcome::TimedOut)
+        })
+        .await;
+        assert_eq!(name, None);
+        assert_eq!(calls, 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn decline_never_retries() {
+        let mut calls = 0;
+        let name = elicit_session_name(|_| {
+            calls += 1;
+            std::future::ready(ElicitNameOutcome::NoName)
+        })
+        .await;
+        assert_eq!(name, None);
+        assert_eq!(calls, 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn transport_failure_retries_once_then_accepts() {
+        let mut calls = 0;
+        let name = elicit_session_name(|attempt| {
+            calls += 1;
+            std::future::ready(if attempt == 0 {
+                ElicitNameOutcome::Failed("no stream yet".to_string())
+            } else {
+                ElicitNameOutcome::Accepted("flight search".to_string())
+            })
+        })
+        .await;
+        assert_eq!(name.as_deref(), Some("flight-search"));
+        assert_eq!(calls, 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn two_transport_failures_give_up() {
+        let mut calls = 0;
+        let name = elicit_session_name(|_| {
+            calls += 1;
+            std::future::ready(ElicitNameOutcome::Failed("still no stream".to_string()))
+        })
+        .await;
+        assert_eq!(name, None);
+        assert_eq!(calls, 2);
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -401,6 +401,60 @@ async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn mcp_initialize_with_elicitation_capability_stays_nonblocking() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let initialize = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": { "elicitation": {} },
+            "clientInfo": { "name": "Claude Code", "version": "1.0" }
+        }
+    });
+    let (status, headers, body) =
+        request_json_with_headers(&app.router, "POST", "/mcp", Some(initialize), &[]).await?;
+    assert_eq!(status, StatusCode::OK, "initialize body: {body:?}");
+    let session_id = headers
+        .get("mcp-session-id")
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| anyhow::anyhow!("missing mcp-session-id"))?
+        .to_string();
+    send_initialized(&app.router, &session_id).await?;
+
+    // The naming task fires in the background; the handshake and tool
+    // surface must stay responsive regardless of the pending elicitation.
+    let list = json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} });
+    let (status, _headers, body) = request_json_with_headers(
+        &app.router,
+        "POST",
+        "/mcp",
+        Some(list),
+        &[("mcp-session-id", &session_id)],
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["result"]["tools"].as_array().is_some_and(|tools| !tools.is_empty()));
+
+    // The initialized notification is acked before the session-start hook
+    // completes, so poll like initialize_mcp does.
+    for _ in 0..50 {
+        if let Some(session) = app
+            .state
+            .sessions
+            .lookup(&SessionId::new(session_id.clone()))
+            .await
+        {
+            assert_eq!(session.session_label().await, None);
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    Err(anyhow::anyhow!("session not minted"))
+}
+
+#[tokio::test]
 async fn mcp_tabs_new_roundtrips_through_mock_cdp() -> anyhow::Result<()> {
     let mock = MockCdp::start().await?;
     let app = test_app_with_cdp_port(mock.cdp_port, false).await?;

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -515,21 +515,15 @@ async fn mcp_initialize_with_elicitation_capability_stays_nonblocking() -> anyho
     assert_eq!(status, StatusCode::OK);
     assert!(body["result"]["tools"].as_array().is_some_and(|tools| !tools.is_empty()));
 
-    // The initialized notification is acked before the session-start hook
-    // completes, so poll like initialize_mcp does.
-    for _ in 0..50 {
-        if let Some(session) = app
-            .state
-            .sessions
-            .lookup(&SessionId::new(session_id.clone()))
-            .await
-        {
-            assert_eq!(session.session_label().await, None);
-            return Ok(());
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-    Err(anyhow::anyhow!("session not minted"))
+    wait_for_session_registration(&app, &session_id).await?;
+    let session = app
+        .state
+        .sessions
+        .lookup(&SessionId::new(session_id.clone()))
+        .await
+        .ok_or_else(|| anyhow::anyhow!("session not minted"))?;
+    assert_eq!(session.session_label().await, None);
+    Ok(())
 }
 
 #[tokio::test]

--- a/packages/browseros-agent/crates/browseros-mcp/src/hooks.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/hooks.rs
@@ -18,6 +18,9 @@ pub struct McpClientInfo {
 pub struct McpSessionStarted {
     pub session_id: String,
     pub client_info: McpClientInfo,
+    /// Live handle to the session's client for server-initiated requests
+    /// (elicitation). None when the transport has no peer (tests, replay).
+    pub peer: Option<rmcp::service::Peer<rmcp::RoleServer>>,
 }
 
 #[derive(Debug, Clone)]

--- a/packages/browseros-agent/crates/browseros-mcp/src/service.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/service.rs
@@ -169,7 +169,11 @@ impl BrowserMcpService {
         self.lifecycle.lock().await.client_info = Some(client_info);
     }
 
-    async fn ensure_session_started(&self, session_id: String) -> Result<String, McpError> {
+    async fn ensure_session_started(
+        &self,
+        session_id: String,
+        peer: Option<rmcp::service::Peer<RoleServer>>,
+    ) -> Result<String, McpError> {
         let event = {
             let mut lifecycle = self.lifecycle.lock().await;
             if lifecycle.session_id.is_none() {
@@ -194,6 +198,7 @@ impl BrowserMcpService {
             McpSessionStarted {
                 session_id,
                 client_info,
+                peer,
             }
         };
         let started_session_id = event.session_id.clone();
@@ -209,13 +214,17 @@ impl BrowserMcpService {
     ) -> Result<String, McpError> {
         let session_id = session_id_from_extensions(&context.extensions)
             .unwrap_or_else(|| self.fallback_session_id.clone());
-        self.ensure_session_started(session_id).await
+        self.ensure_session_started(session_id, Some(context.peer.clone()))
+            .await
     }
 
     async fn learn_session_from_notification(&self, context: &NotificationContext<RoleServer>) {
         let session_id = session_id_from_extensions(&context.extensions)
             .unwrap_or_else(|| self.fallback_session_id.clone());
-        if let Err(err) = self.ensure_session_started(session_id).await {
+        if let Err(err) = self
+            .ensure_session_started(session_id, Some(context.peer.clone()))
+            .await
+        {
             warn!(error = %err, "mcp session start hook failed");
         }
     }


### PR DESCRIPTION
## Summary
- Ports `mcp/session-naming.ts` to the rust claw-server: when an MCP client advertises the `elicitation` capability, a spawned task (never blocking initialize) asks it to name the browser session, normalizes the answer to a 2-3-word label (`normalizeSmallName` semantics, TS test vectors ported), and titles the agent's tab group `<prefix>/<name>` (e.g. `claude/flight-search`).
- Extends the typed `McpHooks` boundary minimally: `McpSessionStarted` now carries the session's `Peer<RoleServer>` (rmcp's native elicitation API — no raw JSON-RPC); enables the `elicitation` cargo feature on the workspace rmcp dep.
- TS retry table mirrored exactly: 120s timeout per attempt; timeout (user ignored) → no retry; transport failure → one retry after 2s; decline/cancel/empty → silent. Label is in-memory only (the TS `sessionLabel` never reaches audit rows — mirrored).

## Design
`ensure_session_started` (crates/browseros-mcp) hands the live peer to the hook; `ClawMcpHooks::session_started` spawns a `SessionNamer` task gated on form-elicitation support. The task's elicit future is raced against the session's cancellation token, so teardown (idle sweep, disconnect, shutdown) frees it immediately; a post-elicit registry lookup handles the swept-session case silently. Late-name arrival retitles the existing group via a `tab_groups` update; a name that lands while the first group create is in flight is applied by a dedicated post-create title update (independent of the color lock, so a color failure can't drop the name); a name known before the first `tabs new` flows into the create's `title` argument. Elicitation prompt + `requestedSchema` are byte-identical to the TS wire format (manual `ElicitationSchema` instead of schemars derive).

Review notes (workflow code-review, high effort — 8 verified findings, 5 fixed):
- Skipped: cross-session title clobber for same-slug concurrent sessions — a consequence of the rust server's *intentional* slug-pooled tab groups (`agent_ref.rs` ownership comment); TS avoids it only because it never pools. Last-namer-wins within the shared pool.
- Skipped: unserialized parallel `tab_groups create` race — pre-existing in `TabGroupOrchestrator`, untouched surface.
- Skipped: rmcp serializes an extra `"mode":"form"` field in elicit params — verified accepted by the real `@modelcontextprotocol/sdk` client (see manual check); newer MCP revisions include `mode`.

## Test plan
- [x] `cargo test -p claw-server-rust -p browseros-mcp` — green (normalizer TS vectors, retry table incl. timeout-no-retry, schema JSON parity with the TS `requestedSchema`, label slot, elicitation-capability initialize integration test)
- [x] `cargo clippy -p browseros-mcp -p claw-server-rust --all-targets` — clean
- [x] Manual check (headless equivalent of "connect Claude Code"): standalone server + a client built on the same `@modelcontextprotocol/sdk` Claude Code embeds, advertising `{elicitation:{}}` → server sent the naming prompt with the exact TS message/schema → client answered "Flight Search" → server log `mcp session named … title=claude/flight-search`. Browser-side retitle path exercises the same `tab_groups` machinery covered by the mock-CDP tests; visible-in-browser confirmation to be done on the devrust watch stack post-merge.

Note: `tests/routes.rs` flaked ~50% on the base tree before #1777's `wait_for_session_registration` workaround (root cause documented there); with main merged in, 3 consecutive full runs green.