### PR TITLE
fix(ota): explain wrong-product appcast selection

### DIFF
--- a/packages/browseros/bos_build/cli/ota.py
+++ b/packages/browseros/bos_build/cli/ota.py
@@ -20,7 +20,12 @@ from ..release.ota.common import (
     SERVER_PLATFORMS,
 )
 from ..release.feeds.publisher import FeedPublisher
+from ..release.feeds.render import (
+    extract_appcast_item_count,
+    extract_appcast_version,
+)
 from ..release.feeds.spec import server_feed
+from ..products import SERVER_BUNDLES
 from ..products.server_binaries import server_ota_bundles_for_product
 
 app = typer.Typer(
@@ -74,6 +79,37 @@ def _feed_publisher() -> FeedPublisher:
         )
         raise typer.Exit(1)
     return FeedPublisher(env=env)
+
+
+def _log_alternate_product_appcasts(
+    selected_product: str, selected_bundle_id: str, channel: str
+) -> None:
+    """Suggest versioned staging appcasts owned by a different product."""
+    for bundle in SERVER_BUNDLES:
+        if bundle.id == selected_bundle_id:
+            continue
+        alternate_products = tuple(
+            product_id
+            for product_id in bundle.product_ids
+            if product_id != selected_product
+        )
+        if not alternate_products:
+            continue
+
+        candidate_path = get_appcast_path(channel, bundle.id).resolve()
+        try:
+            version = extract_appcast_version(candidate_path.read_text())
+        except (OSError, UnicodeError):
+            continue
+        if version is None:
+            continue
+
+        candidate_key = server_feed(bundle.id, channel).key
+        for product_id in alternate_products:
+            log_error(
+                f"Did you mean --product {product_id}? "
+                f"{candidate_key} carries {version}"
+            )
 
 
 @server_app.command("release")
