### PR TITLE
feat(claw-server): anonymous, privacy-first product analytics (PostHog)

### DIFF
--- a/packages/browseros-agent/apps/claw-server/package.json
+++ b/packages/browseros-agent/apps/claw-server/package.json
@@ -43,6 +43,7 @@
     "commander": "^14.0.3",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.3",
+    "posthog-node": "^4.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/browseros-agent/apps/claw-server/src/env.ts
+++ b/packages/browseros-agent/apps/claw-server/src/env.ts
@@ -50,6 +50,13 @@ function readBoolFlagDefaultTrue(name: string): boolean {
   return normalised !== '0' && normalised !== 'false'
 }
 
+/** Trimmed string env read, or undefined when unset/blank. */
+function readString(name: string): string | undefined {
+  // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
+  const raw = process.env[name]?.trim()
+  return raw && raw.length > 0 ? raw : undefined
+}
+
 /**
  * Runtime snapshot shared across services. main.ts applies validated
  * startup config before serving; tests may mutate fields for isolation.
@@ -80,6 +87,14 @@ export const env = {
   screencastScreenshotFallback: readBoolFlagDefaultTrue(
     'CLAW_SCREENCAST_SCREENSHOT_FALLBACK',
   ),
+  // Anonymous product analytics (PostHog). Disabled unless a project
+  // write key is provided (production builds inject it). `posthogHost`
+  // defaults to PostHog US Cloud. `analyticsEnabledByEnv` is an
+  // operator kill-switch (set CLAW_ANALYTICS_ENABLED=0 to force off);
+  // the per-install user opt-out lives in the analytics state file.
+  posthogKey: readString('CLAW_POSTHOG_KEY'),
+  posthogHost: readString('CLAW_POSTHOG_HOST') ?? 'https://us.i.posthog.com',
+  analyticsEnabledByEnv: readBoolFlagDefaultTrue('CLAW_ANALYTICS_ENABLED'),
 }
 
 /** Applies validated startup config to the shared runtime snapshot. */

--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -29,6 +29,7 @@ import { migrateMcpUrls } from './lib/migrate-mcp-urls'
 import { writeRuntimeFile } from './lib/runtime-file'
 import { setLocalServerUrl } from './local-server-url'
 import { createServer } from './server'
+import { captureEvent, shutdownAnalytics } from './services/analytics'
 import { runIntegrityScan } from './services/integrity-scan'
 import { startScreencastPoller } from './services/screencast-poller'
 import { publicMcpUrl } from './shared/mcp-url'
