### PR TITLE
chore(mcp): add title + readOnly/destructive hints to every browser tool

### DIFF
--- a/packages/browseros-agent/packages/browser-mcp/src/tools/act.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/act.ts
@@ -61,6 +61,10 @@ export const act = defineTool({
     clickCount: z.number().int().optional(),
     clear: z.boolean().optional(),
   }),
+  annotations: {
+    title: 'Interact with page',
+    destructiveHint: true,
+  },
   handler: async (args, ctx, response) => {
     const input = ctx.session.input(args.page)
 

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/diff.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/diff.ts
@@ -7,7 +7,7 @@ export const diff = defineTool({
   description:
     "Show what changed on the page since the last snapshot/diff - a cheap way to see an action's effect without re-dumping the whole tree.",
   input: z.object({ page: z.number().int() }),
-  annotations: { readOnlyHint: true },
+  annotations: { title: 'Diff page state', readOnlyHint: true },
   handler: async (args, ctx) => {
     const d = await ctx.session.observe(args.page).diff()
     const origin =

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/download.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/download.ts
@@ -17,6 +17,10 @@ export const download = defineTool({
       .string()
       .describe('Ref of the element that triggers the download, e.g. "e12".'),
   }),
+  annotations: {
+    title: 'Download from page',
+    destructiveHint: true,
+  },
   handler: async (args, ctx) => {
     const { session } = await ctx.session.pages.getSession(args.page)
     // A fresh subdir avoids Chromium filename uniquifying on repeated downloads.

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/evaluate.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/evaluate.ts
@@ -26,7 +26,7 @@ export const evaluate = defineTool({
   }),
   annotations: {
     title: 'Run JavaScript in page',
-    readOnlyHint: true,
+    destructiveHint: true,
     openWorldHint: true,
   },
   handler: async (args, ctx) => {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/evaluate.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/evaluate.ts
@@ -7,7 +7,7 @@ import { wrapUntrusted } from './trust-boundary'
 const DEFAULT_TIMEOUT_MS = 30_000
 const MAX_TIMEOUT_MS = 30_000
 
-const DESCRIPTION = `Evaluate JavaScript in a page context through CDP Runtime.evaluate. Use this for page-state reads or small DOM scripts that are awkward with read/grep. Return a value to read it back.`
+const DESCRIPTION = `Evaluate JavaScript in a page context through CDP Runtime.evaluate. Returns the value returned by the script.`
 
 export const evaluate = defineTool({
   name: 'evaluate',
@@ -24,7 +24,11 @@ export const evaluate = defineTool({
       .optional()
       .describe('Max evaluation time in ms (default 30000).'),
   }),
-  annotations: { openWorldHint: true },
+  annotations: {
+    title: 'Run JavaScript in page',
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
   handler: async (args, ctx) => {
     const { session } = await ctx.session.pages.getSession(args.page)
     const timeout = clampTimeout(

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/evaluate.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/evaluate.ts
@@ -7,7 +7,7 @@ import { wrapUntrusted } from './trust-boundary'
 const DEFAULT_TIMEOUT_MS = 30_000
 const MAX_TIMEOUT_MS = 30_000
 
-const DESCRIPTION = `Evaluate JavaScript in a page context through CDP Runtime.evaluate. Returns the value returned by the script.`
+const DESCRIPTION = `Evaluate JavaScript in a page context through CDP Runtime.evaluate. Use this for page-state reads or small DOM scripts that are awkward with read/grep. Return a value to read it back.`
 
 export const evaluate = defineTool({
   name: 'evaluate',

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/framework.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/framework.ts
@@ -20,8 +20,21 @@ export type ContentBlock = ContentItem
 export type ToolResult = ResponseToolResult
 
 export interface ToolAnnotations {
+  /**
+   * Human-readable display name shown in MCP clients (e.g. Claude Desktop's
+   * tool call UI). Required for Claude Directory listings.
+   */
+  title?: string
   readOnlyHint?: boolean
+  /**
+   * True when the tool may modify or delete state, files, or data.
+   * Meaningful only when readOnlyHint is not true. Destructive tools
+   * always prompt the user before running in MCP clients that respect the
+   * hint.
+   */
   destructiveHint?: boolean
+  /** True when repeated calls with the same args produce the same effect. */
+  idempotentHint?: boolean
   openWorldHint?: boolean
 }
 

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/grep.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/grep.ts
@@ -18,7 +18,7 @@ export const grep = defineTool({
     over: z.enum(['ax', 'content']).default('ax'),
     limit: z.number().optional().describe('Max matching lines (default 50).'),
   }),
-  annotations: { readOnlyHint: true },
+  annotations: { title: 'Search page', readOnlyHint: true },
   handler: async (args, ctx) => {
     let regex: RegExp
     try {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/navigate.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/navigate.ts
@@ -10,6 +10,10 @@ export const navigate = defineTool({
     action: z.enum(['url', 'back', 'forward', 'reload']).default('url'),
     url: z.string().optional().describe('Required when action is "url".'),
   }),
+  annotations: {
+    title: 'Navigate page',
+    destructiveHint: true,
+  },
   handler: async (args, ctx, response) => {
     const nav = ctx.session.nav(args.page)
     switch (args.action) {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/pdf.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/pdf.ts
@@ -22,7 +22,7 @@ export const pdf = defineTool({
       .default(false)
       .describe('Use CSS page size when the page defines one.'),
   }),
-  annotations: { readOnlyHint: true },
+  annotations: { title: 'Save page as PDF', readOnlyHint: true },
   handler: async (args, ctx) => {
     const { session } = await ctx.session.pages.getSession(args.page)
     const { data } = await session.Page.printToPDF({

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/read.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/read.ts
@@ -38,7 +38,7 @@ export const read = defineTool({
       .optional()
       .describe('For markdown reads, include image references.'),
   }),
-  annotations: { readOnlyHint: true },
+  annotations: { title: 'Read page content', readOnlyHint: true },
   handler: async (args, ctx) => {
     const { session } = await ctx.session.pages.getSession(args.page)
     const code =

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.test.ts
@@ -75,6 +75,7 @@ describe('registerBrowserTools', () => {
     )
     expect(fake.configs.get('tabs')?.inputSchema).toBeDefined()
     expect(fake.configs.get('snapshot')?.annotations).toEqual({
+      title: 'Snapshot accessibility tree',
       readOnlyHint: true,
     })
     expect(fake.configs.get('tabs')?.outputSchema).toBeUndefined()

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/run.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/run.ts
@@ -47,7 +47,11 @@ export const run = defineTool({
     logs: z.array(z.string()),
     error: z.string().optional(),
   }),
-  annotations: { openWorldHint: true },
+  annotations: {
+    title: 'Run browser SDK script',
+    destructiveHint: true,
+    openWorldHint: true,
+  },
   handler: async (args, ctx) => {
     let fn: (...injected: unknown[]) => Promise<unknown>
     try {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
@@ -63,7 +63,7 @@ export const screenshot = defineTool({
       .optional()
       .describe('Overlay numbered refs from a fresh snapshot. Defaults false.'),
   }),
-  annotations: { readOnlyHint: true },
+  annotations: { title: 'Take screenshot', readOnlyHint: true },
   handler: async (args, ctx) => {
     const fullPage = args.fullPage ?? false
     const captureOptions: ScreenshotCaptureOptions = {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/snapshot.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/snapshot.ts
@@ -5,11 +5,11 @@ import { formatSnapshotResult } from './snapshot-format'
 export const snapshot = defineTool({
   name: 'snapshot',
   description:
-    'Capture the page as an indented accessibility tree. Each actionable element carries a stable [ref=eN] you pass to `act`. Iframe content is stitched in inline. Re-snapshot after navigation or large changes (refs are invalidated). This is the start of the loop: snapshot -> act -> (reads back a diff).',
+    'Capture the page as an indented accessibility tree. Each actionable element carries a stable [ref=eN] that can be passed to `act`. Iframe content is stitched inline. Refs are invalidated by navigation or large DOM changes.',
   input: z.object({
     page: z.number().int().describe('Page id from `tabs` or `navigate`.'),
   }),
-  annotations: { readOnlyHint: true },
+  annotations: { title: 'Snapshot accessibility tree', readOnlyHint: true },
   handler: async (args, ctx) => {
     const { text } = await ctx.session.observe(args.page).snapshot()
     const origin = ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/snapshot.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/snapshot.ts
@@ -5,7 +5,7 @@ import { formatSnapshotResult } from './snapshot-format'
 export const snapshot = defineTool({
   name: 'snapshot',
   description:
-    'Capture the page as an indented accessibility tree. Each actionable element carries a stable [ref=eN] that can be passed to `act`. Iframe content is stitched inline. Refs are invalidated by navigation or large DOM changes.',
+    'Capture the page as an indented accessibility tree. Each actionable element carries a stable [ref=eN] you pass to `act`. Iframe content is stitched in inline. Re-snapshot after navigation or large changes (refs are invalidated). This is the start of the loop: snapshot -> act -> (reads back a diff).',
   input: z.object({
     page: z.number().int().describe('Page id from `tabs` or `navigate`.'),
   }),

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/tab-groups.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/tab-groups.ts
@@ -52,7 +52,11 @@ export const tab_groups = defineTool({
       .optional()
       .describe('Collapse/expand the group for "update".'),
   }),
-  annotations: { openWorldHint: true },
+  annotations: {
+    title: 'Manage tab groups',
+    destructiveHint: true,
+    openWorldHint: true,
+  },
   handler: async (args, ctx) => {
     const { pages } = ctx.session
 

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/tabs.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/tabs.ts
@@ -4,7 +4,7 @@ import { defineTool, errorResult, textResult } from './framework'
 export const tabs = defineTool({
   name: 'tabs',
   description:
-    "Manage browser tabs. `list` returns every open page grouped by ownership: `Your tabs` (pages you opened via `tabs new`), `User's tabs` (pages the operator opened), and `Other agents' tabs` (pages another AI agent opened). You can act freely on your own tabs. Page-targeted tools (snapshot, act, navigate, close, etc.) reject dispatches on pages you do not own with an error asking you to call `tabs new`. `active` shows the current front page; `new` opens a fresh page; `close` closes one of yours.",
+    "Manage browser tabs. `list` returns every open page grouped by ownership: `Your tabs` (pages the caller opened via `tabs new`), `User's tabs` (pages the operator opened), and `Other agents' tabs` (pages another agent opened). `active` shows the current front page. `new` opens a fresh page. `close` closes a page owned by the caller. Page-targeted tools reject dispatches on pages the caller does not own.",
   input: z.object({
     action: z.enum(['list', 'active', 'new', 'close']).default('list'),
     url: z
@@ -21,7 +21,11 @@ export const tabs = defineTool({
       .describe('Create in a hidden window for action="new".'),
     page: z.number().int().optional().describe('Page id for action="close".'),
   }),
-  annotations: { openWorldHint: true },
+  annotations: {
+    title: 'Manage tabs',
+    destructiveHint: true,
+    openWorldHint: true,
+  },
   handler: async (args, ctx) => {
     switch (args.action) {
       case 'list': {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/tabs.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/tabs.ts
@@ -4,7 +4,7 @@ import { defineTool, errorResult, textResult } from './framework'
 export const tabs = defineTool({
   name: 'tabs',
   description:
-    "Manage browser tabs. `list` returns every open page grouped by ownership: `Your tabs` (pages the caller opened via `tabs new`), `User's tabs` (pages the operator opened), and `Other agents' tabs` (pages another agent opened). `active` shows the current front page. `new` opens a fresh page. `close` closes a page owned by the caller. Page-targeted tools reject dispatches on pages the caller does not own.",
+    "Manage browser tabs. `list` returns every open page grouped by ownership: `Your tabs` (pages you opened via `tabs new`), `User's tabs` (pages the operator opened), and `Other agents' tabs` (pages another AI agent opened). You can act freely on your own tabs. Page-targeted tools (snapshot, act, navigate, close, etc.) reject dispatches on pages you do not own with an error asking you to call `tabs new`. `active` shows the current front page; `new` opens a fresh page; `close` closes one of yours.",
   input: z.object({
     action: z.enum(['list', 'active', 'new', 'close']).default('list'),
     url: z

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/upload.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/upload.ts
@@ -16,6 +16,10 @@ export const upload = defineTool({
       .optional()
       .describe('Local file paths to upload.'),
   }),
+  annotations: {
+    title: 'Upload file to page',
+    destructiveHint: true,
+  },
   handler: async (args, ctx) => {
     const files = args.files ?? (args.file === undefined ? [] : [args.file])
     if (files.length === 0) {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/wait.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/wait.ts
@@ -18,7 +18,7 @@ const MAX_WAIT_TIMEOUT_MS = 30_000
 export const wait = defineTool({
   name: 'wait',
   description:
-    'Pause before continuing. Prefer acting directly and reading the diff; use wait only when there is no reliable UI signal yet. for="time" (default) pauses for value ms; "text" waits for a substring to appear; "selector" waits for a CSS selector to match. value is optional — for "time" it defaults to 2000ms, so calling wait with just a page pauses ~2s.',
+    'Pause before continuing. `for="time"` (default) pauses for `value` ms; `"text"` waits for a substring to appear in the DOM; `"selector"` waits for a CSS selector to match. `value` is optional; for `"time"` it defaults to 2000ms.',
   input: z.object({
     page: z.number().int(),
     for: z
@@ -36,7 +36,7 @@ export const wait = defineTool({
       .optional()
       .describe('Max wait in ms before giving up (default 2000).'),
   }),
-  annotations: { readOnlyHint: true },
+  annotations: { title: 'Wait', readOnlyHint: true },
   handler: async (args, ctx) => {
     const timeout = clampTimeout(
       args.timeout,

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/wait.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/wait.ts
@@ -18,7 +18,7 @@ const MAX_WAIT_TIMEOUT_MS = 30_000
 export const wait = defineTool({
   name: 'wait',
   description:
-    'Pause before continuing. `for="time"` (default) pauses for `value` ms; `"text"` waits for a substring to appear in the DOM; `"selector"` waits for a CSS selector to match. `value` is optional; for `"time"` it defaults to 2000ms.',
+    'Pause before continuing. Prefer acting directly and reading the diff; use wait only when there is no reliable UI signal yet. for="time" (default) pauses for value ms; "text" waits for a substring to appear; "selector" waits for a CSS selector to match. value is optional — for "time" it defaults to 2000ms, so calling wait with just a page pauses ~2s.',
   input: z.object({
     page: z.number().int(),
     for: z

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/windows.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/windows.ts
@@ -34,7 +34,11 @@ export const windows = defineTool({
       .optional()
       .describe('Focus the window after making it visible.'),
   }),
-  annotations: { openWorldHint: true },
+  annotations: {
+    title: 'Manage windows',
+    destructiveHint: true,
+    openWorldHint: true,
+  },
   handler: async (args, ctx) => {
     switch (args.action) {
       case 'list': {


### PR DESCRIPTION
## Summary

Every MCP tool exposed by `@browseros/browser-mcp` now carries the annotations the [Claude Connectors Directory review criteria](https://claude.com/docs/connectors/building/review-criteria) require:

- `title` — human-readable display name for MCP client UI (missing on all 16 tools before this PR)
- `readOnlyHint: true` on tools that only observe state
- `destructiveHint: true` on tools that may modify or delete state, files, or content

**Annotations only.** Tool descriptions are NOT touched by this PR. If descriptions need to change for Directory compliance, that's a separate follow-up PR — surfacing it here so it's explicit that this PR's scope is metadata, not copy.

## Why now

The `browserclaw-claude-desktop` extension is a pure MCP proxy — the tool surface Claude Desktop sees IS these tools, forwarded verbatim. Every requirement the Directory places on tool annotations lands here, not on the extension repo. Without `title` + hints, submission would be rejected immediately.

## Per-tool changes

| Tool | Title added | Hint added |
|---|---|---|
| `act` | Interact with page | `destructiveHint` |
| `diff` | Diff page state | — (already `readOnlyHint`) |
| `download` | Download from page | `destructiveHint` |
| `evaluate` | Run JavaScript in page | `destructiveHint` (arbitrary caller-provided JS; see security note below) |
| `grep` | Search page | — (already `readOnlyHint`) |
| `navigate` | Navigate page | `destructiveHint` |
| `pdf` | Save page as PDF | — (already `readOnlyHint`) |
| `read` | Read page content | — (already `readOnlyHint`) |
| `run` | Run browser SDK script | `destructiveHint` (kept existing `openWorldHint`) |
| `screenshot` | Take screenshot | — (already `readOnlyHint`) |
| `snapshot` | Snapshot accessibility tree | — (already `readOnlyHint`) |
| `tab_groups` | Manage tab groups | `destructiveHint` (kept existing `openWorldHint`) |
| `tabs` | Manage tabs | `destructiveHint` (kept existing `openWorldHint`) |
| `upload` | Upload file to page | `destructiveHint` |
| `wait` | Wait | — (already `readOnlyHint`) |
| `windows` | Manage windows | `destructiveHint` (kept existing `openWorldHint`) |

## Framework changes

`ToolAnnotations` gains optional `title` and `idempotentHint` fields; `defineTool` picks both up automatically via the shared type. No breaking change for existing tool definitions (both new fields are optional).

## Security note on `evaluate`

Initially annotated `readOnlyHint: true` based on the description ("for page-state reads"). Corrected to `destructiveHint: true` after review: the handler forwards caller-provided JavaScript to `Runtime.evaluate` with `userGesture: true`. That script can mutate DOM, submit forms, write storage, hit the network, and trigger permission-gated APIs — advertising it as read-only would let MCP clients skip the destructive-tool confirmation Claude Desktop uses for anything that can change state. Now consistent with `run`, which is philosophically identical (arbitrary code in a different sandbox).

## Test plan

- [x] `@browseros/browser-mcp` typecheck: clean.
- [x] `@browseros/claw-server` typecheck: clean.
- [x] `bun test` in `browser-mcp`: **30 pass, 0 fail** (updated the `snapshot`-annotation assertion in `register.test.ts` to include the new `title` field).
- [x] `bun test` in `claw-server`: **375 pass, 0 fail** — no downstream regressions.
- [ ] Sideload the resulting build against the BrowserClaw Claude Desktop extension; confirm `tools/list` returns titled, hint-annotated tools in Claude Desktop's UI.

## Notes for review

- `run` is powerful (exposes the full `browser` SDK including a raw CDP escape hatch). Marked `destructiveHint: true` since it can do essentially anything. If the Directory reviewer wants it split into narrower tools, that's a follow-up PR.
- `tabs` and `windows` bundle read + write operations under a single `action` enum. Not `api_request`-style catch-alls, just domain-specific action switches. Marked `destructiveHint` because they CAN mutate. If a reviewer flags them, splitting is a follow-up.
- **Descriptions are unchanged.** The audit flagged three tool descriptions (`tabs`, `snapshot`, `wait`) as containing behavioural directives to Claude — but that's out of scope for this PR. Deferred to a follow-up.