### PR TITLE
fix(release): split extension CRX and feed publishing

### DIFF
--- a/.github/workflows/release-browserclaw.yml
+++ b/.github/workflows/release-browserclaw.yml
@@ -320,9 +320,7 @@ jobs:
     with:
       version: ${{ needs.preflight.outputs.extensions_version }}
       extension: browserclaw
-      channel: ${{ inputs.extensions }}
       branch: ${{ github.ref_name }}
-      publish_manifest: false
     secrets: inherit
 
   stage_updates:

--- a/.github/workflows/release-browseros.yml
+++ b/.github/workflows/release-browseros.yml
@@ -315,9 +315,7 @@ jobs:
     with:
       version: ${{ needs.preflight.outputs.extensions_version }}
       extension: agent
-      channel: ${{ inputs.extensions }}
       branch: ${{ github.ref_name }}
-      publish_manifest: false
     secrets: inherit
 
   stage_updates:

--- a/.github/workflows/release-extension-feeds.yml
+++ b/.github/workflows/release-extension-feeds.yml
@@ -1,0 +1,127 @@
+name: "Release: Extension update feeds"
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Update-feed channel"
+        required: true
+        type: choice
+        options:
+          - alpha
+          - prod
+        default: "alpha"
+      pins:
+        description: "Optional name=version pins, separated by commas or spaces"
+        required: false
+        type: string
+        default: ""
+      publish:
+        description: "Write feeds to R2 (unchecked = full dry-run files and diff)"
+        required: false
+        type: boolean
+        default: false
+      allow_downgrade:
+        description: "Allow version downgrades or removal of live entries"
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      channel:
+        description: "Update-feed channel: alpha or prod"
+        required: false
+        type: string
+        default: "alpha"
+      pins:
+        description: "Optional name=version pins, separated by commas or spaces"
+        required: false
+        type: string
+        default: ""
+      publish:
+        description: "Write feeds to R2"
+        required: false
+        type: boolean
+        default: false
+      allow_downgrade:
+        description: "Allow version downgrades or removal of live entries"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      R2_ACCOUNT_ID:
+        required: true
+      R2_ACCESS_KEY_ID:
+        required: true
+      R2_SECRET_ACCESS_KEY:
+        required: true
+      R2_BUCKET:
+        required: true
+
+concurrency:
+  group: release-extension-feeds
+  cancel-in-progress: false
+
+jobs:
+  feeds:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Generate extension update feeds
+        working-directory: packages/browseros
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          PINS: ${{ inputs.pins }}
+          PUBLISH: ${{ inputs.publish }}
+          ALLOW_DOWNGRADE: ${{ inputs.allow_downgrade }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        # Inputs are validated and appended to an args array, never a command string.
+        run: |
+          set -euo pipefail
+
+          case "$CHANNEL" in
+            alpha|prod) ;;
+            *)
+              echo "::error::Invalid channel '$CHANNEL'; expected alpha or prod" >&2
+              exit 1
+              ;;
+          esac
+
+          args=(--channel "$CHANNEL")
+          normalized=${PINS//,/ }
+          normalized=${normalized//$'\n'/ }
+          normalized=${normalized//$'\r'/ }
+          read -r -a pin_tokens <<< "$normalized"
+          for pin in "${pin_tokens[@]}"; do
+            if [[ ! "$pin" =~ ^[a-z][a-z0-9_-]*=[0-9]+([.][0-9]+){0,3}$ ]]; then
+              echo "::error::Invalid pin '$pin'; expected name=version (for example, agent=0.0.119)" >&2
+              exit 1
+            fi
+            args+=(--set "$pin")
+          done
+          if [ "$PUBLISH" = "true" ]; then
+            args+=(--publish)
+          fi
+          if [ "$ALLOW_DOWNGRADE" = "true" ]; then
+            args+=(--allow-downgrade)
+          fi
+
+          {
+            echo "### Extension feed command"
+            echo '```bash'
+            echo "browseros release extensions ${args[*]}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          uv run browseros release extensions "${args[@]}"

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -1,4 +1,4 @@
-name: "Release: Extensions (CRX + feeds)"
+name: "Release: Extensions (CRX)"
 
 on:
   workflow_dispatch:
@@ -23,19 +23,6 @@ on:
         required: false
         type: string
         default: ""
-      channel:
-        description: "Update-feed channel to regenerate"
-        required: true
-        type: choice
-        options:
-          - alpha
-          - prod
-        default: "alpha"
-      publish_manifest:
-        description: "Write regenerated update manifests to R2 (unchecked = dry run)"
-        required: false
-        type: boolean
-        default: false
   workflow_call:
     inputs:
       version:
@@ -47,21 +34,11 @@ on:
         required: false
         type: string
         default: "all"
-      channel:
-        description: "Update-feed channel to regenerate: alpha or prod"
-        required: false
-        type: string
-        default: "alpha"
       branch:
         description: "Branch override (checkout ref for in-repo builds, clone branch for external repos)"
         required: false
         type: string
         default: ""
-      publish_manifest:
-        description: "Write regenerated update manifests to R2"
-        required: false
-        type: boolean
-        default: false
     secrets:
       GH_TOKEN:
         required: false
@@ -133,13 +110,11 @@ jobs:
           VERSION: ${{ inputs.version }}
           EXTENSION: ${{ inputs.extension }}
           BRANCH: ${{ inputs.branch }}
-          CHANNEL: ${{ inputs.channel }}
-          PUBLISH_MANIFEST: ${{ inputs.publish_manifest }}
 
           # Cloning private external extension repos
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-          # Cloudflare R2 (crx upload + feed publisher)
+          # Cloudflare R2 (CRX upload)
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -165,15 +140,12 @@ jobs:
         # string) so a crafted dispatch input cannot break into this shell.
         run: |
           set -euo pipefail
-          args=(--version "$VERSION" --channel "$CHANNEL")
+          args=(--version "$VERSION")
           if [ "$EXTENSION" != "all" ]; then
             args+=(--name "$EXTENSION")
           fi
           if [ -n "$BRANCH" ]; then
             args+=(--branch "$BRANCH")
-          fi
-          if [ "$PUBLISH_MANIFEST" = "true" ]; then
-            args+=(--publish-manifest)
           fi
           {
             echo "### Release command"

--- a/packages/browseros-agent/apps/app/README.md
+++ b/packages/browseros-agent/apps/app/README.md
@@ -142,11 +142,10 @@ GRAPHQL_SCHEMA_PATH=/path/to/api-repo/.../schema.graphql
 
 ## Release Flow
 
-BrowserOS agent extension releases are built as signed CRX artifacts and staged
-with update-feed metadata through the reusable `Release: Extensions (CRX +
-feeds)` workflow. The normal BrowserOS product release path calls that workflow
-from `release-browseros.yml` when the `extensions` input is `alpha` or `prod`
-and `extensions_version` is set.
+BrowserOS agent extension releases are built as signed CRX artifacts through
+the reusable `Release: Extensions (CRX)` workflow. The normal BrowserOS product
+release path calls that workflow from `release-browseros.yml` when the
+`extensions` input is `alpha` or `prod` and `extensions_version` is set.
 
 For a standalone agent extension release, dispatch the reusable workflow with
 the target version and extension name:
@@ -154,15 +153,25 @@ the target version and extension name:
 ```bash
 gh workflow run release-extensions.yml \
   -f version=0.0.119 \
-  -f extension=agent \
-  -f channel=alpha \
-  -f publish_manifest=false
+  -f extension=agent
 ```
 
-Leave `publish_manifest=false` for staging; publish the feed only after the
-staged CRX and generated manifest have been inspected. The previous GitHub
-Release zip distribution and extension component-tag trigger are historical
-only.
+Feed generation is a separate, dry-run-by-default workflow. Publish only after
+inspecting the CRX and generated diff:
+
+```bash
+gh workflow run release-extension-feeds.yml \
+  -f channel=alpha \
+  -f pins=agent=0.0.119
+
+gh workflow run release-extension-feeds.yml \
+  -f channel=alpha \
+  -f pins=agent=0.0.119 \
+  -f publish=true
+```
+
+The previous GitHub Release zip distribution and extension component-tag
+trigger are historical only.
 
 ## Development Tooling
 

--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -32,6 +32,7 @@ live.
 | Release BrowserOS or BrowserClaw | `gh workflow run release-browseros.yml` |
 | Make a staged release live | `browseros release publish`, then `browseros release appcast --publish` |
 | Release an extension CRX | `gh workflow run release-extensions.yml` |
+| Update extension feeds | `gh workflow run release-extension-feeds.yml` |
 | Grab today's signed mac build | Download the `nightly-browseros` / `nightly-browserclaw` prerelease |
 | Check the patch stack | `browseros dev doctor` |
 
@@ -221,26 +222,36 @@ Four extensions ship as signed CRXs: `agent`, `controller`, `bugreporter`,
 `browserclaw`. `agent` and `browserclaw` build from this repo; the other two are
 cloned from external repos. All four version independently of the browser.
 
-The usual path is the workflow:
+CRX release and feed updates are separate workflows. Release the binary first:
 
 ```bash
 gh workflow run release-extensions.yml \
   -f version=0.0.118 \
-  -f extension=agent \
-  -f channel=alpha \
-  -f publish_manifest=false   # dry run; true writes the feeds
+  -f extension=agent
 ```
 
-The per-product release orchestrators call this same workflow with
-`publish_manifest=false`, so a browser release uploads the CRX but never touches
-live manifests.
+Then inspect a feed dry run or publish it explicitly:
+
+```bash
+gh workflow run release-extension-feeds.yml \
+  -f channel=alpha \
+  -f pins='agent=0.0.118,bugreporter=54.0.0.0'
+
+gh workflow run release-extension-feeds.yml \
+  -f channel=alpha \
+  -f pins=agent=0.0.118 \
+  -f publish=true
+```
+
+Pins are optional; extensions not set carry over from the live manifests. The
+per-product release orchestrators upload the selected CRX and separately stage
+feed previews, but never publish live extension manifests.
 
 Locally there are two commands, and the difference matters:
 
 ```bash
-# Build, pack, sign, upload the CRX, then regenerate the feeds.
+# Build, pack, sign, and upload the CRX only.
 browseros ext release --version 0.0.118 --name agent
-browseros ext release --version 0.0.118 --name agent --publish-manifest
 
 # Feeds only, no CRX build. Pin versions; anything unset carries over from live.
 browseros release extensions --channel alpha --set agent=0.0.118

--- a/packages/browseros/bos_build/cli/ext.py
+++ b/packages/browseros/bos_build/cli/ext.py
@@ -68,40 +68,27 @@ def release(
         help="Branch override for external-repo extensions "
         "(in-repo extensions build the current working tree)",
     ),
-    channel: str = typer.Option(
-        "alpha", "--channel", "-c", help="Feed channel to regenerate: alpha or prod"
-    ),
-    publish_manifest: bool = typer.Option(
-        False,
-        "--publish-manifest",
-        help="Write regenerated update manifests to R2 "
-        "(default is a dry run: full files + diff vs live)",
-    ),
     chrome_binary: Optional[str] = typer.Option(
         None, "--chrome-binary", help="Chrome binary for --pack-extension"
     ),
 ):
-    """Build, pack, upload extension CRXs, then regenerate the update feeds.
+    """Build, pack, and upload extension CRXs.
 
     In-repo extensions (agent, browserclaw) build from this working tree and
-    stamp --version into their package.json. The CRX uploads immediately;
-    the manifest trio goes through the feeds publisher rails and is only
-    written with --publish-manifest.
+    stamp --version into their package.json.
 
     \b
-    Release the agent to alpha (manifest dry-run):
+    Release the agent CRX:
       browseros ext release --version 0.0.118 --name agent
 
     \b
-    Release + publish the alpha manifests:
-      browseros ext release --version 0.0.118 --name agent --publish-manifest
+    Update feeds separately (dry run unless --publish is passed):
+      browseros release extensions --channel alpha --set agent=0.0.118
     """
     try:
         steps = build_pipeline(
             version=version,
             name=name,
-            channel=channel,
-            publish_manifest=publish_manifest,
             branch=branch,
             chrome_binary=chrome_binary,
         )

--- a/packages/browseros/bos_build/cli/ext_test.py
+++ b/packages/browseros/bos_build/cli/ext_test.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""CLI surface tests for extension releases."""
+
+import re
+import unittest
+
+from typer.testing import CliRunner
+
+from bos_build.browseros import app
+
+runner = CliRunner()
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+class ExtensionReleaseHelpTest(unittest.TestCase):
+    def test_release_help_is_crx_only(self):
+        result = runner.invoke(app, ["ext", "release", "--help"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        help_text = ANSI_RE.sub("", result.output)
+        self.assertIn("browseros release extensions", help_text)
+        options = help_text.split("Options", 1)[1]
+        self.assertNotIn("--channel", options)
+        self.assertNotIn("--publish-manifest", options)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -22,7 +22,7 @@ release-browseros.yml
     - release-windows.yml -> build-browseros.yml with products=browseros
     - release-macos.yml with products=browseros
   extension CRX, when extensions is alpha or prod
-    - release-extensions.yml with extension=agent and publish_manifest=false
+    - release-extensions.yml with extension=agent
   stage_updates
     - render appcast and extension feed dry runs from R2 metadata
     - upload staged XML/JSON as staged-update-feeds-browseros-<version>
@@ -44,7 +44,7 @@ release-browserclaw.yml
     - release-windows.yml -> build-browseros.yml with products=browserclaw
     - release-macos.yml with products=browserclaw
   extension CRX, when extensions is alpha or prod
-    - release-extensions.yml with extension=browserclaw and publish_manifest=false
+    - release-extensions.yml with extension=browserclaw
   stage_updates
     - upload staged XML/JSON as staged-update-feeds-browserclaw-<version>
   finalize
@@ -61,7 +61,8 @@ the self-hosted macOS builder.
 | `.github/workflows/release-server.yml` | Builds BrowserOS server resource zips for every browser target, uploads versioned R2 resource keys, attaches server release assets, and reflects the server package version. | Manual and `agent-server/v*` tags | Yes, when `include_servers=true` and `products` includes `browseros` |
 | `.github/workflows/release-claw-server.yml` | Builds BrowserClaw server and onboard resource zips, uploads versioned R2 keys, attaches server release assets, and reflects Claw package versions. | Manual and `claw-server/v*` tags | Yes, when `include_servers=true` and `products` includes `browserclaw` |
 | `.github/workflows/release-claw-server-rust.yml` | Builds BrowserClaw Rust server resource zips for every browser target, uploads versioned R2 keys under `claw-server-rust/prod-resources`, and attaches Rust server release assets. | Manual, reusable, and `claw-server-rust/v*` tags | Called by `release-browserclaw.yml` when `include_servers=true` |
-| `.github/workflows/release-extensions.yml` | Builds, signs, uploads, and optionally republishes extension CRX manifests for `agent`, `controller`, `bugreporter`, and `browserclaw`. | Manual and reusable | Called by per-product orchestrators with `secrets: inherit` and `publish_manifest=false` |
+| `.github/workflows/release-extensions.yml` | Builds, signs, and uploads CRXs for `agent`, `controller`, `bugreporter`, and `browserclaw`; it never reads or writes update feeds. | Manual and reusable | Called by per-product orchestrators with `secrets: inherit` |
+| `.github/workflows/release-extension-feeds.yml` | Regenerates extension update feeds through the guarded feed publisher, as a dry run by default or an explicit R2 publish. | Manual and reusable | Independent operator action; no orchestrator dependency |
 | `.github/workflows/release-cli.yml` | Builds browseros-cli release binaries, uploads them to CDN, publishes npm package metadata, and creates the CLI GitHub release. | `cli/v*` tags | No orchestrator use |
 | `.github/workflows/release-linux.yml` | Builds Linux x64 browser artifacts on WarpBuild, one matrix entry per selected product. | Manual | Yes |
 | `.github/workflows/release-windows.yml` | Builds Windows x64 browser artifacts on WarpBuild, one matrix entry per selected product, with optional signing. | Manual | Yes |
@@ -281,6 +282,21 @@ uv run browseros release appcast --version <version> --product browserclaw --pub
 # Publish extension update manifests only if the per-product run built a CRX.
 uv run browseros release extensions --channel alpha --set agent=<agent-extension-version> --publish
 uv run browseros release extensions --channel alpha --set browserclaw=<browserclaw-extension-version> --publish
+```
+
+The extension feed operation is also available as a lightweight workflow that
+does not rebuild CRXs. `pins` accepts comma- or space-separated `name=version`
+pairs; omit `publish` for the full dry run and diff:
+
+```bash
+gh workflow run release-extension-feeds.yml \
+  -f channel=alpha \
+  -f pins='agent=<agent-extension-version>,bugreporter=<bugreporter-version>'
+
+gh workflow run release-extension-feeds.yml \
+  -f channel=alpha \
+  -f pins=agent=<agent-extension-version> \
+  -f publish=true
 ```
 
 Server OTA promotion is also manual. The server release workflows can generate

--- a/packages/browseros/bos_build/release/extensions/release.py
+++ b/packages/browseros/bos_build/release/extensions/release.py
@@ -1,13 +1,5 @@
 #!/usr/bin/env python3
-"""Ext release orchestration: build → stamp → pack → upload per spec, then
-regenerate the update manifests through the Part B feeds publisher.
-
-This is the consolidation the old actions repo could not do — it generated
-update-manifest.xml locally and told the operator to upload it by hand. Here
-the manifests flow through FeedPublisher's rails (dry-run by default,
---publish-manifest to write), so a released crx and its feed entry can no
-longer drift apart.
-"""
+"""Build, stamp, pack, and upload extension CRXs."""
 
 import os
 import re
@@ -18,9 +10,8 @@ from ...core.step import Step, ValidationError
 from ...lib.paths import get_package_root
 from ...lib.r2 import BOTO3_AVAILABLE, get_r2_client, upload_file_to_r2
 from ...lib.utils import log_info, log_success, log_warning
-from ..feeds.spec import CDN_BASE_URL, EXTENSIONS as FEED_EXTENSIONS
+from ..feeds.spec import CDN_BASE_URL
 from .crx import find_chrome_binary, pack_crx
-from .manifests import CHANNELS, ExtensionsFeedModule
 from .specs import (
     ExtensionSpec,
     ExternalRepoSource,
@@ -166,25 +157,10 @@ class ExtensionReleaseModule(Step):
 def build_pipeline(
     version: str,
     name: Optional[str],
-    channel: str,
-    publish_manifest: bool,
     branch: Optional[str],
     chrome_binary: Optional[str],
 ) -> List[Step]:
-    """Assemble the release pipeline for one --name (or every spec).
-
-    Extensions the feeds table knows get their new version pinned into an
-    ExtensionsFeedModule step; a selection with no feed members (controller)
-    releases the crx only — there is nothing to regenerate.
-
-    Channel and version are rejected here, at assembly time — the runner
-    validates steps just-in-time, so leaving this to the feeds step would
-    burn a full build + crx upload before a typo surfaces.
-    """
-    if channel not in CHANNELS:
-        raise ValueError(
-            f"channel must be one of {'/'.join(CHANNELS)}, got '{channel}'"
-        )
+    """Assemble the CRX release pipeline for one --name (or every spec)."""
     if not _VERSION_RE.fullmatch(version):
         raise ValueError(
             f"Invalid version '{version}' — Chrome extension versions are "
@@ -194,7 +170,7 @@ def build_pipeline(
     if branch and branch.startswith("-"):
         raise ValueError(f"Invalid branch name '{branch}'")
     specs = select_specs(name)
-    steps: List[Step] = [
+    return [
         ExtensionReleaseModule(
             version=version,
             names=tuple(spec.name for spec in specs),
@@ -202,15 +178,3 @@ def build_pipeline(
             chrome_binary=chrome_binary,
         )
     ]
-
-    feed_names = {ext.name for ext in FEED_EXTENSIONS}
-    pins = {spec.name: version for spec in specs if spec.name in feed_names}
-    if pins:
-        steps.append(
-            ExtensionsFeedModule(
-                channel=channel,
-                set_versions=pins,
-                publish=publish_manifest,
-            )
-        )
-    return steps

--- a/packages/browseros/bos_build/release/extensions/release_test.py
+++ b/packages/browseros/bos_build/release/extensions/release_test.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch
 
 from ...core.context import Context
 from ...core.step import ValidationError
-from .manifests import ExtensionsFeedModule
 from .release import ExtensionReleaseModule, build_pipeline
 
 MODULE = "bos_build.release.extensions.release"
@@ -37,80 +36,41 @@ class BuildPipelineTest(unittest.TestCase):
             build_pipeline(
                 version="1.0.0",
                 name="agent-v2",
-                channel="alpha",
-                publish_manifest=False,
                 branch=None,
                 chrome_binary=None,
             )
 
-    def test_feed_extension_gets_feeds_step_with_exact_pins(self):
+    def test_named_extension_gets_one_release_step(self):
         steps = build_pipeline(
             version="1.2.3",
             name="agent",
-            channel="prod",
-            publish_manifest=True,
-            branch=None,
-            chrome_binary=None,
-        )
-        self.assertEqual(len(steps), 2)
-        release, feeds = steps
-        self.assertIsInstance(release, ExtensionReleaseModule)
-        self.assertIsInstance(feeds, ExtensionsFeedModule)
-        self.assertEqual(release.names, ("agent",))
-        self.assertEqual(feeds.set_versions, {"agent": "1.2.3"})
-        self.assertEqual(feeds.channel, "prod")
-        self.assertTrue(feeds.publish)
-
-    def test_controller_only_skips_feeds_step(self):
-        steps = build_pipeline(
-            version="1.2.3",
-            name="controller",
-            channel="alpha",
-            publish_manifest=False,
             branch=None,
             chrome_binary=None,
         )
         self.assertEqual(len(steps), 1)
-        self.assertIsInstance(steps[0], ExtensionReleaseModule)
+        release = steps[0]
+        self.assertIsInstance(release, ExtensionReleaseModule)
+        self.assertEqual(release.names, ("agent",))
 
-    def test_all_extensions_pin_only_feed_members(self):
+    def test_all_extensions_get_one_release_step(self):
         steps = build_pipeline(
             version="2.0.0",
             name=None,
-            channel="alpha",
-            publish_manifest=False,
             branch=None,
             chrome_binary=None,
         )
-        release, feeds = steps
+        self.assertEqual(len(steps), 1)
+        release = steps[0]
+        self.assertIsInstance(release, ExtensionReleaseModule)
         self.assertEqual(
             release.names, ("agent", "controller", "bugreporter", "browserclaw")
         )
-        self.assertEqual(
-            feeds.set_versions,
-            {"agent": "2.0.0", "bugreporter": "2.0.0", "browserclaw": "2.0.0"},
-        )
-        self.assertFalse(feeds.publish)
-
-    def test_bad_channel_rejected_at_assembly_even_without_feeds_step(self):
-        for name in ("agent", "controller"):
-            with self.assertRaisesRegex(ValueError, "alpha/prod"):
-                build_pipeline(
-                    version="1.0.0",
-                    name=name,
-                    channel="pord",
-                    publish_manifest=False,
-                    branch=None,
-                    chrome_binary=None,
-                )
 
     def test_dash_prefixed_branch_rejected_at_assembly(self):
         with self.assertRaisesRegex(ValueError, "branch"):
             build_pipeline(
                 version="1.0.0",
                 name="controller",
-                channel="alpha",
-                publish_manifest=False,
                 branch="--upload-pack=/bin/sh",
                 chrome_binary=None,
             )
@@ -121,22 +81,9 @@ class BuildPipelineTest(unittest.TestCase):
                 build_pipeline(
                     version=version,
                     name="agent",
-                    channel="alpha",
-                    publish_manifest=False,
                     branch=None,
                     chrome_binary=None,
                 )
-
-    def test_dry_run_is_default_for_manifests(self):
-        _, feeds = build_pipeline(
-            version="1.0.0",
-            name="agent",
-            channel="alpha",
-            publish_manifest=False,
-            branch=None,
-            chrome_binary=None,
-        )
-        self.assertFalse(feeds.publish)
 
 
 class ValidateTest(unittest.TestCase):

--- a/tools/release_secrets/sync.py
+++ b/tools/release_secrets/sync.py
@@ -25,6 +25,7 @@ RELEASE_WORKFLOW_FILES = (
     Path(".github/workflows/release-browseros.yml"),
     Path(".github/workflows/release-browserclaw.yml"),
     Path(".github/workflows/release-windows.yml"),
+    Path(".github/workflows/release-extension-feeds.yml"),
     Path(".github/workflows/release-extensions.yml"),
     Path(".github/workflows/release-server.yml"),
     Path(".github/workflows/release-claw-server.yml"),
@@ -72,6 +73,7 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browserclaw.yml",
             "release-server.yml",
             "release-claw-server.yml",
+            "release-extension-feeds.yml",
             "release-extensions.yml",
         ),
     ),  # Release artifact downloads/uploads.
@@ -83,6 +85,7 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browserclaw.yml",
             "release-server.yml",
             "release-claw-server.yml",
+            "release-extension-feeds.yml",
             "release-extensions.yml",
         ),
     ),  # Release artifact downloads/uploads.
@@ -94,6 +97,7 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browserclaw.yml",
             "release-server.yml",
             "release-claw-server.yml",
+            "release-extension-feeds.yml",
             "release-extensions.yml",
         ),
     ),  # Release artifact downloads/uploads.
@@ -105,6 +109,7 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browserclaw.yml",
             "release-server.yml",
             "release-claw-server.yml",
+            "release-extension-feeds.yml",
             "release-extensions.yml",
         ),
     ),  # Release artifact downloads/uploads.

--- a/tools/release_secrets/sync_test.py
+++ b/tools/release_secrets/sync_test.py
@@ -1,6 +1,8 @@
 import unittest
 
 from tools.release_secrets.sync import (
+    ALLOWLIST,
+    RELEASE_WORKFLOW_FILES,
     DotenvParseError,
     build_check_result,
     build_plan,
@@ -75,6 +77,21 @@ class WorkflowSecretScannerTest(unittest.TestCase):
         )
 
         self.assertEqual({"BAR_BAZ", "FOO", "QUX"}, refs)
+
+    def test_extension_feed_workflow_uses_only_r2_allowlisted_secrets(self):
+        workflow = "release-extension-feeds.yml"
+        self.assertIn(workflow, {path.name for path in RELEASE_WORKFLOW_FILES})
+
+        consumers = {spec.name for spec in ALLOWLIST if workflow in spec.consumers}
+        self.assertEqual(
+            {
+                "R2_ACCOUNT_ID",
+                "R2_ACCESS_KEY_ID",
+                "R2_SECRET_ACCESS_KEY",
+                "R2_BUCKET",
+            },
+            consumers,
+        )
 
 
 class SecretPlanTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- make `browseros ext release` and `release-extensions.yml` build/upload CRXs only
- add a lightweight, R2-only `release-extension-feeds.yml` for dry runs and explicit feed publishing
- update reusable callers, release-secret tooling, tests, and operator docs for the split

## Design
CRX release and feed publication now have independent command and workflow surfaces. The feed workflow wraps the existing guarded `browseros release extensions` CLI, so unpinned versions still carry over, every referenced CRX is HEAD-checked in R2, and downgrade/removal guards remain unchanged.

## Test plan
- [x] `cd packages/browseros && uv run pytest bos_build/release/extensions/ bos_build/cli/ext_test.py -q` (69 passed)
- [x] `cd packages/browseros && uv run pytest bos_build -q` (702 passed)
- [x] `cd packages/browseros && uv run ruff check bos_build`
- [x] `cd packages/browseros && uv run pyright`
- [x] `actionlint .github/workflows/release-*.yml`
- [x] `uv run --with pytest --project packages/browseros python -m pytest tools/release_secrets/sync_test.py -q` (9 passed)
- [x] stale feed flags/references scan and `git diff --check`

## Operations note
The live `extensions/update-manifest.alpha.xml` still lists browserclaw while the spec marks browserclaw bundled-only. The first alpha feed publish after this lands must run the new `release-extension-feeds.yml` workflow once with `allow_downgrade=true` to drop browserclaw from the live alpha manifest, unless the team instead flips browserclaw's `in_update_feed` setting to `True`. Until then, alpha feed regeneration will keep refusing by design; CRX releases are no longer affected.