### PR TITLE
fix: require Claw PostHog keys in production

### DIFF
--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -270,6 +270,8 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
           VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
+          VITE_CLAW_POSTHOG_KEY: ${{ secrets.VITE_CLAW_POSTHOG_KEY }}
+          VITE_CLAW_POSTHOG_HOST: ${{ secrets.VITE_CLAW_POSTHOG_HOST }}
           VITE_PUBLIC_BROWSEROS_API: https://api.browseros.com
           GRAPHQL_SCHEMA_PATH: apps/app/schema/graphql.schema.json
           NODE_ENV: production
@@ -296,6 +298,8 @@ jobs:
           write_env SENTRY_PROJECT
           write_env VITE_PUBLIC_POSTHOG_KEY
           write_env VITE_PUBLIC_POSTHOG_HOST
+          write_env VITE_CLAW_POSTHOG_KEY
+          write_env VITE_CLAW_POSTHOG_HOST
           write_env VITE_PUBLIC_BROWSEROS_API
           write_env GRAPHQL_SCHEMA_PATH
           write_env NODE_ENV

--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -138,6 +138,7 @@ jobs:
       - name: Stage BrowserClaw nightly resources
         env:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          CLAW_POSTHOG_KEY: ${{ secrets.CLAW_POSTHOG_KEY }}
         run: |
           set -euo pipefail
           agent_root="$BROWSEROS_REPO/packages/browseros-agent"
@@ -146,7 +147,7 @@ jobs:
           cd "$agent_root"
           bun ci
           bun scripts/build/server.ts --target=darwin-arm64 --ci
-          bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
+          bun scripts/build/claw-server.ts --target=darwin-arm64 --no-upload
           bun scripts/build/claw-onboard.ts --ci
           # Rust alternative: run scripts/build/claw-server-rust-local.sh here
           # and flip copy_resources.yaml/download_resources.yaml.

--- a/.github/workflows/release-browserclaw.yml
+++ b/.github/workflows/release-browserclaw.yml
@@ -161,6 +161,8 @@ jobs:
           ESIGNER_TOTP_SECRET: ${{ secrets.ESIGNER_TOTP_SECRET }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
           BROWSERCLAW_KEY: ${{ secrets.BROWSERCLAW_KEY }}
+          CLAW_POSTHOG_KEY: ${{ secrets.CLAW_POSTHOG_KEY }}
+          VITE_CLAW_POSTHOG_KEY: ${{ secrets.VITE_CLAW_POSTHOG_KEY }}
           BROWSEROS_REPO_PATH: ${{ vars.BROWSEROS_REPO_PATH }}
           BROWSEROS_CHROMIUM_SRC: ${{ vars.BROWSEROS_CHROMIUM_SRC }}
         run: |
@@ -201,8 +203,13 @@ jobs:
             require_value BROWSEROS_CHROMIUM_SRC
           fi
 
+          if [ "$INPUT_INCLUDE_SERVERS" = "true" ]; then
+            require_value CLAW_POSTHOG_KEY
+          fi
+
           if [ "$INPUT_EXTENSIONS" != "skip" ]; then
             require_value BROWSERCLAW_KEY
+            require_value VITE_CLAW_POSTHOG_KEY
           fi
 
           if [ "${#missing[@]}" -gt 0 ]; then

--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -1,6 +1,6 @@
 # Required secrets for resource publishing: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID,
-# R2_SECRET_ACCESS_KEY, R2_BUCKET. Optional when publish_ota is true:
-# SPARKLE_PRIVATE_KEY.
+# R2_SECRET_ACCESS_KEY, R2_BUCKET, CLAW_POSTHOG_KEY. Also required when
+# publish_ota is true: SPARKLE_PRIVATE_KEY.
 name: "Release: BrowserClaw Server + Onboard"
 
 on:
@@ -52,7 +52,7 @@ on:
       SPARKLE_PRIVATE_KEY:
         required: false
       CLAW_POSTHOG_KEY:
-        required: false
+        required: true
       CLAW_POSTHOG_HOST:
         required: false
 
@@ -183,6 +183,7 @@ jobs:
             R2_ACCESS_KEY_ID
             R2_SECRET_ACCESS_KEY
             R2_BUCKET
+            CLAW_POSTHOG_KEY
           )
           if [ "${PUBLISH_OTA:-false}" = "true" ]; then
             required+=(SPARKLE_PRIVATE_KEY)

