### PR TITLE
feat: align Rust session identity and naming

### DIFF
--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "browseros-mcp",
  "clap",
  "futures-util",
+ "rand 0.9.4",
  "rmcp",
  "rusqlite",
  "rusqlite_migration",

--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -1519,7 +1519,6 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "tracing",
- "url",
  "uuid",
 ]
 

--- a/packages/browseros-agent/Cargo.toml
+++ b/packages/browseros-agent/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonc-parser = { version = "0.33", features = ["cst"] }
 toml_edit = "0.22"
-rmcp = { version = "2.1", features = ["server", "transport-io", "transport-streamable-http-server", "elicitation"] }
+rmcp = { version = "2.1", features = ["server", "transport-io", "transport-streamable-http-server"] }
 schemars = "1.0"
 axum = "0.8"
 http = "1"

--- a/packages/browseros-agent/apps/claw-server-rust/Cargo.toml
+++ b/packages/browseros-agent/apps/claw-server-rust/Cargo.toml
@@ -27,6 +27,7 @@ futures-util.workspace = true
 rusqlite.workspace = true
 rusqlite_migration.workspace = true
 rmcp.workspace = true
+rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/packages/browseros-agent/apps/claw-server-rust/src/app.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/app.rs
@@ -69,6 +69,7 @@ impl AppState {
             audit.clone(),
             replay.clone(),
             config.session_idle,
+            config.session_retention,
             config.session_sweep_interval,
         );
         let browser = BrowserService::new(config.cdp_port, sessions.ownership());

