### PR TITLE
feat(claw-server-rust): push-based CDP screencast for live tab thumbnails

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
@@ -134,6 +134,7 @@ async fn agents_cancel(
 }
 
 async fn tabs_activity(State(state): State<AppState>) -> AppResult<Json<Value>> {
+    state.screencast.note_read();
     let profiles = state.agents.list_profiles().await?;
     let tabs = state.tab_activity.snapshot().await;
     let mut enriched = Vec::with_capacity(tabs.len());

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/screencast.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/screencast.rs
@@ -1,32 +1,47 @@
 use crate::services::{
     browser::BrowserService,
     now_epoch_ms,
-    tab_activity::{ScreencastFrame, TabActivityService},
+    tab_activity::{ScreencastFrame, TabActivityRecord, TabActivityService},
 };
+use browseros_cdp::CdpEvent;
 use browseros_core::{
-    PageId,
+    BrowserSession, CoreError, PageId, SessionId,
+    screencast::{self, SCREENCAST_FRAME_METHOD, ScreencastOptions},
     screenshot::{ScreenshotCaptureOptions, ScreenshotFormat},
 };
+use serde_json::json;
 use std::{
-    collections::{HashMap, VecDeque},
-    sync::Arc,
+    collections::{HashMap, HashSet, VecDeque},
+    sync::{
+        Arc,
+        atomic::{AtomicI64, Ordering},
+    },
     time::Duration,
 };
 use tokio::{
-    sync::Mutex,
+    sync::{Mutex, broadcast},
     task::JoinHandle,
     time::{MissedTickBehavior, interval},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{debug, warn};
 
+const SUPERVISOR_INTERVAL: Duration = Duration::from_secs(1);
 const POLL_INTERVAL: Duration = Duration::from_millis(1500);
 const FAILURE_BACKOFF_MS: i64 = 5_000;
 const FAILURE_BACKOFF_THRESHOLD: u8 = 3;
+/// No `/tabs/activity` reads for this long means nobody is watching the
+/// cockpit: stop screencasts and skip poll captures until the next read.
+const IDLE_AFTER_MS: i64 = 15_000;
+/// A screencast that stays frameless this long while its page is still the
+/// window's active agent page gets restarted — revives casts silently killed
+/// by a CDP reconnect and refreshes the keyframe on static pages.
+const FRAMELESS_RESTART_MS: i64 = 5_000;
 
-#[derive(Clone)]
 pub struct ScreencastService {
     inner: Arc<Mutex<ScreencastInner>>,
+    casts: Arc<Mutex<HashMap<SessionId, Cast>>>,
+    last_read_ms: AtomicI64,
     cancel: CancellationToken,
     capacity: usize,
 }
@@ -39,11 +54,49 @@ struct ScreencastInner {
     retry_after: HashMap<u32, i64>,
 }
 
+/// A live `Page.startScreencast` on one target session. Keyed in the casts
+/// map by the envelope target session id (string), which routes incoming
+/// `Page.screencastFrame` events; the integer sessionId inside frame params
+/// is only the ack cookie.
+struct Cast {
+    page_id: u32,
+    window_id: i64,
+    target_id: String,
+    session: browseros_core::ProtocolSession,
+    last_frame_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct AgentPage {
+    page_id: u32,
+    target_id: String,
+    window_id: Option<i64>,
+    status_active: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RunningCast {
+    key: SessionId,
+    page_id: u32,
+    target_id: String,
+    window_id: i64,
+    last_frame_at: i64,
+}
+
+#[derive(Debug, Default, PartialEq)]
+struct TickPlan {
+    stop: Vec<SessionId>,
+    start: Vec<(u32, i64)>,
+    poll: Vec<u32>,
+}
+
 impl ScreencastService {
     #[must_use]
     pub fn new(capacity: usize) -> Arc<Self> {
         Arc::new(Self {
             inner: Arc::new(Mutex::new(ScreencastInner::default())),
+            casts: Arc::new(Mutex::new(HashMap::new())),
+            last_read_ms: AtomicI64::new(0),
             cancel: CancellationToken::new(),
             capacity,
         })
@@ -55,13 +108,26 @@ impl ScreencastService {
         tab_activity: Arc<TabActivityService>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
-            let mut ticker = interval(POLL_INTERVAL);
-            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            let mut supervisor = interval(SUPERVISOR_INTERVAL);
+            supervisor.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            let mut poller = interval(POLL_INTERVAL);
+            poller.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            let mut pump: Option<JoinHandle<()>> = None;
             loop {
                 tokio::select! {
-                    () = self.cancel.cancelled() => return,
-                    _ = ticker.tick() => {
-                        self.capture_active_pages(browser.clone(), tab_activity.clone()).await;
+                    () = self.cancel.cancelled() => {
+                        if let Some(pump) = pump.take() {
+                            pump.abort();
+                        }
+                        self.stop_all_casts().await;
+                        return;
+                    }
+                    _ = supervisor.tick() => {
+                        self.ensure_pump(&browser, &mut pump).await;
+                        self.supervise(&browser, &tab_activity).await;
+                    }
+                    _ = poller.tick() => {
+                        self.poll_uncovered_pages(&browser, &tab_activity).await;
                     }
                 }
             }
@@ -76,16 +142,247 @@ impl ScreencastService {
         self.inner.lock().await.frames.get(&page_id).cloned()
     }
 
-    async fn capture_active_pages(
-        &self,
-        browser: Arc<BrowserService>,
-        tab_activity: Arc<TabActivityService>,
+    /// Record a `/tabs/activity` read for the idle governor.
+    pub fn note_read(&self) {
+        self.last_read_ms.store(now_epoch_ms(), Ordering::Relaxed);
+    }
+
+    fn is_idle(&self, now: i64) -> bool {
+        now.saturating_sub(self.last_read_ms.load(Ordering::Relaxed)) > IDLE_AFTER_MS
+    }
+
+    async fn ensure_pump(
+        self: &Arc<Self>,
+        browser: &Arc<BrowserService>,
+        pump: &mut Option<JoinHandle<()>>,
     ) {
+        if pump.as_ref().is_some_and(|handle| !handle.is_finished()) {
+            return;
+        }
         let Some(session) = browser.session().await else {
             return;
         };
+        let events = session.cdp_events();
+        let service = self.clone();
+        *pump = Some(tokio::spawn(async move {
+            service.pump_frames(events).await;
+        }));
+    }
+
+    async fn pump_frames(self: Arc<Self>, mut events: broadcast::Receiver<CdpEvent>) {
+        loop {
+            tokio::select! {
+                () = self.cancel.cancelled() => return,
+                received = events.recv() => match received {
+                    Ok(event) => {
+                        if event.method == SCREENCAST_FRAME_METHOD {
+                            self.handle_frame(event).await;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        debug!(skipped, "screencast frame pump lagged; continuing");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return,
+                }
+            }
+        }
+    }
+
+    async fn handle_frame(&self, event: CdpEvent) {
+        let Some(session_id) = event.session_id else {
+            return;
+        };
+        let Some(frame) = screencast::parse_frame_event(&event.params) else {
+            debug!(%session_id, "ignoring unparseable screencast frame");
+            return;
+        };
+        let owner = {
+            let mut casts = self.casts.lock().await;
+            let Some(cast) = casts.get_mut(&session_id) else {
+                // Frame from a session we do not own — drop it.
+                return;
+            };
+            cast.last_frame_at = now_epoch_ms();
+            (cast.page_id, cast.session.clone())
+        };
+        let (page_id, session) = owner;
+        self.store_frame(
+            page_id,
+            ScreencastFrame {
+                jpeg_base64: frame.data,
+                captured_at: now_epoch_ms(),
+            },
+        )
+        .await;
+        if let Err(err) = screencast::ack_frame(&session, frame.session_id).await {
+            debug!(page_id, error = %err, "screencastFrameAck failed");
+        }
+    }
+
+    async fn supervise(&self, browser: &Arc<BrowserService>, tab_activity: &Arc<TabActivityService>) {
+        let Some(session) = browser.session().await else {
+            // No connection: target sessions are gone, drop the bookkeeping.
+            self.casts.lock().await.clear();
+            return;
+        };
+        let now = now_epoch_ms();
+        let idle = self.is_idle(now);
+        let (agent_pages, active_target_by_window) = if idle {
+            (Vec::new(), HashMap::new())
+        } else {
+            let records = tab_activity.snapshot().await;
+            self.resolve_topology(&session, records).await
+        };
+        let running: Vec<RunningCast> = self
+            .casts
+            .lock()
+            .await
+            .iter()
+            .map(|(key, cast)| RunningCast {
+                key: key.clone(),
+                page_id: cast.page_id,
+                target_id: cast.target_id.clone(),
+                window_id: cast.window_id,
+                last_frame_at: cast.last_frame_at,
+            })
+            .collect();
+        let plan = plan_tick(idle, now, &agent_pages, &active_target_by_window, &running);
+        self.apply_plan(&session, plan, now).await;
+    }
+
+    /// Map agent pages to windows and resolve each relevant window's active
+    /// tab via root `Browser.getActiveTab` — no attach, so the user's own
+    /// tabs are never touched.
+    async fn resolve_topology(
+        &self,
+        session: &Arc<BrowserSession>,
+        records: Vec<TabActivityRecord>,
+    ) -> (Vec<AgentPage>, HashMap<i64, String>) {
+        if records.is_empty() {
+            return (Vec::new(), HashMap::new());
+        }
+        let infos = match session.pages.list().await {
+            Ok(infos) => infos,
+            Err(err) => {
+                debug!(error = %err, "screencast page listing failed");
+                return (Vec::new(), HashMap::new());
+            }
+        };
+        let window_by_page: HashMap<u32, i64> = infos
+            .iter()
+            .filter_map(|info| {
+                info.window_id
+                    .as_ref()
+                    .map(|window| (info.page_id.0, window.0))
+            })
+            .collect();
+        let agent_pages: Vec<AgentPage> = records
+            .into_iter()
+            .map(|record| AgentPage {
+                window_id: window_by_page.get(&record.page_id).copied(),
+                page_id: record.page_id,
+                target_id: record.target_id,
+                status_active: record.status == "active",
+            })
+            .collect();
+        let windows: HashSet<i64> = agent_pages
+            .iter()
+            .filter_map(|page| page.window_id)
+            .collect();
+        let mut active_target_by_window = HashMap::new();
+        for window_id in windows {
+            match get_active_target(session, window_id).await {
+                Ok(Some(target_id)) => {
+                    active_target_by_window.insert(window_id, target_id);
+                }
+                Ok(None) => {}
+                Err(err) => debug!(window_id, error = %err, "getActiveTab failed"),
+            }
+        }
+        (agent_pages, active_target_by_window)
+    }
+
+    async fn apply_plan(&self, session: &Arc<BrowserSession>, plan: TickPlan, now: i64) {
+        for key in plan.stop {
+            let cast = self.casts.lock().await.remove(&key);
+            if let Some(cast) = cast
+                && let Err(err) = screencast::stop_screencast(&cast.session).await
+            {
+                debug!(page_id = cast.page_id, error = %err, "stopScreencast failed");
+            }
+        }
+        for (page_id, window_id) in plan.start {
+            if let Err(err) = self.start_cast(session, page_id, window_id, now).await {
+                debug!(page_id, error = %err, "startScreencast failed");
+            }
+        }
+    }
+
+    async fn start_cast(
+        &self,
+        session: &Arc<BrowserSession>,
+        page_id: u32,
+        window_id: i64,
+        now: i64,
+    ) -> Result<(), CoreError> {
+        let page = session.pages.get_session(PageId(page_id)).await?;
+        // Register before starting so the first frame is routable.
+        self.casts.lock().await.insert(
+            page.session_id.clone(),
+            Cast {
+                page_id,
+                window_id,
+                target_id: page.target_id.into_inner(),
+                session: page.session.clone(),
+                last_frame_at: now,
+            },
+        );
+        if let Err(err) =
+            screencast::start_screencast(&page.session, &ScreencastOptions::default()).await
+        {
+            self.casts.lock().await.remove(&page.session_id);
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    async fn stop_all_casts(&self) {
+        let casts: Vec<Cast> = {
+            let mut guard = self.casts.lock().await;
+            guard.drain().map(|(_, cast)| cast).collect()
+        };
+        for cast in casts {
+            if let Err(err) = screencast::stop_screencast(&cast.session).await {
+                debug!(page_id = cast.page_id, error = %err, "stopScreencast on teardown failed");
+            }
+        }
+    }
+
+    /// Poll fallback for agent pages CDP will not composite (background
+    /// tabs): the pre-screencast captureScreenshot path, unchanged.
+    async fn poll_uncovered_pages(
+        &self,
+        browser: &Arc<BrowserService>,
+        tab_activity: &Arc<TabActivityService>,
+    ) {
+        if self.is_idle(now_epoch_ms()) {
+            return;
+        }
+        let Some(session) = browser.session().await else {
+            return;
+        };
+        let covered: HashSet<u32> = self
+            .casts
+            .lock()
+            .await
+            .values()
+            .map(|cast| cast.page_id)
+            .collect();
         let pages = tab_activity.snapshot().await;
-        for record in pages.into_iter().filter(|record| record.status == "active") {
+        for record in pages
+            .into_iter()
+            .filter(|record| record.status == "active" && !covered.contains(&record.page_id))
+        {
             if self.is_backing_off(record.page_id).await {
                 continue;
             }
@@ -94,6 +391,7 @@ impl ScreencastService {
                 quality: Some(50),
                 full_page: Some(false),
                 annotate: Some(false),
+                // The BrowserOS fork visibly resizes tabs when clip is set.
                 clip: None,
             };
             match session.screenshot(PageId(record.page_id), options).await {
@@ -156,10 +454,213 @@ impl ScreencastService {
     }
 }
 
+async fn get_active_target(
+    session: &Arc<BrowserSession>,
+    window_id: i64,
+) -> Result<Option<String>, CoreError> {
+    let value = session
+        .cdp("Browser.getActiveTab", json!({ "windowId": window_id }), None)
+        .await?;
+    let result: browseros_cdp::browser::GetActiveTabResult =
+        serde_json::from_value(value).map_err(|err| CoreError::Message(err.to_string()))?;
+    Ok(result.tab.map(|tab| tab.target_id))
+}
+
+/// Pure per-tick decision: which casts to stop, which pages to start
+/// screencasting (window's active agent page), and which pages the
+/// captureScreenshot fallback should poll.
+fn plan_tick(
+    idle: bool,
+    now: i64,
+    agent_pages: &[AgentPage],
+    active_target_by_window: &HashMap<i64, String>,
+    running: &[RunningCast],
+) -> TickPlan {
+    let mut plan = TickPlan::default();
+    if idle {
+        plan.stop = running.iter().map(|cast| cast.key.clone()).collect();
+        return plan;
+    }
+    let agent_by_target: HashMap<&str, &AgentPage> = agent_pages
+        .iter()
+        .map(|page| (page.target_id.as_str(), page))
+        .collect();
+    let mut covered: HashSet<u32> = HashSet::new();
+    for cast in running {
+        let still_window_active = active_target_by_window
+            .get(&cast.window_id)
+            .is_some_and(|target| *target == cast.target_id);
+        let still_agent = agent_by_target.contains_key(cast.target_id.as_str());
+        if !still_window_active || !still_agent {
+            plan.stop.push(cast.key.clone());
+            continue;
+        }
+        if now.saturating_sub(cast.last_frame_at) > FRAMELESS_RESTART_MS {
+            plan.stop.push(cast.key.clone());
+            plan.start.push((cast.page_id, cast.window_id));
+        }
+        covered.insert(cast.page_id);
+    }
+    for (window_id, target_id) in active_target_by_window {
+        let Some(page) = agent_by_target.get(target_id.as_str()) else {
+            continue;
+        };
+        if covered.insert(page.page_id) {
+            plan.start.push((page.page_id, *window_id));
+        }
+    }
+    for page in agent_pages {
+        if page.status_active && !covered.contains(&page.page_id) {
+            plan.poll.push(page.page_id);
+        }
+    }
+    plan
+}
+
 #[cfg(test)]
 mod tests {
-    use super::ScreencastService;
+    use super::{AgentPage, RunningCast, ScreencastService, plan_tick};
     use crate::services::tab_activity::ScreencastFrame;
+    use browseros_core::SessionId;
+    use std::collections::HashMap;
+
+    const NOW: i64 = 1_000_000;
+
+    fn page(page_id: u32, target_id: &str, window_id: Option<i64>, status_active: bool) -> AgentPage {
+        AgentPage {
+            page_id,
+            target_id: target_id.to_string(),
+            window_id,
+            status_active,
+        }
+    }
+
+    fn cast(key: &str, page_id: u32, target_id: &str, window_id: i64, last_frame_at: i64) -> RunningCast {
+        RunningCast {
+            key: SessionId::from(key),
+            page_id,
+            target_id: target_id.to_string(),
+            window_id,
+            last_frame_at,
+        }
+    }
+
+    fn active(entries: &[(i64, &str)]) -> HashMap<i64, String> {
+        entries
+            .iter()
+            .map(|(window, target)| (*window, (*target).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn active_agent_page_starts_screencast_and_is_not_polled() {
+        let pages = [page(1, "t1", Some(1), true)];
+        let plan = plan_tick(false, NOW, &pages, &active(&[(1, "t1")]), &[]);
+        assert_eq!(plan.start, vec![(1, 1)]);
+        assert!(plan.stop.is_empty());
+        assert!(plan.poll.is_empty());
+    }
+
+    #[test]
+    fn background_agent_page_polls_instead_of_screencasting() {
+        let pages = [page(1, "t1", Some(1), true), page(2, "t2", Some(1), true)];
+        let plan = plan_tick(false, NOW, &pages, &active(&[(1, "t1")]), &[]);
+        assert_eq!(plan.start, vec![(1, 1)]);
+        assert_eq!(plan.poll, vec![2]);
+    }
+
+    #[test]
+    fn non_agent_active_tab_gets_no_screencast() {
+        let pages = [page(1, "t1", Some(1), true)];
+        let plan = plan_tick(false, NOW, &pages, &active(&[(1, "user-tab")]), &[]);
+        assert!(plan.start.is_empty());
+        assert_eq!(plan.poll, vec![1]);
+    }
+
+    #[test]
+    fn unknown_window_agent_page_still_polls() {
+        let pages = [page(1, "t1", None, true)];
+        let plan = plan_tick(false, NOW, &pages, &HashMap::new(), &[]);
+        assert!(plan.start.is_empty());
+        assert_eq!(plan.poll, vec![1]);
+    }
+
+    #[test]
+    fn idle_agent_page_neither_screencasts_nor_polls_when_backgrounded() {
+        let pages = [page(2, "t2", Some(1), false)];
+        let plan = plan_tick(false, NOW, &pages, &active(&[(1, "user-tab")]), &[]);
+        assert!(plan.start.is_empty());
+        assert!(plan.poll.is_empty());
+    }
+
+    #[test]
+    fn active_page_switch_stops_old_cast_and_starts_new() {
+        let pages = [page(1, "t1", Some(1), true), page(2, "t2", Some(1), true)];
+        let running = [cast("s1", 1, "t1", 1, NOW)];
+        let plan = plan_tick(false, NOW, &pages, &active(&[(1, "t2")]), &running);
+        assert_eq!(plan.stop, vec![SessionId::from("s1")]);
+        assert_eq!(plan.start, vec![(2, 1)]);
+        assert_eq!(plan.poll, vec![1]);
+    }
+
+    #[test]
+    fn cast_whose_page_left_the_agent_set_stops() {
+        let running = [cast("s1", 1, "t1", 1, NOW)];
+        let plan = plan_tick(false, NOW, &[], &HashMap::new(), &running);
+        assert_eq!(plan.stop, vec![SessionId::from("s1")]);
+        assert!(plan.start.is_empty());
+    }
+
+    #[test]
+    fn idle_governor_stops_all_casts_and_skips_polling() {
+        let pages = [page(1, "t1", Some(1), true)];
+        let running = [cast("s1", 1, "t1", 1, NOW), cast("s2", 2, "t2", 2, NOW)];
+        let plan = plan_tick(true, NOW, &pages, &active(&[(1, "t1")]), &running);
+        let mut stopped = plan.stop.clone();
+        stopped.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        assert_eq!(stopped, vec![SessionId::from("s1"), SessionId::from("s2")]);
+        assert!(plan.start.is_empty());
+        assert!(plan.poll.is_empty());
+    }
+
+    #[test]
+    fn resume_after_read_restarts_within_one_tick() {
+        let pages = [page(1, "t1", Some(1), true)];
+        let plan = plan_tick(false, NOW, &pages, &active(&[(1, "t1")]), &[]);
+        assert_eq!(plan.start, vec![(1, 1)]);
+    }
+
+    #[test]
+    fn frameless_cast_on_active_agent_page_restarts() {
+        let pages = [page(1, "t1", Some(1), true)];
+        let running = [cast("s1", 1, "t1", 1, NOW - 6_000)];
+        let plan = plan_tick(false, NOW, &pages, &active(&[(1, "t1")]), &running);
+        assert_eq!(plan.stop, vec![SessionId::from("s1")]);
+        assert_eq!(plan.start, vec![(1, 1)]);
+        assert!(plan.poll.is_empty());
+    }
+
+    #[test]
+    fn cast_with_recent_frame_is_left_alone() {
+        let pages = [page(1, "t1", Some(1), true)];
+        let running = [cast("s1", 1, "t1", 1, NOW - 1_000)];
+        let plan = plan_tick(false, NOW, &pages, &active(&[(1, "t1")]), &running);
+        assert!(plan.stop.is_empty());
+        assert!(plan.start.is_empty());
+        assert!(plan.poll.is_empty());
+    }
+
+    #[test]
+    fn idle_governor_uses_fifteen_second_window() {
+        let service = ScreencastService::new(2);
+        assert!(service.is_idle(NOW), "no reads yet means idle");
+        service
+            .last_read_ms
+            .store(NOW, std::sync::atomic::Ordering::Relaxed);
+        assert!(!service.is_idle(NOW));
+        assert!(!service.is_idle(NOW + 15_000));
+        assert!(service.is_idle(NOW + 15_001));
+    }
 
     #[tokio::test]
     async fn frame_cache_is_lru_capped() {

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/screencast.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/screencast.rs
@@ -19,7 +19,7 @@ use std::{
     time::Duration,
 };
 use tokio::{
-    sync::{Mutex, broadcast},
+    sync::{Mutex, mpsc},
     task::JoinHandle,
     time::{MissedTickBehavior, interval},
 };
@@ -162,37 +162,39 @@ impl ScreencastService {
         let Some(session) = browser.session().await else {
             return;
         };
-        let events = session.cdp_events();
+        // Frames bypass the broadcast ring (they are large and high-rate;
+        // ring slots would retain them long after consumption) — the
+        // targeted channel frees each frame once handled, and CDP's ack
+        // backpressure caps in-flight frames at ~1 per cast.
+        let frames = session.cdp_events_targeted(SCREENCAST_FRAME_METHOD);
         let service = self.clone();
         *pump = Some(tokio::spawn(async move {
-            service.pump_frames(events).await;
+            service.pump_frames(frames).await;
         }));
     }
 
-    async fn pump_frames(self: Arc<Self>, mut events: broadcast::Receiver<CdpEvent>) {
+    async fn pump_frames(self: Arc<Self>, mut frames: mpsc::UnboundedReceiver<CdpEvent>) {
         loop {
             tokio::select! {
                 () = self.cancel.cancelled() => return,
-                received = events.recv() => match received {
-                    Ok(event) => {
-                        if event.method == SCREENCAST_FRAME_METHOD {
-                            self.handle_frame(event).await;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                        debug!(skipped, "screencast frame pump lagged; continuing");
-                    }
-                    Err(broadcast::error::RecvError::Closed) => return,
+                received = frames.recv() => match received {
+                    Some(event) => self.handle_frame(event).await,
+                    // Channel replaced or client gone; the supervisor
+                    // respawns the pump on its next tick.
+                    None => return,
                 }
             }
         }
     }
 
     async fn handle_frame(&self, event: CdpEvent) {
-        let Some(session_id) = event.session_id else {
+        let CdpEvent {
+            params, session_id, ..
+        } = event;
+        let Some(session_id) = session_id else {
             return;
         };
-        let Some(frame) = screencast::parse_frame_event(&event.params) else {
+        let Some(frame) = screencast::parse_frame_event(params) else {
             debug!(%session_id, "ignoring unparseable screencast frame");
             return;
         };
@@ -206,6 +208,15 @@ impl ScreencastService {
             (cast.page_id, cast.session.clone())
         };
         let (page_id, session) = owner;
+        // Ack from a detached task: a wedged ack send must not stall frame
+        // routing for the other casts. Per-session ordering is safe — CDP
+        // sends the next frame only after this ack lands.
+        let ack_id = frame.session_id;
+        tokio::spawn(async move {
+            if let Err(err) = screencast::ack_frame(&session, ack_id).await {
+                debug!(page_id, error = %err, "screencastFrameAck failed");
+            }
+        });
         self.store_frame(
             page_id,
             ScreencastFrame {
@@ -214,9 +225,6 @@ impl ScreencastService {
             },
         )
         .await;
-        if let Err(err) = screencast::ack_frame(&session, frame.session_id).await {
-            debug!(page_id, error = %err, "screencastFrameAck failed");
-        }
     }
 
     async fn supervise(&self, browser: &Arc<BrowserService>, tab_activity: &Arc<TabActivityService>) {
@@ -227,11 +235,16 @@ impl ScreencastService {
         };
         let now = now_epoch_ms();
         let idle = self.is_idle(now);
-        let (agent_pages, active_target_by_window) = if idle {
-            (Vec::new(), HashMap::new())
+        let topology = if idle {
+            Some((Vec::new(), HashMap::new()))
         } else {
             let records = tab_activity.snapshot().await;
             self.resolve_topology(&session, records).await
+        };
+        let Some((agent_pages, active_target_by_window)) = topology else {
+            // Transient CDP failure while listing pages: keep the running
+            // casts and retry next tick instead of tearing them all down.
+            return;
         };
         let running: Vec<RunningCast> = self
             .casts
@@ -257,15 +270,15 @@ impl ScreencastService {
         &self,
         session: &Arc<BrowserSession>,
         records: Vec<TabActivityRecord>,
-    ) -> (Vec<AgentPage>, HashMap<i64, String>) {
+    ) -> Option<(Vec<AgentPage>, HashMap<i64, String>)> {
         if records.is_empty() {
-            return (Vec::new(), HashMap::new());
+            return Some((Vec::new(), HashMap::new()));
         }
         let infos = match session.pages.list().await {
             Ok(infos) => infos,
             Err(err) => {
                 debug!(error = %err, "screencast page listing failed");
-                return (Vec::new(), HashMap::new());
+                return None;
             }
         };
         let window_by_page: HashMap<u32, i64> = infos
@@ -299,7 +312,7 @@ impl ScreencastService {
                 Err(err) => debug!(window_id, error = %err, "getActiveTab failed"),
             }
         }
-        (agent_pages, active_target_by_window)
+        Some((agent_pages, active_target_by_window))
     }
 
     async fn apply_plan(&self, session: &Arc<BrowserSession>, plan: TickPlan, now: i64) {

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -19,7 +19,7 @@ use tokio::{
     net::{TcpListener, TcpStream},
     task::JoinHandle,
 };
-use tokio_tungstenite::{accept_async, tungstenite::Message};
+use tokio_tungstenite::{WebSocketStream, accept_async, tungstenite::Message};
 use tower::ServiceExt;
 
 struct TestApp {
@@ -315,6 +315,19 @@ async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("missing mcp-session-id"))?
         .to_string();
     send_initialized(&app.router, &session_id).await?;
+    // Registration is async after the initialized notification; tools/call
+    // below hits the dispatch guard, which needs the session registered.
+    for _ in 0..50 {
+        if app
+            .state
+            .sessions
+            .contains(&SessionId::new(session_id.clone()))
+            .await
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 
     let list = json!({
         "jsonrpc": "2.0",
@@ -621,6 +634,111 @@ async fn tabs_activity_enriches_by_agent_id_only() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn tabs_activity_serves_pushed_screencast_frames_with_acks() -> anyhow::Result<()> {
+    let mock = MockCdp::start().await?;
+    mock.add_tab(1, "target-1", 1).await;
+    mock.add_tab(2, "target-2", 2).await;
+    let app = test_app_with_cdp_port(mock.cdp_port, false).await?;
+    app.state.browser.connect_once_for_testing().await?;
+    wait_for_cdp_connected(&app.router).await?;
+
+    for (page_id, target_id, agent_id) in [(1, "target-1", "agent-a"), (2, "target-2", "agent-b")] {
+        app.state
+            .tab_activity
+            .record_tool(RecordToolInput {
+                target_id: TargetId::from(target_id.to_string()),
+                page_id,
+                url: format!("https://example.com/{target_id}"),
+                title: target_id.to_string(),
+                agent_id: agent_id.to_string(),
+                slug: "codex".to_string(),
+                tool_name: "tabs".to_string(),
+            })
+            .await;
+    }
+
+    let screencast_task = app
+        .state
+        .screencast
+        .clone()
+        .start(app.state.browser.clone(), app.state.tab_activity.clone());
+
+    // Frame 2 for each target is only released by the mock after the server
+    // acks frame 1 with the right integer sessionId on the right target
+    // session — seeing cast2 frames proves the full route→store→ack loop
+    // for two concurrent screencasts.
+    let mut last_frames: Vec<(String, Option<Value>)> = Vec::new();
+    let mut done = false;
+    for _ in 0..100 {
+        let (status, body) = request_json(&app.router, "GET", "/tabs/activity", None).await?;
+        assert_eq!(status, StatusCode::OK);
+        let rows = body["tabs"]
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("tabs not array"))?;
+        last_frames = rows
+            .iter()
+            .map(|row| {
+                (
+                    row["targetId"].as_str().unwrap_or_default().to_string(),
+                    (!row["screencast"].is_null()).then(|| row["screencast"].clone()),
+                )
+            })
+            .collect();
+        let frame_data = |target: &str| {
+            last_frames
+                .iter()
+                .find(|(target_id, _)| target_id == target)
+                .and_then(|(_, frame)| frame.as_ref())
+                .and_then(|frame| frame["jpegBase64"].as_str())
+                .map(str::to_string)
+        };
+        if frame_data("target-1").as_deref() == Some("cast2-target-1")
+            && frame_data("target-2").as_deref() == Some("cast2-target-2")
+        {
+            done = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        done,
+        "pushed frames never reached /tabs/activity; last: {last_frames:?}"
+    );
+
+    for (_, frame) in &last_frames {
+        let frame = frame
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("missing screencast frame"))?;
+        assert!(frame["capturedAt"].as_i64().is_some_and(|at| at > 0));
+        let data = frame["jpegBase64"].as_str().unwrap_or_default();
+        assert!(
+            data.starts_with("cast2-"),
+            "unexpected frame payload: {data}"
+        );
+    }
+
+    let acks = mock.acks.lock().await.clone();
+    assert!(
+        acks.contains(&("session-target-1".to_string(), 1001)),
+        "missing ack for target-1 frame 1: {acks:?}"
+    );
+    assert!(
+        acks.contains(&("session-target-2".to_string(), 2001)),
+        "missing ack for target-2 frame 1: {acks:?}"
+    );
+    // The frame pushed on the foreign envelope session must never be
+    // stored or acked (its ack ids end in 9).
+    assert!(
+        acks.iter().all(|(_, ack_id)| ack_id % 1000 != 9),
+        "foreign-session frame was acked: {acks:?}"
+    );
+
+    screencast_task.abort();
+    drop(mock);
+    Ok(())
+}
+
 fn test_session(session_id: SessionId, agent_id: &str, slug: &str) -> Arc<Session> {
     Session::new(
         session_id,
@@ -700,23 +818,28 @@ async fn wait_for_cdp_connected(router: &Router) -> anyhow::Result<()> {
 
 struct MockCdp {
     cdp_port: u16,
+    tabs: Arc<tokio::sync::Mutex<Vec<MockTab>>>,
+    acks: Arc<tokio::sync::Mutex<Vec<(String, i64)>>>,
     tasks: Vec<JoinHandle<()>>,
 }
 
 impl MockCdp {
     async fn start() -> anyhow::Result<Self> {
         let tabs = Arc::new(tokio::sync::Mutex::new(Vec::<MockTab>::new()));
+        let acks = Arc::new(tokio::sync::Mutex::new(Vec::<(String, i64)>::new()));
         let ws_listener = TcpListener::bind("127.0.0.1:0").await?;
         let ws_addr = ws_listener.local_addr()?;
         let ws_tabs = tabs.clone();
+        let ws_acks = acks.clone();
         let ws_task = tokio::spawn(async move {
             loop {
                 let Ok((stream, _addr)) = ws_listener.accept().await else {
                     break;
                 };
                 let tabs = ws_tabs.clone();
+                let acks = ws_acks.clone();
                 tokio::spawn(async move {
-                    let _ = handle_mock_ws(stream, tabs).await;
+                    let _ = handle_mock_ws(stream, tabs, acks).await;
                 });
             }
         });
@@ -736,8 +859,21 @@ impl MockCdp {
 
         Ok(Self {
             cdp_port,
+            tabs,
+            acks,
             tasks: vec![ws_task, http_task],
         })
+    }
+
+    async fn add_tab(&self, tab_id: i64, target_id: &str, window_id: i64) {
+        self.tabs.lock().await.push(MockTab {
+            tab_id,
+            target_id: target_id.to_string(),
+            url: format!("https://example.com/{target_id}"),
+            title: format!("Tab {tab_id}"),
+            group_id: None,
+            window_id,
+        });
     }
 }
 
@@ -756,6 +892,7 @@ struct MockTab {
     url: String,
     title: String,
     group_id: Option<String>,
+    window_id: i64,
 }
 
 async fn handle_mock_http(mut stream: TcpStream, ws_port: u16) -> anyhow::Result<()> {
@@ -786,6 +923,7 @@ async fn handle_mock_http(mut stream: TcpStream, ws_port: u16) -> anyhow::Result
 async fn handle_mock_ws(
     stream: TcpStream,
     tabs: Arc<tokio::sync::Mutex<Vec<MockTab>>>,
+    acks: Arc<tokio::sync::Mutex<Vec<(String, i64)>>>,
 ) -> anyhow::Result<()> {
     let mut ws = accept_async(stream).await?;
     while let Some(message) = ws.next().await {
@@ -810,13 +948,96 @@ async fn handle_mock_ws(
             .and_then(Value::as_str)
             .ok_or_else(|| anyhow::anyhow!("missing CDP method"))?;
         let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
-        let result = handle_mock_cdp_method(method, params, tabs.clone()).await;
+        let session = request
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let result = handle_mock_cdp_method(method, params.clone(), tabs.clone()).await;
         let response = match result {
             Ok(result) => json!({ "id": id, "result": result }),
             Err(message) => json!({ "id": id, "error": { "code": -32000, "message": message } }),
         };
         ws.send(Message::Text(response.to_string().into())).await?;
+        match method {
+            // A real browser pushes frames only after startScreencast; ours
+            // pushes one frame on a foreign session (must be dropped by the
+            // server) and then frame 1 on the requesting session.
+            "Page.startScreencast" => {
+                if let Some(session) = &session
+                    && let Some(tab) = find_tab_for_session(&tabs, session).await
+                {
+                    let base = tab.tab_id * 1000;
+                    send_screencast_frame(&mut ws, "session-bogus", "foreign", base + 9).await?;
+                    send_screencast_frame(
+                        &mut ws,
+                        session,
+                        &format!("cast1-{}", tab.target_id),
+                        base + 1,
+                    )
+                    .await?;
+                }
+            }
+            // Frame 2 is released only by a correct ack of frame 1 — the CDP
+            // backpressure contract the server must honor.
+            "Page.screencastFrameAck" => {
+                if let Some(session) = &session
+                    && let Some(ack_id) = params.get("sessionId").and_then(Value::as_i64)
+                {
+                    acks.lock().await.push((session.clone(), ack_id));
+                    if ack_id % 1000 == 1
+                        && let Some(tab) = find_tab_for_session(&tabs, session).await
+                    {
+                        send_screencast_frame(
+                            &mut ws,
+                            session,
+                            &format!("cast2-{}", tab.target_id),
+                            tab.tab_id * 1000 + 2,
+                        )
+                        .await?;
+                    }
+                }
+            }
+            _ => {}
+        }
     }
+    Ok(())
+}
+
+async fn find_tab_for_session(
+    tabs: &Arc<tokio::sync::Mutex<Vec<MockTab>>>,
+    session: &str,
+) -> Option<MockTab> {
+    let target_id = session.strip_prefix("session-")?;
+    tabs.lock()
+        .await
+        .iter()
+        .find(|tab| tab.target_id == target_id)
+        .cloned()
+}
+
+async fn send_screencast_frame(
+    ws: &mut WebSocketStream<TcpStream>,
+    session: &str,
+    data: &str,
+    ack_id: i64,
+) -> anyhow::Result<()> {
+    let event = json!({
+        "method": "Page.screencastFrame",
+        "params": {
+            "data": data,
+            "metadata": {
+                "offsetTop": 0.0,
+                "pageScaleFactor": 1.0,
+                "deviceWidth": 1280.0,
+                "deviceHeight": 800.0,
+                "scrollOffsetX": 0.0,
+                "scrollOffsetY": 0.0
+            },
+            "sessionId": ack_id
+        },
+        "sessionId": session
+    });
+    ws.send(Message::Text(event.to_string().into())).await?;
     Ok(())
 }
 
@@ -844,9 +1065,22 @@ async fn handle_mock_cdp_method(
                     .to_string(),
                 title: format!("Tab {tab_id}"),
                 group_id: None,
+                window_id: 1,
             };
             tabs.push(tab.clone());
             Ok(json!({ "tab": tab_json(&tab) }))
+        }
+        "Browser.getActiveTab" => {
+            let tabs = tabs.lock().await;
+            let window_id = params.get("windowId").and_then(Value::as_i64);
+            let tab = tabs
+                .iter()
+                .find(|tab| Some(tab.window_id) == window_id)
+                .cloned();
+            match tab {
+                Some(tab) => Ok(json!({ "tab": tab_json(&tab) })),
+                None => Ok(json!({})),
+            }
         }
         "Browser.getTabInfo" => {
             let tabs = tabs.lock().await;
@@ -923,7 +1157,7 @@ fn tab_json(tab: &MockTab) -> Value {
         "loadProgress": 1.0,
         "isPinned": false,
         "isHidden": false,
-        "windowId": 1,
+        "windowId": tab.window_id,
         "index": tab.tab_id - 1
     });
     if let (Value::Object(object), Some(group_id)) = (&mut value, &tab.group_id) {

--- a/packages/browseros-agent/crates/browseros-cdp/protocol/browser_protocol.json
+++ b/packages/browseros-agent/crates/browseros-cdp/protocol/browser_protocol.json
@@ -177,6 +177,19 @@
             { "name": "scale", "type": "number" },
             { "name": "zoom", "type": "number", "optional": true }
           ]
+        },
+        {
+          "id": "ScreencastFrameMetadata",
+          "type": "object",
+          "properties": [
+            { "name": "offsetTop", "type": "number" },
+            { "name": "pageScaleFactor", "type": "number" },
+            { "name": "deviceWidth", "type": "number" },
+            { "name": "deviceHeight", "type": "number" },
+            { "name": "scrollOffsetX", "type": "number" },
+            { "name": "scrollOffsetY", "type": "number" },
+            { "name": "timestamp", "type": "number", "optional": true }
+          ]
         }
       ],
       "commands": [
@@ -223,6 +236,31 @@
           "parameters": [
             { "name": "accept", "type": "boolean" },
             { "name": "promptText", "type": "string", "optional": true }
+          ]
+        },
+        {
+          "name": "startScreencast",
+          "parameters": [
+            { "name": "format", "type": "string", "optional": true },
+            { "name": "quality", "type": "integer", "optional": true },
+            { "name": "maxWidth", "type": "integer", "optional": true },
+            { "name": "maxHeight", "type": "integer", "optional": true },
+            { "name": "everyNthFrame", "type": "integer", "optional": true }
+          ]
+        },
+        { "name": "stopScreencast" },
+        {
+          "name": "screencastFrameAck",
+          "parameters": [{ "name": "sessionId", "type": "integer" }]
+        }
+      ],
+      "events": [
+        {
+          "name": "screencastFrame",
+          "parameters": [
+            { "name": "data", "type": "string" },
+            { "name": "metadata", "$ref": "ScreencastFrameMetadata" },
+            { "name": "sessionId", "type": "integer" }
           ]
         }
       ]

--- a/packages/browseros-agent/crates/browseros-cdp/src/client.rs
+++ b/packages/browseros-agent/crates/browseros-cdp/src/client.rs
@@ -17,7 +17,7 @@ use std::{
 };
 use tokio::{
     net::TcpStream,
-    sync::{Mutex, broadcast, oneshot},
+    sync::{Mutex, broadcast, mpsc, oneshot},
     task::JoinHandle,
     time::{sleep, timeout},
 };
@@ -97,6 +97,7 @@ struct Inner {
     pending: Mutex<HashMap<u64, PendingSender>>,
     sink: Mutex<Option<WsSink>>,
     events_tx: broadcast::Sender<CdpEvent>,
+    targeted: std::sync::Mutex<HashMap<String, mpsc::UnboundedSender<CdpEvent>>>,
     connected: AtomicBool,
     disconnecting: AtomicBool,
     reconnecting: AtomicBool,
@@ -115,6 +116,7 @@ impl CdpClient {
             pending: Mutex::new(HashMap::new()),
             sink: Mutex::new(None),
             events_tx,
+            targeted: std::sync::Mutex::new(HashMap::new()),
             connected: AtomicBool::new(false),
             disconnecting: AtomicBool::new(false),
             reconnecting: AtomicBool::new(false),
@@ -230,6 +232,22 @@ impl CdpClient {
 
     pub fn on_event(&self, method: &str) -> EventStream {
         EventStream::new(method, self.events())
+    }
+
+    /// Subscribe to one event method on a dedicated channel. Matching events
+    /// are delivered here INSTEAD of the shared broadcast ring and are freed
+    /// as soon as they are consumed — use for high-rate, large-payload events
+    /// (e.g. `Page.screencastFrame`) whose retention in the 4096-slot
+    /// broadcast ring would pin memory. One subscriber per method: a new
+    /// call replaces the previous one (whose channel closes); dropping the
+    /// receiver restores broadcast delivery for the method.
+    #[must_use]
+    pub fn events_targeted(&self, method: &str) -> mpsc::UnboundedReceiver<CdpEvent> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        if let Ok(mut targeted) = self.inner.targeted.lock() {
+            targeted.insert(method.to_string(), tx);
+        }
+        rx
     }
 
     async fn send_frame(&self, id: u64, method: &str, message: Message) -> Result<Value, CdpError> {
@@ -396,11 +414,34 @@ async fn handle_text_message(inner: &Arc<Inner>, text: &str) {
         .get("sessionId")
         .and_then(Value::as_str)
         .map(SessionId::from);
-    let _ = inner.events_tx.send(CdpEvent {
+    let event = CdpEvent {
         method: method.to_string(),
         params,
         session_id,
-    });
+    };
+    let Some(event) = send_targeted(inner, event) else {
+        return;
+    };
+    let _ = inner.events_tx.send(event);
+}
+
+/// Hands the event to the method's targeted subscriber if one is live;
+/// returns the event back when it should fall through to the broadcast ring.
+fn send_targeted(inner: &Inner, event: CdpEvent) -> Option<CdpEvent> {
+    let Ok(mut targeted) = inner.targeted.lock() else {
+        return Some(event);
+    };
+    let Some(sender) = targeted.get(&event.method) else {
+        return Some(event);
+    };
+    match sender.send(event) {
+        Ok(()) => None,
+        Err(rejected) => {
+            let event = rejected.0;
+            targeted.remove(&event.method);
+            Some(event)
+        }
+    }
 }
 
 async fn start_keepalive(inner: Arc<Inner>) {

--- a/packages/browseros-agent/crates/browseros-core/src/connection.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/connection.rs
@@ -4,7 +4,7 @@ use futures_util::future::BoxFuture;
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
 use std::{fmt, sync::Arc};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc};
 
 pub const EXCLUDED_URL_PREFIXES: &[&str] = &[
     "chrome-extension://",
@@ -29,6 +29,15 @@ pub trait CdpConnection: Send + Sync {
     ) -> BoxFuture<'a, Result<String, CdpError>>;
 
     fn events(&self) -> broadcast::Receiver<CdpEvent>;
+
+    /// Dedicated single-method event channel that bypasses the broadcast
+    /// ring (see `CdpClient::events_targeted`). Default: a closed channel —
+    /// transports without targeted delivery yield no events here.
+    fn events_targeted(&self, _method: &str) -> mpsc::UnboundedReceiver<CdpEvent> {
+        let (_tx, rx) = mpsc::unbounded_channel();
+        rx
+    }
+
     fn is_connected(&self) -> bool;
     fn connection_epoch(&self) -> u64;
 }
@@ -54,6 +63,10 @@ impl CdpConnection for CdpClient {
 
     fn events(&self) -> broadcast::Receiver<CdpEvent> {
         CdpClient::events(self)
+    }
+
+    fn events_targeted(&self, method: &str) -> mpsc::UnboundedReceiver<CdpEvent> {
+        CdpClient::events_targeted(self, method)
     }
 
     fn is_connected(&self) -> bool {

--- a/packages/browseros-agent/crates/browseros-core/src/lib.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod navigation;
 pub mod observer;
 pub mod page_signals;
 pub mod pages;
+pub mod screencast;
 pub mod screenshot;
 pub mod settle;
 pub mod snapshot;

--- a/packages/browseros-agent/crates/browseros-core/src/screencast.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/screencast.rs
@@ -1,0 +1,143 @@
+use crate::{CoreError, ProtocolSession, screenshot::ScreenshotFormat};
+use browseros_cdp::page;
+use serde_json::Value;
+
+pub use browseros_cdp::page::{ScreencastFrameEvent, ScreencastFrameMetadata};
+
+/// The `Page.screencastFrame` event method name, for routing off a raw event stream.
+pub const SCREENCAST_FRAME_METHOD: &str = "Page.screencastFrame";
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ScreencastOptions {
+    pub format: ScreenshotFormat,
+    pub quality: i64,
+    pub max_width: i64,
+    pub max_height: i64,
+    pub every_nth_frame: i64,
+}
+
+impl Default for ScreencastOptions {
+    fn default() -> Self {
+        Self {
+            format: ScreenshotFormat::Jpeg,
+            quality: 60,
+            max_width: 1280,
+            max_height: 800,
+            every_nth_frame: 1,
+        }
+    }
+}
+
+impl ScreencastOptions {
+    #[must_use]
+    pub fn to_params(&self) -> page::StartScreencastParams {
+        page::StartScreencastParams {
+            format: Some(self.format.as_str().to_string()),
+            quality: Some(self.quality),
+            max_width: Some(self.max_width),
+            max_height: Some(self.max_height),
+            every_nth_frame: Some(self.every_nth_frame),
+        }
+    }
+}
+
+pub async fn start_screencast(
+    session: &ProtocolSession,
+    options: &ScreencastOptions,
+) -> Result<(), CoreError> {
+    let _: page::StartScreencastResult = session
+        .send("Page.startScreencast", options.to_params())
+        .await?;
+    Ok(())
+}
+
+pub async fn stop_screencast(session: &ProtocolSession) -> Result<(), CoreError> {
+    let _: page::StopScreencastResult = session
+        .send("Page.stopScreencast", serde_json::json!({}))
+        .await?;
+    Ok(())
+}
+
+/// Ack a received frame with the integer cookie from the event params —
+/// Chrome stops sending frames until the previous one is acked.
+pub async fn ack_frame(session: &ProtocolSession, frame_session_id: i64) -> Result<(), CoreError> {
+    let _: page::ScreencastFrameAckResult = session
+        .send(
+            "Page.screencastFrameAck",
+            page::ScreencastFrameAckParams {
+                session_id: frame_session_id,
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+/// Parse `Page.screencastFrame` event params. The `session_id` inside is the
+/// ack cookie (integer), unrelated to the envelope target session id (string).
+#[must_use]
+pub fn parse_frame_event(params: &Value) -> Option<ScreencastFrameEvent> {
+    serde_json::from_value(params.clone()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn default_options_match_claw_screencast_params() {
+        let options = ScreencastOptions::default();
+        assert_eq!(options.format, ScreenshotFormat::Jpeg);
+        assert_eq!(options.quality, 60);
+        assert_eq!(options.max_width, 1280);
+        assert_eq!(options.max_height, 800);
+        assert_eq!(options.every_nth_frame, 1);
+    }
+
+    #[test]
+    fn start_params_serialize_to_cdp_wire_shape() -> Result<(), serde_json::Error> {
+        let value = serde_json::to_value(ScreencastOptions::default().to_params())?;
+        assert_eq!(
+            value,
+            json!({
+                "format": "jpeg",
+                "quality": 60,
+                "maxWidth": 1280,
+                "maxHeight": 800,
+                "everyNthFrame": 1
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn frame_event_deserializes_with_optional_timestamp() {
+        let params = json!({
+            "data": "aGVsbG8=",
+            "metadata": {
+                "offsetTop": 0.0,
+                "pageScaleFactor": 1.0,
+                "deviceWidth": 1280.0,
+                "deviceHeight": 800.0,
+                "scrollOffsetX": 0.0,
+                "scrollOffsetY": 12.5
+            },
+            "sessionId": 7
+        });
+        let event = parse_frame_event(&params);
+        let Some(event) = event else {
+            panic!("expected frame event to parse: {params}");
+        };
+        assert_eq!(event.data, "aGVsbG8=");
+        assert_eq!(event.session_id, 7);
+        assert_eq!(event.metadata.timestamp, None);
+        assert!((event.metadata.scroll_offset_y - 12.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn frame_event_parse_rejects_garbage() {
+        assert!(parse_frame_event(&json!({ "data": 42 })).is_none());
+        assert!(parse_frame_event(&json!("not an object")).is_none());
+        assert!(parse_frame_event(&json!({})).is_none());
+    }
+}

--- a/packages/browseros-agent/crates/browseros-core/src/screencast.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/screencast.rs
@@ -72,11 +72,12 @@ pub async fn ack_frame(session: &ProtocolSession, frame_session_id: i64) -> Resu
     Ok(())
 }
 
-/// Parse `Page.screencastFrame` event params. The `session_id` inside is the
-/// ack cookie (integer), unrelated to the envelope target session id (string).
+/// Parse `Page.screencastFrame` event params, consuming them so the frame
+/// data string is moved, not copied. The `session_id` inside is the ack
+/// cookie (integer), unrelated to the envelope target session id (string).
 #[must_use]
-pub fn parse_frame_event(params: &Value) -> Option<ScreencastFrameEvent> {
-    serde_json::from_value(params.clone()).ok()
+pub fn parse_frame_event(params: Value) -> Option<ScreencastFrameEvent> {
+    serde_json::from_value(params).ok()
 }
 
 #[cfg(test)]
@@ -124,7 +125,7 @@ mod tests {
             },
             "sessionId": 7
         });
-        let event = parse_frame_event(&params);
+        let event = parse_frame_event(params.clone());
         let Some(event) = event else {
             panic!("expected frame event to parse: {params}");
         };
@@ -136,8 +137,8 @@ mod tests {
 
     #[test]
     fn frame_event_parse_rejects_garbage() {
-        assert!(parse_frame_event(&json!({ "data": 42 })).is_none());
-        assert!(parse_frame_event(&json!("not an object")).is_none());
-        assert!(parse_frame_event(&json!({})).is_none());
+        assert!(parse_frame_event(json!({ "data": 42 })).is_none());
+        assert!(parse_frame_event(json!("not an object")).is_none());
+        assert!(parse_frame_event(json!({})).is_none());
     }
 }

--- a/packages/browseros-agent/crates/browseros-core/src/session.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/session.rs
@@ -15,7 +15,7 @@ use crate::{
 use browseros_cdp::CdpEvent;
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, broadcast, mpsc};
 
 #[derive(Clone, Default)]
 pub struct BrowserSessionHooks {
@@ -166,6 +166,12 @@ impl BrowserSession {
     #[must_use]
     pub fn cdp_events(&self) -> broadcast::Receiver<CdpEvent> {
         self.connection.events()
+    }
+
+    /// See [`crate::connection::CdpConnection::events_targeted`].
+    #[must_use]
+    pub fn cdp_events_targeted(&self, method: &str) -> mpsc::UnboundedReceiver<CdpEvent> {
+        self.connection.events_targeted(method)
     }
 
     #[must_use]


### PR DESCRIPTION
## Summary
- Replaces the 1.5s `Page.captureScreenshot` polling internals of `ScreencastService` with a push pipeline: each BrowserOS window's active agent tab gets a `Page.startScreencast` (jpeg / q60 / 1280x800 / everyNthFrame 1); frames land in the same LRU cache (cap 50) and `GET /tabs/activity` stays byte-identical (`screencast: {jpegBase64, capturedAt} | null`), so claw-app needs zero changes.
- Frames are routed by the envelope target session id (string) and acked immediately with the integer cookie (`Page.screencastFrameAck`) — lifting the TS server's single-active-screencast constraint; concurrent screencasts across windows are safe (proven in the mock-CDP e2e).
- The captureScreenshot poll stays as fallback for background agent tabs (CDP never composites them; `clip: None` preserved — the BrowserOS fork resizes tabs otherwise), with the existing 3-failure→5s backoff. `Page.bringToFront` is never called (it would steal cockpit focus).
- New: 15s idle governor (no `/tabs/activity` reads → stop casts + skip polls; resumes within one 1s supervisor tick) and a 5s frameless-restart that revives casts silently killed by CDP reconnects.

## Design
CDP verbs are code-generated from the curated protocol JSON (`page::StartScreencastParams`, `ScreencastFrameAckParams`, `ScreencastFrameEvent`, `ScreencastFrameMetadata`), with thin helpers in a new `browseros_core::screencast` module. In the service, a 1s supervisor tick snapshots agent pages (tab_activity), maps them to windows (`pages.list()`), resolves each relevant window's active tab via root `Browser.getActiveTab{windowId}`, and feeds a pure `plan_tick` function (unit-tested decision matrix) whose plan starts/stops casts through the existing attach path. A single pump task consumes frames and acks them; casts register before `startScreencast` so the first frame is always routable.

## Deviations from the dispatch design (as requested, noted here)
- **Frame delivery**: the pump consumes a new `CdpClient::events_targeted(method)` per-method mpsc channel instead of the shared broadcast stream. The 4096-slot broadcast ring retains each event until overwritten — sustained casting would pin hundreds of MB of frame payloads. The targeted channel frees frames on consumption, and CDP ack gating bounds depth at ~1 frame in flight per cast. `RecvError::Lagged` handling is moot on this path (mpsc, not broadcast).
- **Active-tab resolution**: root `Browser.getActiveTab{windowId}` via `BrowserSession::cdp` + `pages.get_session` (attach) only when the active tab is agent-driven — `get_active_session_for_window` would attach (Page/Runtime.enable) to the user's own tabs.
- **Idle-governor timestamp** lives in `ScreencastService` (`note_read()` called by the handler) rather than a new `AppState` field — same behavior, no state-shape change.
- **Unit tests** exercise a pure `plan_tick` decision function (start/stop/poll matrix, idle, frameless-restart) instead of tokio test-util time mocking — deterministic, no sleeps.
- Screencast eligibility follows the design letter: the window's active agent page is cast regardless of tab_activity status; status `"active"` gates only the poll fallback. Poll fallback keeps its existing quality 50; screencast uses the specced quality 60.
- Ack sends are spawned (review finding): a wedged ack cannot stall routing for other casts; CDP's ack gating preserves per-session ordering.

## Review
Adversarial subagent review, 2 rounds: round 1 → 1 Important (broadcast ring retention) + 3 Minor, all fixed in 8b01f5b65; 3 findings dropped with recorded reasons (2 resolved by the origin/main #1777 merge, 1 observation). Round 2 → clean.

## Test plan
- [x] `cargo test -p claw-server-rust -p browseros-cdp -p browseros-core` — green (59 core + 50 claw unit + 13 integration; includes 12 new plan_tick/governor unit tests, 4 core wire-shape tests, and the new e2e)
- [x] `cargo clippy --workspace --all-targets` — clean (workspace denies unwrap/expect/unsafe)
- [x] Mock-CDP e2e `tabs_activity_serves_pushed_screencast_frames_with_acks`: two windows cast concurrently; frame 2 is only released after a correct integer ack of frame 1 per target session; foreign-session frames are never stored or acked; `/tabs/activity` serves the pushed frames
- [ ] Manual: `bun run dev:claw-rust:watch` from packages/browseros-agent, open the cockpit, watch thumbnails update live; background agent tabs still show polled frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)