### PR TITLE
refactor(claw-server): fold session-naming into BASE_EFFECTS, nudge state on identity

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/lib/mcp-session/identity.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/mcp-session/identity.ts
@@ -16,6 +16,7 @@ export interface ClientIdentity {
   key: AgentKey
   generatedLabel: string
   label: string
+  renameNudgesLeft: number
   firstSeenAt: number
 }
 
@@ -35,6 +36,7 @@ export interface IdentityService {
   }): ClientIdentity
   getIdentity(sessionId: string): ClientIdentity | null
   setLabel(sessionId: string, label: string): void
+  takeRenameNudge(sessionId: string): boolean
   endSession(sessionId: string): ClientIdentity | null
   list(): ClientIdentity[]
   listRetained(): RetainedIdentity[]
@@ -49,6 +51,7 @@ export interface IdentityServiceDeps {
 }
 
 const SLUG_MAX_LEN = 64
+const SESSION_NAME_NUDGE_LIMIT = 5
 
 export function createIdentityService(
   deps: IdentityServiceDeps = {},
@@ -85,6 +88,7 @@ export function createIdentityService(
         key: agentKeyFromSlug(`${slug}-${generatedLabel}`),
         generatedLabel,
         label: generatedLabel,
+        renameNudgesLeft: SESSION_NAME_NUDGE_LIMIT,
         firstSeenAt: now(),
       }
       records.set(input.sessionId, record)
@@ -96,6 +100,18 @@ export function createIdentityService(
     setLabel(sessionId, label) {
       const record = records.get(sessionId)
       if (record) record.label = label
+    },
+    takeRenameNudge(sessionId) {
+      const record = records.get(sessionId)
+      if (
+        !record ||
+        record.label !== record.generatedLabel ||
+        record.renameNudgesLeft === 0
+      ) {
+        return false
+      }
+      record.renameNudgesLeft -= 1
+      return true
     },
     endSession(sessionId) {
       const record = records.get(sessionId)

--- a/packages/browseros-agent/apps/claw-server/src/mcp/dispatch.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/dispatch.ts
@@ -38,7 +38,7 @@ import { cancellationErrorResult } from './cancellation-result'
 import { composeAbortSignals, dispatchErrorText } from './dispatch-util'
 import { applyAudit } from './effects/audit'
 import { applyOwnershipClaims } from './effects/ownership-claims'
-import { createSessionNamingEffect } from './effects/session-naming'
+import { applySessionNaming } from './effects/session-naming'
 import { applyTabActivity } from './effects/tab-activity'
 import { applyAgentTabGroupTitle, applyTabGroups } from './effects/tab-groups'
 import { applyTabsListView } from './effects/tabs-list-view'
@@ -91,6 +91,9 @@ const BASE_EFFECTS: readonly NamedToolEffect[] = [
   { name: 'audit', run: applyAudit },
   { name: 'tab-activity', run: applyTabActivity },
   { name: 'tab-groups', run: applyTabGroups },
+  // Must stay last: tabs-list-view rewrites result content wholesale, so a
+  // nudge appended before it would be clobbered.
+  { name: 'session-naming', run: applySessionNaming },
 ]
 
 /** Returns the first guard rejection in pipeline order. */
@@ -133,13 +136,6 @@ export function registerBrowserToolsForSingleServer(
   resolveIdentity: (sessionId: string | undefined) => ClientIdentity | null,
 ): void {
   const register = asRegister(server)
-  const effects: readonly NamedToolEffect[] = [
-    ...BASE_EFFECTS,
-    {
-      name: 'session-naming',
-      run: createSessionNamingEffect(),
-    },
-  ]
   for (const tool of BROWSER_TOOLS) {
     register(
       tool.name,
@@ -152,10 +148,7 @@ export function registerBrowserToolsForSingleServer(
         }),
       },
       (args, extra) =>
-        dispatchToolCall(
-          buildToolCall(tool, args, extra, resolveIdentity),
-          effects,
-        ),
+        dispatchToolCall(buildToolCall(tool, args, extra, resolveIdentity)),
     )
   }
   register(
@@ -245,10 +238,7 @@ function buildToolCall(
   }
 }
 
-async function dispatchToolCall(
-  call: ToolCall,
-  effects: readonly NamedToolEffect[],
-): Promise<ToolResult> {
+async function dispatchToolCall(call: ToolCall): Promise<ToolResult> {
   const rejection = runGuards(call)
   if (rejection) return wireResult(rejection)
   const connectedCall = call as ConnectedToolCall
@@ -269,7 +259,7 @@ async function dispatchToolCall(
       error: dispatchErrorText(outcome.result.content),
     })
   }
-  const result = runEffects({ call, ...outcome }, effects)
+  const result = runEffects({ call, ...outcome })
   return wireResult(result)
 }
 

--- a/packages/browseros-agent/apps/claw-server/src/mcp/effects/session-naming.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/effects/session-naming.ts
@@ -7,40 +7,25 @@
 import {
   buildSessionGroupTitle,
   clientPrefixFromSlug,
+  identityService,
 } from '../../lib/mcp-session'
 import type { ToolEffect } from '../dispatch'
 
-const SESSION_NAME_NUDGE_LIMIT = 5
+/** Appends a bounded rename nudge while the session keeps its generated label. */
+export const applySessionNaming: ToolEffect = ({ call, result }) => {
+  const identity = call.identity
+  if (result.isError || call.tool.name === 'name_session' || !identity) {
+    return undefined
+  }
+  if (!identityService.takeRenameNudge(call.sessionId)) return undefined
 
-/** Appends bounded rename nudges while the session keeps its generated label. */
-export function createSessionNamingEffect(): ToolEffect {
-  let remaining = SESSION_NAME_NUDGE_LIMIT
-
-  return ({ call, result }) => {
-    const identity = call.identity
-    if (
-      result.isError ||
-      call.tool.name === 'name_session' ||
-      !identity ||
-      identity.label !== identity.generatedLabel ||
-      remaining === 0
-    ) {
-      return undefined
-    }
-    remaining -= 1
-
-    const title = buildSessionGroupTitle(
-      clientPrefixFromSlug(identity.slug),
-      identity.label,
-    )
-    const tip = `Tip: this session is "${title}" — rename it with name_session name="<2-3 word task label>"`
-    let appended = false
-    const content = result.content.map((item) => {
-      if (appended || item.type !== 'text') return item
-      appended = true
-      return { ...item, text: `${item.text}\n${tip}` }
-    })
-    if (!appended) content.push({ type: 'text', text: tip })
-    return { ...result, content }
+  const title = buildSessionGroupTitle(
+    clientPrefixFromSlug(identity.slug),
+    identity.label,
+  )
+  const tip = `Tip: this session is "${title}" — rename it with name_session name="<2-3 word task label>"`
+  return {
+    ...result,
+    content: [...result.content, { type: 'text', text: tip }],
   }
 }

--- a/packages/browseros-agent/apps/claw-server/tests/lib/mcp-session/identity.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/mcp-session/identity.test.ts
@@ -141,6 +141,46 @@ describe('IdentityService', () => {
     expect(svc.size()).toBe(0)
   })
 
+  it('starts fresh sessions with the full rename-nudge budget', () => {
+    const svc = setup()
+    const record = svc.registerInitialize({
+      sessionId: 's1',
+      clientInfo: { name: 'Claude Code' },
+    })
+    expect(record.renameNudgesLeft).toBe(5)
+  })
+
+  it('grants five rename nudges then refuses', () => {
+    const svc = setup()
+    svc.registerInitialize({
+      sessionId: 's1',
+      clientInfo: { name: 'Claude Code' },
+    })
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(svc.takeRenameNudge('s1')).toBe(true)
+    }
+    expect(svc.takeRenameNudge('s1')).toBe(false)
+    expect(svc.getIdentity('s1')?.renameNudgesLeft).toBe(0)
+  })
+
+  it('refuses rename nudges once the label diverges from the generated one', () => {
+    const svc = setup()
+    svc.registerInitialize({
+      sessionId: 's1',
+      clientInfo: { name: 'Claude Code' },
+    })
+
+    svc.setLabel('s1', 'invoice-processing')
+    expect(svc.takeRenameNudge('s1')).toBe(false)
+  })
+
+  it('refuses rename nudges for unknown or unidentified sessions', () => {
+    const svc = setup()
+    expect(svc.takeRenameNudge('missing')).toBe(false)
+    expect(svc.takeRenameNudge('')).toBe(false)
+  })
+
   it('clear removes live identities and retained reservations', () => {
     const svc = setup()
     svc.registerInitialize({ sessionId: 's1', clientInfo: { name: 'a' } })

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/session-naming-nudge.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/session-naming-nudge.test.ts
@@ -1,35 +1,38 @@
-import { describe, expect, it } from 'bun:test'
-import type { ClientIdentity } from '../../src/lib/mcp-session'
-import type { ToolCall, ToolEffect } from '../../src/mcp/dispatch'
-import { createSessionNamingEffect } from '../../src/mcp/effects/session-naming'
+import { beforeEach, describe, expect, it } from 'bun:test'
+import {
+  buildSessionGroupTitle,
+  type ClientIdentity,
+  clientPrefixFromSlug,
+  identityService,
+} from '../../src/lib/mcp-session'
+import type { ToolCall } from '../../src/mcp/dispatch'
+import { applySessionNaming } from '../../src/mcp/effects/session-naming'
 import type { ToolResult } from '../../src/mcp/register-fn'
 
-const tip =
-  'Tip: this session is "claude/swift-otter" — rename it with name_session name="<2-3 word task label>"'
-
-function identity(label = 'swift-otter'): ClientIdentity {
-  return {
-    sessionId: 's1',
-    clientName: 'Claude Code',
-    clientVersion: '1.0.0',
-    clientTitle: null,
-    slug: 'claude-code',
-    key: 'claude-code-swift-otter' as never,
-    generatedLabel: 'swift-otter',
-    label,
-    firstSeenAt: 0,
-  }
+function register(sessionId: string): ClientIdentity {
+  return identityService.registerInitialize({
+    sessionId,
+    clientInfo: { name: 'Claude Code', version: '1.0.0' },
+  })
 }
 
-function call(value: ClientIdentity, toolName = 'snapshot'): ToolCall {
+function tipFor(identity: ClientIdentity): string {
+  const title = buildSessionGroupTitle(
+    clientPrefixFromSlug(identity.slug),
+    identity.label,
+  )
+  return `Tip: this session is "${title}" — rename it with name_session name="<2-3 word task label>"`
+}
+
+function call(identity: ClientIdentity, toolName = 'snapshot'): ToolCall {
   return {
     tool: { name: toolName } as never,
     args: {},
-    sessionId: value.sessionId,
-    identity: value,
-    key: value.key,
-    agent: { agentId: value.key, slug: value.slug },
-    agentLabel: value.clientName,
+    sessionId: identity.sessionId,
+    identity,
+    key: identity.key,
+    agent: { agentId: identity.key, slug: identity.slug },
+    agentLabel: identity.clientName,
     session: {} as never,
     defaultTabGroupId: null,
     flags: { newPage: false, closePage: false, listTabs: false },
@@ -42,84 +45,106 @@ const ok: ToolResult = {
 }
 
 function apply(
-  effect: ToolEffect,
   toolCall: ToolCall,
   result: ToolResult = ok,
 ): ToolResult | undefined {
-  return effect({ call: toolCall, result, cancelled: false, durationMs: 1 })
+  return applySessionNaming({
+    call: toolCall,
+    result,
+    cancelled: false,
+    durationMs: 1,
+  })
 }
 
 describe('session naming nudge', () => {
-  it('appends the prescribed tip to successive arbitrary tool results', () => {
-    const effect = createSessionNamingEffect()
-    const value = identity()
+  beforeEach(() => identityService.clear())
 
-    expect(apply(effect, call(value, 'snapshot'))?.content).toEqual([
-      { type: 'text', text: `tool result\n${tip}` },
+  it('appends the tip as a trailing text item on successive results', () => {
+    const value = register('s1')
+    const tip = tipFor(value)
+
+    expect(apply(call(value, 'snapshot'))?.content).toEqual([
+      { type: 'text', text: 'tool result' },
+      { type: 'text', text: tip },
     ])
-    expect(apply(effect, call(value, 'read'))?.content).toEqual([
-      { type: 'text', text: `tool result\n${tip}` },
+    expect(apply(call(value, 'read'))?.content).toEqual([
+      { type: 'text', text: 'tool result' },
+      { type: 'text', text: tip },
+    ])
+  })
+
+  it('appends the tip last without splicing into existing text items', () => {
+    const value = register('s1')
+    const multi: ToolResult = {
+      content: [
+        { type: 'text', text: 'first' },
+        { type: 'text', text: 'second' },
+      ],
+      isError: false,
+    }
+
+    expect(apply(call(value, 'read'), multi)?.content).toEqual([
+      { type: 'text', text: 'first' },
+      { type: 'text', text: 'second' },
+      { type: 'text', text: tipFor(value) },
     ])
   })
 
   it('appends exactly five nudges then stays silent', () => {
-    const effect = createSessionNamingEffect()
-    const toolCall = call(identity(), 'tabs')
+    const value = register('s1')
+    const toolCall = call(value, 'tabs')
 
     for (let index = 0; index < 5; index += 1) {
-      expect(apply(effect, toolCall)?.content[0]).toEqual({
-        type: 'text',
-        text: `tool result\n${tip}`,
-      })
+      expect(apply(toolCall)?.content).toEqual([
+        { type: 'text', text: 'tool result' },
+        { type: 'text', text: tipFor(value) },
+      ])
     }
-    expect(apply(effect, toolCall)).toBeUndefined()
+    expect(apply(toolCall)).toBeUndefined()
   })
 
   it('stops immediately after the session is renamed', () => {
-    const effect = createSessionNamingEffect()
-    const value = identity()
+    const value = register('s1')
 
-    expect(apply(effect, call(value))).toBeDefined()
-    value.label = 'invoice-processing'
-    expect(apply(effect, call(value))).toBeUndefined()
+    expect(apply(call(value))).toBeDefined()
+    identityService.setLabel('s1', 'invoice-processing')
+    expect(apply(call(value))).toBeUndefined()
   })
 
   it('skips errors and name_session without consuming nudges', () => {
-    const effect = createSessionNamingEffect()
-    const value = identity()
+    const value = register('s1')
     const toolCall = call(value)
 
-    expect(apply(effect, toolCall, { ...ok, isError: true })).toBeUndefined()
-    expect(apply(effect, call(value, 'name_session'))).toBeUndefined()
+    expect(apply(toolCall, { ...ok, isError: true })).toBeUndefined()
+    expect(apply(call(value, 'name_session'))).toBeUndefined()
 
     for (let index = 0; index < 5; index += 1) {
-      expect(apply(effect, toolCall)).toBeDefined()
+      expect(apply(toolCall)).toBeDefined()
     }
-    expect(apply(effect, toolCall)).toBeUndefined()
+    expect(apply(toolCall)).toBeUndefined()
   })
 
-  it('pushes the tip when the result has no text item', () => {
-    const effect = createSessionNamingEffect()
+  it('appends the tip after image content when no text item exists', () => {
+    const value = register('s1')
     const image = { type: 'image' as const, data: 'AAA', mimeType: 'image/png' }
 
     expect(
-      apply(effect, call(identity(), 'screenshot'), {
+      apply(call(value, 'screenshot'), {
         content: [image],
         isError: false,
       })?.content,
-    ).toEqual([image, { type: 'text', text: tip }])
+    ).toEqual([image, { type: 'text', text: tipFor(value) }])
   })
 
-  it('keeps independent counters for separate effect instances', () => {
-    const first = createSessionNamingEffect()
-    const second = createSessionNamingEffect()
-    const toolCall = call(identity())
+  it('keeps independent counters for separate sessions', () => {
+    const first = register('s1')
+    const second = register('s2')
 
     for (let index = 0; index < 5; index += 1) {
-      expect(apply(first, toolCall)).toBeDefined()
-      expect(apply(second, toolCall)).toBeDefined()
+      expect(apply(call(first))).toBeDefined()
+      expect(apply(call(second))).toBeDefined()
     }
-    expect(apply(first, toolCall)).toBeUndefined()
-    expect(apply(second, toolCall)).toBeUndefined()
+    expect(apply(call(first))).toBeUndefined()
+    expect(apply(call(second))).toBeUndefined()
   })
 })

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-isolation.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-isolation.test.ts
@@ -73,9 +73,14 @@ function ok(structured?: unknown): FakeResult {
   }
 }
 
-function expectNudgedText(text: string | undefined, expected: string): void {
-  expect(text).toStartWith(`${expected}\nTip: this session is "claude/`)
-  expect(text).toEndWith(
+function expectNudgedText(
+  content: Array<{ type: string; text?: string }> | undefined,
+  expected: string,
+): void {
+  expect(content?.[0]?.text).toBe(expected)
+  const tip = content?.[content.length - 1]
+  expect(tip?.text).toStartWith('Tip: this session is "claude/')
+  expect(tip?.text).toEndWith(
     ' — rename it with name_session name="<2-3 word task label>"',
   )
 }
@@ -240,7 +245,7 @@ describe('per-agent tabs isolation', () => {
 
     expect(result.structuredContent).toBeUndefined()
     expectNudgedText(
-      (result.content as Array<{ type: string; text?: string }>)[0]?.text,
+      result.content as Array<{ type: string; text?: string }>,
       'ok\nreturn: 42',
     )
     await client.close()
@@ -455,7 +460,7 @@ describe('per-agent tabs isolation', () => {
     })) as TabsListResult
     expect(list.structuredContent).toBeUndefined()
     expectNudgedText(
-      (list.content as Array<{ type: string; text?: string }>)?.[0]?.text,
+      list.content as Array<{ type: string; text?: string }>,
       '(no open pages)',
     )
     await client.close()


### PR DESCRIPTION
## What

Makes the session-naming rename nudge a **stateless, table-registered effect** like every other effect, and moves its per-session counter onto the identity record.

## Why

`session-naming` was the lone inline effect built inside `registerBrowserToolsForSingleServer`, its counter living in a closure (`let remaining`). That only stayed per-session because the local `effects` array happened to be rebuilt each `buildSession()` — nothing stated or enforced it. Hoisting that array to module scope (which the surrounding static `BASE_EFFECTS` table invites) would have silently shared one nudge counter across all sessions. That implicitness is the bug removed here.

## Changes

- **State on the identity record.** `ClientIdentity` gains `renameNudgesLeft` (init 5), mutated only through a new `IdentityService.takeRenameNudge(sessionId): boolean` — mirrors how `setLabel` keeps mutation inside the service. Returns `false` when the record is missing, the label already diverged from the generated one, or the budget is exhausted; otherwise decrements. State dies with the record on `endSession`, so no cleanup wiring (and nothing added to `RetainedIdentity`).
- **Stateless effect.** `createSessionNamingEffect()` → top-level `applySessionNaming`, importing the `identityService` singleton directly (same pattern `applyOwnershipClaims` uses for `ownershipStore`).
- **Registered in the table.** `{ name: 'session-naming', run: applySessionNaming }` is the **last** entry of `BASE_EFFECTS` — kept last so `tabs-list-view`'s wholesale content rewrite can't clobber the tip (documented with a one-line comment). `registerBrowserToolsForSingleServer` drops its local `effects` array; `dispatchToolCall` no longer threads an effects param.
- **Simpler append.** The tip is now always a single trailing text item (`[...content, tip]`) instead of being spliced onto the first text item — it lands last, where models attend most, exactly once per result.

## Semantics

Unchanged: same tip text, same cap of 5, same skip rules (errors and `name_session` never nudge and never consume the counter, stop-on-rename). The only observable difference is the tip's **position** — a separate final content item.

## Tests

- `session-naming-nudge.test.ts` rewritten against the stateless effect (register through the identity service; two `sessionId`s for per-session isolation; cap-of-5, stop-on-rename, skip errors/`name_session`, trailing-item placement for text-bearing, multi-text, and image-only results).
- `identity.test.ts` extended for `takeRenameNudge` (five-then-refuse, refuse after rename, refuse for unknown/empty session, fresh sessions start at 5).
- `tabs-isolation.test.ts` integration assertions updated to the new placement (original text preserved unglued + tip as final item).

`bun run check` and `bun run test` green from `packages/browseros-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)