--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -65,7 +65,46 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      PUBLISH_OTA: ${{ inputs.publish_ota || false }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+      CLAW_POSTHOG_KEY: ${{ secrets.CLAW_POSTHOG_KEY }}
+    steps:
+      - name: Preflight required secrets
+        run: |
+          set -euo pipefail
+          required=(
+            R2_ACCOUNT_ID
+            R2_ACCESS_KEY_ID
+            R2_SECRET_ACCESS_KEY
+            R2_BUCKET
+            CLAW_POSTHOG_KEY
+          )
+          if [ "${PUBLISH_OTA:-false}" = "true" ]; then
+            required+=(SPARKLE_PRIVATE_KEY)
+          fi
+
+          missing=()
+          for name in "${required[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required secret(s): ${missing[*]}"
+            exit 1
+          fi
+
   release:
+    needs: preflight
     if: github.event_name != 'push' || github.event.deleted != true
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -174,32 +213,6 @@ jobs:
           fetch-depth: 0
           lfs: true
           ref: ${{ needs.release.outputs.release_sha }}
-
-      - name: Preflight required secrets
-        run: |
-          set -euo pipefail
-          required=(
-            R2_ACCOUNT_ID
-            R2_ACCESS_KEY_ID
-            R2_SECRET_ACCESS_KEY
-            R2_BUCKET
-            CLAW_POSTHOG_KEY
-          )
-          if [ "${PUBLISH_OTA:-false}" = "true" ]; then
-            required+=(SPARKLE_PRIVATE_KEY)
-          fi
-
-          missing=()
-          for name in "${required[@]}"; do
-            if [ -z "${!name:-}" ]; then
-              missing+=("$name")
-            fi
-          done
-
-          if [ "${#missing[@]}" -gt 0 ]; then
-            echo "::error::Missing required secret(s): ${missing[*]}"
-            exit 1
-          fi
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -73,7 +73,7 @@ on:
       VITE_PUBLIC_POSTHOG_HOST:
         required: false
       VITE_CLAW_POSTHOG_KEY:
-        required: false
+        required: true
       VITE_CLAW_POSTHOG_HOST:
         required: false
 

--- a/packages/browseros-agent/.env.development.example
+++ b/packages/browseros-agent/.env.development.example
@@ -62,13 +62,13 @@ SENTRY_PROJECT=
 # Optional BrowserClaw state root override.
 # BROWSERCLAW_DIR=~/.browserclaw-dev
 
-# Claw server PostHog project write key.
+# Claw server PostHog project key required by production builds.
 CLAW_POSTHOG_KEY=
 
 # Optional Claw server PostHog host; defaults to PostHog US Cloud.
 # CLAW_POSTHOG_HOST=https://us.i.posthog.com
 
-# BrowserClaw bundle PostHog project write key.
+# BrowserClaw PostHog project key embedded in the shipped client bundle; required by production builds.
 VITE_CLAW_POSTHOG_KEY=
 
 # Optional BrowserClaw bundle PostHog host; defaults to PostHog US Cloud.

--- a/packages/browseros-agent/.env.production.example
+++ b/packages/browseros-agent/.env.production.example
@@ -4,8 +4,17 @@
 
 # --- claw ---
 
-# Claw server PostHog project write key.
+# Claw server PostHog project key required by production builds.
 CLAW_POSTHOG_KEY=
+
+# Optional Claw server PostHog host; defaults to PostHog US Cloud.
+# CLAW_POSTHOG_HOST=https://us.i.posthog.com
+
+# BrowserClaw PostHog project key embedded in the shipped client bundle; required by production builds.
+VITE_CLAW_POSTHOG_KEY=
+
+# Optional BrowserClaw bundle PostHog host; defaults to PostHog US Cloud.
+# VITE_CLAW_POSTHOG_HOST=https://us.i.posthog.com
 
 # --- server ---
 

--- a/packages/browseros-agent/apps/claw-server/tests/build.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/build.test.ts
@@ -100,10 +100,12 @@ describe('claw server build', () => {
     )
   })
 
