### PR TITLE
fix: make MCP structured content opt-in

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/mcp/dispatch.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/dispatch.ts
@@ -218,7 +218,7 @@ async function dispatchToolCall(
   effects: readonly NamedToolEffect[],
 ): Promise<ToolResult> {
   const rejection = runGuards(call)
-  if (rejection) return rejection
+  if (rejection) return wireResult(rejection)
   const connectedCall = call as ConnectedToolCall
 
   if (ARBITRARY_SCRIPT_TOOLS.has(call.tool.name)) {
@@ -238,10 +238,13 @@ async function dispatchToolCall(
     })
   }
   const result = runEffects({ call, ...outcome }, effects)
+  return wireResult(result)
+}
+
+function wireResult(result: ToolResult): ToolResult {
   return {
     content: result.content,
     isError: result.isError,
-    structuredContent: result.structuredContent,
   }
 }
 

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/register-tabs-new.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/register-tabs-new.test.ts
@@ -147,6 +147,7 @@ describe('MCP dispatch: tabs new registry write', () => {
       arguments: { action: 'new', url: 'https://example.com/' },
     })
     expect(result.isError).toBeFalsy()
+    expect(result.structuredContent).toBeUndefined()
     const identity = identityService.getIdentity(transport.sessionId as string)
     if (!identity) throw new Error('missing identity')
     const { agentId, slug } = agentIdentityFromClient(identity)

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-isolation.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-isolation.test.ts
@@ -8,8 +8,7 @@
  * executeTool, then asserts:
  *
  *   - `tabs new` populates the ledger; the follow-up `tabs list`
- *     returns only the newly-opened page (in both text and
- *     structured channels).
+ *     renders ownership in text while structured data stays internal.
  *   - Same-name sessions share durable ownership; different names remain isolated.
  *   - `tabs close` drops the page from the ledger.
  *   - A page-targeted dispatch with a foreign `page` id is rejected
@@ -18,6 +17,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { existsSync } from 'node:fs'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 
@@ -73,6 +73,14 @@ function ok(structured?: unknown): FakeResult {
   }
 }
 
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return
+    await Bun.sleep(2)
+  }
+  throw new Error('condition was not reached')
+}
+
 const { setBrowserSession } = await import('../../src/lib/browser-session')
 const { ownershipStore } = await import('../../src/domain/ownership')
 const { tabActivityRegistry } = await import('../../src/lib/tab-activity')
