### PR TITLE
feat(claw-app): swap Scenes 2/3/6 (InstallMcp, Pan, Loop) to real CockpitOnboarding

### DIFF
--- a/packages/browseros-agent/apps/claw-app/onboarding-video/src/scenes/SceneInstallMcp.tsx
+++ b/packages/browseros-agent/apps/claw-app/onboarding-video/src/scenes/SceneInstallMcp.tsx
@@ -3,20 +3,22 @@
  * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Scene 02: the MCP install beat. Camera stays on the cockpit; the
- * sidebar's `MCP` nav item lights up (via `CockpitFrame`'s
- * `highlightNav="MCP"` prop, which positions the highlight box
- * inside the sidebar's own flex layout so it cannot drift), a
- * floating endpoint card pops in with the local endpoint URL and
- * a Connect action, then flips to a "connected" green check.
- * Establishes the FIRST action the reader must take before their
- * agent can do anything: install BrowserClaw as an MCP.
+ * Scene 02: the MCP install beat. Renders the real
+ * `<CockpitOnboarding state="first-run" />` inside the browser
+ * shell; the natural "Set up MCP endpoint" primary CTA already
+ * carries the "install the MCP" message. A caption above the
+ * shell names the beat.
+ *
+ * Animation: subtle scale settle + opacity fade at the wrapper.
+ * The pulsing primary CTA is styled via the app's design tokens,
+ * not a CSS keyframe, so it renders as a static Signal-blue
+ * button — visually distinct enough without extra motion.
  */
 
 import { AbsoluteFill, Easing, interpolate, useCurrentFrame } from 'remotion'
-import { BROWSER_CHROME_HEIGHT, CockpitFrame } from '../components/CockpitFrame'
+import { CockpitOnboarding } from '@/components/cockpit/CockpitOnboarding'
+import { BrowserShell } from '../components/BrowserShell'
 import { SceneLabel } from '../components/SceneLabel'
-import { fonts } from '../fonts'
 import { palette } from '../palette'
 
 const EASE_OUT = Easing.bezier(0.16, 1, 0.3, 1)
@@ -27,24 +29,14 @@ export function SceneInstallMcp() {
     extrapolateRight: 'clamp',
     easing: EASE_OUT,
   })
