### PR TITLE
fix: disable PDF promo and brand infobar icons

### DIFF
--- a/packages/browseros/chromium_patches/.features.yaml
+++ b/packages/browseros/chromium_patches/.features.yaml
@@ -494,3 +494,12 @@ features:
       - components/os_crypt/common/keychain_password_mac_unittest.mm
       - ui/webui/resources/tools/generate_grd.gni
       - ui/webui/resources/tools/generate_grd.py
+
+  pdf-infobar-icons:
+    description: "feat: pdf-infobar-icons"
+    files:
+      - chrome/browser/ui/pdf/infobar/
+      - chrome/browser/ui/startup/default_browser_prompt/
+      - chrome/browser/ui/startup/startup_launch_infobar_delegate.cc
+      - chrome/browser/ui/startup/startup_launch_infobar_delegate.h
+      - chrome/browser/ui/views/session_restore_infobar/

--- a/packages/browseros/chromium_patches/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.cc
@@ -1,0 +1,28 @@
+diff --git a/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.cc b/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.cc
+index 3f3868e1ba674ed4680ae36a74589209c3a55c04..5523eaedd37bb4ac74e98e598c058dcd5b5d5fa0 100644
+--- a/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.cc
++++ b/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.cc
+@@ -15,10 +15,9 @@
+ #include "chrome/common/buildflags.h"
+ #include "chrome/grit/branded_strings.h"
+ #include "chrome/grit/generated_resources.h"
++#include "chrome/grit/theme_resources.h"
+ #include "components/infobars/content/content_infobar_manager.h"
+ #include "components/infobars/core/infobar.h"
+-#include "components/omnibox/browser/vector_icons.h"
+-#include "components/vector_icons/vector_icons.h"
+ #include "content/public/browser/web_contents.h"
+ #include "ui/base/l10n/l10n_util.h"
+ #include "ui/gfx/native_ui_types.h"
+@@ -130,9 +129,8 @@ infobars::InfoBarDelegate::InfoBarIdentifier PdfInfoBarDelegate::GetIdentifier()
+   return PDF_INFOBAR_DELEGATE;
+ }
+ 
+-const gfx::VectorIcon& PdfInfoBarDelegate::GetVectorIcon() const {
+-  return dark_mode() ? omnibox::kProductChromeRefreshIcon
+-                     : vector_icons::kProductRefreshIcon;
++int PdfInfoBarDelegate::GetIconId() const {
++  return IDR_PRODUCT_LOGO_16;
+ }
+ 
+ std::u16string PdfInfoBarDelegate::GetMessageText() const {

--- a/packages/browseros/chromium_patches/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.h
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.h b/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.h
+index c953edf3ffd56211c01b569bfd55a0bb0ed2937f..431436247ff1ae3b26a3929fd6abf1b42e7a931f 100644
+--- a/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.h
++++ b/chrome/browser/ui/pdf/infobar/pdf_infobar_delegate.h
+@@ -38,7 +38,7 @@ class PdfInfoBarDelegate : public ConfirmInfoBarDelegate {
+ 
+   // InfoBarDelegate:
+   infobars::InfoBarDelegate::InfoBarIdentifier GetIdentifier() const override;
+-  const gfx::VectorIcon& GetVectorIcon() const override;
++  int GetIconId() const override;
+ 
+   // ConfirmInfoBarDelegate:
+   std::u16string GetMessageText() const override;

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.cc
@@ -1,0 +1,28 @@
+diff --git a/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.cc b/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.cc
+index 571ed2313ded67e4cb313eda268495b3ed353723..9591257e8f6a38e652cbc90a62dcebca7ea3c7c4 100644
+--- a/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.cc
++++ b/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.cc
+@@ -12,10 +12,9 @@
+ #include "chrome/browser/ui/startup/default_browser_prompt/default_browser_prompt_prefs.h"
+ #include "chrome/grit/branded_strings.h"
+ #include "chrome/grit/generated_resources.h"
++#include "chrome/grit/theme_resources.h"
+ #include "components/infobars/core/confirm_infobar_delegate.h"
+ #include "components/infobars/core/infobar.h"
+-#include "components/omnibox/browser/vector_icons.h"
+-#include "components/vector_icons/vector_icons.h"
+ #include "ui/base/l10n/l10n_util.h"
+ 
+ // static
+@@ -42,9 +41,8 @@ DefaultBrowserInfoBarDelegate::GetIdentifier() const {
+   return DEFAULT_BROWSER_INFOBAR_DELEGATE;
+ }
+ 
+-const gfx::VectorIcon& DefaultBrowserInfoBarDelegate::GetVectorIcon() const {
+-  return dark_mode() ? omnibox::kProductChromeRefreshIcon
+-                     : vector_icons::kProductRefreshIcon;
++int DefaultBrowserInfoBarDelegate::GetIconId() const {
++  return IDR_PRODUCT_LOGO_16;
+ }
+ 
+ bool DefaultBrowserInfoBarDelegate::ShouldExpire(

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.h
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.h b/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.h
+index 2f2eece414c41285704de005fce2acda224d32b1..207587516423e3a1fae15da362a8bcd65201da62 100644
+--- a/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.h
++++ b/chrome/browser/ui/startup/default_browser_prompt/default_browser_infobar_delegate.h
+@@ -40,7 +40,7 @@ class DefaultBrowserInfoBarDelegate : public ConfirmInfoBarDelegate {
+  private:
+   // ConfirmInfoBarDelegate:
+   infobars::InfoBarDelegate::InfoBarIdentifier GetIdentifier() const override;
+-  const gfx::VectorIcon& GetVectorIcon() const override;
++  int GetIconId() const override;
+   bool ShouldExpire(const NavigationDetails& details) const override;
+   void InfoBarDismissed() override;
+   std::u16string GetMessageText() const override;

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.cc
@@ -1,0 +1,28 @@
+diff --git a/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.cc b/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.cc
+index f598b6139232d21a089401da367641987def6347..59a36a0a9db2dbfe8e3df8bbe3e520476b157a1f 100644
+--- a/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.cc
++++ b/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.cc
+@@ -14,10 +14,9 @@
+ #include "chrome/browser/ui/ui_features.h"
+ #include "chrome/grit/branded_strings.h"
+ #include "chrome/grit/generated_resources.h"
++#include "chrome/grit/theme_resources.h"
+ #include "components/infobars/content/content_infobar_manager.h"
+ #include "components/infobars/core/infobar.h"
+-#include "components/omnibox/browser/vector_icons.h"
+-#include "components/vector_icons/vector_icons.h"
+ #include "ui/base/l10n/l10n_util.h"
+ 
+ #if BUILDFLAG(IS_WIN)
+@@ -96,9 +95,8 @@ infobars::InfoBarDelegate::InfoBarIdentifier PinInfoBarDelegate::GetIdentifier()
+   return PIN_INFOBAR_DELEGATE;
+ }
+ 
+-const gfx::VectorIcon& PinInfoBarDelegate::GetVectorIcon() const {
+-  return dark_mode() ? omnibox::kProductChromeRefreshIcon
+-                     : vector_icons::kProductRefreshIcon;
++int PinInfoBarDelegate::GetIconId() const {
++  return IDR_PRODUCT_LOGO_16;
+ }
+ 
+ std::u16string PinInfoBarDelegate::GetMessageText() const {

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.h
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.h b/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.h
+index 3fa4d27bb7d8e310537768d6cc27816360b66a7d..d158d32359f8175917501f911c9eb41f071324a5 100644
+--- a/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.h
++++ b/chrome/browser/ui/startup/default_browser_prompt/pin_infobar/pin_infobar_delegate.h
+@@ -39,7 +39,7 @@ class PinInfoBarDelegate : public ConfirmInfoBarDelegate {
+ 
+   // InfoBarDelegate:
+   infobars::InfoBarDelegate::InfoBarIdentifier GetIdentifier() const override;
+-  const gfx::VectorIcon& GetVectorIcon() const override;
++  int GetIconId() const override;
+ 
+   // ConfirmInfoBarDelegate:
+   std::u16string GetMessageText() const override;

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_launch_infobar_delegate.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_launch_infobar_delegate.cc
@@ -1,0 +1,29 @@
+diff --git a/chrome/browser/ui/startup/startup_launch_infobar_delegate.cc b/chrome/browser/ui/startup/startup_launch_infobar_delegate.cc
+index a8d86170c9a33617c53be2d6edf56bb71272ad28..559f8e31d2653c41868daa9808542dae573773c7 100644
+--- a/chrome/browser/ui/startup/startup_launch_infobar_delegate.cc
++++ b/chrome/browser/ui/startup/startup_launch_infobar_delegate.cc
+@@ -16,11 +16,10 @@
+ #include "chrome/common/webui_url_constants.h"
+ #include "chrome/grit/branded_strings.h"
+ #include "chrome/grit/generated_resources.h"
++#include "chrome/grit/theme_resources.h"
+ #include "components/infobars/core/confirm_infobar_delegate.h"
+ #include "components/infobars/core/infobar.h"
+-#include "components/omnibox/browser/vector_icons.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/vector_icons/vector_icons.h"
+ #include "ui/base/l10n/l10n_util.h"
+ #include "ui/base/ui_base_types.h"
+ 
+@@ -47,9 +46,8 @@ StartupLaunchInfoBarDelegate::GetIdentifier() const {
+   return STARTUP_LAUNCH_INFOBAR_DELEGATE;
+ }
+ 
+-const gfx::VectorIcon& StartupLaunchInfoBarDelegate::GetVectorIcon() const {
+-  return dark_mode() ? omnibox::kProductChromeRefreshIcon
+-                     : vector_icons::kProductRefreshIcon;
++int StartupLaunchInfoBarDelegate::GetIconId() const {
++  return IDR_PRODUCT_LOGO_16;
+ }
+ 
+ bool StartupLaunchInfoBarDelegate::ShouldExpire(

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_launch_infobar_delegate.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_launch_infobar_delegate.h
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/startup/startup_launch_infobar_delegate.h b/chrome/browser/ui/startup/startup_launch_infobar_delegate.h
+index 4c3e07af3b3a4f0aab0c86f311586b69404a83f1..c5627fad5f6676c78c5cd2c12f4a3fea00ea3164 100644
+--- a/chrome/browser/ui/startup/startup_launch_infobar_delegate.h
++++ b/chrome/browser/ui/startup/startup_launch_infobar_delegate.h
+@@ -37,7 +37,7 @@ class StartupLaunchInfoBarDelegate : public ConfirmInfoBarDelegate {
+  private:
+   // ConfirmInfoBarDelegate:
+   infobars::InfoBarDelegate::InfoBarIdentifier GetIdentifier() const override;
+-  const gfx::VectorIcon& GetVectorIcon() const override;
++  int GetIconId() const override;
+   bool ShouldExpire(const NavigationDetails& details) const override;
+   std::u16string GetMessageText() const override;
+   int GetButtons() const override;

--- a/packages/browseros/chromium_patches/chrome/browser/ui/ui_features.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/ui_features.cc
@@ -1,7 +1,16 @@
 diff --git a/chrome/browser/ui/ui_features.cc b/chrome/browser/ui/ui_features.cc
-index 6db423701529a..80ca4bca6e9f6 100644
+index 6db423701529ad784468e3414b008f99c3a8d8bb..67d895e815c3456189963413aec2b420714744fa 100644
 --- a/chrome/browser/ui/ui_features.cc
 +++ b/chrome/browser/ui/ui_features.cc
+@@ -67,7 +67,7 @@ BASE_FEATURE(kOfferPinToTaskbarInSettings, base::FEATURE_ENABLED_BY_DEFAULT);
+ BASE_FEATURE(kOfferPinToTaskbarInfoBar, base::FEATURE_ENABLED_BY_DEFAULT);
+ // Shows an infobar on PDFs offering to become the default PDF viewer if Chrome
+ // isn't the default already.
+-BASE_FEATURE(kPdfInfoBar, base::FEATURE_ENABLED_BY_DEFAULT);
++BASE_FEATURE(kPdfInfoBar, base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kSeparateDefaultAndPinPrompt, base::FEATURE_DISABLED_BY_DEFAULT);
+ BASE_FEATURE_PARAM(int,
 @@ -154,6 +154,10 @@ BASE_FEATURE_PARAM(int,
                     "max_distance_threshold",
                     20);

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.cc
@@ -1,0 +1,32 @@
+diff --git a/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.cc b/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.cc
+index 32a98bbe7bb4be60015f2a3e3888f7933cc49b16..0704970581cffd1b0e8b7f81cc6f93edcd3ef5c4 100644
+--- a/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.cc
++++ b/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.cc
+@@ -17,14 +17,12 @@
+ #include "chrome/common/pref_names.h"
+ #include "chrome/grit/branded_strings.h"
+ #include "chrome/grit/generated_resources.h"
++#include "chrome/grit/theme_resources.h"
+ #include "components/infobars/content/content_infobar_manager.h"
+ #include "components/infobars/core/infobar.h"
+ #include "components/infobars/core/infobar_manager.h"
+-#include "components/omnibox/browser/vector_icons.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/vector_icons/vector_icons.h"
+ #include "ui/base/l10n/l10n_util.h"
+-#include "ui/gfx/vector_icon_types.h"
+ 
+ namespace session_restore_infobar {
+ 
+@@ -140,9 +138,8 @@ SessionRestoreInfoBarDelegate::GetIdentifier() const {
+       SESSION_RESTORE_INFOBAR_DELEGATE;
+ }
+ 
+-const gfx::VectorIcon& SessionRestoreInfoBarDelegate::GetVectorIcon() const {
+-  return dark_mode() ? omnibox::kProductChromeRefreshIcon
+-                     : vector_icons::kProductRefreshIcon;
++int SessionRestoreInfoBarDelegate::GetIconId() const {
++  return IDR_PRODUCT_LOGO_16;
+ }
+ 
+ bool SessionRestoreInfoBarDelegate::ShouldExpire(

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.h
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.h b/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.h
+index b4cef54f99df89ac0c7997bbb7187e0ce8845ede..3da16fa2c075bc4c07b7956440feceaeff845918 100644
+--- a/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.h
++++ b/chrome/browser/ui/views/session_restore_infobar/session_restore_infobar_delegate.h
+@@ -70,7 +70,7 @@ class SessionRestoreInfoBarDelegate : public ConfirmInfoBarDelegate {
+ 
+   // ConfirmInfoBarDelegate:
+   infobars::InfoBarDelegate::InfoBarIdentifier GetIdentifier() const override;
+-  const gfx::VectorIcon& GetVectorIcon() const override;
++  int GetIconId() const override;
+   bool ShouldExpire(const NavigationDetails& details) const override;
+   std::u16string GetMessageText() const override;
+   std::u16string GetLinkText() const override;


### PR DESCRIPTION
## Summary
- disable the upstream default-PDF-viewer infobar by default while keeping its feature gate intact
- use the per-product 16px logo resource for default-browser, PDF, pin, startup-launch, and session-restore infobars
- register the new patch ownership at the exact infobar paths

## Design
The PDF promo remains fully wired but defaults off, so it can still be re-enabled through the feature system. Product-logo infobars now override GetIconId instead of GetVectorIcon, letting the base infobar delegate load the BrowserOS or BrowserClaw branded resource through ResourceBundle.

## Test plan
- [x] build Chrome through the sfmux global build slot with autoninja -C out/Default_browseros_arm64 chrome
- [x] verify a fresh BrowserOS Dev profile creates no PDF infobar, still shows the default-browser infobar when triggered, and serves an orange IDR_PRODUCT_LOGO_16 with zero blue pixels
- [x] verify all 11 extracted patches byte-match the Chromium tip and apply cleanly to BASE_COMMIT
- [x] confirm no product-refresh vector icon references remain in the scoped infobar delegate paths