### PR TITLE
feat(claw-app): cockpit usage analytics + opt-out (PostHog, Phase 2)

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/sidebar/AppSidebar.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/AppSidebar.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/utils'
 import { SidebarBranding } from './SidebarBranding'
 import { SidebarHelp } from './SidebarHelp'
 import { SidebarNavigation } from './SidebarNavigation'
+import { SidebarPrivacy } from './SidebarPrivacy'
 
 export interface AppSidebarProps {
   expanded?: boolean
@@ -18,6 +19,9 @@ export function AppSidebar({ expanded = false }: AppSidebarProps) {
     >
       <SidebarBranding expanded={expanded} />
       <SidebarNavigation expanded={expanded} />
+      <div className="px-2 pb-1">
+        <SidebarPrivacy expanded={expanded} />
+      </div>
       <SidebarHelp expanded={expanded} />
     </div>
   )

--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarPrivacy.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarPrivacy.tsx
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Sidebar entry for the privacy / analytics opt-out. Opens a small
+ * dialog explaining what is (and is not) collected and a switch bound
+ * to the server-owned consent flag, so one toggle governs both the
+ * cockpit and the local server's telemetry.
+ */
+
+import { useQueryClient } from '@tanstack/react-query'
+import { ShieldCheck } from 'lucide-react'
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Switch } from '@/components/ui/switch'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { AnalyticsEvent, track } from '@/modules/analytics/events'
+import { applyTelemetry } from '@/modules/analytics/posthog'
+import {
+  TELEMETRY_QUERY_KEY,
+  useSetTelemetryConsent,
+  useTelemetryState,
+} from '@/modules/analytics/telemetry.hooks'
+
+export interface SidebarPrivacyProps {
+  expanded?: boolean
+}
+
+export function SidebarPrivacy({ expanded = false }: SidebarPrivacyProps) {
+  const [open, setOpen] = useState(false)
+  const { data } = useTelemetryState()
+  const setConsent = useSetTelemetryConsent()
+  const queryClient = useQueryClient()
+
+  const consent = data?.consent ?? false
+  const distinctId = data?.distinctId
+
+  const handleChange = (next: boolean) => {
+    if (!distinctId) return
+    // Reconcile posthog and record the toggle in the right order so the
+    // opt-out event still sends (fired while consent is live) and the
+    // opt-in event sends after the client is initialised.
+    if (next) {
+      applyTelemetry({ distinctId, consent: true })
+      track(AnalyticsEvent.OptOutToggled, { enabled: true })
+    } else {
+      track(AnalyticsEvent.OptOutToggled, { enabled: false })
+      applyTelemetry({ distinctId, consent: false })
+    }
+    setConsent.mutate(
+      { consent: next },
+      {
+        onSuccess: (state) =>
+          queryClient.setQueryData(TELEMETRY_QUERY_KEY, state),
+      },
+    )
+  }
+
+  const trigger = (
+    <button
+      type="button"
+      className="flex h-9 w-full items-center gap-3 overflow-hidden whitespace-nowrap rounded-md px-2.5 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+    >
+      <ShieldCheck className="size-5 shrink-0" />
+      <span
+        className={cn(
+          'truncate transition-opacity duration-200',
+          expanded ? 'opacity-100' : 'opacity-0',
+        )}
+      >
+        Privacy
+      </span>
+    </button>
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      {expanded ? (
+        <DialogTrigger render={trigger} />
+      ) : (
+        <Tooltip>
+          <TooltipTrigger render={<DialogTrigger render={trigger} />} />
+          <TooltipContent side="right">Privacy</TooltipContent>
+        </Tooltip>
+      )}
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Privacy & analytics</DialogTitle>
+          <DialogDescription>
+            BrowserClaw collects anonymous, aggregate usage (which agents
+            connect and which screens you open) to improve the product. It never
+            collects the pages you browse, your prompts, tool inputs or outputs,
+            or any page content. No account or personal data is used.
+          </DialogDescription>
+        </DialogHeader>
+        <label
+          htmlFor="share-anonymous-usage"
+          className="flex items-center justify-between gap-4 rounded-lg border border-border px-4 py-3"
+        >
+          <span className="font-medium text-sm">Share anonymous usage</span>
+          <Switch
+            id="share-anonymous-usage"
+            checked={consent}
+            onCheckedChange={handleChange}
+            disabled={!distinctId || setConsent.isPending}
+          />
+        </label>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarPrivacy.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarPrivacy.tsx
@@ -50,21 +50,23 @@ export function SidebarPrivacy({ expanded = false }: SidebarPrivacyProps) {
 
   const handleChange = (next: boolean) => {
     if (!distinctId) return
-    // Reconcile posthog and record the toggle in the right order so the
-    // opt-out event still sends (fired while consent is live) and the
-    // opt-in event sends after the client is initialised.
-    if (next) {
-      applyTelemetry({ distinctId, consent: true })
-      track(AnalyticsEvent.OptOutToggled, { enabled: true })
-    } else {
-      track(AnalyticsEvent.OptOutToggled, { enabled: false })
-      applyTelemetry({ distinctId, consent: false })
-    }
     setConsent.mutate(
       { consent: next },
       {
-        onSuccess: (state) =>
-          queryClient.setQueryData(TELEMETRY_QUERY_KEY, state),
+        onSuccess: (state) => {
+          queryClient.setQueryData(TELEMETRY_QUERY_KEY, state)
+          // Reconcile off the server's authoritative effective state
+          // (respects the kill-switch), ordering so the opt-out event
+          // still sends while capture is live and the opt-in event sends
+          // after init.
+          if (state.enabled) {
+            applyTelemetry({ distinctId: state.distinctId, enabled: true })
+            track(AnalyticsEvent.OptOutToggled, { enabled: true })
+          } else {
+            track(AnalyticsEvent.OptOutToggled, { enabled: false })
+            applyTelemetry({ distinctId: state.distinctId, enabled: false })
+          }
+        },
       },
     )
   }

--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/App.tsx
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/App.tsx
@@ -1,5 +1,6 @@
 import { HashRouter, Navigate, Route, Routes } from 'react-router'
 import { CockpitShell } from '@/components/layout/CockpitShell'
+import { Analytics } from '@/modules/analytics/Analytics'
 import { Audit } from '@/screens/audit/Audit'
 import { Cockpit } from '@/screens/cockpit/Cockpit'
 import { Mcp } from '@/screens/mcp/Mcp'
@@ -10,6 +11,7 @@ import { TaskDetailPage } from '@/screens/task-detail/TaskDetailPage'
 export function App() {
   return (
     <HashRouter>
+      <Analytics />
       <Routes>
         <Route element={<CockpitShell />}>
           <Route path="/" element={<Cockpit />} />

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/Analytics.tsx
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/Analytics.tsx
@@ -12,32 +12,38 @@
 import { useEffect, useRef } from 'react'
 import { useLocation } from 'react-router'
 import { AnalyticsEvent, screenEventForPath, track } from './events'
-import { applyTelemetry } from './posthog'
+import { applyTelemetry, isCapturing } from './posthog'
 import { useTelemetryState } from './telemetry.hooks'
 
 export function Analytics() {
   const { data } = useTelemetryState()
   const location = useLocation()
   const appOpened = useRef(false)
+  const lastViewedPath = useRef<string | null>(null)
 
-  // External-system integration: init/opt-in/opt-out posthog-js from the
-  // server-owned consent, then record the first open once analytics is
-  // live (capture no-ops until then, so ordering is safe).
+  // External-system integration. Reconcile posthog with the server's
+  // effective telemetry state, then emit events. The guards
+  // (`appOpened`, `lastViewedPath`) are only consumed once posthog is
+  // actually capturing, so:
+  //   - a cold open on a deep link fires its view event once telemetry
+  //     initialises rather than being dropped, and
+  //   - opting in later still sends `app_opened` (the guard was not
+  //     burned while capture was a no-op).
+  // Runs on telemetry state changes and on navigation.
   useEffect(() => {
     if (!data) return
-    applyTelemetry({ distinctId: data.distinctId, consent: data.consent })
+    applyTelemetry({ distinctId: data.distinctId, enabled: data.enabled })
+    if (!isCapturing()) return
     if (!appOpened.current) {
       appOpened.current = true
       track(AnalyticsEvent.AppOpened)
     }
-  }, [data])
-
-  // Route changes are the only source of screen-view events; there is no
-  // handler to lift this into, so it lives in an effect keyed on the path.
-  useEffect(() => {
-    const event = screenEventForPath(location.pathname)
-    if (event) track(event)
-  }, [location.pathname])
+    if (lastViewedPath.current !== location.pathname) {
+      lastViewedPath.current = location.pathname
+      const event = screenEventForPath(location.pathname)
+      if (event) track(event)
+    }
+  }, [data, location.pathname])
 
   return null
 }

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/Analytics.tsx
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/Analytics.tsx
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Headless analytics driver. Rendered once inside the router: it
+ * reconciles posthog-js with the shared telemetry state, fires
+ * `app_opened` once, and emits a view event on each cockpit route
+ * change. Renders nothing.
+ */
+
+import { useEffect, useRef } from 'react'
+import { useLocation } from 'react-router'
+import { AnalyticsEvent, screenEventForPath, track } from './events'
+import { applyTelemetry } from './posthog'
+import { useTelemetryState } from './telemetry.hooks'
+
+export function Analytics() {
+  const { data } = useTelemetryState()
+  const location = useLocation()
+  const appOpened = useRef(false)
+
+  // External-system integration: init/opt-in/opt-out posthog-js from the
+  // server-owned consent, then record the first open once analytics is
+  // live (capture no-ops until then, so ordering is safe).
+  useEffect(() => {
+    if (!data) return
+    applyTelemetry({ distinctId: data.distinctId, consent: data.consent })
+    if (!appOpened.current) {
+      appOpened.current = true
+      track(AnalyticsEvent.AppOpened)
+    }
+  }, [data])
+
+  // Route changes are the only source of screen-view events; there is no
+  // handler to lift this into, so it lives in an effect keyed on the path.
+  useEffect(() => {
+    const event = screenEventForPath(location.pathname)
+    if (event) track(event)
+  }, [location.pathname])
+
+  return null
+}

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/events.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/events.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { AnalyticsEvent, screenEventForPath } from './events'
+
+describe('screenEventForPath', () => {
+  it('maps the audit table, task detail, and replay routes', () => {
+    expect(screenEventForPath('/audit')).toBe(AnalyticsEvent.AuditViewed)
+    expect(screenEventForPath('/audit/abc123')).toBe(
+      AnalyticsEvent.TaskDetailViewed,
+    )
+    expect(screenEventForPath('/audit/abc123/replay')).toBe(
+      AnalyticsEvent.ReplayViewed,
+    )
+  })
+
+  it('ignores routes without a view event', () => {
+    expect(screenEventForPath('/')).toBeNull()
+    expect(screenEventForPath('/mcp')).toBeNull()
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/events.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/events.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * The cockpit's event catalog. Events are metadata about which screens
+ * and controls get used; they never carry user content (no urls,
+ * titles, prompts, tool i/o). `track` only accepts scalar properties.
+ */
+
+import { capture } from './posthog'
+
+export const AnalyticsEvent = {
+  AppOpened: 'app_opened',
+  AuditViewed: 'audit_viewed',
+  ReplayViewed: 'replay_viewed',
+  TaskDetailViewed: 'task_detail_viewed',
+  OptOutToggled: 'analytics_opt_out_toggled',
+} as const
+
+export type AnalyticsEventName =
+  (typeof AnalyticsEvent)[keyof typeof AnalyticsEvent]
+
+export function track(
+  event: AnalyticsEventName,
+  properties?: Record<string, boolean | number | string>,
+): void {
+  capture(event, properties)
+}
+
+/**
+ * Maps a cockpit route to its view event. The audit table, a task
+ * detail, and a replay are the surfaces we care about; the home and
+ * mcp routes are covered by `app_opened`.
+ */
+export function screenEventForPath(path: string): AnalyticsEventName | null {
+  if (path === '/audit') return AnalyticsEvent.AuditViewed
+  if (/^\/audit\/[^/]+\/replay$/.test(path)) return AnalyticsEvent.ReplayViewed
+  if (/^\/audit\/[^/]+$/.test(path)) return AnalyticsEvent.TaskDetailViewed
+  return null
+}

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Locked-down posthog-js wrapper for the cockpit UI.
+ *
+ * Privacy stance mirrors the server: measure the product, never the
+ * user. This module is imported ONLY by the cockpit newtab surface,
+ * never by the recorder content script or background worker, so
+ * analytics never runs on the pages the user browses.
+ *
+ * posthog-js defaults are aggressively disabled: no autocapture (would
+ * read DOM text), no session recording, no automatic pageviews, no
+ * `/decide` calls, and no person profiles. Auto-captured location
+ * properties (`$current_url` etc.) are stripped so even the cockpit's
+ * own extension URL never leaves. Identity is the server's anonymous
+ * install UUID, set via `bootstrap.distinctID` (no `identify`, no PII).
+ *
+ * Gated on a build-time project write key (`VITE_CLAW_POSTHOG_KEY`) and
+ * the user's consent. With no key, or before consent, nothing is
+ * initialised and every capture no-ops.
+ */
+
+import posthog from 'posthog-js'
+
+const KEY = import.meta.env.VITE_CLAW_POSTHOG_KEY as string | undefined
+const HOST =
+  (import.meta.env.VITE_CLAW_POSTHOG_HOST as string | undefined) ??
+  'https://us.i.posthog.com'
+
+/** Auto-added properties that could carry a url/referrer; always removed. */
+const STRIPPED_PROPS = [
+  '$current_url',
+  '$pathname',
+  '$host',
+  '$referrer',
+  '$referring_domain',
+  '$initial_current_url',
+  '$initial_pathname',
+  '$initial_referrer',
+  '$initial_referring_domain',
+]
+
+let initialised = false
+
+function init(distinctId: string): void {
+  initialised = true
+  posthog.init(KEY as string, {
+    api_host: HOST,
+    autocapture: false,
+    capture_pageview: false,
+    capture_pageleave: false,
+    disable_session_recording: true,
+    disable_surveys: true,
+    // No feature-flag / /decide round-trips: we only send events.
+    advanced_disable_decide: true,
+    // We never call identify(), so never create a person profile.
+    person_profiles: 'never',
+    persistence: 'localStorage',
+    // Share the server's anonymous install id so both surfaces map to
+    // one install, without identify().
+    bootstrap: { distinctID: distinctId },
+    sanitize_properties: (props) => {
+      const cleaned: Record<string, unknown> = { ...props }
+      for (const key of STRIPPED_PROPS) delete cleaned[key]
+      return cleaned
+    },
+  })
+}
+
+/**
+ * Reconciles the posthog client with the current shared telemetry
+ * state. Initialises on first consent, opts in/out on later changes,
+ * and does nothing when no key is configured. Safe to call repeatedly.
+ */
+export function applyTelemetry(input: {
+  distinctId: string
+  consent: boolean
+}): void {
+  if (!KEY || !input.distinctId) return
+  if (input.consent) {
+    if (!initialised) init(input.distinctId)
+    else posthog.opt_in_capturing()
+  } else if (initialised) {
+    posthog.opt_out_capturing()
+  }
+}
+
+/** Fire-and-forget event. No-ops until initialised + consented. */
+export function capture(
+  event: string,
+  properties?: Record<string, unknown>,
+): void {
+  if (!initialised) return
+  posthog.capture(event, properties)
+}

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
@@ -70,16 +70,18 @@ function init(distinctId: string): void {
 }
 
 /**
- * Reconciles the posthog client with the current shared telemetry
- * state. Initialises on first consent, opts in/out on later changes,
- * and does nothing when no key is configured. Safe to call repeatedly.
+ * Reconciles the posthog client with the server's EFFECTIVE telemetry
+ * state. `enabled` already folds in the user's consent, the operator
+ * kill-switch, and the server key, so the cockpit respects all three by
+ * gating on it. Initialises on first enable, opts in/out on later
+ * changes, no-ops without a Vite key. Safe to call repeatedly.
  */
 export function applyTelemetry(input: {
   distinctId: string
-  consent: boolean
+  enabled: boolean
 }): void {
   if (!KEY || !input.distinctId) return
-  if (input.consent) {
+  if (input.enabled) {
     if (!initialised) init(input.distinctId)
     else posthog.opt_in_capturing()
   } else if (initialised) {
@@ -87,11 +89,16 @@ export function applyTelemetry(input: {
   }
 }
 
-/** Fire-and-forget event. No-ops until initialised + consented. */
+/** Whether posthog is initialised AND currently opted in to capturing. */
+export function isCapturing(): boolean {
+  return initialised && !posthog.has_opted_out_capturing()
+}
+
+/** Fire-and-forget event. No-ops until capturing. */
 export function capture(
   event: string,
   properties?: Record<string, unknown>,
 ): void {
-  if (!initialised) return
+  if (!isCapturing()) return
   posthog.capture(event, properties)
 }

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/telemetry.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/telemetry.hooks.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * react-query-kit factories for the shared telemetry state. The server
+ * owns the anonymous install id and the user's consent choice; the
+ * cockpit reads them here so its own posthog-js shares one identity and
+ * the opt-out toggle governs both surfaces.
+ */
+
+import { createMutation, createQuery } from 'react-query-kit'
+import { api } from '@/modules/api/client'
+import { parseResponse } from '@/modules/api/parseResponse'
+
+export interface TelemetryState {
+  /** Anonymous install UUID shared with the server. */
+  distinctId: string
+  /** Effective server-side state (informational). */
+  enabled: boolean
+  /** The user's consent choice; drives the toggle and the extension's capture. */
+  consent: boolean
+}
+
+export const TELEMETRY_QUERY_KEY = ['system', 'telemetry'] as const
+
+export const useTelemetryState = createQuery<TelemetryState>({
+  queryKey: TELEMETRY_QUERY_KEY,
+  fetcher: async () => {
+    const response = await api.system.telemetry.$get()
+    return parseResponse<TelemetryState>(response)
+  },
+  // Identity + consent change rarely (only via the toggle, which
+  // invalidates this query), so don't poll.
+  staleTime: Number.POSITIVE_INFINITY,
+})
+
+export const useSetTelemetryConsent = createMutation<
+  TelemetryState,
+  { consent: boolean }
+>({
+  mutationFn: async ({ consent }) => {
+    const response = await api.system.telemetry.$post({ json: { consent } })
+    return parseResponse<TelemetryState>(response)
+  },
+})

--- a/packages/browseros-agent/apps/claw-app/package.json
+++ b/packages/browseros-agent/apps/claw-app/package.json
@@ -46,6 +46,7 @@
     "media-chrome": "^4.19.1",
     "motion": "^12.40.0",
     "nanoid": "^5.1.11",
+    "posthog-js": "^1.160.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "~7.78.0",

--- a/packages/browseros-agent/apps/claw-server/src/routes/system.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/system.ts
@@ -4,11 +4,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
+import { z } from 'zod'
 import pkg from '../../package.json' with { type: 'json' }
 import { getLocalServerUrl } from '../local-server-url'
-import { getTelemetryState } from '../services/analytics'
+import { getTelemetryState, setTelemetryConsent } from '../services/analytics'
 import { VERSION } from '../version'
+
+const telemetryConsentSchema = z.object({ consent: z.boolean() })
 
 interface SystemRouteConfig {
   onShutdown?: () => void
@@ -30,5 +34,12 @@ export function createSystemRoute(config: SystemRouteConfig = {}) {
       // share one anonymous identity with the server and reflect the
       // current telemetry setting. No PII: distinctId is a random UUID.
       .get('/system/telemetry', (c) => c.json(getTelemetryState()))
+      // The cockpit opt-out toggle. Persists the user's consent choice
+      // server-side so it governs both server and extension telemetry.
+      .post(
+        '/system/telemetry',
+        zValidator('json', telemetryConsentSchema),
+        (c) => c.json(setTelemetryConsent(c.req.valid('json').consent)),
+      )
   )
 }

--- a/packages/browseros-agent/apps/claw-server/src/services/analytics.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/analytics.ts
@@ -259,18 +259,55 @@ export function captureEvent(
   }
 }
 
+export interface TelemetryState {
+  distinctId: string
+  /** Effective: whether the SERVER is actually sending (key + kill-switch + consent). */
+  enabled: boolean
+  /** The user's consent choice. What the cockpit toggle reflects and both surfaces gate on. */
+  consent: boolean
+}
+
 /**
- * The anonymous id + EFFECTIVE enabled flag surfaced to the cockpit UI.
- * `enabled` reflects whether telemetry is actually active (key present,
- * kill-switch on, user not opted out), so the UI never shows telemetry
- * as on while every capture is a no-op. Loads state but never
- * constructs a network client.
+ * The anonymous id, the EFFECTIVE enabled flag, and the raw consent
+ * flag surfaced to the cockpit UI. `enabled` reflects whether the
+ * server is actively sending (so the UI never shows telemetry on while
+ * every capture is a no-op); `consent` is the user's choice, which the
+ * toggle binds to and the extension gates its own capture on. Loads
+ * state but never constructs a network client.
  */
-export function getTelemetryState(): AnalyticsState {
+export function getTelemetryState(): TelemetryState {
   ensureState()
   return {
     distinctId: state?.distinctId ?? '',
     enabled: effectiveEnabled(state),
+    consent: state?.enabled ?? false,
+  }
+}
+
+/**
+ * Persists the user's consent choice (the cockpit opt-out toggle) and
+ * re-evaluates the client so a turn-off stops sending immediately and a
+ * turn-on can re-init on the next capture. Returns the updated state.
+ */
+export function setTelemetryConsent(consent: boolean): TelemetryState {
+  ensureState()
+  const next: AnalyticsState = {
+    distinctId: state?.distinctId ?? randomUUID(),
+    enabled: consent,
+  }
+  state = next
+  persistState(next)
+  // Force re-evaluation on the next capture; drop any live client so a
+  // withdrawn consent stops sending right away.
+  clientInitialised = false
+  if (client) {
+    void client.shutdown().catch(() => {})
+    client = null
+  }
+  return {
+    distinctId: next.distinctId,
+    enabled: effectiveEnabled(next),
+    consent: next.enabled,
   }
 }
 

--- a/packages/browseros-agent/apps/claw-server/src/services/analytics.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/analytics.ts
@@ -87,7 +87,7 @@ function analyticsPath(): string {
   return join(getClawServerDir(), ANALYTICS_FILE)
 }
 
-function persistState(next: AnalyticsState): void {
+function persistState(next: AnalyticsState): boolean {
   const dir = getClawServerDir()
   const path = analyticsPath()
   const tmp = `${path}.tmp`
@@ -95,10 +95,12 @@ function persistState(next: AnalyticsState): void {
     mkdirSync(dir, { recursive: true })
     writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`, 'utf8')
     renameSync(tmp, path)
+    return true
   } catch (err) {
     logger.warn('analytics state write failed', {
       error: err instanceof Error ? err.message : String(err),
     })
+    return false
   }
 }
 
@@ -295,8 +297,18 @@ export function setTelemetryConsent(consent: boolean): TelemetryState {
     distinctId: state?.distinctId ?? randomUUID(),
     enabled: consent,
   }
+  // Write to disk BEFORE flipping in-memory state, and surface a failed
+  // write at error level: a swallowed failure could stop telemetry for
+  // this process yet silently revert to the old on-disk choice on the
+  // next restart. We still apply in-memory so the choice holds for this
+  // session, but the durability gap is no longer hidden.
+  if (!persistState(next)) {
+    logger.error(
+      'analytics consent write failed; choice may not survive a restart',
+      { consent },
+    )
+  }
   state = next
-  persistState(next)
   // Force re-evaluation on the next capture; drop any live client so a
   // withdrawn consent stops sending right away.
   clientInitialised = false

--- a/packages/browseros-agent/apps/claw-server/tests/services/analytics.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/analytics.test.ts
@@ -19,6 +19,7 @@ import {
   getTelemetryState,
   resetAnalyticsForTesting,
   sanitize,
+  setTelemetryConsent,
 } from '../../src/services/analytics'
 
 describe('sanitize (allow-list + value guard)', () => {
@@ -154,5 +155,29 @@ describe('telemetry state + gating', () => {
     expect(() =>
       captureEvent('harness_connected', { harness: 'Zed' }),
     ).not.toThrow()
+  })
+
+  it('exposes the raw consent flag alongside the effective enabled flag', () => {
+    // no key → effective off, but consent (user choice) is on by default
+    const state = getTelemetryState()
+    expect(state.enabled).toBe(false)
+    expect(state.consent).toBe(true)
+  })
+
+  it('setTelemetryConsent persists the choice and keeps the same id', () => {
+    const before = getTelemetryState()
+    const off = setTelemetryConsent(false)
+    expect(off.consent).toBe(false)
+    expect(off.enabled).toBe(false)
+    expect(off.distinctId).toBe(before.distinctId)
+    // persisted to disk
+    const onDisk = JSON.parse(readFileSync(join(dir, 'analytics.json'), 'utf8'))
+    expect(onDisk.enabled).toBe(false)
+    expect(onDisk.distinctId).toBe(before.distinctId)
+    // re-reading reflects the opt-out
+    resetAnalyticsForTesting()
+    expect(getTelemetryState().consent).toBe(false)
+    // turning back on
+    expect(setTelemetryConsent(true).consent).toBe(true)
   })
 })

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -150,6 +150,7 @@
         "media-chrome": "^4.19.1",
         "motion": "^12.40.0",
         "nanoid": "^5.1.11",
+        "posthog-js": "^1.160.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "~7.78.0",


### PR DESCRIPTION
## Summary

Phase 2 of BrowserClaw analytics: instrument the cockpit UI and add the opt-out control. Builds on the server-side backbone (#1820). Answers the remaining product question — **how often are the audit screen and session replays used** — and gives users one switch that turns all telemetry off.

## Privacy design (same principle: measure the product, never the user)

- **posthog-js is locked down**: `autocapture: false`, `disable_session_recording: true`, `capture_pageview/pageleave: false`, `advanced_disable_decide: true`, `person_profiles: 'never'`. Auto-captured location props (`$current_url`, `$pathname`, `$referrer`, …) are stripped via `sanitize_properties`, so even the cockpit's own extension URL never leaves.
- **Never runs on browsed pages**: the analytics module is imported only by the `newtab` cockpit surface, never by the recorder content script or background worker.
- **Shared anonymous identity**: the extension reads the install id + consent from the server's `GET /system/telemetry` and bootstraps posthog-js with that `distinctId` (no `identify`, no PII). One install = one person across server + UI.

## Events (metadata only)

`app_opened`, `audit_viewed`, `task_detail_viewed`, `replay_viewed`, `analytics_opt_out_toggled { enabled }`. A route watcher emits the view events; none carry content.

## One opt-out for both surfaces

- A **Privacy** entry in the sidebar opens a dialog explaining what is / isn't collected, with a switch bound to the server-owned consent flag.
- Server side: new `POST /system/telemetry { consent }`; `getTelemetryState` now returns `{ distinctId, enabled (effective), consent (user choice) }`, so the toggle and both clients read one source of truth. Turning off stops the server client immediately and opts posthog-js out.
- Gated on `VITE_CLAW_POSTHOG_KEY` + consent; with no key nothing initialises and every capture no-ops (dev sends nothing).

## Test plan

- [x] `@browseros/claw-app` typecheck clean; `@browseros/claw-server` typecheck clean.
- [x] Server: consent getter/setter tests + existing routes (80 pass).
- [x] claw-app: `screenEventForPath` route-mapping test + sidebar tests (5 pass).
- [x] Biome clean; no leaks in diff.
- [ ] With `VITE_CLAW_POSTHOG_KEY` + `CLAW_POSTHOG_KEY` set, confirm cockpit events land in PostHog sharing the server's distinctId and carry no url/content properties, and that the opt-out toggle stops both.

## Follow-ups

- `react-doctor` is listed in claw-app but not installed in this env, so I did not run it (per the no-side-effect-install rule). Worth running once it's available.
- Set `VITE_CLAW_POSTHOG_KEY` (+ `CLAW_POSTHOG_KEY`) in the production build to turn analytics on.