### PR TITLE
fix(agent-mcp-manager): isInstalled + link() gate use installCheckPaths, not systemPaths only

### DIFF
--- a/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/client-configs.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/client-configs.ts
@@ -317,17 +317,28 @@ export const opencode: ClientConfig = {
   id: 'opencode',
   displayName: 'OpenCode',
   installCheckPaths: {
+    // `$HOME/.local/share/opencode` is OpenCode's OAuth token store
+    // (per its docs at https://opencode.ai/docs/mcp-servers/). It
+    // exists as soon as the user has authenticated any OAuth MCP
+    // server or run the OpenCode installer, even before they create
+    // their global `opencode.json`.
     darwin: [
       '$XDG_CONFIG_HOME/opencode',
       '$HOME/.config/opencode',
       '$HOME/.opencode',
+      '$HOME/.local/share/opencode',
     ],
     linux: [
       '$XDG_CONFIG_HOME/opencode',
       '$HOME/.config/opencode',
       '$HOME/.opencode',
+      '$HOME/.local/share/opencode',
     ],
-    win32: ['$USERPROFILE\\.config\\opencode', '$USERPROFILE\\.opencode'],
+    win32: [
+      '$USERPROFILE\\.config\\opencode',
+      '$USERPROFILE\\.opencode',
+      '$USERPROFILE\\.local\\share\\opencode',
+    ],
   },
   systemPaths: {
     darwin: [

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/agents.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/agents.ts
@@ -36,6 +36,23 @@ export function getCatalogEntry(agent: AgentId): ClientConfig {
 }
 
 /**
+ * The catalog's install-detection paths for this agent on the
+ * current OS, expanded (env vars substituted, unresolvable entries
+ * dropped). These are the DIRECTORIES / FILES that indicate the
+ * agent is present on the machine, not the config file path we
+ * would write to (that is `resolveAgentMcpConfigPath`). Callers
+ * pass the result to `anyExists` to answer "is this agent
+ * installed?".
+ *
+ * Empty when the catalog has no `installCheckPaths` entry for the
+ * current platform.
+ */
+export function resolveInstallCheckPaths(agent: AgentId): string[] {
+  const entry = getCatalogEntry(agent)
+  return expandPaths(pickOsList(entry.installCheckPaths))
+}
+
+/**
  * Resolve the config file path agent-mcp-manager would write to for
  * this agent under the given scope. Throws when the path isn't
  * resolvable on this OS or when project scope is requested for an

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/api.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/api.ts
@@ -13,8 +13,8 @@
 
 import { dirname } from 'node:path'
 
-import { pathExists } from './_internal/paths'
-import { resolveAgentMcpConfigPath } from './agents'
+import { anyExists, pathExists } from './_internal/paths'
+import { resolveAgentMcpConfigPath, resolveInstallCheckPaths } from './agents'
 import { UnresolvedConfigPathError } from './errors'
 import { applyPlan, readState } from './io/index'
 import {
@@ -248,11 +248,18 @@ export async function rescan(
 // -------------------------------------------------------------------
 // isInstalled: batch check whether agents can safely receive a link.
 //
-// "Installed" here means "the library can write MCP config to this
-// agent's config path": either the config file already exists on disk
-// OR its parent directory does. This is the same signal `link()` uses
-// to gate `AgentNotInstalledError`, so `isInstalled` predicts what
-// `link()` would throw.
+// "Installed" here means the library can write an MCP entry for the
+// agent. In system scope, that's true when the catalog's
+// `installCheckPaths` fingerprint the agent's presence on the machine
+// (`~/.opencode/`, `~/.claude.json`, etc.) OR the resolved config
+// file / its parent directory already exists. Aligned with the
+// `link()` gate so `isInstalled` predicts what `link()` would throw.
+//
+// Why installCheckPaths first: agents whose global config file is
+// USER-CREATED (OpenCode's `opencode.json`, Codex's `config.toml`,
+// ...) have no config file on a fresh install; systemPaths-only
+// probing misses them. installCheckPaths is the catalog's explicit
+// "the agent lives here" enumeration.
 // -------------------------------------------------------------------
 
 export interface IsInstalledInput {
@@ -285,6 +292,13 @@ async function checkOneInstalled(
   scope: AgentScope,
   projectRoot: string | undefined,
 ): Promise<boolean> {
+  // System scope: prefer the catalog's install fingerprint. `project`
+  // scope is answered entirely by the resolved projectRoot path, so
+  // the systemPath branch below covers it on its own.
+  if (scope === 'system') {
+    const checkList = resolveInstallCheckPaths(agent)
+    if (checkList.length > 0 && (await anyExists(checkList))) return true
+  }
   let configPath: string
   try {
     configPath = await resolveAgentMcpConfigPath(agent, scope, projectRoot)

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/io/index.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/io/index.ts
@@ -17,8 +17,8 @@ import {
   readFileWithExistence,
 } from '../_internal/atomic-write'
 import { readManifest } from '../_internal/manifest'
-import { pathExists } from '../_internal/paths'
-import { resolveAgentMcpConfigPath } from '../agents'
+import { anyExists, pathExists } from '../_internal/paths'
+import { resolveAgentMcpConfigPath, resolveInstallCheckPaths } from '../agents'
 import type { AgentFileState, FsOp, Plan, State } from '../planner/types'
 import type { AgentId, AgentScope } from '../types'
 
@@ -55,8 +55,9 @@ export async function readState(
   const scope = opts.scope ?? 'system'
   const agentFiles: AgentFileState[] = []
   for (const agent of agents ?? []) {
+    const override = opts.overrides?.[agent]
     const configPath =
-      opts.overrides?.[agent] ??
+      override ??
       (await resolveAgentMcpConfigPath(agent, scope, opts.projectRoot))
     const { content, exists } = await readFileWithExistence(configPath)
     // When the file exists, the parent must too. Only stat the parent
@@ -64,6 +65,22 @@ export async function readState(
     const parentExists = exists
       ? true
       : await pathExists(path.dirname(configPath))
+    // installCheckPaths widens the install signal past `exists ||
+    // parentExists` for agents whose config file is user-created
+    // (OpenCode's `opencode.json`, Codex's `config.toml`, ...). Only
+    // applied when the caller did NOT pass an explicit configPath
+    // override: an override means the caller chose the write target,
+    // and honoring installCheckPaths there would let `link()` create
+    // arbitrary directories from an unrelated install signal. Also
+    // never applied in project scope (installedness is projectRoot-
+    // based) or when `exists || parentExists` already answers true.
+    let installCheckHit = false
+    if (!override && scope === 'system' && !(exists || parentExists)) {
+      const checkList = resolveInstallCheckPaths(agent)
+      if (checkList.length > 0) {
+        installCheckHit = await anyExists(checkList)
+      }
+    }
     agentFiles.push({
       agent,
       scope,
@@ -71,6 +88,7 @@ export async function readState(
       rawContent: content,
       exists,
       parentExists,
+      installCheckHit,
     })
   }
   return {

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/planner/planner.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/planner/planner.ts
@@ -449,7 +449,18 @@ function requireAgentFile(
 }
 
 function ensureAgentInstalled(agent: AgentId, agentFile: AgentFileState): void {
-  if (agentFile.exists || agentFile.parentExists) return
+  // Any of three signals proves the agent is present:
+  //   1. config file already exists,
+  //   2. config file's parent directory exists,
+  //   3. one of the catalog's installCheckPaths exists (populated in
+  //      readState). Widens (1)+(2) for agents whose global config is
+  //      user-created and therefore absent on a fresh install
+  //      (OpenCode, Codex, ...). When (3) fires and (2) is false,
+  //      applyPlan's writeOp{ensureDir:true} still mkdir -p's the
+  //      parent before the atomic write.
+  if (agentFile.exists || agentFile.parentExists || agentFile.installCheckHit) {
+    return
+  }
   throw new AgentNotInstalledError(
     agent,
     agentFile.configPath,

--- a/packages/browseros-agent/packages/agent-mcp-manager/src/planner/types.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/src/planner/types.ts
@@ -45,6 +45,18 @@ export interface AgentFileState {
    * directory and creating a ghost config.
    */
   parentExists: boolean
+  /**
+   * True when at least one of the catalog's `installCheckPaths`
+   * entries for this agent exists on disk. Agents whose global
+   * config file is user-created (OpenCode, Codex, ...) can be
+   * installed without any of the `systemPaths` files or their
+   * parents existing yet, so this widens the install signal beyond
+   * `exists || parentExists`. Optional so pre-existing tests that
+   * synthesize an `AgentFileState` do not need to be updated;
+   * `readState` populates it in system scope, and the planner
+   * treats `undefined` as `false`.
+   */
+  installCheckHit?: boolean
 }
 
 /**

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/is-installed.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/is-installed.test.ts
@@ -48,9 +48,12 @@ describe('isInstalled', () => {
   })
 
   test('returns installed: false when neither exists', async () => {
-    // Nothing under $HOME/.cursor at all: agent not installed.
-    const result = await isInstalled({ agents: ['cursor'] })
-    expect(result.cursor).toBe(false)
+    // Nothing under $HOME/.codex at all: agent not installed. Uses
+    // codex because every one of its installCheckPaths lives under
+    // $HOME, so redirecting HOME to a fresh tmp dir fully isolates
+    // the probe from whatever real agents live on the runner.
+    const result = await isInstalled({ agents: ['codex'] })
+    expect(result.codex).toBe(false)
   })
 
   test('returns only the requested agents (no extra keys)', async () => {
@@ -75,11 +78,13 @@ describe('isInstalled', () => {
 
   test('reports false when the OS cannot resolve any path candidate', async () => {
     // Clearing $HOME makes all $HOME/... candidates unresolvable on
-    // this OS. resolveAgentMcpConfigPath throws UnresolvedConfigPath
-    // Error, which isInstalled catches and returns false for.
+    // this OS. Both installCheckPaths and systemPaths for codex
+    // reference $HOME, so `resolveInstallCheckPaths` returns an
+    // empty list and `resolveAgentMcpConfigPath` throws
+    // UnresolvedConfigPathError, which isInstalled catches.
     delete process.env.HOME
-    const result = await isInstalled({ agents: ['cursor'] })
-    expect(result.cursor).toBe(false)
+    const result = await isInstalled({ agents: ['codex'] })
+    expect(result.codex).toBe(false)
   })
 
   test('respects scope: project with projectRoot', async () => {
@@ -108,5 +113,28 @@ describe('isInstalled', () => {
     // `in` operator.
     const result = await isInstalled({ agents: ['cursor'] })
     expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
+  })
+
+  test('returns true when only an installCheckPaths entry exists (systemPath absent)', async () => {
+    // Regression coverage for BrowserOS issue #1861: OpenCode's global
+    // `opencode.json` is USER-CREATED. A fresh install has no
+    // systemPath file or parent yet, but the catalog's
+    // installCheckPaths point at OpenCode's data dirs. The probe must
+    // recognize this state as "installed", or the /mcp page hides the
+    // row post-Disconnect.
+    await mkdir(join(workspaceDir, '.local', 'share', 'opencode'), {
+      recursive: true,
+    })
+    const result = await isInstalled({ agents: ['opencode'] })
+    expect(result.opencode).toBe(true)
+  })
+
+  test('returns true when the legacy installCheckPaths entry exists', async () => {
+    // Older OpenCode installs live under ~/.opencode/. That directory
+    // alone still counts as installed even without any of the
+    // XDG-style systemPath files.
+    await mkdir(join(workspaceDir, '.opencode'), { recursive: true })
+    const result = await isInstalled({ agents: ['opencode'] })
+    expect(result.opencode).toBe(true)
   })
 })

--- a/packages/browseros-agent/packages/agent-mcp-manager/test/unit/is-installed.test.ts
+++ b/packages/browseros-agent/packages/agent-mcp-manager/test/unit/is-installed.test.ts
@@ -15,16 +15,25 @@ import { isInstalled } from '../../src/api'
 
 let workspaceDir: string
 let originalHome: string | undefined
+let originalUserProfile: string | undefined
 
 beforeEach(async () => {
   workspaceDir = await mkdtemp(join(tmpdir(), 'acpx-installed-'))
   originalHome = process.env.HOME
+  originalUserProfile = process.env.USERPROFILE
   process.env.HOME = workspaceDir
+  // Redirect the win32 home token too so the catalog's win32
+  // installCheckPaths / systemPaths (all `$USERPROFILE`-based) stay
+  // hermetic under the tmp dir. Without this, tests running on a
+  // win32 runner would silently probe the developer's real home.
+  process.env.USERPROFILE = workspaceDir
 })
 
 afterEach(async () => {
   if (originalHome === undefined) delete process.env.HOME
   else process.env.HOME = originalHome
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE
+  else process.env.USERPROFILE = originalUserProfile
   await rm(workspaceDir, { recursive: true, force: true })
 })
 


### PR DESCRIPTION
## Summary

Fixes #1861. On Windows (and any platform, really), disconnecting OpenCode from BrowserClaw makes the OpenCode row disappear from the /mcp page entirely, because \`checkOneInstalled\` misclassifies a valid OpenCode install as "not installed".

## Root cause

\`checkOneInstalled\` (\`packages/browseros-agent/packages/agent-mcp-manager/src/api.ts:283-298\`) decides installedness by resolving the OS-default configPath from \`systemPaths\` and testing \`pathExists(configPath) || pathExists(dirname(configPath))\`. That's the wrong signal for agents whose global config is USER-CREATED. OpenCode's own docs (https://opencode.ai/docs/config/) say the user creates \`opencode.json\` themselves; a fully-installed and functional OpenCode can have no config file at all.

The catalog already carries the RIGHT signal: \`installCheckPaths\`. \`detectInstalledAgents\` (\`agents.ts:112-120\`) uses it. \`checkOneInstalled\` was ignoring it.

After Disconnect, the manifest link record is gone, so \`listBrowserosConnections\` (\`services/browseros-connect.ts:181\`) leans on the \`isInstalled\` probe alone. The probe returns false, the row is filtered, restart doesn't help because the same probe answers false each boot.

## Fix

### Change 1 - export \`resolveInstallCheckPaths\` from \`agents.ts\`

Small helper that returns the catalog's install-check paths for the current OS, expanded. Empty when the current OS has no install-check list. Mirrors the pattern \`detectInstalledAgents\` already uses inline.

### Change 2 - \`checkOneInstalled\` prefers \`installCheckPaths\` in system scope

Aligns \`isInstalled\` with \`detectInstalledAgents\`. Falls back to the existing systemPath+dirname check when the catalog has no install-check list or none of them exists. Project scope untouched (installedness there is projectRoot-based).

### Change 3 - \`ensureAgentInstalled\` accepts the same signal via \`AgentFileState.installCheckHit\`

So the dual invariant "\`isInstalled\` predicts what \`link()\` would throw" (asserted by \`test/integration/fp-api.test.ts:335\`) is preserved. New optional field on \`AgentFileState\`; \`readState\` populates it in system scope only when \`exists || parentExists\` is false AND no explicit \`configPath\` override was passed. The override guard preserves the historical write-safety invariant: an explicit override + missing parent still throws, because the caller explicitly chose the write target and honoring \`installCheckPaths\` there would create arbitrary directories from an unrelated install signal.

### Change 4 - broaden OpenCode's \`installCheckPaths\`

Add \`~/.local/share/opencode\` (macOS/Linux) and \`%USERPROFILE%\\.local\\share\\opencode\` (Windows). Per OpenCode's docs, this is where it stores OAuth tokens; it exists as soon as a user has authenticated any OAuth MCP server or run the installer, even before they've created their global \`opencode.json\`.

### Non-goal

The defensive log line from the triage doc was intentionally skipped per Dani's instruction. Everything else in the triage design landed.

## What changed (files)

- \`packages/browseros-agent/packages/agent-mcp-manager/src/agents.ts\` - new exported \`resolveInstallCheckPaths\`.
- \`packages/browseros-agent/packages/agent-mcp-manager/src/api.ts\` - \`checkOneInstalled\` uses installCheckPaths first.
- \`packages/browseros-agent/packages/agent-mcp-manager/src/io/index.ts\` - \`readState\` populates \`installCheckHit\` on \`AgentFileState\`.
- \`packages/browseros-agent/packages/agent-mcp-manager/src/planner/types.ts\` - new optional \`installCheckHit\` field.
- \`packages/browseros-agent/packages/agent-mcp-manager/src/planner/planner.ts\` - \`ensureAgentInstalled\` accepts installCheckHit.
- \`packages/browseros-agent/packages/agent-mcp-manager/src/_catalog/client-configs.ts\` - opencode installCheckPaths + \`.local/share/opencode\`.
- \`packages/browseros-agent/packages/agent-mcp-manager/test/unit/is-installed.test.ts\` - two existing tests moved off cursor (its darwin installCheckPaths references \`/Applications/Cursor.app\`, an absolute path that leaks the runner's real state into the probe), two new tests cover the fix.

## Test plan

- [x] \`bun test\` in \`packages/agent-mcp-manager\` - 142/142 pass (was 140, +2 new).
- [x] \`bun test\` in \`apps/claw-server\` - 411/411 pass.
- [x] \`bunx tsc --noEmit\` in both packages - clean.
- [x] biome clean.
- [ ] Manual smoke on macOS: install OpenCode, do not create \`opencode.json\`, launch BrowserClaw, Connect + Disconnect OpenCode, confirm the row persists in the /mcp page.

## Reference

Triage plan at \`plans/browseros-ai/BrowserOS/audits/2026-07-17-2107-claude-code-issue-1861-opencode-disappears.md\` in the control-center repo (local).