### PR TITLE
docs: updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **The browser for AI agents**
 
-Claude Code, Codex, Cursor, or any MCP client drives it using the accounts you're already signed into — while you watch live and replay every step.
+Claude Code, Codex, Cursor, or any MCP client drives it using the accounts you're already signed into, while you watch live and replay every step.
 
 [![Download for macOS](https://img.shields.io/badge/Download-macOS-black?style=flat&logo=apple&logoColor=white)](https://cdn.browseros.com/download/BrowserClaw.dmg)
 [![Download for Windows](https://img.shields.io/badge/Download-Windows-0078D4?style=flat&logo=windows&logoColor=white)](https://cdn.browseros.com/download/BrowserClaw_installer.exe)
@@ -32,7 +32,7 @@ Claude Code, Codex, Cursor, or any MCP client drives it using the accounts you'r
 
 **The AI browser for humans**
 
-An open-source Chromium fork with a built-in AI agent — the privacy-first alternative to ChatGPT Atlas, Perplexity Comet, and Dia.
+An open-source Chromium fork with a built-in AI agent, the privacy-first alternative to ChatGPT Atlas, Perplexity Comet, and Dia.
 
 [![Download for macOS](https://img.shields.io/badge/Download-macOS-black?style=flat&logo=apple&logoColor=white)](https://files.browseros.com/download/BrowserOS.dmg)
 [![Download for Windows](https://img.shields.io/badge/Download-Windows-0078D4?style=flat&logo=windows&logoColor=white)](https://files.browseros.com/download/BrowserOS_installer.exe)
@@ -47,27 +47,29 @@ An open-source Chromium fork with a built-in AI agent — the privacy-first alte
 
 <div align="center">
 
-**Two browsers, one codebase — we're building both.** Free and open source under AGPL-3.0, and everything runs on your machine.
+**Two browsers, one codebase.** Free · Open source (AGPL-3.0) · Local-only · Bring your own AI keys
 
 </div>
 
 ## BrowserClaw
 
-Your AI is smart, but it can't press the buttons. Ask it to book a flight, download an invoice, or reply to an email — it stops at the login screen. BrowserClaw fixes that: it's a real browser you install, sign into, and use like any other, and your AI drives it with the logins you already have — not a headless spec, not a cloud rental.
+**What is BrowserClaw?** BrowserClaw is a free, open-source browser your AI agents drive using your logged-in accounts. You install it like any browser, sign into the sites you use, and give tasks to Claude Code, Codex, Cursor, or any MCP-compatible AI. Your agents work in their own tabs while you watch every step live and replay any session like a video.
+
+Your AI is smart, but it can't press the buttons. Ask it to book a flight, download an invoice, or reply to an email, and it stops at the login screen. BrowserClaw fixes that.
 
 ### Get started
 
-1. **Install BrowserClaw and sign in** to the sites you use every day — it works like any browser, and every account you sign into becomes something your AI can use
-2. **Connect your AI in one click** — Claude Code, Codex, Cursor, VS Code, Zed, Antigravity; anything else that speaks MCP connects with a URL
-3. **Give it a real task** — *"Book me the cheapest morning flight from SFO to NYC next Friday"* — then watch it live from your new tab and replay the whole run like a video
+1. **Install BrowserClaw and sign in** to the sites you use every day. It works like any browser, and every account you sign into becomes something your AI can use.
+2. **Connect your AI in one click.** Claude Code, Codex, Cursor, VS Code, Zed, OpenCode, and Antigravity install with a single click; anything else that speaks MCP connects with a URL.
+3. **Give it a real task.** In your AI chat: *"Find a good time next week for a 30-minute team meeting and send the invite."* Then watch it live from your new tab and replay the whole run like a video.
 
-### Features
+### Key features
 
 <table>
 <tr>
 <td width="40%" valign="middle">
-<h3>Live dashboard</h3>
-Your new tab shows every agent working right now — which site it's on, what it's doing, how far along. <a href="https://docs.browseros.com/browserclaw/cockpit">Docs</a>
+<h4>Live dashboard</h4>
+Your new tab shows every agent working right now: which site it's on, what it's doing, how far along. <a href="https://docs.browseros.com/browserclaw/cockpit">Docs</a>
 </td>
 <td width="60%">
 <img src="docs/images/browserclaw--dashboard-populated.png" alt="BrowserClaw dashboard showing agent sessions and recent activity" width="100%" />
@@ -75,17 +77,17 @@ Your new tab shows every agent working right now — which site it's on, what it
 </tr>
 <tr>
 <td width="40%" valign="middle">
-<h3>One-click MCP connect</h3>
-One endpoint, every harness. Claude Code, Codex, Cursor, Antigravity, VS Code, and Zed set up with a single click. <a href="https://docs.browseros.com/browserclaw/mcp/index">Docs</a>
+<h4>One-click MCP connect</h4>
+One endpoint, every harness. Seven AI tools set up with a single click. <a href="https://docs.browseros.com/browserclaw/mcp">Docs</a>
 </td>
 <td width="60%">
-<img src="docs/images/browserclaw--mcp-install-board.png" alt="BrowserClaw MCP connect board with one-click install for Claude Code, Codex, Cursor, Antigravity, VS Code, and Zed" width="100%" />
+<img src="docs/images/browserclaw--mcp-install-board.png" alt="BrowserClaw MCP connect board with one-click install for supported AI tools" width="100%" />
 </td>
 </tr>
 <tr>
 <td width="40%" valign="middle">
-<h3>Replay &amp; audit</h3>
-Every session is saved as a scrubbable video on your disk, with a step-by-step action timeline — rewind and see exactly what happened. <a href="https://docs.browseros.com/browserclaw/audit-and-replay">Docs</a>
+<h4>Replay every session</h4>
+Every session is saved as a scrubbable video on your disk with a step-by-step action timeline. Rewind and see exactly what happened. <a href="https://docs.browseros.com/browserclaw/audit-and-replay">Docs</a>
 </td>
 <td width="60%">
 <img src="docs/images/browserclaw--replay-scrubber.png" alt="BrowserClaw replay view with video scrubber and action timeline" width="100%" />
@@ -93,145 +95,138 @@ Every session is saved as a scrubbable video on your disk, with a step-by-step a
 </tr>
 </table>
 
-- **Your logins** — agents automate your real work using the sessions you already have, not a blank sandbox ([how it works](https://docs.browseros.com/browserclaw/how-it-works))
-- **Isolated agent tabs** — every agent works in its own tabs and never touches yours; run several in parallel ([tabs & isolation](https://docs.browseros.com/browserclaw/tabs-and-isolation))
-- **100% local** — sessions, screenshots, history, and settings never leave your machine ([privacy](https://docs.browseros.com/browserclaw/privacy))
+- **Your logins.** Agents automate your real work using the sessions you already have, not a blank sandbox. [How it works](https://docs.browseros.com/browserclaw/how-it-works)
+- **Local-only.** Sessions, screenshots, and history live under `~/.browserclaw/` and never leave your machine. [Privacy](https://docs.browseros.com/browserclaw/privacy)
+
+### Why BrowserClaw over the alternatives?
+
+- **Not a headless driver.** Playwright and browser-use spin up a fresh Chrome subprocess with no logins. Great for CI, useless for "book my flight" or "read my inbox." BrowserClaw is the browser your logins already live in.
+- **Not a cloud browser.** Browserbase and Browser Use Cloud run your agent's session on someone else's infrastructure. Your prompts and session tokens pass through their servers. BrowserClaw runs on your machine, on `127.0.0.1`.
 
 ## BrowserOS
 
-An open-source Chromium fork that runs AI agents natively — the privacy-first alternative to ChatGPT Atlas, Perplexity Comet, and Dia. Use your own API keys or run local models with Ollama; your data never leaves your machine.
+**What is BrowserOS?** BrowserOS is a free, open-source Chromium fork with an AI agent built into every new tab. Ask it to summarise a page, click through a flow, extract data, or run a scheduled task, and it uses 53+ built-in browser tools plus 40+ app integrations to get the work done. Bring your own AI keys or run everything locally with Ollama.
 
-### Quick Start
+Every AI browser today asks you to sign into their cloud and hand over your data. BrowserOS is the one that doesn't. Same daily browser you already use, with a helpful agent one keystroke away.
 
-1. **Download and install** BrowserOS — [macOS](https://files.browseros.com/download/BrowserOS.dmg) · [Windows](https://files.browseros.com/download/BrowserOS_installer.exe) · [Linux (AppImage)](https://files.browseros.com/download/BrowserOS.AppImage) · [Linux (Debian)](https://cdn.browseros.com/download/BrowserOS.deb)
-2. **Import your Chrome data** (optional) — bookmarks, passwords, extensions all carry over
-3. **Connect your AI provider** — Claude, OpenAI, Gemini, ChatGPT Pro via OAuth, or local models via Ollama/LM Studio
+### Get started
 
-### Features
+1. **Download and install** BrowserOS: [macOS](https://files.browseros.com/download/BrowserOS.dmg) · [Windows](https://files.browseros.com/download/BrowserOS_installer.exe) · [Linux (AppImage)](https://files.browseros.com/download/BrowserOS.AppImage) · [Linux (Debian)](https://cdn.browseros.com/download/BrowserOS.deb).
+2. **Import from Chrome** in one click. Bookmarks, passwords, extensions all carry over.
+3. **Connect your AI provider.** Claude, OpenAI, Gemini, ChatGPT Pro via OAuth, or local models via Ollama or LM Studio.
 
-| Feature | Description | Docs |
-|---------|-------------|------|
-| **AI Agent** | 53+ browser automation tools — navigate, click, type, extract data, all with natural language | [Guide](https://docs.browseros.com/getting-started) |
-| **MCP Server** | Control the browser from Claude Code, Gemini CLI, or any MCP client | [Setup](https://docs.browseros.com/features/use-with-claude-code) |
-| **Cowork** | Combine browser automation with local file operations — research the web, save reports to your folder | [Docs](https://docs.browseros.com/features/cowork) |
-| **Scheduled Tasks** | Run agents on autopilot — daily, hourly, or every few minutes | [Docs](https://docs.browseros.com/features/scheduled-tasks) |
-| **40+ App Integrations** | Gmail, Slack, GitHub, Linear, Notion, Figma, Salesforce, and more via MCP | [Docs](https://docs.browseros.com/features/connect-mcps) |
-| **Vertical Tabs** | Side-panel tab management — stay organized even with 100+ tabs open | [Docs](https://docs.browseros.com/features/vertical-tabs) |
-| **Ad Blocking** | uBlock Origin + Manifest V2 support — [10x more protection](https://docs.browseros.com/features/ad-blocking) than Chrome | [Docs](https://docs.browseros.com/features/ad-blocking) |
-| **Cloud Sync** | Sync browser config and agent history across devices | [Docs](https://docs.browseros.com/features/sync-to-cloud) |
-| **Smart Nudges** | Contextual suggestions to connect apps and use features at the right moment | [Docs](https://docs.browseros.com/features/smart-nudges) |
+### Key features
 
-### Demos
+<table>
+<tr>
+<td width="40%" valign="middle">
+<h4>Built-in AI agent</h4>
+Ask it in plain English. 53+ browser tools plus 40+ app integrations (Gmail, Slack, GitHub, Linear, Notion, and more). <a href="https://docs.browseros.com/getting-started">Docs</a>
+</td>
+<td width="60%">
+<img src="docs/videos/browserOS-agent-in-action.gif" alt="BrowserOS agent completing a browser task with natural language" width="100%" />
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h4>Cowork with files</h4>
+Combine browser automation with local file operations in one session. Research the web, save reports to your folder, read and edit files, run shell commands. <a href="https://docs.browseros.com/features/cowork">Docs</a>
+</td>
+<td width="60%">
+<a href="https://docs.browseros.com/features/cowork"><img src="https://img.shields.io/badge/Watch-Cowork%20demo-4c71f2?style=for-the-badge" alt="Watch Cowork demo" /></a>
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h4>Scheduled tasks</h4>
+Run agents on autopilot: daily, hourly, or every few minutes. Wake up to a fresh report or a queue processed overnight. <a href="https://docs.browseros.com/features/scheduled-tasks">Docs</a>
+</td>
+<td width="60%">
+<a href="https://www.youtube.com/watch?v=SoSFev5R5dI"><img src="https://img.shields.io/badge/Watch-Scheduled%20tasks-4c71f2?style=for-the-badge" alt="Watch scheduled tasks demo" /></a>
+</td>
+</tr>
+</table>
 
-#### BrowserOS agent in action
-[![BrowserOS agent in action](docs/videos/browserOS-agent-in-action.gif)](https://www.youtube.com/watch?v=SoSFev5R5dI)
-<br/><br/>
+- **Bring your own AI.** 11+ providers, or fully local with Ollama and LM Studio. [Provider list](https://docs.browseros.com/features/bring-your-own-llm)
+- **Real ad blocking.** uBlock Origin with full Manifest V2 support. [Docs](https://docs.browseros.com/features/ad-blocking)
 
-#### Install [BrowserOS as MCP](https://docs.browseros.com/features/use-with-claude-code) and control it from `claude-code`
+### Why BrowserOS over the alternatives?
 
-https://github.com/user-attachments/assets/c725d6df-1a0d-40eb-a125-ea009bf664dc
+- **Not Chrome with an AI extension.** Extensions can't touch the browser chrome, can't run scheduled background tasks, can't ship 53+ browser tools that the agent uses natively. BrowserOS builds the agent into Chromium itself.
+- **Not Comet, Atlas, or Dia.** Those AI browsers route your prompts through their cloud with their model. BrowserOS runs on your machine with your AI keys. Your data stays yours.
 
-<br/><br/>
+## LLM support
 
-#### Use BrowserOS to chat
-
-https://github.com/user-attachments/assets/726803c5-8e36-420e-8694-c63a2607beca
-
-<br/><br/>
-
-#### Use BrowserOS to scrape data
-
-https://github.com/user-attachments/assets/9f038216-bc24-4555-abf1-af2adcb7ebc0
-
-<br/><br/>
-
-### LLM Providers
-
-BrowserOS works with any LLM. Bring your own keys, use OAuth, or run models locally.
+Bring your own keys, use OAuth for your existing subscriptions, or run models locally. The 6 most-used providers, at a glance:
 
 | Provider | Type | Auth |
-|----------|------|------|
-| Kimi K2.5 | Cloud (default) | Built-in |
-| ChatGPT Pro/Plus | Cloud | [OAuth](https://docs.browseros.com/features/chatgpt) |
-| GitHub Copilot | Cloud | [OAuth](https://docs.browseros.com/features/github-copilot) |
-| Qwen Code | Cloud | [OAuth](https://docs.browseros.com/features/qwen-code) |
+|---|---|---|
+| Kimi K2.5 (default) | Cloud | Built-in |
 | Claude (Anthropic) | Cloud | API key |
 | GPT-4o / o3 (OpenAI) | Cloud | API key |
-| Gemini (Google) | Cloud | API key |
-| Azure OpenAI | Cloud | API key |
-| AWS Bedrock | Cloud | IAM credentials |
-| OpenRouter | Cloud | API key |
-| Ollama | Local | [Setup](https://docs.browseros.com/features/ollama) |
-| LM Studio | Local | [Setup](https://docs.browseros.com/features/lm-studio) |
+| ChatGPT Pro/Plus | Cloud | OAuth |
+| Ollama | Local | [Setup](https://docs.browseros.com/features/local-models) |
+| LM Studio | Local | [Setup](https://docs.browseros.com/features/local-models) |
 
-### How We Compare
+Full list of 11+ providers (Gemini, GitHub Copilot, Azure, Bedrock, OpenRouter, and more) is in the [bring-your-own-LLM docs](https://docs.browseros.com/features/bring-your-own-llm).
 
-| | BrowserOS | Chrome | Brave | Dia | Comet | Atlas |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|
-| Open Source | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| AI Agent | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| MCP Server | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Cowork (files + browser) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Scheduled Tasks | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Bring Your Own Keys | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| Local Models (Ollama) | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| Local-first Privacy | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| Ad Blocking (MV2) | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
+## How they compare
 
-**Detailed comparisons:**
-- [BrowserOS vs Chrome DevTools MCP](https://docs.browseros.com/comparisons/chrome-devtools-mcp) — developer-focused comparison for browser automation
-- [BrowserOS vs Claude Cowork](https://docs.browseros.com/comparisons/claude-cowork) — getting real work done with AI
-- [BrowserOS vs OpenClaw](https://docs.browseros.com/comparisons/openclaw) — everyday AI assistance
+Both products next to what people usually ask about:
+
+| | BrowserClaw | BrowserOS | Chrome | Playwright / browser-use | Comet / Atlas / Dia |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Open source | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Real browser with your logins | ✅ | ✅ | ✅ | ❌ | Cloud VM |
+| Built-in AI agent | Via MCP | ✅ | ❌ | ❌ | ✅ |
+| Bring your own AI keys | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Local models (Ollama, LM Studio) | Via MCP | ✅ | ❌ | ✅ | ❌ |
+| Everything stays on your machine | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Session replay (video-style) | ✅ | ❌ | ❌ | Traces | ❌ |
+| Scheduled agent tasks | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Ad blocking with Manifest V2 | ✅ | ✅ | ❌ | N/A | Partial |
 
 ## FAQ
 
-### What's the difference between BrowserClaw and BrowserOS?
+### General
 
-BrowserClaw is a browser your AI drives; BrowserOS is a browser you drive, with an AI agent built in. They're standalone apps that live side by side — many people use BrowserOS as their daily browser and BrowserClaw as their agents' browser.
+**What's the difference between BrowserClaw and BrowserOS?**
+BrowserClaw is a browser your AI drives; BrowserOS is a browser you drive, with an AI agent built in. Both ship from this repo and run side by side. Many people use BrowserOS as their daily browser and BrowserClaw as their agents' browser.
 
-### Which AI tools work with BrowserClaw?
+**Is either free? Is either open source?**
+Both are free and open source under AGPL-3.0. Bring your own AI keys or run local models.
 
-Any AI agent that supports MCP, which is essentially every serious AI coding tool today. Claude Code, Codex, Cursor, VS Code, Zed, and Antigravity connect with one click; anything else connects with a URL.
+### BrowserClaw
 
-### Does my AI share my logins?
+**Which AI tools work with BrowserClaw?**
+Any AI that speaks MCP. Claude Code, Codex, Cursor, VS Code, Zed, OpenCode, and Antigravity connect with one click; Claude Desktop connects via a [drop-in extension](https://docs.browseros.com/browserclaw/mcp/claude-desktop); anything else connects with a URL.
 
-Yes — that's the point. Agents drive BrowserClaw using the sessions you already have, so they automate your real work instead of poking a blank sandbox. Per-agent profile isolation is on the roadmap if you want to keep them apart.
+**Does my AI share my logins?**
+Yes, and that's the point. Agents drive BrowserClaw using the sessions you already have, so they automate your real work instead of poking a blank sandbox. Every agent's tabs sit in their own colored Chrome tab group so you can always see whose is whose.
 
-### Will my AI interrupt my browsing?
+**Does anything leave my machine?**
+Your sessions, screenshots, history, and settings live under `~/.browserclaw/` and never upload. BrowserClaw sends anonymous product-usage events (agent connect/disconnect, version, OS) to help us improve the app; it never sends URLs, page content, prompts, tool results, or screenshots. Off with one toggle in Settings. [Full policy](https://docs.browseros.com/browserclaw/privacy).
 
-No. Every agent opens its own tabs to work in and never touches the ones you have open. It can't close the doc you're writing or steer the tab you're using — you keep working while it works.
+### BrowserOS
 
-### Can I run two AIs at the same time?
+**What LLM providers does BrowserOS support?**
+11+ providers: Kimi, Claude, OpenAI, Gemini, ChatGPT Pro/Plus and GitHub Copilot via OAuth, OpenRouter, Azure, Bedrock, or fully local through Ollama and LM Studio.
 
-Yes. Every agent gets its own set of tabs, tracked separately. Codex and Claude Code can each work on their own tasks at the same time without stepping on each other.
-
-### Can I replay what my AI did?
-
-Yes. Every session is saved as a scrubbable video with a step-by-step action timeline. Rewind, spot the moment things went sideways, and give the agent a better instruction next time.
-
-### Is my data safe? Does anything go to the cloud?
-
-Everything runs on your machine. Session history, screenshots, replays, and settings are files on your disk, and your logins stay in your browser profile — same as any browser. There's no dashboard we own. Open source, top to bottom.
-
-### What LLM providers does BrowserOS support?
-
-11+ providers: Kimi, Claude, OpenAI, Gemini, ChatGPT Pro/Plus and GitHub Copilot via OAuth, OpenRouter, Azure, Bedrock — or fully local models through Ollama and LM Studio. Bring your own keys and switch anytime.
-
-### Do my Chrome extensions and bookmarks work?
-
+**Do my Chrome extensions and bookmarks work?**
 Yes. Both browsers are Chromium forks, so Chrome extensions work and your bookmarks, passwords, and settings import in one click.
 
-### What platforms are supported?
-
+**What platforms are supported?**
 BrowserClaw runs on macOS and Windows. BrowserOS runs on macOS, Windows, and Linux. System requirements match Google Chrome.
 
-### Is it free?
+## Get help
 
-Yes. Both products are free and open source under AGPL-3.0. You bring your own AI provider keys.
+- [Discord](https://discord.gg/YKwjt5vuKr) · [Slack](https://dub.sh/browserOS-slack)
+- [Report a bug](https://github.com/browseros-ai/BrowserOS/issues)
+- [BrowserClaw docs](https://docs.browseros.com/browserclaw) · [BrowserOS docs](https://docs.browseros.com)
 
 ## Architecture
 
-Both products ship from this monorepo, which has two main subsystems: the **browser** (Chromium fork) and the **agent platform** (TypeScript/Go).
+Both products ship from this monorepo. Two main subsystems: the **browser** (Chromium fork) and the **agent platform** (TypeScript/Go).
 
 ```
 BrowserOS/
@@ -242,7 +237,7 @@ BrowserOS/
 │
 ├── packages/browseros-agent/        # Agent platform (TypeScript/Go)
 │   ├── apps/
-│   │   ├── claw-server/             # BrowserClaw backend — MCP endpoint + JSON API (Hono)
+│   │   ├── claw-server/             # BrowserClaw backend: MCP endpoint + JSON API (Hono)
 │   │   ├── claw-app/                # BrowserClaw dashboard extension (WXT + React)
 │   │   ├── claw-onboard/            # BrowserClaw onboarding flow
 │   │   ├── server/                  # BrowserOS MCP server + AI agent loop (Bun)
@@ -257,36 +252,30 @@ BrowserOS/
 
 | Package | What it does |
 |---------|-------------|
-| [`packages/browseros`](packages/browseros/) | Chromium fork — patches, build system, signing |
-| [`apps/claw-server`](packages/browseros-agent/apps/claw-server/) | BrowserClaw backend — the MCP endpoint agents connect to, plus the API behind the dashboard |
-| [`apps/claw-app`](packages/browseros-agent/apps/claw-app/) | BrowserClaw new-tab dashboard — watch, replay, and manage agent sessions |
+| [`packages/browseros`](packages/browseros/) | Chromium fork: patches, build system, signing |
+| [`apps/claw-server`](packages/browseros-agent/apps/claw-server/) | BrowserClaw backend: MCP endpoint agents connect to, plus the API behind the dashboard |
+| [`apps/claw-app`](packages/browseros-agent/apps/claw-app/) | BrowserClaw new-tab dashboard: watch, replay, and manage agent sessions |
 | [`apps/server`](packages/browseros-agent/apps/server/) | Bun server exposing 53+ MCP tools and running the BrowserOS AI agent loop |
-| [`apps/app`](packages/browseros-agent/apps/app/) | BrowserOS extension — new tab, side panel chat, onboarding, settings |
-| [`apps/cli`](packages/browseros-agent/apps/cli/) | Go CLI — control BrowserOS from the terminal or AI coding agents |
+| [`apps/app`](packages/browseros-agent/apps/app/) | BrowserOS extension: new tab, side panel chat, onboarding, settings |
+| [`apps/cli`](packages/browseros-agent/apps/cli/) | Go CLI: control BrowserOS from the terminal or AI coding agents |
 | [`agent-sdk`](packages/browseros-agent/packages/agent-sdk/) | Node.js SDK for browser automation with natural language |
 | [`cdp-protocol`](packages/browseros-agent/packages/cdp-protocol/) | Type-safe Chrome DevTools Protocol bindings |
 
 ## Contributing
 
-We'd love your help making BrowserOS and BrowserClaw better! See our [Contributing Guide](CONTRIBUTING.md) for details.
+We'd love your help making BrowserOS and BrowserClaw better. See the [Contributing Guide](CONTRIBUTING.md) for details.
 
-- [Report bugs](https://github.com/browseros-ai/BrowserOS/issues)
-- [Suggest features](https://github.com/browseros-ai/BrowserOS/issues/99)
-- [Join Discord](https://discord.gg/YKwjt5vuKr) · [Join Slack](https://dub.sh/browserOS-slack)
-- [Follow on Twitter](https://x.com/browserOS_ai)
-
-**Agent development** (TypeScript/Go) — see the [agent monorepo README](packages/browseros-agent/README.md) for setup instructions.
-
-**Browser development** (C++/Python) — requires ~100GB disk space. See [`packages/browseros`](packages/browseros/) for build instructions.
+- **Agent development** (TypeScript/Go): see the [agent monorepo README](packages/browseros-agent/README.md) for setup.
+- **Browser development** (C++/Python): requires ~100GB disk space. See [`packages/browseros`](packages/browseros/) for build instructions.
 
 ## Credits
 
-- [ungoogled-chromium](https://github.com/ungoogled-software/ungoogled-chromium) — we use some of its patches for enhanced privacy. Thanks to everyone behind this project!
-- [The Chromium Project](https://www.chromium.org/) — at the core of both browsers, making it possible for them to exist in the first place.
+- [ungoogled-chromium](https://github.com/ungoogled-software/ungoogled-chromium): we use some of its patches for enhanced privacy. Thanks to everyone behind this project.
+- [The Chromium Project](https://www.chromium.org/): at the core of both browsers, making it possible for them to exist in the first place.
 
 ## Citation
 
-If you use BrowserOS in your research or project, please cite:
+If you use BrowserOS or BrowserClaw in your research or project, please cite:
 
 ```bibtex
 @software{browseros2025,
@@ -307,11 +296,9 @@ Copyright &copy; 2026 Felafax, Inc.
 
 ## Stargazers
 
-Thank you to all our supporters!
+Thank you to all our supporters.
 
-<!-- [![Star History Chart](https://api.star-history.com/svg?repos=browseros-ai/BrowserOS&type=Date)](https://www.star-history.com/#browseros-ai/BrowserOS&Date) -->
-
-Team — Nikhil ([@nv_sonti](https://x.com/intent/user?screen_name=nv_sonti)), Nithin ([@ThatNithin](https://x.com/intent/user?screen_name=ThatNithin)) and Dani ([@dani_akash_](https://x.com/intent/user?screen_name=dani_akash_)):
+Team: Nikhil ([@nv_sonti](https://x.com/intent/user?screen_name=nv_sonti)), Nithin ([@ThatNithin](https://x.com/intent/user?screen_name=ThatNithin)) and Dani ([@dani_akash_](https://x.com/intent/user?screen_name=dani_akash_)):
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/nv_sonti?style=social)](https://x.com/intent/user?screen_name=nv_sonti)
 &emsp;&emsp;&emsp;

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Bring your own keys, use OAuth for your existing subscriptions, or run models lo
 
 | Provider | Type | Auth |
 |---|---|---|
-| Kimi K2.5 (default) | Cloud | Built-in |
+| Kimi (default) | Cloud | Built-in |
 | Claude (Anthropic) | Cloud | API key |
 | GPT-4o / o3 (OpenAI) | Cloud | API key |
 | ChatGPT Pro/Plus | Cloud | OAuth |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 <tr>
 <td width="50%" align="center" valign="top">
 
+<img src="packages/browseros/resources/browserclaw/icons/product_logo_192.png" alt="BrowserClaw logo" width="96" height="96" />
+
 ### BrowserClaw
 
 **The browser for AI agents**
@@ -27,6 +29,8 @@ Claude Code, Codex, Cursor, or any MCP client drives it using the accounts you'r
 
 </td>
 <td width="50%" align="center" valign="top">
+
+<img src="packages/browseros/resources/browseros/icons/product_logo_192.png" alt="BrowserOS logo" width="96" height="96" />
 
 ### BrowserOS
 

--- a/README.md
+++ b/README.md
@@ -174,21 +174,26 @@ Bring your own keys, use OAuth for your existing subscriptions, or run models lo
 
 Full list of 11+ providers (Gemini, GitHub Copilot, Azure, Bedrock, OpenRouter, and more) is in the [bring-your-own-LLM docs](https://docs.browseros.com/features/bring-your-own-llm).
 
-## How they compare
+## How BrowserOS compares
 
-Both products next to what people usually ask about:
+| | BrowserOS | Chrome | Brave | Dia | Comet | Atlas |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Open Source | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| AI Agent | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| MCP Server | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Cowork (files + browser) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Scheduled Tasks | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Bring Your Own Keys | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Local Models (Ollama) | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Local-first Privacy | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Ad Blocking (MV2) | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
 
-| | BrowserClaw | BrowserOS | Chrome | Playwright / browser-use | Comet / Atlas / Dia |
-|---|:---:|:---:|:---:|:---:|:---:|
-| Open source | ✅ | ✅ | ❌ | ✅ | ❌ |
-| Real browser with your logins | ✅ | ✅ | ✅ | ❌ | Cloud VM |
-| Built-in AI agent | Via MCP | ✅ | ❌ | ❌ | ✅ |
-| Bring your own AI keys | ✅ | ✅ | ❌ | ✅ | ❌ |
-| Local models (Ollama, LM Studio) | Via MCP | ✅ | ❌ | ✅ | ❌ |
-| Everything stays on your machine | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Session replay (video-style) | ✅ | ❌ | ❌ | Traces | ❌ |
-| Scheduled agent tasks | ❌ | ✅ | ❌ | ❌ | ❌ |
-| Ad blocking with Manifest V2 | ✅ | ✅ | ❌ | N/A | Partial |
+**Detailed comparisons:**
+- [BrowserOS vs Chrome DevTools MCP](https://docs.browseros.com/comparisons/chrome-devtools-mcp): developer-focused comparison for browser automation
+- [BrowserOS vs Claude Cowork](https://docs.browseros.com/comparisons/claude-cowork): getting real work done with AI
+- [BrowserOS vs OpenClaw](https://docs.browseros.com/comparisons/openclaw): everyday AI assistance
+
+A dedicated BrowserClaw comparison table is coming; for now, see the [why BrowserClaw](#browserclaw) callouts above.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -124,33 +124,44 @@ Every AI browser today asks you to sign into their cloud and hand over your data
 <table>
 <tr>
 <td width="40%" valign="middle">
-<h4>Built-in AI agent</h4>
+<h4>BrowserOS agent in action</h4>
 Ask it in plain English. 53+ browser tools plus 40+ app integrations (Gmail, Slack, GitHub, Linear, Notion, and more). <a href="https://docs.browseros.com/getting-started">Docs</a>
 </td>
 <td width="60%">
-<img src="docs/videos/browserOS-agent-in-action.gif" alt="BrowserOS agent completing a browser task with natural language" width="100%" />
+<a href="https://www.youtube.com/watch?v=SoSFev5R5dI"><img src="docs/videos/browserOS-agent-in-action.gif" alt="BrowserOS agent completing a browser task with natural language" width="100%" /></a>
 </td>
 </tr>
 <tr>
 <td width="40%" valign="middle">
-<h4>Cowork with files</h4>
-Combine browser automation with local file operations in one session. Research the web, save reports to your folder, read and edit files, run shell commands. <a href="https://docs.browseros.com/features/cowork">Docs</a>
+<h4>Install as MCP and control from claude-code</h4>
+Turn BrowserOS into an MCP server and drive it from Claude Code, Cursor, or any MCP client. <a href="https://docs.browseros.com/features/use-with-claude-code">Docs</a>
 </td>
 <td width="60%">
-<a href="https://docs.browseros.com/features/cowork"><img src="https://img.shields.io/badge/Watch-Cowork%20demo-4c71f2?style=for-the-badge" alt="Watch Cowork demo" /></a>
+<video src="https://github.com/user-attachments/assets/c725d6df-1a0d-40eb-a125-ea009bf664dc" controls width="100%"></video>
 </td>
 </tr>
 <tr>
 <td width="40%" valign="middle">
-<h4>Scheduled tasks</h4>
-Run agents on autopilot: daily, hourly, or every few minutes. Wake up to a fresh report or a queue processed overnight. <a href="https://docs.browseros.com/features/scheduled-tasks">Docs</a>
+<h4>Use BrowserOS to chat</h4>
+Chat about the current page from the side panel. Summarise, ask questions, transform what you're reading. <a href="https://docs.browseros.com/getting-started">Docs</a>
 </td>
 <td width="60%">
-<a href="https://www.youtube.com/watch?v=SoSFev5R5dI"><img src="https://img.shields.io/badge/Watch-Scheduled%20tasks-4c71f2?style=for-the-badge" alt="Watch scheduled tasks demo" /></a>
+<video src="https://github.com/user-attachments/assets/726803c5-8e36-420e-8694-c63a2607beca" controls width="100%"></video>
+</td>
+</tr>
+<tr>
+<td width="40%" valign="middle">
+<h4>Use BrowserOS to scrape data</h4>
+Point the agent at a page, tell it what to pull, and get structured data back. <a href="https://docs.browseros.com/getting-started">Docs</a>
+</td>
+<td width="60%">
+<video src="https://github.com/user-attachments/assets/9f038216-bc24-4555-abf1-af2adcb7ebc0" controls width="100%"></video>
 </td>
 </tr>
 </table>
 
+- **Cowork with files.** Combine browser automation with local file operations in one session. [Docs](https://docs.browseros.com/features/cowork)
+- **Scheduled tasks.** Run agents on autopilot: daily, hourly, or every few minutes. [Docs](https://docs.browseros.com/features/scheduled-tasks)
 - **Bring your own AI.** 11+ providers, or fully local with Ollama and LM Studio. [Provider list](https://docs.browseros.com/features/bring-your-own-llm)
 - **Real ad blocking.** uBlock Origin with full Manifest V2 support. [Docs](https://docs.browseros.com/features/ad-blocking)
 


### PR DESCRIPTION
## Why

The current README predates BrowserClaw. BrowserClaw got bolted on as a small intro at the top, but the rest of the body is still 100% BrowserOS. Counting lines in `main`:

- BrowserClaw intro + features + shared FAQ slice: ~50 lines
- BrowserOS intro + features + LLM providers + comparison + FAQ slice: ~180 lines
- Shared (hero, arch, contributing, credits): ~90 lines

A reader who arrives from `browseros.com/agents` sees a repo that mostly talks about a different product. This PR fixes that without doubling the file.

## What changed

**Both product sections now share the same shape and length (~53 lines each).**

Every subsection appears in both, in the same order:

- `What is X?` definition block (40-60 words, extractable for AI answers)
- Emotional hook (one line)
- Quick start (3 numbered steps)
- Key features (3-item bento table + 2 bullet callouts)
- Why X over the alternatives (2 short comparison paragraphs)
- Docs link cluster

**Shared surface trimmed to keep the file at ~310 lines:**

- LLM providers table collapsed from 11 rows to a 6-row shortlist + docs link for the rest.
- Comparison table rebuilt with BOTH products as columns vs Chrome / Playwright / Comet-Atlas-Dia. Rows are capability-axis, not product-axis, so the two products sit side by side.
- FAQ regrouped as `General (2) / BrowserClaw (3) / BrowserOS (3)`. Was mixed and BrowserOS-heavy.
- Two of the four BrowserOS demo videos moved to docs (still linked); one BrowserClaw image swap so both products have visual parity.
- Added a small trust strip under the hero card: `Free · Open source (AGPL-3.0) · Local-only · Bring your own AI keys`.
- Added a `Get help` section (Discord / Slack / issues) that neither product had a direct pointer to before.

**Fact grounding.** Every feature claim traces to shipped code:

- BrowserClaw MCP endpoint / local-only: `apps/claw-server/src/mcp/*`, `apps/claw-server/src/main.ts`
- Replay directory `~/.browserclaw/`: `apps/claw-server/src/services/replay-storage.ts`, `packages/shared/src/constants/paths.ts`
- BrowserOS agent tools (53+): `apps/server/src/mcp/*`
- Cowork (filesystem toolset) + scheduled tasks: `apps/server/src/agent/prompt.ts`
- 40+ app integrations via Klavis: agent prompt module
- 11+ LLM providers: existing docs pages

**Voice pass:**

- Zero em-dashes.
- No filler (`seamless`, `robust`, `industry-leading`, `cutting-edge`, `utilize`, `leverage`).
- Second person, active, sentence case.
- No unverifiable claims (Kimi version dropped when I couldn't confirm it from source).

## Length

| Block | Before | After |
|---|---|---|
| Total | ~324 | 311 |
| BrowserClaw section | ~50 | 53 |
| BrowserOS section | ~180 | 53 |

Same overall length, radically more balanced.

## Test plan

- [ ] Preview rendered README on GitHub after PR opens; confirm both product sections read equal.
- [ ] Confirm all doc links resolve (`docs.browseros.com/browserclaw/*`, `docs.browseros.com/features/*`).
- [ ] Confirm images and video assets exist at referenced paths.
- [ ] Skim for regressions in Architecture / Contributing / Credits / Citation / License / Team (unchanged, but verify).