### PR TITLE
fix: default browser tests to headless

### DIFF
--- a/packages/browseros-agent/.env.development.example
+++ b/packages/browseros-agent/.env.development.example
@@ -86,4 +86,4 @@ LOG_LEVEL=info
 # BROWSEROS_AI_SDK_DEVTOOLS=true
 
 # Headless browser setting for local server tests.
-BROWSEROS_TEST_HEADLESS=false
+BROWSEROS_TEST_HEADLESS=true

--- a/packages/browseros-agent/apps/server/tests/__helpers__/test-runtime.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/test-runtime.ts
@@ -144,10 +144,11 @@ export async function resolveRuntimePorts(): Promise<{
   }
 }
 
+/** Resolves test environment settings into an explicit browser launch plan. */
 export async function createTestRuntimePlan(): Promise<TestRuntimePlan> {
   const resolvedPorts = await resolveRuntimePorts()
   const userDataDir = mkdtempSync(join(tmpdir(), 'browseros-test-'))
-  const headless = process.env.BROWSEROS_TEST_HEADLESS === 'true'
+  const headless = process.env.BROWSEROS_TEST_HEADLESS !== 'false'
   const extraArgs = parseExtraArgs(process.env.BROWSEROS_TEST_EXTRA_ARGS)
 
   return {

--- a/packages/browseros-agent/apps/server/tests/browser-launch-args.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browser-launch-args.test.ts
@@ -26,67 +26,80 @@ async function waitForFile(path: string): Promise<void> {
   throw new Error(`timed out waiting for ${path}`)
 }
 
+/** Runs the real spawn path and returns argv captured by a fake browser binary. */
+async function captureBrowserArgs(headless: boolean): Promise<string[]> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'browseros-launch-args-'))
+  const argsPath = join(tempDir, 'args.txt')
+  const binaryPath = join(tempDir, 'browseros-fake')
+  await Bun.write(
+    binaryPath,
+    [
+      '#!/bin/sh',
+      'args_file="$BROWSEROS_TEST_ARGS_FILE.tmp"',
+      ': > "$args_file"',
+      'for arg in "$@"; do',
+      '  printf "%s\\n" "$arg" >> "$args_file"',
+      'done',
+      'mv "$args_file" "$BROWSEROS_TEST_ARGS_FILE"',
+      'sleep 60',
+    ].join('\n'),
+  )
+  chmodSync(binaryPath, 0o755)
+
+  const cdpServer = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' })
+    response.end('{"Browser":"BrowserOS"}')
+  })
+  await new Promise<void>((resolve) => cdpServer.listen(0, resolve))
+  const address = cdpServer.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('failed to allocate CDP test port')
+  }
+
+  const originalArgsFile = process.env.BROWSEROS_TEST_ARGS_FILE
+  process.env.BROWSEROS_TEST_ARGS_FILE = argsPath
+  try {
+    await spawnBrowser({
+      cdpPort: address.port,
+      serverPort: address.port + 1,
+      extensionPort: address.port + 2,
+      binaryPath,
+      userDataDir: mkdtempSync(join(tmpdir(), 'browseros-test-')),
+      headless,
+      extraArgs: [],
+    })
+
+    await waitForFile(argsPath)
+    return readFileSync(argsPath, 'utf8').split('\n')
+  } finally {
+    if (originalArgsFile === undefined) {
+      delete process.env.BROWSEROS_TEST_ARGS_FILE
+    } else {
+      process.env.BROWSEROS_TEST_ARGS_FILE = originalArgsFile
+    }
+    await killBrowser()
+    await new Promise<void>((resolve, reject) => {
+      cdpServer.close((error) => (error ? reject(error) : resolve()))
+    })
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
 describe('spawnBrowser', () => {
   afterEach(async () => {
     await killBrowser()
   })
 
-  it('uses the dev dock icon for server test browsers', async () => {
-    const tempDir = mkdtempSync(join(tmpdir(), 'browseros-launch-args-'))
-    const argsPath = join(tempDir, 'args.txt')
-    const binaryPath = join(tempDir, 'browseros-fake')
-    await Bun.write(
-      binaryPath,
-      [
-        '#!/bin/sh',
-        'args_file="$BROWSEROS_TEST_ARGS_FILE.tmp"',
-        ': > "$args_file"',
-        'for arg in "$@"; do',
-        '  printf "%s\\n" "$arg" >> "$args_file"',
-        'done',
-        'mv "$args_file" "$BROWSEROS_TEST_ARGS_FILE"',
-        'sleep 60',
-      ].join('\n'),
-    )
-    chmodSync(binaryPath, 0o755)
+  it('uses the dev dock icon without a headless flag in headed mode', async () => {
+    const args = await captureBrowserArgs(false)
 
-    const cdpServer = createServer((_request, response) => {
-      response.writeHead(200, { 'content-type': 'application/json' })
-      response.end('{"Browser":"BrowserOS"}')
-    })
-    await new Promise<void>((resolve) => cdpServer.listen(0, resolve))
-    const address = cdpServer.address()
-    if (!address || typeof address === 'string') {
-      throw new Error('failed to allocate CDP test port')
-    }
+    expect(args).toContain('--browseros-dock-icon=dev')
+    expect(args).not.toContain('--headless=new')
+  })
 
-    const originalArgsFile = process.env.BROWSEROS_TEST_ARGS_FILE
-    process.env.BROWSEROS_TEST_ARGS_FILE = argsPath
-    try {
-      await spawnBrowser({
-        cdpPort: address.port,
-        serverPort: address.port + 1,
-        extensionPort: address.port + 2,
-        binaryPath,
-        userDataDir: mkdtempSync(join(tmpdir(), 'browseros-test-')),
-        headless: false,
-        extraArgs: [],
-      })
+  it('adds the Chromium headless flag in headless mode', async () => {
+    const args = await captureBrowserArgs(true)
 
-      await waitForFile(argsPath)
-      const args = readFileSync(argsPath, 'utf8').split('\n')
-      expect(args).toContain('--browseros-dock-icon=dev')
-    } finally {
-      if (originalArgsFile === undefined) {
-        delete process.env.BROWSEROS_TEST_ARGS_FILE
-      } else {
-        process.env.BROWSEROS_TEST_ARGS_FILE = originalArgsFile
-      }
-      await killBrowser()
-      await new Promise<void>((resolve, reject) => {
-        cdpServer.close((error) => (error ? reject(error) : resolve()))
-      })
-      rmSync(tempDir, { recursive: true, force: true })
-    }
+    expect(args).toContain('--headless=new')
   })
 })

--- a/packages/browseros-agent/apps/server/tests/test-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/test-runtime.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { rmSync } from 'node:fs'
+import {
+  createTestRuntimePlan,
+  type TestRuntimePlan,
+} from './__helpers__/test-runtime'
+
+const originalHeadless = process.env.BROWSEROS_TEST_HEADLESS
+const runtimePlans: TestRuntimePlan[] = []
+
+afterEach(() => {
+  if (originalHeadless === undefined) {
+    delete process.env.BROWSEROS_TEST_HEADLESS
+  } else {
+    process.env.BROWSEROS_TEST_HEADLESS = originalHeadless
+  }
+
+  for (const plan of runtimePlans) {
+    rmSync(plan.userDataDir, { recursive: true, force: true })
+  }
+  runtimePlans.length = 0
+})
+
+async function resolveHeadless(value: string | undefined): Promise<boolean> {
+  if (value === undefined) {
+    delete process.env.BROWSEROS_TEST_HEADLESS
+  } else {
+    process.env.BROWSEROS_TEST_HEADLESS = value
+  }
+
+  const plan = await createTestRuntimePlan()
+  runtimePlans.push(plan)
+  return plan.headless
+}
+
+describe('createTestRuntimePlan headless mode', () => {
+  it('defaults to headless when the flag is absent', async () => {
+    expect(await resolveHeadless(undefined)).toBe(true)
+  })
+
+  it('uses headless mode when the flag is true', async () => {
+    expect(await resolveHeadless('true')).toBe(true)
+  })
+
+  it('uses headed mode when the flag is false', async () => {
+    expect(await resolveHeadless('false')).toBe(false)
+  })
+})

--- a/packages/browseros-agent/packages/shared/src/env/registry.ts
+++ b/packages/browseros-agent/packages/shared/src/env/registry.ts
@@ -271,7 +271,7 @@ export const ENV_REGISTRY: readonly EnvKeySpec[] = [
     description: 'Headless browser setting for local server tests.',
     secret: false,
     schema: stringSchema,
-    modes: { development: { value: 'false' } },
+    modes: { development: { value: 'true' } },
   },
   {
     key: 'AGENT_RUNNER_JWT_SECRET',


### PR DESCRIPTION
## Summary
- default BrowserOS browser-backed tests to headless when `BROWSEROS_TEST_HEADLESS` is unset
- preserve explicit `false` as headed mode and cover both real launch argument paths
- align the shared env registry and generated development example with the headless default

## Design
The existing test runtime remains the single policy boundary: it resolves all values except exact `false` to headless, then both browser-backed test paths pass that explicit boolean into the unchanged generic browser spawn helper.

## Test plan
- [x] `bun test ./apps/server/tests/test-runtime.test.ts ./apps/server/tests/browser-launch-args.test.ts`
- [x] `env -u BROWSEROS_TEST_HEADLESS bun run --filter @browseros/server test:root`
- [x] `bun run env:examples:check`
- [x] `bun run check`
- [x] `env -u BROWSEROS_TEST_HEADLESS bun run test`
- [x] explicit shell `true` and `false` override opposite `--env-file` values
- [x] context-free adversarial review: clean
