### PR TITLE
feat: move replay UI to target-based recordings API

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
@@ -40,7 +40,7 @@ export function TaskHeader({ task }: TaskHeaderProps) {
   const replayMeta = useReplayMetadata({
     variables: { sessionId: task.sessionId },
   })
-  const replayReady = replayMeta.data?.hasData === true
+  const replayReady = replayMeta.data?.exists === true
 
   return (
     <section className="space-y-4">

--- a/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import * as client from './client'
+
+mock.module('./client', () => ({
+  ...client,
+  resolveApiBaseUrl: async () => 'http://127.0.0.1:9200',
+}))
+
+const { fetchReplayEvents, fetchReplayMetadata } = await import(
+  './replay.hooks'
+)
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('replay queries', () => {
+  it('fetches replay metadata from the plural meta endpoint', async () => {
+    const metadata = {
+      exists: true,
+      firstEventAt: 1_000,
+      lastEventAt: 4_000,
+      sizeBytes: 512,
+      targets: [
+        {
+          targetId: 'target-a',
+          tabId: 7,
+          firstEventAt: 1_000,
+          lastEventAt: 4_000,
+        },
+      ],
+    }
+    const request = mock(async () => Response.json(metadata))
+    globalThis.fetch = request as typeof fetch
+
+    await expect(
+      fetchReplayMetadata({ sessionId: 'session/with slash' }),
+    ).resolves.toEqual(metadata)
+    expect(request).toHaveBeenCalledWith(
+      'http://127.0.0.1:9200/audit/replays/session%2Fwith%20slash/meta',
+    )
+  })
+
+  it('preserves the empty metadata shape when no replay exists', async () => {
+    const metadata = { exists: false, sizeBytes: 0, targets: [] }
+    globalThis.fetch = mock(async () => Response.json(metadata)) as typeof fetch
+
+    await expect(
+      fetchReplayMetadata({ sessionId: 'session-1' }),
+    ).resolves.toEqual(metadata)
+  })
+
+  it('parses valid replay lines and skips malformed lines', async () => {
+    const body = [
+      JSON.stringify({
+        sessionId: 'session-1',
+        targetId: 'target-b',
+        tabId: 9,
+        ts: 2_000,
+        type: 4,
+        data: { width: 1280, height: 720 },
+      }),
+      '{not-json',
+      JSON.stringify({
+        sessionId: 'session-1',
+        tabId: 9,
+        ts: 2_500,
+        type: 3,
+        data: {},
+      }),
+      JSON.stringify({
+        sessionId: 'session-1',
+        targetId: 'target-a',
+        tabId: 3,
+        ts: 3_000,
+        type: 2,
+        data: {},
+      }),
+    ].join('\n')
+    const request = mock(async () => new Response(body))
+    globalThis.fetch = request as typeof fetch
+
+    await expect(
+      fetchReplayEvents({ sessionId: 'session-1' }),
+    ).resolves.toEqual({
+      events: [
+        {
+          sessionId: 'session-1',
+          targetId: 'target-b',
+          tabId: 9,
+          ts: 2_000,
+          type: 4,
+          data: { width: 1280, height: 720 },
+        },
+        {
+          sessionId: 'session-1',
+          targetId: 'target-a',
+          tabId: 3,
+          ts: 3_000,
+          type: 2,
+          data: {},
+        },
+      ],
+      targetIds: ['target-b', 'target-a'],
+    })
+    expect(request).toHaveBeenCalledWith(
+      'http://127.0.0.1:9200/audit/replays/session-1',
+    )
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.test.ts
@@ -33,7 +33,7 @@ describe('replay queries', () => {
       ],
     }
     const request = mock(async () => Response.json(metadata))
-    globalThis.fetch = request as typeof fetch
+    globalThis.fetch = request as unknown as typeof fetch
 
     await expect(
       fetchReplayMetadata({ sessionId: 'session/with slash' }),
@@ -45,7 +45,9 @@ describe('replay queries', () => {
 
   it('preserves the empty metadata shape when no replay exists', async () => {
     const metadata = { exists: false, sizeBytes: 0, targets: [] }
-    globalThis.fetch = mock(async () => Response.json(metadata)) as typeof fetch
+    globalThis.fetch = mock(async () =>
+      Response.json(metadata),
+    ) as unknown as typeof fetch
 
     await expect(
       fetchReplayMetadata({ sessionId: 'session-1' }),
@@ -80,7 +82,7 @@ describe('replay queries', () => {
       }),
     ].join('\n')
     const request = mock(async () => new Response(body))
-    globalThis.fetch = request as typeof fetch
+    globalThis.fetch = request as unknown as typeof fetch
 
     await expect(
       fetchReplayEvents({ sessionId: 'session-1' }),

--- a/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
@@ -4,31 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * Session-replay API surface for the claw-app cockpit.
- *
- * Two consumers, two hooks:
- *
- *   - `useReplayMetadata({ sessionId })` polls
- *     `GET /audit/replay/:sessionId/exists` (cheap) so the audit
- *     task page can flip its "View Session Replay" CTA between
- *     enabled and "no replay yet". Refetches while the page is
- *     open so a live session unlocks the CTA without a hard
- *     refresh.
- *
- *   - `useReplayEvents({ sessionId })` fetches the full NDJSON
- *     stream from `GET /audit/replay/:sessionId` and parses each
- *     line into an rrweb event. Mounted only by the replay page;
- *     the cache is keyed on sessionId so swapping between two
- *     audit sessions does not re-fetch when both are still in
- *     view.
- *
- * Type definitions for the visual frame timeline that the existing
- * `screens/replay/` scaffold consumes live here too. Frames are
- * derived in `screens/replay/replay.data.ts` from real
- * tool_dispatches, not from this file.
  */
 
 import { createQuery } from 'react-query-kit'
-import { api } from './client'
+import { resolveApiBaseUrl } from './client'
 import { parseResponse } from './parseResponse'
 
 export type ReplayVerb =
@@ -67,40 +46,51 @@ export interface ReplayFrame {
    * as the operator switches between them.
    */
   pageId?: number | null
+  /** Stable CDP target this frame belongs to, when known. */
+  targetId?: string | null
   /** Optional badge shown on the timeline row ("Blocked", "Cancelled"). */
   note?: string
   /** Source dispatch id so the replay surface can deep-link. */
   dispatchId?: number
 }
 
-/**
- * One rrweb event as parsed from the NDJSON stream. The on-disk line
- * carries `sessionId` (server-trusted) + `tabPageId` (recorder-supplied)
- * + the standard rrweb `{type, data, ts}`. The replay UI filters by
- * `tabPageId` to drive a single rrweb-player instance at a time.
- */
 export interface ReplayEvent {
   sessionId: string
-  tabPageId: number
-  /** rrweb event type 0-5. */
+  targetId: string
+  tabId: number
   type: number
   data: unknown
-  /** Capture timestamp, ms since epoch. */
   ts: number
 }
 
+export interface ReplayTargetMetadata {
+  targetId: string
+  tabId: number
+  firstEventAt: number
+  lastEventAt: number
+}
+
 export interface ReplayMetadata {
-  ok: boolean
-  hasData: boolean
+  exists: boolean
   sizeBytes: number
   firstEventAt?: number
   lastEventAt?: number
-  /** Distinct page ids that contributed events to this session. */
-  tabPageIds: number[]
+  targets: ReplayTargetMetadata[]
 }
 
-interface UseReplayMetadataVariables {
+export interface UseReplayMetadataVariables {
   sessionId: string
+}
+
+/** Fetches the replay target index used by the CTA and tab picker. */
+export async function fetchReplayMetadata({
+  sessionId,
+}: UseReplayMetadataVariables): Promise<ReplayMetadata> {
+  const baseUrl = await resolveApiBaseUrl()
+  const res = await fetch(
+    `${baseUrl}/audit/replays/${encodeURIComponent(sessionId)}/meta`,
+  )
+  return parseResponse<ReplayMetadata>(res)
 }
 
 export const useReplayMetadata = createQuery<
@@ -108,27 +98,60 @@ export const useReplayMetadata = createQuery<
   UseReplayMetadataVariables
 >({
   queryKey: ['replay', 'metadata'],
-  fetcher: async ({ sessionId }) => {
-    const res = await api.audit.replay[':sessionId'].exists.$get({
-      param: { sessionId },
-    })
-    return parseResponse<ReplayMetadata>(res)
-  },
-  // While a live session is still streaming events the metadata
-  // (sizeBytes, lastEventAt, tabPageIds) keeps changing. 10s is a
-  // cheap poll over loopback and is what flips the CTA from
-  // disabled to enabled the first time data arrives.
+  fetcher: fetchReplayMetadata,
   refetchInterval: 10_000,
 })
 
-interface UseReplayEventsVariables {
+export interface UseReplayEventsVariables {
   sessionId: string
 }
 
 export interface ReplayEventsBundle {
   events: ReplayEvent[]
-  /** All distinct tabPageIds in the stream, sorted ascending. */
-  tabPageIds: number[]
+  targetIds: string[]
+}
+
+function isReplayEvent(value: unknown): value is ReplayEvent {
+  if (!value || typeof value !== 'object') return false
+  const event = value as Partial<ReplayEvent>
+  return (
+    typeof event.sessionId === 'string' &&
+    typeof event.targetId === 'string' &&
+    typeof event.tabId === 'number' &&
+    typeof event.ts === 'number' &&
+    typeof event.type === 'number'
+  )
+}
+
+/** Fetches and parses one session's target-addressed NDJSON stream. */
+export async function fetchReplayEvents({
+  sessionId,
+}: UseReplayEventsVariables): Promise<ReplayEventsBundle> {
+  const baseUrl = await resolveApiBaseUrl()
+  const res = await fetch(
+    `${baseUrl}/audit/replays/${encodeURIComponent(sessionId)}`,
+  )
+  if (!res.ok) {
+    if (res.status === 404) return { events: [], targetIds: [] }
+    return parseResponse<ReplayEventsBundle>(res)
+  }
+
+  const events: ReplayEvent[] = []
+  const targetIds: string[] = []
+  const seenTargets = new Set<string>()
+  for (const line of (await res.text()).split('\n')) {
+    if (line.length === 0) continue
+    try {
+      const event: unknown = JSON.parse(line)
+      if (!isReplayEvent(event)) continue
+      events.push(event)
+      if (!seenTargets.has(event.targetId)) {
+        seenTargets.add(event.targetId)
+        targetIds.push(event.targetId)
+      }
+    } catch {}
+  }
+  return { events, targetIds }
 }
 
 export const useReplayEvents = createQuery<
@@ -136,44 +159,6 @@ export const useReplayEvents = createQuery<
   UseReplayEventsVariables
 >({
   queryKey: ['replay', 'events'],
-  fetcher: async ({ sessionId }) => {
-    const res = await api.audit.replay[':sessionId'].$get({
-      param: { sessionId },
-    })
-    if (!res.ok) {
-      // 404 means no replay data; surface a clean empty bundle so
-      // the UI can render its no-data state without an error boundary
-      // catching the parseResponse throw.
-      if (res.status === 404) return { events: [], tabPageIds: [] }
-      return parseResponse<ReplayEventsBundle>(res)
-    }
-    const text = await res.text()
-    const events: ReplayEvent[] = []
-    const tabs = new Set<number>()
-    for (const line of text.split('\n')) {
-      if (line.length === 0) continue
-      try {
-        const ev = JSON.parse(line) as ReplayEvent
-        if (
-          typeof ev.ts === 'number' &&
-          typeof ev.type === 'number' &&
-          typeof ev.tabPageId === 'number'
-        ) {
-          events.push(ev)
-          tabs.add(ev.tabPageId)
-        }
-      } catch {
-        // Malformed line; the recorder shouldn't emit these, but if
-        // a partial line ever sneaks in we skip it rather than abort
-        // the whole stream.
-      }
-    }
-    return {
-      events,
-      tabPageIds: [...tabs].sort((a, b) => a - b),
-    }
-  },
-  // Replay events are immutable once a session ends; for live
-  // sessions a manual refresh button is enough. No refetch interval.
+  fetcher: fetchReplayEvents,
   staleTime: Number.POSITIVE_INFINITY,
 })

--- a/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
@@ -39,12 +39,6 @@ export interface ReplayFrame {
    * result comes back).
    */
   url?: string | null
-  /**
-   * BrowserOS pageId this frame belongs to, or null when the tool
-   * did not target a page. Enables per-tab filtering on the replay
-   * screen so the address bar + caption reflect the selected tab
-   * as the operator switches between them.
-   */
   pageId?: number | null
   /** Stable CDP target this frame belongs to, when known. */
   targetId?: string | null

--- a/packages/browseros-agent/apps/claw-app/package.json
+++ b/packages/browseros-agent/apps/claw-app/package.json
@@ -68,6 +68,7 @@
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "@wxt-dev/module-react": "^1.1.5",
+    "linkedom": "^0.18.12",
     "serve": "^14.2.6",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.2",

--- a/packages/browseros-agent/apps/claw-app/screens/replay/EventTimeline.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/EventTimeline.tsx
@@ -6,9 +6,7 @@ import { formatTime, KIND_STYLE, VERB_META } from './replay.helpers'
 interface EventTimelineProps {
   frames: readonly ReplayFrame[]
   currentFrameIndex: number
-  /** Seconds elapsed, used to dim frames that have not played yet. */
-  currentTime: number
-  onSeek: (seconds: number) => void
+  onSelectFrame: (frame: ReplayFrame) => void
 }
 
 /**
@@ -20,8 +18,7 @@ interface EventTimelineProps {
 export function EventTimeline({
   frames,
   currentFrameIndex,
-  currentTime,
-  onSeek,
+  onSelectFrame,
 }: EventTimelineProps) {
   return (
     <aside className="flex w-[320px] shrink-0 flex-col border-border border-l bg-card">
@@ -31,7 +28,7 @@ export function EventTimeline({
       </header>
       <div className="flex flex-1 flex-col overflow-y-auto px-3 py-2">
         {frames.map((frame, i) => {
-          const seen = frame.t <= currentTime + 0.001
+          const seen = currentFrameIndex >= 0 && i <= currentFrameIndex
           const isCurrent = i === currentFrameIndex
           const verb = VERB_META[frame.verb]
           const kind = KIND_STYLE[frame.kind]
@@ -40,7 +37,7 @@ export function EventTimeline({
             <button
               type="button"
               key={`frame-${frame.kind}-${frame.verb}-${frame.t}`}
-              onClick={() => onSeek(frame.t)}
+              onClick={() => onSelectFrame(frame)}
               className={cn(
                 'flex gap-3 rounded-lg p-2.5 text-left transition-opacity',
                 isCurrent && 'bg-accent-tint',

--- a/packages/browseros-agent/apps/claw-app/screens/replay/EventTimeline.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/EventTimeline.tsx
@@ -36,7 +36,10 @@ export function EventTimeline({
           return (
             <button
               type="button"
-              key={`frame-${frame.kind}-${frame.verb}-${frame.t}`}
+              key={
+                frame.dispatchId ??
+                `frame-${frame.kind}-${frame.verb}-${frame.t}-${i}`
+              }
               onClick={() => onSelectFrame(frame)}
               className={cn(
                 'flex gap-3 rounded-lg p-2.5 text-left transition-opacity',

--- a/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.tsx
@@ -62,14 +62,17 @@ export function PlaybackTransport({
             className="absolute left-0 h-1.5 rounded-full bg-accent transition-[width] duration-100"
             style={{ width: `${progress}%` }}
           />
-          {frames.map((frame) => {
+          {frames.map((frame, index) => {
             if (frame.kind === 'action') return null
             const pct = totalSeconds === 0 ? 0 : (frame.t / totalSeconds) * 100
             const kind = KIND_STYLE[frame.kind]
             return (
               <button
                 type="button"
-                key={`bookmark-${frame.kind}-${frame.t}`}
+                key={
+                  frame.dispatchId ??
+                  `bookmark-${frame.kind}-${frame.t}-${index}`
+                }
                 title={frame.caption}
                 aria-label={`Jump to ${frame.caption}`}
                 onClick={() => onSeek(frame.t)}

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -169,7 +169,10 @@ const frames: ReplayFrame[] = [
   },
 ]
 
-function replayData(replayEvents: readonly ReplayEvent[]) {
+function replayData(
+  replayEvents: readonly ReplayEvent[],
+  replayMetadata = metadata,
+) {
   const eventTargets = buildReplayEventTargets(replayEvents)
   return {
     sessionId: 'session-1',
@@ -185,7 +188,10 @@ function replayData(replayEvents: readonly ReplayEvent[]) {
     steps: '2',
     totalSeconds: 15,
     frames,
-    targetIds: buildReplayTargetIds(metadata.targets, eventTargets.targetIds),
+    targetIds: buildReplayTargetIds(
+      replayMetadata.targets,
+      eventTargets.targetIds,
+    ),
     eventsForTarget: eventTargets.eventsForTarget,
   }
 }
@@ -307,6 +313,42 @@ describe('Replay', () => {
         .querySelector('[data-playback-time]')
         ?.getAttribute('data-playback-time'),
     ).toBe('2')
+
+    replayResult = {
+      ...replayResult,
+      replay: replayData(events, {
+        exists: true,
+        firstEventAt: 1_000,
+        lastEventAt: 5_000,
+        sizeBytes: 512,
+        targets: [
+          {
+            targetId: 'target-a',
+            tabId: 1,
+            firstEventAt: 1_000,
+            lastEventAt: 5_000,
+          },
+        ],
+      }),
+    }
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
+          <Replay />
+        </MemoryRouter>,
+      )
+    })
+
+    expect(
+      container
+        .querySelector('[data-player-targets]')
+        ?.getAttribute('data-player-targets'),
+    ).toBe('target-a,target-a')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { parseHTML } from 'linkedom'
+import { act, createContext, type ReactNode, useContext } from 'react'
+import type { Root } from 'react-dom/client'
+import { MemoryRouter } from 'react-router'
+import type {
+  ReplayEvent,
+  ReplayFrame,
+  ReplayMetadata,
+} from '@/modules/api/replay.hooks'
+import * as replayDataModule from './replay.data'
+import { buildReplayEventTargets, buildReplayTargetIds } from './replay-events'
+
+let replayResult: replayDataModule.UseReplayDataResult
+
+mock.module('./replay.data', () => ({
+  ...replayDataModule,
+  useReplayData: () => replayResult,
+}))
+
+mock.module('./ReplayViewport', () => ({
+  ReplayViewport: ({ events }: { events: readonly ReplayEvent[] }) => (
+    <div
+      data-player-targets={events.map((event) => event.targetId).join(',')}
+    />
+  ),
+}))
+
+mock.module('./PlaybackTransport', () => ({
+  PlaybackTransport: ({ playback }: { playback: { time: number } }) => (
+    <div data-playback-time={playback.time} />
+  ),
+}))
+
+mock.module('./EventTimeline', () => ({
+  EventTimeline: ({
+    frames,
+    onSelectFrame,
+  }: {
+    frames: readonly ReplayFrame[]
+    onSelectFrame: (frame: ReplayFrame) => void
+  }) => (
+    <div>
+      {frames.map((frame) => (
+        <button
+          type="button"
+          key={frame.dispatchId}
+          data-frame-target={frame.targetId}
+          onClick={() => onSelectFrame(frame)}
+        >
+          {frame.caption}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+const TargetSelectContext = createContext<(targetId: string) => void>(() => {})
+
+mock.module('@/components/ui/tabs', () => ({
+  Tabs: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string
+    onValueChange: (targetId: string) => void
+    children: ReactNode
+  }) => (
+    <TargetSelectContext.Provider value={onValueChange}>
+      <div data-selected-target={value}>{children}</div>
+    </TargetSelectContext.Provider>
+  ),
+  TabsList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({
+    value,
+    children,
+  }: {
+    value: string
+    children: ReactNode
+  }) => {
+    const selectTarget = useContext(TargetSelectContext)
+    return (
+      <button
+        type="button"
+        data-target-chip={value}
+        onClick={() => selectTarget(value)}
+      >
+        {children}
+      </button>
+    )
+  },
+}))
+
+const metadata: ReplayMetadata = {
+  exists: true,
+  firstEventAt: 1_000,
+  lastEventAt: 15_000,
+  sizeBytes: 1_024,
+  targets: [
+    {
+      targetId: 'target-b',
+      tabId: 2,
+      firstEventAt: 10_000,
+      lastEventAt: 15_000,
+    },
+    {
+      targetId: 'target-a',
+      tabId: 1,
+      firstEventAt: 1_000,
+      lastEventAt: 5_000,
+    },
+  ],
+}
+
+const events: ReplayEvent[] = [
+  {
+    sessionId: 'session-1',
+    targetId: 'target-a',
+    tabId: 1,
+    ts: 1_000,
+    type: 4,
+    data: { width: 1280, height: 720 },
+  },
+  {
+    sessionId: 'session-1',
+    targetId: 'target-a',
+    tabId: 1,
+    ts: 5_000,
+    type: 3,
+    data: {},
+  },
+  {
+    sessionId: 'session-1',
+    targetId: 'target-b',
+    tabId: 2,
+    ts: 10_000,
+    type: 4,
+    data: { width: 1280, height: 720 },
+  },
+  {
+    sessionId: 'session-1',
+    targetId: 'target-b',
+    tabId: 2,
+    ts: 15_000,
+    type: 3,
+    data: {},
+  },
+]
+
+const frames: ReplayFrame[] = [
+  {
+    t: 1,
+    kind: 'action',
+    verb: 'read',
+    node: 'A',
+    caption: 'Read target A',
+    targetId: 'target-a',
+    dispatchId: 1,
+  },
+  {
+    t: 12,
+    kind: 'action',
+    verb: 'click',
+    node: 'B',
+    caption: 'Click target B',
+    targetId: 'target-b',
+    dispatchId: 2,
+  },
+]
+
+function replayData(replayEvents: readonly ReplayEvent[]) {
+  const eventTargets = buildReplayEventTargets(replayEvents)
+  return {
+    sessionId: 'session-1',
+    agentLabel: 'Codex',
+    taskTitle: 'Replay test',
+    harness: 'Codex',
+    status: 'done' as const,
+    site: 'example.com',
+    startedAt: 'Jul 18, 2026',
+    startedAtMs: 0,
+    duration: '0:15',
+    tokens: '-',
+    steps: '2',
+    totalSeconds: 15,
+    frames,
+    targetIds: buildReplayTargetIds(metadata.targets, eventTargets.targetIds),
+    eventsForTarget: eventTargets.eventsForTarget,
+  }
+}
+
+const globalDescriptors = new Map(
+  ['window', 'document', 'navigator', 'HTMLElement', 'Node', 'Event'].map(
+    (name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)],
+  ),
+)
+
+let root: Root
+let container: HTMLElement
+
+beforeEach(async () => {
+  const dom = parseHTML(
+    '<!doctype html><html><body><div id="root"></div></body></html>',
+  )
+  const globals = {
+    window: dom.window,
+    document: dom.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+  }
+  for (const [name, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    })
+  }
+  Object.assign(dom.window, {
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame: () => undefined,
+  })
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  })
+
+  replayResult = {
+    replay: replayData([]),
+    sessionId: 'session-1',
+    isLoading: false,
+    navigate: mock(() => undefined) as never,
+  }
+  container = dom.document.getElementById('root') as unknown as HTMLElement
+  const { createRoot } = await import('react-dom/client')
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  for (const [name, descriptor] of globalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor)
+    else Reflect.deleteProperty(globalThis, name)
+  }
+  Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
+})
+
+describe('Replay', () => {
+  it('renders metadata targets before events and switches target on frame click', async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
+          <Replay />
+        </MemoryRouter>,
+      )
+    })
+
+    expect(
+      [...container.querySelectorAll('[data-target-chip]')].map(
+        (chip) => chip.textContent,
+      ),
+    ).toEqual(['Tab 1', 'Tab 2'])
+    expect(
+      container
+        .querySelector('[data-player-targets]')
+        ?.getAttribute('data-player-targets'),
+    ).toBe('')
+
+    replayResult = { ...replayResult, replay: replayData(events) }
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
+          <Replay />
+        </MemoryRouter>,
+      )
+    })
+
+    expect(
+      container
+        .querySelector('[data-player-targets]')
+        ?.getAttribute('data-player-targets'),
+    ).toBe('target-a,target-a')
+
+    const targetBFrame = container.querySelector(
+      '[data-frame-target="target-b"]',
+    )
+    if (!targetBFrame) throw new Error('target B frame missing')
+    await act(async () => {
+      targetBFrame.dispatchEvent(new window.Event('click', { bubbles: true }))
+    })
+
+    expect(
+      container
+        .querySelector('[data-selected-target]')
+        ?.getAttribute('data-selected-target'),
+    ).toBe('target-b')
+    expect(
+      container
+        .querySelector('[data-player-targets]')
+        ?.getAttribute('data-player-targets'),
+    ).toBe('target-b,target-b')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('2')
+  })
+})
+
+const { Replay } = await import('./Replay')

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -27,8 +27,15 @@ mock.module('./ReplayViewport', () => ({
 }))
 
 mock.module('./PlaybackTransport', () => ({
-  PlaybackTransport: ({ playback }: { playback: { time: number } }) => (
-    <div data-playback-time={playback.time} />
+  PlaybackTransport: ({
+    playback,
+  }: {
+    playback: { time: number; isPlaying: boolean }
+  }) => (
+    <div
+      data-playback-time={playback.time}
+      data-playback-playing={playback.isPlaying}
+    />
   ),
 }))
 
@@ -289,6 +296,11 @@ describe('Replay', () => {
         .querySelector('[data-player-targets]')
         ?.getAttribute('data-player-targets'),
     ).toBe('target-a,target-a')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
 
     const targetBFrame = container.querySelector(
       '[data-frame-target="target-b"]',

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -34,13 +34,17 @@ export function Replay() {
     if (!replay) return
     const firstTargetId = replay.targetIds[0] ?? null
     if (firstTargetId === null) {
-      if (selectedTargetId !== null) setSelectedTargetId(null)
+      if (selectedTargetId !== null) {
+        pendingTargetSeekRef.current = 0
+        setSelectedTargetId(null)
+      }
       return
     }
     if (
       selectedTargetId === null ||
       !replay.targetIds.includes(selectedTargetId)
     ) {
+      pendingTargetSeekRef.current = 0
       setSelectedTargetId(firstTargetId)
     }
   }, [replay, selectedTargetId])

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -10,11 +10,13 @@ import { useLocation } from 'react-router'
 import { StatusBadge } from '@/components/cockpit/StatusBadge'
 import { Spinner } from '@/components/ui/spinner'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import type { ReplayFrame } from '@/modules/api/replay.hooks'
 import { EventTimeline } from './EventTimeline'
 import { PlaybackTransport } from './PlaybackTransport'
 import { type ReplayPlayerHandle, ReplayViewport } from './ReplayViewport'
 import { buildTabView, EMPTY_TAB_VIEW, useReplayData } from './replay.data'
 import { frameIndexAt } from './replay.helpers'
+import { targetSeekForFrame } from './tab-view'
 import { usePlayback } from './use-playback'
 
 /** Renders the audit replay page and syncs rrweb playback to the transport UI. */
@@ -26,7 +28,7 @@ export function Replay() {
   const playbackTimeRef = useRef(0)
   const playbackSpeedRef = useRef(1)
   const playbackIsPlayingRef = useRef(true)
-  const hasInitializedTabRef = useRef(false)
+  const pendingTargetSeekRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (!replay) return
@@ -43,19 +45,23 @@ export function Replay() {
     }
   }, [replay, selectedTargetId])
 
-  const perTabView = useMemo(
+  const tabViewInput = useMemo(
     () =>
       replay
-        ? buildTabView(
-            {
-              frames: replay.frames,
-              eventsForTarget: replay.eventsForTarget,
-              startedAtMs: replay.startedAtMs,
-            },
-            selectedTargetId,
-          )
+        ? {
+            frames: replay.frames,
+            eventsForTarget: replay.eventsForTarget,
+            startedAtMs: replay.startedAtMs,
+          }
+        : null,
+    [replay],
+  )
+  const perTabView = useMemo(
+    () =>
+      tabViewInput
+        ? buildTabView(tabViewInput, selectedTargetId)
         : EMPTY_TAB_VIEW,
-    [replay, selectedTargetId],
+    [selectedTargetId, tabViewInput],
   )
 
   const playback = usePlayback(perTabView.totalSeconds)
@@ -72,20 +78,6 @@ export function Replay() {
   useEffect(() => {
     playbackIsPlayingRef.current = playback.isPlaying
   }, [playback.isPlaying])
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: tab changes are the only reset trigger; task-duration updates must not restart playback.
-  useEffect(() => {
-    if (selectedTargetId === null) return
-    if (!hasInitializedTabRef.current) {
-      hasInitializedTabRef.current = true
-      playbackTimeRef.current = 0
-      return
-    }
-    const seconds = playback.seek(0)
-    playbackTimeRef.current = seconds
-    playbackIsPlayingRef.current = false
-    playerHandleRef.current?.seek(0)
-  }, [selectedTargetId])
 
   useEffect(() => {
     if (!playerHandleRef.current) return
@@ -123,6 +115,47 @@ export function Replay() {
       playerHandleRef.current?.seek(next * 1000)
     },
     [playback.seek],
+  )
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: target changes must flush pending seeks even when both targets have the same duration.
+  useEffect(() => {
+    const pendingSeconds = pendingTargetSeekRef.current
+    if (pendingSeconds === null) return
+    pendingTargetSeekRef.current = null
+    seekTo(pendingSeconds)
+  }, [seekTo, selectedTargetId])
+
+  const selectTarget = useCallback(
+    (targetId: string) => {
+      if (targetId === selectedTargetId) {
+        seekTo(0)
+        return
+      }
+      pendingTargetSeekRef.current = 0
+      setSelectedTargetId(targetId)
+    },
+    [seekTo, selectedTargetId],
+  )
+
+  const selectFrame = useCallback(
+    (frame: ReplayFrame) => {
+      if (!tabViewInput) return
+      const targetSeek = targetSeekForFrame(
+        tabViewInput,
+        selectedTargetId,
+        frame,
+      )
+      if (
+        targetSeek.targetId !== null &&
+        targetSeek.targetId !== selectedTargetId
+      ) {
+        pendingTargetSeekRef.current = targetSeek.seconds
+        setSelectedTargetId(targetSeek.targetId)
+        return
+      }
+      seekTo(targetSeek.seconds)
+    },
+    [seekTo, selectedTargetId, tabViewInput],
   )
 
   const onPlayerReady = useCallback((handle: ReplayPlayerHandle | null) => {
@@ -163,6 +196,12 @@ export function Replay() {
     cameFromInAppFlow ? navigate(-1) : navigate(`/audit/${replay.sessionId}`)
   const currentTabFrameIndex = frameIndexAt(perTabView.frames, playback.time)
   const currentTabFrame = perTabView.frames[currentTabFrameIndex]
+  const currentTimelineFrameIndex =
+    currentTabFrame?.dispatchId !== undefined
+      ? replay.frames.findIndex(
+          (frame) => frame.dispatchId === currentTabFrame.dispatchId,
+        )
+      : -1
 
   const stats: { label: string; value: string }[] = [
     { label: 'Duration', value: replay.duration },
@@ -212,7 +251,7 @@ export function Replay() {
       <div className="flex min-h-0 flex-1">
         <div className="flex min-w-0 flex-1 flex-col gap-3 p-4">
           {replay.targetIds.length > 1 && selectedTargetId !== null && (
-            <Tabs value={selectedTargetId} onValueChange={setSelectedTargetId}>
+            <Tabs value={selectedTargetId} onValueChange={selectTarget}>
               <TabsList variant="line">
                 {replay.targetIds.map((id, idx) => (
                   <TabsTrigger key={id} value={id}>
@@ -236,10 +275,9 @@ export function Replay() {
           />
         </div>
         <EventTimeline
-          frames={perTabView.frames}
-          currentFrameIndex={currentTabFrameIndex}
-          currentTime={playback.time}
-          onSeek={seekTo}
+          frames={replay.frames}
+          currentFrameIndex={currentTimelineFrameIndex}
+          onSelectFrame={selectFrame}
         />
       </div>
     </div>

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -21,9 +21,7 @@ import { usePlayback } from './use-playback'
 export function Replay() {
   const { replay, isLoading, navigate } = useReplayData()
   const location = useLocation()
-  const [selectedTabPageId, setSelectedTabPageId] = useState<number | null>(
-    null,
-  )
+  const [selectedTargetId, setSelectedTargetId] = useState<string | null>(null)
   const playerHandleRef = useRef<ReplayPlayerHandle | null>(null)
   const playbackTimeRef = useRef(0)
   const playbackSpeedRef = useRef(1)
@@ -31,10 +29,19 @@ export function Replay() {
   const hasInitializedTabRef = useRef(false)
 
   useEffect(() => {
-    if (selectedTabPageId !== null) return
-    if (!replay || replay.tabPageIds.length === 0) return
-    setSelectedTabPageId(replay.tabPageIds[0])
-  }, [replay, selectedTabPageId])
+    if (!replay) return
+    const firstTargetId = replay.targetIds[0] ?? null
+    if (firstTargetId === null) {
+      if (selectedTargetId !== null) setSelectedTargetId(null)
+      return
+    }
+    if (
+      selectedTargetId === null ||
+      !replay.targetIds.includes(selectedTargetId)
+    ) {
+      setSelectedTargetId(firstTargetId)
+    }
+  }, [replay, selectedTargetId])
 
   const perTabView = useMemo(
     () =>
@@ -42,13 +49,13 @@ export function Replay() {
         ? buildTabView(
             {
               frames: replay.frames,
-              eventsForTab: replay.eventsForTab,
+              eventsForTarget: replay.eventsForTarget,
               startedAtMs: replay.startedAtMs,
             },
-            selectedTabPageId,
+            selectedTargetId,
           )
         : EMPTY_TAB_VIEW,
-    [replay, selectedTabPageId],
+    [replay, selectedTargetId],
   )
 
   const playback = usePlayback(perTabView.totalSeconds)
@@ -68,7 +75,7 @@ export function Replay() {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: tab changes are the only reset trigger; task-duration updates must not restart playback.
   useEffect(() => {
-    if (selectedTabPageId === null) return
+    if (selectedTargetId === null) return
     if (!hasInitializedTabRef.current) {
       hasInitializedTabRef.current = true
       playbackTimeRef.current = 0
@@ -78,7 +85,7 @@ export function Replay() {
     playbackTimeRef.current = seconds
     playbackIsPlayingRef.current = false
     playerHandleRef.current?.seek(0)
-  }, [selectedTabPageId])
+  }, [selectedTargetId])
 
   useEffect(() => {
     if (!playerHandleRef.current) return
@@ -204,14 +211,11 @@ export function Replay() {
 
       <div className="flex min-h-0 flex-1">
         <div className="flex min-w-0 flex-1 flex-col gap-3 p-4">
-          {replay.tabPageIds.length > 1 && selectedTabPageId !== null && (
-            <Tabs
-              value={String(selectedTabPageId)}
-              onValueChange={(v) => setSelectedTabPageId(Number(v))}
-            >
+          {replay.targetIds.length > 1 && selectedTargetId !== null && (
+            <Tabs value={selectedTargetId} onValueChange={setSelectedTargetId}>
               <TabsList variant="line">
-                {replay.tabPageIds.map((id, idx) => (
-                  <TabsTrigger key={id} value={String(id)}>
+                {replay.targetIds.map((id, idx) => (
+                  <TabsTrigger key={id} value={id}>
                     Tab {idx + 1}
                   </TabsTrigger>
                 ))}

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -40,10 +40,11 @@ export function Replay() {
       }
       return
     }
-    if (
-      selectedTargetId === null ||
-      !replay.targetIds.includes(selectedTargetId)
-    ) {
+    if (selectedTargetId === null) {
+      setSelectedTargetId(firstTargetId)
+      return
+    }
+    if (!replay.targetIds.includes(selectedTargetId)) {
       pendingTargetSeekRef.current = 0
       setSelectedTargetId(firstTargetId)
     }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -34,7 +34,7 @@ interface ReplayViewportProps {
   site: string
   /** The frame whose caption is currently displayed in the overlay. */
   frame: ReplayFrame | undefined
-  /** rrweb events for the currently-selected tabPageId. */
+  /** rrweb events for the currently selected target. */
   events: readonly ReplayEvent[]
   /** Called when the rrweb Replayer mounts or is destroyed. */
   onPlayerReady: (handle: ReplayPlayerHandle | null) => void

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay-events.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay-events.ts
@@ -4,41 +4,55 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { ReplayEvent } from '@/modules/api/replay.hooks'
+import type {
+  ReplayEvent,
+  ReplayTargetMetadata,
+} from '@/modules/api/replay.hooks'
 
 export const EMPTY_REPLAY_EVENTS: readonly ReplayEvent[] = []
 
-export interface ReplayEventTabs {
-  tabPageIds: number[]
-  eventsForTab: (tabPageId: number) => readonly ReplayEvent[]
+export interface ReplayEventTargets {
+  targetIds: string[]
+  eventsForTarget: (targetId: string) => readonly ReplayEvent[]
 }
 
-/** Groups rrweb events by tab while preserving each tab array's identity. */
-export function buildReplayEventTabs(
+/** Groups rrweb events by target while preserving each target array's identity. */
+export function buildReplayEventTargets(
   events: readonly ReplayEvent[],
-): ReplayEventTabs {
+): ReplayEventTargets {
   if (events.length === 0) {
     return {
-      tabPageIds: [],
-      eventsForTab: () => EMPTY_REPLAY_EVENTS,
+      targetIds: [],
+      eventsForTarget: () => EMPTY_REPLAY_EVENTS,
     }
   }
 
-  const tabPageIds: number[] = []
-  const eventsByTab = new Map<number, ReplayEvent[]>()
+  const targetIds: string[] = []
+  const eventsByTarget = new Map<string, ReplayEvent[]>()
   for (const event of events) {
-    const list = eventsByTab.get(event.tabPageId)
+    const list = eventsByTarget.get(event.targetId)
     if (list) {
       list.push(event)
     } else {
-      eventsByTab.set(event.tabPageId, [event])
-      tabPageIds.push(event.tabPageId)
+      eventsByTarget.set(event.targetId, [event])
+      targetIds.push(event.targetId)
     }
   }
 
   return {
-    tabPageIds,
-    eventsForTab: (tabPageId) =>
-      eventsByTab.get(tabPageId) ?? EMPTY_REPLAY_EVENTS,
+    targetIds,
+    eventsForTarget: (targetId) =>
+      eventsByTarget.get(targetId) ?? EMPTY_REPLAY_EVENTS,
   }
+}
+
+/** Returns metadata-ordered targets, falling back to stream discovery. */
+export function buildReplayTargetIds(
+  targets: readonly ReplayTargetMetadata[] | undefined,
+  discoveredTargetIds: readonly string[],
+): string[] {
+  if (!targets) return [...discoveredTargetIds]
+  return [...targets]
+    .sort((a, b) => a.firstEventAt - b.firstEventAt)
+    .map((target) => target.targetId)
 }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -18,11 +18,13 @@ import {
   type ReplayKind,
   type ReplayVerb,
   useReplayEvents,
+  useReplayMetadata,
 } from '@/modules/api/replay.hooks'
 import {
-  buildReplayEventTabs,
+  buildReplayEventTargets,
+  buildReplayTargetIds,
   EMPTY_REPLAY_EVENTS,
-  type ReplayEventTabs,
+  type ReplayEventTargets,
 } from './replay-events'
 
 export interface ReplayData {
@@ -47,10 +49,8 @@ export interface ReplayData {
   /** Total seconds the session covers, from start to last dispatch. */
   totalSeconds: number
   frames: ReplayFrame[]
-  /** Distinct tabPageIds with rrweb events. */
-  tabPageIds: number[]
-  /** Filter helper: events scoped to one tabPageId. */
-  eventsForTab: (tabPageId: number) => readonly ReplayEvent[]
+  targetIds: string[]
+  eventsForTarget: (targetId: string) => readonly ReplayEvent[]
 }
 
 // `buildTabView` and the `TabView` shape live in `./tab-view.ts` so
@@ -82,18 +82,27 @@ export function useReplayData(): UseReplayDataResult {
     variables: { sessionId },
     enabled: sessionId.length > 0,
   })
+  const metadataQuery = useReplayMetadata({
+    variables: { sessionId },
+    enabled: sessionId.length > 0,
+  })
 
   const events = eventsQuery.data?.events ?? EMPTY_REPLAY_EVENTS
-  const eventTabs = useMemo(() => buildReplayEventTabs(events), [events])
+  const eventTargets = useMemo(() => buildReplayEventTargets(events), [events])
+  const targetIds = useMemo(
+    () =>
+      buildReplayTargetIds(metadataQuery.data?.targets, eventTargets.targetIds),
+    [eventTargets.targetIds, metadataQuery.data?.targets],
+  )
   const replay = useMemo<ReplayData | null>(() => {
     if (!taskQuery.data) return null
-    return buildReplayData(taskQuery.data, eventTabs)
-  }, [taskQuery.data, eventTabs])
+    return buildReplayData(taskQuery.data, eventTargets, targetIds)
+  }, [taskQuery.data, eventTargets, targetIds])
 
   return {
     replay,
     sessionId,
-    isLoading: taskQuery.isLoading || eventsQuery.isLoading,
+    isLoading: taskQuery.isLoading,
     navigate,
   }
 }
@@ -101,7 +110,8 @@ export function useReplayData(): UseReplayDataResult {
 /** Converts task rows into replay metadata while reusing event buckets. */
 function buildReplayData(
   task: TaskDetail,
-  eventTabs: ReplayEventTabs,
+  eventTargets: ReplayEventTargets,
+  targetIds: string[],
 ): ReplayData {
   const sessionStartMs = task.startedAt
   const lastDispatchAt = task.dispatches.length
@@ -130,8 +140,8 @@ function buildReplayData(
     steps: String(task.dispatchCount),
     totalSeconds: totalMs / 1000,
     frames,
-    tabPageIds: eventTabs.tabPageIds,
-    eventsForTab: eventTabs.eventsForTab,
+    targetIds,
+    eventsForTarget: eventTargets.eventsForTarget,
   }
 }
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -176,6 +176,7 @@ function mapDispatchToFrame(
     caption,
     url: row.url,
     pageId: row.pageId,
+    targetId: row.targetId,
     note,
     dispatchId: row.id,
   }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
@@ -214,4 +214,20 @@ describe('targetSeekForFrame', () => {
       seconds: 2,
     })
   })
+
+  it('translates an unaddressed session frame into the selected target clock', () => {
+    const sessionFrame = frame(7, null, { dispatchId: 23 })
+    const input = makeInput({
+      frames: [frame(5, 'target-a'), sessionFrame],
+      eventsForTarget: (targetId) => [
+        event(1_005_000, targetId),
+        event(1_010_000, targetId),
+      ],
+    })
+
+    expect(targetSeekForFrame(input, 'target-a', sessionFrame)).toEqual({
+      targetId: 'target-a',
+      seconds: 2,
+    })
+  })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
@@ -11,7 +11,11 @@
 import { describe, expect, it } from 'bun:test'
 import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
 import { buildReplayEventTargets, buildReplayTargetIds } from './replay-events'
-import { type BuildTabViewInput, buildTabView } from './tab-view'
+import {
+  type BuildTabViewInput,
+  buildTabView,
+  targetSeekForFrame,
+} from './tab-view'
 
 function frame(
   t: number,
@@ -191,5 +195,23 @@ describe('buildReplayTargetIds', () => {
       'target-b',
       'target-a',
     ])
+  })
+})
+
+describe('targetSeekForFrame', () => {
+  it('switches to the frame target and returns its target-relative time', () => {
+    const targetFrame = frame(12, 'target-b', { dispatchId: 22 })
+    const input = makeInput({
+      frames: [frame(1, 'target-a'), targetFrame],
+      eventsForTarget: (targetId) =>
+        targetId === 'target-b'
+          ? [event(1_010_000, targetId), event(1_015_000, targetId)]
+          : [event(1_001_000, targetId), event(1_005_000, targetId)],
+    })
+
+    expect(targetSeekForFrame(input, 'target-a', targetFrame)).toEqual({
+      targetId: 'target-b',
+      seconds: 2,
+    })
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
@@ -10,12 +10,12 @@
 
 import { describe, expect, it } from 'bun:test'
 import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
-import { buildReplayEventTabs } from './replay-events'
+import { buildReplayEventTargets, buildReplayTargetIds } from './replay-events'
 import { type BuildTabViewInput, buildTabView } from './tab-view'
 
 function frame(
   t: number,
-  pageId: number | null,
+  targetId: string | null,
   extra: Partial<ReplayFrame> = {},
 ): ReplayFrame {
   return {
@@ -24,13 +24,13 @@ function frame(
     verb: 'read',
     node: 'test',
     caption: 'test',
-    pageId,
+    targetId,
     ...extra,
   }
 }
 
-function event(ts: number, tabPageId: number): ReplayEvent {
-  return { sessionId: 'test', tabPageId, type: 3, data: {}, ts }
+function event(ts: number, targetId: string): ReplayEvent {
+  return { sessionId: 'test', targetId, tabId: 1, type: 3, data: {}, ts }
 }
 
 function makeInput(
@@ -38,14 +38,14 @@ function makeInput(
 ): BuildTabViewInput {
   return {
     frames: [],
-    eventsForTab: () => [],
+    eventsForTarget: () => [],
     startedAtMs: 1_000_000,
     ...overrides,
   }
 }
 
 describe('buildTabView', () => {
-  it('returns EMPTY for null tabPageId', () => {
+  it('returns EMPTY for a null targetId', () => {
     const v = buildTabView(makeInput(), null)
     expect(v.frames).toEqual([])
     expect(v.events).toEqual([])
@@ -53,7 +53,7 @@ describe('buildTabView', () => {
   })
 
   it('returns EMPTY when the tab has no frames AND no events', () => {
-    const v = buildTabView(makeInput({ frames: [frame(5, 1)] }), 42)
+    const v = buildTabView(makeInput({ frames: [frame(5, 'target-a')] }), 'x')
     expect(v.frames).toEqual([])
     expect(v.events).toEqual([])
     expect(v.totalSeconds).toBe(0)
@@ -62,21 +62,33 @@ describe('buildTabView', () => {
   it('filters frames to only the target tab', () => {
     const v = buildTabView(
       makeInput({
-        frames: [frame(1, 1), frame(2, 4), frame(3, 1), frame(4, 5)],
+        frames: [
+          frame(1, 'target-a'),
+          frame(2, 'target-b'),
+          frame(3, 'target-a'),
+          frame(4, 'target-c'),
+        ],
       }),
-      1,
+      'target-a',
     )
     expect(v.frames).toHaveLength(2)
-    expect(v.frames.map((f) => f.pageId)).toEqual([1, 1])
+    expect(v.frames.map((f) => f.targetId)).toEqual(['target-a', 'target-a'])
   })
 
   it('shifts frame `t` to be tab-relative (first frame at t=0)', () => {
     const v = buildTabView(
       makeInput({
-        frames: [frame(5, 7), frame(8, 7), frame(12, 7)],
-        eventsForTab: () => [event(1_005_000, 7), event(1_012_000, 7)],
+        frames: [
+          frame(5, 'target-a'),
+          frame(8, 'target-a'),
+          frame(12, 'target-a'),
+        ],
+        eventsForTarget: () => [
+          event(1_005_000, 'target-a'),
+          event(1_012_000, 'target-a'),
+        ],
       }),
-      7,
+      'target-a',
     )
     expect(v.frames.map((f) => f.t)).toEqual([0, 3, 7])
   })
@@ -84,10 +96,13 @@ describe('buildTabView', () => {
   it('totalSeconds = tab activity window (last event - first event)', () => {
     const v = buildTabView(
       makeInput({
-        frames: [frame(3, 1), frame(6, 1)],
-        eventsForTab: () => [event(1_003_000, 1), event(1_007_500, 1)],
+        frames: [frame(3, 'target-a'), frame(6, 'target-a')],
+        eventsForTarget: () => [
+          event(1_003_000, 'target-a'),
+          event(1_007_500, 'target-a'),
+        ],
       }),
-      1,
+      'target-a',
     )
     expect(v.totalSeconds).toBeCloseTo(4.5)
   })
@@ -95,10 +110,10 @@ describe('buildTabView', () => {
   it('falls back to frame timespan when no events exist', () => {
     const v = buildTabView(
       makeInput({
-        frames: [frame(2, 9), frame(10, 9)],
-        eventsForTab: () => [],
+        frames: [frame(2, 'target-a'), frame(10, 'target-a')],
+        eventsForTarget: () => [],
       }),
-      9,
+      'target-a',
     )
     expect(v.totalSeconds).toBe(8)
     expect(v.frames.map((f) => f.t)).toEqual([0, 8])
@@ -107,38 +122,74 @@ describe('buildTabView', () => {
   it('preserves other frame fields when shifting `t`', () => {
     const v = buildTabView(
       makeInput({
-        frames: [frame(5, 3, { verb: 'navigate', url: 'https://example.com' })],
+        frames: [
+          frame(5, 'target-a', {
+            verb: 'navigate',
+            url: 'https://example.com',
+          }),
+        ],
       }),
-      3,
+      'target-a',
     )
     expect(v.frames[0]?.verb).toBe('navigate')
     expect(v.frames[0]?.url).toBe('https://example.com')
-    expect(v.frames[0]?.pageId).toBe(3)
+    expect(v.frames[0]?.targetId).toBe('target-a')
     expect(v.frames[0]?.t).toBe(0)
   })
 
   it('keeps a tab events array stable across task-only data changes', () => {
-    const eventTabs = buildReplayEventTabs([
-      event(1_002_000, 3),
-      event(1_003_000, 3),
-      event(1_004_000, 8),
+    const eventTargets = buildReplayEventTargets([
+      event(1_002_000, 'target-a'),
+      event(1_003_000, 'target-a'),
+      event(1_004_000, 'target-b'),
     ])
     const first = buildTabView(
       makeInput({
-        frames: [frame(2, 3)],
-        eventsForTab: eventTabs.eventsForTab,
+        frames: [frame(2, 'target-a')],
+        eventsForTarget: eventTargets.eventsForTarget,
       }),
-      3,
+      'target-a',
     )
     const afterTaskPoll = buildTabView(
       makeInput({
-        frames: [frame(2, 3), frame(4, 3)],
-        eventsForTab: eventTabs.eventsForTab,
+        frames: [frame(2, 'target-a'), frame(4, 'target-a')],
+        eventsForTarget: eventTargets.eventsForTarget,
       }),
-      3,
+      'target-a',
     )
 
     expect(afterTaskPoll.events).toBe(first.events)
     expect(afterTaskPoll.frames).not.toBe(first.frames)
+  })
+})
+
+describe('buildReplayTargetIds', () => {
+  it('sorts metadata targets by first event time', () => {
+    expect(
+      buildReplayTargetIds(
+        [
+          {
+            targetId: 'target-later',
+            tabId: 2,
+            firstEventAt: 4_000,
+            lastEventAt: 5_000,
+          },
+          {
+            targetId: 'target-first',
+            tabId: 1,
+            firstEventAt: 1_000,
+            lastEventAt: 3_000,
+          },
+        ],
+        ['stream-only'],
+      ),
+    ).toEqual(['target-first', 'target-later'])
+  })
+
+  it('falls back to first-seen stream targets before metadata loads', () => {
+    expect(buildReplayTargetIds(undefined, ['target-b', 'target-a'])).toEqual([
+      'target-b',
+      'target-a',
+    ])
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
@@ -78,6 +78,15 @@ export function targetSeekForFrame(
   const targetFrames = input.frames.filter(
     (candidate) => candidate.targetId === targetId,
   )
+  if (frame.targetId == null) {
+    const targetEvents = input.eventsForTarget(targetId)
+    const originT =
+      targetEvents.length > 0
+        ? ((targetEvents[0]?.ts ?? input.startedAtMs) - input.startedAtMs) /
+          1000
+        : (targetFrames[0]?.t ?? 0)
+    return { targetId, seconds: Math.max(0, frame.t - originT) }
+  }
   const targetFrameIndex = targetFrames.indexOf(frame)
   const targetView = buildTabView(input, targetId)
   const shiftedFrame = targetView.frames[targetFrameIndex]

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
@@ -8,7 +8,7 @@ import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
 
 /**
  * A single tab's replay view. All fields are scoped to one
- * `tabPageId`:
+ * target:
  *   - `frames`: filtered AND time-shifted so `t=0` is the tab's
  *     first activity, not session start.
  *   - `events`: pass-through. rrweb treats the first event's `ts`
@@ -29,21 +29,19 @@ export const EMPTY_TAB_VIEW: TabView = {
 }
 
 export interface BuildTabViewInput {
-  /** Session-scoped frames (any pageId). */
   frames: ReplayFrame[]
-  eventsForTab: (tabPageId: number) => readonly ReplayEvent[]
-  /** Session start in ms since epoch. Anchor for frame `t` values. */
+  eventsForTarget: (targetId: string) => readonly ReplayEvent[]
   startedAtMs: number
 }
 
 /** Builds the frame/event/duration view for the selected replay tab. */
 export function buildTabView(
   input: BuildTabViewInput,
-  tabPageId: number | null,
+  targetId: string | null,
 ): TabView {
-  if (tabPageId === null) return EMPTY_TAB_VIEW
-  const rawFrames = input.frames.filter((f) => f.pageId === tabPageId)
-  const events = input.eventsForTab(tabPageId)
+  if (targetId === null) return EMPTY_TAB_VIEW
+  const rawFrames = input.frames.filter((frame) => frame.targetId === targetId)
+  const events = input.eventsForTarget(targetId)
   if (rawFrames.length === 0 && events.length === 0) return EMPTY_TAB_VIEW
   const startedMs = input.startedAtMs
   const originMs =

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
@@ -60,3 +60,26 @@ export function buildTabView(
   }))
   return { frames, events, totalSeconds }
 }
+
+export interface TargetSeek {
+  targetId: string | null
+  seconds: number
+}
+
+/** Resolves a session frame to its target and target-relative playback time. */
+export function targetSeekForFrame(
+  input: BuildTabViewInput,
+  selectedTargetId: string | null,
+  frame: ReplayFrame,
+): TargetSeek {
+  const targetId = frame.targetId ?? selectedTargetId
+  if (targetId === null) return { targetId, seconds: frame.t }
+
+  const targetFrames = input.frames.filter(
+    (candidate) => candidate.targetId === targetId,
+  )
+  const targetFrameIndex = targetFrames.indexOf(frame)
+  const targetView = buildTabView(input, targetId)
+  const shiftedFrame = targetView.frames[targetFrameIndex]
+  return { targetId, seconds: shiftedFrame?.t ?? frame.t }
+}

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -172,6 +172,7 @@
         "@types/react": "^19.1.12",
         "@types/react-dom": "^19.1.9",
         "@wxt-dev/module-react": "^1.1.5",
+        "linkedom": "^0.18.12",
         "serve": "^14.2.6",
         "tailwindcss": "^4.1.17",
         "typescript": "^5.9.2",


### PR DESCRIPTION
## Summary

- load replay metadata and NDJSON events from the recordings API
- group playback by target with metadata chips and cross-target timeline seeking
- cover multi-target replay behavior with hook, data, and rendered screen tests

## Test plan

- bun run typecheck
- bun run check
- bun run test
