### PR TITLE
feat: wire Claw PostHog env into release builds

### DIFF
--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -51,6 +51,10 @@ on:
         required: true
       SPARKLE_PRIVATE_KEY:
         required: false
+      CLAW_POSTHOG_KEY:
+        required: false
+      CLAW_POSTHOG_HOST:
+        required: false
 
 permissions:
   contents: write
@@ -160,6 +164,8 @@ jobs:
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
       SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+      CLAW_POSTHOG_KEY: ${{ secrets.CLAW_POSTHOG_KEY }}
+      CLAW_POSTHOG_HOST: ${{ secrets.CLAW_POSTHOG_HOST }}
       NODE_ENV: production
 
     steps:

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -72,6 +72,10 @@ on:
         required: false
       VITE_PUBLIC_POSTHOG_HOST:
         required: false
+      VITE_CLAW_POSTHOG_KEY:
+        required: false
+      VITE_CLAW_POSTHOG_HOST:
+        required: false
 
 concurrency:
   group: release-extensions
@@ -134,6 +138,8 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
           VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
+          VITE_CLAW_POSTHOG_KEY: ${{ secrets.VITE_CLAW_POSTHOG_KEY }}
+          VITE_CLAW_POSTHOG_HOST: ${{ secrets.VITE_CLAW_POSTHOG_HOST }}
           VITE_PUBLIC_BROWSEROS_API: https://api.browseros.com
           NODE_ENV: production
         # Args are quoted at execution time (never baked into a command

--- a/packages/browseros-agent/.env.development.example
+++ b/packages/browseros-agent/.env.development.example
@@ -62,6 +62,18 @@ SENTRY_PROJECT=
 # Optional BrowserClaw state root override.
 # BROWSERCLAW_DIR=~/.browserclaw-dev
 
+# Claw server PostHog project write key.
+CLAW_POSTHOG_KEY=
+
+# Optional Claw server PostHog host; defaults to PostHog US Cloud.
+# CLAW_POSTHOG_HOST=https://us.i.posthog.com
+
+# BrowserClaw bundle PostHog project write key.
+VITE_CLAW_POSTHOG_KEY=
+
+# Optional BrowserClaw bundle PostHog host; defaults to PostHog US Cloud.
+# VITE_CLAW_POSTHOG_HOST=https://us.i.posthog.com
+
 # --- server ---
 
 # BrowserOS server config URL required by production builds.

--- a/packages/browseros-agent/.env.production.example
+++ b/packages/browseros-agent/.env.production.example
@@ -2,6 +2,11 @@
 # This is the production env example for the BrowserOS monorepo root.
 # Copy it to .env.production; real .env.production files are gitignored.
 
+# --- claw ---
+
+# Claw server PostHog project write key.
+CLAW_POSTHOG_KEY=
+
 # --- server ---
 
 # BrowserOS server config URL required by production builds.
@@ -37,3 +42,17 @@ R2_SECRET_ACCESS_KEY=
 
 # R2 bucket for production artifact uploads.
 R2_BUCKET=browseros
+
+# --- sign ---
+
+# BrowserOS build eSigner username for Windows production signing.
+ESIGNER_USERNAME=
+
+# BrowserOS build eSigner password for Windows production signing.
+ESIGNER_PASSWORD=
+
+# BrowserOS build eSigner TOTP secret for Windows production signing.
+ESIGNER_TOTP_SECRET=
+
+# BrowserOS build eSigner credential ID for Windows production signing.
+ESIGNER_CREDENTIAL_ID=

--- a/packages/browseros-agent/apps/claw-server/src/env.ts
+++ b/packages/browseros-agent/apps/claw-server/src/env.ts
@@ -50,10 +50,9 @@ function readBoolFlagDefaultTrue(name: string): boolean {
   return normalised !== '0' && normalised !== 'false'
 }
 
