### PR TITLE
fix: keep CRX assets off GitHub releases

### DIFF
--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -24,7 +24,7 @@ on:
         type: string
         default: ""
       github_release:
-        description: "Create or update the GitHub release and attach built CRXs"
+        description: "Create or update the GitHub release"
         required: false
         type: boolean
         default: true
@@ -45,7 +45,7 @@ on:
         type: string
         default: ""
       github_release:
-        description: "Create or update the GitHub release and attach built CRXs"
+        description: "Create or update the GitHub release"
         required: false
         type: boolean
         default: false
@@ -218,22 +218,6 @@ jobs:
           if [ "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "true" ]; then
             gh release edit "$RELEASE_TAG" --draft=false
           fi
-
-      - name: Attach CRXs to GitHub release
-        if: ${{ inputs.github_release }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          RELEASE_TAG="extensions/v$VERSION"
-          ASSET_DIR="packages/browseros/build/extensions/dist"
-          mapfile -t crx_assets < <(find "$ASSET_DIR" -maxdepth 1 -type f -name '*.crx' | sort)
-          if [ "${#crx_assets[@]}" -eq 0 ]; then
-            echo "::error::No CRX assets found in $ASSET_DIR"
-            exit 1
-          fi
-          gh release upload "$RELEASE_TAG" "${crx_assets[@]}" --clobber
 
       - name: Upload CRX artifacts
         if: always()


### PR DESCRIPTION
## Summary
- stop attaching built CRXs to `extensions/v<version>` GitHub releases
- keep release creation and CDN-linked CRX notes intact
- clarify both `github_release` inputs now that GitHub asset upload is removed

## Design
The workflow keeps the existing R2/CDN publication path and versioned GitHub release creation, but removes the dedicated `gh release upload` step. GitHub release pages therefore retain automatic source archives and point to CRXs on the CDN, while the separate Actions artifact upload remains available for workflow diagnostics.

## Test plan
- [x] `actionlint .github/workflows/release-extensions.yml`
- [x] verify no `Attach CRXs to GitHub release` step or `gh release upload` command remains
- [x] verify the diff changes only `.github/workflows/release-extensions.yml`
