### PR TITLE
docs(browserclaw): correct tabs-and-isolation; classification not enforcement

### DIFF
--- a/docs/browserclaw/tabs-and-isolation.mdx
+++ b/docs/browserclaw/tabs-and-isolation.mdx
@@ -1,42 +1,29 @@
 ---
 title: "Your tabs and agent tabs"
-description: "How BrowserClaw keeps your own browsing separate from what your AI is doing."
-keywords: ["BrowserClaw tab isolation", "agent tabs", "personal tabs", "AI browser sandbox"]
+description: "How BrowserClaw groups your tabs and your AI's tabs so you always know what's what."
+keywords: ["BrowserClaw tabs", "agent tabs", "personal tabs", "AI browser"]
 ---
 
-You use your browser for your own work. Your bank, your inbox, your team's docs, your notes. When an AI drives BrowserClaw, it works in tabs of its own, right next to yours. Yours stay yours.
+You use your browser for your own work. When an AI drives BrowserClaw, it works in tabs of its own, right next to yours.
 
-## Three tab groups, one browser
+## Two kinds of tabs, one browser
 
-BrowserClaw sorts every open page into one of three groups:
+- **Your tabs.** Pages you opened yourself.
+- **The AI's tabs.** Pages your AI opened for the task you gave it.
 
-- **Your tabs.** Pages you opened yourself. Personal browsing, work docs, whatever you were doing before your AI started.
-- **This AI's tabs.** Pages your AI opened while working on the task you gave it.
-- **Another AI's tabs.** If you're running more than one AI at once, each one has its own pages. This AI cannot touch another AI's tabs either.
+Each AI's tabs land in their own colored tab group at the top of your tab strip, titled with the AI's name. Your tabs stay outside any group. One glance tells you what belongs to whom.
 
-Each AI gets its own colored tab group at the top of your tab strip, titled with the AI's name. Your tabs stay outside any group. Two AIs running side by side means two colored groups sitting next to your own tabs. One glance tells you what belongs to whom.
+## Your AI knows the difference
 
-## What each AI can and cannot do
+BrowserClaw tells your AI which tabs belong to you and which it opened itself. Your AI uses that to stay out of your workflow by default. It knows your tabs are there and can read their titles and URLs, so it has context, but it doesn't jump in.
 
-An AI running in BrowserClaw can:
-
-- Open new tabs for its own work. They land in its own colored group automatically.
-- Read, click, type, and scroll on tabs it opened.
-- See a list of every open tab, including yours, so it knows what else is going on.
-
-By default, your AI will not touch your tabs. It stays out of your workflow unless you ask.
-
-If you want your AI to help with something you have open, reply to the email you're reading, extract the numbers from the doc on your screen, just ask. Your AI will handle it.
-
-What your AI can never do is touch another AI's tabs. Cross-AI isolation stays strict, no matter what you ask.
-
-The rule is: **your AI stays out of your tabs unless you ask, and it never touches another AI's.**
+If you want your AI to help with something you have open, reply to the email you're reading, extract the numbers from the doc on your screen, just ask. Your AI can work on the tab. That's your call.
 
 ## When an AI's session ends
 
 Close an AI's session and its tab group closes with it. The tabs it opened go away in one step. Your tabs are never touched.
 
-If you close one of an AI's tabs while it's still running, the AI notices right away and stops trying to act on it. Nothing gets stuck.
+If you close one of an AI's tabs while it's still running, the AI notices right away. Nothing gets stuck.
 
 ## Where to next
 


### PR DESCRIPTION
Fixes overclaims in PR #1814. That PR merged before I could correct it. This PR rewrites the tabs-and-isolation page to accurately describe what the product actually does.

## What was wrong in the merged page

Two overclaims I invented from a too-literal reading of the code:

1. **"Cross-AI isolation stays strict"** — this claimed BrowserClaw enforces separation between concurrent agents. That's not a marketed feature; multi-AI is not a shipped scenario. The docs shouldn't promise something that isn't a product.

2. **"AI cannot / any action gets refused"** — framed the classification as a hard restriction on what the AI can do. What ships is just a classifier: BrowserClaw labels tabs so the AI knows what's yours and what's its own. No hard restrictions. The AI politely stays out of your tabs by default; if you ask it to work on a tab of yours, it will.

## What the shipped product actually does

- Classifies every open page (yours vs. the AI's).
- Renders each AI's tabs in their own colored Chrome tab group with the AI's name.
- Tells the AI which is which so it can make sensible choices.
- Does NOT enforce restrictions beyond what the AI itself decides based on the classification.

## Rewrite

- Two-bucket model (your tabs / the AI's tabs). Dropped the "another AI's tabs" bucket entirely.
- Framed as "your AI knows the difference" (polite, not restricted).
- Removed every "cannot", "refused", "never touch", "isolation stays strict" claim. The one remaining "never" is the session-close claim (`Your tabs are never touched`), which is accurate: shipped `closeAgentTabGroupForAgent` only closes the agent's own tab group.
- Frontmatter description reframed: "How BrowserClaw groups your tabs and your AI's tabs so you always know what's what."
- Dropped "sandbox" from keywords for the same reason.

## Voice discipline
- Zero em-dashes.
- Zero mentions of Chromium.
- Zero mentions of "cockpit" in visible copy.
- Zero mentions of "MCP" in body copy.

## Non-goals
- No `docs.json` changes.
- No changes to any other page.

## Test plan
- [ ] After merge + Mintlify redeploys: `docs.browseros.com/browserclaw/tabs-and-isolation` reflects the corrected framing.
- [ ] Grep the rendered page for "cross-AI", "cannot touch", "isolation stays strict" — all absent.