### PR TITLE
fix(claw-onboard): let users skip the onboarding import step

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.tsx
@@ -141,7 +141,12 @@ export function OnboardingV2() {
             onContinue={() => setStep(2)}
           />
         )}
-        {step === 2 && <ReadyStep onDone={finishOnboarding} />}
+        {step === 2 && (
+          <ReadyStep
+            imported={importPhase === 'imported'}
+            onDone={finishOnboarding}
+          />
+        )}
       </OnboardingShell>
     </Form>
   )

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
@@ -14,9 +14,20 @@ import {
   type OnboardingFormValues,
   onboardingFormDefaults,
   onboardingFormResolver,
+  onboardingFormSchema,
 } from '../onboarding-v2.schemas'
 import type { ImportPhase } from '../onboarding-v2.types'
 import { ImportStep } from './ImportStep'
+
+// Take the message from the resolver rather than restating it, so these tests
+// track the production copy instead of a string they hardcoded themselves.
+const unpickedResult = onboardingFormSchema.safeParse({
+  selectedSourceId: '',
+  selectedItems: [],
+})
+const PICK_PROFILE_MESSAGE = unpickedResult.success
+  ? ''
+  : (unpickedResult.error.issues[0]?.message ?? '')
 
 function readyState(
   overrides: Partial<BrowserOSOnboardingState> = {},
@@ -51,7 +62,7 @@ function Harness({
   if (unpicked) {
     form.setError('selectedSourceId', {
       type: 'required',
-      message: 'Pick a profile.',
+      message: PICK_PROFILE_MESSAGE,
     })
   }
   return (
@@ -387,7 +398,8 @@ describe('ImportStep', () => {
   it('still asks for a pick when profiles are there to pick from', () => {
     const html = render('picker', readyState(), {}, true)
 
+    expect(PICK_PROFILE_MESSAGE).not.toBe('')
     expect(html).toContain('data-slot="form-message"')
-    expect(html).toContain('Pick a profile.')
+    expect(html).toContain(PICK_PROFILE_MESSAGE)
   })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
@@ -77,6 +77,25 @@ function checklistRowFor(html: string, label: string): string {
   return html.slice(rowStart, rowEnd + '</label>'.length)
 }
 
+// The empty picker renders a disabled import CTA next to an enabled skip, so
+// `disabled` assertions have to be scoped to one button's own markup. Labels can
+// also appear outside buttons ("Pick a profile" is a prefix of the "Pick a
+// profile to import" heading), so skip matches that aren't inside a button.
+function buttonMarkupFor(html: string, label: string): string {
+  for (
+    let labelIndex = html.indexOf(label);
+    labelIndex !== -1;
+    labelIndex = html.indexOf(label, labelIndex + 1)
+  ) {
+    const buttonStart = html.lastIndexOf('<button', labelIndex)
+    const buttonEnd = html.indexOf('</button>', labelIndex)
+    if (buttonStart === -1 || buttonEnd === -1) continue
+    if (html.indexOf('</button>', buttonStart) !== buttonEnd) continue
+    return html.slice(buttonStart, buttonEnd + '</button>'.length)
+  }
+  return ''
+}
+
 describe('ImportStep', () => {
   it('renders the picker, the Keychain notice, and an Import button in picker phase', () => {
     const html = render('picker')
@@ -277,5 +296,54 @@ describe('ImportStep', () => {
     expect(html).toContain('Imported 0 items from Work')
     expect(html).toContain('No completed items reported')
     expect(html).not.toContain('History, Bookmarks')
+  })
+
+  it('leaves an enabled way forward when no profiles are found', () => {
+    const html = render('picker', readyState({ sources: [] }))
+    const skip = buttonMarkupFor(html, 'Skip for now')
+
+    expect(html).toContain('No profiles found.')
+    expect(buttonMarkupFor(html, 'Pick a profile')).toContain('disabled=""')
+    expect(skip).toContain('Skip for now')
+    expect(skip).not.toContain('disabled=""')
+  })
+
+  it('keeps the skip available when profiles are present', () => {
+    const skip = buttonMarkupFor(render('picker'), 'Skip for now')
+
+    expect(skip).toContain('Skip for now')
+    expect(skip).not.toContain('disabled=""')
+  })
+
+  it('keeps the skip enabled while profiles are still being detected', () => {
+    const html = render('picker', readyState({ status: 'detecting' }))
+    const skip = buttonMarkupFor(html, 'Skip for now')
+
+    expect(html).toContain('Looking for profiles')
+    expect(skip).toContain('Skip for now')
+    expect(skip).not.toContain('disabled=""')
+  })
+
+  it('offers a skip out of a failed import', () => {
+    const html = render('failed', readyState({ status: 'failed', sources: [] }))
+    const skip = buttonMarkupFor(html, 'Skip for now')
+
+    expect(html).toContain('Try again')
+    expect(html).toContain('Refresh profiles')
+    expect(skip).toContain('Skip for now')
+    expect(skip).not.toContain('disabled=""')
+  })
+
+  it('does not offer a skip while an import is running', () => {
+    const html = render('importing', readyState({ status: 'importing' }))
+
+    expect(html).not.toContain('Skip for now')
+  })
+
+  it('does not offer a skip once the import has succeeded', () => {
+    const html = render('imported', readyState({ status: 'succeeded' }))
+
+    expect(html).toContain('Continue')
+    expect(html).not.toContain('Skip for now')
   })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
@@ -33,15 +33,27 @@ function Harness({
   phase,
   state = readyState(),
   formValues = {},
+  unpicked = false,
 }: {
   phase: ImportPhase
   state?: BrowserOSOnboardingState
   formValues?: Partial<OnboardingFormValues>
+  unpicked?: boolean
 }) {
   const form = useForm<OnboardingFormValues>({
     resolver: onboardingFormResolver,
     defaultValues: { ...onboardingFormDefaults, ...formValues },
   })
+  // Reproduces the error OnboardingV2 sets on itself: its sources effect calls
+  // setValue('selectedSourceId', '', { shouldValidate: true }), and the resolver
+  // rejects the empty id. Seeding it here is the only way to get a form error
+  // into a server render — nothing else validates (no events, no effects).
+  if (unpicked) {
+    form.setError('selectedSourceId', {
+      type: 'required',
+      message: 'Pick a profile.',
+    })
+  }
   return (
     <Form {...form}>
       <ImportStep
@@ -60,10 +72,16 @@ function render(
   phase: ImportPhase,
   state: BrowserOSOnboardingState = readyState(),
   formValues: Partial<OnboardingFormValues> = {},
+  unpicked = false,
 ): string {
   return renderToStaticMarkup(
     <MemoryRouter>
-      <Harness phase={phase} state={state} formValues={formValues} />
+      <Harness
+        phase={phase}
+        state={state}
+        formValues={formValues}
+        unpicked={unpicked}
+      />
     </MemoryRouter>,
   )
 }
@@ -345,5 +363,31 @@ describe('ImportStep', () => {
 
     expect(html).toContain('Continue')
     expect(html).not.toContain('Skip for now')
+  })
+
+  it('does not blame the user when there is no profile to pick', () => {
+    const html = render('picker', readyState({ sources: [] }), {}, true)
+
+    expect(html).toContain('No profiles found.')
+    expect(html).not.toContain('data-slot="form-message"')
+  })
+
+  it('does not blame the user while profiles are still being detected', () => {
+    const html = render(
+      'picker',
+      readyState({ status: 'detecting', sources: [] }),
+      {},
+      true,
+    )
+
+    expect(html).toContain('Looking for profiles')
+    expect(html).not.toContain('data-slot="form-message"')
+  })
+
+  it('still asks for a pick when profiles are there to pick from', () => {
+    const html = render('picker', readyState(), {}, true)
+
+    expect(html).toContain('data-slot="form-message"')
+    expect(html).toContain('Pick a profile.')
   })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
@@ -69,6 +69,7 @@ export function ImportStep({
     selectedSource?.browserName ||
     'source'
   const isDetecting = state.status === 'detecting'
+  const hasNoProfiles = !isDetecting && state.sources.length === 0
   const hasSupportedItems = (selectedSource?.supportedItems.length ?? 0) > 0
   const isPickerValid =
     Boolean(selectedSource) &&
@@ -169,12 +170,15 @@ export function ImportStep({
                     }}
                   />
                 ))}
-                {!isDetecting && state.sources.length === 0 && (
+                {hasNoProfiles && (
                   <div className="rounded-xl border border-border-2 bg-card p-4 text-[12.5px] text-ink-2">
                     No profiles found.
                   </div>
                 )}
-                <FormMessage />
+                {/* With nothing to pick and a skip on offer, "Pick a profile."
+                    is noise the user did not cause: OnboardingV2 clears
+                    selectedSourceId with shouldValidate when sources is empty. */}
+                {!hasNoProfiles && <FormMessage />}
               </FormItem>
             )}
           />
@@ -191,15 +195,25 @@ export function ImportStep({
             </div>
           )}
           <MacKeychainNotice />
-          <Button
-            type="button"
-            size="lg"
-            onClick={onImport}
-            disabled={!isPickerValid}
-          >
-            <Download className="size-4" />
-            {importButtonLabel}
-          </Button>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              size="lg"
+              onClick={onImport}
+              disabled={!isPickerValid}
+            >
+              <Download className="size-4" />
+              {importButtonLabel}
+            </Button>
+            <Button
+              type="button"
+              size="lg"
+              variant="ghost"
+              onClick={onContinue}
+            >
+              Skip for now
+            </Button>
+          </div>
         </>
       )}
 
@@ -237,6 +251,14 @@ export function ImportStep({
             <Button type="button" size="lg" variant="ghost" onClick={onRefresh}>
               <RefreshCw className="size-4" />
               Refresh profiles
+            </Button>
+            <Button
+              type="button"
+              size="lg"
+              variant="ghost"
+              onClick={onContinue}
+            >
+              Skip for now
             </Button>
           </div>
         </>

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
@@ -175,10 +175,11 @@ export function ImportStep({
                     No profiles found.
                   </div>
                 )}
-                {/* With nothing to pick and a skip on offer, "Pick a profile."
-                    is noise the user did not cause: OnboardingV2 clears
-                    selectedSourceId with shouldValidate when sources is empty. */}
-                {!hasNoProfiles && <FormMessage />}
+                {/* Only ask for a pick when there is one to make. With no
+                    sources the error is self-inflicted and unactionable:
+                    OnboardingV2 clears selectedSourceId with shouldValidate
+                    whenever the list is empty, including while detecting. */}
+                {state.sources.length > 0 && <FormMessage />}
               </FormItem>
             )}
           />

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.test.tsx
@@ -4,28 +4,55 @@ import { MemoryRouter } from 'react-router'
 import { STARTER_PROMPTS } from '../onboarding-v2.helpers'
 import { ReadyStep } from './ReadyStep'
 
-function render(): string {
+function render(imported = true): string {
   return renderToStaticMarkup(
     <MemoryRouter>
-      <ReadyStep onDone={() => undefined} />
+      <ReadyStep imported={imported} onDone={() => undefined} />
     </MemoryRouter>,
   )
+}
+
+// The "Connect your AI" CTA would satisfy a whole-document match for either
+// heading variant, so heading assertions have to be scoped to the <h1>.
+function headingOf(html: string): string {
+  const start = html.indexOf('<h1')
+  const end = html.indexOf('</h1>')
+  if (start === -1 || end === -1) return ''
+  return html.slice(start, end + '</h1>'.length)
 }
 
 describe('ReadyStep', () => {
   it('confirms imported logins before pointing to MCP setup', () => {
     const html = render()
 
-    expect(html).toContain('Logins')
-    expect(html).toContain('imported')
+    expect(headingOf(html)).toContain('Logins')
+    expect(headingOf(html)).toContain('imported')
     expect(html).toContain('One step left.')
     expect(html).toContain('Open the MCP page in BrowserClaw')
     expect(html).toContain('Claude Code, Cursor, Codex')
     expect(html).toContain('You watch, approve, and audit.')
   })
 
+  it('does not claim an import happened when the step was skipped', () => {
+    const heading = headingOf(render(false))
+
+    expect(heading).toContain('Connect your')
+    expect(heading).toContain('AI.')
+    expect(heading).not.toContain('Logins')
+    expect(heading).not.toContain('imported')
+  })
+
   it('renders the MCP setup CTA', () => {
     expect(render()).toContain('Connect your AI')
+    expect(render(false)).toContain('Connect your AI')
+  })
+
+  it('keeps the MCP copy identical whether or not the import ran', () => {
+    const html = render(false)
+
+    expect(html).toContain('One step left.')
+    expect(html).toContain('Open the MCP page in BrowserClaw')
+    expect(html).toContain('You watch, approve, and audit.')
   })
 
   it('frames starter prompts as post-connection examples', () => {

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.tsx
@@ -6,20 +6,29 @@ import { StepWrap } from '../components/StepWrap'
 import { STARTER_PROMPTS } from '../onboarding-v2.helpers'
 
 interface ReadyStepProps {
+  imported: boolean
   onDone: () => void
 }
 
 /**
- * Final onboarding step. Confirms the import landed and points at
- * the MCP page for harness link-up. Reached only after a successful
- * import; the reconnect path from Welcome bypasses this step and
- * completes onboarding directly.
+ * Final onboarding step. Points at the MCP page for harness link-up, and
+ * confirms the import only when one actually landed — users who skipped the
+ * import step reach this step too. The reconnect path from Welcome bypasses
+ * this step and completes onboarding directly.
  */
-export function ReadyStep({ onDone }: ReadyStepProps) {
+export function ReadyStep({ imported, onDone }: ReadyStepProps) {
   return (
     <StepWrap>
       <DisplayHeading>
-        Logins <Em>imported.</Em>
+        {imported ? (
+          <>
+            Logins <Em>imported.</Em>
+          </>
+        ) : (
+          <>
+            Connect your <Em>AI.</Em>
+          </>
+        )}
       </DisplayHeading>
       <StepCopy>
         One step left. Open the MCP page in BrowserClaw and link your AI: Claude


### PR DESCRIPTION
## Summary

Fixes the dead end from the Discord thread: a user with no Chrome installed reached the Import step (2 of 3), saw **"No profiles found."**, a red **"Pick a profile."** error, and a **disabled** primary CTA — with no way forward and no way back.

- **Always-enabled ghost "Skip for now"** in the Import step's `picker` and `failed` phases, wired to the existing `onContinue` transition. Enabled with zero sources, with nothing selected, and while detection is still running. Import stays the visually primary action.
- **No skip in `importing`** (it would abandon a running import) or in `imported` (already has Continue).
- **Stop painting the red "Pick a profile." error when there is no profile to pick.** It was self-inflicted, not a user mistake: `OnboardingV2`'s sources effect calls `setValue('selectedSourceId', '', { shouldValidate: true })` whenever the list is empty, so the form validated itself into an error with zero user interaction.
- **`ReadyStep` stops claiming "Logins imported."** after a skip. It takes a required `imported: boolean`; `false` renders "Connect your AI." instead. Body copy is unchanged.

`failed` mattered as much as `picker`: its "Try again" is also `disabled={!isPickerValid}`, so a zero-source or repeatedly-failing user was trapped there too.

## Design

Skip reuses the existing `onContinue` prop (`() => setStep(2)`) rather than adding an `onSkip` prop, a bridge event, or new state — "skip" and "continue" are the *same* transition (advance to Ready without importing anything more). Skip deliberately routes **through** Ready rather than calling `finishOnboarding()`, because Ready carries the "Connect your AI" MCP pointer that every user needs, importer or not. `imported` is derived from existing state (`importPhase === 'imported'`) and is a **required** prop, so no call site can silently keep the old claim.

## Test plan

- [x] `bun run check` — green (lint + typecheck + fallow)
- [x] `bun run test` — green; claw-onboard **73 pass / 0 fail**
- [x] Skip renders **enabled** in `picker` with zero sources while the import CTA is disabled — i.e. an escape provably exists on the exact screen from the report
- [x] Skip renders in `picker` with sources, in `picker` while detecting, and in `failed`
- [x] No skip in `importing` or `imported`
- [x] The "Pick a profile." message is suppressed with zero sources **and** while detecting, and still shown when sources exist
- [x] `ReadyStep` renders both heading variants by the `imported` prop
- [x] Every new test mutation-checked (revert the behavior → the test goes red), so none pass vacuously

## Notes for review

- **Copy call for you, @nsonti1:** on the skip path the `<h1>` reads "Connect your **AI.**" while the primary CTA is the verbatim "Connect your AI" — the heading echoes the button instead of saying something of its own. This is the copy that was specified, so I implemented it as-is; if you'd rather it carried its own information ("You're **set up.**", "Ready to **connect.**"), it's a one-line change in `ReadyStep.tsx`.
- **Known trade-offs, both consequences of "no new state"** (accepted, not accidents): (1) between clicking Import and Chromium echoing `importing`, the phase is still `picker`, so the skip is briefly clickable — the import isn't cancelled, it completes in the background and Ready is where the user was headed anyway; (2) `imported` is derived from live state, so on the imported path `complete()` can flip the heading for a frame on the already-unmounting page.
- **Residual, out of scope:** `importing` has no controls by design. If the Chromium importer never reports a terminal status (e.g. it hangs on the Keychain prompt), the user is stuck there with no affordance. A watchdog that pushes a hung import to `failed` would close the last hole.
- **No click-level tests**, because the monorepo has no DOM test harness at all — every React test is `renderToStaticMarkup`, which strips event handlers, and `useEffect` never runs under SSR. Adding `happy-dom`/testing-library would mean a `preload` in the **root** `bunfig.toml`, injecting `window` into every server and CLI test in the repo. Not worth it for one ghost button; the tests instead pin exactly what static markup can prove — that an *enabled* way forward renders in each stuck state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)