### PR TITLE
feat: publish extension releases and both feed channels

### DIFF
--- a/.github/workflows/release-browserclaw.yml
+++ b/.github/workflows/release-browserclaw.yml
@@ -323,7 +323,7 @@ jobs:
       }}
     uses: ./.github/workflows/release-extensions.yml
     permissions:
-      contents: read
+      contents: write
     with:
       version: ${{ needs.preflight.outputs.extensions_version }}
       extension: browserclaw

--- a/.github/workflows/release-browseros.yml
+++ b/.github/workflows/release-browseros.yml
@@ -311,7 +311,7 @@ jobs:
       }}
     uses: ./.github/workflows/release-extensions.yml
     permissions:
-      contents: read
+      contents: write
     with:
       version: ${{ needs.preflight.outputs.extensions_version }}
       extension: agent

--- a/.github/workflows/release-extension-feeds.yml
+++ b/.github/workflows/release-extension-feeds.yml
@@ -10,6 +10,7 @@ on:
         options:
           - alpha
           - prod
+          - both
         default: "alpha"
       pins:
         description: "Optional name=version pins, separated by commas or spaces"
@@ -29,7 +30,7 @@ on:
   workflow_call:
     inputs:
       channel:
-        description: "Update-feed channel: alpha or prod"
+        description: "Update-feed channel: alpha, prod, or both"
         required: false
         type: string
         default: "alpha"
@@ -92,9 +93,9 @@ jobs:
           set -euo pipefail
 
           case "$CHANNEL" in
-            alpha|prod) ;;
+            alpha|prod|both) ;;
             *)
-              echo "::error::Invalid channel '$CHANNEL'; expected alpha or prod" >&2
+              echo "::error::Invalid channel '$CHANNEL'; expected alpha, prod, or both" >&2
               exit 1
               ;;
           esac
@@ -118,10 +119,23 @@ jobs:
             args+=(--allow-downgrade)
           fi
 
-          {
-            echo "### Extension feed command"
-            echo '```bash'
-            echo "browseros release extensions ${args[*]}"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          uv run browseros release extensions "${args[@]}"
+          if [ "$CHANNEL" = "both" ]; then
+            for ch in alpha prod; do
+              args[1]="$ch"
+              {
+                echo "### Extension feed command ($ch)"
+                echo '```bash'
+                echo "browseros release extensions ${args[*]}"
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
+              uv run browseros release extensions "${args[@]}"
+            done
+          else
+            {
+              echo "### Extension feed command"
+              echo '```bash'
+              echo "browseros release extensions ${args[*]}"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            uv run browseros release extensions "${args[@]}"
+          fi

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: ""
+      github_release:
+        description: "Create or update the GitHub release and attach built CRXs"
+        required: false
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       version:
@@ -39,6 +44,11 @@ on:
         required: false
         type: string
         default: ""
+      github_release:
+        description: "Create or update the GitHub release and attach built CRXs"
+        required: false
+        type: boolean
+        default: false
     secrets:
       GH_TOKEN:
         required: false
@@ -86,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -160,6 +170,70 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           uv run browseros ext release "${args[@]}"
+
+      - name: Create GitHub release
+        if: ${{ inputs.github_release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          EXTENSION: ${{ inputs.extension }}
+        run: |
+          set -euo pipefail
+
+          RELEASE_TAG="extensions/v$VERSION"
+          TITLE="Extensions - v$VERSION"
+          NOTES_FILE="/tmp/extension-release-notes.md"
+          ASSET_DIR="packages/browseros/build/extensions/dist"
+          mapfile -t crx_assets < <(find "$ASSET_DIR" -maxdepth 1 -type f -name '*.crx' | sort)
+          if [ "${#crx_assets[@]}" -eq 0 ]; then
+            echo "::error::No CRX assets found in $ASSET_DIR"
+            exit 1
+          fi
+
+          {
+            echo "# $TITLE"
+            echo
+            echo "- Extension selection: \`$EXTENSION\`"
+            echo "- Version: \`$VERSION\`"
+            echo
+            echo "## CRX downloads"
+            for crx in "${crx_assets[@]}"; do
+              filename=$(basename "$crx")
+              echo "- [\`$filename\`](https://cdn.browseros.com/extensions/$filename)"
+            done
+          } > "$NOTES_FILE"
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" \
+              --title "$TITLE" \
+              --notes-file "$NOTES_FILE"
+          else
+            TARGET_SHA=$(git rev-parse HEAD)
+            gh release create "$RELEASE_TAG" \
+              --target "$TARGET_SHA" \
+              --title "$TITLE" \
+              --notes-file "$NOTES_FILE"
+          fi
+
+          if [ "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "true" ]; then
+            gh release edit "$RELEASE_TAG" --draft=false
+          fi
+
+      - name: Attach CRXs to GitHub release
+        if: ${{ inputs.github_release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="extensions/v$VERSION"
+          ASSET_DIR="packages/browseros/build/extensions/dist"
+          mapfile -t crx_assets < <(find "$ASSET_DIR" -maxdepth 1 -type f -name '*.crx' | sort)
+          if [ "${#crx_assets[@]}" -eq 0 ]; then
+            echo "::error::No CRX assets found in $ASSET_DIR"
+            exit 1
+          fi
+          gh release upload "$RELEASE_TAG" "${crx_assets[@]}" --clobber
 
       - name: Upload CRX artifacts
         if: always()


### PR DESCRIPTION
## Summary
- create or update `extensions/v<version>` GitHub releases after manual CRX builds, with notes, undrafting, and clobbered CRX assets
- preserve the CRX/feed split and keep reusable product callers opted out by default while granting compatible permissions
- add `channel=both` to publish alpha then prod with the same feed arguments

## Design
The workflow mirrors the existing claw-server release lifecycle locally in `release-extensions.yml`, using the built-in GitHub token and targeting the checked-out SHA only when creating a new tag. Feed publishing remains solely in `release-extension-feeds.yml`; its existing args array is reused sequentially for alpha and prod.

## Test plan
- [x] `actionlint .github/workflows/release-extensions.yml .github/workflows/release-extension-feeds.yml .github/workflows/release-browseros.yml .github/workflows/release-browserclaw.yml`
- [x] shell harness verifies new-release, existing-draft, notes, and CRX upload commands
- [x] shell harness verifies unchanged alpha/prod commands and ordered alpha-then-prod behavior for `both`
- [x] adversarial diff review completed with no kept findings