@@ -89,6 +97,14 @@ const {
 const { env } = await import('../../src/env')
 const { setAuditDbForTesting, resetAuditDbForTesting } = await import(
   '../../src/modules/db/db'
+)
+const { listDispatches } = await import('../../src/services/audit-log')
+const { screencastCache } = await import('../../src/services/screencast-cache')
+const { clearFirstCapturesForTesting, screenshotPath } = await import(
+  '../../src/services/screenshots'
+)
+const { withTempBrowserClawDir } = await import(
+  '../_helpers/temp-browserclaw-dir'
 )
 const app = (await import('../../src/server')).default
 
@@ -132,9 +148,7 @@ async function connect(clientName: string) {
 interface TabsListResult {
   isError?: boolean
   content?: Array<{ type: string; text?: string }>
-  structuredContent?: {
-    pages?: Array<{ page: number; url?: string; title?: string }>
-  }
+  structuredContent?: unknown
 }
 
 const ORIGINAL_IDLE = env.sessionIdleMs
@@ -149,6 +163,8 @@ describe('per-agent tabs isolation', () => {
     ownershipStore.clear()
     resetTabGroupEffectsForTesting()
     tabActivityRegistry.clear()
+    screencastCache.resetForTesting()
+    clearFirstCapturesForTesting()
     env.sessionIdleMs = 50
   })
   afterEach(() => {
@@ -158,9 +174,66 @@ describe('per-agent tabs isolation', () => {
     ownershipStore.clear()
     resetTabGroupEffectsForTesting()
     tabActivityRegistry.clear()
+    screencastCache.resetForTesting()
+    clearFirstCapturesForTesting()
     setBrowserSession(null)
     env.sessionIdleMs = ORIGINAL_IDLE
     resetAuditDbForTesting()
+  })
+
+  it('strips the wire result after audit, screenshot, ownership, and grouping effects', async () => {
+    await withTempBrowserClawDir(async () => {
+      stubSessionForPage(7, 'target-7')
+      const jpegBase64 = Buffer.from('cached-jpeg').toString('base64')
+      screencastCache.set(7, {
+        jpegBase64,
+        capturedAt: Date.now(),
+        byteLength: Buffer.from(jpegBase64, 'base64').length,
+      })
+      queue(
+        ok({ page: 7 }),
+        ok({ group: { groupId: 'G1', windowId: 42 } }),
+        ok(),
+      )
+      const { client, key, sessionId } = await connect('claude-code')
+
+      const result = await client.callTool({
+        name: 'tabs',
+        arguments: { action: 'new', url: 'https://example.com/' },
+      })
+
+      expect(result.structuredContent).toBeUndefined()
+      expect([...ownershipStore.pagesOf(key)]).toEqual([7])
+      await waitFor(() => ownershipStore.groupOf(key)?.id === 'G1')
+      const rows = listDispatches({ sessionId }).rows
+      expect(rows).toHaveLength(1)
+      const row = rows[0]
+      if (!row) throw new Error('missing audit row')
+      expect(JSON.parse(row.resultMeta).structuredKeys).toEqual(['page'])
+      await waitFor(() => existsSync(screenshotPath(row.id)))
+      expect(existsSync(screenshotPath(row.id))).toBe(true)
+
+      await client.close()
+    })
+  })
+
+  it('strips schema-shaped run output while preserving its text', async () => {
+    setBrowserSession({ pages: { getInfo: () => undefined } } as never)
+    queue({
+      isError: false,
+      content: [{ type: 'text', text: 'ok\nreturn: 42' }],
+      structuredContent: { ok: true, value: 42, logs: [] },
+    })
+    const { client } = await connect('claude-code')
+
+    const result = await client.callTool({
+      name: 'run',
+      arguments: { code: 'return 42' },
+    })
+
+    expect(result.structuredContent).toBeUndefined()
+    expect(result.content).toEqual([{ type: 'text', text: 'ok\nreturn: 42' }])
+    await client.close()
   })
 
   it('tabs new populates the ledger; follow-up tabs list groups your tab and the user tab separately', async () => {
@@ -191,24 +264,7 @@ describe('per-agent tabs isolation', () => {
       arguments: { action: 'list' },
     })) as TabsListResult
     expect(listResult.isError).toBeFalsy()
-    expect(listResult.structuredContent?.pages).toEqual([
-      {
-        page: 7,
-        url: 'https://news.google.com/',
-        title: 'News',
-        ownership: 'mine',
-        ownerAgentId: key,
-        ownerLabel: null,
-      },
-      {
-        page: 42,
-        url: 'https://operator.example/',
-        title: "Op's tab",
-        ownership: 'user',
-        ownerAgentId: null,
-        ownerLabel: null,
-      },
-    ])
+    expect(listResult.structuredContent).toBeUndefined()
     const text = (
       listResult.content as Array<{ type: string; text?: string }>
     )?.[0]?.text
@@ -269,21 +325,7 @@ describe('per-agent tabs isolation', () => {
       name: 'tabs',
       arguments: { action: 'list' },
     })) as TabsListResult
-    expect(listA.structuredContent?.pages).toEqual([
-      {
-        ...opTabs[0],
-        ownership: 'mine',
-        ownerAgentId: a.key,
-        ownerLabel: null,
-      },
-      {
-        ...opTabs[1],
-        ownership: 'other-agent',
-        ownerAgentId: b.key,
-        ownerLabel: 'cursor',
-      },
-      { ...opTabs[2], ownership: 'user', ownerAgentId: null, ownerLabel: null },
-    ])
+    expect(listA.structuredContent).toBeUndefined()
     const textA = (listA.content as Array<{ type: string; text?: string }>)?.[0]
       ?.text
     expect(textA).toContain('Your tabs:')
@@ -296,21 +338,11 @@ describe('per-agent tabs isolation', () => {
       name: 'tabs',
       arguments: { action: 'list' },
     })) as TabsListResult
-    expect(listB.structuredContent?.pages).toEqual([
-      {
-        ...opTabs[0],
-        ownership: 'other-agent',
-        ownerAgentId: a.key,
-        ownerLabel: 'claude-code',
-      },
-      {
-        ...opTabs[1],
-        ownership: 'mine',
-        ownerAgentId: b.key,
-        ownerLabel: null,
-      },
-      { ...opTabs[2], ownership: 'user', ownerAgentId: null, ownerLabel: null },
-    ])
+    expect(listB.structuredContent).toBeUndefined()
+    const textB = (listB.content as Array<{ type: string; text?: string }>)?.[0]
+      ?.text
+    expect(textB).toContain('Your tabs:')
+    expect(textB).toContain(', owned by claude-code')
 
     await a.client.close()
     await b.client.close()
@@ -347,16 +379,7 @@ describe('per-agent tabs isolation', () => {
       name: 'tabs',
       arguments: { action: 'list' },
     })) as TabsListResult
-    expect(listB.structuredContent?.pages).toEqual([
-      {
-        page: 1,
-        url: 'https://a.example/',
-        title: 'A',
-        ownership: 'mine',
-        ownerAgentId: a.key,
-        ownerLabel: null,
-      },
-    ])
+    expect(listB.structuredContent).toBeUndefined()
     const textB = (listB.content as Array<{ type: string; text?: string }>)?.[0]
       ?.text
     expect(textB).toContain('Your tabs:')
@@ -396,16 +419,7 @@ describe('per-agent tabs isolation', () => {
       name: 'tabs',
       arguments: { action: 'list' },
     })) as TabsListResult
-    expect(list.structuredContent?.pages).toEqual([
-      {
-        page: 100,
-        url: 'https://only-operator.example/',
-        title: 'Op',
-        ownership: 'user',
-        ownerAgentId: null,
-        ownerLabel: null,
-      },
-    ])
+    expect(list.structuredContent).toBeUndefined()
     const text = (list.content as Array<{ type: string; text?: string }>)?.[0]
       ?.text
     expect(text).toContain("User's tabs:")
@@ -427,7 +441,7 @@ describe('per-agent tabs isolation', () => {
       name: 'tabs',
       arguments: { action: 'list' },
     })) as TabsListResult
-    expect(list.structuredContent?.pages).toEqual([])
+    expect(list.structuredContent).toBeUndefined()
     expect(
       (list.content as Array<{ type: string; text?: string }>)?.[0]?.text,
     ).toBe('(no open pages)')
@@ -452,11 +466,11 @@ describe('per-agent tabs isolation', () => {
     })) as TabsListResult
     expect([...ownershipStore.pagesOf(key)]).toEqual([7])
     expect(ownershipStore.ownerOf(8)).toBeNull()
-    expect(list.structuredContent?.pages?.[0]).toMatchObject({
-      page: 7,
-      ownership: 'mine',
-      ownerAgentId: key,
-    })
+    expect(list.structuredContent).toBeUndefined()
+    const text = (list.content as Array<{ type: string; text?: string }>)?.[0]
+      ?.text
+    expect(text).toContain('Your tabs:')
+    expect(text).toContain('[7] https://live.example/ (Live)')
     await client.close()
   })
 
@@ -629,24 +643,7 @@ describe('per-agent tabs isolation', () => {
       name: 'tabs',
       arguments: { action: 'list' },
     })) as TabsListResult