--- a/packages/browseros-agent/apps/claw-server-rust/src/config.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/config.rs
@@ -11,6 +11,7 @@ use std::{
 const DEFAULT_SERVER_PORT: u16 = 9200;
 const DEFAULT_CDP_PORT: u16 = 49337;
 const DEFAULT_SESSION_IDLE_MS: u64 = 5 * 60 * 1000;
+const DEFAULT_SESSION_RETENTION_MS: u64 = 2 * 60 * 60 * 1000;
 const DEFAULT_SESSION_SWEEP_INTERVAL_MS: u64 = 60 * 1000;
 const BROWSERCLAW_DIR_NAME: &str = ".browserclaw";
 const DEV_BROWSERCLAW_DIR_NAME: &str = ".browserclaw-dev";
@@ -32,6 +33,7 @@ pub struct Config {
     pub resources_dir: PathBuf,
     pub browserclaw_dir: PathBuf,
     pub session_idle: Duration,
+    pub session_retention: Duration,
     pub session_sweep_interval: Duration,
     pub screencast_screenshot_fallback: bool,
     pub dev_mode: bool,
@@ -156,6 +158,11 @@ impl Config {
                 "CLAW_SESSION_IDLE_MS",
                 DEFAULT_SESSION_IDLE_MS,
             )),
+            session_retention: Duration::from_millis(read_positive_ms(
+                env,
+                "CLAW_SESSION_RETENTION_MS",
+                DEFAULT_SESSION_RETENTION_MS,
+            )),
             session_sweep_interval: Duration::from_millis(read_positive_ms(
                 env,
                 "CLAW_SESSION_SWEEP_INTERVAL_MS",
@@ -265,6 +272,7 @@ mod tests {
             dir.path().join("browserclaw").to_string_lossy().to_string(),
         );
         vars.insert("CLAW_SESSION_IDLE_MS".to_string(), "1000".to_string());
+        vars.insert("CLAW_SESSION_RETENTION_MS".to_string(), "2000".to_string());
         let cfg = Config::load_with_env(
             &config_path,
             &ConfigEnv::with_vars(vars, PathBuf::from("/tmp/home")),
@@ -273,6 +281,7 @@ mod tests {
         assert_eq!(cfg.cdp_port, 49337);
         assert_eq!(cfg.proxy_port, None);
         assert_eq!(cfg.session_idle, Duration::from_millis(1000));
+        assert_eq!(cfg.session_retention, Duration::from_millis(2000));
         assert!(cfg.browserclaw_dir.ends_with("browserclaw"));
         assert_eq!(cfg.public_mcp_url(), "http://127.0.0.1:9200/mcp");
         Ok(())
@@ -342,18 +351,20 @@ mod tests {
         fs::write(&config_path, r#"{"ports":{},"directories":{}}"#)?;
         let home = dir.path().join("home");
 
-        let cases: &[(&str, &str, Duration, Duration)] = &[
-            // (idle raw, sweep raw, expected idle, expected sweep)
+        let cases: &[(&str, &str, Duration, Duration, Duration)] = &[
+            // (idle raw, sweep raw, expected idle, expected retention, expected sweep)
             (
                 "garbage",
                 "-500",
                 Duration::from_millis(300_000),
+                Duration::from_millis(7_200_000),
                 Duration::from_millis(60_000),
             ),
             (
                 "0",
                 "0x10",
                 Duration::from_millis(300_000),
+                Duration::from_millis(7_200_000),
                 Duration::from_millis(60_000),
             ),
             // Number.parseInt parity: integer prefix wins, trailing garbage
@@ -363,11 +374,16 @@ mod tests {
                 "500ms",
                 Duration::from_millis(2500),
                 Duration::from_millis(500),
+                Duration::from_millis(500),
             ),
         ];
-        for (idle_raw, sweep_raw, expected_idle, expected_sweep) in cases {
+        for (idle_raw, sweep_raw, expected_idle, expected_retention, expected_sweep) in cases {
             let mut vars = BTreeMap::new();
             vars.insert("CLAW_SESSION_IDLE_MS".to_string(), (*idle_raw).to_string());
+            vars.insert(
+                "CLAW_SESSION_RETENTION_MS".to_string(),
+                (*sweep_raw).to_string(),
+            );
             vars.insert(
                 "CLAW_SESSION_SWEEP_INTERVAL_MS".to_string(),
                 (*sweep_raw).to_string(),
@@ -375,6 +391,10 @@ mod tests {
             let cfg =
                 Config::load_with_env(&config_path, &ConfigEnv::with_vars(vars, home.clone()))?;
             assert_eq!(cfg.session_idle, *expected_idle, "idle raw: {idle_raw:?}");
+            assert_eq!(
+                cfg.session_retention, *expected_retention,
+                "retention raw: {sweep_raw:?}"
+            );
             assert_eq!(
                 cfg.session_sweep_interval, *expected_sweep,
                 "sweep raw: {sweep_raw:?}"
@@ -386,6 +406,7 @@ mod tests {
             &ConfigEnv::with_vars(BTreeMap::new(), home.clone()),
         )?;
         assert_eq!(cfg.session_idle, Duration::from_millis(300_000));
+        assert_eq!(cfg.session_retention, Duration::from_millis(7_200_000));
         assert_eq!(cfg.session_sweep_interval, Duration::from_millis(60_000));
         Ok(())
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/agent_ref.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/agent_ref.rs
@@ -1,10 +1,4 @@
-use crate::{
-    domain::{
-        ids::{AgentId, ProfileId, SessionId},
-        ownership::AgentKey,
-    },
-    services::agents::StoredAgentProfile,
-};
+use crate::{domain::ids::ProfileId, services::agents::StoredAgentProfile};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -20,12 +14,10 @@ pub struct ClientInfo {
 pub enum AgentRef {
     Profile {
         profile_id: ProfileId,
-        agent_id: AgentId,
         slug: String,
         label: String,
     },
     Ephemeral {
-        agent_id: AgentId,
         slug: String,
         label: String,
     },
@@ -33,44 +25,22 @@ pub enum AgentRef {
 
 impl AgentRef {
     #[must_use]
-    pub fn resolve(
-        session_id: &SessionId,
-        client_info: &ClientInfo,
-        profiles: &[StoredAgentProfile],
-    ) -> Self {
-        let client_slug = slugify_client_name(&client_info.name)
-            .unwrap_or_else(|| fallback_slug_for_session(session_id));
+    pub fn resolve(client_info: &ClientInfo, profiles: &[StoredAgentProfile]) -> Self {
+        let client_slug = slugify_client_name(&client_info.name).unwrap_or_else(|| "agent".into());
         if let Some(profile) = profiles.iter().find(|profile| {
             profile.slug == client_slug
                 || names_match(profile.name.as_str(), client_info.name.as_str())
         }) {
             return Self::Profile {
                 profile_id: ProfileId::new(profile.id.clone()),
-                agent_id: AgentId::new(format!(
-                    "{}-{}",
-                    profile.slug,
-                    hash_tail(session_id.as_str())
-                )),
                 slug: profile.slug.clone(),
                 label: profile.name.clone(),
             };
         }
         let label = clean_label(&client_info.name).unwrap_or_else(|| client_slug.clone());
         Self::Ephemeral {
-            agent_id: AgentId::new(format!(
-                "{}-{}",
-                client_slug,
-                hash_tail(session_id.as_str())
-            )),
             slug: client_slug,
             label,
-        }
-    }
-
-    #[must_use]
-    pub fn agent_id(&self) -> &AgentId {
-        match self {
-            Self::Profile { agent_id, .. } | Self::Ephemeral { agent_id, .. } => agent_id,
         }
     }
 
@@ -93,16 +63,6 @@ impl AgentRef {
         match self {
             Self::Profile { profile_id, .. } => Some(profile_id),
             Self::Ephemeral { .. } => None,
-        }
-    }
-
-    #[must_use]
-    pub fn ownership_key(&self) -> AgentKey {
-        match self {
-            Self::Profile { profile_id, .. } => AgentKey::new(profile_id.as_str().to_string()),
-            // Ephemeral identity is clientInfo-derived, so two unrelated harnesses that send the
-            // same name intentionally share a pool; configured profiles avoid that collision.
-            Self::Ephemeral { slug, .. } => AgentKey::new(slug.clone()),
         }
     }
 }
@@ -133,10 +93,6 @@ pub fn slugify_client_name(raw: &str) -> Option<String> {
     }
 }
 
-fn fallback_slug_for_session(session_id: &SessionId) -> String {
-    format!("unknown-{}", hash_tail(session_id.as_str()))
-}
-
 fn clean_label(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -150,25 +106,10 @@ fn names_match(profile_name: &str, client_name: &str) -> bool {
     slugify_client_name(profile_name).as_deref() == slugify_client_name(client_name).as_deref()
 }
 
-fn hash_tail(input: &str) -> String {
-    let mut hash = 0x811c9dc5_u32;
-    for byte in input.as_bytes() {
-        hash ^= u32::from(*byte);
-        hash = hash.wrapping_add(
-            (hash << 1)
-                .wrapping_add(hash << 4)
-                .wrapping_add(hash << 7)
-                .wrapping_add(hash << 8)
-                .wrapping_add(hash << 24),
-        );
-    }
-    format!("{hash:08x}").chars().take(6).collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::{AgentRef, ClientInfo, slugify_client_name};
-    use crate::{domain::SessionId, services::agents::StoredAgentProfile};
+    use crate::services::agents::StoredAgentProfile;
     use std::collections::BTreeMap;
 
     fn profile() -> StoredAgentProfile {
@@ -201,7 +142,6 @@ mod tests {
     #[test]
     fn resolves_profile_when_client_name_matches_slug() {
         let resolved = AgentRef::resolve(
-            &SessionId::new("s1"),
             &ClientInfo {
                 name: "finance ops".to_string(),
                 version: "1".to_string(),
@@ -223,7 +163,6 @@ mod tests {
     #[test]
     fn falls_back_to_ephemeral_for_unknown_client() {
         let resolved = AgentRef::resolve(
-            &SessionId::new("s1"),
             &ClientInfo {
                 name: "Other".to_string(),
                 version: "1".to_string(),
@@ -238,32 +177,16 @@ mod tests {
     }
 
     #[test]
-    fn ownership_key_prefers_profile_id_over_slug() {
+    fn empty_client_name_uses_agent_slug() {
         let resolved = AgentRef::resolve(
-            &SessionId::new("s1"),
             &ClientInfo {
-                name: "finance ops".to_string(),
+                name: "...".to_string(),
                 version: "1".to_string(),
                 title: None,
             },
-            &[profile()],
+            &[],
         );
 
-        assert_eq!(resolved.ownership_key().as_str(), "p1");
-    }
-
-    #[test]
-    fn ownership_key_uses_slug_for_ephemeral_agent() {
-        let resolved = AgentRef::resolve(
-            &SessionId::new("s1"),
-            &ClientInfo {
-                name: "Other".to_string(),
-                version: "1".to_string(),
-                title: None,
-            },
-            &[profile()],
-        );
-
-        assert_eq!(resolved.ownership_key().as_str(), "other");
+        assert_eq!(resolved.slug(), "agent");
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/mod.rs
@@ -3,9 +3,11 @@ pub mod ids;
 pub mod ownership;
 pub mod registry;
 pub mod session;
+pub mod session_identity;
 
 pub use agent_ref::{AgentRef, ClientInfo};
 pub use ids::{AgentId, DispatchId, ProfileId, SessionId};
 pub use ownership::{AgentKey, AgentPageOwnership};
 pub use registry::SessionRegistry;
 pub use session::{Session, TabGroupColor, color_for_slug, hex_for_slug};
+pub use session_identity::{GenerateFunNameError, SessionIdentity, generate_fun_name};

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/mod.rs
@@ -8,6 +8,6 @@ pub mod session_identity;
 pub use agent_ref::{AgentRef, ClientInfo};
 pub use ids::{AgentId, DispatchId, ProfileId, SessionId};
 pub use ownership::{AgentKey, AgentPageOwnership};
-pub use registry::SessionRegistry;
+pub use registry::{RetainedGroupAction, SessionRegistry};
 pub use session::{Session, TabGroupColor, color_for_slug, hex_for_slug};
 pub use session_identity::{GenerateFunNameError, SessionIdentity, generate_fun_name};

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/ownership.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/ownership.rs
@@ -44,6 +44,17 @@ struct AgentOwnershipState {
     tab_group_ref: Option<String>,
     tab_group_color: Option<TabGroupColor>,
     tab_group_collapsed: bool,
+    desired_group_title: Option<String>,
+    group_title_sync_pending: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AgentTabGroupState {
+    pub group_ref: Option<String>,
+    pub color: Option<TabGroupColor>,
+    pub collapsed: bool,
+    pub desired_title: Option<String>,
+    pub title_sync_pending: bool,
 }
 
 impl AgentPageOwnership {
@@ -127,6 +138,7 @@ impl AgentPageOwnership {
         agent.tab_group_ref = value;
         if agent.tab_group_ref.is_none() {
             agent.tab_group_collapsed = false;
+            agent.group_title_sync_pending = false;
         }
         inner.remove_empty_agents();
     }
@@ -162,6 +174,21 @@ impl AgentPageOwnership {
         inner.remove_empty_agents();
     }
 
+    pub async fn set_tab_group_collapsed_if_current(
+        &self,
+        agent_key: &AgentKey,
+        group_ref: &str,
+        collapsed: bool,
+    ) {
+        let mut inner = self.inner.write().await;
+        let Some(agent) = inner.agents.get_mut(agent_key) else {
+            return;
+        };
+        if agent.tab_group_ref.as_deref() == Some(group_ref) {
+            agent.tab_group_collapsed = collapsed;
+        }
+    }
+
     pub async fn set_tab_group(
         &self,
         agent_key: AgentKey,
@@ -173,7 +200,79 @@ impl AgentPageOwnership {
         agent.tab_group_ref = group_ref;
         agent.tab_group_color = color;
         agent.tab_group_collapsed = false;
+        if agent.tab_group_ref.is_none() {
+            agent.group_title_sync_pending = false;
+        }
         inner.remove_empty_agents();
+    }
+
+    /// Installs a newly created group with the title already applied by Chromium.
+    pub async fn set_tab_group_with_title(
+        &self,
+        agent_key: AgentKey,
+        group_ref: String,
+        color: TabGroupColor,
+        title: String,
+    ) {
+        let mut inner = self.inner.write().await;
+        let agent = inner.agents.entry(agent_key).or_default();
+        agent.tab_group_ref = Some(group_ref);
+        agent.tab_group_color = Some(color);
+        agent.tab_group_collapsed = false;
+        agent.desired_group_title = Some(title);
+        agent.group_title_sync_pending = false;
+    }
+
+    pub async fn tab_group_state(&self, agent_key: &AgentKey) -> Option<AgentTabGroupState> {
+        self.inner
+            .read()
+            .await
+            .agents
+            .get(agent_key)
+            .map(|agent| AgentTabGroupState {
+                group_ref: agent.tab_group_ref.clone(),
+                color: agent.tab_group_color,
+                collapsed: agent.tab_group_collapsed,
+                desired_title: agent.desired_group_title.clone(),
+                title_sync_pending: agent.group_title_sync_pending,
+            })
+    }
+
+    /// Records the authoritative title before any best-effort browser update.
+    pub async fn set_desired_group_title(&self, agent_key: AgentKey, title: String) {
+        let mut inner = self.inner.write().await;
+        let agent = inner.agents.entry(agent_key).or_default();
+        agent.desired_group_title = Some(title);
+        agent.group_title_sync_pending = agent.tab_group_ref.is_some();
+    }
+
+    pub async fn pending_group_title(&self, agent_key: &AgentKey) -> Option<(String, String)> {
+        let inner = self.inner.read().await;
+        let agent = inner.agents.get(agent_key)?;
+        if !agent.group_title_sync_pending {
+            return None;
+        }
+        Some((
+            agent.tab_group_ref.clone()?,
+            agent.desired_group_title.clone()?,
+        ))
+    }
+
+    pub async fn mark_group_title_synced(
+        &self,
+        agent_key: &AgentKey,
+        group_ref: &str,
+        title: &str,
+    ) {
+        let mut inner = self.inner.write().await;
+        let Some(agent) = inner.agents.get_mut(agent_key) else {
+            return;
+        };
+        if agent.tab_group_ref.as_deref() == Some(group_ref)
+            && agent.desired_group_title.as_deref() == Some(title)
+        {
+            agent.group_title_sync_pending = false;
+        }
     }
 
     /// Removes all durable ownership and tab-group state for an agent key.
@@ -195,6 +294,8 @@ impl OwnershipInner {
             !agent.pages.is_empty()
                 || agent.tab_group_ref.is_some()
                 || agent.tab_group_color.is_some()
+                || agent.desired_group_title.is_some()
+                || agent.group_title_sync_pending
         });
     }
 }
@@ -296,5 +397,49 @@ mod tests {
         ownership.set_tab_group_ref(codex.clone(), None).await;
 
         assert!(!ownership.tab_group_collapsed(&codex).await);
+    }
+
+    #[tokio::test]
+    async fn desired_title_stays_pending_until_matching_group_sync() {
+        let ownership = AgentPageOwnership::new();
+        let codex = AgentKey::new("codex");
+        ownership
+            .set_desired_group_title(codex.clone(), "codex/first".to_string())
+            .await;
+        assert_eq!(ownership.pending_group_title(&codex).await, None);
+        ownership
+            .set_tab_group_with_title(
+                codex.clone(),
+                "group-1".to_string(),
+                TabGroupColor::Purple,
+                "codex/first".to_string(),
+            )
+            .await;
+        ownership
+            .set_desired_group_title(codex.clone(), "codex/second".to_string())
+            .await;
+        assert_eq!(
+            ownership.pending_group_title(&codex).await,
+            Some(("group-1".to_string(), "codex/second".to_string()))
+        );
+
+        ownership
+            .mark_group_title_synced(&codex, "group-1", "codex/first")
+            .await;
+        assert!(
+            ownership
+                .tab_group_state(&codex)
+                .await
+                .is_some_and(|state| state.title_sync_pending)
+        );
+        ownership
+            .mark_group_title_synced(&codex, "group-1", "codex/second")
+            .await;
+        assert!(
+            ownership
+                .tab_group_state(&codex)
+                .await
+                .is_some_and(|state| !state.title_sync_pending)
+        );
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/registry.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/registry.rs
@@ -1,6 +1,9 @@
 use crate::{
-    domain::{AgentKey, AgentPageOwnership, AgentRef, ClientInfo, Session, SessionId},
-    error::AppResult,
+    domain::{
+        AgentKey, AgentPageOwnership, AgentRef, ClientInfo, Session, SessionId, SessionIdentity,
+        generate_fun_name,
+    },
+    error::{AppError, AppResult},
     services::{audit::AuditService, replay::ReplayService},
 };
 use futures_util::future::BoxFuture;
@@ -10,7 +13,7 @@ use std::{
     time::Duration,
 };
 use tokio::{
-    sync::RwLock,
+    sync::{Mutex, RwLock},
     task::JoinHandle,
     time::{Instant, MissedTickBehavior, interval},
 };
@@ -25,6 +28,7 @@ pub struct SessionRegistry {
     ownership: Arc<AgentPageOwnership>,
     audit: Arc<AuditService>,
     replay: Arc<ReplayService>,
+    reserved_keys: Mutex<HashSet<AgentKey>>,
     fallback_sessions: RwLock<HashSet<SessionId>>,
     last_session_teardown_hook: OnceLock<LastSessionTeardownHook>,
     idle_after: Duration,
@@ -44,6 +48,7 @@ impl SessionRegistry {
             ownership: Arc::new(AgentPageOwnership::new()),
             audit,
             replay,
+            reserved_keys: Mutex::new(HashSet::new()),
             fallback_sessions: RwLock::new(HashSet::new()),
             last_session_teardown_hook: OnceLock::new(),
             idle_after,
@@ -76,17 +81,35 @@ impl SessionRegistry {
         agent: AgentRef,
         client: ClientInfo,
     ) -> AppResult<Arc<Session>> {
-        let session = Session::new(id.clone(), agent, Instant::now());
-        self.audit
+        let identity = {
+            let mut reserved_keys = self.reserved_keys.lock().await;
+            let generated_label = generate_fun_name(rand::random::<f64>, |label| {
+                !reserved_keys.contains(&AgentKey::new(format!("{}-{label}", agent.slug())))
+            })
+            .map_err(|error| AppError::Internal(error.to_string()))?;
+            let identity = SessionIdentity::new(agent.slug(), generated_label);
+            reserved_keys.insert(identity.ownership_key().clone());
+            identity
+        };
+        let session = Session::new(id.clone(), agent, identity, Instant::now());
+        if let Err(error) = self
+            .audit
             .record_session_start(
                 id.as_str(),
-                session.agent().agent_id().as_str(),
+                session.agent_id().as_str(),
                 session.agent().slug(),
                 session.agent().label(),
                 client.name.as_str(),
                 client.version.as_str(),
             )
-            .await?;
+            .await
+        {
+            self.reserved_keys
+                .lock()
+                .await
+                .remove(session.ownership_key());
+            return Err(error);
+        }
         if super::agent_ref::slugify_client_name(&client.name).is_none() {
             self.fallback_sessions.write().await.insert(id.clone());
         }
@@ -95,6 +118,10 @@ impl SessionRegistry {
     }
 
     pub async fn insert_for_testing(&self, session: Arc<Session>) {
+        self.reserved_keys
+            .lock()
+            .await
+            .insert(session.ownership_key().clone());
         self.sessions
             .write()
             .await
@@ -132,7 +159,7 @@ impl SessionRegistry {
         let sessions: Vec<Arc<Session>> = self.sessions.read().await.values().cloned().collect();
         let mut cancelled = 0;
         for session in sessions {
-            if session.agent().agent_id().as_str() == agent_id {
+            if session.agent_id().as_str() == agent_id {
                 cancelled += session.cancel_active_dispatches().await;
             }
         }
@@ -191,27 +218,11 @@ impl SessionRegistry {
             let mut guard = self.fallback_sessions.write().await;
             std::mem::take(&mut *guard)
         };
-        let mut remaining_by_key = HashMap::<AgentKey, usize>::new();
-        for session in sessions.values() {
-            *remaining_by_key
-                .entry(session.agent().ownership_key())
-                .or_default() += 1;
-        }
         let mut count = 0;
         for session in sessions.into_values() {
-            let key = session.agent().ownership_key();
-            let remaining = remaining_by_key.entry(key).or_default();
-            *remaining = remaining.saturating_sub(1);
-            let last_for_key = *remaining == 0;
             let fallback = fallback_sessions.contains(session.id());
-            self.teardown(
-                session,
-                "closed",
-                Some("server shutdown"),
-                last_for_key,
-                fallback,
-            )
-            .await?;
+            self.teardown(session, "closed", Some("server shutdown"), true, fallback)
+                .await?;
             count += 1;
         }
         Ok(count)
@@ -247,7 +258,7 @@ impl SessionRegistry {
             .audit
             .record_session_end(session.id().as_str(), kind, reason)
             .await;
-        let key = session.agent().ownership_key();
+        let key = session.ownership_key().clone();
         for page_id in self.ownership.owned_pages(&key).await {
             session.forget_first_capture(&page_id).await;
         }
@@ -263,7 +274,7 @@ impl SessionRegistry {
         let sessions = self.sessions.read().await;
         if sessions
             .values()
-            .any(|candidate| candidate.agent().ownership_key() == *key)
+            .any(|candidate| candidate.ownership_key() == key)
         {
             return;
         }
@@ -280,7 +291,7 @@ impl SessionRegistry {
 mod tests {
     use super::SessionRegistry;
     use crate::{
-        domain::{AgentRef, ClientInfo, Session, SessionId},
+        domain::{AgentRef, ClientInfo, Session, SessionId, SessionIdentity},
         services::{audit::AuditService, replay::ReplayService},
     };
     use std::{
@@ -311,10 +322,10 @@ mod tests {
         let session = Session::new(
             SessionId::new("s1"),
             AgentRef::Ephemeral {
-                agent_id: crate::domain::AgentId::new("a1"),
                 slug: "a1".to_string(),
                 label: "A1".to_string(),
             },
+            SessionIdentity::new("a1", "agile-alpaca".to_string()),
             Instant::now(),
         );
         registry.insert_for_testing(session).await;
@@ -344,7 +355,6 @@ mod tests {
         let session = registry
             .mint(
                 AgentRef::Ephemeral {
-                    agent_id: crate::domain::AgentId::new("agent-1"),
                     slug: "agent".to_string(),
                     label: "Agent".to_string(),
                 },
@@ -360,7 +370,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ownership_survives_reconnect_and_preserves_tab_group() -> anyhow::Result<()> {
+    async fn same_client_sessions_get_distinct_identity_and_ownership() -> anyhow::Result<()> {
         let dir = tempdir()?;
         let audit = Arc::new(AuditService::open(dir.path().join("audit.sqlite")).await?);
         let replay = Arc::new(ReplayService::new(
@@ -374,69 +384,49 @@ mod tests {
             Duration::from_secs(60),
             Duration::from_secs(1),
         );
-        let session1 = Session::new(
-            SessionId::new("s1"),
-            AgentRef::Ephemeral {
-                agent_id: crate::domain::AgentId::new("codex-a"),
-                slug: "codex".to_string(),
-                label: "Codex".to_string(),
-            },
-            Instant::now(),
-        );
-        let key1 = session1.agent().ownership_key();
-        registry.insert_for_testing(session1.clone()).await;
+        let client = ClientInfo {
+            name: "Codex".to_string(),
+            version: "1".to_string(),
+            title: None,
+        };
+        let agent = AgentRef::Ephemeral {
+            slug: "codex".to_string(),
+            label: "Codex".to_string(),
+        };
+        let session1 = registry.mint(agent.clone(), client.clone()).await?;
+        let key1 = session1.ownership_key().clone();
         registry
             .ownership()
             .claim_page(key1.clone(), browseros_core::PageId(1))
             .await;
+        let session2 = registry.mint(agent, client).await?;
+        let key2 = session2.ownership_key().clone();
         registry
             .ownership()
-            .claim_page(key1.clone(), browseros_core::PageId(2))
-            .await;
-        registry
-            .ownership()
-            .set_tab_group(
-                key1.clone(),
-                Some("group-1".to_string()),
-                Some(crate::domain::TabGroupColor::Purple),
-            )
+            .claim_page(key2.clone(), browseros_core::PageId(2))
             .await;
 
-        assert!(
-            registry
-                .remove(session1.id(), "closed", Some("reconnect"))
-                .await?
-        );
-
-        let session2 = Session::new(
-            SessionId::new("s2"),
-            AgentRef::Ephemeral {
-                agent_id: crate::domain::AgentId::new("codex-b"),
-                slug: "codex".to_string(),
-                label: "Codex".to_string(),
-            },
-            Instant::now(),
-        );
-        let key2 = session2.agent().ownership_key();
-        registry.insert_for_testing(session2).await;
-
-        assert_eq!(key1, key2);
+        assert_ne!(session1.agent_id(), session2.agent_id());
+        assert_ne!(key1, key2);
         assert_eq!(
             registry
                 .ownership()
-                .owned_pages(&key2)
+                .owned_pages(&key1)
                 .await
                 .into_iter()
                 .collect::<Vec<_>>(),
-            vec![browseros_core::PageId(1), browseros_core::PageId(2)]
+            vec![browseros_core::PageId(1)]
         );
+        assert!(Arc::ptr_eq(
+            &registry
+                .lookup(session1.id())
+                .await
+                .ok_or_else(|| anyhow::anyhow!("session missing"))?,
+            &session1
+        ));
         assert_eq!(
-            registry.ownership().tab_group_ref(&key2).await.as_deref(),
-            Some("group-1")
-        );
-        assert_eq!(
-            registry.ownership().tab_group_color(&key2).await,
-            Some(crate::domain::TabGroupColor::Purple)
+            registry.ownership().owned_pages(&key2).await,
+            std::collections::BTreeSet::from([browseros_core::PageId(2)])
         );
         Ok(())
     }
@@ -461,7 +451,6 @@ mod tests {
             .mint_with_id(
                 session_id.clone(),
                 AgentRef::Ephemeral {
-                    agent_id: crate::domain::AgentId::new("unknown-a"),
                     slug: "unknown-a".to_string(),
                     label: "unknown-a".to_string(),
                 },
@@ -472,7 +461,7 @@ mod tests {
                 },
             )
             .await?;
-        let key = session.agent().ownership_key();
+        let key = session.ownership_key().clone();
         registry
             .ownership()
             .claim_page(key.clone(), browseros_core::PageId(4))
@@ -500,7 +489,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn last_session_teardown_hook_fires_once_per_ownership_key() -> anyhow::Result<()> {
+    async fn teardown_hook_fires_for_each_session_key() -> anyhow::Result<()> {
         let dir = tempdir()?;
         let audit = Arc::new(AuditService::open(dir.path().join("audit.sqlite")).await?);
         let replay = Arc::new(ReplayService::new(
@@ -528,10 +517,10 @@ mod tests {
                 .insert_for_testing(Session::new(
                     SessionId::new(id),
                     AgentRef::Ephemeral {
-                        agent_id: crate::domain::AgentId::new(format!("codex-{id}")),
                         slug: "codex".to_string(),
                         label: "Codex".to_string(),
                     },
+                    SessionIdentity::new("codex", format!("agile-{id}")),
                     Instant::now(),
                 ))
                 .await;
@@ -540,79 +529,11 @@ mod tests {
         registry
             .remove(&SessionId::new("s1"), "closed", None)
             .await?;
-        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
         registry
             .remove(&SessionId::new("s2"), "closed", None)
             .await?;
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn inactive_key_finalization_rechecks_for_a_reconnected_session() -> anyhow::Result<()> {
-        let dir = tempdir()?;
-        let audit = Arc::new(AuditService::open(dir.path().join("audit.sqlite")).await?);
-        let replay = Arc::new(ReplayService::new(
-            dir.path().join("replays"),
-            50,
-            Duration::from_secs(30),
-        ));
-        let registry = SessionRegistry::new(
-            audit,
-            replay,
-            Duration::from_secs(60),
-            Duration::from_secs(1),
-        );
-        let calls = Arc::new(AtomicUsize::new(0));
-        let hook_calls = calls.clone();
-        registry.set_last_session_teardown_hook(Arc::new(move |ownership, key| {
-            let hook_calls = hook_calls.clone();
-            Box::pin(async move {
-                let _ = (ownership, key);
-                hook_calls.fetch_add(1, Ordering::SeqCst);
-            })
-        }));
-        let session1 = Session::new(
-            SessionId::new("s1"),
-            AgentRef::Ephemeral {
-                agent_id: crate::domain::AgentId::new("codex-a"),
-                slug: "codex".to_string(),
-                label: "Codex".to_string(),
-            },
-            Instant::now(),
-        );
-        let key = session1.agent().ownership_key();
-        registry.insert_for_testing(session1.clone()).await;
-        registry
-            .ownership()
-            .set_tab_group_ref(key.clone(), Some("group-1".to_string()))
-            .await;
-
-        let removed = registry.sessions.write().await.remove(session1.id());
-        assert!(removed.is_some());
-        registry
-            .mint_with_id(
-                SessionId::new("s2"),
-                AgentRef::Ephemeral {
-                    agent_id: crate::domain::AgentId::new("codex-b"),
-                    slug: "codex".to_string(),
-                    label: "Codex".to_string(),
-                },
-                ClientInfo {
-                    name: "Codex".to_string(),
-                    version: "1".to_string(),
-                    title: None,
-                },
-            )
-            .await?;
-
-        registry.finalize_inactive_key(&key, true).await;
-
-        assert_eq!(calls.load(Ordering::SeqCst), 0);
-        assert_eq!(
-            registry.ownership().tab_group_ref(&key).await.as_deref(),
-            Some("group-1")
-        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/registry.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/registry.rs
@@ -20,8 +20,22 @@ use tokio::{
 use tracing::{debug, warn};
 use ulid::Ulid;
 
-pub type LastSessionTeardownHook =
-    Arc<dyn Fn(Arc<AgentPageOwnership>, AgentKey) -> BoxFuture<'static, ()> + Send + Sync>;
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum RetainedGroupAction {
+    Collapse,
+    Close,
+}
+
+pub type RetainedGroupHook = Arc<
+    dyn Fn(Arc<AgentPageOwnership>, AgentKey, RetainedGroupAction) -> BoxFuture<'static, bool>
+        + Send
+        + Sync,
+>;
+
+struct RetainedSession {
+    session: Arc<Session>,
+    ended_at: Instant,
+}
 
 pub struct SessionRegistry {
     sessions: RwLock<HashMap<SessionId, Arc<Session>>>,
@@ -29,9 +43,11 @@ pub struct SessionRegistry {
     audit: Arc<AuditService>,
     replay: Arc<ReplayService>,
     reserved_keys: Mutex<HashSet<AgentKey>>,
-    fallback_sessions: RwLock<HashSet<SessionId>>,
-    last_session_teardown_hook: OnceLock<LastSessionTeardownHook>,
+    retained: RwLock<HashMap<AgentKey, RetainedSession>>,
+    reaping_keys: Mutex<HashSet<AgentKey>>,
+    retained_group_hook: OnceLock<RetainedGroupHook>,
     idle_after: Duration,
+    retention: Duration,
     sweep_interval: Duration,
 }
 
@@ -41,6 +57,7 @@ impl SessionRegistry {
         audit: Arc<AuditService>,
         replay: Arc<ReplayService>,
         idle_after: Duration,
+        retention: Duration,
         sweep_interval: Duration,
     ) -> Arc<Self> {
         Arc::new(Self {
@@ -49,9 +66,11 @@ impl SessionRegistry {
             audit,
             replay,
             reserved_keys: Mutex::new(HashSet::new()),
-            fallback_sessions: RwLock::new(HashSet::new()),
-            last_session_teardown_hook: OnceLock::new(),
+            retained: RwLock::new(HashMap::new()),
+            reaping_keys: Mutex::new(HashSet::new()),
+            retained_group_hook: OnceLock::new(),
             idle_after,
+            retention,
             sweep_interval,
         })
     }
@@ -61,9 +80,9 @@ impl SessionRegistry {
         self.ownership.clone()
     }
 
-    /// Installs the host cleanup invoked when an ownership key loses its final session.
-    pub fn set_last_session_teardown_hook(&self, hook: LastSessionTeardownHook) {
-        let _ = self.last_session_teardown_hook.set(hook);
+    /// Installs browser-backed retained-group collapse and close operations.
+    pub fn set_retained_group_hook(&self, hook: RetainedGroupHook) {
+        let _ = self.retained_group_hook.set(hook);
     }
 
     pub async fn mint(
@@ -109,9 +128,6 @@ impl SessionRegistry {
                 .await
                 .remove(session.ownership_key());
             return Err(error);
-        }
-        if super::agent_ref::slugify_client_name(&client.name).is_none() {
-            self.fallback_sessions.write().await.insert(id.clone());
         }
         self.sessions.write().await.insert(id, session.clone());
         Ok(session)
@@ -178,8 +194,7 @@ impl SessionRegistry {
     ) -> AppResult<bool> {
         let session = self.sessions.write().await.remove(id);
         if let Some(session) = session {
-            let fallback = self.fallback_sessions.write().await.remove(id);
-            self.teardown(session, kind, reason, true, fallback).await?;
+            self.teardown(session, kind, reason).await?;
             return Ok(true);
         }
         Ok(false)
@@ -206,6 +221,7 @@ impl SessionRegistry {
                 removed += 1;
             }
         }
+        self.reap_retained(now).await;
         Ok(removed)
     }
 
@@ -214,14 +230,9 @@ impl SessionRegistry {
             let mut guard = self.sessions.write().await;
             std::mem::take(&mut *guard)
         };
-        let fallback_sessions = {
-            let mut guard = self.fallback_sessions.write().await;
-            std::mem::take(&mut *guard)
-        };
         let mut count = 0;
         for session in sessions.into_values() {
-            let fallback = fallback_sessions.contains(session.id());
-            self.teardown(session, "closed", Some("server shutdown"), true, fallback)
+            self.teardown(session, "closed", Some("server shutdown"))
                 .await?;
             count += 1;
         }
@@ -248,8 +259,6 @@ impl SessionRegistry {
         session: Arc<Session>,
         kind: &str,
         reason: Option<&str>,
-        finalize_key: bool,
-        fallback: bool,
     ) -> AppResult<()> {
         session.cancel_active_dispatches().await;
         session.cancel();
@@ -259,45 +268,92 @@ impl SessionRegistry {
             .record_session_end(session.id().as_str(), kind, reason)
             .await;
         let key = session.ownership_key().clone();
-        for page_id in self.ownership.owned_pages(&key).await {
-            session.forget_first_capture(&page_id).await;
-        }
-        if finalize_key {
-            self.finalize_inactive_key(&key, fallback).await;
+        self.retained.write().await.insert(
+            key.clone(),
+            RetainedSession {
+                session,
+                ended_at: Instant::now(),
+            },
+        );
+        if let Some(hook) = self.retained_group_hook.get() {
+            hook(self.ownership.clone(), key, RetainedGroupAction::Collapse).await;
         }
         replay_result?;
         audit_result?;
         Ok(())
     }
 
-    async fn finalize_inactive_key(&self, key: &AgentKey, fallback: bool) {
-        let sessions = self.sessions.read().await;
-        if sessions
-            .values()
-            .any(|candidate| candidate.ownership_key() == key)
+    async fn reap_retained(&self, now: Instant) -> usize {
+        let retained: Vec<(AgentKey, Instant)> = self
+            .retained
+            .read()
+            .await
+            .iter()
+            .map(|(key, retained)| (key.clone(), retained.ended_at))
+            .collect();
+        let mut expired = Vec::new();
+        let mut active = Vec::new();
         {
-            return;
+            let mut reaping = self.reaping_keys.lock().await;
+            for (key, ended_at) in retained {
+                if now.duration_since(ended_at) >= self.retention {
+                    if reaping.insert(key.clone()) {
+                        expired.push(key);
+                    }
+                } else if !reaping.contains(&key) {
+                    active.push(key);
+                }
+            }
         }
-        if let Some(hook) = self.last_session_teardown_hook.get() {
-            hook(self.ownership.clone(), key.clone()).await;
+        if let Some(hook) = self.retained_group_hook.get() {
+            for key in active {
+                hook(self.ownership.clone(), key, RetainedGroupAction::Collapse).await;
+            }
         }
-        if fallback {
-            self.ownership.forget(key).await;
+
+        let mut reaped = 0;
+        for key in expired {
+            let closed = match self.retained_group_hook.get() {
+                Some(hook) => {
+                    hook(
+                        self.ownership.clone(),
+                        key.clone(),
+                        RetainedGroupAction::Close,
+                    )
+                    .await
+                }
+                None => self.ownership.tab_group_ref(&key).await.is_none(),
+            };
+            if closed {
+                let retained = self.retained.write().await.remove(&key);
+                if let Some(retained) = retained {
+                    for page_id in self.ownership.owned_pages(&key).await {
+                        retained.session.forget_first_capture(&page_id).await;
+                    }
+                    self.ownership.forget(&key).await;
+                    self.reserved_keys.lock().await.remove(&key);
+                    reaped += 1;
+                }
+            }
+            self.reaping_keys.lock().await.remove(&key);
         }
+        reaped
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::SessionRegistry;
+    use super::{RetainedGroupAction, SessionRegistry};
     use crate::{
-        domain::{AgentRef, ClientInfo, Session, SessionId, SessionIdentity},
+        domain::{
+            AgentKey, AgentRef, ClientInfo, Session, SessionId, SessionIdentity, generate_fun_name,
+        },
         services::{audit::AuditService, replay::ReplayService},
     };
     use std::{
         sync::{
             Arc,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
         },
         time::Duration,
     };
@@ -317,6 +373,7 @@ mod tests {
             audit.clone(),
             replay,
             Duration::from_secs(5),
+            Duration::from_secs(60),
             Duration::from_secs(1),
         );
         let session = Session::new(
@@ -350,6 +407,7 @@ mod tests {
             audit,
             replay,
             Duration::from_secs(60),
+            Duration::from_secs(60),
             Duration::from_secs(1),
         );
         let session = registry
@@ -381,6 +439,7 @@ mod tests {
         let registry = SessionRegistry::new(
             audit,
             replay,
+            Duration::from_secs(60),
             Duration::from_secs(60),
             Duration::from_secs(1),
         );
@@ -431,8 +490,9 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn fallback_identity_is_forgotten_after_its_last_session() -> anyhow::Result<()> {
+    #[tokio::test(start_paused = true)]
+    async fn retained_session_collapses_then_closes_and_forgets_after_expiry() -> anyhow::Result<()>
+    {
         let dir = tempdir()?;
         let audit = Arc::new(AuditService::open(dir.path().join("audit.sqlite")).await?);
         let replay = Arc::new(ReplayService::new(
@@ -444,24 +504,33 @@ mod tests {
             audit,
             replay,
             Duration::from_secs(60),
+            Duration::from_secs(10),
             Duration::from_secs(1),
         );
-        let session_id = SessionId::new("fallback-session");
-        let session = registry
-            .mint_with_id(
-                session_id.clone(),
-                AgentRef::Ephemeral {
-                    slug: "unknown-a".to_string(),
-                    label: "unknown-a".to_string(),
-                },
-                ClientInfo {
-                    name: "...".to_string(),
-                    version: "1".to_string(),
-                    title: None,
-                },
-            )
-            .await?;
+        let actions = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let hook_actions = actions.clone();
+        registry.set_retained_group_hook(Arc::new(move |_, _, action| {
+            let hook_actions = hook_actions.clone();
+            Box::pin(async move {
+                hook_actions
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .push(action);
+                true
+            })
+        }));
+        let session_id = SessionId::new("s1");
+        let session = Session::new(
+            session_id.clone(),
+            AgentRef::Ephemeral {
+                slug: "codex".to_string(),
+                label: "Codex".to_string(),
+            },
+            SessionIdentity::new("codex", "agile-alpaca".to_string()),
+            Instant::now(),
+        );
         let key = session.ownership_key().clone();
+        registry.insert_for_testing(session.clone()).await;
         registry
             .ownership()
             .claim_page(key.clone(), browseros_core::PageId(4))
@@ -475,21 +544,48 @@ mod tests {
             .await;
 
         assert!(registry.remove(&session_id, "closed", None).await?);
-
+        assert_eq!(registry.retained.read().await.len(), 1);
+        assert_eq!(
+            actions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .as_slice(),
+            &[RetainedGroupAction::Collapse]
+        );
         assert_eq!(
             registry
                 .ownership()
                 .owner_of_page(&browseros_core::PageId(4))
                 .await,
-            None
+            Some(key.clone())
         );
+        assert!(session.has_first_capture(&browseros_core::PageId(4)).await);
+
+        tokio::time::advance(Duration::from_secs(9)).await;
+        assert_eq!(registry.reap_retained(Instant::now()).await, 0);
+        assert_eq!(registry.retained.read().await.len(), 1);
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert_eq!(registry.reap_retained(Instant::now()).await, 1);
+        assert_eq!(registry.retained.read().await.len(), 0);
         assert_eq!(registry.ownership().tab_group_ref(&key).await, None);
         assert!(!session.has_first_capture(&browseros_core::PageId(4)).await);
+        assert!(!registry.reserved_keys.lock().await.contains(&key));
+        assert_eq!(
+            actions
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .as_slice(),
+            &[
+                RetainedGroupAction::Collapse,
+                RetainedGroupAction::Collapse,
+                RetainedGroupAction::Close
+            ]
+        );
         Ok(())
     }
 
-    #[tokio::test]
-    async fn teardown_hook_fires_for_each_session_key() -> anyhow::Result<()> {
+    #[tokio::test(start_paused = true)]
+    async fn failed_or_disconnected_close_retries_without_forgetting_state() -> anyhow::Result<()> {
         let dir = tempdir()?;
         let audit = Arc::new(AuditService::open(dir.path().join("audit.sqlite")).await?);
         let replay = Arc::new(ReplayService::new(
@@ -501,39 +597,180 @@ mod tests {
             audit,
             replay,
             Duration::from_secs(60),
+            Duration::from_secs(10),
             Duration::from_secs(1),
         );
-        let calls = Arc::new(AtomicUsize::new(0));
-        let hook_calls = calls.clone();
-        registry.set_last_session_teardown_hook(Arc::new(move |ownership, key| {
-            let hook_calls = hook_calls.clone();
+        let close_allowed = Arc::new(AtomicBool::new(false));
+        let close_attempts = Arc::new(AtomicUsize::new(0));
+        let hook_allowed = close_allowed.clone();
+        let hook_attempts = close_attempts.clone();
+        registry.set_retained_group_hook(Arc::new(move |_, _, action| {
+            let hook_allowed = hook_allowed.clone();
+            let hook_attempts = hook_attempts.clone();
             Box::pin(async move {
-                let _ = (ownership, key);
-                hook_calls.fetch_add(1, Ordering::SeqCst);
+                if matches!(action, RetainedGroupAction::Close) {
+                    hook_attempts.fetch_add(1, Ordering::SeqCst);
+                    return hook_allowed.load(Ordering::SeqCst);
+                }
+                false
             })
         }));
-        for id in ["s1", "s2"] {
-            registry
-                .insert_for_testing(Session::new(
-                    SessionId::new(id),
-                    AgentRef::Ephemeral {
-                        slug: "codex".to_string(),
-                        label: "Codex".to_string(),
-                    },
-                    SessionIdentity::new("codex", format!("agile-{id}")),
-                    Instant::now(),
-                ))
-                .await;
-        }
+        let session = Session::new(
+            SessionId::new("s1"),
+            AgentRef::Ephemeral {
+                slug: "codex".to_string(),
+                label: "Codex".to_string(),
+            },
+            SessionIdentity::new("codex", "agile-alpaca".to_string()),
+            Instant::now(),
+        );
+        let key = session.ownership_key().clone();
+        registry.insert_for_testing(session.clone()).await;
+        registry
+            .ownership()
+            .claim_page(key.clone(), browseros_core::PageId(7))
+            .await;
+        registry
+            .ownership()
+            .set_tab_group_ref(key.clone(), Some("group-7".to_string()))
+            .await;
+        registry.remove(session.id(), "closed", None).await?;
 
-        registry
-            .remove(&SessionId::new("s1"), "closed", None)
-            .await?;
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-        registry
-            .remove(&SessionId::new("s2"), "closed", None)
-            .await?;
-        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        tokio::time::advance(Duration::from_secs(10)).await;
+        assert_eq!(registry.reap_retained(Instant::now()).await, 0);
+        assert_eq!(close_attempts.load(Ordering::SeqCst), 1);
+        assert_eq!(registry.retained.read().await.len(), 1);
+        assert_eq!(
+            registry
+                .ownership()
+                .owner_of_page(&browseros_core::PageId(7))
+                .await,
+            Some(key.clone())
+        );
+
+        close_allowed.store(true, Ordering::SeqCst);
+        assert_eq!(registry.reap_retained(Instant::now()).await, 1);
+        assert_eq!(close_attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(registry.retained.read().await.len(), 0);
+        assert_eq!(
+            registry
+                .ownership()
+                .owner_of_page(&browseros_core::PageId(7))
+                .await,
+            None
+        );
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn generated_key_stays_reserved_until_retained_cleanup() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = Arc::new(AuditService::open(dir.path().join("audit.sqlite")).await?);
+        let replay = Arc::new(ReplayService::new(
+            dir.path().join("replays"),
+            50,
+            Duration::from_secs(30),
+        ));
+        let registry = SessionRegistry::new(
+            audit,
+            replay,
+            Duration::from_secs(60),
+            Duration::from_secs(10),
+            Duration::from_secs(1),
+        );
+        let session = Session::new(
+            SessionId::new("s1"),
+            AgentRef::Ephemeral {
+                slug: "codex".to_string(),
+                label: "Codex".to_string(),
+            },
+            SessionIdentity::new("codex", "agile-alpaca".to_string()),
+            Instant::now(),
+        );
+        registry.insert_for_testing(session.clone()).await;
+        registry.remove(session.id(), "closed", None).await?;
+
+        let candidate_while_retained = {
+            let reserved = registry.reserved_keys.lock().await;
+            generate_fun_name(
+                || 0.0,
+                |label| !reserved.contains(&AgentKey::new(format!("codex-{label}"))),
+            )?
+        };
+        assert_eq!(candidate_while_retained, "agile-alpaca-2");
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        assert_eq!(registry.reap_retained(Instant::now()).await, 1);
+        let candidate_after_cleanup = {
+            let reserved = registry.reserved_keys.lock().await;
+            generate_fun_name(
+                || 0.0,
+                |label| !reserved.contains(&AgentKey::new(format!("codex-{label}"))),
+            )?
+        };
+        assert_eq!(candidate_after_cleanup, "agile-alpaca");
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn overlapping_retained_sweeps_issue_one_close() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = Arc::new(AuditService::open(dir.path().join("audit.sqlite")).await?);
+        let replay = Arc::new(ReplayService::new(
+            dir.path().join("replays"),
+            50,
+            Duration::from_secs(30),
+        ));
+        let registry = SessionRegistry::new(
+            audit,
+            replay,
+            Duration::from_secs(60),
+            Duration::from_secs(10),
+            Duration::from_secs(1),
+        );
+        let close_attempts = Arc::new(AtomicUsize::new(0));
+        let close_entered = Arc::new(tokio::sync::Notify::new());
+        let close_release = Arc::new(tokio::sync::Notify::new());
+        let hook_attempts = close_attempts.clone();
+        let hook_entered = close_entered.clone();
+        let hook_release = close_release.clone();
+        registry.set_retained_group_hook(Arc::new(move |_, _, action| {
+            let hook_attempts = hook_attempts.clone();
+            let hook_entered = hook_entered.clone();
+            let hook_release = hook_release.clone();
+            Box::pin(async move {
+                if matches!(action, RetainedGroupAction::Close) {
+                    hook_attempts.fetch_add(1, Ordering::SeqCst);
+                    hook_entered.notify_one();
+                    hook_release.notified().await;
+                }
+                true
+            })
+        }));
+        let session = Session::new(
+            SessionId::new("s1"),
+            AgentRef::Ephemeral {
+                slug: "codex".to_string(),
+                label: "Codex".to_string(),
+            },
+            SessionIdentity::new("codex", "agile-alpaca".to_string()),
+            Instant::now(),
+        );
+        registry.insert_for_testing(session.clone()).await;
+        registry.remove(session.id(), "closed", None).await?;
+        tokio::time::advance(Duration::from_secs(10)).await;
+        let now = Instant::now();
+        let entered = close_entered.notified();
+        let first_registry = registry.clone();
+        let first = tokio::spawn(async move { first_registry.reap_retained(now).await });
+        entered.await;
+
+        assert_eq!(registry.reap_retained(now).await, 0);
+        assert_eq!(close_attempts.load(Ordering::SeqCst), 1);
+        close_release.notify_one();
+        assert_eq!(first.await?, 1);
+        assert_eq!(registry.reap_retained(now).await, 0);
+        assert_eq!(close_attempts.load(Ordering::SeqCst), 1);
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/session.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/session.rs
@@ -1,4 +1,4 @@
-use crate::domain::{AgentRef, DispatchId, SessionId};
+use crate::domain::{AgentId, AgentKey, AgentRef, DispatchId, SessionId, SessionIdentity};
 use browseros_core::PageId;
 use serde::Serialize;
 use std::{
@@ -115,28 +115,31 @@ fn fnv1a(input: &str) -> u32 {
 pub struct Session {
     id: SessionId,
     agent: AgentRef,
+    identity: SessionIdentity,
     first_captures: RwLock<BTreeSet<PageId>>,
     active_dispatches: Mutex<BTreeMap<DispatchId, CancellationToken>>,
     cancel: CancellationToken,
     replay_handle: Mutex<Option<String>>,
     last_activity: Mutex<Instant>,
-    /// User-facing session name gathered via MCP elicitation. In-memory only,
-    /// mirroring the TS identity map's sessionLabel (never persisted to audit).
-    session_label: RwLock<Option<String>>,
 }
 
 impl Session {
     #[must_use]
-    pub fn new(id: SessionId, agent: AgentRef, now: Instant) -> Arc<Self> {
+    pub fn new(
+        id: SessionId,
+        agent: AgentRef,
+        identity: SessionIdentity,
+        now: Instant,
+    ) -> Arc<Self> {
         Arc::new(Self {
             id,
             agent,
+            identity,
             first_captures: RwLock::new(BTreeSet::new()),
             active_dispatches: Mutex::new(BTreeMap::new()),
             cancel: CancellationToken::new(),
             replay_handle: Mutex::new(None),
             last_activity: Mutex::new(now),
-            session_label: RwLock::new(None),
         })
     }
 
@@ -148,6 +151,33 @@ impl Session {
     #[must_use]
     pub fn agent(&self) -> &AgentRef {
         &self.agent
+    }
+
+    #[must_use]
+    pub fn agent_id(&self) -> &AgentId {
+        self.identity.agent_id()
+    }
+
+    #[must_use]
+    pub fn ownership_key(&self) -> &AgentKey {
+        self.identity.ownership_key()
+    }
+
+    #[must_use]
+    pub fn generated_label(&self) -> &str {
+        self.identity.generated_label()
+    }
+
+    pub async fn label(&self) -> String {
+        self.identity.label().await
+    }
+
+    pub async fn rename(&self, new_label: String) -> String {
+        self.identity.rename(new_label).await
+    }
+
+    pub async fn take_rename_nudge(&self) -> Option<String> {
+        self.identity.take_rename_nudge().await
     }
 
     pub async fn touch(&self, now: Instant) {
@@ -172,14 +202,6 @@ impl Session {
 
     pub async fn set_replay_handle(&self, value: Option<String>) {
         *self.replay_handle.lock().await = value;
-    }
-
-    pub async fn session_label(&self) -> Option<String> {
-        self.session_label.read().await.clone()
-    }
-
-    pub async fn set_session_label(&self, label: String) {
-        *self.session_label.write().await = Some(label);
     }
 
     pub fn cancel(&self) {

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/session_identity.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/session_identity.rs
@@ -1,0 +1,209 @@
+use crate::domain::{AgentId, AgentKey};
+use tokio::sync::Mutex;
+
+const ADJECTIVES: [&str; 46] = [
+    "agile", "amber", "bold", "breezy", "bright", "brisk", "calm", "clever", "cozy", "curious",
+    "dapper", "eager", "fancy", "fleet", "fuzzy", "gentle", "glad", "golden", "happy", "jolly",
+    "keen", "kind", "lively", "lucky", "merry", "mighty", "nimble", "peppy", "plucky", "proud",
+    "quick", "quiet", "radiant", "rapid", "ready", "silky", "snappy", "spry", "steady", "sunny",
+    "swift", "tidy", "vivid", "warm", "witty", "zesty",
+];
+const ANIMALS: [&str; 46] = [
+    "alpaca", "badger", "beaver", "bison", "bobcat", "capybara", "caribou", "cheetah", "corgi",
+    "dolphin", "falcon", "ferret", "finch", "fox", "gecko", "heron", "ibis", "jaguar", "koala",
+    "lemur", "leopard", "lynx", "marten", "moose", "narwhal", "ocelot", "orca", "otter", "owl",
+    "panda", "parrot", "penguin", "puffin", "quokka", "rabbit", "raven", "seal", "sparrow",
+    "stoat", "tamarin", "tiger", "toucan", "turtle", "walrus", "weasel", "wombat",
+];
+const REDRAW_ATTEMPTS: usize = 5;
+const MAX_SUFFIX: usize = 999;
+const RENAME_NUDGE_LIMIT: u8 = 5;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, thiserror::Error)]
+#[error("unable to mint a unique session name")]
+pub struct GenerateFunNameError;
+
+/// Draws an available docker-style session name, suffixing after repeated collisions.
+pub fn generate_fun_name(
+    mut random: impl FnMut() -> f64,
+    mut is_available: impl FnMut(&str) -> bool,
+) -> Result<String, GenerateFunNameError> {
+    let mut candidate = String::new();
+    for _ in 0..REDRAW_ATTEMPTS {
+        candidate = format!(
+            "{}-{}",
+            pick(&ADJECTIVES, random()),
+            pick(&ANIMALS, random())
+        );
+        if is_available(&candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    for suffix in 2..=MAX_SUFFIX {
+        let suffixed = format!("{candidate}-{suffix}");
+        if is_available(&suffixed) {
+            return Ok(suffixed);
+        }
+    }
+    Err(GenerateFunNameError)
+}
+
+fn pick<'a>(words: &'a [&str], draw: f64) -> &'a str {
+    let clamped = draw.max(0.0).min(1.0 - f64::EPSILON);
+    let index = (clamped * words.len() as f64).floor() as usize;
+    words.get(index).copied().unwrap_or(words[0])
+}
+
+#[derive(Debug)]
+pub struct SessionIdentity {
+    agent_id: AgentId,
+    ownership_key: AgentKey,
+    generated_label: String,
+    naming: Mutex<SessionNamingState>,
+}
+
+#[derive(Debug)]
+struct SessionNamingState {
+    label: String,
+    rename_nudges_left: u8,
+}
+
+impl SessionIdentity {
+    /// Creates the per-conversation identity used by MCP, ownership, and naming flows.
+    #[must_use]
+    pub fn new(client_slug: &str, generated_label: String) -> Self {
+        let opaque_id = format!("{client_slug}-{generated_label}");
+        Self {
+            agent_id: AgentId::new(opaque_id.clone()),
+            ownership_key: AgentKey::new(opaque_id),
+            generated_label: generated_label.clone(),
+            naming: Mutex::new(SessionNamingState {
+                label: generated_label,
+                rename_nudges_left: RENAME_NUDGE_LIMIT,
+            }),
+        }
+    }
+
+    #[must_use]
+    pub fn agent_id(&self) -> &AgentId {
+        &self.agent_id
+    }
+
+    #[must_use]
+    pub fn ownership_key(&self) -> &AgentKey {
+        &self.ownership_key
+    }
+
+    #[must_use]
+    pub fn generated_label(&self) -> &str {
+        &self.generated_label
+    }
+
+    pub async fn label(&self) -> String {
+        self.naming.lock().await.label.clone()
+    }
+
+    pub async fn rename(&self, new_label: String) -> String {
+        let mut naming = self.naming.lock().await;
+        std::mem::replace(&mut naming.label, new_label)
+    }
+
+    /// Atomically consumes one rename reminder while the generated label remains active.
+    pub async fn take_rename_nudge(&self) -> Option<String> {
+        let mut naming = self.naming.lock().await;
+        if naming.label != self.generated_label || naming.rename_nudges_left == 0 {
+            return None;
+        }
+        naming.rename_nudges_left -= 1;
+        Some(naming.label.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GenerateFunNameError, SessionIdentity, generate_fun_name};
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex},
+    };
+
+    fn draws(values: impl IntoIterator<Item = f64>) -> impl FnMut() -> f64 {
+        let values = Mutex::new(VecDeque::from_iter(values));
+        move || {
+            values
+                .lock()
+                .ok()
+                .and_then(|mut values| values.pop_front())
+                .unwrap_or(0.0)
+        }
+    }
+
+    #[test]
+    fn selects_from_the_exact_vectors_and_clamps_random_draws() {
+        assert_eq!(
+            generate_fun_name(draws([0.0, 0.0]), |_| true).as_deref(),
+            Ok("agile-alpaca")
+        );
+        assert_eq!(
+            generate_fun_name(draws([1.5, -1.0]), |_| true).as_deref(),
+            Ok("zesty-alpaca")
+        );
+    }
+
+    #[test]
+    fn redraws_collisions_before_suffixing_the_last_candidate() {
+        let mut checked = Vec::new();
+        let name = generate_fun_name(draws([0.0; 10]), |candidate| {
+            checked.push(candidate.to_string());
+            candidate == "agile-alpaca-3"
+        });
+
+        assert_eq!(name.as_deref(), Ok("agile-alpaca-3"));
+        assert_eq!(checked.len(), 7);
+        assert_eq!(checked[5], "agile-alpaca-2");
+    }
+
+    #[test]
+    fn reports_exhaustion_after_suffix_999() {
+        assert_eq!(
+            generate_fun_name(draws([0.0; 10]), |_| false),
+            Err(GenerateFunNameError)
+        );
+    }
+
+    #[tokio::test]
+    async fn parallel_nudge_attempts_succeed_exactly_five_times() -> anyhow::Result<()> {
+        let identity = Arc::new(SessionIdentity::new("codex", "agile-alpaca".to_string()));
+        let mut tasks = Vec::new();
+        for _ in 0..20 {
+            let identity = identity.clone();
+            tasks.push(tokio::spawn(async move {
+                identity.take_rename_nudge().await.is_some()
+            }));
+        }
+
+        let mut successes = 0;
+        for task in tasks {
+            if task.await? {
+                successes += 1;
+            }
+        }
+        assert_eq!(successes, 5);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rename_returns_the_old_label_and_stops_nudges() {
+        let identity = SessionIdentity::new("codex", "agile-alpaca".to_string());
+        assert_eq!(identity.agent_id().as_str(), "codex-agile-alpaca");
+        assert_eq!(identity.ownership_key().as_str(), "codex-agile-alpaca");
+        assert_eq!(identity.generated_label(), "agile-alpaca");
+        assert_eq!(
+            identity.rename("invoice-processing".to_string()).await,
+            "agile-alpaca"
+        );
+        assert_eq!(identity.label().await, "invoice-processing");
+        assert_eq!(identity.take_rename_nudge().await, None);
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/session_identity.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/session_identity.rs
@@ -50,7 +50,7 @@ pub fn generate_fun_name(
 }
 
 fn pick<'a>(words: &'a [&str], draw: f64) -> &'a str {
-    let clamped = draw.max(0.0).min(1.0 - f64::EPSILON);
+    let clamped = draw.clamp(0.0, 1.0 - f64::EPSILON);
     let index = (clamped * words.len() as f64).floor() as usize;
     words.get(index).copied().unwrap_or(words[0])
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -178,6 +178,7 @@ mod tests {
             resources_dir: root.path().join("resources"),
             browserclaw_dir: root.path().to_path_buf(),
             session_idle: Duration::from_secs(300),
+            session_retention: Duration::from_secs(7_200),
             session_sweep_interval: Duration::from_secs(60),
             screencast_screenshot_fallback: true,
             dev_mode: false,

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/dispatch.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/dispatch.rs
@@ -10,15 +10,11 @@ use browseros_mcp::{
 };
 use futures_util::future::BoxFuture;
 use rmcp::{
-    ErrorData as McpError, RoleServer,
-    model::{CallToolResult, ContentBlock, RequestId},
-    service::Peer,
+    ErrorData as McpError,
+    model::{CallToolResult, ContentBlock},
 };
 use serde_json::{Value, json};
-use std::{
-    sync::{Arc, atomic::AtomicBool},
-    time::Instant,
-};
+use std::{sync::Arc, time::Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
@@ -48,7 +44,6 @@ pub struct ToolCall {
     tool_index: usize,
     pub raw_args: Value,
     pub session_id: SessionId,
-    pub request_id: RequestId,
     pub identity: Option<ToolIdentity>,
     pub browser_session: Option<Arc<BrowserSession>>,
     pub cancel: CancellationToken,
@@ -59,8 +54,6 @@ pub struct ToolCall {
     pub state: AppState,
     pub dispatch_id: DispatchId,
     pub output_files: OutputFileAccess,
-    pub peer: Option<Peer<RoleServer>>,
-    pub naming_started: Arc<AtomicBool>,
 }
 
 impl ToolCall {
@@ -72,7 +65,6 @@ impl ToolCall {
         tool_index: usize,
         raw_args: Value,
         session_id: SessionId,
-        request_id: RequestId,
         identity: Option<ToolIdentity>,
         browser_session: Option<Arc<BrowserSession>>,
         cancel: CancellationToken,
@@ -81,8 +73,6 @@ impl ToolCall {
         default_tab_group_id: Option<String>,
         state: AppState,
         output_files: OutputFileAccess,
-        peer: Option<Peer<RoleServer>>,
-        naming_started: Arc<AtomicBool>,
     ) -> Self {
         let tool_name = catalog[tool_index].name;
         let flags = if tool_name == "tabs" {
@@ -113,7 +103,6 @@ impl ToolCall {
             tool_index,
             raw_args,
             session_id,
-            request_id,
             identity,
             browser_session,
             cancel,
@@ -124,8 +113,6 @@ impl ToolCall {
             state,
             dispatch_id: DispatchId::new(),
             output_files,
-            peer,
-            naming_started,
         }
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/audit.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/audit.rs
@@ -84,7 +84,7 @@ async fn record_dispatch(
         .state
         .audit
         .record_tool_dispatch(RecordToolDispatchInput {
-            agent_id: identity.agent.agent_id().as_str().to_string(),
+            agent_id: identity.session.agent_id().as_str().to_string(),
             slug: identity.agent.slug().to_string(),
             agent_label: identity.agent_label.clone(),
             session_id: call.session_id.as_str().to_string(),

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/ownership_claims.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/ownership_claims.rs
@@ -29,7 +29,7 @@ pub fn apply(
                         page_id,
                         url: info.url,
                         title: info.title,
-                        agent_id: identity.agent.agent_id().as_str().to_string(),
+                        agent_id: identity.session.agent_id().as_str().to_string(),
                         slug: identity.agent.slug().to_string(),
                         tool_name: "tabs".to_string(),
                     })

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/session_naming.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/session_naming.rs
@@ -1,89 +1,32 @@
 use crate::mcp::{
     dispatch::{ToolEffect, ToolEffectContext},
-    effects::tab_groups::retitle_agent_tab_group,
-    naming::{
-        build_session_group_title, client_prefix_from_slug, elicit_session_name,
-        peer_elicit_session_name,
-    },
+    naming::{build_session_group_title, client_prefix_from_slug},
 };
 use browseros_mcp::ToolResult;
 use futures_util::future::BoxFuture;
-use rmcp::service::ElicitationMode;
-use std::sync::atomic::Ordering;
-use tracing::{debug, warn};
+use rmcp::model::ContentBlock;
 
-/// Starts naming on the first successful `tabs new` dispatch for a session.
+/// Appends a bounded rename reminder while the generated session label remains active.
 pub fn apply(context: ToolEffectContext<'_>) -> BoxFuture<'_, anyhow::Result<Option<ToolResult>>> {
     Box::pin(async move {
-        if context.result.is_error || !context.call.flags.new_page {
-            return Ok(None);
-        }
-        if context.call.naming_started.swap(true, Ordering::SeqCst) {
+        if context.result.is_error {
             return Ok(None);
         }
         let Some(identity) = &context.call.identity else {
             return Ok(None);
         };
-        let Some(peer) = context.call.peer.clone() else {
-            warn!(
-                session_id = %context.call.session_id,
-                request_id = ?context.call.request_id,
-                "mcp session naming peer unavailable"
-            );
+        let Some(label) = identity.session.take_rename_nudge().await else {
             return Ok(None);
         };
-        if !peer
-            .supported_elicitation_modes()
-            .contains(&ElicitationMode::Form)
-        {
-            tracing::info!(
-                session_id = %context.call.session_id,
-                "mcp client lacks elicitation capability"
-            );
-            return Ok(None);
-        }
-        let Some(tab_groups) = context.call.tool_named("tab_groups").cloned() else {
-            warn!("tab_groups tool unavailable for session naming");
-            return Ok(None);
-        };
-        let state = context.call.state.clone();
-        let session = identity.session.clone();
-        let ownership_key = identity.ownership_key.clone();
-        // rmcp 2.1 routes server-initiated requests only through its common SSE channel;
-        // it has no related-request API that can target the still-open tool POST stream.
-        tokio::spawn(async move {
-            let prefix = client_prefix_from_slug(session.agent().slug()).to_string();
-            let name = tokio::select! {
-                name = elicit_session_name(|| peer_elicit_session_name(&peer, &prefix)) => name,
-                () = session.child_token().cancelled_owned() => {
-                    debug!(session_id = %session.id(), "session closed during naming elicitation");
-                    return;
-                }
-            };
-            let Some(name) = name else {
-                return;
-            };
-            if state.sessions.lookup(session.id()).await.is_none() {
-                debug!(session_id = %session.id(), "session closed before naming applied");
-                return;
-            }
-            session.rename(name.clone()).await;
-            let title = build_session_group_title(&prefix, &name);
-            tracing::info!(session_id = %session.id(), title = %title, "mcp session named");
-            let Some(browser) = state.browser.session().await else {
-                return;
-            };
-            retitle_agent_tab_group(
-                &tab_groups,
-                &browser,
-                &state.sessions.ownership(),
-                &ownership_key,
-                &title,
-                session.child_token(),
-            )
-            .await;
-        });
-        Ok(None)
+        let title = build_session_group_title(
+            client_prefix_from_slug(identity.session.agent().slug()),
+            &label,
+        );
+        let mut result = context.result.clone();
+        result.content.push(ContentBlock::text(format!(
+            "Tip: this session is \"{title}\" — rename it with name_session name=\"<2-3 word task label>\""
+        )));
+        Ok(Some(result))
     })
 }
 
@@ -94,34 +37,87 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-    #[tokio::test]
-    async fn failed_tabs_new_does_not_consume_naming_attempt() -> anyhow::Result<()> {
-        let call = crate::mcp::test_support::tool_call("tabs", json!({ "action": "new" })).await?;
-        let result = ToolResult::error("failed");
-        apply(ToolEffectContext {
-            call: &call,
-            result: &result,
+    async fn apply_result(
+        call: &crate::mcp::dispatch::ToolCall,
+        result: &ToolResult,
+    ) -> anyhow::Result<ToolResult> {
+        Ok(apply(ToolEffectContext {
+            call,
+            result,
             cancelled: false,
             duration_ms: 1,
         })
-        .await
-        .unwrap_or_else(|error| panic!("effect failed: {error}"));
-        assert!(!call.naming_started.load(Ordering::SeqCst));
+        .await?
+        .unwrap_or_else(|| result.clone()))
+    }
+
+    fn assert_result_eq(actual: &ToolResult, expected: &ToolResult) {
+        assert_eq!(actual.content, expected.content);
+        assert_eq!(actual.is_error, expected.is_error);
+        assert_eq!(actual.structured_content, expected.structured_content);
+    }
+
+    #[tokio::test]
+    async fn appends_exactly_five_trailing_tips_and_preserves_image_content() -> anyhow::Result<()>
+    {
+        let call = crate::mcp::test_support::tool_call("tabs", json!({ "action": "list" })).await?;
+        let image = ContentBlock::image("aW1hZ2U=".to_string(), "image/png".to_string());
+        let original = ToolResult {
+            content: vec![ContentBlock::text("ok"), image.clone()],
+            is_error: false,
+            structured_content: Some(json!({ "pages": [] })),
+        };
+
+        for _ in 0..5 {
+            let result = apply_result(&call, &original).await?;
+            assert_eq!(result.content[..2], original.content);
+            assert_eq!(
+                result
+                    .content
+                    .last()
+                    .and_then(ContentBlock::as_text)
+                    .map(|text| text.text.as_str()),
+                Some(
+                    "Tip: this session is \"codex/agile-alpaca\" — rename it with name_session name=\"<2-3 word task label>\""
+                )
+            );
+            assert_eq!(result.structured_content, original.structured_content);
+        }
+        assert_result_eq(&apply_result(&call, &original).await?, &original);
         Ok(())
     }
 
     #[tokio::test]
-    async fn first_successful_tabs_new_consumes_naming_attempt() -> anyhow::Result<()> {
+    async fn errors_do_not_consume_a_nudge_and_rename_stops_tips() -> anyhow::Result<()> {
         let call = crate::mcp::test_support::tool_call("tabs", json!({ "action": "new" })).await?;
-        let result = ToolResult::text("opened", Some(json!({ "page": 1 })));
-        apply(ToolEffectContext {
-            call: &call,
-            result: &result,
-            cancelled: false,
-            duration_ms: 1,
-        })
-        .await?;
-        assert!(call.naming_started.load(Ordering::SeqCst));
+        let error = ToolResult::error("failed");
+        assert_result_eq(&apply_result(&call, &error).await?, &error);
+
+        let success = ToolResult::text("opened", Some(json!({ "page": 1 })));
+        assert_eq!(apply_result(&call, &success).await?.content.len(), 2);
+        let session = &call
+            .identity
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("identity missing"))?
+            .session;
+        session.rename("invoice-processing".to_string()).await;
+        assert_result_eq(&apply_result(&call, &success).await?, &success);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn separate_sessions_have_independent_nudge_budgets() -> anyhow::Result<()> {
+        let first =
+            crate::mcp::test_support::tool_call("tabs", json!({ "action": "list" })).await?;
+        let second =
+            crate::mcp::test_support::tool_call("tabs", json!({ "action": "list" })).await?;
+        let success = ToolResult::text("ok", None);
+
+        for _ in 0..5 {
+            assert_eq!(apply_result(&first, &success).await?.content.len(), 2);
+        }
+        assert_result_eq(&apply_result(&first, &success).await?, &success);
+        assert_eq!(apply_result(&second, &success).await?.content.len(), 2);
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/session_naming.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/session_naming.rs
@@ -67,7 +67,7 @@ pub fn apply(context: ToolEffectContext<'_>) -> BoxFuture<'_, anyhow::Result<Opt
                 debug!(session_id = %session.id(), "session closed before naming applied");
                 return;
             }
-            session.set_session_label(name.clone()).await;
+            session.rename(name.clone()).await;
             let title = build_session_group_title(&prefix, &name);
             tracing::info!(session_id = %session.id(), title = %title, "mcp session named");
             let Some(browser) = state.browser.session().await else {

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/tab_activity.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/tab_activity.rs
@@ -28,7 +28,7 @@ pub fn apply(context: ToolEffectContext<'_>) -> BoxFuture<'_, anyhow::Result<Opt
                 page_id,
                 url: info.url,
                 title: info.title,
-                agent_id: identity.agent.agent_id().as_str().to_string(),
+                agent_id: identity.session.agent_id().as_str().to_string(),
                 slug: identity.agent.slug().to_string(),
                 tool_name: context.call.tool().name.to_string(),
             })

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/tab_groups.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/tab_groups.rs
@@ -22,9 +22,9 @@ use tokio::{sync::Mutex, task::JoinHandle, time::timeout};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-type GroupCreateLock = Mutex<()>;
+type GroupOperationLock = Mutex<()>;
 
-static INFLIGHT_CREATES: OnceLock<Mutex<HashMap<AgentKey, Weak<GroupCreateLock>>>> =
+static GROUP_OPERATION_LOCKS: OnceLock<Mutex<HashMap<AgentKey, Weak<GroupOperationLock>>>> =
     OnceLock::new();
 
 /// Creates or joins the durable tab group for a successful `tabs new` call.
@@ -59,16 +59,27 @@ async fn run_tab_group_work(call: ToolCall, page_id: Option<u32>) {
         return;
     };
     let ownership = call.state.sessions.ownership();
-    let expand = expand_agent_tab_group(
+    let operation_lock = group_operation_lock(&identity.ownership_key).await;
+    let _guard = operation_lock.lock().await;
+    sync_pending_group_title_unlocked(
         tab_groups,
         browser,
         &ownership,
         &identity.ownership_key,
         identity.session.child_token(),
         call.output_files.clone(),
-    );
+    )
+    .await;
+    expand_agent_tab_group_unlocked(
+        tab_groups,
+        browser,
+        &ownership,
+        &identity.ownership_key,
+        identity.session.child_token(),
+        call.output_files.clone(),
+    )
+    .await;
     let Some(page_id) = page_id else {
-        expand.await;
         return;
     };
     if let Some(default_group_id) = &call.default_tab_group_id {
@@ -78,21 +89,16 @@ async fn run_tab_group_work(call: ToolCall, page_id: Option<u32>) {
             .await
             .and_then(|page| page.group_id);
         if page_group_id.as_ref() == Some(default_group_id) {
-            expand.await;
             return;
         }
         ownership
             .set_tab_group_ref(identity.ownership_key.clone(), None)
             .await;
     }
-    tokio::join!(
-        expand,
-        ensure_agent_tab_group(&call, tab_groups, browser, &ownership, page_id)
-    );
+    ensure_agent_tab_group_unlocked(&call, tab_groups, browser, &ownership, page_id).await;
 }
 
-/// Serializes durable group creation and joins concurrent pages to the winning group.
-async fn ensure_agent_tab_group(
+async fn ensure_agent_tab_group_unlocked(
     call: &ToolCall,
     tab_groups: &ToolDef,
     browser: &Arc<BrowserSession>,
@@ -102,8 +108,6 @@ async fn ensure_agent_tab_group(
     let Some(identity) = call.identity.as_ref() else {
         return;
     };
-    let create_lock = group_create_lock(&identity.ownership_key).await;
-    let _guard = create_lock.lock().await;
     if let Some(group_id) = ownership.tab_group_ref(&identity.ownership_key).await {
         if let Err(reason) = dispatch_tab_groups(
             tab_groups,
@@ -131,6 +135,9 @@ async fn ensure_agent_tab_group(
         .await
         .unwrap_or_else(|| color_for_slug(identity.agent.slug()));
     let creation_title = desired_group_title(&identity.session).await;
+    ownership
+        .set_desired_group_title(identity.ownership_key.clone(), creation_title.clone())
+        .await;
     let group_result = match dispatch_tab_groups(
         tab_groups,
         browser,
@@ -158,10 +165,11 @@ async fn ensure_agent_tab_group(
         return;
     };
     ownership
-        .set_tab_group(
+        .set_tab_group_with_title(
             identity.ownership_key.clone(),
-            Some(group_id.clone()),
-            Some(color),
+            group_id.clone(),
+            color,
+            creation_title.clone(),
         )
         .await;
     if let Err(reason) = dispatch_tab_groups(
@@ -181,26 +189,24 @@ async fn ensure_agent_tab_group(
         );
     }
     let desired_title = desired_group_title(&identity.session).await;
-    if desired_title != creation_title
-        && let Err(reason) = dispatch_tab_groups(
+    if desired_title != creation_title {
+        ownership
+            .set_desired_group_title(identity.ownership_key.clone(), desired_title)
+            .await;
+        sync_pending_group_title_unlocked(
             tab_groups,
             browser,
+            ownership,
+            &identity.ownership_key,
             identity.session.child_token(),
             call.output_files.clone(),
-            json!({ "action": "update", "groupId": group_id, "title": desired_title }),
         )
-        .await
-    {
-        warn!(
-            dispatch_id = %call.dispatch_id,
-            error = %reason,
-            "tab group late title apply failed"
-        );
+        .await;
     }
 }
 
-async fn group_create_lock(key: &AgentKey) -> Arc<GroupCreateLock> {
-    let locks = INFLIGHT_CREATES.get_or_init(|| Mutex::new(HashMap::new()));
+async fn group_operation_lock(key: &AgentKey) -> Arc<GroupOperationLock> {
+    let locks = GROUP_OPERATION_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
     let mut locks = locks.lock().await;
     locks.retain(|_, lock| lock.strong_count() > 0);
     if let Some(lock) = locks.get(key).and_then(Weak::upgrade) {
@@ -217,6 +223,8 @@ pub async fn collapse_agent_tab_group(
     ownership: &Arc<AgentPageOwnership>,
     key: &AgentKey,
 ) {
+    let operation_lock = group_operation_lock(key).await;
+    let _guard = operation_lock.lock().await;
     if ownership.tab_group_collapsed(key).await {
         return;
     }
@@ -233,13 +241,15 @@ pub async fn collapse_agent_tab_group(
     .await
     {
         Ok(_) => {
-            ownership.set_tab_group_collapsed(key.clone(), true).await;
+            ownership
+                .set_tab_group_collapsed_if_current(key, &group_id, true)
+                .await;
         }
         Err(reason) => warn!(key = %key, error = %reason, "agent tab group collapse failed"),
     }
 }
 
-async fn expand_agent_tab_group(
+async fn expand_agent_tab_group_unlocked(
     tab_groups: &ToolDef,
     browser: &Arc<BrowserSession>,
     ownership: &Arc<AgentPageOwnership>,
@@ -263,34 +273,69 @@ async fn expand_agent_tab_group(
     .await
     {
         Ok(_) => {
-            ownership.set_tab_group_collapsed(key.clone(), false).await;
+            ownership
+                .set_tab_group_collapsed_if_current(key, &group_id, false)
+                .await;
         }
         Err(reason) => warn!(key = %key, error = %reason, "agent tab group expand failed"),
     }
 }
 
-/// Applies a completed session name to the durable group when it exists.
-pub async fn retitle_agent_tab_group(
-    tab_groups: &ToolDef,
-    browser: &Arc<BrowserSession>,
+/// Stores the desired title and best-effort applies it to the current group.
+pub async fn apply_agent_tab_group_title(
+    browser: Option<&Arc<BrowserSession>>,
     ownership: &Arc<AgentPageOwnership>,
     key: &AgentKey,
     title: &str,
     cancel: CancellationToken,
 ) {
-    let Some(group_id) = ownership.tab_group_ref(key).await else {
+    let operation_lock = group_operation_lock(key).await;
+    let _guard = operation_lock.lock().await;
+    ownership
+        .set_desired_group_title(key.clone(), title.to_string())
+        .await;
+    let Some(browser) = browser else {
         return;
     };
-    if let Err(reason) = dispatch_tab_groups(
+    sync_pending_group_title_unlocked(
+        cached_tab_groups_tool(),
+        browser,
+        ownership,
+        key,
+        cancel,
+        browseros_mcp::output_file::create_browser_output_file_access(),
+    )
+    .await;
+}
+
+async fn sync_pending_group_title_unlocked(
+    tab_groups: &ToolDef,
+    browser: &Arc<BrowserSession>,
+    ownership: &Arc<AgentPageOwnership>,
+    key: &AgentKey,
+    cancel: CancellationToken,
+    output_files: OutputFileAccess,
+) {
+    let Some((group_id, title)) = ownership.pending_group_title(key).await else {
+        return;
+    };
+    match dispatch_tab_groups(
         tab_groups,
         browser,
         cancel,
-        browseros_mcp::output_file::create_browser_output_file_access(),
+        output_files,
         json!({ "action": "update", "groupId": group_id, "title": title }),
     )
     .await
     {
-        warn!(key = %key, error = %reason, "session name tab group retitle failed");
+        Ok(_) => {
+            ownership
+                .mark_group_title_synced(key, &group_id, &title)
+                .await;
+        }
+        Err(reason) => {
+            warn!(key = %key, error = %reason, "session name tab group retitle failed");
+        }
     }
 }
 
@@ -379,6 +424,7 @@ mod tests {
         calls: StdMutex<Vec<(String, Value)>>,
         members: StdMutex<HashMap<String, BTreeSet<i64>>>,
         block_create: AtomicBool,
+        fail_title_updates: AtomicBool,
         create_release: Notify,
     }
 
@@ -390,6 +436,7 @@ mod tests {
                 calls: StdMutex::new(Vec::new()),
                 members: StdMutex::new(HashMap::new()),
                 block_create: AtomicBool::new(false),
+                fail_title_updates: AtomicBool::new(false),
                 create_release: Notify::new(),
             }
         }
@@ -439,12 +486,39 @@ mod tests {
                 .unwrap_or_default()
         }
 
+        fn create_title(&self) -> Option<String> {
+            self.calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .iter()
+                .find(|(method, _)| method == "Browser.createTabGroup")
+                .and_then(|(_, params)| params.get("title"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        }
+
+        fn title_updates(&self) -> Vec<String> {
+            self.calls
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .iter()
+                .filter(|(method, _)| method == "Browser.updateTabGroup")
+                .filter_map(|(_, params)| params.get("title"))
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        }
+
         fn block_group_creation(&self) {
             self.block_create.store(true, Ordering::SeqCst);
         }
 
         fn release_group_creation(&self) {
             self.create_release.notify_one();
+        }
+
+        fn fail_title_updates(&self, fail: bool) {
+            self.fail_title_updates.store(fail, Ordering::SeqCst);
         }
     }
 
@@ -500,6 +574,14 @@ mod tests {
                         Ok(self.group_result(group_id, &params))
                     }
                     "Browser.updateTabGroup" => {
+                        if params.get("title").is_some()
+                            && self.fail_title_updates.load(Ordering::SeqCst)
+                        {
+                            return Err(CdpError::Protocol {
+                                code: -1,
+                                message: "title update failed".to_string(),
+                            });
+                        }
                         let group_id = params
                             .get("groupId")
                             .and_then(Value::as_str)
@@ -555,6 +637,17 @@ mod tests {
             "windowId": 1,
             "index": tab_id - 101
         })
+    }
+
+    async fn connected_call(
+        recorder: Arc<GroupDispatchRecorder>,
+    ) -> anyhow::Result<(ToolCall, Arc<BrowserSession>)> {
+        let browser = BrowserSession::new(recorder, BrowserSessionHooks::default());
+        assert_eq!(browser.pages.list().await?.len(), 2);
+        let mut call =
+            crate::mcp::test_support::tool_call("tabs", json!({ "action": "new" })).await?;
+        call.browser_session = Some(browser.clone());
+        Ok((call, browser))
     }
 
     #[test]
@@ -637,6 +730,175 @@ mod tests {
                 .as_deref(),
             Some("group-1")
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rename_before_first_tab_sets_the_creation_title() -> anyhow::Result<()> {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        let (call, _browser) = connected_call(recorder.clone()).await?;
+        let identity = call
+            .identity
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("identity missing"))?;
+        identity
+            .session
+            .rename("invoice-processing".to_string())
+            .await;
+
+        spawn_tab_group_work(call.clone(), Some(1)).await?;
+
+        assert_eq!(
+            recorder.create_title().as_deref(),
+            Some("codex/invoice-processing")
+        );
+        let state = call
+            .state
+            .sessions
+            .ownership()
+            .tab_group_state(&identity.ownership_key)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("group state missing"))?;
+        assert_eq!(
+            state.desired_title.as_deref(),
+            Some("codex/invoice-processing")
+        );
+        assert!(!state.title_sync_pending);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn existing_group_rename_and_rapid_second_rename_keep_the_newest_title()
+    -> anyhow::Result<()> {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        let (call, browser) = connected_call(recorder.clone()).await?;
+        spawn_tab_group_work(call.clone(), Some(1)).await?;
+        let identity = call
+            .identity
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("identity missing"))?;
+        let ownership = call.state.sessions.ownership();
+
+        for title in ["codex/invoice-processing", "codex/quarterly-reporting"] {
+            apply_agent_tab_group_title(
+                Some(&browser),
+                &ownership,
+                &identity.ownership_key,
+                title,
+                identity.session.child_token(),
+            )
+            .await;
+        }
+
+        assert_eq!(
+            recorder.title_updates().last().map(String::as_str),
+            Some("codex/quarterly-reporting")
+        );
+        let state = ownership
+            .tab_group_state(&identity.ownership_key)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("group state missing"))?;
+        assert_eq!(
+            state.desired_title.as_deref(),
+            Some("codex/quarterly-reporting")
+        );
+        assert!(!state.title_sync_pending);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rename_during_group_creation_ends_with_the_newest_title() -> anyhow::Result<()> {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        recorder.block_group_creation();
+        let (call, browser) = connected_call(recorder.clone()).await?;
+        let identity = call
+            .identity
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("identity missing"))?;
+        let creation = spawn_tab_group_work(call.clone(), Some(1));
+        for _ in 0..100 {
+            if recorder.create_count() > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(recorder.create_count(), 1);
+        identity
+            .session
+            .rename("invoice-processing".to_string())
+            .await;
+        recorder.release_group_creation();
+        creation.await?;
+        apply_agent_tab_group_title(
+            Some(&browser),
+            &call.state.sessions.ownership(),
+            &identity.ownership_key,
+            "codex/invoice-processing",
+            identity.session.child_token(),
+        )
+        .await;
+
+        assert_eq!(
+            recorder.title_updates().last().map(String::as_str),
+            Some("codex/invoice-processing")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn disconnected_and_failed_title_updates_retry_on_later_dispatch() -> anyhow::Result<()> {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        let (call, browser) = connected_call(recorder.clone()).await?;
+        spawn_tab_group_work(call.clone(), Some(1)).await?;
+        let identity = call
+            .identity
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("identity missing"))?;
+        let ownership = call.state.sessions.ownership();
+
+        apply_agent_tab_group_title(
+            None,
+            &ownership,
+            &identity.ownership_key,
+            "codex/disconnected-rename",
+            identity.session.child_token(),
+        )
+        .await;
+        assert!(
+            ownership
+                .tab_group_state(&identity.ownership_key)
+                .await
+                .is_some_and(|state| state.title_sync_pending)
+        );
+        run_tab_group_work(call.clone(), None).await;
+        assert_eq!(
+            recorder.title_updates().last().map(String::as_str),
+            Some("codex/disconnected-rename")
+        );
+
+        recorder.fail_title_updates(true);
+        apply_agent_tab_group_title(
+            Some(&browser),
+            &ownership,
+            &identity.ownership_key,
+            "codex/retry-title",
+            identity.session.child_token(),
+        )
+        .await;
+        assert!(
+            ownership
+                .tab_group_state(&identity.ownership_key)
+                .await
+                .is_some_and(|state| state.title_sync_pending)
+        );
+        recorder.fail_title_updates(false);
+        run_tab_group_work(call.clone(), None).await;
+        let state = ownership
+            .tab_group_state(&identity.ownership_key)
+            .await
+            .ok_or_else(|| anyhow::anyhow!("group state missing"))?;
+        assert_eq!(state.desired_title.as_deref(), Some("codex/retry-title"));
+        assert!(!state.title_sync_pending);
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/tab_groups.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/tab_groups.rs
@@ -1,5 +1,5 @@
 use crate::{
-    domain::{AgentKey, AgentPageOwnership, color_for_slug},
+    domain::{AgentKey, AgentPageOwnership, Session, color_for_slug},
     mcp::{
         dispatch::{ToolCall, ToolEffect, ToolEffectContext, result_page_id},
         naming::desired_group_title,
@@ -58,15 +58,23 @@ async fn run_tab_group_work(call: ToolCall, page_id: Option<u32>) {
     ) else {
         return;
     };
+    let session_cancel = identity.session.child_token();
+    if session_cancel.is_cancelled() {
+        return;
+    }
     let ownership = call.state.sessions.ownership();
     let operation_lock = group_operation_lock(&identity.ownership_key).await;
     let _guard = operation_lock.lock().await;
+    if session_cancel.is_cancelled() {
+        return;
+    }
+    let operation_cancel = CancellationToken::new();
     sync_pending_group_title_unlocked(
         tab_groups,
         browser,
         &ownership,
         &identity.ownership_key,
-        identity.session.child_token(),
+        operation_cancel.child_token(),
         call.output_files.clone(),
     )
     .await;
@@ -75,7 +83,7 @@ async fn run_tab_group_work(call: ToolCall, page_id: Option<u32>) {
         browser,
         &ownership,
         &identity.ownership_key,
-        identity.session.child_token(),
+        operation_cancel.child_token(),
         call.output_files.clone(),
     )
     .await;
@@ -95,7 +103,15 @@ async fn run_tab_group_work(call: ToolCall, page_id: Option<u32>) {
             .set_tab_group_ref(identity.ownership_key.clone(), None)
             .await;
     }
-    ensure_agent_tab_group_unlocked(&call, tab_groups, browser, &ownership, page_id).await;
+    ensure_agent_tab_group_unlocked(
+        &call,
+        tab_groups,
+        browser,
+        &ownership,
+        &operation_cancel,
+        page_id,
+    )
+    .await;
 }
 
 async fn ensure_agent_tab_group_unlocked(
@@ -103,24 +119,28 @@ async fn ensure_agent_tab_group_unlocked(
     tab_groups: &ToolDef,
     browser: &Arc<BrowserSession>,
     ownership: &Arc<AgentPageOwnership>,
+    operation_cancel: &CancellationToken,
     page_id: u32,
 ) {
     let Some(identity) = call.identity.as_ref() else {
         return;
     };
     if let Some(group_id) = ownership.tab_group_ref(&identity.ownership_key).await {
+        let output_files = call.output_files.clone();
         if let Err(reason) = dispatch_tab_groups(
             tab_groups,
             browser,
-            identity.session.child_token(),
-            call.output_files.clone(),
+            operation_cancel.child_token(),
+            output_files.clone(),
             json!({ "action": "create", "groupId": group_id, "pages": [page_id] }),
         )
         .await
         {
-            ownership
-                .set_tab_group(identity.ownership_key.clone(), None, None)
-                .await;
+            if group_exists_unlocked(browser, &group_id, output_files).await == Some(false) {
+                ownership
+                    .set_tab_group(identity.ownership_key.clone(), None, None)
+                    .await;
+            }
             warn!(
                 dispatch_id = %call.dispatch_id,
                 error = %reason,
@@ -141,7 +161,7 @@ async fn ensure_agent_tab_group_unlocked(
     let group_result = match dispatch_tab_groups(
         tab_groups,
         browser,
-        identity.session.child_token(),
+        operation_cancel.child_token(),
         call.output_files.clone(),
         json!({ "action": "create", "pages": [page_id], "title": creation_title }),
     )
@@ -175,7 +195,7 @@ async fn ensure_agent_tab_group_unlocked(
     if let Err(reason) = dispatch_tab_groups(
         tab_groups,
         browser,
-        identity.session.child_token(),
+        operation_cancel.child_token(),
         call.output_files.clone(),
         json!({ "action": "update", "groupId": group_id, "color": color }),
     )
@@ -198,7 +218,7 @@ async fn ensure_agent_tab_group_unlocked(
             browser,
             ownership,
             &identity.ownership_key,
-            identity.session.child_token(),
+            operation_cancel.child_token(),
             call.output_files.clone(),
         )
         .await;
@@ -357,14 +377,13 @@ pub async fn apply_agent_tab_group_title(
     browser: Option<&Arc<BrowserSession>>,
     ownership: &Arc<AgentPageOwnership>,
     key: &AgentKey,
-    title: &str,
+    session: &Session,
     cancel: CancellationToken,
 ) {
     let operation_lock = group_operation_lock(key).await;
     let _guard = operation_lock.lock().await;
-    ownership
-        .set_desired_group_title(key.clone(), title.to_string())
-        .await;
+    let title = desired_group_title(session).await;
+    ownership.set_desired_group_title(key.clone(), title).await;
     let Some(browser) = browser else {
         return;
     };
@@ -495,6 +514,7 @@ mod tests {
         calls: StdMutex<Vec<(String, Value)>>,
         members: StdMutex<HashMap<String, BTreeSet<i64>>>,
         block_create: AtomicBool,
+        fail_group_add: AtomicBool,
         fail_title_updates: AtomicBool,
         fail_close: AtomicBool,
         fail_list: AtomicBool,
@@ -509,6 +529,7 @@ mod tests {
                 calls: StdMutex::new(Vec::new()),
                 members: StdMutex::new(HashMap::new()),
                 block_create: AtomicBool::new(false),
+                fail_group_add: AtomicBool::new(false),
                 fail_title_updates: AtomicBool::new(false),
                 fail_close: AtomicBool::new(false),
                 fail_list: AtomicBool::new(false),
@@ -596,6 +617,10 @@ mod tests {
             self.fail_title_updates.store(fail, Ordering::SeqCst);
         }
 
+        fn fail_group_add(&self, fail: bool) {
+            self.fail_group_add.store(fail, Ordering::SeqCst);
+        }
+
         fn seed_group(&self, group_id: &str, tab_ids: impl IntoIterator<Item = i64>) {
             self.members
                 .lock()
@@ -669,6 +694,12 @@ mod tests {
                         Ok(self.group_result("group-1", &params))
                     }
                     "Browser.addTabsToGroup" => {
+                        if self.fail_group_add.load(Ordering::SeqCst) {
+                            return Err(CdpError::Protocol {
+                                code: -1,
+                                message: "group add failed".to_string(),
+                            });
+                        }
                         let group_id = params
                             .get("groupId")
                             .and_then(Value::as_str)
@@ -932,6 +963,80 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_cancellation_during_create_still_records_the_group() -> anyhow::Result<()> {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        recorder.block_group_creation();
+        let (call, _browser) = connected_call(recorder.clone()).await?;
+        let identity = call
+            .identity
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("identity missing"))?;
+        let creation = spawn_tab_group_work(call.clone(), Some(1));
+        for _ in 0..100 {
+            if recorder.create_count() > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(recorder.create_count(), 1);
+        identity.session.cancel();
+        recorder.release_group_creation();
+        creation.await?;
+
+        assert_eq!(
+            call.state
+                .sessions
+                .ownership()
+                .tab_group_ref(&identity.ownership_key)
+                .await
+                .as_deref(),
+            Some("group-1")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn group_work_does_not_start_after_session_teardown() -> anyhow::Result<()> {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        let (call, _browser) = connected_call(recorder.clone()).await?;
+        let identity = call
+            .identity
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("identity missing"))?;
+        identity.session.cancel();
+
+        spawn_tab_group_work(call, Some(1)).await?;
+
+        assert_eq!(recorder.create_count(), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn transient_group_add_failure_keeps_the_winning_group_reference() -> anyhow::Result<()> {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        let (call, _browser) = connected_call(recorder.clone()).await?;
+        spawn_tab_group_work(call.clone(), Some(1)).await?;
+        recorder.fail_group_add(true);
+        spawn_tab_group_work(call.clone(), Some(2)).await?;
+        let identity = call
+            .identity
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("identity missing"))?;
+
+        assert_eq!(recorder.create_count(), 1);
+        assert_eq!(
+            call.state
+                .sessions
+                .ownership()
+                .tab_group_ref(&identity.ownership_key)
+                .await
+                .as_deref(),
+            Some("group-1")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn rename_before_first_tab_sets_the_creation_title() -> anyhow::Result<()> {
         let recorder = Arc::new(GroupDispatchRecorder::new());
         let (call, _browser) = connected_call(recorder.clone()).await?;
@@ -977,12 +1082,13 @@ mod tests {
             .ok_or_else(|| anyhow::anyhow!("identity missing"))?;
         let ownership = call.state.sessions.ownership();
 
-        for title in ["codex/invoice-processing", "codex/quarterly-reporting"] {
+        for label in ["invoice-processing", "quarterly-reporting"] {
+            identity.session.rename(label.to_string()).await;
             apply_agent_tab_group_title(
                 Some(&browser),
                 &ownership,
                 &identity.ownership_key,
-                title,
+                identity.session.as_ref(),
                 identity.session.child_token(),
             )
             .await;
@@ -1001,6 +1107,45 @@ mod tests {
             Some("codex/quarterly-reporting")
         );
         assert!(!state.title_sync_pending);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delayed_rename_publication_recomputes_the_current_session_title() -> anyhow::Result<()>
+    {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        let (call, browser) = connected_call(recorder.clone()).await?;
+        spawn_tab_group_work(call.clone(), Some(1)).await?;
+        let identity = call
+            .identity
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("identity missing"))?;
+        let ownership = call.state.sessions.ownership();
+        identity.session.rename("first-rename".to_string()).await;
+        identity.session.rename("newest-rename".to_string()).await;
+
+        for _ in 0..2 {
+            apply_agent_tab_group_title(
+                Some(&browser),
+                &ownership,
+                &identity.ownership_key,
+                identity.session.as_ref(),
+                identity.session.child_token(),
+            )
+            .await;
+        }
+
+        assert_eq!(
+            recorder.title_updates().last().map(String::as_str),
+            Some("codex/newest-rename")
+        );
+        assert_eq!(
+            ownership
+                .tab_group_state(&identity.ownership_key)
+                .await
+                .and_then(|state| state.desired_title),
+            Some("codex/newest-rename".to_string())
+        );
         Ok(())
     }
 
@@ -1031,7 +1176,7 @@ mod tests {
             Some(&browser),
             &call.state.sessions.ownership(),
             &identity.ownership_key,
-            "codex/invoice-processing",
+            identity.session.as_ref(),
             identity.session.child_token(),
         )
         .await;
@@ -1054,11 +1199,15 @@ mod tests {
             .ok_or_else(|| anyhow::anyhow!("identity missing"))?;
         let ownership = call.state.sessions.ownership();
 
+        identity
+            .session
+            .rename("disconnected-rename".to_string())
+            .await;
         apply_agent_tab_group_title(
             None,
             &ownership,
             &identity.ownership_key,
-            "codex/disconnected-rename",
+            identity.session.as_ref(),
             identity.session.child_token(),
         )
         .await;
@@ -1075,11 +1224,12 @@ mod tests {
         );
 
         recorder.fail_title_updates(true);
+        identity.session.rename("retry-title".to_string()).await;
         apply_agent_tab_group_title(
             Some(&browser),
             &ownership,
             &identity.ownership_key,
-            "codex/retry-title",
+            identity.session.as_ref(),
             identity.session.child_token(),
         )
         .await;

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/tab_groups.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/tab_groups.rs
@@ -217,19 +217,22 @@ async fn group_operation_lock(key: &AgentKey) -> Arc<GroupOperationLock> {
     lock
 }
 
-/// Collapses the durable group after its final live session ends.
+/// Collapses the durable group when its session enters retention.
 pub async fn collapse_agent_tab_group(
-    browser: &Arc<BrowserSession>,
+    browser: Option<&Arc<BrowserSession>>,
     ownership: &Arc<AgentPageOwnership>,
     key: &AgentKey,
-) {
+) -> bool {
     let operation_lock = group_operation_lock(key).await;
     let _guard = operation_lock.lock().await;
     if ownership.tab_group_collapsed(key).await {
-        return;
+        return true;
     }
     let Some(group_id) = ownership.tab_group_ref(key).await else {
-        return;
+        return true;
+    };
+    let Some(browser) = browser else {
+        return false;
     };
     match dispatch_tab_groups(
         cached_tab_groups_tool(),
@@ -244,9 +247,77 @@ pub async fn collapse_agent_tab_group(
             ownership
                 .set_tab_group_collapsed_if_current(key, &group_id, true)
                 .await;
+            true
         }
-        Err(reason) => warn!(key = %key, error = %reason, "agent tab group collapse failed"),
+        Err(reason) => {
+            warn!(key = %key, error = %reason, "agent tab group collapse failed");
+            false
+        }
     }
+}
+
+/// Closes a retained session group, confirming absence after a failed close.
+pub async fn close_agent_tab_group(
+    browser: Option<&Arc<BrowserSession>>,
+    ownership: &Arc<AgentPageOwnership>,
+    key: &AgentKey,
+) -> bool {
+    let operation_lock = group_operation_lock(key).await;
+    let _guard = operation_lock.lock().await;
+    let Some(group_id) = ownership.tab_group_ref(key).await else {
+        return true;
+    };
+    let Some(browser) = browser else {
+        return false;
+    };
+    let output_files = browseros_mcp::output_file::create_browser_output_file_access();
+    let closed = dispatch_tab_groups(
+        cached_tab_groups_tool(),
+        browser,
+        CancellationToken::new(),
+        output_files.clone(),
+        json!({ "action": "close", "groupId": group_id }),
+    )
+    .await;
+    let close_error = match closed {
+        Ok(_) => {
+            ownership.set_tab_group_ref(key.clone(), None).await;
+            return true;
+        }
+        Err(error) => error,
+    };
+    if group_exists_unlocked(browser, &group_id, output_files).await == Some(false) {
+        ownership.set_tab_group_ref(key.clone(), None).await;
+        return true;
+    }
+    warn!(key = %key, error = %close_error, "agent tab group close failed");
+    false
+}
+
+async fn group_exists_unlocked(
+    browser: &Arc<BrowserSession>,
+    group_id: &str,
+    output_files: OutputFileAccess,
+) -> Option<bool> {
+    let result = dispatch_tab_groups(
+        cached_tab_groups_tool(),
+        browser,
+        CancellationToken::new(),
+        output_files,
+        json!({ "action": "list" }),
+    )
+    .await
+    .ok()?;
+    let groups = result
+        .structured_content
+        .as_ref()?
+        .get("groups")?
+        .as_array()?;
+    Some(
+        groups
+            .iter()
+            .any(|group| group.get("groupId").and_then(Value::as_str) == Some(group_id)),
+    )
 }
 
 async fn expand_agent_tab_group_unlocked(
@@ -425,6 +496,8 @@ mod tests {
         members: StdMutex<HashMap<String, BTreeSet<i64>>>,
         block_create: AtomicBool,
         fail_title_updates: AtomicBool,
+        fail_close: AtomicBool,
+        fail_list: AtomicBool,
         create_release: Notify,
     }
 
@@ -437,6 +510,8 @@ mod tests {
                 members: StdMutex::new(HashMap::new()),
                 block_create: AtomicBool::new(false),
                 fail_title_updates: AtomicBool::new(false),
+                fail_close: AtomicBool::new(false),
+                fail_list: AtomicBool::new(false),
                 create_release: Notify::new(),
             }
         }
@@ -520,6 +595,21 @@ mod tests {
         fn fail_title_updates(&self, fail: bool) {
             self.fail_title_updates.store(fail, Ordering::SeqCst);
         }
+
+        fn seed_group(&self, group_id: &str, tab_ids: impl IntoIterator<Item = i64>) {
+            self.members
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .insert(group_id.to_string(), tab_ids.into_iter().collect());
+        }
+
+        fn fail_close(&self, fail: bool) {
+            self.fail_close.store(fail, Ordering::SeqCst);
+        }
+
+        fn fail_list(&self, fail: bool) {
+            self.fail_list.store(fail, Ordering::SeqCst);
+        }
     }
 
     impl CdpConnection for GroupDispatchRecorder {
@@ -535,6 +625,31 @@ mod tests {
                     "Browser.getTabs" => Ok(json!({
                         "tabs": [test_tab(101, "target-1"), test_tab(102, "target-2")]
                     })),
+                    "Browser.getTabGroups" => {
+                        if self.fail_list.load(Ordering::SeqCst) {
+                            return Err(CdpError::Protocol {
+                                code: -1,
+                                message: "group list failed".to_string(),
+                            });
+                        }
+                        let group_ids = self
+                            .members
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
+                            .keys()
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        let groups = group_ids
+                            .iter()
+                            .map(|group_id| {
+                                self.group_result(group_id, &json!({}))
+                                    .get("group")
+                                    .cloned()
+                                    .unwrap_or(Value::Null)
+                            })
+                            .collect::<Vec<_>>();
+                        Ok(json!({ "groups": groups }))
+                    }
                     "Browser.createTabGroup" => {
                         if self.block_create.load(Ordering::SeqCst) {
                             self.create_release.notified().await;
@@ -587,6 +702,21 @@ mod tests {
                             .and_then(Value::as_str)
                             .unwrap_or("group-1");
                         Ok(self.group_result(group_id, &params))
+                    }
+                    "Browser.closeTabGroup" => {
+                        if self.fail_close.load(Ordering::SeqCst) {
+                            return Err(CdpError::Protocol {
+                                code: -1,
+                                message: "group close failed".to_string(),
+                            });
+                        }
+                        if let Some(group_id) = params.get("groupId").and_then(Value::as_str) {
+                            self.members
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                                .remove(group_id);
+                        }
+                        Ok(json!({}))
                     }
                     _ => Err(CdpError::Protocol {
                         code: -1,
@@ -657,11 +787,79 @@ mod tests {
     }
 
     #[test]
-    fn teardown_fallback_tool_definition_is_cached() {
+    fn cached_tab_groups_tool_definition_is_reused() {
         assert!(std::ptr::eq(
             cached_tab_groups_tool(),
             cached_tab_groups_tool()
         ));
+    }
+
+    #[tokio::test]
+    async fn retained_group_collapse_updates_state_and_disconnected_close_retries()
+    -> anyhow::Result<()> {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        recorder.seed_group("group-1", [101]);
+        let browser = BrowserSession::new(recorder, BrowserSessionHooks::default());
+        assert_eq!(browser.pages.list().await?.len(), 2);
+        let ownership = Arc::new(AgentPageOwnership::new());
+        let key = AgentKey::new("codex-agile-alpaca");
+        ownership
+            .set_tab_group_ref(key.clone(), Some("group-1".to_string()))
+            .await;
+
+        assert!(collapse_agent_tab_group(Some(&browser), &ownership, &key).await);
+        assert!(ownership.tab_group_collapsed(&key).await);
+        assert!(!close_agent_tab_group(None, &ownership, &key).await);
+        assert_eq!(
+            ownership.tab_group_ref(&key).await.as_deref(),
+            Some("group-1")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retained_group_close_succeeds_and_confirms_already_absent_groups() -> anyhow::Result<()>
+    {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        recorder.seed_group("group-1", [101]);
+        let browser = BrowserSession::new(recorder.clone(), BrowserSessionHooks::default());
+        assert_eq!(browser.pages.list().await?.len(), 2);
+        let ownership = Arc::new(AgentPageOwnership::new());
+        let key = AgentKey::new("codex-agile-alpaca");
+        ownership
+            .set_tab_group_ref(key.clone(), Some("group-1".to_string()))
+            .await;
+
+        assert!(close_agent_tab_group(Some(&browser), &ownership, &key).await);
+        ownership
+            .set_tab_group_ref(key.clone(), Some("group-1".to_string()))
+            .await;
+        recorder.fail_close(true);
+        assert!(close_agent_tab_group(Some(&browser), &ownership, &key).await);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retained_group_close_keeps_state_when_group_may_still_exist() -> anyhow::Result<()> {
+        let recorder = Arc::new(GroupDispatchRecorder::new());
+        recorder.seed_group("group-1", [101]);
+        recorder.fail_close(true);
+        let browser = BrowserSession::new(recorder.clone(), BrowserSessionHooks::default());
+        assert_eq!(browser.pages.list().await?.len(), 2);
+        let ownership = Arc::new(AgentPageOwnership::new());
+        let key = AgentKey::new("codex-agile-alpaca");
+        ownership
+            .set_tab_group_ref(key.clone(), Some("group-1".to_string()))
+            .await;
+
+        assert!(!close_agent_tab_group(Some(&browser), &ownership, &key).await);
+        recorder.fail_list(true);
+        assert!(!close_agent_tab_group(Some(&browser), &ownership, &key).await);
+        assert_eq!(
+            ownership.tab_group_ref(&key).await.as_deref(),
+            Some("group-1")
+        );
+        Ok(())
     }
 
     #[tokio::test]

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/tabs_list_view.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/effects/tabs_list_view.rs
@@ -39,7 +39,7 @@ pub fn apply(context: ToolEffectContext<'_>) -> BoxFuture<'_, anyhow::Result<Opt
             .into_iter()
             .map(|session| {
                 (
-                    session.agent().ownership_key(),
+                    session.ownership_key().clone(),
                     session.agent().label().to_string(),
                 )
             })
@@ -167,13 +167,16 @@ mod tests {
         let other_session = crate::domain::Session::new(
             crate::domain::SessionId::new("s2"),
             crate::domain::AgentRef::Ephemeral {
-                agent_id: crate::domain::AgentId::new("cowork-a"),
                 slug: "other".to_string(),
                 label: "Cowork".to_string(),
             },
+            crate::domain::SessionIdentity::new("other", "bright-beaver".to_string()),
             tokio::time::Instant::now(),
         );
-        call.state.sessions.insert_for_testing(other_session).await;
+        call.state
+            .sessions
+            .insert_for_testing(other_session.clone())
+            .await;
         call.state
             .sessions
             .ownership()
@@ -182,12 +185,12 @@ mod tests {
         call.state
             .sessions
             .ownership()
-            .claim_page(crate::domain::AgentKey::new("other"), PageId(3))
+            .claim_page(other_session.ownership_key().clone(), PageId(3))
             .await;
         call.state
             .sessions
             .ownership()
-            .claim_page(crate::domain::AgentKey::new("other"), PageId(9))
+            .claim_page(other_session.ownership_key().clone(), PageId(9))
             .await;
         let result = ToolResult::text(
             "all tabs",
@@ -217,7 +220,7 @@ mod tests {
                         "url": "https://owned.test",
                         "title": "Owned",
                         "ownership": "mine",
-                        "ownerAgentId": "codex",
+                        "ownerAgentId": "codex-agile-alpaca",
                         "ownerLabel": null
                     },
                     {
@@ -233,7 +236,7 @@ mod tests {
                         "url": "https://other.test",
                         "title": "Other",
                         "ownership": "other-agent",
-                        "ownerAgentId": "other",
+                        "ownerAgentId": "other-bright-beaver",
                         "ownerLabel": "Cowork"
                     }
                 ]

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/guards/page_ownership.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/guards/page_ownership.rs
@@ -22,7 +22,7 @@ pub fn guard(call: &ToolCall) -> BoxFuture<'_, Option<ToolResult>> {
             tool = call.tool().name,
             session_id = %call.session_id,
             key = %identity.ownership_key,
-            agent_id = %identity.agent.agent_id(),
+            agent_id = %identity.session.agent_id(),
             page = page_id.0,
             "cockpit rejected foreign-page dispatch"
         );

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/mod.rs
@@ -9,7 +9,7 @@ mod timeouts;
 #[cfg(test)]
 pub mod test_support;
 
-use crate::AppState;
+use crate::{AppState, domain::RetainedGroupAction};
 use rmcp::transport::streamable_http_server::{
     session::local::LocalSessionManager,
     tower::{StreamableHttpServerConfig, StreamableHttpService},
@@ -24,16 +24,31 @@ pub fn browser_mcp_service(state: AppState) -> ClawMcpService {
     let browser = Arc::downgrade(&state.browser);
     state
         .sessions
-        .set_last_session_teardown_hook(Arc::new(move |ownership, key| {
+        .set_retained_group_hook(Arc::new(move |ownership, key, action| {
             let browser = browser.clone();
             Box::pin(async move {
-                let Some(browser) = browser.upgrade() else {
-                    return;
+                let session = match browser.upgrade() {
+                    Some(browser) => browser.session().await,
+                    None => None,
                 };
-                let Some(session) = browser.session().await else {
-                    return;
-                };
-                effects::tab_groups::collapse_agent_tab_group(&session, &ownership, &key).await;
+                match action {
+                    RetainedGroupAction::Collapse => {
+                        effects::tab_groups::collapse_agent_tab_group(
+                            session.as_ref(),
+                            &ownership,
+                            &key,
+                        )
+                        .await
+                    }
+                    RetainedGroupAction::Close => {
+                        effects::tab_groups::close_agent_tab_group(
+                            session.as_ref(),
+                            &ownership,
+                            &key,
+                        )
+                        .await
+                    }
+                }
             })
         }));
     ClawMcpService::new(state)

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/naming.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/naming.rs
@@ -71,12 +71,10 @@ fn session_name_schema() -> ElicitationSchema {
 
 /// Tab-group title the orchestrator should apply for this session right now.
 pub async fn desired_group_title(session: &Session) -> String {
-    match session.session_label().await {
-        Some(label) => {
-            build_session_group_title(client_prefix_from_slug(session.agent().slug()), &label)
-        }
-        None => session.agent().slug().to_string(),
-    }
+    build_session_group_title(
+        client_prefix_from_slug(session.agent().slug()),
+        &session.label().await,
+    )
 }
 
 /// One elicitation attempt's result, folded into the TS retry table.
@@ -149,7 +147,7 @@ pub async fn peer_elicit_session_name(peer: &Peer<RoleServer>, prefix: &str) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{AgentId, AgentRef, SessionId};
+    use crate::domain::{AgentRef, SessionId, SessionIdentity};
     use serde_json::json;
 
     #[tokio::test]
@@ -157,14 +155,14 @@ mod tests {
         let session = Session::new(
             SessionId::new("s1"),
             AgentRef::Ephemeral {
-                agent_id: AgentId::new("claude-code-abc123"),
                 slug: "claude-code".to_string(),
                 label: "Claude Code".to_string(),
             },
+            SessionIdentity::new("claude-code", "agile-alpaca".to_string()),
             tokio::time::Instant::now(),
         );
-        assert_eq!(desired_group_title(&session).await, "claude-code");
-        session.set_session_label("flight-search".to_string()).await;
+        assert_eq!(desired_group_title(&session).await, "claude/agile-alpaca");
+        session.rename("flight-search".to_string()).await;
         assert_eq!(desired_group_title(&session).await, "claude/flight-search");
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/naming.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/naming.rs
@@ -1,24 +1,7 @@
-//! MCP session naming via elicitation, ported from the TS claw-server
-//! (`src/lib/mcp-session/naming.ts` + `src/mcp/session-naming.ts`). The
-//! normalizer, prompt, schema, and retry table must stay in lockstep with
-//! the TS oracle so both servers title tab groups identically.
-
 use crate::domain::Session;
-use rmcp::{
-    RoleServer,
-    model::{ElicitRequestParams, ElicitationAction, ElicitationSchema},
-    service::{Peer, ServiceError},
-};
-use serde_json::Value;
-use std::time::Duration;
-use tracing::debug;
 
-const ELICITATION_TIMEOUT: Duration = Duration::from_secs(120);
-const ELICITATION_RETRY_DELAY: Duration = Duration::from_secs(2);
 const SMALL_NAME_WORD_LIMIT: usize = 3;
 const SMALL_NAME_MAX_LEN: usize = 32;
-const SESSION_NAME_INPUT_MAX_LEN: u32 = 64;
-const NAME_GUIDANCE: &str = "a small lowercase 2-3 word name for what this session is doing";
 
 /// Normalizes a user-provided session label into a short tab-group slug.
 #[must_use]
@@ -48,27 +31,6 @@ pub fn build_session_group_title(prefix: &str, small_name: &str) -> String {
     format!("{prefix}/{small_name}")
 }
 
-/// Builds the elicitation message with the concrete client prefix.
-#[must_use]
-pub fn build_session_name_prompt(prefix: &str) -> String {
-    format!(
-        "Name this browser session: {NAME_GUIDANCE} (e.g. \"invoice processing\"). Tabs will be grouped as {prefix}/<name>."
-    )
-}
-
-fn session_name_schema() -> ElicitationSchema {
-    ElicitationSchema::builder()
-        .required_string_property("name", |schema| {
-            schema
-                .title("Session name")
-                .description(format!(
-                    "Use {NAME_GUIDANCE}, such as \"invoice processing\"."
-                ))
-                .max_length(SESSION_NAME_INPUT_MAX_LEN)
-        })
-        .build_unchecked()
-}
-
 /// Tab-group title the orchestrator should apply for this session right now.
 pub async fn desired_group_title(session: &Session) -> String {
     build_session_group_title(
@@ -77,78 +39,10 @@ pub async fn desired_group_title(session: &Session) -> String {
     )
 }
 
-/// One elicitation attempt's result, folded into the TS retry table.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ElicitNameOutcome {
-    /// Client accepted and returned a raw `name` string.
-    Accepted(String),
-    /// Decline, cancel, or accept without a usable string: stop silently.
-    NoName,
-    /// The 120s window elapsed — the user ignored the prompt; never retry.
-    TimedOut,
-    /// Transport-level failure (eg. no SSE stream yet): retry once after 2s.
-    Failed(String),
-}
-
-/// Runs the elicitation retry table and returns the normalized label.
-pub async fn elicit_session_name<F, Fut>(mut elicit: F) -> Option<String>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = ElicitNameOutcome>,
-{
-    for attempt in 0..2 {
-        match elicit().await {
-            ElicitNameOutcome::Accepted(raw) => {
-                let name = normalize_small_name(&raw);
-                return if name.is_empty() { None } else { Some(name) };
-            }
-            ElicitNameOutcome::NoName => return None,
-            ElicitNameOutcome::TimedOut => {
-                debug!("mcp session naming elicitation timed out");
-                return None;
-            }
-            ElicitNameOutcome::Failed(reason) => {
-                debug!(error = %reason, "mcp session naming elicitation unavailable");
-                if attempt == 0 {
-                    tokio::time::sleep(ELICITATION_RETRY_DELAY).await;
-                }
-            }
-        }
-    }
-    None
-}
-
-/// Sends one session-name elicitation over the live peer.
-pub async fn peer_elicit_session_name(peer: &Peer<RoleServer>, prefix: &str) -> ElicitNameOutcome {
-    let params = ElicitRequestParams::FormElicitationParams {
-        meta: None,
-        message: build_session_name_prompt(prefix),
-        requested_schema: session_name_schema(),
-    };
-    match peer
-        .create_elicitation_with_timeout(params, Some(ELICITATION_TIMEOUT))
-        .await
-    {
-        Ok(result) => match result.action {
-            ElicitationAction::Accept => result
-                .content
-                .as_ref()
-                .and_then(|content| content.get("name"))
-                .and_then(Value::as_str)
-                .map(|name| ElicitNameOutcome::Accepted(name.to_string()))
-                .unwrap_or(ElicitNameOutcome::NoName),
-            _ => ElicitNameOutcome::NoName,
-        },
-        Err(ServiceError::Timeout { .. }) => ElicitNameOutcome::TimedOut,
-        Err(err) => ElicitNameOutcome::Failed(err.to_string()),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::domain::{AgentRef, SessionId, SessionIdentity};
-    use serde_json::json;
 
     #[tokio::test]
     async fn desired_group_title_uses_label_when_named() {
@@ -196,108 +90,5 @@ mod tests {
             build_session_group_title("claude", "invoice-processing"),
             "claude/invoice-processing"
         );
-    }
-
-    #[test]
-    fn prompt_names_the_group_namespace() {
-        let prompt = build_session_name_prompt("claude");
-        assert!(prompt.contains("Tabs will be grouped as claude/<name>"));
-        assert!(prompt.starts_with("Name this browser session:"));
-    }
-
-    #[test]
-    fn schema_matches_ts_requested_schema() -> anyhow::Result<()> {
-        let schema = serde_json::to_value(session_name_schema())?;
-        assert_eq!(
-            schema,
-            json!({
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "title": "Session name",
-                        "description": "Use a small lowercase 2-3 word name for what this session is doing, such as \"invoice processing\".",
-                        "maxLength": 64
-                    }
-                },
-                "required": ["name"]
-            })
-        );
-        Ok(())
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn accepted_name_is_normalized() {
-        let name = elicit_session_name(|| {
-            std::future::ready(ElicitNameOutcome::Accepted(
-                "Invoice Processing".to_string(),
-            ))
-        })
-        .await;
-        assert_eq!(name.as_deref(), Some("invoice-processing"));
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn accepted_name_normalizing_to_empty_is_dropped() {
-        let mut calls = 0;
-        let name = elicit_session_name(|| {
-            calls += 1;
-            std::future::ready(ElicitNameOutcome::Accepted("!!!".to_string()))
-        })
-        .await;
-        assert_eq!(name, None);
-        assert_eq!(calls, 1);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn timeout_never_retries() {
-        let mut calls = 0;
-        let name = elicit_session_name(|| {
-            calls += 1;
-            std::future::ready(ElicitNameOutcome::TimedOut)
-        })
-        .await;
-        assert_eq!(name, None);
-        assert_eq!(calls, 1);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn decline_never_retries() {
-        let mut calls = 0;
-        let name = elicit_session_name(|| {
-            calls += 1;
-            std::future::ready(ElicitNameOutcome::NoName)
-        })
-        .await;
-        assert_eq!(name, None);
-        assert_eq!(calls, 1);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn transport_failure_retries_once_then_accepts() {
-        let mut calls = 0;
-        let name = elicit_session_name(|| {
-            calls += 1;
-            std::future::ready(if calls == 1 {
-                ElicitNameOutcome::Failed("no stream yet".to_string())
-            } else {
-                ElicitNameOutcome::Accepted("flight search".to_string())
-            })
-        })
-        .await;
-        assert_eq!(name.as_deref(), Some("flight-search"));
-        assert_eq!(calls, 2);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn two_transport_failures_give_up() {
-        let mut calls = 0;
-        let name = elicit_session_name(|| {
-            calls += 1;
-            std::future::ready(ElicitNameOutcome::Failed("still no stream".to_string()))
-        })
-        .await;
-        assert_eq!(name, None);
-        assert_eq!(calls, 2);
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/prompt.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/prompt.rs
@@ -11,6 +11,8 @@ installed BrowserClaw precisely so they don't have to keep asking.
 Shared with other agents:
 - Open your own tab with tabs action="new". Pages you don't own are rejected —
   tabs action="list" shows yours vs other agents' vs the user's.
+- Rename your session early with name_session using a 2-3 word task label;
+  tabs group as <client>/<name>.
 - Work in your own tabs and close them when done; touch a tab you don't own
   only when the user points you at it.
 - The user oversees this browser from the BrowserClaw cockpit (live view,

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/service.rs
@@ -3,7 +3,7 @@ use crate::{
     domain::{AgentRef, ClientInfo, Session, SessionId},
     mcp::{
         dispatch::{ToolCall, ToolIdentity, dispatch_tool_call, linked_cancel_token},
-        effects::tab_groups::retitle_agent_tab_group,
+        effects::tab_groups::apply_agent_tab_group_title,
         naming::{build_session_group_title, client_prefix_from_slug, normalize_small_name},
         prompt::BROWSERCLAW_MCP_INSTRUCTIONS,
     },
@@ -94,20 +94,15 @@ impl ClawMcpService {
                 return CallToolResult::error(vec![rmcp::model::ContentBlock::text(message)]);
             }
         };
-        if let (Some(browser), Some(tab_groups)) = (
-            self.state.browser.session().await,
-            self.catalog.iter().find(|tool| tool.name == "tab_groups"),
-        ) {
-            retitle_agent_tab_group(
-                tab_groups,
-                &browser,
-                &self.state.sessions.ownership(),
-                session.ownership_key(),
-                &rename.new_title,
-                session.child_token(),
-            )
-            .await;
-        }
+        let browser = self.state.browser.session().await;
+        apply_agent_tab_group_title(
+            browser.as_ref(),
+            &self.state.sessions.ownership(),
+            session.ownership_key(),
+            &rename.new_title,
+            session.child_token(),
+        )
+        .await;
         CallToolResult::success(vec![rmcp::model::ContentBlock::text(rename.response)])
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/service.rs
@@ -3,6 +3,8 @@ use crate::{
     domain::{AgentRef, ClientInfo, Session, SessionId},
     mcp::{
         dispatch::{ToolCall, ToolIdentity, dispatch_tool_call, linked_cancel_token},
+        effects::tab_groups::retitle_agent_tab_group,
+        naming::{build_session_group_title, client_prefix_from_slug, normalize_small_name},
         prompt::BROWSERCLAW_MCP_INSTRUCTIONS,
     },
 };
@@ -13,11 +15,11 @@ use rmcp::{
     model::{
         CallToolRequestMethod, CallToolRequestParams, CallToolResult, Implementation,
         InitializeRequestParams, InitializeResult, JsonObject, ListToolsResult,
-        PaginatedRequestParams, ServerCapabilities, Tool,
+        PaginatedRequestParams, ServerCapabilities, Tool, ToolAnnotations,
     },
     service::{NotificationContext, Peer, RequestContext},
 };
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
@@ -29,10 +31,14 @@ use ulid::Ulid;
 
 const SERVER_NAME: &str = "browserclaw";
 const SERVER_TITLE: &str = "BrowserClaw";
+const NAME_SESSION_TOOL_NAME: &str = "name_session";
+const NAME_SESSION_DESCRIPTION: &str = "Rename this browser session: a small lowercase 2-3 word label for what this session is doing, e.g. \"invoice processing\". Tabs are grouped as <client>/<name>. Call again to rename.";
+const NAME_SESSION_INPUT_MAX_LEN: usize = 64;
 
 pub struct ClawMcpService {
     state: AppState,
     catalog: Arc<Vec<ToolDef>>,
+    name_session_tool: Tool,
     output_files: OutputFileAccess,
     lifecycle: Arc<Mutex<ServiceLifecycle>>,
     fallback_session_id: SessionId,
@@ -63,6 +69,7 @@ impl ClawMcpService {
         Self {
             state,
             catalog: Arc::new(catalog()),
+            name_session_tool: name_session_tool(),
             output_files: browseros_mcp::output_file::create_browser_output_file_access(),
             lifecycle: Arc::new(Mutex::new(ServiceLifecycle::default())),
             fallback_session_id: SessionId::new(format!("stdio-{}", Ulid::new())),
@@ -72,6 +79,40 @@ impl ClawMcpService {
 
     fn find_tool_index(&self, name: &str) -> Option<usize> {
         self.catalog.iter().position(|tool| tool.name == name)
+    }
+
+    fn listed_tools(&self) -> Vec<Tool> {
+        let mut tools = self
+            .catalog
+            .iter()
+            .map(ToolDef::to_mcp_tool)
+            .collect::<Vec<_>>();
+        tools.push(self.name_session_tool.clone());
+        tools
+    }
+
+    async fn call_name_session(&self, session: Arc<Session>, raw_args: &Value) -> CallToolResult {
+        let rename = match rename_session(Some(session.as_ref()), raw_args).await {
+            Ok(rename) => rename,
+            Err(message) => {
+                return CallToolResult::error(vec![rmcp::model::ContentBlock::text(message)]);
+            }
+        };
+        if let (Some(browser), Some(tab_groups)) = (
+            self.state.browser.session().await,
+            self.catalog.iter().find(|tool| tool.name == "tab_groups"),
+        ) {
+            retitle_agent_tab_group(
+                tab_groups,
+                &browser,
+                &self.state.sessions.ownership(),
+                session.ownership_key(),
+                &rename.new_title,
+                session.child_token(),
+            )
+            .await;
+        }
+        CallToolResult::success(vec![rmcp::model::ContentBlock::text(rename.response)])
     }
 
     async fn set_client_info(&self, request: &InitializeRequestParams, peer: Peer<RoleServer>) {
@@ -251,15 +292,13 @@ impl ServerHandler for ClawMcpService {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
-        let tools = self
-            .catalog
-            .iter()
-            .map(ToolDef::to_mcp_tool)
-            .collect::<Vec<_>>();
-        std::future::ready(Ok(ListToolsResult::with_all_items(tools)))
+        std::future::ready(Ok(ListToolsResult::with_all_items(self.listed_tools())))
     }
 
     fn get_tool(&self, name: &str) -> Option<Tool> {
+        if name == NAME_SESSION_TOOL_NAME {
+            return Some(self.name_session_tool.clone());
+        }
         self.find_tool_index(name)
             .map(|index| self.catalog[index].to_mcp_tool())
     }
@@ -269,15 +308,23 @@ impl ServerHandler for ClawMcpService {
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
-        let Some(tool_index) = self.find_tool_index(&request.name) else {
+        let is_name_session = request.name == NAME_SESSION_TOOL_NAME;
+        let tool_index = self.find_tool_index(&request.name);
+        if !is_name_session && tool_index.is_none() {
             return Err(McpError::method_not_found::<CallToolRequestMethod>());
-        };
+        }
         let raw_args = request
             .arguments
             .map(Value::Object)
             .unwrap_or_else(|| Value::Object(JsonObject::new()));
         let started = self.learn_session_from_request(&context).await?;
         started.session.touch(tokio::time::Instant::now()).await;
+        if is_name_session {
+            return Ok(self.call_name_session(started.session, &raw_args).await);
+        }
+        let Some(tool_index) = tool_index else {
+            return Err(McpError::method_not_found::<CallToolRequestMethod>());
+        };
         let browser_session = self.state.browser.session().await;
         let ownership_key = started.session.ownership_key().clone();
         let default_tab_group_id = self
@@ -319,6 +366,64 @@ impl ServerHandler for ClawMcpService {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct SessionRename {
+    new_title: String,
+    response: String,
+}
+
+/// Validates and commits a session rename before any browser-side title synchronization.
+async fn rename_session(
+    session: Option<&Session>,
+    raw_args: &Value,
+) -> Result<SessionRename, &'static str> {
+    let Some(session) = session else {
+        return Err("unable to resolve this session");
+    };
+    let Some(raw_name) = raw_args.get("name").and_then(Value::as_str) else {
+        return Err("name must be a string");
+    };
+    if raw_name.chars().count() > NAME_SESSION_INPUT_MAX_LEN {
+        return Err("name must be at most 64 characters");
+    }
+    let label = normalize_small_name(raw_name);
+    if label.is_empty() {
+        return Err("name must contain a usable session name");
+    }
+
+    let prefix = client_prefix_from_slug(session.agent().slug());
+    let old_label = session.rename(label.clone()).await;
+    let old_title = build_session_group_title(prefix, &old_label);
+    let new_title = build_session_group_title(prefix, &label);
+    Ok(SessionRename {
+        response: format!("renamed to {new_title} (was {old_title})"),
+        new_title,
+    })
+}
+
+fn name_session_tool() -> Tool {
+    let Value::Object(input_schema) = json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string", "maxLength": NAME_SESSION_INPUT_MAX_LEN }
+        },
+        "required": ["name"]
+    }) else {
+        unreachable!();
+    };
+    Tool::new(
+        NAME_SESSION_TOOL_NAME,
+        NAME_SESSION_DESCRIPTION,
+        input_schema,
+    )
+    .with_annotations(
+        ToolAnnotations::with_title("Name session")
+            .read_only(false)
+            .destructive(false)
+            .idempotent(true),
+    )
+}
+
 fn clean_client_field(value: &str, fallback: &str) -> String {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -358,6 +463,96 @@ mod tests {
         assert!(info.instructions.as_deref().is_some_and(|instructions| {
             instructions.contains("BrowserClaw — the browser for agents")
         }));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn name_session_schema_and_annotations_are_registered_locally() -> anyhow::Result<()> {
+        let call = crate::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let service = ClawMcpService::new(call.state);
+        let listed = service
+            .listed_tools()
+            .into_iter()
+            .find(|tool| tool.name == NAME_SESSION_TOOL_NAME)
+            .ok_or_else(|| anyhow::anyhow!("name_session missing from list"))?;
+        let fetched = service
+            .get_tool(NAME_SESSION_TOOL_NAME)
+            .ok_or_else(|| anyhow::anyhow!("name_session missing from get_tool"))?;
+
+        assert_eq!(listed, fetched);
+        assert_eq!(
+            listed.description.as_deref(),
+            Some(NAME_SESSION_DESCRIPTION)
+        );
+        assert_eq!(
+            Value::Object(listed.input_schema.as_ref().clone()),
+            json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "maxLength": 64 }
+                },
+                "required": ["name"]
+            })
+        );
+        assert_eq!(
+            listed.annotations,
+            Some(
+                ToolAnnotations::with_title("Name session")
+                    .read_only(false)
+                    .destructive(false)
+                    .idempotent(true)
+            )
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn name_session_validates_and_renames_without_a_browser() -> anyhow::Result<()> {
+        let call = crate::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let session = call
+            .identity
+            .as_ref()
+            .map(|identity| identity.session.clone())
+            .ok_or_else(|| anyhow::anyhow!("session missing"))?;
+        let generated = session.generated_label().to_string();
+
+        let first = rename_session(
+            Some(session.as_ref()),
+            &json!({ "name": "  Invoice Processing!!!  " }),
+        )
+        .await
+        .map_err(anyhow::Error::msg)?;
+        assert_eq!(
+            first.response,
+            format!("renamed to codex/invoice-processing (was codex/{generated})")
+        );
+        assert_eq!(session.label().await, "invoice-processing");
+
+        let second = rename_session(
+            Some(session.as_ref()),
+            &json!({ "name": "Quarterly Reporting" }),
+        )
+        .await
+        .map_err(anyhow::Error::msg)?;
+        assert_eq!(
+            second.response,
+            "renamed to codex/quarterly-reporting (was codex/invoice-processing)"
+        );
+
+        let current = session.label().await;
+        assert_eq!(
+            rename_session(Some(session.as_ref()), &json!({ "name": "!!!" })).await,
+            Err("name must contain a usable session name")
+        );
+        assert_eq!(
+            rename_session(Some(session.as_ref()), &json!({ "name": "x".repeat(65) })).await,
+            Err("name must be at most 64 characters")
+        );
+        assert_eq!(session.label().await, current);
+        assert_eq!(
+            rename_session(None, &json!({ "name": "invoice processing" })).await,
+            Err("unable to resolve this session")
+        );
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/service.rs
@@ -17,7 +17,7 @@ use rmcp::{
         InitializeRequestParams, InitializeResult, JsonObject, ListToolsResult,
         PaginatedRequestParams, ServerCapabilities, Tool, ToolAnnotations,
     },
-    service::{NotificationContext, Peer, RequestContext},
+    service::{NotificationContext, RequestContext},
 };
 use serde_json::{Value, json};
 use std::sync::{
@@ -49,16 +49,12 @@ pub struct ClawMcpService {
 struct ServiceLifecycle {
     client_info: Option<ClientInfo>,
     session_id: Option<SessionId>,
-    peer: Option<Peer<RoleServer>>,
-    naming_started: Arc<AtomicBool>,
     started: bool,
 }
 
 #[derive(Clone)]
 struct StartedSession {
     session: Arc<Session>,
-    peer: Peer<RoleServer>,
-    naming_started: Arc<AtomicBool>,
     agent_label: String,
 }
 
@@ -115,7 +111,7 @@ impl ClawMcpService {
         CallToolResult::success(vec![rmcp::model::ContentBlock::text(rename.response)])
     }
 
-    async fn set_client_info(&self, request: &InitializeRequestParams, peer: Peer<RoleServer>) {
+    async fn set_client_info(&self, request: &InitializeRequestParams) {
         let mut lifecycle = self.lifecycle.lock().await;
         lifecycle.client_info = Some(ClientInfo {
             name: clean_client_field(&request.client_info.name, "agent"),
@@ -128,16 +124,13 @@ impl ClawMcpService {
                 .filter(|value| !value.is_empty())
                 .map(str::to_string),
         });
-        lifecycle.peer = Some(peer);
     }
 
     async fn ensure_session_started(
         &self,
         session_id: SessionId,
-        peer: Peer<RoleServer>,
     ) -> Result<StartedSession, McpError> {
         let mut lifecycle = self.lifecycle.lock().await;
-        lifecycle.peer = Some(peer.clone());
         if lifecycle.session_id.is_none() {
             lifecycle.session_id = Some(session_id.clone());
         }
@@ -186,7 +179,6 @@ impl ClawMcpService {
             );
             session
         };
-        let peer = lifecycle.peer.clone().unwrap_or(peer);
         let agent_label = client
             .title
             .as_deref()
@@ -196,8 +188,6 @@ impl ClawMcpService {
             .to_string();
         Ok(StartedSession {
             session,
-            peer,
-            naming_started: lifecycle.naming_started.clone(),
             agent_label,
         })
     }
@@ -208,17 +198,13 @@ impl ClawMcpService {
     ) -> Result<StartedSession, McpError> {
         let session_id = session_id_from_extensions(&context.extensions)
             .unwrap_or_else(|| self.fallback_session_id.clone());
-        self.ensure_session_started(session_id, context.peer.clone())
-            .await
+        self.ensure_session_started(session_id).await
     }
 
     async fn learn_session_from_notification(&self, context: &NotificationContext<RoleServer>) {
         let session_id = session_id_from_extensions(&context.extensions)
             .unwrap_or_else(|| self.fallback_session_id.clone());
-        if let Err(error) = self
-            .ensure_session_started(session_id, context.peer.clone())
-            .await
-        {
+        if let Err(error) = self.ensure_session_started(session_id).await {
             warn!(error = %error, "mcp session start failed");
         }
     }
@@ -272,14 +258,12 @@ impl ServerHandler for ClawMcpService {
         context: RequestContext<RoleServer>,
     ) -> Result<InitializeResult, McpError> {
         context.peer.set_peer_info(request.clone());
-        self.set_client_info(&request, context.peer.clone()).await;
+        self.set_client_info(&request).await;
         let info = self.get_info();
         let Some(session_id) = session_id_from_extensions(&context.extensions) else {
             return Ok(info);
         };
-        let _ = self
-            .ensure_session_started(session_id, context.peer.clone())
-            .await?;
+        let _ = self.ensure_session_started(session_id).await?;
         Ok(info)
     }
 
@@ -350,7 +334,6 @@ impl ServerHandler for ClawMcpService {
             tool_index,
             raw_args,
             started.session.id().clone(),
-            context.id,
             Some(identity),
             browser_session,
             cancel,
@@ -359,8 +342,6 @@ impl ServerHandler for ClawMcpService {
             default_tab_group_id,
             self.state.clone(),
             self.output_files.clone(),
-            Some(started.peer),
-            started.naming_started,
         );
         dispatch_tool_call(call).await
     }
@@ -462,6 +443,11 @@ mod tests {
         );
         assert!(info.instructions.as_deref().is_some_and(|instructions| {
             instructions.contains("BrowserClaw — the browser for agents")
+        }));
+        assert!(info.instructions.as_deref().is_some_and(|instructions| {
+            instructions.contains(
+                "- Rename your session early with name_session using a 2-3 word task label;\n  tabs group as <client>/<name>."
+            )
         }));
         Ok(())
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/service.rs
@@ -128,7 +128,7 @@ impl ClawMcpService {
             let profiles = self.state.agents.list_profiles().await.map_err(|error| {
                 McpError::internal_error(format!("agent profile lookup failed: {error}"), None)
             })?;
-            let agent = AgentRef::resolve(&session_id, &client, &profiles);
+            let agent = AgentRef::resolve(&client, &profiles);
             let session = self
                 .state
                 .sessions
@@ -140,7 +140,7 @@ impl ClawMcpService {
             lifecycle.started = true;
             tracing::info!(
                 session_id = %session.id(),
-                agent = %session.agent().agent_id(),
+                agent = %session.agent_id(),
                 "mcp session initialized"
             );
             session
@@ -279,7 +279,7 @@ impl ServerHandler for ClawMcpService {
         let started = self.learn_session_from_request(&context).await?;
         started.session.touch(tokio::time::Instant::now()).await;
         let browser_session = self.state.browser.session().await;
-        let ownership_key = started.session.agent().ownership_key();
+        let ownership_key = started.session.ownership_key().clone();
         let default_tab_group_id = self
             .state
             .sessions

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/service.rs
@@ -99,7 +99,7 @@ impl ClawMcpService {
             browser.as_ref(),
             &self.state.sessions.ownership(),
             session.ownership_key(),
-            &rename.new_title,
+            session.as_ref(),
             session.child_token(),
         )
         .await;
@@ -344,7 +344,6 @@ impl ServerHandler for ClawMcpService {
 
 #[derive(Debug, PartialEq, Eq)]
 struct SessionRename {
-    new_title: String,
     response: String,
 }
 
@@ -373,7 +372,6 @@ async fn rename_session(
     let new_title = build_session_group_title(prefix, &label);
     Ok(SessionRename {
         response: format!("renamed to {new_title} (was {old_title})"),
-        new_title,
     })
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/test_support.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/test_support.rs
@@ -28,6 +28,7 @@ pub async fn tool_call_with_fallback(
         resources_dir: root.join("resources"),
         browserclaw_dir: root,
         session_idle: Duration::from_secs(300),
+        session_retention: Duration::from_secs(7_200),
         session_sweep_interval: Duration::from_secs(60),
         screencast_screenshot_fallback,
         dev_mode: false,

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/test_support.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/test_support.rs
@@ -4,7 +4,6 @@ use crate::{
     domain::{AgentRef, Session, SessionId, SessionIdentity},
     mcp::dispatch::{ToolCall, ToolIdentity, linked_cancel_token},
 };
-use rmcp::model::RequestId;
 use serde_json::Value;
 use std::{sync::Arc, time::Duration};
 use tokio_util::sync::CancellationToken;
@@ -63,7 +62,6 @@ pub async fn tool_call_with_fallback(
         tool_index,
         raw_args,
         session.id().clone(),
-        RequestId::Number(1),
         Some(ToolIdentity {
             session: session.clone(),
             agent: session.agent().clone(),
@@ -77,7 +75,5 @@ pub async fn tool_call_with_fallback(
         None,
         state,
         browseros_mcp::output_file::create_browser_output_file_access(),
-        None,
-        Arc::default(),
     ))
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/mcp/test_support.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/mcp/test_support.rs
@@ -1,7 +1,7 @@
 use crate::{
     AppState,
     config::Config,
-    domain::{AgentId, AgentRef, Session, SessionId},
+    domain::{AgentRef, Session, SessionId, SessionIdentity},
     mcp::dispatch::{ToolCall, ToolIdentity, linked_cancel_token},
 };
 use rmcp::model::RequestId;
@@ -38,10 +38,10 @@ pub async fn tool_call_with_fallback(
     let session = Session::new(
         SessionId::new("s1"),
         AgentRef::Ephemeral {
-            agent_id: AgentId::new("codex-a"),
             slug: "codex".to_string(),
             label: "Codex".to_string(),
         },
+        SessionIdentity::new("codex", "agile-alpaca".to_string()),
         tokio::time::Instant::now(),
     );
     state.sessions.insert_for_testing(session.clone()).await;
@@ -57,7 +57,7 @@ pub async fn tool_call_with_fallback(
         client_cancel.clone(),
         dispatch_cancel.clone(),
     );
-    let ownership_key = session.agent().ownership_key();
+    let ownership_key = session.ownership_key().clone();
     Ok(ToolCall::new(
         catalog,
         tool_index,

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
@@ -22,7 +22,7 @@ use axum::{
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
-use std::{str::FromStr, time::Instant};
+use std::{collections::HashMap, str::FromStr, time::Instant};
 use tracing::{Instrument, info_span};
 use ulid::Ulid;
 
@@ -216,15 +216,26 @@ async fn agents_cancel(State(state): State<AppState>, Path(agent_id): Path<Strin
 async fn tabs_activity(State(state): State<AppState>) -> AppResult<Json<Value>> {
     state.screencast.note_read();
     let profiles = state.agents.list_profiles().await?;
+    let live_sessions = state.sessions.snapshot().await;
+    let sessions_by_agent_id = live_sessions
+        .iter()
+        .map(|session| (session.agent_id().as_str(), session))
+        .collect::<HashMap<_, _>>();
     let tabs = state.tab_activity.snapshot().await;
     let mut enriched = Vec::with_capacity(tabs.len());
     for record in tabs {
-        let profile = profiles
-            .iter()
-            .find(|profile| profile.id == record.agent_id);
+        let session = sessions_by_agent_id.get(record.agent_id.as_str()).copied();
+        let profile = session
+            .and_then(|session| session.agent().profile_id())
+            .and_then(|profile_id| {
+                profiles
+                    .iter()
+                    .find(|profile| profile.id == profile_id.as_str())
+            });
         enriched.push(EnrichedTabRecord {
             agent_label: profile
                 .map(|profile| profile.name.clone())
+                .or_else(|| session.map(|session| session.agent().label().to_string()))
                 .unwrap_or_else(|| record.slug.clone()),
             harness: profile.map(|profile| profile.harness.to_string()),
             color: Some(crate::domain::hex_for_slug(&record.slug).to_string()),

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/replay_tabs.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/replay_tabs.rs
@@ -29,7 +29,7 @@ pub async fn list_replay_tabs(
     let live = sessions.snapshot().await;
     let mut live_by_agent_id = HashMap::with_capacity(live.len());
     for session in live {
-        let agent_id = session.agent().agent_id().as_str().to_string();
+        let agent_id = session.agent_id().as_str().to_string();
         live_by_agent_id.entry(agent_id).or_insert(session);
     }
 
@@ -39,7 +39,7 @@ pub async fn list_replay_tabs(
         let Some(session) = live_by_agent_id.get(record.agent_id.as_str()) else {
             continue;
         };
-        let agent_key = session.agent().ownership_key();
+        let agent_key = session.ownership_key().clone();
         tabs.push(ReplayTab {
             session_id: session.id().as_str().to_string(),
             tab_page_id: record.page_id,

--- a/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
@@ -298,6 +298,7 @@ async fn test_router(browserclaw_dir: &Path, home: &Path) -> anyhow::Result<Rout
         resources_dir: browserclaw_dir.join("resources"),
         browserclaw_dir: browserclaw_dir.to_path_buf(),
         session_idle: Duration::from_secs(300),
+        session_retention: Duration::from_secs(7_200),
         session_sweep_interval: Duration::from_secs(60),
         screencast_screenshot_fallback: true,
         dev_mode: false,

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -51,6 +51,7 @@ async fn test_app_with_options(
         resources_dir: dir.path().join("resources"),
         browserclaw_dir: root,
         session_idle: Duration::from_secs(300),
+        session_retention: Duration::from_secs(7_200),
         session_sweep_interval: Duration::from_secs(60),
         screencast_screenshot_fallback,
         dev_mode: false,

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -7,7 +7,7 @@ use browseros_core::TargetId;
 use claw_server_rust::{
     AppState, build_router,
     config::Config,
-    domain::{AgentId, AgentRef, Session, SessionId, TabGroupColor},
+    domain::{AgentRef, ProfileId, Session, SessionId, SessionIdentity, TabGroupColor},
     services::tab_activity::RecordToolInput,
 };
 use futures_util::{SinkExt, StreamExt};
@@ -278,6 +278,8 @@ async fn audit_empty_and_replay_gone() -> anyhow::Result<()> {
 #[tokio::test]
 async fn replay_tabs_tracks_only_live_agent_sessions() -> anyhow::Result<()> {
     let app = test_app().await?;
+    let session_id = SessionId::new("session-live");
+    let session = test_session(session_id.clone(), "agent-live", "codex");
     app.state
         .tab_activity
         .record_tool(RecordToolInput {
@@ -285,7 +287,7 @@ async fn replay_tabs_tracks_only_live_agent_sessions() -> anyhow::Result<()> {
             page_id: 7,
             url: "https://example.com/live".to_string(),
             title: "Live Tab".to_string(),
-            agent_id: "agent-live".to_string(),
+            agent_id: session.agent_id().as_str().to_string(),
             slug: "codex".to_string(),
             tool_name: "tabs".to_string(),
         })
@@ -295,8 +297,6 @@ async fn replay_tabs_tracks_only_live_agent_sessions() -> anyhow::Result<()> {
     assert_eq!(status, StatusCode::OK, "initialize body: {body:?}");
     assert_eq!(body, json!({ "tabs": [] }));
 
-    let session_id = SessionId::new("session-live");
-    let session = test_session(session_id.clone(), "agent-live", "codex");
     app.state.sessions.insert_for_testing(session.clone()).await;
 
     let (status, body) = request_json(&app.router, "GET", "/replay/tabs", None).await?;
@@ -315,7 +315,7 @@ async fn replay_tabs_tracks_only_live_agent_sessions() -> anyhow::Result<()> {
         .sessions
         .ownership()
         .set_tab_group(
-            session.agent().ownership_key(),
+            session.ownership_key().clone(),
             Some("group-live".to_string()),
             Some(TabGroupColor::Purple),
         )
@@ -337,40 +337,39 @@ async fn replay_tabs_tracks_only_live_agent_sessions() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn replay_tabs_keeps_first_live_session_per_agent_id() -> anyhow::Result<()> {
+async fn replay_tabs_maps_each_session_scoped_agent_id() -> anyhow::Result<()> {
     let app = test_app().await?;
-    app.state
-        .tab_activity
-        .record_tool(RecordToolInput {
-            target_id: TargetId::from("target-duplicate".to_string()),
-            page_id: 8,
-            url: "https://example.com/duplicate".to_string(),
-            title: "Duplicate".to_string(),
-            agent_id: "agent-duplicate".to_string(),
-            slug: "codex".to_string(),
-            tool_name: "tabs".to_string(),
-        })
-        .await;
-    app.state
-        .sessions
-        .insert_for_testing(test_session(
-            SessionId::new("session-a"),
-            "agent-duplicate",
-            "codex",
-        ))
-        .await;
-    app.state
-        .sessions
-        .insert_for_testing(test_session(
-            SessionId::new("session-b"),
-            "agent-duplicate",
-            "codex",
-        ))
-        .await;
+    let session_a = test_session(SessionId::new("session-a"), "agile-alpaca", "codex");
+    let session_b = test_session(SessionId::new("session-b"), "bright-beaver", "codex");
+    for (index, session) in [&session_a, &session_b].into_iter().enumerate() {
+        app.state
+            .tab_activity
+            .record_tool(RecordToolInput {
+                target_id: TargetId::from(format!("target-{index}")),
+                page_id: u32::try_from(index + 8)?,
+                url: format!("https://example.com/{index}"),
+                title: format!("Session {index}"),
+                agent_id: session.agent_id().as_str().to_string(),
+                slug: "codex".to_string(),
+                tool_name: "tabs".to_string(),
+            })
+            .await;
+    }
+    app.state.sessions.insert_for_testing(session_a).await;
+    app.state.sessions.insert_for_testing(session_b).await;
 
     let (status, body) = request_json(&app.router, "GET", "/replay/tabs", None).await?;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["tabs"][0]["sessionId"], "session-a");
+    let session_ids = body["tabs"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("tabs not array"))?
+        .iter()
+        .filter_map(|tab| tab["sessionId"].as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        session_ids,
+        std::collections::BTreeSet::from(["session-a", "session-b"])
+    );
     Ok(())
 }
 
@@ -598,7 +597,7 @@ async fn mcp_session_naming_triggers_once_after_first_successful_tabs_new() -> a
         .lookup(&SessionId::new(session_id.clone()))
         .await
         .ok_or_else(|| anyhow::anyhow!("session not minted"))?;
-    assert_eq!(session.session_label().await, None);
+    assert_eq!(session.label().await, session.generated_label());
 
     let mut stream = McpSseStream::open(&app.router, &session_id).await?;
     let (status, _headers, body) = request_json_with_headers(
@@ -642,7 +641,7 @@ async fn mcp_session_naming_triggers_once_after_first_successful_tabs_new() -> a
 
     let mut applied = false;
     for _ in 0..100 {
-        let label_ready = session.session_label().await.as_deref() == Some("invoice-processing");
+        let label_ready = session.label().await == "invoice-processing";
         let title_ready = mock.group_updates.lock().await.iter().any(|params| {
             params.get("title").and_then(Value::as_str) == Some("claude/invoice-processing")
         });
@@ -657,7 +656,7 @@ async fn mcp_session_naming_triggers_once_after_first_successful_tabs_new() -> a
         app.state
             .sessions
             .ownership()
-            .tab_group_ref(&session.agent().ownership_key())
+            .tab_group_ref(session.ownership_key())
             .await
             .as_deref(),
         Some("group-1")
@@ -852,7 +851,7 @@ async fn cancel_endpoint_aborts_in_flight_dispatch() -> anyhow::Result<()> {
         .lookup(&SessionId::new(session_id.clone()))
         .await
         .ok_or_else(|| anyhow::anyhow!("missing test session"))?;
-    let agent_id = session.agent().agent_id().as_str().to_string();
+    let agent_id = session.agent_id().as_str().to_string();
 
     let (status, _headers, body) = request_json_with_headers(
         &app.router,
@@ -932,7 +931,7 @@ async fn cancel_endpoint_aborts_in_flight_dispatch() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn tabs_activity_enriches_by_agent_id_only() -> anyhow::Result<()> {
+async fn tabs_activity_enriches_through_live_session_profile_identity() -> anyhow::Result<()> {
     let app = test_app().await?;
     let agents_dir = app.state.config.browserclaw_dir.join("agents");
     tokio::fs::create_dir_all(&agents_dir).await?;
@@ -957,6 +956,27 @@ async fn tabs_activity_enriches_by_agent_id_only() -> anyhow::Result<()> {
     )
     .await?;
 
+    let stored_session = Session::new(
+        SessionId::new("stored-session"),
+        AgentRef::Profile {
+            profile_id: ProfileId::new("stored-agent"),
+            slug: "mcp".to_string(),
+            label: "Stored Agent".to_string(),
+        },
+        SessionIdentity::new("mcp", "agile-alpaca".to_string()),
+        tokio::time::Instant::now(),
+    );
+    let ephemeral_session =
+        test_session(SessionId::new("ephemeral-session"), "bright-beaver", "mcp");
+    app.state
+        .sessions
+        .insert_for_testing(stored_session.clone())
+        .await;
+    app.state
+        .sessions
+        .insert_for_testing(ephemeral_session.clone())
+        .await;
+
     app.state
         .tab_activity
         .record_tool(RecordToolInput {
@@ -964,7 +984,7 @@ async fn tabs_activity_enriches_by_agent_id_only() -> anyhow::Result<()> {
             page_id: 1,
             url: "https://example.com/exact".to_string(),
             title: "Exact".to_string(),
-            agent_id: "stored-agent".to_string(),
+            agent_id: stored_session.agent_id().as_str().to_string(),
             slug: "mcp".to_string(),
             tool_name: "tabs".to_string(),
         })
@@ -976,7 +996,7 @@ async fn tabs_activity_enriches_by_agent_id_only() -> anyhow::Result<()> {
             page_id: 2,
             url: "https://example.com/fallback".to_string(),
             title: "Fallback".to_string(),
-            agent_id: "ephemeral-agent".to_string(),
+            agent_id: ephemeral_session.agent_id().as_str().to_string(),
             slug: "mcp".to_string(),
             tool_name: "tabs".to_string(),
         })
@@ -1104,13 +1124,17 @@ async fn tabs_activity_embeds_polled_screenshot_frames() -> anyhow::Result<()> {
 }
 
 fn test_session(session_id: SessionId, agent_id: &str, slug: &str) -> Arc<Session> {
+    let generated_label = agent_id
+        .strip_prefix(&format!("{slug}-"))
+        .unwrap_or(agent_id)
+        .to_string();
     Session::new(
         session_id,
         AgentRef::Ephemeral {
-            agent_id: AgentId::new(agent_id),
             slug: slug.to_string(),
             label: slug.to_string(),
         },
+        claw_server_rust::domain::SessionIdentity::new(slug, generated_label),
         tokio::time::Instant::now(),
     )
 }

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -547,6 +547,106 @@ async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn mcp_name_session_lists_and_renames_while_disconnected() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let session_id = initialize_mcp(&app).await?;
+    let headers = [("mcp-session-id", session_id.as_str())];
+
+    let (status, _headers, body) = request_json_with_headers(
+        &app.router,
+        "POST",
+        "/mcp",
+        Some(json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} })),
+        &headers,
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    let tool = body["result"]["tools"]
+        .as_array()
+        .and_then(|tools| tools.iter().find(|tool| tool["name"] == "name_session"))
+        .ok_or_else(|| anyhow::anyhow!("name_session missing"))?;
+    assert_eq!(
+        tool["description"],
+        "Rename this browser session: a small lowercase 2-3 word label for what this session is doing, e.g. \"invoice processing\". Tabs are grouped as <client>/<name>. Call again to rename."
+    );
+    assert_eq!(
+        tool["inputSchema"],
+        json!({
+            "type": "object",
+            "properties": { "name": { "type": "string", "maxLength": 64 } },
+            "required": ["name"]
+        })
+    );
+    assert_eq!(
+        tool["annotations"],
+        json!({
+            "title": "Name session",
+            "readOnlyHint": false,
+            "destructiveHint": false,
+            "idempotentHint": true
+        })
+    );
+
+    let session = app
+        .state
+        .sessions
+        .lookup(&SessionId::new(session_id.clone()))
+        .await
+        .ok_or_else(|| anyhow::anyhow!("session not minted"))?;
+    let generated = session.generated_label().to_string();
+    let (status, _headers, body) = request_json_with_headers(
+        &app.router,
+        "POST",
+        "/mcp",
+        Some(name_session_request(3, "  Invoice Processing!!!  ")),
+        &headers,
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["result"]["isError"], false);
+    assert_eq!(
+        body["result"]["content"][0]["text"],
+        format!("renamed to codex/invoice-processing (was codex/{generated})")
+    );
+    assert_eq!(session.label().await, "invoice-processing");
+
+    let (_status, _headers, body) = request_json_with_headers(
+        &app.router,
+        "POST",
+        "/mcp",
+        Some(name_session_request(4, "Quarterly Reporting")),
+        &headers,
+    )
+    .await?;
+    assert_eq!(
+        body["result"]["content"][0]["text"],
+        "renamed to codex/quarterly-reporting (was codex/invoice-processing)"
+    );
+
+    for (id, invalid, message) in [
+        (
+            5,
+            "!!!".to_string(),
+            "name must contain a usable session name",
+        ),
+        (6, "x".repeat(65), "name must be at most 64 characters"),
+    ] {
+        let (_status, _headers, body) = request_json_with_headers(
+            &app.router,
+            "POST",
+            "/mcp",
+            Some(name_session_request(id, &invalid)),
+            &headers,
+        )
+        .await?;
+        assert_eq!(body["result"]["isError"], true);
+        assert_eq!(body["result"]["content"][0]["text"], message);
+        assert_eq!(session.label().await, "quarterly-reporting");
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn mcp_session_naming_triggers_once_after_first_successful_tabs_new() -> anyhow::Result<()> {
     let mock = MockCdp::start().await?;
     let app = test_app_with_cdp_port(mock.cdp_port, false).await?;
@@ -1178,6 +1278,18 @@ fn tabs_new_request(id: u64) -> Value {
         "params": {
             "name": "tabs",
             "arguments": { "action": "new", "url": "https://example.com" }
+        }
+    })
+}
+
+fn name_session_request(id: u64, name: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": "name_session",
+            "arguments": { "name": name }
         }
     })
 }

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -483,7 +483,7 @@ async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
             .as_array()
             .ok_or_else(|| anyhow::anyhow!("tools not array"))?
             .len(),
-        16
+        17
     );
 
     let blocked = json!({
@@ -647,7 +647,7 @@ async fn mcp_name_session_lists_and_renames_while_disconnected() -> anyhow::Resu
 }
 
 #[tokio::test]
-async fn mcp_session_naming_triggers_once_after_first_successful_tabs_new() -> anyhow::Result<()> {
+async fn mcp_session_naming_appends_five_tips_without_elicitation() -> anyhow::Result<()> {
     let mock = MockCdp::start().await?;
     let app = test_app_with_cdp_port(mock.cdp_port, false).await?;
     app.state.browser.connect_once_for_testing().await?;
@@ -658,7 +658,7 @@ async fn mcp_session_naming_triggers_once_after_first_successful_tabs_new() -> a
         "method": "initialize",
         "params": {
             "protocolVersion": "2025-06-18",
-            "capabilities": { "elicitation": {} },
+            "capabilities": {},
             "clientInfo": { "name": "Claude Code", "version": "1.0" }
         }
     });
@@ -672,24 +672,6 @@ async fn mcp_session_naming_triggers_once_after_first_successful_tabs_new() -> a
         .to_string();
     send_initialized(&app.router, &session_id).await?;
 
-    // Naming starts only after a successful tabs-new call, so initialize and
-    // tool discovery must not create an elicitation or session label.
-    let list = json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} });
-    let (status, _headers, body) = request_json_with_headers(
-        &app.router,
-        "POST",
-        "/mcp",
-        Some(list),
-        &[("mcp-session-id", &session_id)],
-    )
-    .await?;
-    assert_eq!(status, StatusCode::OK);
-    assert!(
-        body["result"]["tools"]
-            .as_array()
-            .is_some_and(|tools| !tools.is_empty())
-    );
-
     wait_for_session_registration(&app, &session_id).await?;
     let session = app
         .state
@@ -697,81 +679,43 @@ async fn mcp_session_naming_triggers_once_after_first_successful_tabs_new() -> a
         .lookup(&SessionId::new(session_id.clone()))
         .await
         .ok_or_else(|| anyhow::anyhow!("session not minted"))?;
-    assert_eq!(session.label().await, session.generated_label());
+    let generated = session.generated_label().to_string();
+    assert_eq!(session.label().await, generated);
 
     let mut stream = McpSseStream::open(&app.router, &session_id).await?;
-    let (status, _headers, body) = request_json_with_headers(
-        &app.router,
-        "POST",
-        "/mcp",
-        Some(tabs_new_request(3)),
-        &[("mcp-session-id", &session_id)],
-    )
-    .await?;
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["result"]["isError"], false, "tabs_new body: {body:?}");
-
-    let elicitation = tokio::time::timeout(
-        Duration::from_secs(2),
-        stream.next_method("elicitation/create"),
-    )
-    .await??;
-    assert_eq!(elicitation["params"]["mode"], "form");
-    assert_eq!(
-        elicitation["params"]["requestedSchema"]["required"],
-        json!(["name"])
+    let tip = format!(
+        "Tip: this session is \"claude/{generated}\" — rename it with name_session name=\"<2-3 word task label>\""
     );
-    let request_id = elicitation["id"].clone();
-    let (status, _headers, _body) = request_json_with_headers(
-        &app.router,
-        "POST",
-        "/mcp",
-        Some(json!({
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "result": {
-                "action": "accept",
-                "content": { "name": "Invoice Processing!!!" }
-            }
-        })),
-        &[("mcp-session-id", &session_id)],
-    )
-    .await?;
-    assert_eq!(status, StatusCode::ACCEPTED);
-
-    let mut applied = false;
-    for _ in 0..100 {
-        let label_ready = session.label().await == "invoice-processing";
-        let title_ready = mock.group_updates.lock().await.iter().any(|params| {
-            params.get("title").and_then(Value::as_str) == Some("claude/invoice-processing")
-        });
-        if label_ready && title_ready {
-            applied = true;
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
+    for id in 3..=7 {
+        let (status, _headers, body) = request_json_with_headers(
+            &app.router,
+            "POST",
+            "/mcp",
+            Some(tabs_new_request(id)),
+            &[("mcp-session-id", &session_id)],
+        )
+        .await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["result"]["isError"], false, "tabs_new body: {body:?}");
+        assert_eq!(
+            body["result"]["content"]
+                .as_array()
+                .and_then(|content| content.last())
+                .and_then(|block| block["text"].as_str()),
+            Some(tip.as_str())
+        );
     }
-    assert!(applied, "session label or group title was not applied");
-    assert_eq!(
-        app.state
-            .sessions
-            .ownership()
-            .tab_group_ref(session.ownership_key())
-            .await
-            .as_deref(),
-        Some("group-1")
-    );
-
     let (status, _headers, body) = request_json_with_headers(
         &app.router,
         "POST",
         "/mcp",
-        Some(tabs_new_request(4)),
+        Some(tabs_new_request(8)),
         &[("mcp-session-id", &session_id)],
     )
     .await?;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["result"]["isError"], false, "tabs_new body: {body:?}");
+    assert!(!body.to_string().contains("Tip: this session is"));
     match tokio::time::timeout(
         Duration::from_millis(250),
         stream.next_method("elicitation/create"),
@@ -779,9 +723,10 @@ async fn mcp_session_naming_triggers_once_after_first_successful_tabs_new() -> a
     .await
     {
         Err(_) => {}
-        Ok(Ok(request)) => anyhow::bail!("second tabs new elicited again: {request:?}"),
+        Ok(Ok(request)) => anyhow::bail!("unexpected elicitation: {request:?}"),
         Ok(Err(error)) => return Err(error),
     }
+    assert!(!mock.group_updates.lock().await.is_empty());
     drop(mock);
     Ok(())
 }

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -846,6 +846,113 @@ async fn mcp_tabs_new_roundtrips_through_mock_cdp() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn same_name_mcp_sessions_have_distinct_groups_and_reject_cross_page_access()
+-> anyhow::Result<()> {
+    let mock = MockCdp::start().await?;
+    let app = test_app_with_cdp_port(mock.cdp_port, false).await?;
+    app.state.browser.connect_once_for_testing().await?;
+    wait_for_cdp_connected(&app.router).await?;
+    let session_a_id = initialize_mcp(&app).await?;
+    let session_b_id = initialize_mcp(&app).await?;
+    let session_a = app
+        .state
+        .sessions
+        .lookup(&SessionId::new(session_a_id.clone()))
+        .await
+        .ok_or_else(|| anyhow::anyhow!("first session missing"))?;
+    let session_b = app
+        .state
+        .sessions
+        .lookup(&SessionId::new(session_b_id.clone()))
+        .await
+        .ok_or_else(|| anyhow::anyhow!("second session missing"))?;
+    assert_ne!(session_a.agent_id(), session_b.agent_id());
+    assert_ne!(session_a.ownership_key(), session_b.ownership_key());
+
+    for (id, session_id) in [(10, &session_a_id), (11, &session_b_id)] {
+        let (status, _headers, body) = request_json_with_headers(
+            &app.router,
+            "POST",
+            "/mcp",
+            Some(tabs_new_request(id)),
+            &[("mcp-session-id", session_id)],
+        )
+        .await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["result"]["isError"], false, "tabs new: {body:?}");
+    }
+
+    let ownership = app.state.sessions.ownership();
+    let (group_a, group_b) = wait_for_distinct_session_groups(
+        &ownership,
+        session_a.ownership_key(),
+        session_b.ownership_key(),
+    )
+    .await?;
+    assert_ne!(group_a, group_b);
+    let pages_a = ownership.owned_pages(session_a.ownership_key()).await;
+    let pages_b = ownership.owned_pages(session_b.ownership_key()).await;
+    assert_eq!(pages_a.len(), 1);
+    assert_eq!(pages_b.len(), 1);
+    assert!(pages_a.is_disjoint(&pages_b));
+    let page_a = pages_a
+        .first()
+        .map(|page| page.0)
+        .ok_or_else(|| anyhow::anyhow!("first session page missing"))?;
+    let page_b = pages_b
+        .first()
+        .map(|page| page.0)
+        .ok_or_else(|| anyhow::anyhow!("second session page missing"))?;
+
+    for (id, name, arguments) in [
+        (12, "snapshot", json!({ "page": page_b })),
+        (
+            13,
+            "navigate",
+            json!({ "page": page_b, "url": "https://example.org" }),
+        ),
+    ] {
+        let (status, _headers, body) = request_json_with_headers(
+            &app.router,
+            "POST",
+            "/mcp",
+            Some(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/call",
+                "params": { "name": name, "arguments": arguments }
+            })),
+            &[("mcp-session-id", &session_a_id)],
+        )
+        .await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["result"]["isError"], true, "cross-page body: {body:?}");
+        assert_eq!(
+            body["result"]["content"][0]["text"],
+            format!(
+                "page {page_b} is not owned by this agent; call `tabs new` to open a fresh page and use the returned page id."
+            )
+        );
+    }
+    let (_status, _headers, body) = request_json_with_headers(
+        &app.router,
+        "POST",
+        "/mcp",
+        Some(json!({
+            "jsonrpc": "2.0",
+            "id": 14,
+            "method": "tools/call",
+            "params": { "name": "snapshot", "arguments": { "page": page_a } }
+        })),
+        &[("mcp-session-id", &session_b_id)],
+    )
+    .await?;
+    assert_eq!(body["result"]["isError"], true);
+    drop(mock);
+    Ok(())
+}
+
+#[tokio::test]
 async fn screencast_fallback_flag_disables_fallback_screenshots() -> anyhow::Result<()> {
     let mock = MockCdp::start().await?;
     let app = test_app_with_options(mock.cdp_port, false, false).await?;
@@ -1288,6 +1395,22 @@ async fn wait_for_cdp_connected(router: &Router) -> anyhow::Result<()> {
     ))
 }
 
+async fn wait_for_distinct_session_groups(
+    ownership: &Arc<claw_server_rust::domain::AgentPageOwnership>,
+    key_a: &claw_server_rust::domain::AgentKey,
+    key_b: &claw_server_rust::domain::AgentKey,
+) -> anyhow::Result<(String, String)> {
+    for _ in 0..100 {
+        let group_a = ownership.tab_group_ref(key_a).await;
+        let group_b = ownership.tab_group_ref(key_b).await;
+        if let (Some(group_a), Some(group_b)) = (group_a, group_b) {
+            return Ok((group_a, group_b));
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    anyhow::bail!("session tab groups were not created")
+}
+
 struct MockCdp {
     cdp_port: u16,
     tabs: Arc<tokio::sync::Mutex<Vec<MockTab>>>,
@@ -1516,6 +1639,14 @@ async fn handle_mock_cdp_method(
         "Page.captureScreenshot" => Ok(json!({ "data": "anBlZw==" })),
         "Browser.createTabGroup" => {
             let mut tabs = tabs.lock().await;
+            let group_id = format!(
+                "group-{}",
+                tabs.iter()
+                    .filter_map(|tab| tab.group_id.as_deref())
+                    .collect::<std::collections::BTreeSet<_>>()
+                    .len()
+                    + 1
+            );
             let tab_ids = params
                 .get("tabIds")
                 .and_then(Value::as_array)
@@ -1525,12 +1656,12 @@ async fn handle_mock_cdp_method(
                 if let Some(tab_id) = id.as_i64()
                     && let Some(tab) = tabs.iter_mut().find(|tab| tab.tab_id == tab_id)
                 {
-                    tab.group_id = Some("group-1".to_string());
+                    tab.group_id = Some(group_id.clone());
                 }
             }
             Ok(json!({
                 "group": {
-                    "groupId": "group-1",
+                    "groupId": group_id,
                     "windowId": 1,
                     "title": params.get("title").and_then(Value::as_str).unwrap_or("group"),
                     "color": "blue",

--- a/packages/browseros-agent/apps/claw-server-rust/tests/telemetry.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/telemetry.rs
@@ -138,6 +138,7 @@ async fn test_router(root: &Path) -> anyhow::Result<Router> {
         resources_dir: root.join("resources"),
         browserclaw_dir: root.to_path_buf(),
         session_idle: Duration::from_secs(300),
+        session_retention: Duration::from_secs(7_200),
         session_sweep_interval: Duration::from_secs(60),
         screencast_screenshot_fallback: true,
         dev_mode: false,


### PR DESCRIPTION
## Summary
- make Rust agent IDs and ownership keys identify individual MCP conversations while stored profile IDs continue to drive permissions, labels, and harness enrichment
- remove MCP elicitation, add the Claw-local `name_session` tool with disconnected support, and append at most five rename nudges
- make tab-group rename/lifecycle operations race-safe, retain ended session groups, and close them after `CLAW_SESSION_RETENTION_MS` (two hours by default)

## Design
Stored `AgentRef` remains the profile and policy identity, while a new `SessionIdentity` owns each conversation's opaque agent ID, ownership key, generated/current label, and nudge state. Group operations serialize per session key, defer title synchronization across Chromium disconnects, and retain ended groups until confirmed closure so temporary browser outages cannot orphan live state.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo build -p claw-server-rust`
- [x] `cargo test -p claw-server-rust`
- [x] `cargo clippy -p claw-server-rust --all-targets -- -D warnings`
- [x] `cargo test -p browseros-mcp`
- [x] context-free adversarial review, fixes, and clean second pass