-  const highlightIn = interpolate(frame, [10, 30], [0, 1], {
+  const shellScale = interpolate(frame, [0, 30], [0.99, 1], {
     extrapolateRight: 'clamp',
     easing: EASE_OUT,
   })
-  const cardIn = interpolate(frame, [25, 55], [0, 1], {
+  const shellOpacity = interpolate(frame, [0, 20], [0.4, 1], {
     extrapolateRight: 'clamp',
     easing: EASE_OUT,
   })
-  const cardSlide = interpolate(frame, [25, 55], [-24, 0], {
-    extrapolateRight: 'clamp',
-    easing: EASE_OUT,
-  })
-  const connectPressed = frame >= 66
-  const checkIn = interpolate(frame, [72, 92], [0, 1], {
-    extrapolateRight: 'clamp',
-    easing: EASE_OUT,
-  })
-
   return (
     <AbsoluteFill style={{ background: palette.bgCanvas, padding: 24 }}>
       <div
@@ -56,123 +48,28 @@ export function SceneInstallMcp() {
         }}
       >
         <SceneLabel text="first: install the mcp" opacity={labelIn} />
-        <div style={{ flex: 1, position: 'relative' }}>
-          <CockpitFrame
-            showLandingDot
-            highlightNav="MCP"
-            highlightIntensity={highlightIn}
-          />
-          <EndpointCard
-            opacity={cardIn}
-            translateX={cardSlide}
-            connectPressed={connectPressed}
-            checkOpacity={checkIn}
-          />
+        <div
+          style={{
+            flex: 1,
+            minHeight: 0,
+            scale: shellScale,
+            opacity: shellOpacity,
+            transformOrigin: 'top center',
+          }}
+        >
+          <BrowserShell>
+            <div
+              style={{
+                height: '100%',
+                overflow: 'hidden',
+                background: 'var(--color-bg-canvas)',
+              }}
+            >
+              <CockpitOnboarding state="first-run" />
+            </div>
+          </BrowserShell>
         </div>
       </div>
     </AbsoluteFill>
-  )
-}
-
-function EndpointCard({
-  opacity,
-  translateX,
-  connectPressed,
-  checkOpacity,
-}: {
-  opacity: number
-  translateX: number
-  connectPressed: boolean
-  checkOpacity: number
-}) {
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        left: 250,
-        top: 140 + BROWSER_CHROME_HEIGHT,
-        width: 420,
-        borderRadius: 16,
-        background: palette.card,
-        border: `1px solid ${palette.border2}`,
-        boxShadow: '0 30px 60px -20px rgba(10, 13, 20, 0.35)',
-        padding: '18px 20px',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 12,
-        opacity,
-        translate: `${translateX}px 0`,
-      }}
-    >
-      <div
-        style={{
-          fontFamily: fonts.mono,
-          fontSize: 10,
-          letterSpacing: 1.6,
-          color: palette.ink3,
-        }}
-      >
-        MCP ENDPOINT
-      </div>
-      <div
-        style={{
-          fontFamily: fonts.mono,
-          fontSize: 13,
-          color: palette.ink,
-        }}
-      >
-        http://127.0.0.1:9200/mcp
-      </div>
-      <div
-        style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4 }}
-      >
-        <div
-          style={{
-            padding: '6px 12px',
-            borderRadius: 8,
-            background: connectPressed ? palette.accentTint : palette.accent,
-            color: connectPressed ? palette.accent : palette.card,
-            border: `1px solid ${palette.accent}`,
-            fontSize: 12,
-            fontWeight: 700,
-            scale: connectPressed ? 0.96 : 1,
-            transformOrigin: 'center',
-          }}
-        >
-          Connect
-        </div>
-        <div
-          aria-hidden
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 6,
-            color: palette.green,
-            fontSize: 12,
-            fontWeight: 700,
-            opacity: checkOpacity,
-            translate: `${interpolate(checkOpacity, [0, 1], [-8, 0])}px 0`,
-          }}
-        >
-          <span
-            style={{
-              width: 16,
-              height: 16,
-              borderRadius: 999,
-              background: palette.green,
-              color: palette.card,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: 12,
-              fontWeight: 900,
-            }}
-          >
-            ✓
-          </span>
-          Endpoint installed.
-        </div>
-      </div>
-    </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/onboarding-video/src/scenes/SceneLoop.tsx
+++ b/packages/browseros-agent/apps/claw-app/onboarding-video/src/scenes/SceneLoop.tsx
@@ -3,15 +3,16 @@
  * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Scene 06: the CTA + loop reset. First half holds the "set it up
- * below" caption + a downward chevron so the reader learns the
- * scroll affordance BEFORE the loop restarts; second half fades
- * back to the initial cockpit + landing-dot state so Scene 01 can
- * restart without a visible seam.
+ * Scene 06: the CTA + loop reset. Real `<CockpitOnboarding />`
+ * fades back in behind a "set it up below" pill + bouncing
+ * downward chevron so the reader learns the scroll affordance
+ * before the loop restarts. Second half fades the CTA out so
+ * scene 01 can restart without a visible seam.
  */
 
 import { AbsoluteFill, Easing, interpolate, useCurrentFrame } from 'remotion'
-import { CockpitFrame } from '../components/CockpitFrame'
+import { CockpitOnboarding } from '@/components/cockpit/CockpitOnboarding'
+import { BrowserShell } from '../components/BrowserShell'
 import { SceneLabel } from '../components/SceneLabel'
 import { palette } from '../palette'
 
