### PR TITLE
fix(ci): pass VITE_CLAW_POSTHOG_KEY to claw nightly build

### DIFF
--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -193,6 +193,8 @@ jobs:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
           CHROMIUM_SRC: ${{ steps.build_inputs.outputs.chromium_src }}
           UPLOAD_TO_R2: ${{ steps.build_inputs.outputs.upload_to_r2 }}
+          VITE_CLAW_POSTHOG_KEY: ${{ secrets.VITE_CLAW_POSTHOG_KEY }}
+          VITE_CLAW_POSTHOG_HOST: ${{ secrets.VITE_CLAW_POSTHOG_HOST }}
         run: |
           set -euo pipefail
           cd "$BROWSEROS_REPO/packages/browseros"


### PR DESCRIPTION
Nightly claw run 29562522456 failed preflight: `bundled_extensions` requires `VITE_CLAW_POSTHOG_KEY` for the locally built BrowserClaw app extension. The VITE_ posthog set was added to `build-browseros.yml` (secrets exist, synced 2026-07-14) but the claw nightly's build step still only passed legacy `CLAW_POSTHOG_KEY` to the resource-staging step. Adds the KEY+HOST mapping to the build step env, mirroring build-browseros.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)