### PR TITLE
feat(claw-server): write runtime.json on bind for external port discovery

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/lib/runtime-file.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/runtime-file.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Atomic writer for `<CONFIG_DIR>/runtime.json`, the single-purpose
+ * record of claw-server's currently-bound base URL. External processes
+ * (the BrowserClaw Claude Desktop extension, primarily) read this file
+ * to discover the running port without probing or scanning.
+ *
+ * Contract:
+ *   - Written exactly once per successful bind, right after Bun.serve
+ *     returns. If a subsequent bind on the same port happens (rebind,
+ *     dev reload), the file is atomically overwritten with the new URL.
+ *   - Atomic on POSIX: writes to `runtime.json.tmp` then renames. A
+ *     concurrent reader either sees the previous content or the new
+ *     content, never a torn write.
+ *   - NOT deleted on shutdown. SIGKILL or a crash can't clean up
+ *     anyway, and readers are expected to health-probe the URL before
+ *     trusting it. Leaving a stale file behind is harmless.
+ *   - Failures are logged, not thrown. The runtime file is a nice-to
+ *     have; a claw-server that failed to write it still serves.
+ */
+
+import { mkdir, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { getClawServerDir } from './browserclaw-dir'
+import { logger } from './logger'
+
+const RUNTIME_FILE = 'runtime.json'
+
+export async function writeRuntimeFile(url: string): Promise<void> {
+  const dir = getClawServerDir()
+  const path = join(dir, RUNTIME_FILE)
+  const tmp = `${path}.tmp`
+  const payload = `${JSON.stringify({ url }, null, 2)}\n`
+  try {
+    await mkdir(dir, { recursive: true })
+    await writeFile(tmp, payload, { encoding: 'utf8' })
+    await rename(tmp, path)
+  } catch (err) {
+    logger.warn('runtime file write failed', {
+      path,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}

--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -26,6 +26,7 @@ import { setBrowserSession } from './lib/browser-session'
 import { getClawServerDir } from './lib/browserclaw-dir'
 import { logger } from './lib/logger'
 import { migrateMcpUrls } from './lib/migrate-mcp-urls'
+import { writeRuntimeFile } from './lib/runtime-file'
 import { setLocalServerUrl } from './local-server-url'
 import { createServer } from './server'
 import { runIntegrityScan } from './services/integrity-scan'
@@ -55,6 +56,11 @@ async function start(): Promise<void> {
   const url = `http://${httpServer.hostname}:${httpServer.port}`
   setLocalServerUrl(url)
   logger.info('claw-server listening', { url })
+  // Publish the running URL to <CONFIG_DIR>/runtime.json so external
+  // discovery (the Claude Desktop extension) can read the port without
+  // scanning, log-tailing, or waiting for a harness link to populate
+  // the mcp-manager manifest.
+  await writeRuntimeFile(url)
 
   // Self-heal loop 1: diff manifest vs. on-disk agent configs and
   // relink any drifted / missing entries from the manifest-stored

--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -60,7 +60,14 @@ async function start(): Promise<void> {
   // discovery (the Claude Desktop extension) can read the port without
   // scanning, log-tailing, or waiting for a harness link to populate
   // the mcp-manager manifest.
-  await writeRuntimeFile(url)
+  //
+  // Intentionally NOT awaited: writeRuntimeFile owns its own error
+  // handling (logs a warning on failure, never throws). Awaiting here
+  // would gate the integrity scan, browser bootstrap, and MCP URL
+  // migration on a best-effort disk write that can hang on a stalled
+  // network / FUSE / container-mounted filesystem even though the
+  // socket is already bound and serving.
+  void writeRuntimeFile(url)
 
   // Self-heal loop 1: diff manifest vs. on-disk agent configs and
   // relink any drifted / missing entries from the manifest-stored

--- a/packages/browseros-agent/apps/claw-server/tests/lib/runtime-file.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/runtime-file.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { env } from '../../src/env'
+import { writeRuntimeFile } from '../../src/lib/runtime-file'
+
+const prior = {
+  browserClawDirOverride: env.browserClawDirOverride,
+}
+
+let tmp: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'claw-runtime-'))
+  env.browserClawDirOverride = tmp
+})
+
+afterEach(() => {
+  env.browserClawDirOverride = prior.browserClawDirOverride
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('writeRuntimeFile', () => {
+  test('writes a JSON blob with the running URL', async () => {
+    await writeRuntimeFile('http://127.0.0.1:9200')
+
+    const raw = readFileSync(join(tmp, 'runtime.json'), 'utf8')
+    expect(JSON.parse(raw)).toEqual({ url: 'http://127.0.0.1:9200' })
+  })
+
+  test('overwrites an existing runtime file with the new URL', async () => {
+    writeFileSync(
+      join(tmp, 'runtime.json'),
+      JSON.stringify({ url: 'http://127.0.0.1:9500' }),
+      'utf8',
+    )
+
+    await writeRuntimeFile('http://127.0.0.1:9600')
+
+    const raw = readFileSync(join(tmp, 'runtime.json'), 'utf8')
+    expect(JSON.parse(raw)).toEqual({ url: 'http://127.0.0.1:9600' })
+  })
+
+  test('creates the state directory if it does not exist', async () => {
+    // Point the override at a not-yet-created subdir.
+    env.browserClawDirOverride = join(tmp, 'nested', 'state')
+
+    await writeRuntimeFile('http://127.0.0.1:9700')
+
+    const raw = readFileSync(
+      join(tmp, 'nested', 'state', 'runtime.json'),
+      'utf8',
+    )
+    expect(JSON.parse(raw)).toEqual({ url: 'http://127.0.0.1:9700' })
+  })
+
+  test('does not leave the .tmp sidecar around after a successful write', async () => {
+    await writeRuntimeFile('http://127.0.0.1:9200')
+
+    // After atomic rename, only runtime.json survives.
+    expect(() => readFileSync(join(tmp, 'runtime.json'), 'utf8')).not.toThrow()
+    expect(() => readFileSync(join(tmp, 'runtime.json.tmp'), 'utf8')).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

Adds `~/.browserclaw/runtime.json` (or `~/.browserclaw-dev/runtime.json` in dev) as a single-purpose record of claw-server's currently-bound base URL. Written atomically immediately after `Bun.serve()` returns.

## Motivation

External processes need to discover the running port without probing arbitrary port ranges. The `BrowserClaw Claude Desktop extension` is the immediate consumer: it currently prefers `~/.browserclaw/mcp-manager/manifest.json`, but that file only exists after the user has clicked \"Connect\" for at least one harness. On a fresh install where no harness has been linked yet, discovery falls back to tailing `claw-server.log` (JSON per line, pino-shaped).

The runtime file gives the extension a small, structured, always-present source of truth after any successful bind:

- Exists after any successful bind, not only after a harness link.
- Small structured JSON blob, not pino-shaped text.
- Atomically written (write-tmp-then-rename); readers cannot see a torn write.
- Left in place on shutdown; readers health-probe the URL before trusting it, so a stale file after a crash is harmless.

## Shape

Deliberately minimal so future extensions cannot break readers:

```json
{
  \"url\": \"http://127.0.0.1:9200\"
}
```

## What changed

- **New**: `packages/browseros-agent/apps/claw-server/src/lib/runtime-file.ts` - `writeRuntimeFile(url)`. Uses the existing `getClawServerDir()` helper for path consistency with the log file. `mkdir -p` the dir, `writeFile` a `.tmp`, `rename` into place. Failures are logged as a warning; do not throw.
- **Modified**: `packages/browseros-agent/apps/claw-server/src/main.ts` - one new import + one new line after `logger.info('claw-server listening', { url })` calling `await writeRuntimeFile(url)`.
- **New tests**: `packages/browseros-agent/apps/claw-server/tests/lib/runtime-file.test.ts` - 4 cases covering the happy path, overwrite of an existing runtime file, missing-parent-dir creation, and absence of the `.tmp` sidecar after the atomic rename completes.

## Test plan

- [x] `bun test tests/lib/runtime-file.test.ts` in claw-server: 4/4 pass.
- [x] `bun test` in claw-server: 387/387 pass (up from 383; the 4 additions are all-new coverage, no regressions).
- [x] `bun run --filter '@browseros/claw-server' typecheck`: clean.
- [x] `bun run build:claw-server:test`: `browseros-claw-server-darwin-arm64` staged successfully.
- [ ] Sideload the built binary on a real BrowserOS install; confirm `~/.browserclaw/runtime.json` appears after launch and its `.url` matches the actual bound port.