### PR TITLE
chore(claw-server): rename cockpit logger messages

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/mcp/dispatch.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/dispatch.ts
@@ -112,7 +112,7 @@ export function runEffects(
     try {
       result = effect.run({ ...context, result }) ?? result
     } catch (error) {
-      warn('cockpit v2 tool dispatch effect failed', {
+      warn('cockpit tool dispatch effect failed', {
         tool: context.call.tool.name,
         sessionId: context.call.sessionId || undefined,
         effect: effect.name,
@@ -222,7 +222,7 @@ async function dispatchToolCall(
   const connectedCall = call as ConnectedToolCall
 
   if (ARBITRARY_SCRIPT_TOOLS.has(call.tool.name)) {
-    logger.warn('cockpit v2 dispatched arbitrary-script tool', {
+    logger.warn('cockpit dispatched arbitrary-script tool', {
       tool: call.tool.name,
       sessionId: call.sessionId || undefined,
     })
@@ -230,7 +230,7 @@ async function dispatchToolCall(
 
   const outcome = await executeWithCancellation(connectedCall)
   if (outcome.result.isError && !outcome.cancelled) {
-    logger.warn('cockpit v2 tool dispatch failed', {
+    logger.warn('cockpit tool dispatch failed', {
       tool: call.tool.name,
       sessionId: call.sessionId || undefined,
       durationMs: outcome.durationMs,
@@ -298,10 +298,10 @@ function logThrownDispatch(
     durationMs: Date.now() - dispatchStart,
   }
   if (call.signal?.aborted) {
-    logger.info('cockpit v2 tool dispatch cancelled by client', fields)
+    logger.info('cockpit tool dispatch cancelled by client', fields)
     return
   }
-  logger.error('cockpit v2 tool dispatch threw', {
+  logger.error('cockpit tool dispatch threw', {
     ...fields,
     error: error instanceof Error ? error.message : String(error),
   })

--- a/packages/browseros-agent/apps/claw-server/src/mcp/effects/audit.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/effects/audit.ts
@@ -25,7 +25,7 @@ export const applyAudit: ToolEffect = ({
   }
   if (result.isError) return undefined
   if (!call.agent || !call.agentLabel) {
-    logger.warn('cockpit v2 dispatch missing identity', {
+    logger.warn('cockpit dispatch missing identity', {
       tool: call.tool.name,
       sessionId: call.sessionId || undefined,
     })

--- a/packages/browseros-agent/apps/claw-server/src/mcp/guards/browser-connected.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/guards/browser-connected.ts
@@ -11,7 +11,7 @@ import type { ToolGuard } from '../dispatch'
 export const guardBrowserConnected: ToolGuard = (call) => {
   if (call.session) return null
 
-  logger.warn('cockpit v2 tool dispatch rejected', {
+  logger.warn('cockpit tool dispatch rejected', {
     tool: call.tool.name,
     sessionId: call.sessionId || undefined,
     reason: 'browser session not connected',

--- a/packages/browseros-agent/apps/claw-server/src/mcp/guards/navigate-scheme.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/guards/navigate-scheme.ts
@@ -19,7 +19,7 @@ export const guardNavigateScheme: ToolGuard = (call: ToolCall) => {
   const scheme = trimmedUrl.slice(0, trimmedUrl.indexOf(':') + 1).toLowerCase()
   if (!NAVIGATE_BLOCKED_SCHEMES.has(scheme)) return null
 
-  logger.warn('cockpit v2 tool dispatch rejected', {
+  logger.warn('cockpit tool dispatch rejected', {
     tool: call.tool.name,
     sessionId: call.sessionId || undefined,
     reason: 'blocked navigate scheme',

--- a/packages/browseros-agent/apps/claw-server/src/mcp/guards/page-ownership.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/guards/page-ownership.ts
@@ -28,7 +28,7 @@ export const guardPageOwnership: ToolGuard = (call) => {
   // `tabs new`. This fires before executeTool; unknown identities fail open.
   if (ownershipStore.pagesOf(call.key).has(page)) return null
 
-  logger.warn('cockpit v2 rejected foreign-page dispatch', {
+  logger.warn('cockpit rejected foreign-page dispatch', {
     tool: call.tool.name,
     sessionId: call.sessionId || undefined,
     key: call.key,

--- a/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
@@ -137,7 +137,7 @@ function buildSession(): Session {
       clientName: identity.clientName,
       clientVersion: identity.clientVersion,
     })
-    logger.info('cockpit v2 mcp session opened', {
+    logger.info('cockpit mcp session opened', {
       sessionId,
       clientName: clientInfo?.name ?? '',
     })
@@ -205,7 +205,7 @@ function cleanupSessionState(sessionId: string): void {
       if (usesFallbackKey) ownershipStore.forget(key)
     }
   }
-  logger.info('cockpit v2 mcp session closed', { sessionId })
+  logger.info('cockpit mcp session closed', { sessionId })
 }
 
 /**

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/dispatch-pipeline.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/dispatch-pipeline.test.ts
@@ -74,7 +74,7 @@ describe('dispatch pipeline', () => {
     expect(returned).toBe(result)
     expect(warnings).toEqual([
       {
-        message: 'cockpit v2 tool dispatch effect failed',
+        message: 'cockpit tool dispatch effect failed',
         fields: {
           tool: 'navigate',
           sessionId: undefined,


### PR DESCRIPTION
## Summary

- rename every claw-server logger message that still called the component “cockpit v2”
- preserve log levels, structured metadata, and dispatch/session behavior
- update the existing warning assertion and verify the repository-wide logging terminology invariant

## Design

This uses direct literal normalization at the existing logger call sites. It keeps the cleanup explicit and scoped, avoiding a new prefix abstraction or changes to unrelated product, protocol, API, and implementation identifiers.

## Test plan

- [x] `bun test apps/claw-server/tests/mcp/dispatch-pipeline.test.ts`
- [x] `bun run check`
- [x] `bun run test`
- [x] repository-wide case-insensitive logger search finds no cockpit/v2 pairing
- [x] `git diff --check`
