### PR TITLE
chore: drop CRX downloads section from extension release notes

### DIFF
--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -183,24 +183,12 @@ jobs:
           RELEASE_TAG="extensions/v$VERSION"
           TITLE="Extensions - v$VERSION"
           NOTES_FILE="/tmp/extension-release-notes.md"
-          ASSET_DIR="packages/browseros/build/extensions/dist"
-          mapfile -t crx_assets < <(find "$ASSET_DIR" -maxdepth 1 -type f -name '*.crx' | sort)
-          if [ "${#crx_assets[@]}" -eq 0 ]; then
-            echo "::error::No CRX assets found in $ASSET_DIR"
-            exit 1
-          fi
 
           {
             echo "# $TITLE"
             echo
             echo "- Extension selection: \`$EXTENSION\`"
             echo "- Version: \`$VERSION\`"
-            echo
-            echo "## CRX downloads"
-            for crx in "${crx_assets[@]}"; do
-              filename=$(basename "$crx")
-              echo "- [\`$filename\`](https://cdn.browseros.com/extensions/$filename)"
-            done
           } > "$NOTES_FILE"
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then


### PR DESCRIPTION
## What

Removes the **"CRX downloads"** section from the release notes generated in the *Create GitHub release* step of `release-extensions.yml`. That section (a bullet list of `cdn.browseros.com` links) was the last CRX reference still appearing on the extensions GitHub release page.

After this change the release page shows only:
- the title (`Extensions - vX.Y.Z.W`)
- `Extension selection` and `Version` bullets
- GitHub's automatic Source code (zip/tar.gz) assets

## Why

Follow-up to #1828 (added GitHub-release creation) and #1829 (kept CRX assets off the release *Assets* list). Release `extensions/v0.0.2.0` still surfaced CRX links in the notes body — this removes that final reference. CRX distribution itself is unchanged: builds still upload to R2/CDN via `browseros ext release`, and the `Upload CRX artifacts` workflow-artifact step is untouched.

## Changes

Single file, 12 deletions:
- Dropped the `## CRX downloads` heading and its `cdn.browseros.com` link loop from the notes heredoc.
- Removed the now-unused `ASSET_DIR` var, the `mapfile` CRX scan, and the "No CRX assets found" guard (they only fed the removed links).

Everything else is byte-identical: release gating, tag, `--target HEAD` create/edit, undraft snippet, and the CRX artifact upload step.

## Verification
- `actionlint .github/workflows/release-extensions.yml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