-  it('builds a local artifact without apps/server env files', async () => {
+  it('builds a local artifact with only the Claw production key', async () => {
     rmSync(zipPath, { force: true })
     const pkg = await Bun.file(versionPkgPath).json()
     const expectedVersion: string = pkg.version
+    const env = buildEnv(UNNEEDED_SERVER_AND_R2_ENV_KEYS)
+    env.CLAW_POSTHOG_KEY = 'phc_claw_local_build_fixture'
 
     const build = Bun.spawn(
       ['bun', buildScript, `--target=${target.id}`, '--no-upload'],
@@ -111,7 +113,7 @@ describe('claw server build', () => {
         cwd: rootDir,
         stdout: 'pipe',
         stderr: 'pipe',
-        env: buildEnv(UNNEEDED_SERVER_AND_R2_ENV_KEYS),
+        env,
       },
     )
     const buildExit = await build.exited
@@ -214,6 +216,7 @@ describe('claw server build', () => {
       setProcessEnv('R2_ACCESS_KEY_ID', 'test')
       setProcessEnv('R2_SECRET_ACCESS_KEY', 'test')
       setProcessEnv('R2_BUCKET', 'test')
+      setProcessEnv('CLAW_POSTHOG_KEY', 'phc_claw_upload_config_fixture')
       deleteProcessEnv('R2_UPLOAD_PREFIX')
 
       const defaultConfig = loadBuildConfig(rootDir, clawServerBuildProduct, {

--- a/packages/browseros-agent/packages/shared/src/env/generate.test.ts
+++ b/packages/browseros-agent/packages/shared/src/env/generate.test.ts
@@ -59,7 +59,7 @@ describe('ENV_REGISTRY', () => {
     )
   })
 
-  test('registers optional Claw analytics and production eSigner inputs', () => {
+  test('registers the Claw analytics production contract and eSigner inputs', () => {
     const specs = Object.fromEntries(
       ENV_REGISTRY.map((spec) => [spec.key, spec]),
     )
@@ -80,18 +80,32 @@ describe('ENV_REGISTRY', () => {
           value: 'https://us.i.posthog.com',
           commented: true,
         },
+        production: {
+          value: 'https://us.i.posthog.com',
+          commented: true,
+        },
       },
     })
     expect(specs.VITE_CLAW_POSTHOG_KEY).toMatchObject({
       section: 'claw',
       secret: true,
-      modes: { development: { value: '' } },
+      modes: {
+        development: { value: '' },
+        production: { value: '' },
+      },
     })
+    expect(specs.VITE_CLAW_POSTHOG_KEY.description).toContain(
+      'embedded in the shipped client bundle',
+    )
     expect(specs.VITE_CLAW_POSTHOG_HOST).toMatchObject({
       section: 'claw',
       secret: false,
       modes: {
         development: {
+          value: 'https://us.i.posthog.com',
+          commented: true,
+        },
+        production: {
           value: 'https://us.i.posthog.com',
           commented: true,
         },
@@ -145,8 +159,13 @@ describe('generateEnvExample', () => {
     )
 
     expect(production).toContain('\nCLAW_POSTHOG_KEY=\n')
-    expect(production).not.toContain('CLAW_POSTHOG_HOST')
-    expect(production).not.toContain('VITE_CLAW_POSTHOG')
+    expect(production).toContain(
+      '\n# CLAW_POSTHOG_HOST=https://us.i.posthog.com\n',
+    )
+    expect(production).toContain('\nVITE_CLAW_POSTHOG_KEY=\n')
+    expect(production).toContain(
+      '\n# VITE_CLAW_POSTHOG_HOST=https://us.i.posthog.com\n',
+    )
     expect(production).toContain('\n# --- sign ---\n')
     expect(production).toContain('\nESIGNER_USERNAME=\n')
     expect(production).toContain('\nESIGNER_PASSWORD=\n')

--- a/packages/browseros-agent/packages/shared/src/env/registry.ts
+++ b/packages/browseros-agent/packages/shared/src/env/registry.ts
@@ -199,7 +199,8 @@ export const ENV_REGISTRY: readonly EnvKeySpec[] = [
   {
     key: 'CLAW_POSTHOG_KEY',
     section: 'claw',
-    description: 'Claw server PostHog project write key.',
+    description:
+      'Claw server PostHog project key required by production builds.',
     secret: true,
     schema: stringSchema,
     modes: { development: { value: '' }, production: { value: '' } },
@@ -216,15 +217,20 @@ export const ENV_REGISTRY: readonly EnvKeySpec[] = [
         value: 'https://us.i.posthog.com',
         commented: true,
       },
+      production: {
+        value: 'https://us.i.posthog.com',
+        commented: true,
+      },
     },
   },
   {
     key: 'VITE_CLAW_POSTHOG_KEY',
     section: 'claw',
-    description: 'BrowserClaw bundle PostHog project write key.',
+    description:
+      'BrowserClaw PostHog project key embedded in the shipped client bundle; required by production builds.',
     secret: true,
     schema: stringSchema,
-    modes: { development: { value: '' } },
+    modes: { development: { value: '' }, production: { value: '' } },
   },
   {
     key: 'VITE_CLAW_POSTHOG_HOST',
@@ -235,6 +241,10 @@ export const ENV_REGISTRY: readonly EnvKeySpec[] = [
     schema: stringSchema,
     modes: {
       development: {
+        value: 'https://us.i.posthog.com',
+        commented: true,
+      },
+      production: {
         value: 'https://us.i.posthog.com',
         commented: true,
       },

--- a/packages/browseros-agent/scripts/build/claw-server/descriptor.test.ts
+++ b/packages/browseros-agent/scripts/build/claw-server/descriptor.test.ts
@@ -46,7 +46,9 @@ describe('claw server build descriptor', () => {
   })
 
   it('inlines NODE_ENV from the production env file', async () => {
-    const rootDir = await writeClawPackageRoot('NODE_ENV=production\n')
+    const rootDir = await writeClawPackageRoot(
+      'NODE_ENV=production\nCLAW_POSTHOG_KEY=phc_claw_test\n',
+    )
 
     const config = loadBuildConfig(rootDir, clawServerBuildProduct)
 
@@ -74,7 +76,7 @@ describe('claw server build descriptor', () => {
     expect(config.envVars.NODE_ENV).toBe('production')
   })
 
-  it('inlines optional Claw PostHog values from the production env', async () => {
+  it('inlines required key and optional host from the production env', async () => {
     const rootDir = await writeClawPackageRoot(
       [
         'CLAW_POSTHOG_KEY=phc_claw_test',
@@ -88,14 +90,22 @@ describe('claw server build descriptor', () => {
     expect(config.envVars.CLAW_POSTHOG_HOST).toBe('https://eu.i.posthog.com')
   })
 
-  it('keeps Claw PostHog values optional and absent from CI defaults', async () => {
+  it('requires the Claw PostHog key for production builds', async () => {
+    const rootDir = await writeClawPackageRoot('NODE_ENV=production\n')
+
+    expect(() => loadBuildConfig(rootDir, clawServerBuildProduct)).toThrow(
+      'BrowserOS Claw server: Missing required env: CLAW_POSTHOG_KEY (section: claw)',
+    )
+  })
+
+  it('keeps CI fixture builds keyless and the host optional', async () => {
     const rootDir = await writeClawPackageRoot()
 
     const config = loadBuildConfig(rootDir, clawServerBuildProduct, {
       ci: true,
     })
 
-    expect(clawServerBuildProduct.env.requiredInlineEnvKeys).not.toContain(
+    expect(clawServerBuildProduct.env.requiredInlineEnvKeys).toContain(
       'CLAW_POSTHOG_KEY',
     )
     expect(config.envVars.CLAW_POSTHOG_KEY).toBeUndefined()

--- a/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
+++ b/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
@@ -2,8 +2,9 @@ import type { BuildProductDescriptor } from '@browseros/build-server-tools'
 
 export const CLAW_SERVER_BUNDLE_ENTRYPOINT = 'apps/claw-server/src/main.ts'
 
+const REQUIRED_PROD_VARS = ['CLAW_POSTHOG_KEY'] as const
 const INLINED_ENV_VARS = [
-  'CLAW_POSTHOG_KEY',
+  ...REQUIRED_PROD_VARS,
   'CLAW_POSTHOG_HOST',
   'NODE_ENV',
 ] as const
@@ -21,7 +22,7 @@ export const clawServerBuildProduct: BuildProductDescriptor = {
   archiveBaseName: 'browseros-claw-server-resources',
   defaultManifestPath: 'scripts/build/config/claw-server-prod-resources.json',
   env: {
-    requiredInlineEnvKeys: [],
+    requiredInlineEnvKeys: REQUIRED_PROD_VARS,
     inlineEnvKeys: INLINED_ENV_VARS,
     ciInlineEnvDefaults: PRODUCTION_INLINE_ENV,
     inlineEnvOverrides: PRODUCTION_INLINE_ENV,

--- a/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
@@ -10,6 +10,10 @@ const workflow = readFileSync(
   resolve(repoRoot, '.github/workflows/release-claw-server.yml'),
   'utf8',
 )
+const nightlyWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/nightly-browserclaw.yml'),
+  'utf8',
+)
 const shellVersionPlaceholder = '$' + '{VERSION}'
 const shellTargetPlaceholder = '$' + '{target}'
 const shellServerAssetsPlaceholder = '$' + '{server_assets[@]}'
@@ -57,14 +61,30 @@ describe('release-claw-server workflow', () => {
       `CLAW_POSTHOG_HOST: ${'$'}{{ secrets.CLAW_POSTHOG_HOST }}`,
     )
 
-    const preflightStart = workflow.indexOf(
-      '- name: Preflight required secrets',
-    )
-    const preflightEnd = workflow.indexOf('- name: Setup Bun', preflightStart)
+    const preflightStart = workflow.indexOf('  preflight:')
+    const preflightEnd = workflow.indexOf('  release:', preflightStart)
     expect(preflightStart).toBeGreaterThanOrEqual(0)
     expect(preflightEnd).toBeGreaterThan(preflightStart)
-    expect(workflow.slice(preflightStart, preflightEnd)).toMatch(
-      /required=\([\s\S]*CLAW_POSTHOG_KEY/,
+    const preflight = workflow.slice(preflightStart, preflightEnd)
+    expect(preflight).toMatch(/required=\([\s\S]*CLAW_POSTHOG_KEY/)
+    expect(preflight).toContain('- name: Preflight required secrets')
+
+    const releaseStart = preflightEnd
+    const releaseEnd = workflow.indexOf('  build-publish:', releaseStart)
+    expect(workflow.slice(releaseStart, releaseEnd)).toContain(
+      'needs: preflight',
+    )
+  })
+
+  it('uses production key validation for published BrowserClaw nightlies', () => {
+    expect(nightlyWorkflow).toContain(
+      `CLAW_POSTHOG_KEY: ${'$'}{{ secrets.CLAW_POSTHOG_KEY }}`,
+    )
+    expect(nightlyWorkflow).toContain(
+      'bun scripts/build/claw-server.ts --target=darwin-arm64 --no-upload',
+    )
+    expect(nightlyWorkflow).not.toContain(
+      'bun scripts/build/claw-server.ts --target=darwin-arm64 --ci',
     )
   })
 

--- a/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
@@ -47,14 +47,24 @@ describe('release-claw-server workflow', () => {
     expect(workflow).toContain('publish_ota:')
   })
 
-  it('forwards optional Claw PostHog values into production builds', () => {
-    expect(workflow).toMatch(/CLAW_POSTHOG_KEY:\n\s+required: false/)
+  it('requires the Claw PostHog key and keeps the host optional', () => {
+    expect(workflow).toMatch(/CLAW_POSTHOG_KEY:\n\s+required: true/)
     expect(workflow).toMatch(/CLAW_POSTHOG_HOST:\n\s+required: false/)
     expect(workflow).toContain(
       `CLAW_POSTHOG_KEY: ${'$'}{{ secrets.CLAW_POSTHOG_KEY }}`,
     )
     expect(workflow).toContain(
       `CLAW_POSTHOG_HOST: ${'$'}{{ secrets.CLAW_POSTHOG_HOST }}`,
+    )
+
+    const preflightStart = workflow.indexOf(
+      '- name: Preflight required secrets',
+    )
+    const preflightEnd = workflow.indexOf('- name: Setup Bun', preflightStart)
+    expect(preflightStart).toBeGreaterThanOrEqual(0)
+    expect(preflightEnd).toBeGreaterThan(preflightStart)
+    expect(workflow.slice(preflightStart, preflightEnd)).toMatch(
+      /required=\([\s\S]*CLAW_POSTHOG_KEY/,
     )
   })
 

--- a/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
@@ -7,16 +7,58 @@ const workflow = readFileSync(
   resolve(repoRoot, '.github/workflows/release-extensions.yml'),
   'utf8',
 )
+const browserBuildWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/build-browseros.yml'),
+  'utf8',
+)
+const browserClawWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/release-browserclaw.yml'),
+  'utf8',
+)
 
 describe('release-extensions workflow', () => {
-  it('forwards optional BrowserClaw PostHog values into extension builds', () => {
-    expect(workflow).toMatch(/VITE_CLAW_POSTHOG_KEY:\n\s+required: false/)
+  it('requires the BrowserClaw PostHog key and keeps the host optional', () => {
+    expect(workflow).toMatch(/VITE_CLAW_POSTHOG_KEY:\n\s+required: true/)
     expect(workflow).toMatch(/VITE_CLAW_POSTHOG_HOST:\n\s+required: false/)
     expect(workflow).toContain(
       `VITE_CLAW_POSTHOG_KEY: ${'$'}{{ secrets.VITE_CLAW_POSTHOG_KEY }}`,
     )
     expect(workflow).toContain(
       `VITE_CLAW_POSTHOG_HOST: ${'$'}{{ secrets.VITE_CLAW_POSTHOG_HOST }}`,
+    )
+  })
+
+  it('forwards BrowserClaw PostHog values to local bundled builds', () => {
+    expect(browserBuildWorkflow).toContain(
+      `VITE_CLAW_POSTHOG_KEY: ${'$'}{{ secrets.VITE_CLAW_POSTHOG_KEY }}`,
+    )
+    expect(browserBuildWorkflow).toContain(
+      `VITE_CLAW_POSTHOG_HOST: ${'$'}{{ secrets.VITE_CLAW_POSTHOG_HOST }}`,
+    )
+    expect(browserBuildWorkflow).toContain('write_env VITE_CLAW_POSTHOG_KEY')
+    expect(browserBuildWorkflow).toContain('write_env VITE_CLAW_POSTHOG_HOST')
+  })
+
+  it('preflights selected BrowserClaw keys in the full release caller', () => {
+    const start = browserClawWorkflow.indexOf(
+      '- name: Validate selected lane configuration',
+    )
+    const end = browserClawWorkflow.indexOf('  server_browserclaw:', start)
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+    const preflight = browserClawWorkflow.slice(start, end)
+
+    expect(preflight).toContain(
+      `CLAW_POSTHOG_KEY: ${'$'}{{ secrets.CLAW_POSTHOG_KEY }}`,
+    )
+    expect(preflight).toContain(
+      `VITE_CLAW_POSTHOG_KEY: ${'$'}{{ secrets.VITE_CLAW_POSTHOG_KEY }}`,
+    )
+    expect(preflight).toMatch(
+      /INPUT_INCLUDE_SERVERS[\s\S]*require_value CLAW_POSTHOG_KEY/,
+    )
+    expect(preflight).toMatch(
+      /INPUT_EXTENSIONS[\s\S]*require_value VITE_CLAW_POSTHOG_KEY/,
     )
   })
 })

--- a/packages/browseros/bos_build/release/extensions/release.py
+++ b/packages/browseros/bos_build/release/extensions/release.py
@@ -20,6 +20,7 @@ from .specs import (
     spec_by_name,
 )
 from .workspace import (
+    require_env,
     resolve_source,
     run_command,
     update_manifest_version,
@@ -28,15 +29,6 @@ from .workspace import (
 
 # Chrome requires extension versions to be 1-4 dot-separated integers.
 _VERSION_RE = re.compile(r"^\d+(\.\d+){0,3}$")
-
-
-def _require_env(name: str) -> str:
-    value = os.environ.get(name, "").strip()
-    # <=1 mirrors the old release tool's guard: 0-1 chars is an unset or
-    # placeholder value ("0", "-"), never a real key.
-    if len(value) <= 1:
-        raise EnvironmentError(f"Missing or empty environment variable: {name}")
-    return value
 
 
 class ExtensionReleaseModule(Step):
@@ -75,12 +67,20 @@ class ExtensionReleaseModule(Step):
 
         for spec in specs:
             try:
-                _require_env(spec.signing_key_env)
+                require_env(spec.signing_key_env)
             except EnvironmentError:
                 raise ValidationError(
                     f"Signing key env var '{spec.signing_key_env}' for "
                     f"'{spec.name}' is missing or empty"
                 )
+            for name in spec.required_env:
+                try:
+                    require_env(name)
+                except EnvironmentError:
+                    raise ValidationError(
+                        f"Required build env var '{name}' for "
+                        f"'{spec.name}' is missing or empty"
+                    )
 
         if not BOTO3_AVAILABLE:
             raise ValidationError("boto3 library not installed - run: pip install boto3")
@@ -136,14 +136,18 @@ class ExtensionReleaseModule(Step):
                 env_dir = (
                     source_root / spec.env_dir if spec.env_dir else source_root
                 )
-                write_env_file(env_dir, spec.env)
+                write_env_file(
+                    env_dir,
+                    spec.env,
+                    required_names=spec.required_env,
+                )
             if spec.pre_build:
                 run_command(spec.pre_build, source_root)
             run_command(spec.build, source_root)
 
             crx_path = pack_crx(
                 source_root / spec.dist_path,
-                _require_env(spec.signing_key_env),
+                require_env(spec.signing_key_env),
                 chrome,
                 work_root / "dist" / spec.crx_filename(self.version),
             )

--- a/packages/browseros/bos_build/release/extensions/release_test.py
+++ b/packages/browseros/bos_build/release/extensions/release_test.py
@@ -18,6 +18,7 @@ ALL_KEYS = {
     "BROWSEROS_CONTROLLER_KEY": "controller-pem",
     "BUGREPORTER_KEY": "bugreporter-pem",
     "BROWSERCLAW_KEY": "claw-pem",
+    "VITE_CLAW_POSTHOG_KEY": "phc-claw-app",
 }
 
 
@@ -107,6 +108,16 @@ class ValidateTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValidationError, "R2"):
                     self._module().validate(_ctx(has_r2=False))
 
+    def test_missing_browserclaw_build_env_names_the_variable(self):
+        env = dict(ALL_KEYS)
+        env.pop("VITE_CLAW_POSTHOG_KEY")
+        with patch.dict("os.environ", env, clear=True):
+            with patch(f"{MODULE}.find_chrome_binary", return_value="chrome"):
+                with self.assertRaisesRegex(
+                    ValidationError, "VITE_CLAW_POSTHOG_KEY"
+                ):
+                    self._module(names=("browserclaw",)).validate(_ctx())
+
     def test_chrome_resolution_failure_fails_validation(self):
         with patch.dict("os.environ", ALL_KEYS):
             with patch(
@@ -193,6 +204,9 @@ class ExecuteTest(unittest.TestCase):
         env_args = self.mocks["write_env_file"].call_args.args
         self.assertEqual(env_args[0], Path("/src/agent/apps/app"))
         self.assertIn("VITE_PUBLIC_BROWSEROS_API", env_args[1])
+        self.assertEqual(self.mocks["write_env_file"].call_args.kwargs, {
+            "required_names": (),
+        })
 
         commands = [c.args for c in self.mocks["run_command"].call_args_list]
         self.assertEqual(

--- a/packages/browseros/bos_build/release/extensions/specs.py
+++ b/packages/browseros/bos_build/release/extensions/specs.py
@@ -42,9 +42,10 @@ class ExtensionSpec:
     """One packagable extension; name is the crx filename prefix.
 
     dist_path / manifest_path / env_dir are relative to the resolved source
-    root. env lists the variable names the build reads; they are also
-    written to <env_dir or source root>/.env because some bundler configs
-    only read env from file.
+    root. env lists the variable names the build reads; required_env is the
+    subset that must be present before production builds. Values are written
+    to <env_dir or source root>/.env because some bundler configs only read
+    env from file.
     """
 
     name: str
@@ -56,6 +57,7 @@ class ExtensionSpec:
     extension_id: str
     signing_key_env: str
     env: Tuple[str, ...] = ()
+    required_env: Tuple[str, ...] = ()
     env_dir: str = ""
 
     def crx_filename(self, version: str) -> str:
@@ -129,6 +131,7 @@ EXTENSION_SPECS: Tuple[ExtensionSpec, ...] = (
             "VITE_CLAW_POSTHOG_HOST",
             "NODE_ENV",
         ),
+        required_env=("VITE_CLAW_POSTHOG_KEY",),
         env_dir="apps/claw-app",
     ),
 )

--- a/packages/browseros/bos_build/release/extensions/specs_test.py
+++ b/packages/browseros/bos_build/release/extensions/specs_test.py
@@ -114,7 +114,12 @@ class SpecTableTest(unittest.TestCase):
                 "NODE_ENV",
             ),
         )
+        self.assertEqual(browserclaw.required_env, ("VITE_CLAW_POSTHOG_KEY",))
         self.assertEqual(browserclaw.env_dir, "apps/claw-app")
+
+    def test_non_claw_extensions_have_no_required_build_env(self):
+        for name in ("agent", "controller", "bugreporter"):
+            self.assertEqual(spec_by_name(name).required_env, (), name)
 
     def test_in_repo_manifest_paths_exist_in_working_tree(self):
         monorepo_root = get_package_root().parent.parent

--- a/packages/browseros/bos_build/release/extensions/workspace.py
+++ b/packages/browseros/bos_build/release/extensions/workspace.py
@@ -103,12 +103,30 @@ def update_manifest_version(manifest_path: Path, version: str) -> None:
     log_success(f"{manifest_path.name}: version {old} -> {version}")
 
 
-def write_env_file(directory: Path, names: Iterable[str]) -> Path:
+def require_env(name: str) -> str:
+    """Return a non-placeholder env value or raise with the release convention."""
+    value = os.environ.get(name, "").strip()
+    # 0-1 chars is an unset or placeholder value ("0", "-"), never a real key.
+    if len(value) <= 1:
+        raise EnvironmentError(f"Missing or empty environment variable: {name}")
+    return value
+
+
+def write_env_file(
+    directory: Path,
+    names: Iterable[str],
+    *,
+    required_names: Iterable[str] = (),
+) -> Path:
     """Recreate <directory>/.env from the named process env vars.
 
     Some bundler configs only read env from file (old builder.py constraint),
-    so the build env is materialized next to the app. Unset vars are skipped.
+    so the build env is materialized next to the app. Required values are
+    checked before replacing the file; other unset vars are skipped.
     """
+    for name in required_names:
+        require_env(name)
+
     env_path = directory / ".env"
     env_path.write_text("")
     for name in names:

--- a/packages/browseros/bos_build/release/extensions/workspace_test.py
+++ b/packages/browseros/bos_build/release/extensions/workspace_test.py
@@ -208,6 +208,26 @@ class WriteEnvFileTest(unittest.TestCase):
             self.assertNotIn("MISSING_VAR", content)
             self.assertNotIn("STALE", content)
 
+    def test_missing_required_var_fails_before_replacing_existing_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_dir = Path(tmp)
+            env_path = env_dir / ".env"
+            env_path.write_text("PRESERVED=old\n")
+            with patch.dict("os.environ", {}, clear=False):
+                import os
+
+                os.environ.pop("VITE_CLAW_POSTHOG_KEY", None)
+                with self.assertRaisesRegex(
+                    EnvironmentError, "VITE_CLAW_POSTHOG_KEY"
+                ):
+                    write_env_file(
+                        env_dir,
+                        ("VITE_CLAW_POSTHOG_KEY", "VITE_CLAW_POSTHOG_HOST"),
+                        required_names=("VITE_CLAW_POSTHOG_KEY",),
+                    )
+
+            self.assertEqual(env_path.read_text(), "PRESERVED=old\n")
+
 
 class RunCommandTest(unittest.TestCase):
     def test_nonzero_exit_raises_with_command(self):

--- a/packages/browseros/bos_build/steps/extensions/bundled_extensions.py
+++ b/packages/browseros/bos_build/steps/extensions/bundled_extensions.py
@@ -8,7 +8,6 @@ while required external extensions continue to download from the CDN manifest.
 """
 
 import json
-import os
 import shutil
 import sys
 import xml.etree.ElementTree as ET
@@ -28,6 +27,7 @@ from ...release.extensions.specs import (
     InRepoSource,
 )
 from ...release.extensions.workspace import (
+    require_env,
     resolve_source,
     run_command,
     write_env_file,
@@ -301,7 +301,11 @@ class BundledExtensionsModule(Step):
         version = self._read_manifest_version(source_root / spec.manifest_path)
         if spec.env:
             env_dir = source_root / spec.env_dir if spec.env_dir else source_root
-            write_env_file(env_dir, spec.env)
+            write_env_file(
+                env_dir,
+                spec.env,
+                required_names=spec.required_env,
+            )
         if spec.pre_build:
             run_command(spec.pre_build, source_root)
         run_command(spec.build, source_root)
@@ -327,12 +331,7 @@ class BundledExtensionsModule(Step):
         return version
 
     def _require_signing_key(self, spec: ExtensionSpec) -> str:
-        value = os.environ.get(spec.signing_key_env, "").strip()
-        if len(value) <= 1:
-            raise RuntimeError(
-                f"Missing or empty environment variable: {spec.signing_key_env}"
-            )
-        return value
+        return require_env(spec.signing_key_env)
 
     def _validate_local_bundle_requirements(self, ctx: Context) -> None:
         missing = []
@@ -343,13 +342,14 @@ class BundledExtensionsModule(Step):
             if spec is None:
                 continue
             has_local_required = True
-            try:
-                self._require_signing_key(spec)
-            except RuntimeError:
-                missing.append(f"{name}: {spec.signing_key_env}")
+            for env_name in (spec.signing_key_env, *spec.required_env):
+                try:
+                    require_env(env_name)
+                except EnvironmentError:
+                    missing.append(f"{name}: {env_name}")
         if missing:
             raise ValidationError(
-                "Local bundled extension signing key env var(s) missing: "
+                "Local bundled extension env var(s) missing: "
                 + ", ".join(missing)
             )
         if not has_local_required:

--- a/packages/browseros/bos_build/steps/extensions/bundled_extensions_test.py
+++ b/packages/browseros/bos_build/steps/extensions/bundled_extensions_test.py
@@ -342,10 +342,27 @@ class BundledExtensionsManifestTest(unittest.TestCase):
                 self._ctx("browseros", bundle_local_extensions=True)
             )
 
-    def test_browserclaw_local_preflight_requires_only_claw_key(self) -> None:
+    def test_browserclaw_local_preflight_accepts_signing_and_posthog_keys(self) -> None:
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "BROWSERCLAW_KEY": "claw-pem",
+                    "VITE_CLAW_POSTHOG_KEY": "phc-claw-app",
+                },
+                clear=True,
+            ),
+            patch(f"{MODULE}.find_chrome_binary", return_value="chrome-bin"),
+        ):
+            BundledExtensionsModule().preflight(
+                self._ctx("browserclaw", bundle_local_extensions=True)
+            )
+
+    def test_browserclaw_local_preflight_names_missing_posthog_key(self) -> None:
         with (
             patch.dict(os.environ, {"BROWSERCLAW_KEY": "claw-pem"}, clear=True),
             patch(f"{MODULE}.find_chrome_binary", return_value="chrome-bin"),
+            self.assertRaisesRegex(ValidationError, "VITE_CLAW_POSTHOG_KEY"),
         ):
             BundledExtensionsModule().preflight(
                 self._ctx("browserclaw", bundle_local_extensions=True)

--- a/tools/release_secrets/sync.py
+++ b/tools/release_secrets/sync.py
@@ -123,8 +123,8 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
     ),  # Server and extension release analytics key.
     SecretSpec(
         "CLAW_POSTHOG_KEY",
-        ("release-claw-server.yml",),
-    ),  # Optional Claw server analytics key.
+        ("release-browserclaw.yml", "release-claw-server.yml"),
+    ),  # Required Claw server production analytics key.
     SecretSpec(
         "CLAW_POSTHOG_HOST",
         ("release-claw-server.yml",),
@@ -237,11 +237,15 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
     ),  # Extension build-time PostHog host.
     SecretSpec(
         "VITE_CLAW_POSTHOG_KEY",
-        ("release-extensions.yml",),
-    ),  # Optional BrowserClaw build-time analytics key.
+        (
+            "build-browseros.yml",
+            "release-browserclaw.yml",
+            "release-extensions.yml",
+        ),
+    ),  # Required BrowserClaw build-time analytics key.
     SecretSpec(
         "VITE_CLAW_POSTHOG_HOST",
-        ("release-extensions.yml",),
+        ("build-browseros.yml", "release-extensions.yml"),
     ),  # Optional BrowserClaw build-time analytics host.
 )
 
@@ -258,10 +262,8 @@ KNOWN_OPTIONAL_SECRETS = frozenset(
     {
         "AGENT_RUNNER_JWT_SECRET",
         "CLAW_POSTHOG_HOST",
-        "CLAW_POSTHOG_KEY",
         "ESIGNER_CREDENTIAL_ID",
         "VITE_CLAW_POSTHOG_HOST",
-        "VITE_CLAW_POSTHOG_KEY",
     }
 )
 

--- a/tools/release_secrets/sync.py
+++ b/tools/release_secrets/sync.py
@@ -123,7 +123,11 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
     ),  # Server and extension release analytics key.
     SecretSpec(
         "CLAW_POSTHOG_KEY",
-        ("release-browserclaw.yml", "release-claw-server.yml"),
+        (
+            "nightly-browserclaw.yml",
+            "release-browserclaw.yml",
+            "release-claw-server.yml",
+        ),
     ),  # Required Claw server production analytics key.
     SecretSpec(
         "CLAW_POSTHOG_HOST",

--- a/tools/release_secrets/sync_test.py
+++ b/tools/release_secrets/sync_test.py
@@ -96,13 +96,25 @@ class WorkflowSecretScannerTest(unittest.TestCase):
             consumers,
         )
 
-    def test_claw_posthog_workflow_secrets_are_allowlisted_and_optional(self):
+    def test_claw_posthog_keys_are_required_and_hosts_are_optional(self):
         expected_consumers = {
-            "CLAW_POSTHOG_KEY": ("release-claw-server.yml",),
+            "CLAW_POSTHOG_KEY": (
+                "release-browserclaw.yml",
+                "release-claw-server.yml",
+            ),
             "CLAW_POSTHOG_HOST": ("release-claw-server.yml",),
-            "VITE_CLAW_POSTHOG_KEY": ("release-extensions.yml",),
-            "VITE_CLAW_POSTHOG_HOST": ("release-extensions.yml",),
+            "VITE_CLAW_POSTHOG_KEY": (
+                "build-browseros.yml",
+                "release-browserclaw.yml",
+                "release-extensions.yml",
+            ),
+            "VITE_CLAW_POSTHOG_HOST": (
+                "build-browseros.yml",
+                "release-extensions.yml",
+            ),
         }
+        required_keys = {"CLAW_POSTHOG_KEY", "VITE_CLAW_POSTHOG_KEY"}
+        optional_hosts = {"CLAW_POSTHOG_HOST", "VITE_CLAW_POSTHOG_HOST"}
         referenced = scan_workflow_secret_refs(REPO_ROOT)
         allowlisted = {
             spec.name: spec.consumers
@@ -112,11 +124,12 @@ class WorkflowSecretScannerTest(unittest.TestCase):
 
         self.assertEqual(set(expected_consumers), referenced & set(expected_consumers))
         self.assertEqual(expected_consumers, allowlisted)
-        self.assertTrue(set(expected_consumers) <= KNOWN_OPTIONAL_SECRETS)
+        self.assertTrue(optional_hosts <= KNOWN_OPTIONAL_SECRETS)
+        self.assertTrue(required_keys.isdisjoint(KNOWN_OPTIONAL_SECRETS))
 
         result = build_check_result(set(expected_consumers), set())
-        self.assertEqual(sorted(expected_consumers), result.optional)
-        self.assertEqual([], result.missing_required)
+        self.assertEqual(sorted(optional_hosts), result.optional)
+        self.assertEqual(sorted(required_keys), result.missing_required)
 
 
 class SecretPlanTest(unittest.TestCase):

--- a/tools/release_secrets/sync_test.py
+++ b/tools/release_secrets/sync_test.py
@@ -99,6 +99,7 @@ class WorkflowSecretScannerTest(unittest.TestCase):
     def test_claw_posthog_keys_are_required_and_hosts_are_optional(self):
         expected_consumers = {
             "CLAW_POSTHOG_KEY": (
+                "nightly-browserclaw.yml",
                 "release-browserclaw.yml",
                 "release-claw-server.yml",
             ),


### PR DESCRIPTION
## Summary

- require the Claw server PostHog key before production resource builds and releases, including nightly staging
- require the BrowserClaw Vite PostHog key across standalone and locally bundled CRX builds while keeping host overrides optional
- align reusable workflow contracts, release-secret preflight, and generated environment documentation

## Design

Use the existing declarative required-environment contracts for each artifact: `requiredInlineEnvKeys` for Claw server builds and `ExtensionSpec.required_env` for BrowserClaw builds. Shared validation blocks artifact production before an uninstrumented release can be created.

The actual GitHub secret values are intentionally not read or changed here; that sync remains owned by the parent session.

## Test plan

- [x] `bun run check`
- [x] `bun run test`
- [x] `actionlint` on all touched workflows
- [x] focused Python release/build tests and `ruff`
- [x] release-secret sync unit tests and generated env example check
- [x] Claw server production build descriptor tests