@@ -166,7 +202,11 @@ def server_release_appcast(
         log_error(str(e))
         raise typer.Exit(1)
 
-    source_path = appcast_file or get_appcast_path(channel, bundle_id)
+    source_path = (appcast_file or get_appcast_path(channel, bundle_id)).resolve()
+    log_info(
+        f"Resolved appcast: product={product} bundle={bundle_id} "
+        f"channel={channel} spec={spec.key} source={source_path}"
+    )
     if not source_path.exists():
         log_error(f"Appcast file not found: {source_path}")
         if not appcast_file:
@@ -175,10 +215,17 @@ def server_release_appcast(
             )
         raise typer.Exit(1)
 
+    content = source_path.read_text()
+    if extract_appcast_item_count(content) == 0:
+        log_error(f"{spec.key} has no <item> entries: {source_path}")
+        if appcast_file is None:
+            _log_alternate_product_appcasts(product, bundle_id, channel)
+        raise typer.Exit(1)
+
     publisher = _feed_publisher()
     if not publisher.publish(
         spec,
-        source_path.read_text(),
+        content,
         publish=publish,
         allow_downgrade=allow_downgrade,
     ):

--- a/packages/browseros/bos_build/cli/ota_test.py
+++ b/packages/browseros/bos_build/cli/ota_test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""CLI tests for product-aware server appcast publication."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from typer.testing import CliRunner
+
+from bos_build.browseros import app
+from bos_build.cli import ota as ota_cli
+from bos_build.release.feeds.publisher import FeedPublisher
+from bos_build.release.feeds.spec import server_feed
+
+runner = CliRunner()
+
+
+class _MissingR2Client:
+    class exceptions:
+        class NoSuchKey(Exception):
+            pass
+
+    def get_object(self, Bucket, Key):
+        raise self.exceptions.NoSuchKey(Key)
+
+
+def _appcast(bundle_id: str, channel: str, version: str | None = None) -> str:
+    spec = server_feed(bundle_id, channel)
+    item = ""
+    if version is not None:
+        item = f"""
+    <item>
+      <sparkle:version>{version}</sparkle:version>
+    </item>
+"""
+    return f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>{spec.title}</title>
+    <link>{spec.link}</link>{item}
+  </channel>
+</rss>
+"""
+
+
+def _combined_output(result) -> str:
+    output = result.output
+    try:
+        output += result.stderr
+    except (AttributeError, ValueError):
+        pass
+    return output
+
+
+class ReleaseAppcastCliTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.paths = {
+            "browseros-server": self.root / "appcast-server.xml",
+            "browserclaw-server": self.root / "appcast-claw-server.xml",
+        }
+
+    def _get_appcast_path(self, channel: str, bundle_id: str) -> Path:
+        self.assertEqual(channel, "prod")
+        return self.paths[bundle_id]
+
+    def _publisher(self) -> FeedPublisher:
+        return FeedPublisher(
+            env=SimpleNamespace(r2_bucket="browseros"),
+            r2_client=_MissingR2Client(),
+            http_head=lambda _: 200,
+            appcast_staging_dir=self.root / "staged",
+        )
+
+    def _invoke(self, *args: str):
+        return runner.invoke(
+            app, ["ota", "server", "release-appcast", "--channel", "prod", *args]
+        )
+
+    def test_empty_default_feed_names_selection_and_hints_browserclaw(self):
+        self.paths["browseros-server"].write_text(
+            _appcast("browseros-server", "prod")
+        )
+        self.paths["browserclaw-server"].write_text(
+            _appcast("browserclaw-server", "prod", "0.0.12")
+        )
+
+        with (
+            mock.patch.object(
+                ota_cli, "get_appcast_path", side_effect=self._get_appcast_path
+            ),
+            mock.patch.object(ota_cli, "_feed_publisher") as publisher_factory,
+        ):
+            result = self._invoke("--publish")
+
+        output = _combined_output(result)
+        self.assertEqual(result.exit_code, 1, output)
+        self.assertIn(
+            "Resolved appcast: product=browseros bundle=browseros-server "
+            "channel=prod spec=appcast-server.xml "
+            f"source={self.paths['browseros-server'].resolve()}",
+            output,
+        )
+        self.assertIn(
+            f"appcast-server.xml has no <item> entries: "
+            f"{self.paths['browseros-server'].resolve()}",
+            output,
+        )
+        self.assertIn(
+            "Did you mean --product browserclaw? "
+            "appcast-claw-server.xml carries 0.0.12",
+            output,
+        )
+        publisher_factory.assert_not_called()
+
+    def test_missing_sibling_feed_does_not_mask_empty_error(self):
+        self.paths["browseros-server"].write_text(
+            _appcast("browseros-server", "prod")
+        )
+
+        with (
+            mock.patch.object(
+                ota_cli, "get_appcast_path", side_effect=self._get_appcast_path
+            ),
+            mock.patch.object(ota_cli, "_feed_publisher") as publisher_factory,
+        ):
+            result = self._invoke()
+
+        output = _combined_output(result)
+        self.assertEqual(result.exit_code, 1, output)
+        self.assertIn("appcast-server.xml has no <item> entries", output)
+        self.assertNotIn("Did you mean --product", output)
+        publisher_factory.assert_not_called()
+
+    def test_explicit_browserclaw_uses_versioned_claw_feed(self):
+        self.paths["browserclaw-server"].write_text(
+            _appcast("browserclaw-server", "prod", "0.0.12")
+        )
+
+        with (
+            mock.patch.object(
+                ota_cli, "get_appcast_path", side_effect=self._get_appcast_path
+            ),
+            mock.patch.object(
+                ota_cli, "_feed_publisher", side_effect=self._publisher
+            ),
+        ):
+            result = self._invoke("--product", "browserclaw")
+
+        output = _combined_output(result)
+        self.assertEqual(result.exit_code, 0, output)
+        self.assertIn(
+            "Resolved appcast: product=browserclaw bundle=browserclaw-server "
+            "channel=prod spec=appcast-claw-server.xml "
+            f"source={self.paths['browserclaw-server'].resolve()}",
+            output,
+        )
+        self.assertNotIn("no sparkle:version", output)
+
+    def test_custom_empty_file_does_not_suggest_another_product(self):
+        custom = self.root / "custom.xml"
+        custom.write_text(_appcast("browseros-server", "prod"))
+        self.paths["browserclaw-server"].write_text(
+            _appcast("browserclaw-server", "prod", "0.0.12")
+        )
+
+        with mock.patch.object(ota_cli, "_feed_publisher") as publisher_factory:
+            result = self._invoke("--file", str(custom))
+
+        output = _combined_output(result)
+        self.assertEqual(result.exit_code, 1, output)
+        self.assertIn(f"source={custom.resolve()}", output)
+        self.assertNotIn("Did you mean --product", output)
+        publisher_factory.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/release/feeds/publisher.py
+++ b/packages/browseros/bos_build/release/feeds/publisher.py
@@ -20,6 +20,7 @@ from ...lib.paths import get_package_root
 from ...lib.r2 import get_r2_client
 from ...lib.utils import log_error, log_info, log_success, log_warning
 from .render import (
+    extract_appcast_item_count,
     extract_appcast_version,
     extract_channel_metadata,
     extract_enclosure_urls,
@@ -149,7 +150,7 @@ class FeedPublisher:
             spec.kind in ("browser", "server")
             and extract_appcast_version(content) is None
         ):
-            log_error(f"{spec.key}: new content carries no sparkle:version")
+            self._log_appcast_version_error(spec, content)
             return False
 
         if not self._check_download_urls(spec, content):
@@ -289,7 +290,7 @@ class FeedPublisher:
     ) -> bool:
         new_version = extract_appcast_version(content)
         if new_version is None:
-            log_error(f"{spec.key}: new content carries no sparkle:version")
+            self._log_appcast_version_error(spec, content)
             return False
 
         live_version = extract_appcast_version(live)
@@ -298,6 +299,14 @@ class FeedPublisher:
 
         return self._refuse_downgrade(
             spec, f"{spec.key}", new_version, live_version, allow_downgrade
+        )
+
+    def _log_appcast_version_error(self, spec: FeedSpec, content: str) -> None:
+        if extract_appcast_item_count(content) == 0:
+            log_error(f"{spec.key}: new content has no <item> entries")
+            return
+        log_error(
+            f"{spec.key}: new content has <item> entries but no sparkle:version"
         )
 
     def _guard_manifest_versions(

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 from .publisher import FeedPublisher
 from .render import (
@@ -72,6 +73,19 @@ def _mac_appcast(sparkle_version="10000.0.47.0.2"):
         sparkle_version,
         "2026-06-19T06:41:33Z",
     )
+
+
+def _empty_mac_appcast():
+    spec = feed_by_key("appcast.xml")
+    return f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>{spec.title}</title>
+    <link>{spec.link}</link>
+  </channel>
+</rss>
+"""
 
 
 class PublisherTestCase(unittest.TestCase):
@@ -312,16 +326,76 @@ class PublisherTestCase(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(self.client.calls, [])
 
-    def test_versionless_appcast_refused_even_on_first_publish(self):
+    def test_empty_appcast_refused_with_item_error(self):
+        publisher = self._publisher()
+
+        with mock.patch(
+            "bos_build.release.feeds.publisher.log_error"
+        ) as log_error:
+            ok = publisher.publish(
+                feed_by_key("appcast.xml"), _empty_mac_appcast(), publish=True
+            )
+
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
+        log_error.assert_called_with(
+            "appcast.xml: new content has no <item> entries"
+        )
+
+    def test_versionless_appcast_refused_with_version_error(self):
         content = _mac_appcast().replace(
             "<sparkle:version>10000.0.47.0.2</sparkle:version>", ""
         )
         publisher = self._publisher()
 
-        ok = publisher.publish(feed_by_key("appcast.xml"), content, publish=True)
+        with mock.patch(
+            "bos_build.release.feeds.publisher.log_error"
+        ) as log_error:
+            ok = publisher.publish(
+                feed_by_key("appcast.xml"), content, publish=True
+            )
 
         self.assertFalse(ok)
         self.assertEqual(self.client.calls, [])
+        log_error.assert_called_with(
+            "appcast.xml: new content has <item> entries but no sparkle:version"
+        )
+
+    def test_live_guard_distinguishes_empty_appcast(self):
+        publisher = self._publisher()
+
+        with mock.patch(
+            "bos_build.release.feeds.publisher.log_error"
+        ) as log_error:
+            ok = publisher._guard_appcast_version(
+                feed_by_key("appcast.xml"),
+                _empty_mac_appcast(),
+                _mac_appcast(),
+                False,
+            )
+
+        self.assertFalse(ok)
+        log_error.assert_called_with(
+            "appcast.xml: new content has no <item> entries"
+        )
+
+    def test_live_guard_distinguishes_versionless_items(self):
+        content = _mac_appcast().replace(
+            "<sparkle:version>10000.0.47.0.2</sparkle:version>", ""
+        )
+        publisher = self._publisher()
+
+        with mock.patch(
+            "bos_build.release.feeds.publisher.log_error"
+        ) as log_error:
+            ok = publisher._guard_appcast_version(
+                feed_by_key("appcast.xml"), content, _mac_appcast(), False
+            )
+
+        self.assertFalse(ok)
+        log_error.assert_called_with(
+            "appcast.xml: new content has <item> entries but no sparkle:version"
+        )
 
     def test_json_array_document_refused_cleanly(self):
         publisher = self._publisher()

--- a/packages/browseros/bos_build/release/feeds/render.py
+++ b/packages/browseros/bos_build/release/feeds/render.py
@@ -372,6 +372,15 @@ def extract_appcast_version(content: str) -> Optional[str]:
     return max(versions, key=parse_dotted_version)
 
 
+def extract_appcast_item_count(content: str) -> Optional[int]:
+    """Return the channel item count, or None for malformed XML."""
+    try:
+        root = ET.fromstring(content)
+    except ET.ParseError:
+        return None
+    return len(root.findall("channel/item"))
+
+
 def _gupdate_apps(root: ET.Element) -> List[ET.Element]:
     apps = root.findall(f".//{{{GUPDATE_NS}}}app")
     return apps if apps else root.findall(".//app")

--- a/packages/browseros/bos_build/release/feeds/render_test.py
+++ b/packages/browseros/bos_build/release/feeds/render_test.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from .render import (
     ExistingAppcast,
     SignedArtifact,
+    extract_appcast_item_count,
     extract_appcast_version,
     extract_channel_metadata,
     extract_enclosure_urls,
@@ -320,6 +321,11 @@ class VersionHelpersTest(unittest.TestCase):
         )
         self.assertEqual(extract_appcast_version(GOLDEN_CLAW_SERVER_APPCAST), "0.0.5")
         self.assertIsNone(extract_appcast_version("<rss><channel/></rss>"))
+
+    def test_extract_appcast_item_count(self):
+        self.assertEqual(extract_appcast_item_count(GOLDEN_MAC_APPCAST), 1)
+        self.assertEqual(extract_appcast_item_count("<rss><channel/></rss>"), 0)
+        self.assertIsNone(extract_appcast_item_count("<rss><channel>"))
 
     def test_extract_manifest_versions(self):
         self.assertEqual(


### PR DESCRIPTION
## Summary
- log the resolved product, server bundle, channel, feed key, and source path before appcast publication checks
- fail confirmed empty appcasts before R2 credentials and suggest a versioned sibling product feed when present
- distinguish zero-item appcasts from items missing sparkle:version in both publisher guard paths

## Design
The CLI retains explicit product selection and only scans canonical sibling staging appcasts to produce diagnostic hints. Shared XML inspection classifies well-formed empty feeds, while FeedPublisher remains responsible for malformed content, metadata, download, downgrade, backup, and write rails.

## Test plan
- [x] uv run pytest bos_build/cli/ota_test.py bos_build/release/feeds/render_test.py bos_build/release/feeds/publisher_test.py
- [x] uv run ruff check on all touched Python files
- [x] uv run pyright on touched production modules
- [x] uv run pytest (768 passed)
