### PR TITLE
fix(claw-server): source version from package manifest

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/routes/system.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/system.ts
@@ -5,10 +5,9 @@
  */
 
 import { Hono } from 'hono'
-// Package version is read off the bundled package.json. resolveJsonModule
-// + bun's loader resolve this without a build step.
 import pkg from '../../package.json' with { type: 'json' }
 import { getLocalServerUrl } from '../local-server-url'
+import { VERSION } from '../version'
 
 interface SystemRouteConfig {
   onShutdown?: () => void
@@ -21,8 +20,6 @@ export function createSystemRoute(config: SystemRouteConfig = {}) {
       setImmediate(() => config.onShutdown?.())
       return c.json({ status: 'ok' as const })
     })
-    .get('/system/version', (c) =>
-      c.json({ name: pkg.name, version: pkg.version }),
-    )
+    .get('/system/version', (c) => c.json({ name: pkg.name, version: VERSION }))
     .get('/system/url', (c) => c.json({ url: getLocalServerUrl() }))
 }

--- a/packages/browseros-agent/apps/claw-server/src/version.ts
+++ b/packages/browseros-agent/apps/claw-server/src/version.ts
@@ -1,6 +1,8 @@
+import pkg from '../package.json' with { type: 'json' }
+
 declare const __BROWSEROS_VERSION__: string
 
 export const VERSION: string =
   typeof __BROWSEROS_VERSION__ !== 'undefined'
     ? __BROWSEROS_VERSION__
-    : '0.0.0-dev'
+    : pkg.version

--- a/packages/browseros-agent/apps/claw-server/tests/routes/system.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/routes/system.test.ts
@@ -5,7 +5,9 @@
  */
 
 import { describe, expect, mock, test } from 'bun:test'
+import pkg from '../../package.json' with { type: 'json' }
 import app, { createServer } from '../../src/server'
+import { VERSION } from '../../src/version'
 
 describe('system routes', () => {
   test('default server exposes system health', async () => {
@@ -13,6 +15,17 @@ describe('system routes', () => {
 
     expect(res.status).toBe(200)
     await expect(res.json()).resolves.toEqual({ status: 'ok' })
+  })
+
+  test('system version uses the shared package version', async () => {
+    const res = await app.fetch(new Request('http://localhost/system/version'))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      name: pkg.name,
+      version: VERSION,
+    })
+    expect(VERSION).toBe(pkg.version)
   })
 
   test('system shutdown responds before invoking the shutdown hook', async () => {

--- a/packages/browseros-agent/apps/claw-server/tests/version.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/version.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test'
+import { resolve } from 'node:path'
+import pkg from '../package.json' with { type: 'json' }
+import { VERSION } from '../src/version'
+
+describe('Claw server version', () => {
+  test('uses the package manifest during direct source execution', () => {
+    expect(VERSION).toBe(pkg.version)
+  })
+
+  test('prints the package manifest version from the TypeScript entrypoint', async () => {
+    const child = Bun.spawn(
+      ['bun', resolve(import.meta.dir, '../src/main.ts'), '--version'],
+      {
+        cwd: resolve(import.meta.dir, '..'),
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ])
+
+    expect(exitCode, stderr).toBe(0)
+    expect(stdout.trim()).toBe(pkg.version)
+  })
+})


### PR DESCRIPTION
## Summary
- use the Claw package manifest as the direct Bun/TypeScript fallback for `VERSION`
- preserve the injected `__BROWSEROS_VERSION__` override for compiled releases
- route Commander, MCP metadata, and `/system/version` through the shared version value

## Design
`src/version.ts` remains the single resolution boundary: compiled builds prefer the version injected by the build configuration, while direct source execution imports `package.json.version`. The system route retains its manifest-backed package name and now consumes the same `VERSION` export as the CLI and MCP server.

## Test plan
- [x] `bun test apps/claw-server/tests/version.test.ts apps/claw-server/tests/routes/system.test.ts`
- [x] `bun test apps/claw-server/tests/build.test.ts`
- [x] `bun run --filter @browseros/claw-server typecheck`
- [x] `bun run --filter @browseros/claw-server lint`
- [x] `bun run --filter @browseros/claw-server test`
- [x] `bun run check`
- [x] `bun run test`