-/** Trimmed string env read, or undefined when unset/blank. */
-function readString(name: string): string | undefined {
-  // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
-  const raw = process.env[name]?.trim()
+/** Trims a string value, returning undefined when it is unset or blank. */
+function trimmedString(value: string | undefined): string | undefined {
+  const raw = value?.trim()
   return raw && raw.length > 0 ? raw : undefined
 }
 
@@ -92,8 +91,11 @@ export const env = {
   // defaults to PostHog US Cloud. `analyticsEnabledByEnv` is an
   // operator kill-switch (set CLAW_ANALYTICS_ENABLED=0 to force off);
   // the per-install user opt-out lives in the analytics state file.
-  posthogKey: readString('CLAW_POSTHOG_KEY'),
-  posthogHost: readString('CLAW_POSTHOG_HOST') ?? 'https://us.i.posthog.com',
+  // biome-ignore lint/style/noProcessEnv: static access allows production builds to inline the key
+  posthogKey: trimmedString(process.env.CLAW_POSTHOG_KEY),
+  posthogHost:
+    // biome-ignore lint/style/noProcessEnv: static access allows production builds to inline the host
+    trimmedString(process.env.CLAW_POSTHOG_HOST) ?? 'https://us.i.posthog.com',
   analyticsEnabledByEnv: readBoolFlagDefaultTrue('CLAW_ANALYTICS_ENABLED'),
 }
 

--- a/packages/browseros-agent/apps/claw-server/tests/build.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/build.test.ts
@@ -173,6 +173,9 @@ describe('claw server build', () => {
 
   it('archives CI builds without R2 credentials', async () => {
     rmSync(zipPath, { force: true })
+    const inlinedPosthogKey = 'phc_claw_binary_inline_evidence_42'
+    const env = buildEnv(UNNEEDED_SERVER_AND_R2_ENV_KEYS)
+    env.CLAW_POSTHOG_KEY = inlinedPosthogKey
 
     const build = Bun.spawn(
       ['bun', buildScript, `--target=${target.id}`, '--ci'],
@@ -180,7 +183,7 @@ describe('claw server build', () => {
         cwd: rootDir,
         stdout: 'pipe',
         stderr: 'pipe',
-        env: buildEnv(UNNEEDED_SERVER_AND_R2_ENV_KEYS),
+        env,
       },
     )
     const buildExit = await build.exited
@@ -197,6 +200,10 @@ describe('claw server build', () => {
     assert.ok(
       existsSync(migrationJournalPath),
       `Expected packaged migrations at ${migrationJournalPath}`,
+    )
+    assert.ok(
+      readFileSync(binaryPath).includes(Buffer.from(inlinedPosthogKey)),
+      'Expected the production Claw binary to contain its inlined PostHog key',
     )
   }, 300_000)
 

--- a/packages/browseros-agent/apps/server/tests/__helpers__/run-test-group.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/run-test-group.ts
@@ -7,7 +7,7 @@ const testsRoot = resolve(projectRoot, 'tests')
 const cleanupScript = resolve(testsRoot, '__helpers__/cleanup.sh')
 const testPreloadPath = './tests/__helpers__/test-env.ts'
 const preferredDirectoryGroups = ['agent', 'api', 'tools', 'browser']
-const ignoredDirectories = new Set(['__fixtures__', '__helpers__'])
+const ignoredDirectories = new Set(['__fixtures__', '__helpers__', '_helpers'])
 const rootGroupExclusions = new Set(['server.integration.test.ts'])
 const testFilePattern = /\.(test|spec)\.[cm]?[jt]sx?$/
 

--- a/packages/browseros-agent/apps/server/tests/run-test-group.test.ts
+++ b/packages/browseros-agent/apps/server/tests/run-test-group.test.ts
@@ -38,6 +38,12 @@ describe('test groups', () => {
     expect(listAllGroups()).toContain('lib')
   })
 
+  it('excludes helper-only directories from the group list', () => {
+    expect(listAllGroups()).not.toContain('_helpers')
+    expect(listAllGroups()).not.toContain('__helpers__')
+    expect(listAllGroups()).not.toContain('__fixtures__')
+  })
+
   it('runs available integration tests in the integration group', () => {
     expect(getAtomicGroupTargets('integration')).toEqual([
       './tests/server.integration.test.ts',

--- a/packages/browseros-agent/packages/shared/src/env/generate.test.ts
+++ b/packages/browseros-agent/packages/shared/src/env/generate.test.ts
@@ -29,6 +29,10 @@ describe('ENV_REGISTRY', () => {
       'BROWSEROS_USER_DATA_DIR',
       'BROWSEROS_CLAW_CDP_PORT',
       'BROWSERCLAW_DIR',
+      'CLAW_POSTHOG_KEY',
+      'CLAW_POSTHOG_HOST',
+      'VITE_CLAW_POSTHOG_KEY',
+      'VITE_CLAW_POSTHOG_HOST',
       'BROWSEROS_CONFIG_URL',
       'BROWSEROS_TRUSTED_ORIGINS',
       'POSTHOG_API_KEY',
@@ -42,6 +46,10 @@ describe('ENV_REGISTRY', () => {
       'R2_ACCESS_KEY_ID',
       'R2_SECRET_ACCESS_KEY',
       'R2_BUCKET',
+      'ESIGNER_USERNAME',
+      'ESIGNER_PASSWORD',
+      'ESIGNER_TOTP_SECRET',
+      'ESIGNER_CREDENTIAL_ID',
     ])
     expect(ENV_REGISTRY.map((spec) => spec.key)).not.toContain(
       'R2_UPLOAD_PREFIX',
@@ -49,6 +57,67 @@ describe('ENV_REGISTRY', () => {
     expect(ENV_REGISTRY.map((spec) => spec.key)).not.toContain(
       'R2_DOWNLOAD_PREFIX',
     )
+  })
+
+  test('registers optional Claw analytics and production eSigner inputs', () => {
+    const specs = Object.fromEntries(
+      ENV_REGISTRY.map((spec) => [spec.key, spec]),
+    )
+
+    expect(specs.CLAW_POSTHOG_KEY).toMatchObject({
+      section: 'claw',
+      secret: true,
+      modes: {
+        development: { value: '' },
+        production: { value: '' },
+      },
+    })
+    expect(specs.CLAW_POSTHOG_HOST).toMatchObject({
+      section: 'claw',
+      secret: false,
+      modes: {
+        development: {
+          value: 'https://us.i.posthog.com',
+          commented: true,
+        },
+      },
+    })
+    expect(specs.VITE_CLAW_POSTHOG_KEY).toMatchObject({
+      section: 'claw',
+      secret: true,
+      modes: { development: { value: '' } },
+    })
+    expect(specs.VITE_CLAW_POSTHOG_HOST).toMatchObject({
+      section: 'claw',
+      secret: false,
+      modes: {
+        development: {
+          value: 'https://us.i.posthog.com',
+          commented: true,
+        },
+      },
+    })
+
+    expect(specs.ESIGNER_USERNAME).toMatchObject({
+      section: 'sign',
+      secret: false,
+      modes: { production: { value: '' } },
+    })
+    expect(specs.ESIGNER_PASSWORD).toMatchObject({
+      section: 'sign',
+      secret: true,
+      modes: { production: { value: '' } },
+    })
+    expect(specs.ESIGNER_TOTP_SECRET).toMatchObject({
+      section: 'sign',
+      secret: true,
+      modes: { production: { value: '' } },
+    })
+    expect(specs.ESIGNER_CREDENTIAL_ID).toMatchObject({
+      section: 'sign',
+      secret: false,
+      modes: { production: { value: '' } },
+    })
   })
 })
 
@@ -59,6 +128,32 @@ describe('generateEnvExample', () => {
     )
     expect(generateEnvExample('production')).toBe(
       generateEnvExample('production'),
+    )
+  })
+
+  test('renders Claw analytics by mode and eSigner inputs for production', () => {
+    const development = generateEnvExample('development')
+    const production = generateEnvExample('production')
+
+    expect(development).toContain('\nCLAW_POSTHOG_KEY=\n')
+    expect(development).toContain(
+      '\n# CLAW_POSTHOG_HOST=https://us.i.posthog.com\n',
+    )
+    expect(development).toContain('\nVITE_CLAW_POSTHOG_KEY=\n')
+    expect(development).toContain(
+      '\n# VITE_CLAW_POSTHOG_HOST=https://us.i.posthog.com\n',
+    )
+
+    expect(production).toContain('\nCLAW_POSTHOG_KEY=\n')
+    expect(production).not.toContain('CLAW_POSTHOG_HOST')
+    expect(production).not.toContain('VITE_CLAW_POSTHOG')
+    expect(production).toContain('\n# --- sign ---\n')
+    expect(production).toContain('\nESIGNER_USERNAME=\n')
+    expect(production).toContain('\nESIGNER_PASSWORD=\n')
+    expect(production).toContain('\nESIGNER_TOTP_SECRET=\n')
+    expect(production).toContain('\nESIGNER_CREDENTIAL_ID=\n')
+    expect(production.indexOf('# --- sign ---')).toBeGreaterThan(
+      production.indexOf('# --- upload ---'),
     )
   })
 

--- a/packages/browseros-agent/packages/shared/src/env/generate.ts
+++ b/packages/browseros-agent/packages/shared/src/env/generate.ts
@@ -7,6 +7,7 @@ const SECTION_ORDER: readonly EnvSection[] = [
   'server',
   'build',
   'upload',
+  'sign',
 ]
 
 /** Generates the root env example text from the ordered registry. */

--- a/packages/browseros-agent/packages/shared/src/env/registry.ts
+++ b/packages/browseros-agent/packages/shared/src/env/registry.ts
@@ -8,6 +8,7 @@ export type EnvSection =
   | 'server'
   | 'build'
   | 'upload'
+  | 'sign'
 
 export interface EnvExampleEntry {
   value: string
@@ -196,6 +197,50 @@ export const ENV_REGISTRY: readonly EnvKeySpec[] = [
     modes: { development: { value: '~/.browserclaw-dev', commented: true } },
   },
   {
+    key: 'CLAW_POSTHOG_KEY',
+    section: 'claw',
+    description: 'Claw server PostHog project write key.',
+    secret: true,
+    schema: stringSchema,
+    modes: { development: { value: '' }, production: { value: '' } },
+  },
+  {
+    key: 'CLAW_POSTHOG_HOST',
+    section: 'claw',
+    description:
+      'Optional Claw server PostHog host; defaults to PostHog US Cloud.',
+    secret: false,
+    schema: stringSchema,
+    modes: {
+      development: {
+        value: 'https://us.i.posthog.com',
+        commented: true,
+      },
+    },
+  },
+  {
+    key: 'VITE_CLAW_POSTHOG_KEY',
+    section: 'claw',
+    description: 'BrowserClaw bundle PostHog project write key.',
+    secret: true,
+    schema: stringSchema,
+    modes: { development: { value: '' } },
+  },
+  {
+    key: 'VITE_CLAW_POSTHOG_HOST',
+    section: 'claw',
+    description:
+      'Optional BrowserClaw bundle PostHog host; defaults to PostHog US Cloud.',
+    secret: false,
+    schema: stringSchema,
+    modes: {
+      development: {
+        value: 'https://us.i.posthog.com',
+        commented: true,
+      },
+    },
+  },
+  {
     key: 'BROWSEROS_CONFIG_URL',
     section: 'server',
     description: 'BrowserOS server config URL required by production builds.',
@@ -313,6 +358,42 @@ export const ENV_REGISTRY: readonly EnvKeySpec[] = [
     secret: false,
     schema: stringSchema,
     modes: { production: { value: 'browseros' } },
+  },
+  {
+    key: 'ESIGNER_USERNAME',
+    section: 'sign',
+    description:
+      'BrowserOS build eSigner username for Windows production signing.',
+    secret: false,
+    schema: stringSchema,
+    modes: { production: { value: '' } },
+  },
+  {
+    key: 'ESIGNER_PASSWORD',
+    section: 'sign',
+    description:
+      'BrowserOS build eSigner password for Windows production signing.',
+    secret: true,
+    schema: stringSchema,
+    modes: { production: { value: '' } },
+  },
+  {
+    key: 'ESIGNER_TOTP_SECRET',
+    section: 'sign',
+    description:
+      'BrowserOS build eSigner TOTP secret for Windows production signing.',
+    secret: true,
+    schema: stringSchema,
+    modes: { production: { value: '' } },
+  },
+  {
+    key: 'ESIGNER_CREDENTIAL_ID',
+    section: 'sign',
+    description:
+      'BrowserOS build eSigner credential ID for Windows production signing.',
+    secret: false,
+    schema: stringSchema,
+    modes: { production: { value: '' } },
   },
 ]
 

--- a/packages/browseros-agent/scripts/build/claw-server/descriptor.test.ts
+++ b/packages/browseros-agent/scripts/build/claw-server/descriptor.test.ts
@@ -10,10 +10,16 @@ import { clawServerBuildProduct } from './descriptor'
 describe('claw server build descriptor', () => {
   let tempRoot: string | null = null
   let originalNodeEnv: string | undefined
+  let originalPosthogKey: string | undefined
+  let originalPosthogHost: string | undefined
 
   beforeEach(() => {
     originalNodeEnv = process.env.NODE_ENV
+    originalPosthogKey = process.env.CLAW_POSTHOG_KEY
+    originalPosthogHost = process.env.CLAW_POSTHOG_HOST
     delete process.env.NODE_ENV
+    delete process.env.CLAW_POSTHOG_KEY
+    delete process.env.CLAW_POSTHOG_HOST
   })
 
   afterEach(async () => {
@@ -21,6 +27,16 @@ describe('claw server build descriptor', () => {
       delete process.env.NODE_ENV
     } else {
       process.env.NODE_ENV = originalNodeEnv
+    }
+    if (originalPosthogKey === undefined) {
+      delete process.env.CLAW_POSTHOG_KEY
+    } else {
+      process.env.CLAW_POSTHOG_KEY = originalPosthogKey
+    }
+    if (originalPosthogHost === undefined) {
+      delete process.env.CLAW_POSTHOG_HOST
+    } else {
+      process.env.CLAW_POSTHOG_HOST = originalPosthogHost
     }
 
     if (tempRoot) {
@@ -56,6 +72,34 @@ describe('claw server build descriptor', () => {
     })
 
     expect(config.envVars.NODE_ENV).toBe('production')
+  })
+
+  it('inlines optional Claw PostHog values from the production env', async () => {
+    const rootDir = await writeClawPackageRoot(
+      [
+        'CLAW_POSTHOG_KEY=phc_claw_test',
+        'CLAW_POSTHOG_HOST=https://eu.i.posthog.com',
+      ].join('\n'),
+    )
+
+    const config = loadBuildConfig(rootDir, clawServerBuildProduct)
+
+    expect(config.envVars.CLAW_POSTHOG_KEY).toBe('phc_claw_test')
+    expect(config.envVars.CLAW_POSTHOG_HOST).toBe('https://eu.i.posthog.com')
+  })
+
+  it('keeps Claw PostHog values optional and absent from CI defaults', async () => {
+    const rootDir = await writeClawPackageRoot()
+
+    const config = loadBuildConfig(rootDir, clawServerBuildProduct, {
+      ci: true,
+    })
+
+    expect(clawServerBuildProduct.env.requiredInlineEnvKeys).not.toContain(
+      'CLAW_POSTHOG_KEY',
+    )
+    expect(config.envVars.CLAW_POSTHOG_KEY).toBeUndefined()
+    expect(config.envVars.CLAW_POSTHOG_HOST).toBeUndefined()
   })
 
   async function writeClawPackageRoot(envContent?: string): Promise<string> {

--- a/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
+++ b/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
@@ -2,7 +2,11 @@ import type { BuildProductDescriptor } from '@browseros/build-server-tools'
 
 export const CLAW_SERVER_BUNDLE_ENTRYPOINT = 'apps/claw-server/src/main.ts'
 
-const INLINED_ENV_VARS = ['NODE_ENV'] as const
+const INLINED_ENV_VARS = [
+  'CLAW_POSTHOG_KEY',
+  'CLAW_POSTHOG_HOST',
+  'NODE_ENV',
+] as const
 const PRODUCTION_INLINE_ENV = {
   NODE_ENV: 'production',
 }

--- a/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
@@ -47,6 +47,17 @@ describe('release-claw-server workflow', () => {
     expect(workflow).toContain('publish_ota:')
   })
 
+  it('forwards optional Claw PostHog values into production builds', () => {
+    expect(workflow).toMatch(/CLAW_POSTHOG_KEY:\n\s+required: false/)
+    expect(workflow).toMatch(/CLAW_POSTHOG_HOST:\n\s+required: false/)
+    expect(workflow).toContain(
+      `CLAW_POSTHOG_KEY: ${'$'}{{ secrets.CLAW_POSTHOG_KEY }}`,
+    )
+    expect(workflow).toContain(
+      `CLAW_POSTHOG_HOST: ${'$'}{{ secrets.CLAW_POSTHOG_HOST }}`,
+    )
+  })
+
   it('publishes claw-server and claw-onboard resources to their consumer prefixes', () => {
     expect(clawServerBuildProduct.env.defaultR2UploadPrefix).toBe(
       'claw-server/prod-resources',

--- a/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dir, '../../../..')
+const workflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/release-extensions.yml'),
+  'utf8',
+)
+
+describe('release-extensions workflow', () => {
+  it('forwards optional BrowserClaw PostHog values into extension builds', () => {
+    expect(workflow).toMatch(/VITE_CLAW_POSTHOG_KEY:\n\s+required: false/)
+    expect(workflow).toMatch(/VITE_CLAW_POSTHOG_HOST:\n\s+required: false/)
+    expect(workflow).toContain(
+      `VITE_CLAW_POSTHOG_KEY: ${'$'}{{ secrets.VITE_CLAW_POSTHOG_KEY }}`,
+    )
+    expect(workflow).toContain(
+      `VITE_CLAW_POSTHOG_HOST: ${'$'}{{ secrets.VITE_CLAW_POSTHOG_HOST }}`,
+    )
+  })
+})

--- a/packages/browseros/bos_build/release/extensions/specs.py
+++ b/packages/browseros/bos_build/release/extensions/specs.py
@@ -124,7 +124,11 @@ EXTENSION_SPECS: Tuple[ExtensionSpec, ...] = (
         manifest_path="apps/claw-app/package.json",
         extension_id=BROWSERCLAW_EXTENSION_ID,
         signing_key_env="BROWSERCLAW_KEY",
-        env=("NODE_ENV",),
+        env=(
+            "VITE_CLAW_POSTHOG_KEY",
+            "VITE_CLAW_POSTHOG_HOST",
+            "NODE_ENV",
+        ),
         env_dir="apps/claw-app",
     ),
 )

--- a/packages/browseros/bos_build/release/extensions/specs_test.py
+++ b/packages/browseros/bos_build/release/extensions/specs_test.py
@@ -104,6 +104,18 @@ class SpecTableTest(unittest.TestCase):
             self.assertTrue(spec.manifest_path.endswith("package.json"), name)
             self.assertTrue(spec.env_dir)
 
+    def test_browserclaw_forwards_posthog_env_to_claw_app(self):
+        browserclaw = spec_by_name("browserclaw")
+        self.assertEqual(
+            browserclaw.env,
+            (
+                "VITE_CLAW_POSTHOG_KEY",
+                "VITE_CLAW_POSTHOG_HOST",
+                "NODE_ENV",
+            ),
+        )
+        self.assertEqual(browserclaw.env_dir, "apps/claw-app")
+
     def test_in_repo_manifest_paths_exist_in_working_tree(self):
         monorepo_root = get_package_root().parent.parent
         for name in ("agent", "browserclaw"):

--- a/tools/release_secrets/sync.py
+++ b/tools/release_secrets/sync.py
@@ -122,6 +122,14 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
         ("release-browseros.yml", "release-server.yml", "release-extensions.yml"),
     ),  # Server and extension release analytics key.
     SecretSpec(
+        "CLAW_POSTHOG_KEY",
+        ("release-claw-server.yml",),
+    ),  # Optional Claw server analytics key.
+    SecretSpec(
+        "CLAW_POSTHOG_HOST",
+        ("release-claw-server.yml",),
+    ),  # Optional Claw server analytics host.
+    SecretSpec(
         "SENTRY_DSN",
         ("release-browseros.yml", "release-server.yml"),
     ),  # BrowserOS server inline Sentry DSN.
@@ -227,6 +235,14 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
         "VITE_PUBLIC_POSTHOG_HOST",
         ("release-extensions.yml",),
     ),  # Extension build-time PostHog host.
+    SecretSpec(
+        "VITE_CLAW_POSTHOG_KEY",
+        ("release-extensions.yml",),
+    ),  # Optional BrowserClaw build-time analytics key.
+    SecretSpec(
+        "VITE_CLAW_POSTHOG_HOST",
+        ("release-extensions.yml",),
+    ),  # Optional BrowserClaw build-time analytics host.
 )
 
 KNOWN_AUTOMATIC_SECRETS = frozenset({"GITHUB_TOKEN"})
@@ -239,7 +255,14 @@ KNOWN_EXTERNAL_SECRETS = frozenset(
     }
 )
 KNOWN_OPTIONAL_SECRETS = frozenset(
-    {"AGENT_RUNNER_JWT_SECRET", "ESIGNER_CREDENTIAL_ID"}
+    {
+        "AGENT_RUNNER_JWT_SECRET",
+        "CLAW_POSTHOG_HOST",
+        "CLAW_POSTHOG_KEY",
+        "ESIGNER_CREDENTIAL_ID",
+        "VITE_CLAW_POSTHOG_HOST",
+        "VITE_CLAW_POSTHOG_KEY",
+    }
 )
 
 

--- a/tools/release_secrets/sync_test.py
+++ b/tools/release_secrets/sync_test.py
@@ -2,12 +2,15 @@ import unittest
 
 from tools.release_secrets.sync import (
     ALLOWLIST,
+    KNOWN_OPTIONAL_SECRETS,
+    REPO_ROOT,
     RELEASE_WORKFLOW_FILES,
     DotenvParseError,
     build_check_result,
     build_plan,
     parse_dotenv_text,
     scan_secret_refs_from_text,
+    scan_workflow_secret_refs,
     verify_dotenv_round_trip,
 )
 
@@ -92,6 +95,28 @@ class WorkflowSecretScannerTest(unittest.TestCase):
             },
             consumers,
         )
+
+    def test_claw_posthog_workflow_secrets_are_allowlisted_and_optional(self):
+        expected_consumers = {
+            "CLAW_POSTHOG_KEY": ("release-claw-server.yml",),
+            "CLAW_POSTHOG_HOST": ("release-claw-server.yml",),
+            "VITE_CLAW_POSTHOG_KEY": ("release-extensions.yml",),
+            "VITE_CLAW_POSTHOG_HOST": ("release-extensions.yml",),
+        }
+        referenced = scan_workflow_secret_refs(REPO_ROOT)
+        allowlisted = {
+            spec.name: spec.consumers
+            for spec in ALLOWLIST
+            if spec.name in expected_consumers
+        }
+
+        self.assertEqual(set(expected_consumers), referenced & set(expected_consumers))
+        self.assertEqual(expected_consumers, allowlisted)
+        self.assertTrue(set(expected_consumers) <= KNOWN_OPTIONAL_SECRETS)
+
+        result = build_check_result(set(expected_consumers), set())
+        self.assertEqual(sorted(expected_consumers), result.optional)
+        self.assertEqual([], result.missing_required)
 
 
 class SecretPlanTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- register all four Claw PostHog variables in the consolidated env system and generate the development/production examples
- inline optional Claw server analytics values into production binaries and forward BrowserClaw Vite values into CRX builds
- add production eSigner entries, keep release-secret checks optional, and restore the full server test composite by excluding a helper-only directory

## Design
The change extends the existing owners rather than adding another env path: the shared registry generates local examples, the claw-server build descriptor feeds Bun's static `process.env` definitions, and the BrowserClaw extension spec materializes its Vite values into `apps/claw-app/.env`. Missing analytics keys remain a silent no-op, no CI placeholder is introduced, and `CLAW_ANALYTICS_ENABLED` stays an uninlined runtime kill-switch.

## Test plan
- [x] `bun run env:examples:check`
- [x] `bun run check`
- [x] `bun run test`
- [x] `uv run pytest bos_build/release/extensions/` (69 passed)
- [x] `python3 -m unittest discover -s tools/release_secrets -t . -p '*_test.py' -v` (10 passed)
- [x] `tools/release_secrets/sync.py --check` (new analytics names reported optional; no missing required secrets)
- [x] compiled claw-server binary contains a configured sentinel `CLAW_POSTHOG_KEY`
- [x] `git diff --check`

## Manual follow-ups
- Add repository secrets `CLAW_POSTHOG_KEY` and `VITE_CLAW_POSTHOG_KEY` before the next claw-server and BrowserClaw extension releases. Add `CLAW_POSTHOG_HOST` / `VITE_CLAW_POSTHOG_HOST` only when overriding PostHog US Cloud.
- Populate the relevant local `.env.production` with the PostHog and `ESIGNER_*` values before local production release/signing work. The committed examples intentionally leave credentials empty.
