### PR TITLE
fix(release): one GitHub release per extension in ext-<name>/v* namespace

### DIFF
--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          # Full history and tags: per-extension release notes diff against the
+          # previous ext-<name>/v* tag and need the whole commit range.
+          fetch-depth: 0
           ref: ${{ inputs.branch || github.ref }}
 
       - name: Setup uv
@@ -171,41 +174,104 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           uv run browseros ext release "${args[@]}"
 
-      - name: Create GitHub release
+      - name: Create GitHub releases
         if: ${{ inputs.github_release }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
           EXTENSION: ${{ inputs.extension }}
+          BRANCH: ${{ inputs.branch }}
+        # One release per selected extension, each in its own ext-<name>/v* tag
+        # namespace (mirrors the agent-server/v* convention in release-server.yml).
+        # Inputs arrive via env and are only ever used quoted, so a crafted
+        # dispatch value cannot break out of this shell; the extension name is
+        # additionally validated against the known set before it feeds a tag.
         run: |
           set -euo pipefail
 
-          RELEASE_TAG="extensions/v$VERSION"
-          TITLE="Extensions - v$VERSION"
-          NOTES_FILE="/tmp/extension-release-notes.md"
+          TARGET_SHA="$(git rev-parse HEAD)"
 
-          {
-            echo "# $TITLE"
-            echo
-            echo "- Extension selection: \`$EXTENSION\`"
-            echo "- Version: \`$VERSION\`"
-          } > "$NOTES_FILE"
-
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release edit "$RELEASE_TAG" \
-              --title "$TITLE" \
-              --notes-file "$NOTES_FILE"
+          if [ "$EXTENSION" = "all" ]; then
+            names=(agent controller bugreporter browserclaw)
           else
-            TARGET_SHA=$(git rev-parse HEAD)
-            gh release create "$RELEASE_TAG" \
-              --target "$TARGET_SHA" \
-              --title "$TITLE" \
-              --notes-file "$NOTES_FILE"
+            names=("$EXTENSION")
           fi
 
-          if [ "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "true" ]; then
-            gh release edit "$RELEASE_TAG" --draft=false
-          fi
+          for NAME in "${names[@]}"; do
+            case "$NAME" in
+              agent)
+                TITLE="BrowserOS Agent Extension - v$VERSION"
+                KIND="in-repo"
+                SCOPE_PATH="packages/browseros-agent/apps/app"
+                ;;
+              browserclaw)
+                TITLE="BrowserClaw Extension - v$VERSION"
+                KIND="in-repo"
+                SCOPE_PATH="packages/browseros-agent/apps/claw-app"
+                ;;
+              controller)
+                TITLE="BrowserOS Controller Extension - v$VERSION"
+                KIND="external"
+                REPO="browseros-ai/BrowserOS-agent"
+                EXT_BRANCH="${BRANCH:-main}"
+                ;;
+              bugreporter)
+                TITLE="BrowserOS Bug Reporter Extension - v$VERSION"
+                KIND="external"
+                REPO="browseros-ai/BrowserOS-feedback-extension"
+                EXT_BRANCH="${BRANCH:-main}"
+                ;;
+              *)
+                echo "::error::Unknown extension '$NAME'"
+                exit 1
+                ;;
+            esac
+
+            RELEASE_TAG="ext-${NAME}/v${VERSION}"
+            NOTES_FILE="/tmp/notes-${NAME}.md"
+
+            if [ "$KIND" = "in-repo" ]; then
+              # Newest existing ext-<name>/v* tag by version order, excluding the
+              # tag being released so idempotent re-runs still diff from the prior one.
+              PREVIOUS_TAG="$(git tag --list "ext-${NAME}/v*" | { grep -vFx "$RELEASE_TAG" || true; } | sort -V | tail -n1)"
+              CHANGELOG_FILE="/tmp/changelog-${NAME}.md"
+
+              if [ -z "$PREVIOUS_TAG" ]; then
+                echo "Initial ${TITLE} release." > "$CHANGELOG_FILE"
+              else
+                git log "${PREVIOUS_TAG}..${TARGET_SHA}" --pretty=format:"- %s (%h)" -- "$SCOPE_PATH" > "$CHANGELOG_FILE"
+                if [ ! -s "$CHANGELOG_FILE" ]; then
+                  echo "No changes in ${SCOPE_PATH} since ${PREVIOUS_TAG}." > "$CHANGELOG_FILE"
+                fi
+              fi
+
+              node packages/browseros-agent/scripts/release/cap-release-changelog.mjs \
+                --input "$CHANGELOG_FILE" \
+                --output "$NOTES_FILE" \
+                --max-entries 15 \
+                --previous-tag "$PREVIOUS_TAG" \
+                --release-tag "$RELEASE_TAG"
+            else
+              # Built from another repo, so this monorepo's git log says nothing
+              # about it — record the source instead of inventing a changelog.
+              echo "Built from ${REPO} @ ${EXT_BRANCH}." > "$NOTES_FILE"
+            fi
+
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              gh release edit "$RELEASE_TAG" \
+                --title "$TITLE" \
+                --notes-file "$NOTES_FILE"
+            else
+              gh release create "$RELEASE_TAG" \
+                --target "$TARGET_SHA" \
+                --title "$TITLE" \
+                --notes-file "$NOTES_FILE"
+            fi
+
+            if [ "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "true" ]; then
+              gh release edit "$RELEASE_TAG" --draft=false
+            fi
+          done
 
       - name: Upload CRX artifacts
         if: always()


### PR DESCRIPTION
## What

Redesigns how `.github/workflows/release-extensions.yml` names and formats its GitHub releases: **one release per selected extension**, each in its own `ext-<name>/v<version>` tag namespace, titled and written like the sibling server releases (`release-server.yml` / `release-claw-server.yml`).

## Why

The workflow published a single `extensions/v<version>` release for whatever was dispatched. That shape was broken three ways:

1. **Badly formatted notes** — the title was duplicated as an H1 inside the notes, and the body just echoed the dispatch form (`Extension selection: browserclaw` / `Version: 0.0.2.0`).
2. **Ambiguous tag** — the four extensions version independently, but a single shared `extensions/v*` tag couldn't say *which* extension was released.
3. **Silent clobber** — re-releasing a *different* extension at the *same* version would `gh release edit` the other extension's release out from under it.

## Before → After

**Before** — `extension=browserclaw`, `version=0.0.2.0`:

| | |
|---|---|
| Tag | `extensions/v0.0.2.0` |
| Title | `Extensions - v0.0.2.0` |
| Notes | `# Extensions - v0.0.2.0`<br>`- Extension selection: `browserclaw`` <br>`- Version: `0.0.2.0`` |

**After** — `extension=browserclaw`, `version=0.0.2.0`:

| | |
|---|---|
| Tag | `ext-browserclaw/v0.0.2.0` |
| Title | `BrowserClaw Extension - v0.0.2.0` |
| Notes | `- fix(claw): … (a1b2c3d)`<br>`- feat(claw): … (e4f5g6h)` &nbsp; *(path-scoped changelog since the previous `ext-browserclaw/v*` tag; or `Initial BrowserClaw Extension - v0.0.2.0 release.` on the first release)* |

**After** — `extension=all` produces four releases, one per extension:

- `ext-agent/v<v>` — *BrowserOS Agent Extension - v<v>* — changelog scoped to `packages/browseros-agent/apps/app`
- `ext-browserclaw/v<v>` — *BrowserClaw Extension - v<v>* — changelog scoped to `packages/browseros-agent/apps/claw-app`
- `ext-controller/v<v>` — *BrowserOS Controller Extension - v<v>* — `Built from browseros-ai/BrowserOS-agent @ main.`
- `ext-bugreporter/v<v>` — *BrowserOS Bug Reporter Extension - v<v>* — `Built from browseros-ai/BrowserOS-feedback-extension @ main.`

## Design

- **Tag namespace** `ext-<name>/v<version>` mirrors the house `<component>/v*` convention (`agent-server/v*`, `claw-server/v*`).
- **Notes never repeat the title, no H1, no CRX links.**
  - *In-repo* extensions (agent, browserclaw): `git log <previous ext-<name>/v* tag>..HEAD` **path-scoped** to the extension's app dir, capped through `cap-release-changelog.mjs --max-entries 15` — the same generator `release-server.yml` uses. No previous tag → `Initial <title> release.`; empty range → `No changes in <path> since <previous tag>.`
  - *External-repo* extensions (controller, bugreporter): the monorepo git log says nothing about them, so a single `Built from <owner/repo> @ <branch>.` line (honors the `branch` input override).
- **Previous-tag resolution** per extension: newest existing `ext-<name>/v*` by version order, excluding the tag being released (keeps idempotent re-runs diffing against the prior tag).
- **Checkout** switches to `fetch-depth: 0` so the changelog diff has full history and tags (same as `release-server.yml`).
- **Idempotent**: view → edit else create (`--target HEAD`, no pre-pushed tag), then the standard undraft step.
- The `extension` name is validated against the four known names in the loop before it feeds a tag; all inputs arrive via `env:` and are only used quoted.

**Unchanged:** `github_release` gating/defaults (dispatch `true` / call `false`), `GH_TOKEN`, job `permissions: contents: write`, the build step's R2 upload, the `Upload CRX artifacts` step, the concurrency group, and both caller workflows (`release-browseros.yml` / `release-browserclaw.yml` pass `extension: agent|browserclaw` without `github_release`, so they only build+upload — no release step).

## Cleanup

The old `extensions/v*` releases and tags are left untouched by this change and can be **deleted manually** once no longer needed.

## Verification

- `actionlint` passes.
- The release step's shell body extracted and checked with `bash -n` **and** `shellcheck` (clean).
- Ran the loop end-to-end against a throwaway git repo (stubbed `gh` + cap script) for `browserclaw`, `all`, and `controller` (with/without a `branch` override): confirmed one release per extension, correct titles, path-scoped changelogs (agent's notes exclude claw-app commits in the same range), correct 4-part previous-tag ordering (`sort -V` picks `v0.0.1.5` over `v0.0.1`), and the external "Built from … @ <branch>" lines.

Only `.github/workflows/release-extensions.yml` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
