### PR TITLE
fix(release): enable BrowserClaw extension update feed

### DIFF
--- a/packages/browseros/bos_build/release/extensions/manifests_test.py
+++ b/packages/browseros/bos_build/release/extensions/manifests_test.py
@@ -97,10 +97,14 @@ class ExtensionsFeedModuleTest(unittest.TestCase):
         )
         manifest, json_content, bundled = [c.content for c in self.publisher.calls]
 
-        # Channel manifest: --set wins, bugreporter carried from live manifest.
+        # Channel manifest: --set wins and other versions carry from live sources.
         self.assertEqual(
             extract_manifest_versions(manifest),
-            {AGENT_ID: "0.0.118.0", BUGREPORTER_ID: "54.0.0.0"},
+            {
+                AGENT_ID: "0.0.118.0",
+                BUGREPORTER_ID: "54.0.0.0",
+                BROWSERCLAW_ID: "0.0.0.2",
+            },
         )
         # JSON points every update-feed id at the channel manifest URL.
         self.assertIn(
@@ -109,8 +113,8 @@ class ExtensionsFeedModuleTest(unittest.TestCase):
         )
         self.assertIn(AGENT_ID, json_content)
         self.assertIn(BUGREPORTER_ID, json_content)
-        self.assertNotIn(BROWSERCLAW_ID, json_content)
-        # Bundled carries the same channel versions plus bundled-only claw.
+        self.assertIn(BROWSERCLAW_ID, json_content)
+        # Bundled retains all resolved extension versions.
         self.assertEqual(
             extract_manifest_versions(bundled),
             {
@@ -126,7 +130,11 @@ class ExtensionsFeedModuleTest(unittest.TestCase):
         manifest = self.publisher.calls[0].content
         self.assertEqual(
             extract_manifest_versions(manifest),
-            {AGENT_ID: "0.0.117.0", BUGREPORTER_ID: "54.0.0.0"},
+            {
+                AGENT_ID: "0.0.117.0",
+                BUGREPORTER_ID: "54.0.0.0",
+                BROWSERCLAW_ID: "0.0.0.2",
+            },
         )
 
     def test_bundled_never_regresses_below_live_on_channel_run(self):
@@ -153,6 +161,9 @@ class ExtensionsFeedModuleTest(unittest.TestCase):
         bundled = publisher.calls[2].content
         self.assertEqual(
             extract_manifest_versions(manifest)[AGENT_ID], "0.0.118.0"
+        )
+        self.assertEqual(
+            extract_manifest_versions(manifest)[BROWSERCLAW_ID], "0.0.0.2"
         )
         self.assertEqual(extract_manifest_versions(bundled)[AGENT_ID], "0.0.119.0")
         # Both agent crx versions are referenced somewhere — both checked.

--- a/packages/browseros/bos_build/release/feeds/render_test.py
+++ b/packages/browseros/bos_build/release/feeds/render_test.py
@@ -139,6 +139,9 @@ GOLDEN_EXTENSIONS_JSON = """\
     },
     "bflpfmnmnokmjhmgnolecpppdbdophmk": {
       "external_update_url": "https://cdn.browseros.com/extensions/update-manifest.alpha.xml"
+    },
+    "pjimfkbpehlcllblajnpfamdfjhhlgkc": {
+      "external_update_url": "https://cdn.browseros.com/extensions/update-manifest.alpha.xml"
     }
   }
 }
@@ -286,6 +289,7 @@ class ExtensionsRenderTest(unittest.TestCase):
 
     def test_extensions_json_prod_points_at_prod_manifest(self):
         content = render_extensions_json("prod")
+        self.assertIn("pjimfkbpehlcllblajnpfamdfjhhlgkc", content)
         self.assertIn(
             "https://cdn.browseros.com/extensions/update-manifest.xml", content
         )

--- a/packages/browseros/bos_build/release/feeds/spec.py
+++ b/packages/browseros/bos_build/release/feeds/spec.py
@@ -37,11 +37,10 @@ class ExtensionSpec:
         return f"{CDN_BASE_URL}/{self.crx_key(version)}"
 
 
-# browserclaw ships bundled-only until it joins the live update feeds.
 EXTENSIONS: Tuple[ExtensionSpec, ...] = (
     ExtensionSpec("agent", BROWSEROS_AGENT_EXTENSION_ID, True),
     ExtensionSpec("bugreporter", BROWSEROS_BUG_REPORTER_EXTENSION_ID, True),
-    ExtensionSpec("browserclaw", BROWSERCLAW_EXTENSION_ID, False),
+    ExtensionSpec("browserclaw", BROWSERCLAW_EXTENSION_ID, True),
 )
 
 

--- a/packages/browseros/bos_build/release/feeds/spec_test.py
+++ b/packages/browseros/bos_build/release/feeds/spec_test.py
@@ -144,7 +144,7 @@ class ExtensionRegistryTest(unittest.TestCase):
         by_name = {ext.name: ext for ext in EXTENSIONS}
         self.assertTrue(by_name["agent"].in_update_feed)
         self.assertTrue(by_name["bugreporter"].in_update_feed)
-        self.assertFalse(by_name["browserclaw"].in_update_feed)
+        self.assertTrue(by_name["browserclaw"].in_update_feed)
 
     def test_crx_url_scheme(self):
         agent = extension_by_name("agent")


### PR DESCRIPTION
## Summary
- enable BrowserClaw in the shared production and alpha extension update feeds
- keep bundled-manifest generation unchanged
- update focused registry, renderer, and manifest-generation coverage

## Design
BrowserClaw now opts into the existing `in_update_feed` registry policy. The existing manifest and JSON renderers continue deriving membership from that single boundary, so both products retain the shared channel URLs without special cases.

## Test plan
- [x] `uv run python -m unittest bos_build.release.feeds.spec_test bos_build.release.feeds.render_test bos_build.release.extensions.manifests_test -v` (51 passed)
- [x] `uv run ruff check bos_build`
- [x] `uv run pyright`
- [x] `uv run python -m unittest discover -s bos_build -t . -p "*_test.py" -q` (704 passed)