### PR TITLE
feat(claw-server): self-heal MCP config paths at boot

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/lib/migrate-mcp-config-paths.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/migrate-mcp-config-paths.ts
@@ -20,7 +20,8 @@
  */
 
 import { access, unlink, writeFile } from 'node:fs/promises'
-import { resolve as resolvePath } from 'node:path'
+import { homedir } from 'node:os'
+import { join, resolve as resolvePath } from 'node:path'
 import type {
   AgentId,
   AgentScope,
@@ -214,7 +215,20 @@ async function tryRestore(
 }
 
 function samePath(a: string, b: string): boolean {
-  return resolvePath(a) === resolvePath(b)
+  return resolvePath(expandHome(a)) === resolvePath(expandHome(b))
+}
+
+// `path.resolve` does NOT expand `~`. The library's own resolver
+// always emits `$HOME`-expanded absolute paths into the manifest,
+// so this branch is defensive: it prevents a boot-time re-migration
+// loop if a direct API caller (or a future manifest-format change)
+// hands us a `~`-prefixed configPath.
+function expandHome(p: string): string {
+  if (p === '~') return homedir()
+  if (p.startsWith('~/') || p.startsWith('~\\')) {
+    return join(homedir(), p.slice(2))
+  }
+  return p
 }
 
 async function safeList(

--- a/packages/browseros-agent/apps/claw-server/src/lib/migrate-mcp-config-paths.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/migrate-mcp-config-paths.ts
@@ -1,0 +1,282 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Boot-time config-path migration for the shared BrowserClaw MCP
+ * server. When the agent catalog's OS-resolved default path moves
+ * between BrowserClaw versions (e.g. Antigravity 1.x -> 2.x moved
+ * from `~/.gemini/antigravity/` to `~/.gemini/config/`), an existing
+ * install's manifest still records the OLD path and every downstream
+ * self-heal loop keeps writing there. Users see a green "Configured"
+ * badge while the harness reads a different file and never sees the
+ * entry.
+ *
+ * This loop diffs the manifest-recorded configPath against the
+ * catalog's current default and, when they disagree, relocates the
+ * entry: strip from OLD, write at NEW, update the link record. Per
+ * link failures are isolated. A durable pending marker forces retry
+ * on the next boot when a run is interrupted.
+ */
+
+import { access, unlink, writeFile } from 'node:fs/promises'
+import { resolve as resolvePath } from 'node:path'
+import type {
+  AgentId,
+  AgentScope,
+  BoundApi,
+  ManifestServerEntry,
+  McpServerSpec,
+} from '@browseros/agent-mcp-manager'
+import { resolveAgentMcpConfigPath as defaultResolveAgentMcpConfigPath } from '@browseros/agent-mcp-manager'
+import { BROWSEROS_MCP_SERVER_NAME } from '../shared/mcp-url'
+import { resolveClawServerPath } from './browserclaw-dir'
+import { logger } from './logger'
+import { getMcpManager } from './mcp-manager'
+
+const MIGRATION_PENDING_FILE = 'mcp-config-path-migration.pending'
+
+interface MigrationCounters {
+  migrated: number
+  skipped: number
+  failed: number
+}
+
+type ConfigPathResolver = (agent: AgentId, scope: AgentScope) => Promise<string>
+
+let configPathResolver: ConfigPathResolver = (agent, scope) =>
+  defaultResolveAgentMcpConfigPath(agent, scope)
+
+/**
+ * Test hook. Swaps the OS-default resolver so unit tests can stage
+ * arbitrary "current default" paths without shelling out to the
+ * per-OS filesystem probing inside `resolveAgentMcpConfigPath`.
+ */
+export function setConfigPathResolverForTesting(
+  next: ConfigPathResolver | null,
+): void {
+  configPathResolver =
+    next ?? ((agent, scope) => defaultResolveAgentMcpConfigPath(agent, scope))
+}
+
+export async function migrateMcpConfigPaths(): Promise<MigrationCounters> {
+  const mgr = getMcpManager()
+  const counters: MigrationCounters = { migrated: 0, skipped: 0, failed: 0 }
+  const servers = await safeList(mgr)
+  if (servers === null) return counters
+
+  const server = servers.find(
+    (entry) => entry.name === BROWSEROS_MCP_SERVER_NAME,
+  )
+  if (!server) return counters
+
+  const hasPendingMigration = await pendingMigrationExists()
+  const targets = await collectTargets(server, counters)
+  if (targets.length === 0) {
+    if (hasPendingMigration && !(await clearPendingMarker())) {
+      counters.failed++
+    }
+    return counters
+  }
+  if (!(await writePendingMarker())) {
+    counters.failed++
+    return counters
+  }
+
+  for (const target of targets) {
+    const ok = await migrateOne(mgr, server, target)
+    if (ok) counters.migrated++
+    else counters.failed++
+  }
+  if (counters.failed === 0 && !(await clearPendingMarker())) {
+    counters.failed++
+  }
+  return counters
+}
+
+interface MigrationTarget {
+  agent: AgentId
+  scope: AgentScope
+  oldConfigPath: string
+  newConfigPath: string
+}
+
+async function collectTargets(
+  server: ManifestServerEntry,
+  counters: MigrationCounters,
+): Promise<MigrationTarget[]> {
+  const targets: MigrationTarget[] = []
+  for (const agentRaw of Object.keys(server.links)) {
+    const agent = agentRaw as AgentId
+    const link = server.links[agent]
+    if (!link) continue
+    const scope: AgentScope = 'system'
+    let resolvedDefault: string
+    try {
+      resolvedDefault = await configPathResolver(agent, scope)
+    } catch (err) {
+      counters.skipped++
+      logger.info('mcpConfigPath migration: default path unresolved, skipped', {
+        serverName: BROWSEROS_MCP_SERVER_NAME,
+        agent,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      continue
+    }
+    if (samePath(link.configPath, resolvedDefault)) {
+      counters.skipped++
+      continue
+    }
+    targets.push({
+      agent,
+      scope,
+      oldConfigPath: link.configPath,
+      newConfigPath: resolvedDefault,
+    })
+  }
+  return targets
+}
+
+async function migrateOne(
+  mgr: BoundApi,
+  server: ManifestServerEntry,
+  target: MigrationTarget,
+): Promise<boolean> {
+  const spec = server.spec
+  try {
+    await mgr.unlink({
+      serverName: BROWSEROS_MCP_SERVER_NAME,
+      agent: target.agent,
+      scope: target.scope,
+      configPath: target.oldConfigPath,
+    })
+  } catch (err) {
+    logger.warn('mcpConfigPath migration: unlink at old path failed', {
+      serverName: BROWSEROS_MCP_SERVER_NAME,
+      agent: target.agent,
+      oldConfigPath: target.oldConfigPath,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return false
+  }
+  try {
+    await mgr.link({
+      server: { name: BROWSEROS_MCP_SERVER_NAME, spec },
+      agent: target.agent,
+      scope: target.scope,
+      allowOverwrite: true,
+    })
+    logger.info('mcpConfigPath migration: relocated', {
+      serverName: BROWSEROS_MCP_SERVER_NAME,
+      agent: target.agent,
+      from: target.oldConfigPath,
+      to: target.newConfigPath,
+    })
+    return true
+  } catch (err) {
+    logger.warn('mcpConfigPath migration: link at new path failed', {
+      serverName: BROWSEROS_MCP_SERVER_NAME,
+      agent: target.agent,
+      newConfigPath: target.newConfigPath,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    await tryRestore(mgr, target, spec)
+    return false
+  }
+}
+
+async function tryRestore(
+  mgr: BoundApi,
+  target: MigrationTarget,
+  spec: McpServerSpec,
+): Promise<void> {
+  try {
+    await mgr.link({
+      server: { name: BROWSEROS_MCP_SERVER_NAME, spec },
+      agent: target.agent,
+      scope: target.scope,
+      configPath: target.oldConfigPath,
+      allowOverwrite: true,
+    })
+    logger.info('mcpConfigPath migration: restored link at old path', {
+      serverName: BROWSEROS_MCP_SERVER_NAME,
+      agent: target.agent,
+      oldConfigPath: target.oldConfigPath,
+    })
+  } catch (err) {
+    logger.error('mcpConfigPath migration: restore failed', {
+      serverName: BROWSEROS_MCP_SERVER_NAME,
+      agent: target.agent,
+      oldConfigPath: target.oldConfigPath,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+function samePath(a: string, b: string): boolean {
+  return resolvePath(a) === resolvePath(b)
+}
+
+async function safeList(
+  mgr: BoundApi,
+): Promise<Awaited<ReturnType<BoundApi['list']>> | null> {
+  try {
+    return await mgr.list()
+  } catch (err) {
+    logger.warn('mcpConfigPath migration: manifest list failed', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return null
+  }
+}
+
+async function pendingMigrationExists(): Promise<boolean> {
+  try {
+    await access(resolveClawServerPath(MIGRATION_PENDING_FILE))
+    return true
+  } catch (err) {
+    if (isFsError(err, 'ENOENT')) return false
+    logger.warn('mcpConfigPath migration: pending marker check failed', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return true
+  }
+}
+
+async function writePendingMarker(): Promise<boolean> {
+  try {
+    await writeFile(
+      resolveClawServerPath(MIGRATION_PENDING_FILE),
+      `${new Date().toISOString()}\n`,
+      { encoding: 'utf8', mode: 0o600 },
+    )
+    return true
+  } catch (err) {
+    logger.warn('mcpConfigPath migration: could not write pending marker', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return false
+  }
+}
+
+async function clearPendingMarker(): Promise<boolean> {
+  try {
+    await unlink(resolveClawServerPath(MIGRATION_PENDING_FILE))
+    return true
+  } catch (err) {
+    if (isFsError(err, 'ENOENT')) return true
+    logger.warn('mcpConfigPath migration: could not clear pending marker', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return false
+  }
+}
+
+function isFsError(err: unknown, code: string): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === code
+  )
+}

--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -25,6 +25,7 @@ import { bootstrapBrowserosBrowser } from './lib/browser-bootstrap'
 import { setBrowserSession } from './lib/browser-session'
 import { getClawServerDir } from './lib/browserclaw-dir'
 import { logger } from './lib/logger'
+import { migrateMcpConfigPaths } from './lib/migrate-mcp-config-paths'
 import { migrateMcpUrls } from './lib/migrate-mcp-urls'
 import { writeRuntimeFile } from './lib/runtime-file'
 import { setLocalServerUrl } from './local-server-url'
@@ -152,6 +153,23 @@ async function start(): Promise<void> {
     logger.info('mcpUrl migration finished', { ...migration })
   } catch (err) {
     logger.error('mcpUrl migration failed unexpectedly', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+
+  // Self-heal loop 3: relocate BrowserClaw MCP entries when the
+  // agent catalog's OS-resolved default config path has moved
+  // between BrowserClaw versions (Antigravity 1.x -> 2.x moved
+  // from `~/.gemini/antigravity/` to `~/.gemini/config/`; future
+  // agent updates will do the same). Without this, existing
+  // installs keep rewriting the OLD file while the harness reads
+  // the NEW one, and users see a green "Configured" badge on a
+  // broken connection.
+  try {
+    const pathMigration = await migrateMcpConfigPaths()
+    logger.info('mcpConfigPath migration finished', { ...pathMigration })
+  } catch (err) {
+    logger.error('mcpConfigPath migration failed unexpectedly', {
       error: err instanceof Error ? err.message : String(err),
     })
   }

--- a/packages/browseros-agent/apps/claw-server/tests/lib/migrate-mcp-config-paths.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/migrate-mcp-config-paths.test.ts
@@ -1,0 +1,354 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { stat, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { setMcpManagerForTesting } from '../../src/lib/mcp-manager'
+import {
+  migrateMcpConfigPaths,
+  setConfigPathResolverForTesting,
+} from '../../src/lib/migrate-mcp-config-paths'
+import { createStubMcpManager } from '../_helpers/stub-mcp-manager'
+import { withTempBrowserClawDir } from '../_helpers/temp-browserclaw-dir'
+
+const OLD_ANTI = '/tmp/legacy/.gemini/antigravity/mcp_config.json'
+// Stub records `/tmp/stub-${agent}.json` when `mgr.link` is called
+// without a configPath override. Tests align "current OS default"
+// with that so a migration relinks to what the stub would emit.
+const NEW_ANTI = '/tmp/stub-antigravity.json'
+const CLAUDE_HOME = '/tmp/stub-claude-code.json'
+const CURSOR_HOME = '/tmp/stub-cursor.json'
+const URL = 'http://127.0.0.1:9200/mcp'
+
+afterEach(() => {
+  setConfigPathResolverForTesting(null)
+})
+
+describe('migrateMcpConfigPaths', () => {
+  test('an empty manifest returns zero counts and does not throw', async () => {
+    await withTempBrowserClawDir(async () => {
+      const stub = createStubMcpManager()
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async () => NEW_ANTI)
+      const result = await migrateMcpConfigPaths()
+      expect(result).toEqual({ migrated: 0, skipped: 0, failed: 0 })
+    })
+  })
+
+  test('no BrowserClaw server in the manifest is a no-op', async () => {
+    await withTempBrowserClawDir(async () => {
+      const stub = createStubMcpManager()
+      await stub.link({
+        server: {
+          name: 'some-other-server',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: OLD_ANTI,
+      })
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async () => NEW_ANTI)
+      stub.reset()
+      const result = await migrateMcpConfigPaths()
+      expect(result).toEqual({ migrated: 0, skipped: 0, failed: 0 })
+      expect(stub.calls.some((c) => c.method === 'link')).toBe(false)
+      expect(stub.calls.some((c) => c.method === 'unlink')).toBe(false)
+    })
+  })
+
+  test('a link whose configPath already matches the OS default is skipped', async () => {
+    await withTempBrowserClawDir(async () => {
+      const stub = createStubMcpManager()
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: NEW_ANTI,
+      })
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async () => NEW_ANTI)
+      stub.reset()
+      const result = await migrateMcpConfigPaths()
+      expect(result).toEqual({ migrated: 0, skipped: 1, failed: 0 })
+      expect(stub.calls.some((c) => c.method === 'link')).toBe(false)
+      expect(stub.calls.some((c) => c.method === 'unlink')).toBe(false)
+    })
+  })
+
+  test('a link whose configPath differs is unlinked at OLD and relinked at NEW', async () => {
+    await withTempBrowserClawDir(async () => {
+      const stub = createStubMcpManager()
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: OLD_ANTI,
+      })
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async () => NEW_ANTI)
+      stub.reset()
+
+      const result = await migrateMcpConfigPaths()
+
+      expect(result).toEqual({ migrated: 1, skipped: 0, failed: 0 })
+      const unlinkCall = stub.calls.find((c) => c.method === 'unlink')
+      expect(unlinkCall?.payload).toMatchObject({
+        serverName: 'BrowserClaw',
+        agent: 'antigravity',
+        configPath: OLD_ANTI,
+      })
+      const linkCall = stub.calls.find((c) => c.method === 'link')
+      expect(linkCall?.payload).toMatchObject({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        allowOverwrite: true,
+      })
+      expect(
+        (linkCall?.payload as { configPath?: string }).configPath,
+      ).toBeUndefined()
+      const [server] = await stub.list()
+      expect(server?.links.antigravity?.configPath).toBe(NEW_ANTI)
+    })
+  })
+
+  test('multiple links: matching ones skipped, mismatching ones migrated', async () => {
+    await withTempBrowserClawDir(async () => {
+      const stub = createStubMcpManager()
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: OLD_ANTI,
+      })
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'claude-code',
+        configPath: CLAUDE_HOME,
+      })
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'cursor',
+        configPath: CURSOR_HOME,
+      })
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async (agent) => {
+        if (agent === 'antigravity') return NEW_ANTI
+        if (agent === 'claude-code') return CLAUDE_HOME
+        if (agent === 'cursor') return CURSOR_HOME
+        throw new Error(`unexpected agent ${agent}`)
+      })
+      stub.reset()
+
+      const result = await migrateMcpConfigPaths()
+
+      expect(result).toEqual({ migrated: 1, skipped: 2, failed: 0 })
+      expect(stub.calls.filter((c) => c.method === 'unlink')).toHaveLength(1)
+      expect(stub.calls.filter((c) => c.method === 'link')).toHaveLength(1)
+    })
+  })
+
+  test('resolver throw for an agent skips that link and keeps sweeping others', async () => {
+    await withTempBrowserClawDir(async () => {
+      const stub = createStubMcpManager()
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: OLD_ANTI,
+      })
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'claude-code',
+        configPath: '/tmp/old-claude.json',
+      })
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async (agent) => {
+        if (agent === 'antigravity') {
+          throw new Error('antigravity no longer installed')
+        }
+        return CLAUDE_HOME
+      })
+      stub.reset()
+
+      const result = await migrateMcpConfigPaths()
+
+      expect(result).toEqual({ migrated: 1, skipped: 1, failed: 0 })
+      const linkCall = stub.calls.find(
+        (c) =>
+          c.method === 'link' &&
+          (c.payload as { agent?: string }).agent === 'claude-code',
+      )
+      expect(linkCall).toBeDefined()
+    })
+  })
+
+  test('link failure after unlink success attempts restore and counts as failed', async () => {
+    await withTempBrowserClawDir(async () => {
+      const stub = createStubMcpManager()
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: OLD_ANTI,
+      })
+      const originalLink = stub.link
+      let sawOverride = false
+      stub.link = async (input) => {
+        if (input.configPath === undefined) {
+          throw new Error('new-path write locked')
+        }
+        if (input.configPath === OLD_ANTI) sawOverride = true
+        return originalLink(input)
+      }
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async () => NEW_ANTI)
+      stub.reset()
+
+      const result = await migrateMcpConfigPaths()
+
+      expect(result).toEqual({ migrated: 0, skipped: 0, failed: 1 })
+      expect(sawOverride).toBe(true)
+      const [server] = await stub.list()
+      expect(server?.links.antigravity?.configPath).toBe(OLD_ANTI)
+    })
+  })
+
+  test('non-BrowserClaw manifest entries are ignored', async () => {
+    await withTempBrowserClawDir(async () => {
+      const stub = createStubMcpManager()
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: OLD_ANTI,
+      })
+      await stub.link({
+        server: {
+          name: 'legacy-profile-slug',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: '/tmp/some-other-file.json',
+      })
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async () => NEW_ANTI)
+      stub.reset()
+
+      const result = await migrateMcpConfigPaths()
+
+      expect(result).toEqual({ migrated: 1, skipped: 0, failed: 0 })
+      const unlinkCalls = stub.calls.filter((c) => c.method === 'unlink')
+      expect(unlinkCalls).toHaveLength(1)
+      expect(unlinkCalls[0]?.payload).toMatchObject({
+        serverName: 'BrowserClaw',
+      })
+    })
+  })
+
+  test('keeps a pending marker so an interrupted run retries on next boot', async () => {
+    await withTempBrowserClawDir(async () => {
+      const stub = createStubMcpManager()
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: OLD_ANTI,
+      })
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'claude-code',
+        configPath: '/tmp/old-claude.json',
+      })
+      const originalLink = stub.link
+      let failAnti = true
+      stub.link = async (input) => {
+        if (
+          failAnti &&
+          input.agent === 'antigravity' &&
+          input.configPath === undefined
+        ) {
+          throw new Error('anti locked')
+        }
+        return originalLink(input)
+      }
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async (agent) =>
+        agent === 'antigravity' ? NEW_ANTI : CLAUDE_HOME,
+      )
+      stub.reset()
+
+      const first = await migrateMcpConfigPaths()
+
+      expect(first).toEqual({ migrated: 1, skipped: 0, failed: 1 })
+
+      failAnti = false
+      stub.reset()
+      const second = await migrateMcpConfigPaths()
+
+      expect(second).toEqual({ migrated: 1, skipped: 1, failed: 0 })
+      const [server] = await stub.list()
+      expect(server?.links.antigravity?.configPath).toBe(NEW_ANTI)
+      expect(server?.links['claude-code']?.configPath).toBe(CLAUDE_HOME)
+    })
+  })
+
+  test('a stale pending marker with nothing to migrate is cleared', async () => {
+    await withTempBrowserClawDir(async (root) => {
+      const marker = join(root, 'mcp-config-path-migration.pending')
+      await writeFile(marker, 'stale', 'utf8')
+      const stub = createStubMcpManager()
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: NEW_ANTI,
+      })
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async () => NEW_ANTI)
+      stub.reset()
+
+      const result = await migrateMcpConfigPaths()
+
+      expect(result).toEqual({ migrated: 0, skipped: 1, failed: 0 })
+      const stillExists = await stat(marker)
+        .then(() => true)
+        .catch(() => false)
+      expect(stillExists).toBe(false)
+    })
+  })
+})

