### PR TITLE
fix(bos-build): download all arch server bundles for universal builds

### DIFF
--- a/packages/browseros/bos_build/cli/build.py
+++ b/packages/browseros/bos_build/cli/build.py
@@ -613,6 +613,7 @@ def _resolve_preset(
                         Context(
                             chromium_src=src,
                             architecture=run_arch,
+                            plan_architectures=tuple(switches.architectures),
                             build_type=switches.build_type,
                             product=switches.product,
                             extra_gn_args=extra_gn_args,

--- a/packages/browseros/bos_build/core/context.py
+++ b/packages/browseros/bos_build/core/context.py
@@ -65,6 +65,11 @@ class Context:
     chromium_src: Path = Path()
     out_dir: str = "out/Default"
     architecture: str = ""  # Defaults to host arch in __post_init__
+    # Full architecture set of the overall build invocation. A universal
+    # invocation expands into per-arch run Contexts whose own `architecture`
+    # is "arm64"/"x64"; this preserves the invocation's intent so the prep
+    # run still fetches every arch's resources. Empty = single-arch/unknown.
+    plan_architectures: tuple = ()
     build_type: str = "debug"
     chromium_version: str = ""
     browseros_build_offset: str = ""

--- a/packages/browseros/bos_build/core/resolver.py
+++ b/packages/browseros/bos_build/core/resolver.py
@@ -85,6 +85,7 @@ def resolve_config(cli_args: Dict[str, Any]) -> List[Context]:
         Context(
             chromium_src=chromium_src,
             architecture=architecture,
+            plan_architectures=(architecture,),
             build_type=build_type,
             product=product,
             extra_gn_args=extra_gn_args,

--- a/packages/browseros/bos_build/steps/compile/universal.py
+++ b/packages/browseros/bos_build/steps/compile/universal.py
@@ -9,17 +9,68 @@ ctx(universal).get_app_path() resolves; sign/package/upload then treat
 it like any other build.
 """
 
+import json
 from pathlib import Path
+from typing import Optional
 
 from ...core.context import Context
 from ...core.step import Step, ValidationError, step
 from ..package.merge import merge_architectures
+from ..storage.download import ARTIFACT_METADATA_NAME
 
 UNIVERSAL_ARCHITECTURES = ("arm64", "x64")
 
 
 def _universalizer_script(ctx: Context) -> Path:
     return ctx.root_dir / "bos_build/steps/package/universalizer_patched.py"
+
+
+def _read_artifact_metadata(path: Path) -> Optional[dict]:
+    """Parse an artifact-metadata.json, or None if absent/unreadable."""
+    try:
+        data = json.loads(path.read_bytes())
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _assert_server_bundles_aligned(binaries_dir: Path) -> None:
+    """Fail if a family's darwin-arm64/-x64 bundles disagree on version.
+
+    The universal merge folds both arch server bundles into one app. A
+    skewed pair (fresh arm64 vs stale x64) either trips the universalizer
+    on differing non-Mach-O files or, for all-Mach-O bundles, silently
+    ships mismatched server versions (BrowserClaw 0.47.11). A correct
+    universal build re-downloads both dirs, so this only fires on stale
+    state left by a --from resume or --no-download flow. Families missing
+    either metadata file are skipped (older layouts, non-artifact dirs).
+    """
+    if not binaries_dir.is_dir():
+        return
+    for family_dir in sorted(binaries_dir.iterdir()):
+        if not family_dir.is_dir():
+            continue
+        arm_meta = _read_artifact_metadata(
+            family_dir / "darwin-arm64" / ARTIFACT_METADATA_NAME
+        )
+        x64_meta = _read_artifact_metadata(
+            family_dir / "darwin-x64" / ARTIFACT_METADATA_NAME
+        )
+        if arm_meta is None or x64_meta is None:
+            continue
+        arm_version = arm_meta.get("version")
+        x64_version = x64_meta.get("version")
+        if arm_version == x64_version:
+            continue
+        raise ValidationError(
+            f"Skewed '{family_dir.name}' server bundle: "
+            f"darwin-arm64 version {arm_version!r} "
+            f"(generated {arm_meta.get('generatedAt', 'unknown')}) "
+            f"!= darwin-x64 version {x64_version!r} "
+            f"(generated {x64_meta.get('generatedAt', 'unknown')}). "
+            "Re-run with resource downloads enabled so both arch bundles "
+            "refresh from R2."
+        )
 
 
 def _arch_app_path(ctx: Context, arch: str) -> Path:
@@ -55,6 +106,7 @@ class MergeUniversalModule(Step):
             app = _arch_app_path(ctx, arch)
             if not app.exists():
                 raise ValidationError(f"{arch} app not found (build it first): {app}")
+        _assert_server_bundles_aligned(ctx.root_dir / "resources" / "binaries")
 
     def execute(self, ctx: Context) -> None:
         arm64_app, x64_app = (

--- a/packages/browseros/bos_build/steps/compile/universal_test.py
+++ b/packages/browseros/bos_build/steps/compile/universal_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for the merge_universal step."""
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -104,6 +105,70 @@ class PreflightTest(MergeUniversalTestBase):
         ):
             with self.assertRaisesRegex(ValidationError, "not found"):
                 MergeUniversalModule().preflight(self.ctx)
+
+
+class ServerBundleSkewTest(unittest.TestCase):
+    """The merge-time guard against version-skewed per-arch server bundles."""
+
+    def _write_bundle(
+        self,
+        family_dir: Path,
+        arch_dir: str,
+        version: str,
+        generated_at: str = "2026-01-01T00:00:00.000Z",
+    ) -> None:
+        arch_path = family_dir / arch_dir
+        arch_path.mkdir(parents=True)
+        (arch_path / "artifact-metadata.json").write_text(
+            json.dumps(
+                {"version": version, "generatedAt": generated_at, "files": []}
+            )
+        )
+
+    def test_matching_versions_pass(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            binaries = Path(tmp)
+            family = binaries / "browseros_server"
+            self._write_bundle(family, "darwin-arm64", "0.0.10")
+            self._write_bundle(family, "darwin-x64", "0.0.10")
+
+            universal._assert_server_bundles_aligned(binaries)  # no raise
+
+    def test_mismatched_versions_raise_with_both_versions_and_timestamps(self):
+        # Mirrors the BrowserClaw 0.47.11 skew: fresh arm64 vs stale x64.
+        with tempfile.TemporaryDirectory() as tmp:
+            binaries = Path(tmp)
+            family = binaries / "browseros_claw_server"
+            self._write_bundle(
+                family, "darwin-arm64", "0.0.10", "2026-07-14T00:00:00.000Z"
+            )
+            self._write_bundle(
+                family, "darwin-x64", "0.0.3", "2026-06-30T00:00:00.000Z"
+            )
+
+            with self.assertRaises(ValidationError) as caught:
+                universal._assert_server_bundles_aligned(binaries)
+
+            message = str(caught.exception)
+            self.assertIn("browseros_claw_server", message)
+            self.assertIn("0.0.10", message)
+            self.assertIn("0.0.3", message)
+            self.assertIn("2026-07-14T00:00:00.000Z", message)
+            self.assertIn("2026-06-30T00:00:00.000Z", message)
+
+    def test_absent_x64_metadata_skips_family(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            binaries = Path(tmp)
+            family = binaries / "browseros_server"
+            self._write_bundle(family, "darwin-arm64", "0.0.10")
+            # x64 dir exists but carries no metadata (partial/older layout).
+            (family / "darwin-x64").mkdir(parents=True)
+
+            universal._assert_server_bundles_aligned(binaries)  # no raise
+
+    def test_missing_binaries_dir_is_noop(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            universal._assert_server_bundles_aligned(Path(tmp) / "absent")  # no raise
 
 
 class RegistrationTest(unittest.TestCase):

--- a/packages/browseros/bos_build/steps/storage/download.py
+++ b/packages/browseros/bos_build/steps/storage/download.py
@@ -305,9 +305,14 @@ class DownloadResourcesModule(Step):
         current_arch = context.architecture
         current_build_type = context.build_type
 
-        # For universal builds, we need both arm64 and x64
+        # For universal builds we need every macOS arch. A universal
+        # invocation expands into per-arch runs (arm64 prep, then x64, then
+        # merge), so the prep run executes with architecture="arm64" while
+        # carrying plan_architectures=("universal",) — expand here too, or
+        # the x64 server bundle is never refreshed and the merge folds a
+        # stale sibling arch into the app (release 29377078861).
         target_archs = [current_arch]
-        if current_arch == "universal":
+        if current_arch == "universal" or "universal" in context.plan_architectures:
             target_archs = ["arm64", "x64", "universal"]
 
         filtered = []

--- a/packages/browseros/bos_build/steps/storage/download_test.py
+++ b/packages/browseros/bos_build/steps/storage/download_test.py
@@ -310,6 +310,38 @@ class DownloadResourceConfigTest(unittest.TestCase):
             [op["name"] for op in filtered],
         )
 
+    def test_universal_plan_expands_arm64_prep_run_to_both_arches(self) -> None:
+        # A universal invocation expands into per-arch runs; the arm64 prep
+        # run executes with architecture="arm64" but carries
+        # plan_architectures=("universal",), so it must still download the
+        # x64 server bundles the merge folds in (release 29377078861).
+        operations = self._real_download_operations()
+
+        filtered = self._filter_operations(
+            operations, "macos", "arm64", plan_architectures=("universal",)
+        )
+        names = [op["name"] for op in filtered]
+
+        self.assertIn("BrowserOS Server Resources - macOS ARM64", names)
+        self.assertIn("BrowserOS Server Resources - macOS x64", names)
+        self.assertIn("BrowserOS Claw Server Resources - macOS ARM64", names)
+        self.assertIn("BrowserOS Claw Server Resources - macOS x64", names)
+
+    def test_flat_multi_arch_plan_stays_arch_scoped(self) -> None:
+        # Flat multi-arch (arm64, x64 without universal) plans a full
+        # per-arch run each with its own download step, so a single run must
+        # stay arch-scoped and NOT pull the sibling arch.
+        operations = self._real_download_operations()
+
+        filtered = self._filter_operations(
+            operations, "macos", "arm64", plan_architectures=("arm64", "x64")
+        )
+        names = [op["name"] for op in filtered]
+
+        self.assertIn("BrowserOS Server Resources - macOS ARM64", names)
+        self.assertNotIn("BrowserOS Server Resources - macOS x64", names)
+        self.assertNotIn("BrowserOS Claw Server Resources - macOS x64", names)
+
     def test_real_config_includes_claw_onboard_resources_everywhere(self) -> None:
         # The onboarding dist is platform-independent and its grit pak is
         # built for every product, so the operation must carry no gates.
@@ -426,11 +458,13 @@ class DownloadResourceConfigTest(unittest.TestCase):
         platform: str,
         architecture: str,
         product: str = "browseros",
+        plan_architectures: tuple = (),
     ) -> list[dict]:
         ctx = cast(
             Context,
             SimpleNamespace(
                 architecture=architecture,
+                plan_architectures=plan_architectures,
                 build_type="release",
                 product=get_product_descriptor(product),
             ),


### PR DESCRIPTION
## Summary

Universal macOS builds baked a **stale sibling-arch server bundle** into the app. This failed release run **29377078861** (BrowserOS 0.47.15 universal) and silently shipped a version-skewed claw server in **BrowserClaw 0.47.11 universal**.

`--arch universal` expands into three sequential `bos_build` runs (`planner._plan_universal_runs`):

1. **Run 1 (arm64)** — prep (incl. `download_resources`) + arch tail. `DownloadResourcesModule._filter_operations` filtered ops by `context.architecture`, which is `"arm64"` here, so **only arm64 bundles refreshed**. `resources/binaries/browseros_server/darwin-x64` was never touched.
2. **Run 2 (x64)** — arch tail only, **no download step**. It copied a **June-19-stale** `darwin-x64` dir into the x64 app.
3. **Run 3 (universal)** — `merge_universal` → `universalizer_patched.py` raised `CantMergeException: non-Mach-O files differ` on `Contents/Resources/BrowserOSServer/default/resources/db/migrations/meta/_journal.json` (fresh arm64 server bundle vs stale x64).

**Live evidence (self-hosted runner, same machine):**
- `resources/binaries/browseros_server/darwin-arm64` — mtime **Jul 14** (fresh)
- `resources/binaries/browseros_server/darwin-x64` — mtime **Jun 19** (stale, journal sha `e9e1337…`)
- Run 2's job log shows **no `download_resources` step**
- R2 `latest/` zips are consistent — this is purely local staleness from arch-scoped download filtering in a universal plan

**Silent variant (no tripwire):** `browseros_claw_server/darwin-x64` was also stale — artifact-metadata version `0.0.1` (2026-06-30) vs `darwin-arm64` `0.0.10` (fresh). Claw bundles are **all Mach-O**, so `lipo` happily folds a fresh arm64 server with a month-old x64 server and the universalizer never complains — that skew already shipped in BrowserClaw 0.47.11 universal.

The download step *already had* the universal expansion branch (`if current_arch == "universal": target_archs = [...]`) — it just never fired, because no run in a universal plan executes with `context.architecture == "universal"` during prep.

## The fix (three parts)

1. **`Context.plan_architectures`** — a new field recording the full arch set of the overall invocation (empty = single-arch/unknown). Stamped by `cli/build.py` (preset path, `tuple(switches.architectures)`) and `core/resolver.py` (direct/modules path, `(architecture,)`).
2. **Download filter expansion** — `_filter_operations` now expands `target_archs` to arm64+x64+universal when `current_arch == "universal"` **or** `"universal" in context.plan_architectures`, so run 1's prep refreshes every arch's bundle. Flat multi-arch (`arm64,x64` without universal) stays arch-scoped — each arch plans its own full run with its own download step.
3. **Merge-time skew guard** — `merge_universal.validate()` compares `darwin-arm64` vs `darwin-x64` `artifact-metadata.json` `version` fields per family under `resources/binaries/` before merging. On mismatch it fails with the family, both versions, both `generatedAt` timestamps, and the remedy. This is belt-and-suspenders for `--from` resume / `--no-download` flows where downloads don't re-run (the silent claw case). Missing metadata/dirs → skip silently (older layouts, non-artifact families like `browseros_claw_onboard`).

`universalizer_patched.py` is left **untouched** — its strict non-Mach-O check is the net that surfaced the original failure.

## Test plan

- [x] `bos_build/steps/storage/download_test.py` — new tests: a universal-plan arm64 prep context (`plan_architectures=("universal",)`) includes both arch server bundles; a flat multi-arch context (`("arm64","x64")`) stays arch-scoped (no sibling x64).
- [x] `bos_build/steps/compile/universal_test.py` — new `ServerBundleSkewTest`: matching versions pass, mismatched versions raise with both versions + timestamps, absent metadata skips, missing dir is a no-op.
- [x] Full suite green: `uv run python -m unittest discover -s bos_build -t . -p "*_test.py"` → **710 passed**; `uv run ruff check bos_build` → clean; CLI smoke (`build --list`, `--show-plan`, `product doctor`) all pass.
- [x] End-to-end wiring verified with a real `Context`: the arm64 prep run of a `--arch universal` plan resolves x64 server ops.

## Review notes

A high-effort adversarial review surfaced three PLAUSIBLE (none confirmed) findings, each consciously kept as-is:

- **Missing-metadata skips a family** — intentional per design ("missing metadata → skip"); the real staleness case (a complete but *old* bundle) retains its metadata and *is* caught. The flagged trigger (interrupted extraction leaving files without metadata) is partial-corruption, not version skew, and the universalizer tripwire still covers non-Mach-O families.
- **Mid-build R2 `latest` republish aborts the merge** — this is the guard working as intended: genuinely different arch versions must not ship in one app; the abort is self-healing (re-run re-downloads both) and strictly better than silently shipping skew.
- **Prefer per-arch `download_resources` over `plan_architectures`** — the explicitly rejected alternative; adding a download step to run 2/3 duplicates ~400MB and changes `--from` resume semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
