### PR TITLE
fix(agent-mcp-manager): write Antigravity config to `.gemini/config/`, not `.gemini/antigravity/`

### DIFF
--- a/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/client-configs.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/client-configs.ts
@@ -695,9 +695,9 @@ export const antigravity: ClientConfig = {
     win32: ['$USERPROFILE\\.gemini\\antigravity'],
   },
   systemPaths: {
-    darwin: ['$HOME/.gemini/antigravity/mcp_config.json'],
-    linux: ['$HOME/.gemini/antigravity/mcp_config.json'],
-    win32: ['$USERPROFILE\\.gemini\\antigravity\\mcp_config.json'],
+    darwin: ['$HOME/.gemini/config/mcp_config.json'],
+    linux: ['$HOME/.gemini/config/mcp_config.json'],
+    win32: ['$USERPROFILE\\.gemini\\config\\mcp_config.json'],
   },
   format: 'json',
   supportedTransports: { system: ['stdio', 'http'] },
@@ -710,7 +710,7 @@ export const antigravity: ClientConfig = {
     firstParty: 'https://antigravity.google/',
     smithery: SMITHERY_URL,
     notes:
-      "Google's Antigravity editor. Uses `serverUrl` for remote entries (matches Windsurf's convention).",
+      "Google's Antigravity editor. Config lives at `~/.gemini/config/mcp_config.json` (schema id: https://antigravity.google/schemas/mcp_config.json). Uses `serverUrl` for remote entries (matches Windsurf's convention).",
     verified: VERIFIED,
   },
 }


### PR DESCRIPTION
## Summary

Fixes #1860. The 1-click Antigravity install writes its `mcp_config.json` to the wrong directory, so users see the install "succeed" but Antigravity never picks up the entry.

**Root cause.** Antigravity 2.x reads its MCP registry from `~/.gemini/config/mcp_config.json`. The catalog was writing to `~/.gemini/antigravity/mcp_config.json`.

**Evidence** (Antigravity 2.3.1 on macOS):
- The shipped `Antigravity.app/Contents/Resources/bin/language_server` binary contains the literal string `/.gemini/config/mcp_config.json`.
- The shipped MCP schema advertises `$id: https://antigravity.google/schemas/mcp_config.json` and matches the format already emitted by the catalog (`{ "mcpServers": { "<name>": { "serverUrl": "..." } } }`).
- The reporter (Windows) independently confirmed that moving the file from `.gemini\antigravity\mcp_config.json` to `.gemini\config\mcp_config.json` made Antigravity see the server.

## Scope

- Update `systemPaths` for the `antigravity` catalog entry: `~/.gemini/config/mcp_config.json` on darwin/linux, `%USERPROFILE%\.gemini\config\mcp_config.json` on win32.
- Leave `installCheckPaths` on `~/.gemini/antigravity/` — that directory is what proves Antigravity is installed on the machine. The bug was purely in the write target.
- Note the schema id in `sources.notes` so the next maintainer can find the source of truth.

## Non-goals

The reporter's secondary error (`Get "http://127.0.0.1:9010/mcp": ... unexpected EOF`) is unrelated: `publicMcpUrl()` resolves from `env.proxyPort ?? env.serverPort` and defaults to 9200. 9010 is BrowserOS' dev CDP port, not any BrowserClaw MCP port. That symptom is a stale/manual config value on the reporter's machine, not a code bug; not addressed here.

## Test plan

- [x] `bun test test/unit/catalog.test.ts test/unit/agents.test.ts` in `packages/agent-mcp-manager` (21/21 pass).
- [ ] Reviewer sanity check: on a machine with Antigravity installed, run the 1-click install for BrowserClaw, then open Antigravity and confirm the `browseros` MCP entry appears without needing to move the file.