### PR TITLE
feat(claw-server): repeat session-rename nudge until renamed

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/mcp/effects/session-naming.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/effects/session-naming.ts
@@ -10,18 +10,24 @@ import {
 } from '../../lib/mcp-session'
 import type { ToolEffect } from '../dispatch'
 
-/** Nudges the agent after its first successful tabs-new call. */
+const SESSION_NAME_NUDGE_LIMIT = 5
+
+/** Appends bounded rename nudges while the session keeps its generated label. */
 export function createSessionNamingEffect(): ToolEffect {
-  let sawSuccessfulTabsNew = false
+  let remaining = SESSION_NAME_NUDGE_LIMIT
 
   return ({ call, result }) => {
-    if (result.isError || !call.flags.newPage || sawSuccessfulTabsNew) {
+    const identity = call.identity
+    if (
+      result.isError ||
+      call.tool.name === 'name_session' ||
+      !identity ||
+      identity.label !== identity.generatedLabel ||
+      remaining === 0
+    ) {
       return undefined
     }
-    sawSuccessfulTabsNew = true
-    const identity = call.identity
-    if (!identity || identity.label !== identity.generatedLabel)
-      return undefined
+    remaining -= 1
 
     const title = buildSessionGroupTitle(
       clientPrefixFromSlug(identity.slug),

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/session-naming-nudge.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/session-naming-nudge.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'bun:test'
 import type { ClientIdentity } from '../../src/lib/mcp-session'
-import type { ToolCall } from '../../src/mcp/dispatch'
+import type { ToolCall, ToolEffect } from '../../src/mcp/dispatch'
 import { createSessionNamingEffect } from '../../src/mcp/effects/session-naming'
+import type { ToolResult } from '../../src/mcp/register-fn'
+
+const tip =
+  'Tip: this session is "claude/swift-otter" — rename it with name_session name="<2-3 word task label>"'
 
 function identity(label = 'swift-otter'): ClientIdentity {
   return {
@@ -17,10 +21,10 @@ function identity(label = 'swift-otter'): ClientIdentity {
   }
 }
 
-function call(value: ClientIdentity): ToolCall {
+function call(value: ClientIdentity, toolName = 'snapshot'): ToolCall {
   return {
-    tool: { name: 'tabs' } as never,
-    args: { action: 'new' },
+    tool: { name: toolName } as never,
+    args: {},
     sessionId: value.sessionId,
     identity: value,
     key: value.key,
@@ -28,96 +32,94 @@ function call(value: ClientIdentity): ToolCall {
     agentLabel: value.clientName,
     session: {} as never,
     defaultTabGroupId: null,
-    flags: { newPage: true, closePage: false, listTabs: false },
+    flags: { newPage: false, closePage: false, listTabs: false },
   }
 }
 
-const ok = {
-  content: [{ type: 'text' as const, text: 'opened page 7' }],
+const ok: ToolResult = {
+  content: [{ type: 'text', text: 'tool result' }],
   isError: false,
 }
 
+function apply(
+  effect: ToolEffect,
+  toolCall: ToolCall,
+  result: ToolResult = ok,
+): ToolResult | undefined {
+  return effect({ call: toolCall, result, cancelled: false, durationMs: 1 })
+}
+
 describe('session naming nudge', () => {
-  it('appends the prescribed tip to the first successful tabs new', () => {
+  it('appends the prescribed tip to successive arbitrary tool results', () => {
     const effect = createSessionNamingEffect()
-    const result = effect({
-      call: call(identity()),
-      result: ok,
-      cancelled: false,
-      durationMs: 1,
-    })
+    const value = identity()
 
-    expect(result?.content).toEqual([
-      {
-        type: 'text',
-        text: 'opened page 7\nTip: this session is "claude/swift-otter" — rename it with name_session name="<2-3 word task label>"',
-      },
+    expect(apply(effect, call(value, 'snapshot'))?.content).toEqual([
+      { type: 'text', text: `tool result\n${tip}` },
     ])
-
-    expect(
-      effect({
-        call: call(identity()),
-        result: ok,
-        cancelled: false,
-        durationMs: 1,
-      }),
-    ).toBeUndefined()
+    expect(apply(effect, call(value, 'read'))?.content).toEqual([
+      { type: 'text', text: `tool result\n${tip}` },
+    ])
   })
 
-  it('consumes the first successful tabs new without nudging after rename', () => {
+  it('appends exactly five nudges then stays silent', () => {
     const effect = createSessionNamingEffect()
-    const renamed = identity('invoice-processing')
+    const toolCall = call(identity(), 'tabs')
 
-    expect(
-      effect({
-        call: call(renamed),
-        result: ok,
-        cancelled: false,
-        durationMs: 1,
-      }),
-    ).toBeUndefined()
-
-    renamed.label = renamed.generatedLabel
-    expect(
-      effect({
-        call: call(renamed),
-        result: ok,
-        cancelled: false,
-        durationMs: 1,
-      }),
-    ).toBeUndefined()
+    for (let index = 0; index < 5; index += 1) {
+      expect(apply(effect, toolCall)?.content[0]).toEqual({
+        type: 'text',
+        text: `tool result\n${tip}`,
+      })
+    }
+    expect(apply(effect, toolCall)).toBeUndefined()
   })
 
-  it('does not consume the nudge on an error or a non-new call', () => {
+  it('stops immediately after the session is renamed', () => {
     const effect = createSessionNamingEffect()
+    const value = identity()
+
+    expect(apply(effect, call(value))).toBeDefined()
+    value.label = 'invoice-processing'
+    expect(apply(effect, call(value))).toBeUndefined()
+  })
+
+  it('skips errors and name_session without consuming nudges', () => {
+    const effect = createSessionNamingEffect()
+    const value = identity()
+    const toolCall = call(value)
+
+    expect(apply(effect, toolCall, { ...ok, isError: true })).toBeUndefined()
+    expect(apply(effect, call(value, 'name_session'))).toBeUndefined()
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(apply(effect, toolCall)).toBeDefined()
+    }
+    expect(apply(effect, toolCall)).toBeUndefined()
+  })
+
+  it('pushes the tip when the result has no text item', () => {
+    const effect = createSessionNamingEffect()
+    const image = { type: 'image' as const, data: 'AAA', mimeType: 'image/png' }
+
+    expect(
+      apply(effect, call(identity(), 'screenshot'), {
+        content: [image],
+        isError: false,
+      })?.content,
+    ).toEqual([image, { type: 'text', text: tip }])
+  })
+
+  it('keeps independent counters for separate effect instances', () => {
+    const first = createSessionNamingEffect()
+    const second = createSessionNamingEffect()
     const toolCall = call(identity())
 
-    expect(
-      effect({
-        call: toolCall,
-        result: { ...ok, isError: true },
-        cancelled: false,
-        durationMs: 1,
-      }),
-    ).toBeUndefined()
-    toolCall.flags.newPage = false
-    expect(
-      effect({
-        call: toolCall,
-        result: ok,
-        cancelled: false,
-        durationMs: 1,
-      }),
-    ).toBeUndefined()
-
-    toolCall.flags.newPage = true
-    expect(
-      effect({
-        call: toolCall,
-        result: ok,
-        cancelled: false,
-        durationMs: 1,
-      })?.content[0],
-    ).toMatchObject({ text: expect.stringContaining('Tip: this session is') })
+    for (let index = 0; index < 5; index += 1) {
+      expect(apply(first, toolCall)).toBeDefined()
+      expect(apply(second, toolCall)).toBeDefined()
+    }
+    expect(apply(first, toolCall)).toBeUndefined()
+    expect(apply(second, toolCall)).toBeUndefined()
   })
 })

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-isolation.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-isolation.test.ts
@@ -73,6 +73,13 @@ function ok(structured?: unknown): FakeResult {
   }
 }
 
+function expectNudgedText(text: string | undefined, expected: string): void {
+  expect(text).toStartWith(`${expected}\nTip: this session is "claude/`)
+  expect(text).toEndWith(
+    ' — rename it with name_session name="<2-3 word task label>"',
+  )
+}
+
 async function waitFor(predicate: () => boolean): Promise<void> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     if (predicate()) return
@@ -232,7 +239,10 @@ describe('per-agent tabs isolation', () => {
     })
 
     expect(result.structuredContent).toBeUndefined()
-    expect(result.content).toEqual([{ type: 'text', text: 'ok\nreturn: 42' }])
+    expectNudgedText(
+      (result.content as Array<{ type: string; text?: string }>)[0]?.text,
+      'ok\nreturn: 42',
+    )
     await client.close()
   })
 
@@ -444,9 +454,10 @@ describe('per-agent tabs isolation', () => {
       arguments: { action: 'list' },
     })) as TabsListResult
     expect(list.structuredContent).toBeUndefined()
-    expect(
+    expectNudgedText(
       (list.content as Array<{ type: string; text?: string }>)?.[0]?.text,
-    ).toBe('(no open pages)')
+      '(no open pages)',
+    )
     await client.close()
   })
 


### PR DESCRIPTION
## Summary\n- repeat the existing session-rename tip on every eligible successful BrowserClaw tool result\n- stop immediately after rename and cap delivery at five nudges per MCP session\n- cover arbitrary tools, skipped calls, no-text results, and independent sessions\n\n## Design\nThe existing tail effect now keeps a five-count allowance in its already session-scoped closure. Error results, name_session, missing identities, and renamed identities return without consuming the allowance; eligible results reuse the existing tip literal and append mechanics unchanged.\n\n## Test plan\n- [x] bun test apps/claw-server/tests/mcp/session-naming-nudge.test.ts apps/claw-server/tests/mcp/tabs-isolation.test.ts\n- [x] bun run check\n- [x] bun run test\n- [x] context-free adversarial review: clean