### PR TITLE
fix(audit): group Agent filter by slug, not per-connection agentId

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
@@ -19,11 +19,11 @@ interface FilterBarProps {
   agentOptions: AgentChip[]
   statusOptions: { status: TaskStatus; count: number }[]
   siteOptions: { site: string; count: number }[]
-  selectedAgentId: string | null
+  selectedAgentSlug: string | null
   selectedStatus: TaskStatus | null
   selectedSite: string | null
   search: string
-  onAgentChange: (agentId: string | null) => void
+  onAgentChange: (slug: string | null) => void
   onStatusChange: (status: TaskStatus | null) => void
   onSiteChange: (site: string | null) => void
   onSearchChange: (q: string) => void
@@ -33,7 +33,7 @@ export function FilterBar({
   agentOptions,
   statusOptions,
   siteOptions,
-  selectedAgentId,
+  selectedAgentSlug,
   selectedStatus,
   selectedSite,
   search,
@@ -42,7 +42,7 @@ export function FilterBar({
   onSiteChange,
   onSearchChange,
 }: FilterBarProps) {
-  const selectedAgent = agentOptions.find((a) => a.agentId === selectedAgentId)
+  const selectedAgent = agentOptions.find((a) => a.slug === selectedAgentSlug)
   // Local search state so each keystroke updates the input
   // immediately, but the URL + refetch only fires after the operator
   // has paused typing. Without this every character triggered a
@@ -87,17 +87,17 @@ export function FilterBar({
         <DropdownMenuContent align="start" className="min-w-52">
           <DropdownMenuItem onClick={() => onAgentChange(null)}>
             <span className="flex-1">All</span>
-            {selectedAgentId === null && <Check className="size-3.5" />}
+            {selectedAgentSlug === null && <Check className="size-3.5" />}
           </DropdownMenuItem>
           {agentOptions.map((opt) => (
             <DropdownMenuItem
-              key={opt.agentId}
-              onClick={() => onAgentChange(opt.agentId)}
+              key={opt.slug}
+              onClick={() => onAgentChange(opt.slug)}
             >
               <AgentDot slug={opt.slug} className="mr-1.5" />
               <span className="flex-1">{opt.agentLabel}</span>
               <span className="ml-2 text-[11.5px] text-ink-3">{opt.count}</span>
-              {selectedAgentId === opt.agentId && (
+              {selectedAgentSlug === opt.slug && (
                 <Check className="ml-2 size-3.5" />
               )}
             </DropdownMenuItem>

--- a/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
@@ -95,6 +95,7 @@ export interface ListTasksResponse {
 
 export interface UseTasksVars {
   agentId?: string
+  slug?: string
   status?: TaskStatus
   site?: string
   search?: string
@@ -112,6 +113,7 @@ export const useTasks = createInfiniteQuery<
   fetcher: async (vars, { pageParam }) => {
     const query: Record<string, string> = {}
     if (vars?.agentId) query.agentId = vars.agentId
+    if (vars?.slug) query.slug = vars.slug
     if (vars?.status) query.status = vars.status
     if (vars?.site) query.site = vars.site
     if (vars?.search) query.search = vars.search

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
@@ -21,7 +21,7 @@ const baseData: AuditScreenData = {
   isFetchingNextPage: false,
   fetchNextPage: () => undefined,
   filters: {
-    agentId: null,
+    agentSlug: null,
     status: null,
     site: null,
     search: '',
@@ -107,7 +107,6 @@ describe('Audit screen', () => {
       tasks: [sampleTask],
       agentOptions: [
         {
-          agentId: 'claude-code',
           slug: 'claude-code',
           agentLabel: 'Claude Code',
           count: 1,
@@ -139,7 +138,7 @@ describe('Audit screen', () => {
       ...baseData,
       tasks: [],
       filters: {
-        agentId: null,
+        agentSlug: null,
         status: null,
         site: null,
         search: 'nothing-matches',
@@ -171,7 +170,7 @@ describe('Audit screen', () => {
       isLoading: true,
       tasks: [],
       filters: {
-        agentId: null,
+        agentSlug: null,
         status: 'live',
         site: null,
         search: '',

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
@@ -62,7 +62,7 @@ export function Audit() {
   const location = useLocation()
 
   const hasActiveFilters =
-    filters.agentId !== null ||
+    filters.agentSlug !== null ||
     filters.status !== null ||
     filters.site !== null ||
     filters.search.length > 0
@@ -118,7 +118,7 @@ export function Audit() {
           agentOptions={agentOptions}
           statusOptions={statusOptions}
           siteOptions={siteOptions}
-          selectedAgentId={filters.agentId}
+          selectedAgentSlug={filters.agentSlug}
           selectedStatus={filters.status}
           selectedSite={filters.site}
           search={filters.search}

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.data.ts
@@ -38,7 +38,7 @@ export interface AuditScreenData {
   isFetchingNextPage: boolean
   fetchNextPage: () => void
   filters: AuditFilters
-  setAgentFilter: (agentId: string | null) => void
+  setAgentFilter: (slug: string | null) => void
   setStatusFilter: (status: TaskStatus | null) => void
   setSiteFilter: (site: string | null) => void
   setSearch: (q: string) => void
@@ -72,7 +72,7 @@ export function useAuditScreenData(): AuditScreenData {
 
   const query = useTasks({
     variables: {
-      agentId: filters.agentId ?? undefined,
+      slug: filters.agentSlug ?? undefined,
       status: filters.status ?? undefined,
       site: filters.site ?? undefined,
       search: filters.search || undefined,
@@ -99,8 +99,8 @@ export function useAuditScreenData(): AuditScreenData {
   const autoFetchCount = useRef(0)
   const filterKey = useMemo(
     () =>
-      `${filters.agentId ?? ''}|${filters.status ?? ''}|${filters.site ?? ''}|${filters.search}`,
-    [filters.agentId, filters.status, filters.site, filters.search],
+      `${filters.agentSlug ?? ''}|${filters.status ?? ''}|${filters.site ?? ''}|${filters.search}`,
+    [filters.agentSlug, filters.status, filters.site, filters.search],
   )
   const prevFilterKey = useRef(filterKey)
   if (prevFilterKey.current !== filterKey) {
@@ -145,7 +145,7 @@ export function useAuditScreenData(): AuditScreenData {
       void query.fetchNextPage()
     },
     filters,
-    setAgentFilter: (agentId) => update({ agentId }),
+    setAgentFilter: (agentSlug) => update({ agentSlug }),
     setStatusFilter: (status) => update({ status }),
     setSiteFilter: (site) => update({ site }),
     setSearch: (search) => update({ search }),

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.helpers.ts
@@ -84,7 +84,6 @@ export function abbreviateSequence(seq: string[], cap = 5): string {
 }
 
 export interface AgentChip {
-  agentId: string
   slug: string
   agentLabel: string
   count: number
@@ -93,13 +92,12 @@ export interface AgentChip {
 export function agentChipsFor(tasks: TaskSummary[]): AgentChip[] {
   const map = new Map<string, AgentChip>()
   for (const t of tasks) {
-    const existing = map.get(t.agentId)
+    const existing = map.get(t.slug)
     if (existing) {
       existing.count += 1
       continue
     }
-    map.set(t.agentId, {
-      agentId: t.agentId,
+    map.set(t.slug, {
       slug: t.slug,
       agentLabel: t.agentLabel,
       count: 1,

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.search-params.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.search-params.ts
@@ -1,7 +1,7 @@
 import type { TaskStatus } from '@/modules/api/audit.hooks'
 
 export interface AuditFilters {
-  agentId: string | null
+  agentSlug: string | null
   status: TaskStatus | null
   site: string | null
   search: string
@@ -9,7 +9,7 @@ export interface AuditFilters {
 }
 
 export const DEFAULT_FILTERS: AuditFilters = {
-  agentId: null,
+  agentSlug: null,
   status: null,
   site: null,
   search: '',
@@ -38,7 +38,7 @@ export function paramsToFilters(params: URLSearchParams): AuditFilters {
     if (id) sort = { id, desc: dir !== 'asc' }
   }
   return {
-    agentId: params.get(KEYS.agent),
+    agentSlug: params.get(KEYS.agent),
     status,
     site: params.get(KEYS.site),
     search: params.get(KEYS.q) ?? '',
@@ -48,7 +48,7 @@ export function paramsToFilters(params: URLSearchParams): AuditFilters {
 
 export function filtersToParams(filters: AuditFilters): URLSearchParams {
   const params = new URLSearchParams()
-  if (filters.agentId) params.set(KEYS.agent, filters.agentId)
+  if (filters.agentSlug) params.set(KEYS.agent, filters.agentSlug)
   if (filters.status) params.set(KEYS.status, filters.status)
   if (filters.site) params.set(KEYS.site, filters.site)
   if (filters.search) params.set(KEYS.q, filters.search)

--- a/packages/browseros-agent/apps/claw-server/src/routes/audit/tasks.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/audit/tasks.ts
@@ -20,6 +20,7 @@ import { getTask, listTasks } from '../../services/tasks'
 
 const listQuerySchema = z.object({
   agentId: z.string().optional(),
+  slug: z.string().optional(),
   status: z.enum(['live', 'done', 'failed']).optional(),
   site: z.string().optional(),
   search: z.string().optional(),

--- a/packages/browseros-agent/apps/claw-server/src/services/tasks.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/tasks.ts
@@ -92,6 +92,7 @@ export interface TaskDetail extends TaskSummary {
 
 export interface ListTasksQuery {
   agentId?: string
+  slug?: string
   status?: TaskStatus
   site?: string
   search?: string
@@ -114,6 +115,7 @@ export function listTasks(query: ListTasksQuery): ListTasksResult {
 
   const wheres = []
   if (query.agentId) wheres.push(eq(toolDispatches.agentId, query.agentId))
+  if (query.slug) wheres.push(eq(toolDispatches.slug, query.slug))
   if (typeof query.cursor === 'number') {
     wheres.push(lt(toolDispatches.id, query.cursor))
   }


### PR DESCRIPTION
## What was broken

On the audit page, the **Agent** filter dropdown lists each MCP connection as its own entry:

- \`codex-mcp-client\` shows up 15+ times, each with count \`1\`
- \`browserclaw-claude-desktop-wrapper\` shows up 3+ times, each with count \`1\`
- \`claude-code\` shows once

Every reconnection of the same client creates a fresh row instead of incrementing a single \"codex-mcp-client (N)\" entry.

## Root cause

\`agentChipsFor\` in \`packages/browseros-agent/apps/claw-app/screens/audit/audit.helpers.ts\` dedupes tasks by \`t.agentId\`. But \`agentId\` is minted per MCP session/connection; the field that identifies the agent kind is \`slug\`. So the map's keys were effectively unique per session, and the \"Agent\" filter turned into a session list.

## The fix

Group by \`slug\` everywhere in the audit filter path.

**Client**
- \`AgentChip\` drops \`agentId\`, keyed by \`slug\`
- \`agentChipsFor\` maps by \`t.slug\`
- \`AuditFilters.agentId\` -> \`AuditFilters.agentSlug\` (URL search-param key stays \`agent\` for shareable-link compatibility; only the stored value semantics changed)
- \`FilterBar\` prop rename: \`selectedAgentId\` -> \`selectedAgentSlug\`
- \`useTasks\` gains a \`slug?: string\` variable that maps to a \`slug\` query param
- Test fixtures updated to the new field names

**Server**
- \`GET /audit/tasks\` accepts an optional \`slug\` query param
- \`listTasks\` predicates \`eq(toolDispatches.slug, query.slug)\` when provided
- Existing \`agentId\` filter kept (2 lines added, nothing removed)

## Deliberately not touched

- Cockpit's live-agent grid (\`RunningGrid.tsx\`, \`cockpit.helpers.ts\`) still uses \`agentId\`. That's correct there: focus / cancel actions target a specific live session, not an agent type.

## Backwards compat

Old \`?agent=<oldAgentId>\` bookmarks will silently show no results (an agentId won't match any slug). Acceptable because the field was buggy: those bookmarks were already showing a single random session's worth of data mislabelled as the entire agent's history.

## Test plan

- [x] \`bun run typecheck\` (claw-app): pass
- [x] \`bun run typecheck\` (claw-server): pass
- [x] \`bun test screens/audit\`: 9/9 pass
- [x] biome check on changed files: 3 pre-existing warnings on untouched lines in \`services/tasks.ts\`; no new warnings
- [ ] Manual verification: open /audit, open Agent dropdown, confirm each agent type appears exactly once with a correct total count; picking one filters the list to that agent kind