-    expect(list.structuredContent?.pages).toEqual([
-      {
-        page: 7,
-        url: 'https://x.com/',
-        title: 'Stale',
-        ownership: 'mine',
-        ownerAgentId: first.key,
-        ownerLabel: null,
-      },
-      {
-        page: 99,
-        url: 'https://operator.example/',
-        title: 'Op',
-        ownership: 'user',
-        ownerAgentId: null,
-        ownerLabel: null,
-      },
-    ])
+    expect(list.structuredContent).toBeUndefined()
     const text = (list.content as Array<{ type: string; text?: string }>)?.[0]
       ?.text
     expect(text).toContain("User's tabs:")

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -220,6 +220,9 @@ func TestGrepMatchLinesUsesStructuredMatches(t *testing.T) {
 	result := &mcp.ToolResult{
 		Content: []mcp.ContentItem{{Type: "text", Text: "[UNTRUSTED_PAGE_CONTENT]\nignored\n[END_UNTRUSTED_PAGE_CONTENT]"}},
 		StructuredContent: map[string]any{
+			"page":  7,
+			"over":  "ax",
+			"count": 2,
 			"matches": []any{
 				`- button "Add to Cart" [ref=e12]`,
 				`- button "Add to Cart" [ref=e13]`,

--- a/packages/browseros-agent/apps/cli/mcp/client.go
+++ b/packages/browseros-agent/apps/cli/mcp/client.go
@@ -38,7 +38,7 @@ func (c *Client) connect(ctx context.Context) (*sdkmcp.ClientSession, error) {
 	}, nil)
 
 	transport := &sdkmcp.StreamableClientTransport{
-		Endpoint:             c.BaseURL + "/mcp",
+		Endpoint:             c.BaseURL + "/mcp?structured=1",
 		HTTPClient:           c.HTTPClient,
 		DisableStandaloneSSE: true,
 	}

--- a/packages/browseros-agent/apps/cli/mcp/client_test.go
+++ b/packages/browseros-agent/apps/cli/mcp/client_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,22 @@ import (
 	"testing"
 	"time"
 )
+
+func TestConnectOptsIntoStructuredContent(t *testing.T) {
+	var requestURI string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestURI = r.URL.RequestURI()
+		http.Error(w, "stop after capturing endpoint", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL, "test", time.Second)
+	_, _ = client.connect(context.Background())
+
+	if requestURI != "/mcp?structured=1" {
+		t.Fatalf("MCP request URI = %q, want /mcp?structured=1", requestURI)
+	}
+}
 
 func TestHealthUsesCanonicalSystemHealthEndpoint(t *testing.T) {
 	var paths []string

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -97,6 +97,7 @@ export function createMcpRoutes(deps: McpRouteDeps) {
     const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
     metrics.log('mcp.request', { scopeId })
     const source = c.req.query('source') || undefined
+    const includeStructuredContent = c.req.query('structured') === '1'
 
     const defaultWindowId = parseOptionalNumber(
       c.req.header('X-BrowserOS-Default-Window-Id'),
@@ -132,6 +133,7 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       connectorScope: { selectedServerNames },
       defaultWindowId,
       defaultTabGroupId,
+      includeStructuredContent,
       executionDir: deps.executionDir,
       remoteAgentHarness: harness,
       activity: deps.activity,

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
@@ -22,6 +22,7 @@ export interface McpServiceDeps {
   connectorScope?: ConnectorToolScope
   defaultWindowId?: number
   defaultTabGroupId?: string
+  includeStructuredContent?: boolean
   executionDir: string
   remoteAgentHarness?: RemoteAgentHarnessTools
   activity?: ServerActivity
@@ -48,6 +49,7 @@ export function createMcpServer(deps: McpServiceDeps) {
     defaultTabGroupId: deps.defaultTabGroupId,
     instructions: MCP_INSTRUCTIONS,
     registration: {
+      includeStructuredContent: deps.includeStructuredContent ?? false,
       outputFileAccess: deps.remoteAgentHarness?.outputFileAccess,
       logger,
       onToolExecutionStart: () => deps.activity?.beginMcpToolExecution(),

--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
@@ -11,6 +11,7 @@ import type {
 
 interface McpServerCreation {
   executionDir: string | undefined
+  includeStructuredContent: boolean | undefined
   remoteAgentHarness: { outputFileAccess?: unknown } | undefined
   proxyStatus: KlavisProxyStatus | null
   selectedServerNames: readonly string[] | undefined
@@ -37,10 +38,12 @@ const createMcpServerSpy = mock(
     klavis?: { getProxyStatus(): KlavisProxyStatus }
     connectorScope?: ConnectorToolScope
     executionDir?: string
+    includeStructuredContent?: boolean
     remoteAgentHarness?: { outputFileAccess?: unknown }
   }) => {
     serverCreations.push({
       executionDir: deps.executionDir,
+      includeStructuredContent: deps.includeStructuredContent,
       remoteAgentHarness: deps.remoteAgentHarness,
       proxyStatus: deps.klavis?.getProxyStatus() ?? null,
       selectedServerNames: deps.connectorScope?.selectedServerNames,
@@ -132,12 +135,14 @@ describe('createMcpRoutes', () => {
     expect(serverCreations).toEqual([
       {
         executionDir: '/tmp/browseros-execution',
+        includeStructuredContent: false,
         remoteAgentHarness: undefined,
         proxyStatus: { state: 'connecting' },
         selectedServerNames: [],
       },
       {
         executionDir: '/tmp/browseros-execution',
+        includeStructuredContent: false,
         remoteAgentHarness: undefined,
         proxyStatus: { state: 'ready', toolCount: 3 },
         selectedServerNames: ['Slack', 'Google Docs'],
@@ -162,12 +167,14 @@ describe('createMcpRoutes', () => {
     expect(serverCreations).toEqual([
       {
         executionDir: '/tmp/browseros-execution',
+        includeStructuredContent: false,
         remoteAgentHarness: undefined,
         proxyStatus: null,
         selectedServerNames: [],
       },
       {
         executionDir: '/tmp/browseros-execution',
+        includeStructuredContent: false,
         remoteAgentHarness: { outputFileAccess: expect.any(Object) },
         proxyStatus: null,
         selectedServerNames: [],
@@ -184,5 +191,17 @@ describe('createMcpRoutes', () => {
     expect(serverCreations[0].remoteAgentHarness).toBe(
       serverCreations[1].remoteAgentHarness,
     )
+  })
+
+  it('opts into browser structured content only for structured=1', async () => {
+    const app = createTestMcpRoutes()
+
+    await postMcp(app)
+    await postMcp(app, {}, '/?structured=1')
+    await postMcp(app, {}, '/?structured=true')
+
+    expect(
+      serverCreations.map((creation) => creation.includeStructuredContent),
+    ).toEqual([false, true, false])
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/mcp-server.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/mcp-server.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test'
+import type { BrowserSession } from '@browseros/browser-core/core/session'
+import { createMcpServer } from '../../../../src/api/services/mcp/mcp-server'
+
+type RegisteredTool = {
+  handler: (args: Record<string, unknown>) => Promise<{
+    content: unknown
+    isError?: boolean
+    structuredContent?: unknown
+  }>
+}
+
+type InspectableMcpServer = {
+  _registeredTools: Record<string, RegisteredTool>
+}
+
+function inspect(server: unknown): InspectableMcpServer {
+  return server as InspectableMcpServer
+}
+
+function browserSession(): BrowserSession {
+  return {
+    pages: {
+      newPage: async () => 42,
+      getInfo: () => ({ url: 'https://example.com' }),
+    },
+    observe: () => ({
+      snapshot: async () => ({ text: 'button "Save" [ref=e1]' }),
+    }),
+  } as unknown as BrowserSession
+}
+
+describe('createMcpServer structured browser results', () => {
+  it('strips ordinary envelopes by default while retaining run output', async () => {
+    const server = inspect(
+      createMcpServer({
+        version: 'test',
+        browserSession: browserSession(),
+        executionDir: '/tmp/browseros-execution',
+      }),
+    )
+
+    const tabs = await server._registeredTools.tabs.handler({ action: 'new' })
+    const run = await server._registeredTools.run.handler({ code: 'return 42' })
+
+    expect(tabs).not.toHaveProperty('structuredContent')
+    expect(run.structuredContent).toEqual({ ok: true, value: 42, logs: [] })
+  })
+
+  it('returns grep matches for opted-in machine clients', async () => {
+    const server = inspect(
+      createMcpServer({
+        version: 'test',
+        browserSession: browserSession(),
+        executionDir: '/tmp/browseros-execution',
+        includeStructuredContent: true,
+      }),
+    )
+
+    const result = await server._registeredTools.grep.handler({
+      page: 1,
+      pattern: 'save',
+      over: 'ax',
+    })
+
+    expect(result.structuredContent).toEqual({
+      page: 1,
+      over: 'ax',
+      count: 1,
+      matches: ['button "Save" [ref=e1]'],
+    })
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/tools/browser/grep.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/grep.test.ts
@@ -11,7 +11,7 @@ function sessionWithSnapshot(text: string): BrowserSession {
 }
 
 describe('grep tool', () => {
-  it('returns matched lines with page, over, and count in structured output', async () => {
+  it('returns matched lines in structured output', async () => {
     const session = sessionWithSnapshot(
       'button "Save" [ref=e1]\nlink "Home"\nbutton "Save draft" [ref=e2]',
     )
@@ -27,10 +27,11 @@ describe('grep tool', () => {
       page: 4,
       over: 'ax',
       count: 2,
+      matches: ['button "Save" [ref=e1]', 'button "Save draft" [ref=e2]'],
     })
   })
 
-  it('reports zero matches without a matches array', async () => {
+  it('reports zero matches with an empty matches array', async () => {
     const session = sessionWithSnapshot('link "Home"\nlink "About"')
 
     const result = await executeTool(
@@ -44,6 +45,7 @@ describe('grep tool', () => {
       page: 4,
       over: 'ax',
       count: 0,
+      matches: [],
     })
   })
 })

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/grep.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/grep.test.ts
@@ -148,6 +148,27 @@ describe('grep tool', () => {
     })
   })
 
+  it('does not preserve ref-like suffixes that exceed the line budget', async () => {
+    await withBrowserosDir(async () => {
+      const oversizedSuffix = ` [ref=e${'1'.repeat(1_000)}]`
+      const line = `needle ${'x'.repeat(6_000)}${oversizedSuffix}`
+      const result = await executeTool(
+        grep,
+        { page: 4, pattern: 'needle', over: 'ax' },
+        { session: sessionWithSnapshot(line) },
+      )
+      const data = result.structuredContent as { matches: string[] } | undefined
+      const renderedLine = data?.matches[0] ?? ''
+
+      expect(result.isError).toBeFalsy()
+      expect(renderedLine.length).toBeLessThanOrEqual(
+        TOOL_LIMITS.GREP_MATCH_LINE_MAX_CHARS,
+      )
+      expect(renderedLine).toEndWith('... [truncated]')
+      expect(renderedLine).not.toContain(oversizedSuffix)
+    })
+  })
+
   it('keeps clamped matches inline when spilling fails', async () => {
     await withOutputWriteFailure(async () => {
       const tail = 'tail-marker'

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/grep.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/grep.test.ts
@@ -65,7 +65,7 @@ function restoreBrowserosDir(previous: string | undefined): void {
 }
 
 describe('grep tool', () => {
-  it('returns small matches with metadata-only structured output', async () => {
+  it('returns small matches in bounded structured output', async () => {
     const result = await executeTool(
       grep,
       { page: 4, pattern: 'save', over: 'ax' },
@@ -81,12 +81,12 @@ describe('grep tool', () => {
       page: 4,
       over: 'ax',
       count: 2,
+      matches: ['button "Save" [ref=e1]', 'button "Save draft" [ref=e2]'],
     })
-    expect(result.structuredContent).not.toHaveProperty('matches')
     expect(textOf(result)).toContain('button "Save" [ref=e1]')
   })
 
-  it('reports zero matches without a matches array', async () => {
+  it('reports zero matches with an empty matches array', async () => {
     const result = await executeTool(
       grep,
       { page: 4, pattern: 'checkout', over: 'ax' },
@@ -98,13 +98,14 @@ describe('grep tool', () => {
       page: 4,
       over: 'ax',
       count: 0,
+      matches: [],
     })
   })
 
-  it('clamps pathological single-line matches and spills the full line', async () => {
+  it('preserves refs while clamping matches and spills the full line', async () => {
     await withBrowserosDir(async () => {
-      const tail = 'tail-marker'
-      const line = `needle ${'x'.repeat(100_000)} ${tail}`
+      const ref = '[ref=e123]'
+      const line = `needle ${'x'.repeat(100_000)} ${ref}`
       const result = await executeTool(
         grep,
         { page: 4, pattern: 'needle', over: 'ax' },
@@ -115,7 +116,9 @@ describe('grep tool', () => {
             page: number
             over: string
             count: number
-            truncated: boolean
+            matches: string[]
+            contentLength: number
+            writtenToFile: boolean
             path: string
           }
         | undefined
@@ -127,19 +130,21 @@ describe('grep tool', () => {
         page: 4,
         over: 'ax',
         count: 1,
-        truncated: true,
+        matches: [expect.stringMatching(/\.\.\. \[truncated\] \[ref=e123\]$/)],
+        contentLength: line.length,
+        writtenToFile: true,
       })
       const path = data?.path
       expect(typeof path).toBe('string')
       if (typeof path !== 'string') throw new Error('expected output path')
-      expect(data).not.toHaveProperty('matches')
       expect(renderedLine.length).toBeLessThanOrEqual(
         TOOL_LIMITS.GREP_MATCH_LINE_MAX_CHARS,
       )
       expect(renderedLine).toContain('... [truncated]')
+      expect(renderedLine).toEndWith(ref)
+      expect(data?.matches).toEqual([renderedLine])
       expect(text).toContain(path)
-      expect(text).not.toContain(tail)
-      expect(readFileSync(path, 'utf8')).toContain(tail)
+      expect(readFileSync(path, 'utf8')).toContain(line)
     })
   })
 
@@ -157,7 +162,8 @@ describe('grep tool', () => {
             page: number
             over: string
             count: number
-            truncated: boolean
+            matches: string[]
+            contentLength: number
             writtenToFile: boolean
             outputWriteFailed: boolean
             error: string
@@ -171,17 +177,18 @@ describe('grep tool', () => {
         page: 4,
         over: 'ax',
         count: 1,
-        truncated: true,
+        matches: [expect.stringContaining('... [truncated]')],
+        contentLength: line.length,
         writtenToFile: false,
         outputWriteFailed: true,
         error: expect.any(String),
       })
       expect(data).not.toHaveProperty('path')
-      expect(data).not.toHaveProperty('matches')
       expect(renderedLine.length).toBeLessThanOrEqual(
         TOOL_LIMITS.GREP_MATCH_LINE_MAX_CHARS,
       )
       expect(renderedLine).toContain('... [truncated]')
+      expect(data?.matches).toEqual([renderedLine])
       expect(text).toContain('could not be saved')
       expect(text).not.toContain(tail)
     })
@@ -208,6 +215,10 @@ describe('grep tool', () => {
       page: 4,
       over: 'ax',
       count: TOOL_LIMITS.GREP_MAX_MATCHES,
+      matches: Array.from(
+        { length: TOOL_LIMITS.GREP_MAX_MATCHES },
+        (_, index) => `match ${index}`,
+      ),
     })
     expect(textOf(result)).toContain(
       `match ${TOOL_LIMITS.GREP_MAX_MATCHES - 1}`,

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/grep.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/grep.ts
@@ -6,6 +6,7 @@ import { wrapUntrusted } from './trust-boundary'
 
 const DEFAULT_LIMIT = 50
 const LINE_TRUNCATION_MARKER = '... [truncated]'
+const REF_SUFFIX_PATTERN = / \[ref=e\d+\]$/
 
 export const grep = defineTool({
   name: 'grep',
@@ -50,6 +51,7 @@ export const grep = defineTool({
         page: args.page,
         over: args.over,
         count: 0,
+        matches: [],
       })
     }
 
@@ -83,7 +85,9 @@ export const grep = defineTool({
             page: args.page,
             over: args.over,
             count: matches.length,
-            truncated: true,
+            matches: renderedMatches,
+            contentLength: fullMatchesText.length,
+            writtenToFile: true,
             path,
           },
         )
@@ -98,7 +102,8 @@ export const grep = defineTool({
             page: args.page,
             over: args.over,
             count: matches.length,
-            truncated: true,
+            matches: renderedMatches,
+            contentLength: fullMatchesText.length,
             writtenToFile: false,
             outputWriteFailed: true,
             error: saveError,
@@ -111,6 +116,7 @@ export const grep = defineTool({
       page: args.page,
       over: args.over,
       count: matches.length,
+      matches: renderedMatches,
     })
   },
 })
@@ -122,6 +128,14 @@ function clampLimit(limit: number | undefined): number {
 }
 
 function clampRenderedLine(line: string): string {
+  const refSuffix = line.match(REF_SUFFIX_PATTERN)?.[0]
+  if (refSuffix && line.length > TOOL_LIMITS.GREP_MATCH_LINE_MAX_CHARS) {
+    const prefix = line.slice(0, -refSuffix.length)
+    return `${clampText(
+      prefix,
+      TOOL_LIMITS.GREP_MATCH_LINE_MAX_CHARS - refSuffix.length,
+    )}${refSuffix}`
+  }
   return clampText(line, TOOL_LIMITS.GREP_MATCH_LINE_MAX_CHARS)
 }
 

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/grep.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/grep.ts
@@ -128,15 +128,17 @@ function clampLimit(limit: number | undefined): number {
 }
 
 function clampRenderedLine(line: string): string {
+  const maxChars = TOOL_LIMITS.GREP_MATCH_LINE_MAX_CHARS
   const refSuffix = line.match(REF_SUFFIX_PATTERN)?.[0]
-  if (refSuffix && line.length > TOOL_LIMITS.GREP_MATCH_LINE_MAX_CHARS) {
+  if (
+    refSuffix &&
+    line.length > maxChars &&
+    refSuffix.length + LINE_TRUNCATION_MARKER.length <= maxChars
+  ) {
     const prefix = line.slice(0, -refSuffix.length)
-    return `${clampText(
-      prefix,
-      TOOL_LIMITS.GREP_MATCH_LINE_MAX_CHARS - refSuffix.length,
-    )}${refSuffix}`
+    return `${clampText(prefix, maxChars - refSuffix.length)}${refSuffix}`
   }
-  return clampText(line, TOOL_LIMITS.GREP_MATCH_LINE_MAX_CHARS)
+  return clampText(line, maxChars)
 }
 
 function clampText(text: string, maxChars: number): string {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.test.ts
@@ -16,7 +16,12 @@ function createFakeServer() {
   const handlers = new Map<string, RegisteredHandler>()
   const configs = new Map<
     string,
-    { description: string; inputSchema?: unknown; annotations?: unknown }
+    {
+      description: string
+      inputSchema?: unknown
+      outputSchema?: unknown
+      annotations?: unknown
+    }
   >()
 
   return {
@@ -28,6 +33,7 @@ function createFakeServer() {
         config: {
           description: string
           inputSchema?: unknown
+          outputSchema?: unknown
           annotations?: unknown
         },
         handler: RegisteredHandler,
@@ -71,6 +77,73 @@ describe('registerBrowserTools', () => {
     expect(fake.configs.get('snapshot')?.annotations).toEqual({
       readOnlyHint: true,
     })
+    expect(fake.configs.get('tabs')?.outputSchema).toBeUndefined()
+    expect(fake.configs.get('run')?.outputSchema).toBeDefined()
+  })
+
+  it('preserves structured results when the option is omitted', async () => {
+    const fake = createFakeServer()
+    const session = {
+      pages: { newPage: async () => 42 },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('tabs')?.({ action: 'new' })
+
+    expect(result?.structuredContent).toEqual({ page: 42 })
+    expect(result).toHaveProperty('structuredContent')
+  })
+
+  it('omits ordinary structured results when explicitly disabled', async () => {
+    const fake = createFakeServer()
+    const debugLogs: Array<{
+      message: string
+      meta?: Record<string, unknown>
+    }> = []
+    const session = {
+      pages: { newPage: async () => 42 },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(
+      fake.server as never,
+      session,
+      {},
+      {
+        includeStructuredContent: false,
+        logger: {
+          debug: (message, meta) => debugLogs.push({ message, meta }),
+        },
+      },
+    )
+
+    const result = await fake.handlers.get('tabs')?.({ action: 'new' })
+
+    expect(result).not.toHaveProperty('structuredContent')
+    expect(debugLogs.at(-1)).toEqual({
+      message: 'MCP browser tool completed',
+      meta: expect.objectContaining({ hasStructuredContent: false }),
+    })
+  })
+
+  it('keeps schema-declared run structured in both modes', async () => {
+    for (const includeStructuredContent of [undefined, false]) {
+      const fake = createFakeServer()
+      registerBrowserTools(
+        fake.server as never,
+        { pages: {} } as unknown as BrowserSession,
+        {},
+        { includeStructuredContent },
+      )
+
+      const result = await fake.handlers.get('run')?.({ code: 'return 42' })
+
+      expect(result?.structuredContent).toEqual({
+        ok: true,
+        value: 42,
+        logs: [],
+      })
+    }
   })
 
   it('logs sampled registration and records failed tool executions', async () => {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
@@ -37,6 +37,7 @@ interface BrowserToolLogger {
 }
 
 export interface BrowserToolRegistrationOptions {
+  includeStructuredContent?: boolean
   outputFileAccess?: BrowserOutputFileAccess
   onToolExecutionStart?: (event: BrowserToolLifecycleEvent) => void
   onToolExecutionEnd?: (event: BrowserToolLifecycleEvent) => void
@@ -177,11 +178,16 @@ export function registerBrowserTools(
           const errorSummary = result.isError
             ? resultTextSummary(result.content)
             : undefined
+          const structuredContent =
+            (options.includeStructuredContent ?? true) ||
+            tool.output !== undefined
+              ? result.structuredContent
+              : undefined
           options.logger?.debug?.('MCP browser tool completed', {
             ...logBase,
             durationMs,
             isError: Boolean(result.isError),
-            hasStructuredContent: result.structuredContent !== undefined,
+            hasStructuredContent: structuredContent !== undefined,
           })
           if (result.isError) {
             options.logger?.info?.('MCP browser tool returned error', {
@@ -193,7 +199,7 @@ export function registerBrowserTools(
           return {
             content: result.content,
             isError: result.isError,
-            structuredContent: result.structuredContent,
+            ...(structuredContent !== undefined && { structuredContent }),
           }
         } catch (error) {
           const errorText =

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/structured-contract.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/structured-contract.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { BrowserSession } from '@browseros/browser-core/core/session'
+import type { WindowInfo } from '@browseros/browser-core/core/windows'
+import { executeTool } from './framework'
+import { BROWSER_TOOLS } from './registry'
+
+const page = {
+  pageId: 1,
+  targetId: 'target-1',
+  tabId: 11,
+  url: 'https://example.com',
+  title: 'Example',
+  isActive: true,
+  isLoading: false,
+  loadProgress: 1,
+  isPinned: false,
+  isHidden: false,
+}
+
+const windowInfo: WindowInfo = {
+  windowId: 7,
+  windowType: 'normal',
+  bounds: {},
+  isActive: true,
+  isVisible: true,
+  tabCount: 1,
+}
+
+function createContractSession(): BrowserSession {
+  let downloadBegin:
+    | ((params: { guid: string; suggestedFilename: string }) => void)
+    | undefined
+  let downloadProgress:
+    | ((params: { guid: string; state: 'completed' }) => void)
+    | undefined
+
+  const pageSession = {
+    Runtime: {
+      evaluate: async (params: { expression: string }) => ({
+        result: {
+          value:
+            params.expression.includes('.includes(') ||
+            params.expression.includes('querySelector(')
+              ? true
+              : 'page value',
+        },
+      }),
+    },
+    Page: {
+      getLayoutMetrics: async () => ({
+        layoutViewport: {
+          pageX: 0,
+          pageY: 0,
+          clientWidth: 1024,
+          clientHeight: 768,
+        },
+      }),
+      printToPDF: async () => ({
+        data: Buffer.from('pdf').toString('base64'),
+      }),
+      setDownloadBehavior: async () => {},
+      on: (event: string, callback: (params: never) => void): (() => void) => {
+        if (event === 'downloadWillBegin') {
+          downloadBegin = callback as typeof downloadBegin
+          return () => {
+            downloadBegin = undefined
+          }
+        }
+        downloadProgress = callback as typeof downloadProgress
+        return () => {
+          downloadProgress = undefined
+        }
+      },
+    },
+  }
+
+  const input = {
+    click: async () => {
+      if (downloadBegin && downloadProgress) {
+        downloadBegin({ guid: 'download-1', suggestedFilename: 'report.txt' })
+        downloadProgress({ guid: 'download-1', state: 'completed' })
+      }
+    },
+    uploadFile: async () => {},
+  }
+
+  return {
+    pages: {
+      list: async () => [page],
+      getActive: async () => page,
+      newPage: async () => 2,
+      close: async () => {},
+      refresh: async () => page,
+      getInfo: (pageId: number) =>
+        pageId === 1 ? page : { ...page, pageId, tabId: pageId + 10 },
+      getSession: async () => ({ session: pageSession }),
+      resolveTabIds: async (tabIds: number[]) =>
+        new Map(tabIds.map((tabId) => [tabId, tabId - 10])),
+    },
+    nav: () => ({
+      goto: async () => {},
+      back: async () => {},
+      forward: async () => {},
+      reload: async () => {},
+    }),
+    observe: () => ({
+      snapshot: async () => ({ text: 'button "Save" [ref=e1]' }),
+      diff: async () => ({
+        changed: true,
+        text: '+ button "Saved" [ref=e1]',
+        added: 1,
+        removed: 0,
+        afterUrl: page.url,
+      }),
+    }),
+    input: () => input,
+    screenshot: async () => ({
+      data: Buffer.from('image').toString('base64'),
+      mimeType: 'image/jpeg',
+      annotations: [],
+    }),
+    windows: {
+      list: async () => [windowInfo],
+      create: async () => windowInfo,
+      close: async () => {},
+      activate: async () => {},
+      setVisibility: async () => ({
+        previousWindowId: 7,
+        newWindowId: 8,
+        replaced: true,
+        window: { ...windowInfo, windowId: 8, isVisible: false },
+      }),
+    },
+    cdp: async (method: string) => {
+      if (method === 'Browser.getTabGroups') {
+        return {
+          groups: [
+            {
+              groupId: 'group-1',
+              windowId: 7,
+              title: 'Work',
+              color: 'blue',
+              collapsed: false,
+              tabIds: [11],
+            },
+          ],
+        }
+      }
+      if (
+        method === 'Browser.createTabGroup' ||
+        method === 'Browser.addTabsToGroup' ||
+        method === 'Browser.updateTabGroup'
+      ) {
+        return {
+          group: {
+            groupId: 'group-1',
+            windowId: 7,
+            title: 'Work',
+            color: 'blue',
+            collapsed: false,
+            tabIds: [11],
+          },
+        }
+      }
+      return {}
+    },
+  } as unknown as BrowserSession
+}
+
+function structuredKeys(structuredContent: unknown): string[] {
+  if (
+    typeof structuredContent !== 'object' ||
+    structuredContent === null ||
+    Array.isArray(structuredContent)
+  ) {
+    throw new Error('expected a structured object')
+  }
+  return Object.keys(structuredContent).sort()
+}
+
+describe('browser tool structured contract', () => {
+  it('pins the exact structured keys emitted by every browser tool', async () => {
+    const previous = process.env.BROWSEROS_DIR
+    const browserosDir = mkdtempSync(join(tmpdir(), 'structured-contract-'))
+    process.env.BROWSEROS_DIR = browserosDir
+    try {
+      const session = createContractSession()
+      const byName = new Map(BROWSER_TOOLS.map((tool) => [tool.name, tool]))
+      const call = async (name: string, args: Record<string, unknown>) => {
+        const tool = byName.get(name)
+        if (!tool) throw new Error(`missing browser tool: ${name}`)
+        const result = await executeTool(tool, args, { session })
+        expect(result.isError, `${name} should succeed`).toBeFalsy()
+        return structuredKeys(result.structuredContent)
+      }
+
+      const actual = {
+        'tabs.list': await call('tabs', { action: 'list' }),
+        'tabs.active': await call('tabs', { action: 'active' }),
+        'tabs.new': await call('tabs', { action: 'new' }),
+        'tabs.close': await call('tabs', { action: 'close', page: 1 }),
+        'tab_groups.list': await call('tab_groups', { action: 'list' }),
+        'tab_groups.create': await call('tab_groups', {
+          action: 'create',
+          pages: [1],
+        }),
+        'tab_groups.update': await call('tab_groups', {
+          action: 'update',
+          groupId: 'group-1',
+          title: 'Updated',
+        }),
+        'tab_groups.ungroup': await call('tab_groups', {
+          action: 'ungroup',
+          pages: [1],
+        }),
+        'tab_groups.close': await call('tab_groups', {
+          action: 'close',
+          groupId: 'group-1',
+        }),
+        navigate: await call('navigate', {
+          page: 1,
+          action: 'url',
+          url: page.url,
+        }),
+        snapshot: await call('snapshot', { page: 1 }),
+        diff: await call('diff', { page: 1 }),
+        act: await call('act', { page: 1, kind: 'click', ref: 'e1' }),
+        download: await call('download', { page: 1, ref: 'e1' }),
+        upload: await call('upload', {
+          page: 1,
+          ref: 'e2',
+          file: '/tmp/upload.txt',
+        }),
+        read: await call('read', { page: 1, format: 'text' }),
+        grep: await call('grep', {
+          page: 1,
+          pattern: 'save',
+          over: 'ax',
+        }),
+        screenshot: await call('screenshot', { page: 1 }),
+        pdf: await call('pdf', { page: 1 }),
+        'wait.time': await call('wait', {
+          page: 1,
+          for: 'time',
+          value: 0,
+        }),
+        'wait.selector': await call('wait', {
+          page: 1,
+          for: 'selector',
+          value: '#ready',
+        }),
+        'windows.list': await call('windows', { action: 'list' }),
+        'windows.create': await call('windows', { action: 'create' }),
+        'windows.close': await call('windows', {
+          action: 'close',
+          windowId: 7,
+        }),
+        'windows.activate': await call('windows', {
+          action: 'activate',
+          windowId: 7,
+        }),
+        'windows.set_visibility': await call('windows', {
+          action: 'set_visibility',
+          windowId: 7,
+          visible: false,
+        }),
+        evaluate: await call('evaluate', {
+          page: 1,
+          code: 'return document.title',
+        }),
+        run: await call('run', { code: 'return { answer: 42 }' }),
+      }
+
+      expect(actual).toEqual({
+        'tabs.list': ['pages'],
+        'tabs.active': ['action', 'page'],
+        'tabs.new': ['page'],
+        'tabs.close': ['page'],
+        'tab_groups.list': ['count', 'groups'],
+        'tab_groups.create': ['group'],
+        'tab_groups.update': ['group'],
+        'tab_groups.ungroup': ['count', 'pageIds'],
+        'tab_groups.close': ['groupId'],
+        navigate: ['page', 'url'],
+        snapshot: ['contentLength', 'page', 'tokenEstimate', 'writtenToFile'],
+        diff: ['added', 'changed', 'removed'],
+        act: ['changed', 'kind'],
+        download: ['filename', 'page', 'path', 'ref'],
+        upload: ['files', 'page', 'ref', 'uploaded'],
+        read: ['contentLength', 'format', 'page', 'writtenToFile'],
+        grep: ['count', 'matches', 'over', 'page'],
+        screenshot: ['bytes', 'format', 'page'],
+        pdf: ['bytes', 'page', 'path'],
+        'wait.time': ['matched', 'waitedMs'],
+        'wait.selector': ['matched'],
+        'windows.list': ['action', 'count', 'windows'],
+        'windows.create': ['action', 'window'],
+        'windows.close': ['action', 'windowId'],
+        'windows.activate': ['action', 'windowId'],
+        'windows.set_visibility': [
+          'action',
+          'newWindowId',
+          'previousWindowId',
+          'replaced',
+          'window',
+        ],
+        evaluate: ['page', 'value'],
+        run: ['logs', 'ok', 'value'],
+      })
+    } finally {
+      if (previous === undefined) {
+        delete process.env.BROWSEROS_DIR
+      } else {
+        process.env.BROWSEROS_DIR = previous
+      }
+      rmSync(browserosDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- make browser-tool `structuredContent` a wire-level opt-in: schema-declared tools retain it, `/mcp?structured=1` enables it for machine clients, and ordinary chat-harness endpoints omit it
- keep BrowserClaw's internal structured envelopes available to audit, screenshot, ownership, and grouping effects, then strip them from the returned wire result
- restore grep's bounded `matches` machine contract, preserve actionable trailing refs while clamping, and align spill metadata with the other text tools
- pin every browser tool's exact structured envelope keys so machine-consumer regressions are visible in TypeScript tests

## Design

Browser tools continue producing their existing envelopes. Presentation is decided only at the registration/dispatch boundary: `structuredContent` is included when the tool declares an `outputSchema` (currently only `run`) or when the server endpoint explicitly opts in. The apps/server MCP route defaults browser tools to content-only and accepts `?structured=1`; the CLI uses that query contract. BrowserClaw has only chat-harness clients today, so it strips structured output after all internal effects and has no opt-in plumbing.

No output schemas were added, and full payload mirrors were not restored for snapshot, diff, read, or evaluate.

## Claude Code behavior

Claude Code versions in the affected behavior range surface only `structuredContent` when both result channels are present, while falling back to `content` when structured output is absent. Upstream reports:

- https://github.com/anthropics/claude-code/issues/55677
- https://github.com/anthropics/claude-code/issues/15412
- https://github.com/anthropics/claude-code/issues/9962

## Machine client contract

Machine clients that consume browser-tool envelopes must connect to `/mcp?structured=1`. The BrowserOS CLI now does so. Grep again includes the bounded rendered `matches` array that `find` and batch find steps parse for `[ref=eN]` targets.

## Rollout

The server's strip-by-default behavior and the CLI's `?structured=1` endpoint change must ship in the same release train. Already-installed CLIs will temporarily lose structured browser fields after the server update until their updater under `apps/cli/update` brings them forward.

## Test plan

- [x] `bun run check`
- [x] `bun run test`
- [x] browser-mcp, apps/server, and BrowserClaw focused contract/integration tests
- [x] `gofmt`, `go vet ./...`, `go build ./...`, and `go test ./...` in `apps/cli`