@@ -20,13 +21,10 @@ const EASE_STANDARD = Easing.bezier(0.4, 0, 0.6, 1)
 
 export function SceneLoop() {
   const frame = useCurrentFrame()
-  // Fade in the cockpit chrome so the loop returns to the poster.
   const cockpitOpacity = interpolate(frame, [0, 30], [0, 1], {
     extrapolateRight: 'clamp',
     easing: EASE_STANDARD,
   })
-  // CTA caption: appears for the first ~2s of the scene, then fades
-  // out over the last ~1s. Chevron bounces subtly for the whole time.
   const ctaIn = interpolate(frame, [0, 12], [0, 1], {
     extrapolateRight: 'clamp',
     easing: EASE_OUT,
@@ -37,7 +35,6 @@ export function SceneLoop() {
     easing: EASE_STANDARD,
   })
   const ctaOpacity = Math.min(ctaIn, ctaOut)
-  // Bounce the chevron up-and-down every second (~30 frames).
   const bounceProgress = (frame % 30) / 30
   const chevronY = interpolate(bounceProgress, [0, 0.5, 1], [0, 8, 0], {
     easing: EASE_STANDARD,
@@ -54,8 +51,18 @@ export function SceneLoop() {
         }}
       >
         <SceneLabel text="you are here" opacity={cockpitOpacity} />
-        <div style={{ flex: 1 }}>
-          <CockpitFrame showLandingDot />
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <BrowserShell>
+            <div
+              style={{
+                height: '100%',
+                overflow: 'hidden',
+                background: 'var(--color-bg-canvas)',
+              }}
+            >
+              <CockpitOnboarding state="first-run" />
+            </div>
+          </BrowserShell>
         </div>
       </div>
       <div

--- a/packages/browseros-agent/apps/claw-app/onboarding-video/src/scenes/ScenePan.tsx
+++ b/packages/browseros-agent/apps/claw-app/onboarding-video/src/scenes/ScenePan.tsx
@@ -3,41 +3,44 @@
  * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Scene 02: the pan. The cockpit slides to the left; an agent
- * terminal card slides in from the right. Both surfaces settle into
- * a side-by-side composition. Labels above each surface name their
- * role: "you watch here" over the cockpit, "your work happens here"
- * over the terminal.
+ * Scene 03: the pan. The real `<CockpitOnboarding />` slides to
+ * the left half; the agent terminal slides in from the right.
+ * Labels above each surface name their role: "you watch here"
+ * over the cockpit, "then: prompt your agent" over the terminal.
+ * `AgentTerminal` stays composition-local because the extension
+ * has no equivalent widget.
  */
 
 import { AbsoluteFill, Easing, interpolate, useCurrentFrame } from 'remotion'
+import { CockpitOnboarding } from '@/components/cockpit/CockpitOnboarding'
 import { AgentTerminal } from '../components/AgentTerminal'
-import { CockpitFrame } from '../components/CockpitFrame'
+import { BrowserShell } from '../components/BrowserShell'
 import { SceneLabel } from '../components/SceneLabel'
 import { palette } from '../palette'
 
+const EASE_OUT = Easing.bezier(0.16, 1, 0.3, 1)
+
 export function ScenePan() {
   const frame = useCurrentFrame()
-  // Cockpit slides from centered to left half. Terminal slides in from off-canvas right.
   const cockpitX = interpolate(frame, [0, 50], [0, -400], {
     extrapolateRight: 'clamp',
-    easing: Easing.bezier(0.16, 1, 0.3, 1),
+    easing: EASE_OUT,
   })
   const terminalX = interpolate(frame, [0, 50], [1200, 0], {
     extrapolateRight: 'clamp',
-    easing: Easing.bezier(0.16, 1, 0.3, 1),
+    easing: EASE_OUT,
   })
   const cockpitScale = interpolate(frame, [0, 50], [1, 0.78], {
     extrapolateRight: 'clamp',
-    easing: Easing.bezier(0.16, 1, 0.3, 1),
+    easing: EASE_OUT,
   })
   const terminalOpacity = interpolate(frame, [10, 55], [0, 1], {
     extrapolateRight: 'clamp',
-    easing: Easing.bezier(0.16, 1, 0.3, 1),
+    easing: EASE_OUT,
   })
   const labelIn = interpolate(frame, [55, 80], [0, 1], {
     extrapolateRight: 'clamp',
-    easing: Easing.bezier(0.16, 1, 0.3, 1),
+    easing: EASE_OUT,
   })
   return (
     <AbsoluteFill style={{ background: palette.bgCanvas, padding: 24 }}>
@@ -59,7 +62,17 @@ export function ScenePan() {
           style={{ marginBottom: 14 }}
         />
         <div style={{ height: 'calc(100% - 34px)' }}>
-          <CockpitFrame showLandingDot />
+          <BrowserShell>
+            <div
+              style={{
+                height: '100%',
+                overflow: 'hidden',
+                background: 'var(--color-bg-canvas)',
+              }}
+            >
+              <CockpitOnboarding state="first-run" />
+            </div>
+          </BrowserShell>
         </div>
       </div>
       <div


### PR DESCRIPTION
## Summary

PR 6 of the [claw-app-remotion-real-ui epic](https://github.com/browseros-ai/BrowserOS/tree/epic/claw-app-remotion-real-ui). Extends PR 5's `SceneCockpit` swap to the three remaining onboarding-facing scenes so every cockpit beat renders the real `<CockpitOnboarding state=\"first-run\" />` from `@/components/cockpit/` instead of the hand-built `CockpitFrame` mockup.

## Per-scene detail

**Scene 2 (SceneInstallMcp)** — \"first: install the mcp\"
Replaces `CockpitFrame` + a floating `EndpointCard` overlay with `BrowserShell` + `CockpitOnboarding`. The natural `Set up MCP endpoint` primary CTA button in the onboarding already carries the install-the-MCP message; no separate endpoint card needed. Retires the local `EndpointCard` component + the `CockpitFrame` `highlightNav` usage from this scene.

**Scene 3 (ScenePan)** — \"you watch here\" + \"then: prompt your agent\"
Replaces `CockpitFrame` with `BrowserShell` + `CockpitOnboarding` for the left-side cockpit half. `AgentTerminal` on the right stays composition-local (no in-app equivalent). Same slide + scale animation as before; only the cockpit content changed.

**Scene 6 (SceneLoop)** — CTA + loop reset
Replaces `CockpitFrame` with `BrowserShell` + `CockpitOnboarding` for the base surface. Keeps the \"Set it up below\" pill + bouncing chevron overlay composition-local (they're not part of the actual app).

## Line count

The MCP scene shrinks the most (from 179 lines to 68) because the whole `EndpointCard` micro-component + its animation state can go — the real primary CTA carries the message.

## What is NOT in this PR

- Scene 5 (Activity) still uses `CockpitFrame`. Coming in PR 7, which needs a seeded query cache for `useTasks`.
- `CockpitFrame` file itself is not deleted yet. That's PR 8, once every scene has stopped importing it.
- No new webpack aliases needed — the `FirstRunVideo` → static-stub alias from PR 5 already covers these three scenes because they all mount the same `CockpitOnboarding` tree.

## Verified locally

- `bun install --frozen-lockfile`: clean.
- `bun run typecheck` on claw-app: clean.
- `bun run video:render`: succeeds. 20s MP4 at 1.7 MB.
- Per-scene stills at mid-scene frames:
  - scene 2 (frame 130): browser shell + hero + primary CTA area, \"first: install the mcp\" label.
  - scene 3 (frame 225): cockpit slid left, terminal `\$ claude` prompt on right.
  - scene 6 (frame 555): browser shell + hero + \"Set it up below\" pill + downward chevron.
- `bunx fallow dead-code`: zero boundary violations.
- `bunx biome ci onboarding-video/`: clean.
- Extension `bun run build:dev`: 2.37 MB, clean.

## Base

\`epic/claw-app-remotion-real-ui\`. Does not touch main.

## Test plan
- [x] Composition renders end-to-end.
- [x] Each scene visually recognisable in its rendered still.
- [x] Fallow boundary invariant preserved.
- [x] Extension bundle byte-comparable.
- [ ] CI passes.