@@ -56,6 +57,8 @@ async function start(): Promise<void> {
   const url = `http://${httpServer.hostname}:${httpServer.port}`
   setLocalServerUrl(url)
   logger.info('claw-server listening', { url })
+  // Anonymous active-install signal (one per boot). No url/port sent.
+  captureEvent('server_started')
   // Publish the running URL to <CONFIG_DIR>/runtime.json so external
   // discovery (the Claude Desktop extension) can read the port without
   // scanning, log-tailing, or waiting for a harness link to populate
@@ -116,7 +119,25 @@ async function start(): Promise<void> {
       exiting = true
       screencast.stop()
       setTimeout(() => process.exit(1), 5_000).unref()
-      bootstrap.disconnect().finally(() => process.exit(0))
+      // Drain queued analytics alongside the CDP disconnect so the
+      // last session event is not stranded; the 5s kill switch above
+      // bounds either hanging.
+      Promise.allSettled([bootstrap.disconnect(), shutdownAnalytics()]).finally(
+        () => process.exit(0),
+      )
+    }
+    shutdown = cleanup
+    process.once('SIGINT', cleanup)
+    process.once('SIGTERM', cleanup)
+  } else {
+    // No browser attached (BrowserOS not reachable): still flush
+    // analytics on exit so boot/connect events are not lost.
+    let exiting = false
+    const cleanup = (): void => {
+      if (exiting) return
+      exiting = true
+      setTimeout(() => process.exit(1), 5_000).unref()
+      shutdownAnalytics().finally(() => process.exit(0))
     }
     shutdown = cleanup
     process.once('SIGINT', cleanup)

--- a/packages/browseros-agent/apps/claw-server/src/routes/system.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/system.ts
@@ -7,6 +7,7 @@
 import { Hono } from 'hono'
 import pkg from '../../package.json' with { type: 'json' }
 import { getLocalServerUrl } from '../local-server-url'
+import { getTelemetryState } from '../services/analytics'
 import { VERSION } from '../version'
 
 interface SystemRouteConfig {
@@ -14,12 +15,20 @@ interface SystemRouteConfig {
 }
 
 export function createSystemRoute(config: SystemRouteConfig = {}) {
-  return new Hono()
-    .get('/system/health', (c) => c.json({ status: 'ok' as const }))
-    .post('/system/shutdown', (c) => {
-      setImmediate(() => config.onShutdown?.())
-      return c.json({ status: 'ok' as const })
-    })
-    .get('/system/version', (c) => c.json({ name: pkg.name, version: VERSION }))
-    .get('/system/url', (c) => c.json({ url: getLocalServerUrl() }))
+  return (
+    new Hono()
+      .get('/system/health', (c) => c.json({ status: 'ok' as const }))
+      .post('/system/shutdown', (c) => {
+        setImmediate(() => config.onShutdown?.())
+        return c.json({ status: 'ok' as const })
+      })
+      .get('/system/version', (c) =>
+        c.json({ name: pkg.name, version: VERSION }),
+      )
+      .get('/system/url', (c) => c.json({ url: getLocalServerUrl() }))
+      // The anonymous install id + opt-out state, so the cockpit UI can
+      // share one anonymous identity with the server and reflect the
+      // current telemetry setting. No PII: distinctId is a random UUID.
+      .get('/system/telemetry', (c) => c.json(getTelemetryState()))
+  )
 }

--- a/packages/browseros-agent/apps/claw-server/src/services/analytics.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/analytics.ts
@@ -80,7 +80,8 @@ export interface AnalyticsState {
 
 let state: AnalyticsState | null = null
 let client: PostHog | null = null
-let initialised = false
+let stateLoaded = false
+let clientInitialised = false
 
 function analyticsPath(): string {
   return join(getClawServerDir(), ANALYTICS_FILE)
@@ -102,13 +103,33 @@ function persistState(next: AnalyticsState): void {
 }
 
 /**
- * Reads the persisted anonymous id + opt-out flag, generating and
- * writing a fresh anonymous UUID on first run. A missing or corrupt
- * file regenerates rather than throwing.
+ * Reads the persisted anonymous id + opt-out flag. A genuinely MISSING
+ * file (first run) mints a fresh id with consent on (the opt-out
+ * default). A file that EXISTS but is unreadable or corrupt fails
+ * CLOSED (consent off) and is left untouched, so a prior opt-out can
+ * never be silently lost.
  */
 function loadOrCreateState(): AnalyticsState {
+  let raw: string
   try {
-    const parsed = JSON.parse(readFileSync(analyticsPath(), 'utf8')) as Partial<
+    raw = readFileSync(analyticsPath(), 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      // First run: no prior choice exists, so honour the opt-out
+      // default (telemetry on) and persist a fresh anonymous id.
+      const fresh: AnalyticsState = { distinctId: randomUUID(), enabled: true }
+      persistState(fresh)
+      return fresh
+    }
+    // The file exists but could not be read (permissions, IO). A prior
+    // opt-out may be hiding in it, so fail CLOSED and do not overwrite.
+    logger.warn('analytics state unreadable; disabling to preserve consent', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return { distinctId: randomUUID(), enabled: false }
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<
       Record<keyof AnalyticsState, unknown>
     >
     if (typeof parsed.distinctId === 'string' && parsed.distinctId.length > 0) {
@@ -118,30 +139,47 @@ function loadOrCreateState(): AnalyticsState {
       }
     }
   } catch {
-    // Missing or unreadable: fall through and mint a fresh id.
+    // Fall through to the fail-closed path below.
   }
-  const fresh: AnalyticsState = { distinctId: randomUUID(), enabled: true }
-  persistState(fresh)
-  return fresh
+  // The file exists but is corrupt or missing an id. We cannot tell
+  // whether the user had opted out, so fail CLOSED and leave the file
+  // untouched for recovery rather than silently re-enabling.
+  logger.warn('analytics state corrupt; disabling to preserve consent')
+  return { distinctId: randomUUID(), enabled: false }
 }
 
-function ensureInit(): void {
-  if (initialised) return
-  initialised = true
-  state = loadOrCreateState()
+/**
+ * Every gate that must pass before telemetry is actually active on
+ * this server: a configured write key, the operator kill-switch on,
+ * and the user's consent. This is the single source of truth reported
+ * to the UI and used to decide whether to construct the client, so the
+ * two can never disagree.
+ */
+function effectiveEnabled(s: AnalyticsState | null): boolean {
+  return Boolean(s?.enabled && env.analyticsEnabledByEnv && env.posthogKey)
+}
 
-  const disabledReason = !env.posthogKey
-    ? 'no-key'
-    : !env.analyticsEnabledByEnv
-      ? 'env-off'
-      : !state.enabled
-        ? 'user-opt-out'
-        : null
-  if (disabledReason) {
-    logger.info('analytics disabled', { reason: disabledReason })
+/** Loads the anonymous id + consent flag. Does NOT construct a client. */
+function ensureState(): void {
+  if (stateLoaded) return
+  stateLoaded = true
+  state = loadOrCreateState()
+}
+
+/** Constructs the PostHog client iff every gate in `effectiveEnabled` passes. */
+function ensureClient(): void {
+  ensureState()
+  if (clientInitialised) return
+  clientInitialised = true
+  if (!effectiveEnabled(state)) {
+    const reason = !env.posthogKey
+      ? 'no-key'
+      : !env.analyticsEnabledByEnv
+        ? 'env-off'
+        : 'user-opt-out'
+    logger.info('analytics disabled', { reason })
     return
   }
-
   client = new PostHog(env.posthogKey as string, {
     host: env.posthogHost,
     // Local, low-volume process: flush each event promptly so a
@@ -201,7 +239,7 @@ export function captureEvent(
   event: string,
   props: Record<string, unknown> = {},
 ): void {
-  ensureInit()
+  ensureClient()
   if (!client || !state) return
   try {
     client.capture({
@@ -222,12 +260,18 @@ export function captureEvent(
 }
 
 /**
- * The anonymous id + enabled flag surfaced to the cockpit UI so it
- * can share the same install identity and reflect the opt-out state.
+ * The anonymous id + EFFECTIVE enabled flag surfaced to the cockpit UI.
+ * `enabled` reflects whether telemetry is actually active (key present,
+ * kill-switch on, user not opted out), so the UI never shows telemetry
+ * as on while every capture is a no-op. Loads state but never
+ * constructs a network client.
  */
 export function getTelemetryState(): AnalyticsState {
-  ensureInit()
-  return state ?? { distinctId: '', enabled: false }
+  ensureState()
+  return {
+    distinctId: state?.distinctId ?? '',
+    enabled: effectiveEnabled(state),
+  }
 }
 
 /** Flush pending events. Called from the boot shutdown path. */
@@ -244,5 +288,6 @@ export async function shutdownAnalytics(): Promise<void> {
 export function resetAnalyticsForTesting(): void {
   state = null
   client = null
-  initialised = false
+  stateLoaded = false
+  clientInitialised = false
 }

--- a/packages/browseros-agent/apps/claw-server/src/services/analytics.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/analytics.ts
@@ -1,0 +1,248 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Anonymous, privacy-first product analytics (PostHog).
+ *
+ * Principle: measure the product, never the user. We report only
+ * metadata about which features get used (a session opened, which
+ * agent connected, a harness was linked). We NEVER send urls, page
+ * titles/content, prompts, tool arguments or results, screenshots,
+ * agent labels, file paths, tokens, or emails. Two defenses keep
+ * that true regardless of call sites:
+ *
+ *   1. `sanitize()` is an ALLOW-LIST: any property key not in
+ *      `SAFE_KEYS` is dropped, and any value that looks like a url,
+ *      email, or path is dropped, so a mistake at a call site cannot
+ *      leak content.
+ *   2. Free-text-ish fields (`client_name`) are bucketed to a known
+ *      set via `bucketClientName`; anything else becomes `"other"`.
+ *
+ * Identity is a single anonymous UUID generated once and persisted at
+ * `<clawServerDir>/analytics.json` alongside the user's opt-out flag.
+ * No `identify`, no PII. The same id is served to the cockpit UI via
+ * `/system/telemetry` so both surfaces share one anonymous install.
+ *
+ * Analytics is OFF unless a project write key is configured
+ * (`CLAW_POSTHOG_KEY`), the operator kill-switch is on
+ * (`CLAW_ANALYTICS_ENABLED`, default on), and the user has not opted
+ * out. When off, no client is constructed and every capture no-ops.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { PostHog } from 'posthog-node'
+import { env } from '../env'
+import { getClawServerDir } from '../lib/browserclaw-dir'
+import { logger } from '../lib/logger'
+import { VERSION } from '../version'
+
+const ANALYTICS_FILE = 'analytics.json'
+
+/** Property keys allowed to leave the machine. Anything else is dropped. */
+const SAFE_KEYS: ReadonlySet<string> = new Set([
+  'client_name',
+  'harness',
+  'kind',
+  'server_version',
+  'os_platform',
+  'enabled',
+])
+
+/**
+ * MCP client names we recognise. Anything else buckets to `"other"`
+ * so a custom or self-built client can never leak a user-authored
+ * string as a property value.
+ */
+const KNOWN_CLIENTS: ReadonlySet<string> = new Set([
+  'claude-desktop',
+  'claude-code',
+  'claude-ai',
+  'cursor',
+  'vscode',
+  'vscode-insiders',
+  'codex',
+  'zed',
+  'opencode',
+  'antigravity',
+  'windsurf',
+  'cline',
+  'continue',
+  'goose',
+])
+
+export interface AnalyticsState {
+  distinctId: string
+  enabled: boolean
+}
+
+let state: AnalyticsState | null = null
+let client: PostHog | null = null
+let initialised = false
+
+function analyticsPath(): string {
+  return join(getClawServerDir(), ANALYTICS_FILE)
+}
+
+function persistState(next: AnalyticsState): void {
+  const dir = getClawServerDir()
+  const path = analyticsPath()
+  const tmp = `${path}.tmp`
+  try {
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`, 'utf8')
+    renameSync(tmp, path)
+  } catch (err) {
+    logger.warn('analytics state write failed', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+/**
+ * Reads the persisted anonymous id + opt-out flag, generating and
+ * writing a fresh anonymous UUID on first run. A missing or corrupt
+ * file regenerates rather than throwing.
+ */
+function loadOrCreateState(): AnalyticsState {
+  try {
+    const parsed = JSON.parse(readFileSync(analyticsPath(), 'utf8')) as Partial<
+      Record<keyof AnalyticsState, unknown>
+    >
+    if (typeof parsed.distinctId === 'string' && parsed.distinctId.length > 0) {
+      return {
+        distinctId: parsed.distinctId,
+        enabled: parsed.enabled !== false,
+      }
+    }
+  } catch {
+    // Missing or unreadable: fall through and mint a fresh id.
+  }
+  const fresh: AnalyticsState = { distinctId: randomUUID(), enabled: true }
+  persistState(fresh)
+  return fresh
+}
+
+function ensureInit(): void {
+  if (initialised) return
+  initialised = true
+  state = loadOrCreateState()
+
+  const disabledReason = !env.posthogKey
+    ? 'no-key'
+    : !env.analyticsEnabledByEnv
+      ? 'env-off'
+      : !state.enabled
+        ? 'user-opt-out'
+        : null
+  if (disabledReason) {
+    logger.info('analytics disabled', { reason: disabledReason })
+    return
+  }
+
+  client = new PostHog(env.posthogKey as string, {
+    host: env.posthogHost,
+    // Local, low-volume process: flush each event promptly so a
+    // browser close does not strand the last session event, and
+    // shutdownAnalytics() drains anything in flight.
+    flushAt: 1,
+    flushInterval: 0,
+  })
+  logger.info('analytics enabled', { host: env.posthogHost })
+}
+
+/** Slug-and-bucket an MCP client name to a known token or `"other"`. */
+export function bucketClientName(raw: string): string {
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return KNOWN_CLIENTS.has(slug) ? slug : 'other'
+}
+
+/**
+ * A value is rejected if it looks like it could carry user content:
+ * a url, an email, a filesystem path, or an unexpectedly long string.
+ * All legitimate event values (short enum tokens, versions, booleans)
+ * pass; anything content-shaped is dropped.
+ */
+function looksSensitive(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  return (
+    /https?:\/\//i.test(value) ||
+    value.includes('@') ||
+    value.includes('/') ||
+    value.includes('\\') ||
+    value.length > 48
+  )
+}
+
+/** Allow-list keys + drop content-shaped values. Defense in depth. */
+export function sanitize(
+  props: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(props)) {
+    if (!SAFE_KEYS.has(key)) continue
+    if (looksSensitive(value)) continue
+    out[key] = value
+  }
+  return out
+}
+
+/**
+ * Fire-and-forget capture. No-ops when analytics is disabled. Every
+ * event carries the anonymous install id plus server version + OS,
+ * and its properties are sanitized before send. Never throws.
+ */
+export function captureEvent(
+  event: string,
+  props: Record<string, unknown> = {},
+): void {
+  ensureInit()
+  if (!client || !state) return
+  try {
+    client.capture({
+      distinctId: state.distinctId,
+      event,
+      properties: {
+        server_version: VERSION,
+        os_platform: process.platform,
+        ...sanitize(props),
+      },
+    })
+  } catch (err) {
+    logger.warn('analytics capture failed', {
+      event,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+/**
+ * The anonymous id + enabled flag surfaced to the cockpit UI so it
+ * can share the same install identity and reflect the opt-out state.
+ */
+export function getTelemetryState(): AnalyticsState {
+  ensureInit()
+  return state ?? { distinctId: '', enabled: false }
+}
+
+/** Flush pending events. Called from the boot shutdown path. */
+export async function shutdownAnalytics(): Promise<void> {
+  if (!client) return
+  try {
+    await client.shutdown()
+  } catch {
+    // Best-effort flush on exit; nothing to recover.
+  }
+}
+
+/** Test-only: reset module state so each test starts clean. */
+export function resetAnalyticsForTesting(): void {
+  state = null
+  client = null
+  initialised = false
+}

--- a/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
@@ -22,6 +22,7 @@ import { logger } from '../lib/logger'
 import { getMcpManager } from '../lib/mcp-manager'
 import { tildifyHomePath } from '../lib/tildify'
 import { BROWSEROS_MCP_SERVER_NAME, publicMcpUrl } from '../shared/mcp-url'
+import { captureEvent } from './analytics'
 import { HARNESS_TO_AGENT_ID, type Harness, harnessEnum } from './harnesses'
 import { relinkManagedServer } from './mcp-relink'
 import { specFor } from './spec-for'
@@ -71,6 +72,9 @@ export async function connectBrowserosToHarness(
       agent: agentId,
       configPath: rawConfigPath,
     })
+    // Which agents users are wiring BrowserClaw into. `harness` is a
+    // fixed enum label, not user data.
+    captureEvent('harness_connected', { harness })
     return {
       harness,
       installed: true,
@@ -105,6 +109,7 @@ export async function disconnectBrowserosFromHarness(
       unlinked: summary.unlinked,
       removedManifest: summary.removedManifest,
     })
+    captureEvent('harness_disconnected', { harness })
     return {
       harness,
       installed: false,

--- a/packages/browseros-agent/apps/claw-server/src/services/session-events.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/session-events.ts
@@ -14,6 +14,7 @@ import {
   agentSessionEnds,
   agentSessionStarts,
 } from '../modules/db/schema/schema'
+import { bucketClientName, captureEvent } from './analytics'
 
 export interface RecordSessionStartInput {
   sessionId: string
@@ -35,6 +36,12 @@ export function recordSessionStart(input: RecordSessionStartInput): void {
       error: err instanceof Error ? err.message : String(err),
     })
   }
+  // Anonymous usage signal: a session happened and which agent ran it.
+  // `client_name` is bucketed to a known set; no session/agent id, no
+  // label, no content.
+  captureEvent('agent_session_started', {
+    client_name: bucketClientName(input.clientName),
+  })
 }
 
 export interface RecordSessionEndInput {
@@ -60,4 +67,6 @@ export function recordSessionEnd(input: RecordSessionEndInput): void {
       error: err instanceof Error ? err.message : String(err),
     })
   }
+  // Session ended; `kind` distinguishes a clean close from an error.
+  captureEvent('agent_session_ended', { kind: input.kind })
 }

--- a/packages/browseros-agent/apps/claw-server/tests/services/analytics.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/analytics.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { env } from '../../src/env'
@@ -76,36 +76,80 @@ describe('bucketClientName', () => {
   })
 })
 
-describe('telemetry state + disabled default', () => {
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+describe('telemetry state + gating', () => {
   let dir: string
-  let prior: string | undefined
+  let priorDir: string | undefined
+  let priorKey: string | undefined
+  let priorEnvEnabled: boolean
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'claw-analytics-'))
-    prior = env.browserClawDirOverride
+    priorDir = env.browserClawDirOverride
+    priorKey = env.posthogKey
+    priorEnvEnabled = env.analyticsEnabledByEnv
     env.browserClawDirOverride = dir
+    env.posthogKey = undefined
+    env.analyticsEnabledByEnv = true
     resetAnalyticsForTesting()
   })
 
   afterEach(() => {
-    env.browserClawDirOverride = prior
+    env.browserClawDirOverride = priorDir
+    env.posthogKey = priorKey
+    env.analyticsEnabledByEnv = priorEnvEnabled
     resetAnalyticsForTesting()
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('mints and persists an anonymous uuid, enabled by default', () => {
+  it('mints and persists an anonymous uuid with consent on by default', () => {
     const state = getTelemetryState()
-    expect(state.enabled).toBe(true)
-    expect(state.distinctId).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    )
+    expect(state.distinctId).toMatch(UUID_RE)
     const onDisk = JSON.parse(readFileSync(join(dir, 'analytics.json'), 'utf8'))
     expect(onDisk.distinctId).toBe(state.distinctId)
+    expect(onDisk.enabled).toBe(true)
+  })
+
+  it('reports enabled=false without a key, even with consent on', () => {
+    // The reported flag is the EFFECTIVE state, so the UI never shows
+    // telemetry as on while every capture is a no-op.
+    expect(getTelemetryState().enabled).toBe(false)
+  })
+
+  it('reports enabled=true only when key + kill-switch + consent all pass', () => {
+    env.posthogKey = 'phc_test'
+    resetAnalyticsForTesting()
+    expect(getTelemetryState().enabled).toBe(true)
+    // Operator kill-switch overrides consent.
+    env.analyticsEnabledByEnv = false
+    resetAnalyticsForTesting()
+    expect(getTelemetryState().enabled).toBe(false)
+  })
+
+  it('fails closed on a corrupt state file and leaves it untouched', () => {
+    const path = join(dir, 'analytics.json')
+    writeFileSync(path, '{ not valid json', 'utf8')
+    env.posthogKey = 'phc_test'
+    resetAnalyticsForTesting()
+    // A prior opt-out might be hiding in the corrupt file, so we must
+    // not silently re-enable.
+    expect(getTelemetryState().enabled).toBe(false)
+    expect(readFileSync(path, 'utf8')).toBe('{ not valid json')
+  })
+
+  it('honours a persisted opt-out even with a key present', () => {
+    writeFileSync(
+      join(dir, 'analytics.json'),
+      JSON.stringify({ distinctId: 'abc', enabled: false }),
+      'utf8',
+    )
+    env.posthogKey = 'phc_test'
+    resetAnalyticsForTesting()
+    expect(getTelemetryState().enabled).toBe(false)
   })
 
   it('is a no-op (no throw) when no PostHog key is configured', () => {
-    // Default dev/test env has no CLAW_POSTHOG_KEY, so no client is
-    // constructed and capture must be a safe no-op.
     expect(() => captureEvent('server_started')).not.toThrow()
     expect(() =>
       captureEvent('harness_connected', { harness: 'Zed' }),

--- a/packages/browseros-agent/apps/claw-server/tests/services/analytics.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/analytics.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Privacy guard for analytics. The whole point of the feature is that
+ * it can never carry user content, so these tests pin the two defenses
+ * (allow-list sanitizer + client-name bucketing) that enforce it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { env } from '../../src/env'
+import {
+  bucketClientName,
+  captureEvent,
+  getTelemetryState,
+  resetAnalyticsForTesting,
+  sanitize,
+} from '../../src/services/analytics'
+
+describe('sanitize (allow-list + value guard)', () => {
+  it('drops any property key not on the allow-list', () => {
+    const out = sanitize({
+      client_name: 'cursor',
+      // none of these may ever survive
+      url: 'http://127.0.0.1:9200/mcp',
+      title: 'Inbox',
+      agent_label: 'my agent',
+      session_id: 'abc',
+      prompt: 'do the thing',
+    })
+    expect(out).toEqual({ client_name: 'cursor' })
+  })
+
+  it('drops values that look like user content even on allowed keys', () => {
+    // A bug at a call site puts content into an allowed key; the value
+    // guard still refuses it.
+    expect(sanitize({ client_name: 'https://example.com' })).toEqual({})
+    expect(sanitize({ client_name: 'user@example.com' })).toEqual({})
+    expect(sanitize({ client_name: '/home/user/secret' })).toEqual({})
+    expect(sanitize({ client_name: 'C:\\Users\\someone' })).toEqual({})
+    expect(sanitize({ client_name: 'x'.repeat(64) })).toEqual({})
+  })
+
+  it('keeps legitimate short metadata values', () => {
+    expect(
+      sanitize({
+        client_name: 'claude-code',
+        harness: 'VS Code',
+        kind: 'closed',
+        enabled: true,
+      }),
+    ).toEqual({
+      client_name: 'claude-code',
+      harness: 'VS Code',
+      kind: 'closed',
+      enabled: true,
+    })
+  })
+})
+
+describe('bucketClientName', () => {
+  it('maps known clients to their slug', () => {
+    expect(bucketClientName('Claude Code')).toBe('claude-code')
+    expect(bucketClientName('cursor')).toBe('cursor')
+    expect(bucketClientName('VSCode')).toBe('vscode')
+  })
+
+  it('buckets anything unknown to "other" so custom names cannot leak', () => {
+    expect(bucketClientName('my-secret-internal-tool')).toBe('other')
+    expect(bucketClientName('user@example.com')).toBe('other')
+    expect(bucketClientName('')).toBe('other')
+  })
+})
+
+describe('telemetry state + disabled default', () => {
+  let dir: string
+  let prior: string | undefined
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'claw-analytics-'))
+    prior = env.browserClawDirOverride
+    env.browserClawDirOverride = dir
+    resetAnalyticsForTesting()
+  })
+
+  afterEach(() => {
+    env.browserClawDirOverride = prior
+    resetAnalyticsForTesting()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('mints and persists an anonymous uuid, enabled by default', () => {
+    const state = getTelemetryState()
+    expect(state.enabled).toBe(true)
+    expect(state.distinctId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    )
+    const onDisk = JSON.parse(readFileSync(join(dir, 'analytics.json'), 'utf8'))
+    expect(onDisk.distinctId).toBe(state.distinctId)
+  })
+
+  it('is a no-op (no throw) when no PostHog key is configured', () => {
+    // Default dev/test env has no CLAW_POSTHOG_KEY, so no client is
+    // constructed and capture must be a safe no-op.
+    expect(() => captureEvent('server_started')).not.toThrow()
+    expect(() =>
+      captureEvent('harness_connected', { harness: 'Zed' }),
+    ).not.toThrow()
+  })
+})

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -218,6 +218,7 @@
         "commander": "^14.0.3",
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.3",
+        "posthog-node": "^4.0.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary

Phase 1 of BrowserClaw usage analytics: instrument the local cockpit server (`claw-server`) with PostHog so we can answer three product questions:

1. **How many sessions** users have (agents connecting and running).
2. **What agents** they connect (which client apps / harnesses).
3. (Phase 2, claw-app) how often they visit audit / replay.

Guiding principle: **measure the product, never the user.** Zero user content ever leaves the machine.

## What's sent (metadata only)

| Event | Properties |
|---|---|
| `server_started` | `server_version`, `os_platform` |
| `agent_session_started` | `client_name` (bucketed to a known set) |
| `agent_session_ended` | `kind` (closed / errored) |
| `harness_connected` / `harness_disconnected` | `harness` (fixed enum) |

Every event also carries an anonymous install id. **Never sent:** urls, page titles/content, prompts, tool arguments/results, screenshots, agent labels, session/agent ids, file paths, tokens, emails.

Tool-call counts are intentionally not tracked.

## Privacy design

- **Anonymous identity:** a single random UUID minted once and persisted at `<clawServerDir>/analytics.json` with the user's opt-out flag. No `identify`, no PII. Exposed via `GET /system/telemetry` so the cockpit UI (Phase 2) shares one identity.
- **Two enforced defenses (regardless of call sites):**
  1. `sanitize()` is an allow-list — any property key not explicitly safe is dropped, and any value shaped like a url / email / path / long string is dropped.
  2. `bucketClientName()` maps client names to a known set or `"other"`, so a custom client can't leak a user-authored string.
  A unit test pins both.
- **Off by default / kill-switch:** analytics is disabled unless a project write key is configured (`CLAW_POSTHOG_KEY`), the operator flag is on (`CLAW_ANALYTICS_ENABLED`, default on), and the user hasn't opted out. When off, no client is constructed and every capture no-ops. Dev/CI has no key, so nothing is ever sent locally.
- **Flush on exit:** events drain via `posthog.shutdown()` inside the existing SIGINT/SIGTERM cleanup (within the 5s window); capture is fire-and-forget so it never blocks a session.
- Defaults to PostHog US Cloud.

## Test plan

- [x] `bun run --filter '@browseros/claw-server' typecheck` clean.
- [x] New `tests/services/analytics.test.ts`: allow-list sanitizer, value guard (url/email/path/long dropped), client-name bucketing, anonymous-id persistence, no-op when unconfigured. 7 pass.
- [x] Existing `tests/services` + `tests/routes` green (189 pass) — session-events and connect instrumentation didn't change behaviour.
- [ ] With a real key set, confirm events land in PostHog and carry no content properties.

## Follow-up

- Phase 2: claw-app `posthog-js` (autocapture / session-replay / pageviews OFF) reading the shared id from `/system/telemetry`, the audit/replay/app-open view events, and the opt-out toggle in the cockpit.