--- a/packages/browseros-agent/apps/claw-server/tests/lib/migrate-mcp-config-paths.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/migrate-mcp-config-paths.test.ts
@@ -6,6 +6,7 @@
 
 import { afterEach, describe, expect, test } from 'bun:test'
 import { stat, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { setMcpManagerForTesting } from '../../src/lib/mcp-manager'
 import {
@@ -75,6 +76,37 @@ describe('migrateMcpConfigPaths', () => {
       setConfigPathResolverForTesting(async () => NEW_ANTI)
       stub.reset()
       const result = await migrateMcpConfigPaths()
+      expect(result).toEqual({ migrated: 0, skipped: 1, failed: 0 })
+      expect(stub.calls.some((c) => c.method === 'link')).toBe(false)
+      expect(stub.calls.some((c) => c.method === 'unlink')).toBe(false)
+    })
+  })
+
+  test('a tilde-prefixed manifest path is treated as equal to its expanded home form', async () => {
+    // Defensive against a direct API caller (or future manifest
+    // format change) that hands us `~/...`. The library today
+    // always emits `$HOME`-expanded absolute paths, so this branch
+    // is not reachable via the manager's own writes, but the
+    // migration is idempotent enough that a false-positive here
+    // would silently loop every boot.
+    await withTempBrowserClawDir(async () => {
+      const stub = createStubMcpManager()
+      const tildePath = '~/.gemini/config/mcp_config.json'
+      const expanded = join(homedir(), '.gemini/config/mcp_config.json')
+      await stub.link({
+        server: {
+          name: 'BrowserClaw',
+          spec: { transport: 'http', url: URL },
+        },
+        agent: 'antigravity',
+        configPath: tildePath,
+      })
+      setMcpManagerForTesting(stub)
+      setConfigPathResolverForTesting(async () => expanded)
+      stub.reset()
+
+      const result = await migrateMcpConfigPaths()
+
       expect(result).toEqual({ migrated: 0, skipped: 1, failed: 0 })
       expect(stub.calls.some((c) => c.method === 'link')).toBe(false)
       expect(stub.calls.some((c) => c.method === 'unlink')).toBe(false)


### PR DESCRIPTION
## Summary

Adds Self-heal loop 3: on every launch, `claw-server` walks every link on the `BrowserClaw` manifest entry, compares the recorded `configPath` against the agent catalog's current OS-resolved default via `resolveAgentMcpConfigPath(agent, 'system')`, and when they disagree, relocates the entry (unlink at OLD, link at OS default). Per-link failure isolation and a durable pending marker so an interrupted run replays on the next boot.

This is the runtime companion to PR #1862 (which fixes the Antigravity `systemPaths` in the catalog for new installs). Without loop 3, an existing install still has the buggy `configPath: '~/.gemini/antigravity/mcp_config.json'` recorded in its manifest; every subsequent boot loop (URL migration, integrity scan) writes to that OLD file while Antigravity 2.x reads the new one. The UI shows a green Configured badge on a broken connection.

## Design

- **Scope: BrowserClaw's own server only.** Symmetric with `migrateMcpUrls`. Third-party MCP servers in the manifest keep whatever configPath the user chose.
- **Ordering: after `migrateMcpUrls`.** URL migration operates on the manifest-recorded configPath; reversing the order would rewrite the same file twice.
- **Rollback:** if unlink-at-OLD succeeds but link-at-NEW fails, we attempt a restore link at OLD and count as failed. Both the failed run's pending marker AND the retry semantics of the outer counter mean the next boot re-attempts.
- **Skip semantics:** if `resolveAgentMcpConfigPath` throws (agent uninstalled, env unset, unresolvable), that link is logged and skipped so the sweep continues for the other agents.
- **Marker cleanup:** even when a boot finds nothing to migrate, a stale pending marker from a previous run is cleared so the check short-circuits on subsequent boots.

Generalized beyond Antigravity: the catalog is data, and it will move again. Every future `systemPaths` change is now automatically reconciled without user action.

## What changed

- `packages/browseros-agent/apps/claw-server/src/lib/migrate-mcp-config-paths.ts` (new).
- `packages/browseros-agent/apps/claw-server/src/main.ts` (wire loop 3 after loop 2).
- `packages/browseros-agent/apps/claw-server/tests/lib/migrate-mcp-config-paths.test.ts` (new, 10 unit tests).

## Test plan

- [x] `bun test tests/lib/migrate-mcp-config-paths.test.ts` in `apps/claw-server` (10/10 pass).
- [x] `bun test tests/lib/migrate-mcp-urls.test.ts` still green (13/13).
- [x] `bunx tsc -p tsconfig.json --noEmit` in `apps/claw-server` clean.
- [x] `bunx @biomejs/biome check` clean on all changed files.
- [ ] End-to-end sanity on macOS with Antigravity installed: pair this branch with PR #1862, launch `claw-server` once with a manifest containing an entry at `~/.gemini/antigravity/mcp_config.json`, confirm the entry moves to `~/.gemini/config/mcp_config.json`, Antigravity picks it up on next launch, `mcp-config-path-migration.pending` is cleared, and log line `mcpConfigPath migration finished { migrated: 1 }` appears in the claw-server log.

## Related

- PR #1862 catalog `systemPaths` fix for new installs.
- Issue #1860 original bug report.