### PR TITLE
feat(claw-app): make recording delivery resilient

### DIFF
--- a/packages/browseros-agent/apps/claw-app/entrypoints/background.ts
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/background.ts
@@ -14,6 +14,7 @@ export default defineBackground(() => {
     resolveServerBaseUrl: resolveBrowserOSServerBaseUrl,
   })
   const requestResnapshot = (tabId: number) => {
+    // Tabs can disappear between recovery detection and message delivery.
     try {
       void chrome.tabs
         .sendMessage(tabId, { type: 'recorder-resnapshot' })

--- a/packages/browseros-agent/apps/claw-app/entrypoints/background.ts
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/background.ts
@@ -13,6 +13,15 @@ export default defineBackground(() => {
   const relay = createRecordingsRelay({
     resolveServerBaseUrl: resolveBrowserOSServerBaseUrl,
   })
+  const requestResnapshot = (tabId: number) => {
+    try {
+      void chrome.tabs
+        .sendMessage(tabId, { type: 'recorder-resnapshot' })
+        .catch(() => {})
+    } catch {}
+  }
+
+  relay.onTabRecoveredAfterLoss(requestResnapshot)
 
   chrome.runtime.onMessage.addListener((message, sender) => {
     const recorderMessage = message as {
@@ -31,5 +40,14 @@ export default defineBackground(() => {
     return false
   })
 
-  void relay.serverHasRecordings()
+  // Background memory owns the retry queue, so every restart means surviving
+  // documents need a new checkpoint after any batches that died with it.
+  void chrome.tabs
+    .query({})
+    .then((tabs) => {
+      for (const tab of tabs) {
+        if (typeof tab.id === 'number') requestResnapshot(tab.id)
+      }
+    })
+    .catch(() => {})
 })

--- a/packages/browseros-agent/apps/claw-app/entrypoints/recorder.content.ts
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/recorder.content.ts
@@ -55,8 +55,22 @@ export default defineContentScript({
       flush: buffer.flushNow,
     })
 
+    let recorderActive = false
+    chrome.runtime.onMessage.addListener((message) => {
+      const recorderMessage = message as { type?: unknown }
+      if (recorderMessage.type !== 'recorder-resnapshot' || !recorderActive) {
+        return false
+      }
+      try {
+        rrweb.record.takeFullSnapshot()
+      } catch (error) {
+        console.warn('[browseros-claw replay] resnapshot failed', error)
+      }
+      return false
+    })
+
     try {
-      rrweb.record({
+      const stopRecording = rrweb.record({
         maskInputOptions: { password: true },
         sampling: {
           mousemove: false,
@@ -67,6 +81,7 @@ export default defineContentScript({
         recordCanvas: false,
         emit: buffer.emit,
       })
+      recorderActive = typeof stopRecording === 'function'
     } catch (error) {
       console.warn('[browseros-claw replay] rrweb.record threw', error)
       buffer.close()

--- a/packages/browseros-agent/apps/claw-app/modules/recorder/recorder.types.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/recorder/recorder.types.ts
@@ -9,4 +9,8 @@ export interface RecorderEventsMessage {
   ndjson: string
 }
 
-export type RecorderMessage = RecorderEventsMessage
+export interface RecorderResnapshotMessage {
+  type: 'recorder-resnapshot'
+}
+
+export type RecorderMessage = RecorderEventsMessage | RecorderResnapshotMessage

--- a/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.test.ts
@@ -188,4 +188,33 @@ describe('createRecordingsRelay', () => {
     expect(bodies).toEqual(['terminal', 'next'])
     expect(recoveredTabs).toEqual([7])
   })
+
+  it('warns again when a new outage begins after delivery recovered', async () => {
+    const clock = createFakeClock()
+    const warnings: unknown[][] = []
+    let serverUp = false
+    const relay = createRecordingsRelay({
+      resolveServerBaseUrl: async () => serverBaseUrl,
+      fetch: async () => {
+        if (!serverUp) throw new TypeError('connection refused')
+        return Response.json({ ok: true, accepted: 1 })
+      },
+      now: clock.now,
+      setTimeout: clock.setTimeout,
+      clearTimeout: clock.clearTimeout,
+      warn: (...args) => warnings.push(args),
+    })
+
+    await relay.post(3, 'first-outage')
+    serverUp = true
+    await clock.advanceBy(5_000)
+    serverUp = false
+    await relay.post(3, 'second-outage')
+
+    expect(
+      warnings.filter(
+        ([message]) => message === '[browseros-claw replay] events POST failed',
+      ),
+    ).toHaveLength(2)
+  })
 })

--- a/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.test.ts
@@ -134,6 +134,42 @@ describe('createRecordingsRelay', () => {
     expect(bodies).toEqual(['legacy-detected', 'after-ttl'])
   })
 
+  it('heals tabs whose batches were dropped by a legacy interval', async () => {
+    const clock = createFakeClock()
+    const recoveredTabs: number[] = []
+    let response: 'transient' | 'legacy' | 'success' = 'transient'
+    let attempts = 0
+    const relay = createRecordingsRelay({
+      resolveServerBaseUrl: async () => serverBaseUrl,
+      fetch: async () => {
+        attempts++
+        if (response === 'transient') throw new TypeError('connection refused')
+        if (response === 'legacy') return new Response('{}', { status: 404 })
+        return Response.json({ ok: true, accepted: 1 })
+      },
+      now: clock.now,
+      setTimeout: clock.setTimeout,
+      clearTimeout: clock.clearTimeout,
+      warn: () => {},
+    })
+    relay.onTabRecoveredAfterLoss((tabId) => recoveredTabs.push(tabId))
+
+    await relay.post(1, 'queued-trigger')
+    await relay.post(2, 'queued-cleared')
+    response = 'legacy'
+    await clock.advanceBy(5_000)
+    const attemptsAfter404 = attempts
+    await relay.post(3, 'dropped-inside-ttl')
+    expect(attempts).toBe(attemptsAfter404)
+
+    response = 'success'
+    await clock.advanceBy(10 * 60_000)
+    await relay.post(1, 'tab-1-recovers')
+    await relay.post(2, 'tab-2-recovers')
+    await relay.post(3, 'tab-3-recovers')
+    expect(recoveredTabs).toEqual([1, 2, 3])
+  })
+
   it('marks an evicted tab gapped and requests a resnapshot after recovery', async () => {
     const clock = createFakeClock()
     const recoveredTabs: number[] = []

--- a/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.test.ts
@@ -3,115 +3,189 @@ import { createRecordingsRelay } from './recordings-relay'
 
 const serverBaseUrl = 'http://127.0.0.1:9511'
 
+interface FakeTimer {
+  id: number
+  at: number
+  callback: () => void
+}
+
+function createFakeClock() {
+  let now = 0
+  let nextTimerId = 1
+  const timers: FakeTimer[] = []
+
+  return {
+    now: () => now,
+    setTimeout(callback: () => void, delayMs: number) {
+      const timer = { id: nextTimerId++, at: now + delayMs, callback }
+      timers.push(timer)
+      return timer.id as unknown as ReturnType<typeof globalThis.setTimeout>
+    },
+    clearTimeout(handle: ReturnType<typeof globalThis.setTimeout>) {
+      const index = timers.findIndex((timer) => timer.id === Number(handle))
+      if (index !== -1) timers.splice(index, 1)
+    },
+    async advanceBy(delayMs: number) {
+      now += delayMs
+      while (true) {
+        timers.sort((a, b) => a.at - b.at)
+        const timer = timers[0]
+        if (!timer || timer.at > now) return
+        timers.shift()
+        await timer.callback()
+      }
+    },
+    pendingTimers: () => timers.length,
+  }
+}
+
+function requestHeader(init: RequestInit | undefined, name: string): string {
+  return new Headers(init?.headers).get(name) ?? ''
+}
+
 describe('createRecordingsRelay', () => {
-  it('health-gates and posts a batch to the sender tab path', async () => {
-    const requests: Array<{ url: string; init?: RequestInit }> = []
+  it('queues batches while the server is down, then delivers them in order after recovery with stable ids', async () => {
+    const clock = createFakeClock()
+    const attempts: Array<{
+      url: string
+      body: string
+      batchId: string
+      contentType: string
+      succeeded: boolean
+    }> = []
+    let serverUp = false
     const relay = createRecordingsRelay({
       resolveServerBaseUrl: async () => serverBaseUrl,
       fetch: async (input, init) => {
-        const url = String(input)
-        requests.push({ url, init })
-        return url.endsWith('/health')
-          ? Response.json({ ok: true })
+        attempts.push({
+          url: String(input),
+          body: String(init?.body),
+          batchId: requestHeader(init, 'X-Recording-Batch-Id'),
+          contentType: requestHeader(init, 'content-type'),
+          succeeded: serverUp,
+        })
+        if (!serverUp) throw new TypeError('connection refused')
+        return Response.json({ ok: true, accepted: 1 })
+      },
+      now: clock.now,
+      setTimeout: clock.setTimeout,
+      clearTimeout: clock.clearTimeout,
+      warn: () => {},
+    })
+
+    await relay.post(42, 'first')
+    await relay.post(42, 'second')
+
+    expect(
+      attempts.every(
+        ({ url }) => url === `${serverBaseUrl}/recordings/tabs/42/events`,
+      ),
+    ).toBe(true)
+    expect(
+      attempts.every(
+        ({ contentType }) => contentType === 'application/x-ndjson',
+      ),
+    ).toBe(true)
+    expect(attempts.every(({ body }) => body === 'first')).toBe(true)
+    expect(clock.pendingTimers()).toBe(1)
+
+    serverUp = true
+    await clock.advanceBy(5_000)
+
+    const successful = attempts.filter(({ succeeded }) => succeeded)
+    expect(successful.map(({ body }) => body)).toEqual(['first', 'second'])
+    const firstIds = attempts
+      .filter(({ body }) => body === 'first')
+      .map(({ batchId }) => batchId)
+    expect(new Set(firstIds).size).toBe(1)
+    expect(firstIds[0]).not.toBe('')
+    expect(successful[1]?.batchId).not.toBe('')
+    expect(successful[1]?.batchId).not.toBe(firstIds[0])
+    expect(clock.pendingTimers()).toBe(0)
+  })
+
+  it('drops during the legacy TTL after a real 404, then attempts again', async () => {
+    const clock = createFakeClock()
+    const bodies: string[] = []
+    let status = 404
+    const relay = createRecordingsRelay({
+      resolveServerBaseUrl: async () => serverBaseUrl,
+      fetch: async (_input, init) => {
+        bodies.push(String(init?.body))
+        return Response.json(
+          status === 404 ? { ok: false } : { ok: true, accepted: 1 },
+          { status },
+        )
+      },
+      now: clock.now,
+      setTimeout: clock.setTimeout,
+      clearTimeout: clock.clearTimeout,
+      warn: () => {},
+    })
+
+    await relay.post(1, 'legacy-detected')
+    await relay.post(1, 'dropped-inside-ttl')
+    expect(bodies).toEqual(['legacy-detected'])
+    expect(clock.pendingTimers()).toBe(0)
+
+    status = 200
+    await clock.advanceBy(10 * 60_000)
+    await relay.post(1, 'after-ttl')
+    expect(bodies).toEqual(['legacy-detected', 'after-ttl'])
+  })
+
+  it('marks an evicted tab gapped and requests a resnapshot after recovery', async () => {
+    const clock = createFakeClock()
+    const recoveredTabs: number[] = []
+    let serverUp = false
+    const relay = createRecordingsRelay({
+      resolveServerBaseUrl: async () => serverBaseUrl,
+      fetch: async () => {
+        if (!serverUp) throw new TypeError('connection refused')
+        return Response.json({ ok: true, accepted: 1 })
+      },
+      now: clock.now,
+      setTimeout: clock.setTimeout,
+      clearTimeout: clock.clearTimeout,
+      warn: () => {},
+    })
+    relay.onTabRecoveredAfterLoss((tabId) => recoveredTabs.push(tabId))
+
+    await relay.post(1, 'a'.repeat(6 * 1024 * 1024))
+    await relay.post(2, 'b'.repeat(6 * 1024 * 1024))
+
+    serverUp = true
+    await clock.advanceBy(5_000)
+    expect(recoveredTabs).toEqual([])
+
+    await relay.post(1, 'fresh-checkpoint-request')
+    expect(recoveredTabs).toEqual([1])
+  })
+
+  it('drops an unknown-tab response without retrying and heals on the next success', async () => {
+    const clock = createFakeClock()
+    const bodies: string[] = []
+    const recoveredTabs: number[] = []
+    const relay = createRecordingsRelay({
+      resolveServerBaseUrl: async () => serverBaseUrl,
+      fetch: async (_input, init) => {
+        bodies.push(String(init?.body))
+        return bodies.length === 1
+          ? Response.json({ ok: false, reason: 'unknown tab' })
           : Response.json({ ok: true, accepted: 1 })
       },
+      now: clock.now,
+      setTimeout: clock.setTimeout,
+      clearTimeout: clock.clearTimeout,
+      warn: () => {},
     })
+    relay.onTabRecoveredAfterLoss((tabId) => recoveredTabs.push(tabId))
 
-    await relay.post(42, '{"ts":1,"type":3,"data":{}}')
+    await relay.post(7, 'terminal')
+    expect(clock.pendingTimers()).toBe(0)
 
-    expect(requests.map(({ url }) => url)).toEqual([
-      `${serverBaseUrl}/recordings/health`,
-      `${serverBaseUrl}/recordings/tabs/42/events`,
-    ])
-    expect(requests[1].init).toMatchObject({
-      method: 'POST',
-      headers: { 'content-type': 'application/x-ndjson' },
-      body: '{"ts":1,"type":3,"data":{}}',
-      credentials: 'omit',
-    })
-  })
-
-  it('drops batches quietly while an unhealthy probe is cached', async () => {
-    const requests: string[] = []
-    let now = 0
-    const warnings: unknown[][] = []
-    const relay = createRecordingsRelay({
-      resolveServerBaseUrl: async () => serverBaseUrl,
-      fetch: async (input) => {
-        requests.push(String(input))
-        return new Response('{}', { status: 404 })
-      },
-      now: () => now,
-      warn: (...args) => warnings.push(args),
-    })
-
-    await relay.post(1, 'first')
-    await relay.post(1, 'second')
-    expect(requests).toEqual([`${serverBaseUrl}/recordings/health`])
-    expect(warnings).toEqual([])
-
-    now = 60_000
-    await relay.post(1, 'third')
-    expect(requests).toEqual([
-      `${serverBaseUrl}/recordings/health`,
-      `${serverBaseUrl}/recordings/health`,
-    ])
-  })
-
-  it('re-probes on the next batch after a failed post', async () => {
-    const requests: string[] = []
-    const warnings: unknown[][] = []
-    let now = 0
-    const relay = createRecordingsRelay({
-      resolveServerBaseUrl: async () => serverBaseUrl,
-      fetch: async (input) => {
-        const url = String(input)
-        requests.push(url)
-        return url.endsWith('/health')
-          ? Response.json({ ok: true })
-          : new Response('{}', { status: 503 })
-      },
-      now: () => now,
-      warn: (...args) => warnings.push(args),
-    })
-
-    await relay.post(7, 'first')
-    await relay.post(7, 'second')
-
-    expect(requests).toEqual([
-      `${serverBaseUrl}/recordings/health`,
-      `${serverBaseUrl}/recordings/tabs/7/events`,
-      `${serverBaseUrl}/recordings/health`,
-      `${serverBaseUrl}/recordings/tabs/7/events`,
-    ])
-    expect(warnings).toHaveLength(1)
-
-    now = 60_000
-    await relay.post(7, 'third')
-    expect(warnings).toHaveLength(2)
-  })
-
-  it('rearms the warning after event ingestion recovers', async () => {
-    const warnings: unknown[][] = []
-    let eventPosts = 0
-    const relay = createRecordingsRelay({
-      resolveServerBaseUrl: async () => serverBaseUrl,
-      fetch: async (input) => {
-        const url = String(input)
-        if (url.endsWith('/health')) return Response.json({ ok: true })
-        eventPosts++
-        return eventPosts === 2
-          ? Response.json({ ok: true, accepted: 1 })
-          : new Response('{}', { status: 503 })
-      },
-      now: () => 0,
-      warn: (...args) => warnings.push(args),
-    })
-
-    await relay.post(7, 'failed')
-    await relay.post(7, 'recovered')
-    await relay.post(7, 'failed-again')
-
-    expect(warnings).toHaveLength(2)
+    await relay.post(7, 'next')
+    expect(bodies).toEqual(['terminal', 'next'])
+    expect(recoveredTabs).toEqual([7])
   })
 })

--- a/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.ts
@@ -252,7 +252,9 @@ export function createRecordingsRelay(
     }
   }
 
-  function markLegacy(): void {
+  function markLegacy(triggeringTabId: number): void {
+    gappedTabs.add(triggeringTabId)
+    for (const queuedTabId of queues.keys()) gappedTabs.add(queuedTabId)
     legacyUntil = now() + LEGACY_TTL_MS
     clearQueues()
   }
@@ -298,7 +300,7 @@ export function createRecordingsRelay(
           progressed = true
 
           if (outcome.kind === 'legacy') {
-            markLegacy()
+            markLegacy(tabId)
             return
           }
           if (outcome.kind === 'unknown-tab') {
@@ -319,7 +321,10 @@ export function createRecordingsRelay(
 
   async function post(tabId: number, ndjson: string): Promise<void> {
     try {
-      if (now() < legacyUntil) return
+      if (now() < legacyUntil) {
+        gappedTabs.add(tabId)
+        return
+      }
       const batch = makeBatch(ndjson)
       if ((queues.get(tabId)?.length ?? 0) > 0 || sendingTabs.has(tabId)) {
         addBatch(tabId, batch)
@@ -332,11 +337,12 @@ export function createRecordingsRelay(
       sendingTabs.delete(tabId)
 
       if (outcome.kind === 'legacy') {
-        markLegacy()
+        markLegacy(tabId)
         return
       }
       if (outcome.kind === 'transient') {
         if (now() >= legacyUntil) addBatch(tabId, batch, true)
+        else gappedTabs.add(tabId)
         warnRateLimited(
           'transient-send',
           '[browseros-claw replay] events POST failed',

--- a/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.ts
@@ -10,16 +10,14 @@ export type Fetcher = (
 ) => ReturnType<typeof globalThis.fetch>
 
 type TimerHandle = ReturnType<typeof globalThis.setTimeout>
-type SetTimer = (callback: () => void, delayMs: number) => TimerHandle
-type ClearTimer = (handle: TimerHandle) => void
 
 export interface RecordingsRelayOptions {
   resolveServerBaseUrl: () => Promise<string>
   fetch?: Fetcher
   now?: () => number
   warn?: (...args: unknown[]) => void
-  setTimeout?: SetTimer
-  clearTimeout?: ClearTimer
+  setTimeout?: (callback: () => void, delayMs: number) => TimerHandle
+  clearTimeout?: (handle: TimerHandle) => void
 }
 
 export interface RecordingsRelay {
@@ -207,6 +205,11 @@ export function createRecordingsRelay(
     }
   }
 
+  function markDeliverySuccess(tabId: number): void {
+    lastWarningAt.delete('transient-send')
+    notifyRecovered(tabId)
+  }
+
   async function sendBatch(
     tabId: number,
     batch: QueuedBatch,
@@ -301,7 +304,7 @@ export function createRecordingsRelay(
           if (outcome.kind === 'unknown-tab') {
             gappedTabs.add(tabId)
           } else {
-            notifyRecovered(tabId)
+            markDeliverySuccess(tabId)
           }
         }
       }
@@ -345,7 +348,7 @@ export function createRecordingsRelay(
       if (outcome.kind === 'unknown-tab') {
         gappedTabs.add(tabId)
       } else {
-        notifyRecovered(tabId)
+        markDeliverySuccess(tabId)
       }
 
       if ((queues.get(tabId)?.length ?? 0) > 0) await drainQueues()

--- a/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.ts
@@ -9,109 +9,361 @@ export type Fetcher = (
   init?: Parameters<typeof globalThis.fetch>[1],
 ) => ReturnType<typeof globalThis.fetch>
 
+type TimerHandle = ReturnType<typeof globalThis.setTimeout>
+type SetTimer = (callback: () => void, delayMs: number) => TimerHandle
+type ClearTimer = (handle: TimerHandle) => void
+
 export interface RecordingsRelayOptions {
   resolveServerBaseUrl: () => Promise<string>
   fetch?: Fetcher
   now?: () => number
   warn?: (...args: unknown[]) => void
+  setTimeout?: SetTimer
+  clearTimeout?: ClearTimer
 }
 
 export interface RecordingsRelay {
-  serverHasRecordings: () => Promise<boolean>
   post: (tabId: number, ndjson: string) => Promise<void>
+  onTabRecoveredAfterLoss: (listener: (tabId: number) => void) => () => void
 }
 
-const HEALTH_RETRY_MS = 60_000
+interface QueuedBatch {
+  batchId: string
+  ndjson: string
+  bytes: number
+}
+
+type SendOutcome =
+  | { kind: 'success' }
+  | { kind: 'legacy' }
+  | { kind: 'unknown-tab' }
+  | { kind: 'transient'; error: unknown }
+
+export const RECORDINGS_QUEUE_MAX_BYTES = 10 * 1024 * 1024
+const LEGACY_TTL_MS = 10 * 60_000
+const RETRY_INTERVAL_MS = 5_000
 const WARNING_INTERVAL_MS = 60_000
 
-/** Relays tab-scoped recorder batches only while the server supports ingestion. */
+/** Relays recorder batches in per-tab order and repairs streams after loss. */
 export function createRecordingsRelay(
   options: RecordingsRelayOptions,
 ): RecordingsRelay {
   const fetch = options.fetch ?? globalThis.fetch
   const now = options.now ?? Date.now
   const warn = options.warn ?? console.warn
-  let healthyBaseUrl: string | null = null
-  let unhealthyUntil = 0
-  let healthProbe: Promise<string | null> | null = null
-  let lastPostFailureWarningAt: number | null = null
+  const setTimer = options.setTimeout ?? globalThis.setTimeout
+  const clearTimer = options.clearTimeout ?? globalThis.clearTimeout
+  const encoder = new TextEncoder()
+  const queues = new Map<number, QueuedBatch[]>()
+  const queuedBytesByTab = new Map<number, number>()
+  const sendingTabs = new Set<number>()
+  const sendingQueuedBatchIds = new Set<string>()
+  const gappedTabs = new Set<number>()
+  const recoveredListeners = new Set<(tabId: number) => void>()
+  const lastWarningAt = new Map<string, number>()
+  let legacyUntil = 0
+  let totalBytes = 0
+  let queuedBatchCount = 0
+  let retryTimer: TimerHandle | null = null
+  let drainPromise: Promise<void> | null = null
 
-  async function probeServer(): Promise<string | null> {
+  function safeWarn(...args: unknown[]): void {
     try {
-      const baseUrl = await options.resolveServerBaseUrl()
-      const response = await fetch(`${baseUrl}/recordings/health`, {
-        credentials: 'omit',
-      })
-      if (!response.ok) {
-        unhealthyUntil = now() + HEALTH_RETRY_MS
-        return null
-      }
-      const body = (await response.json()) as { ok?: unknown }
-      if (body.ok !== true) {
-        unhealthyUntil = now() + HEALTH_RETRY_MS
-        return null
-      }
-      healthyBaseUrl = baseUrl
-      unhealthyUntil = 0
-      return baseUrl
+      warn(...args)
     } catch {
-      unhealthyUntil = now() + HEALTH_RETRY_MS
-      return null
+      // Logging must not change delivery behavior.
     }
   }
 
-  async function resolveHealthyBaseUrl(): Promise<string | null> {
-    if (healthyBaseUrl) return healthyBaseUrl
-    if (now() < unhealthyUntil) return null
-    if (!healthProbe) healthProbe = probeServer()
-    const currentProbe = healthProbe
-    try {
-      return await currentProbe
-    } finally {
-      if (healthProbe === currentProbe) healthProbe = null
-    }
-  }
-
-  function markPostFailure(error: unknown): void {
-    healthyBaseUrl = null
-    unhealthyUntil = 0
+  function warnRateLimited(
+    kind: string,
+    message: string,
+    error: unknown,
+  ): void {
     const timestamp = now()
-    if (
-      lastPostFailureWarningAt !== null &&
-      timestamp - lastPostFailureWarningAt < WARNING_INTERVAL_MS
-    ) {
-      return
-    }
-    lastPostFailureWarningAt = timestamp
-    warn('[browseros-claw replay] events POST failed', {
+    const lastAt = lastWarningAt.get(kind)
+    if (lastAt !== undefined && timestamp - lastAt < WARNING_INTERVAL_MS) return
+    lastWarningAt.set(kind, timestamp)
+    safeWarn(message, {
       error: error instanceof Error ? error.message : String(error),
     })
   }
 
-  return {
-    async serverHasRecordings(): Promise<boolean> {
-      return (await resolveHealthyBaseUrl()) !== null
-    },
-    async post(tabId, ndjson): Promise<void> {
-      const baseUrl = await resolveHealthyBaseUrl()
-      if (!baseUrl) return
-      try {
-        const response = await fetch(
-          `${baseUrl}/recordings/tabs/${tabId}/events`,
-          {
-            method: 'POST',
-            headers: { 'content-type': 'application/x-ndjson' },
-            body: ndjson,
-            credentials: 'omit',
-          },
+  function cancelRetry(): void {
+    if (retryTimer === null) return
+    clearTimer(retryTimer)
+    retryTimer = null
+  }
+
+  function reportQueueTransition(previousCount: number): void {
+    if (previousCount === 0 && queuedBatchCount > 0) {
+      safeWarn('[browseros-claw replay] delivery interrupted; events queued')
+    } else if (previousCount > 0 && queuedBatchCount === 0) {
+      safeWarn('[browseros-claw replay] queued event delivery recovered')
+    }
+  }
+
+  function addBatch(tabId: number, batch: QueuedBatch, atFront = false): void {
+    const previousCount = queuedBatchCount
+    const queue = queues.get(tabId)
+    if (queue) {
+      if (atFront) queue.unshift(batch)
+      else queue.push(batch)
+    } else {
+      queues.set(tabId, [batch])
+    }
+    queuedBytesByTab.set(
+      tabId,
+      (queuedBytesByTab.get(tabId) ?? 0) + batch.bytes,
+    )
+    totalBytes += batch.bytes
+    queuedBatchCount++
+    reportQueueTransition(previousCount)
+    enforceQueueBudget()
+  }
+
+  function removeBatchAt(tabId: number, index: number): QueuedBatch | null {
+    const queue = queues.get(tabId)
+    const batch = queue?.[index]
+    if (!queue || !batch) return null
+    const previousCount = queuedBatchCount
+    queue.splice(index, 1)
+    if (queue.length === 0) queues.delete(tabId)
+    const remainingBytes = (queuedBytesByTab.get(tabId) ?? 0) - batch.bytes
+    if (remainingBytes > 0) queuedBytesByTab.set(tabId, remainingBytes)
+    else queuedBytesByTab.delete(tabId)
+    totalBytes -= batch.bytes
+    queuedBatchCount--
+    reportQueueTransition(previousCount)
+    if (queuedBatchCount === 0) cancelRetry()
+    return batch
+  }
+
+  function removeBatch(tabId: number, batchId: string): QueuedBatch | null {
+    const index =
+      queues.get(tabId)?.findIndex((batch) => batch.batchId === batchId) ?? -1
+    return index === -1 ? null : removeBatchAt(tabId, index)
+  }
+
+  function clearQueues(): void {
+    if (queuedBatchCount === 0) return
+    const previousCount = queuedBatchCount
+    queues.clear()
+    queuedBytesByTab.clear()
+    totalBytes = 0
+    queuedBatchCount = 0
+    reportQueueTransition(previousCount)
+    cancelRetry()
+  }
+
+  function enforceQueueBudget(): void {
+    while (totalBytes > RECORDINGS_QUEUE_MAX_BYTES) {
+      let eviction:
+        | { tabId: number; batchIndex: number; queuedBytes: number }
+        | undefined
+      for (const [tabId, queue] of queues) {
+        const batchIndex = queue.findIndex(
+          (batch) => !sendingQueuedBatchIds.has(batch.batchId),
         )
-        if (!response.ok) {
-          throw new Error(`recordings ingest returned ${response.status}`)
+        if (batchIndex === -1) continue
+        const queuedBytes = queuedBytesByTab.get(tabId) ?? 0
+        if (!eviction || queuedBytes > eviction.queuedBytes) {
+          eviction = { tabId, batchIndex, queuedBytes }
         }
-        lastPostFailureWarningAt = null
-      } catch (error) {
-        markPostFailure(error)
       }
+      if (!eviction) return
+
+      // Evict from the largest producer so one hot tab cannot starve all others.
+      removeBatchAt(eviction.tabId, eviction.batchIndex)
+      gappedTabs.add(eviction.tabId)
+      warnRateLimited(
+        'queue-eviction',
+        '[browseros-claw replay] recording batch evicted under queue pressure',
+        `tab ${eviction.tabId}`,
+      )
+    }
+  }
+
+  function makeBatch(ndjson: string): QueuedBatch {
+    return {
+      batchId: crypto.randomUUID(),
+      ndjson,
+      bytes: encoder.encode(ndjson).byteLength,
+    }
+  }
+
+  function notifyRecovered(tabId: number): void {
+    if (!gappedTabs.delete(tabId)) return
+    for (const listener of recoveredListeners) {
+      try {
+        listener(tabId)
+      } catch (error) {
+        warnRateLimited(
+          'recovery-listener',
+          '[browseros-claw replay] recovery listener failed',
+          error,
+        )
+      }
+    }
+  }
+
+  async function sendBatch(
+    tabId: number,
+    batch: QueuedBatch,
+  ): Promise<SendOutcome> {
+    try {
+      const baseUrl = await options.resolveServerBaseUrl()
+      const response = await fetch(
+        `${baseUrl}/recordings/tabs/${tabId}/events`,
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/x-ndjson',
+            'X-Recording-Batch-Id': batch.batchId,
+          },
+          body: batch.ndjson,
+          credentials: 'omit',
+        },
+      )
+      if (response.status === 404) return { kind: 'legacy' }
+      if (!response.ok) {
+        return {
+          kind: 'transient',
+          error: new Error(`recordings ingest returned ${response.status}`),
+        }
+      }
+      try {
+        const body = (await response.json()) as {
+          ok?: unknown
+          reason?: unknown
+        }
+        if (body.ok === false && body.reason === 'unknown tab') {
+          return { kind: 'unknown-tab' }
+        }
+      } catch {
+        // Successful ingest responses may not have a JSON body.
+      }
+      return { kind: 'success' }
+    } catch (error) {
+      return { kind: 'transient', error }
+    }
+  }
+
+  function markLegacy(): void {
+    legacyUntil = now() + LEGACY_TTL_MS
+    clearQueues()
+  }
+
+  function armRetry(): void {
+    if (queuedBatchCount === 0 || retryTimer !== null) return
+    retryTimer = setTimer(() => {
+      retryTimer = null
+      return drainQueues()
+    }, RETRY_INTERVAL_MS)
+  }
+
+  async function drainQueues(): Promise<void> {
+    if (drainPromise) return drainPromise
+    cancelRetry()
+    const drain = async () => {
+      let progressed = true
+      while (progressed && queuedBatchCount > 0 && now() >= legacyUntil) {
+        progressed = false
+        for (const [tabId, queue] of [...queues]) {
+          const batch = queue[0]
+          if (!batch || sendingTabs.has(tabId)) continue
+          sendingTabs.add(tabId)
+          sendingQueuedBatchIds.add(batch.batchId)
+          const outcome = await sendBatch(tabId, batch)
+
+          if (outcome.kind === 'transient') {
+            sendingTabs.delete(tabId)
+            sendingQueuedBatchIds.delete(batch.batchId)
+            enforceQueueBudget()
+            warnRateLimited(
+              'transient-send',
+              '[browseros-claw replay] events POST failed',
+              outcome.error,
+            )
+            return
+          }
+
+          removeBatch(tabId, batch.batchId)
+          sendingTabs.delete(tabId)
+          sendingQueuedBatchIds.delete(batch.batchId)
+          enforceQueueBudget()
+          progressed = true
+
+          if (outcome.kind === 'legacy') {
+            markLegacy()
+            return
+          }
+          if (outcome.kind === 'unknown-tab') {
+            gappedTabs.add(tabId)
+          } else {
+            notifyRecovered(tabId)
+          }
+        }
+      }
+    }
+
+    drainPromise = drain().finally(() => {
+      drainPromise = null
+      armRetry()
+    })
+    return drainPromise
+  }
+
+  async function post(tabId: number, ndjson: string): Promise<void> {
+    try {
+      if (now() < legacyUntil) return
+      const batch = makeBatch(ndjson)
+      if ((queues.get(tabId)?.length ?? 0) > 0 || sendingTabs.has(tabId)) {
+        addBatch(tabId, batch)
+        await drainQueues()
+        return
+      }
+
+      sendingTabs.add(tabId)
+      const outcome = await sendBatch(tabId, batch)
+      sendingTabs.delete(tabId)
+
+      if (outcome.kind === 'legacy') {
+        markLegacy()
+        return
+      }
+      if (outcome.kind === 'transient') {
+        if (now() >= legacyUntil) addBatch(tabId, batch, true)
+        warnRateLimited(
+          'transient-send',
+          '[browseros-claw replay] events POST failed',
+          outcome.error,
+        )
+        armRetry()
+        return
+      }
+      if (outcome.kind === 'unknown-tab') {
+        gappedTabs.add(tabId)
+      } else {
+        notifyRecovered(tabId)
+      }
+
+      if ((queues.get(tabId)?.length ?? 0) > 0) await drainQueues()
+    } catch (error) {
+      sendingTabs.delete(tabId)
+      warnRateLimited(
+        'relay-internal',
+        '[browseros-claw replay] relay failed unexpectedly',
+        error,
+      )
+    }
+  }
+
+  return {
+    post,
+    onTabRecoveredAfterLoss(listener) {
+      recoveredListeners.add(listener)
+      return () => recoveredListeners.delete(listener)
     },
   }
 }

--- a/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.ts
@@ -42,7 +42,11 @@ const LEGACY_TTL_MS = 10 * 60_000
 const RETRY_INTERVAL_MS = 5_000
 const WARNING_INTERVAL_MS = 60_000
 
-/** Relays recorder batches in per-tab order and repairs streams after loss. */
+/**
+ * Session-lived delivery boundary between recorder content scripts and the
+ * local recordings ingest. It preserves each tab's rrweb order in memory and
+ * reports recovered gaps so the background can request a fresh checkpoint.
+ */
 export function createRecordingsRelay(
   options: RecordingsRelayOptions,
 ): RecordingsRelay {
@@ -253,6 +257,8 @@ export function createRecordingsRelay(
   }
 
   function markLegacy(triggeringTabId: number): void {
+    // A legacy verdict can outlive the server process that produced it. Keep
+    // dropped tabs gapped so a later endpoint can heal them after the TTL.
     gappedTabs.add(triggeringTabId)
     for (const queuedTabId of queues.keys()) gappedTabs.add(queuedTabId)
     legacyUntil = now() + LEGACY_TTL_MS

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -22,6 +22,7 @@ mock.module('./ReplayViewport', () => ({
   ReplayViewport: ({ events }: { events: readonly ReplayEvent[] }) => (
     <div
       data-player-targets={events.map((event) => event.targetId).join(',')}
+      data-player-types={events.map((event) => event.type).join(',')}
     />
   ),
 }))
@@ -133,6 +134,14 @@ const events: ReplayEvent[] = [
     sessionId: 'session-1',
     targetId: 'target-a',
     tabId: 1,
+    ts: 1_001,
+    type: 2,
+    data: {},
+  },
+  {
+    sessionId: 'session-1',
+    targetId: 'target-a',
+    tabId: 1,
     ts: 5_000,
     type: 3,
     data: {},
@@ -144,6 +153,14 @@ const events: ReplayEvent[] = [
     ts: 10_000,
     type: 4,
     data: { width: 1280, height: 720 },
+  },
+  {
+    sessionId: 'session-1',
+    targetId: 'target-b',
+    tabId: 2,
+    ts: 10_001,
+    type: 2,
+    data: {},
   },
   {
     sessionId: 'session-1',
@@ -276,11 +293,8 @@ describe('Replay', () => {
         (chip) => chip.textContent,
       ),
     ).toEqual(['Tab 1', 'Tab 2'])
-    expect(
-      container
-        .querySelector('[data-player-targets]')
-        ?.getAttribute('data-player-targets'),
-    ).toBe('')
+    expect(container.textContent).toContain('No visual recording for this tab')
+    expect(container.querySelector('[data-player-targets]')).toBeNull()
 
     replayResult = { ...replayResult, replay: replayData(events) }
     await act(async () => {
@@ -295,7 +309,7 @@ describe('Replay', () => {
       container
         .querySelector('[data-player-targets]')
         ?.getAttribute('data-player-targets'),
-    ).toBe('target-a,target-a')
+    ).toBe('target-a,target-a,target-a')
     expect(
       container
         .querySelector('[data-playback-playing]')
@@ -319,7 +333,7 @@ describe('Replay', () => {
       container
         .querySelector('[data-player-targets]')
         ?.getAttribute('data-player-targets'),
-    ).toBe('target-b,target-b')
+    ).toBe('target-b,target-b,target-b')
     expect(
       container
         .querySelector('[data-playback-time]')
@@ -355,12 +369,62 @@ describe('Replay', () => {
       container
         .querySelector('[data-player-targets]')
         ?.getAttribute('data-player-targets'),
-    ).toBe('target-a,target-a')
+    ).toBe('target-a,target-a,target-a')
     expect(
       container
         .querySelector('[data-playback-time]')
         ?.getAttribute('data-playback-time'),
     ).toBe('0')
+  })
+
+  it('slices orphan mutations and explains where visual playback starts', async () => {
+    const incompleteEvents: ReplayEvent[] = [
+      {
+        sessionId: 'session-1',
+        targetId: 'target-a',
+        tabId: 1,
+        ts: 1_000,
+        type: 3,
+        data: {},
+      },
+      {
+        sessionId: 'session-1',
+        targetId: 'target-a',
+        tabId: 1,
+        ts: 4_000,
+        type: 2,
+        data: {},
+      },
+      {
+        sessionId: 'session-1',
+        targetId: 'target-a',
+        tabId: 1,
+        ts: 5_000,
+        type: 3,
+        data: {},
+      },
+    ]
+    replayResult = {
+      ...replayResult,
+      replay: replayData(incompleteEvents),
+    }
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
+          <Replay />
+        </MemoryRouter>,
+      )
+    })
+
+    expect(
+      container
+        .querySelector('[data-player-types]')
+        ?.getAttribute('data-player-types'),
+    ).toBe('2,3')
+    expect(container.textContent).toContain(
+      'Recording incomplete — playback starts at 0:03',
+    )
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -69,7 +69,10 @@ export function Replay() {
     [selectedTargetId, tabViewInput],
   )
 
-  const playback = usePlayback(perTabView.totalSeconds)
+  const playbackTotalSeconds = perTabView.hasFullSnapshot
+    ? perTabView.totalSeconds
+    : 0
+  const playback = usePlayback(playbackTotalSeconds)
 
   useEffect(() => {
     playbackTimeRef.current = playback.time
@@ -94,7 +97,7 @@ export function Replay() {
   }, [playback.isPlaying])
 
   useEffect(() => {
-    if (!playback.isPlaying || perTabView.totalSeconds === 0) return
+    if (!playback.isPlaying || playbackTotalSeconds === 0) return
     let rafId = 0
     let active = true
     const sync = () => {
@@ -110,7 +113,7 @@ export function Replay() {
       active = false
       window.cancelAnimationFrame(rafId)
     }
-  }, [playback.isPlaying, playback.syncFromPlayer, perTabView.totalSeconds])
+  }, [playback.isPlaying, playback.syncFromPlayer, playbackTotalSeconds])
 
   const seekTo = useCallback(
     (seconds: number) => {
@@ -266,18 +269,35 @@ export function Replay() {
               </TabsList>
             </Tabs>
           )}
-          <ReplayViewport
-            site={replay.site}
-            frame={currentTabFrame}
-            events={perTabView.events}
-            onPlayerReady={onPlayerReady}
-          />
-          <PlaybackTransport
-            playback={playback}
-            totalSeconds={perTabView.totalSeconds}
-            frames={perTabView.frames}
-            onSeek={seekTo}
-          />
+          {perTabView.incompleteUntilMs !== null && (
+            <div
+              role="status"
+              className="rounded-lg border border-amber/30 bg-amber-tint px-3 py-2 font-medium text-ink-2 text-xs"
+            >
+              Recording incomplete — playback starts at{' '}
+              {formatIncompleteOffset(perTabView.incompleteUntilMs)}
+            </div>
+          )}
+          {perTabView.hasFullSnapshot ? (
+            <>
+              <ReplayViewport
+                site={replay.site}
+                frame={currentTabFrame}
+                events={perTabView.events}
+                onPlayerReady={onPlayerReady}
+              />
+              <PlaybackTransport
+                playback={playback}
+                totalSeconds={perTabView.totalSeconds}
+                frames={perTabView.frames}
+                onSeek={seekTo}
+              />
+            </>
+          ) : (
+            <div className="flex flex-1 items-center justify-center rounded-2xl border border-border-2 bg-card text-ink-3 text-sm shadow-sm">
+              No visual recording for this tab
+            </div>
+          )}
         </div>
         <EventTimeline
           frames={replay.frames}
@@ -287,4 +307,11 @@ export function Replay() {
       </div>
     </div>
   )
+}
+
+function formatIncompleteOffset(milliseconds: number): string {
+  const totalSeconds = Math.floor(milliseconds / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
 }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
@@ -33,8 +33,8 @@ function frame(
   }
 }
 
-function event(ts: number, targetId: string): ReplayEvent {
-  return { sessionId: 'test', targetId, tabId: 1, type: 3, data: {}, ts }
+function event(ts: number, targetId: string, type = 2): ReplayEvent {
+  return { sessionId: 'test', targetId, tabId: 1, type, data: {}, ts }
 }
 
 function makeInput(
@@ -164,6 +164,56 @@ describe('buildTabView', () => {
 
     expect(afterTaskPoll.events).toBe(first.events)
     expect(afterTaskPoll.frames).not.toBe(first.frames)
+  })
+
+  it('starts at the first full snapshot when leading mutations are orphaned', () => {
+    const events = [
+      event(1_001_000, 'target-a', 3),
+      event(1_002_000, 'target-a', 3),
+      event(1_004_000, 'target-a', 2),
+      event(1_005_000, 'target-a', 3),
+    ]
+    const view = buildTabView(
+      makeInput({ eventsForTarget: () => events }),
+      'target-a',
+    )
+
+    expect(view.events.map(({ type }) => type)).toEqual([2, 3])
+    expect(view.hasFullSnapshot).toBe(true)
+    expect(view.incompleteUntilMs).toBe(3_000)
+    expect(view.totalSeconds).toBe(1)
+  })
+
+  it('marks a target without a full snapshot as having no visual recording', () => {
+    const view = buildTabView(
+      makeInput({
+        eventsForTarget: () => [
+          event(1_001_000, 'target-a', 4),
+          event(1_002_000, 'target-a', 3),
+        ],
+      }),
+      'target-a',
+    )
+
+    expect(view.events).toEqual([])
+    expect(view.hasFullSnapshot).toBe(false)
+    expect(view.incompleteUntilMs).toBeNull()
+  })
+
+  it('keeps a clean stream including metadata before its full snapshot', () => {
+    const events = [
+      event(1_001_000, 'target-a', 4),
+      event(1_002_000, 'target-a', 2),
+      event(1_003_000, 'target-a', 3),
+    ]
+    const view = buildTabView(
+      makeInput({ eventsForTarget: () => events }),
+      'target-a',
+    )
+
+    expect(view.events).toBe(events)
+    expect(view.hasFullSnapshot).toBe(true)
+    expect(view.incompleteUntilMs).toBeNull()
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
@@ -12,7 +12,8 @@ import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
  *   - `frames`: filtered AND time-shifted so `t=0` is the tab's
  *     first activity, not session start.
  *   - `events`: pass-through. rrweb treats the first event's `ts`
- *     as the tab-relative playback origin.
+ *     as the tab-relative playback origin, except when leading orphan
+ *     mutations must be dropped before the first usable checkpoint.
  *   - `totalSeconds`: duration of this tab's activity window (from
  *     first event to last event). 0 for empty tabs.
  */
@@ -20,13 +21,20 @@ export interface TabView {
   frames: ReplayFrame[]
   events: readonly ReplayEvent[]
   totalSeconds: number
+  hasFullSnapshot: boolean
+  /** Captured time omitted before the first playable checkpoint. */
+  incompleteUntilMs: number | null
 }
 
 export const EMPTY_TAB_VIEW: TabView = {
   frames: [],
   events: [],
   totalSeconds: 0,
+  hasFullSnapshot: false,
+  incompleteUntilMs: null,
 }
+
+const NO_VISUAL_EVENTS: readonly ReplayEvent[] = []
 
 export interface BuildTabViewInput {
   frames: ReplayFrame[]
@@ -41,16 +49,33 @@ export function buildTabView(
 ): TabView {
   if (targetId === null) return EMPTY_TAB_VIEW
   const rawFrames = input.frames.filter((frame) => frame.targetId === targetId)
-  const events = input.eventsForTarget(targetId)
-  if (rawFrames.length === 0 && events.length === 0) return EMPTY_TAB_VIEW
+  const rawEvents = input.eventsForTarget(targetId)
+  if (rawFrames.length === 0 && rawEvents.length === 0) return EMPTY_TAB_VIEW
+  const firstSnapshotIndex = rawEvents.findIndex((event) => event.type === 2)
+  const hasFullSnapshot = firstSnapshotIndex !== -1
+  const hasLeadingMutation =
+    firstSnapshotIndex > 0 &&
+    rawEvents.slice(0, firstSnapshotIndex).some((event) => event.type === 3)
+  const events = !hasFullSnapshot
+    ? NO_VISUAL_EVENTS
+    : hasLeadingMutation
+      ? rawEvents.slice(firstSnapshotIndex)
+      : rawEvents
+  const incompleteUntilMs = hasLeadingMutation
+    ? Math.max(
+        0,
+        (rawEvents[firstSnapshotIndex]?.ts ?? 0) - (rawEvents[0]?.ts ?? 0),
+      )
+    : null
+  const timingEvents = hasFullSnapshot ? events : rawEvents
   const startedMs = input.startedAtMs
   const originMs =
-    events.length > 0
-      ? events[0]?.ts
+    timingEvents.length > 0
+      ? timingEvents[0]?.ts
       : startedMs + (rawFrames[0]?.t ?? 0) * 1000
   const endMs =
-    events.length > 0
-      ? events[events.length - 1]?.ts
+    timingEvents.length > 0
+      ? timingEvents[timingEvents.length - 1]?.ts
       : startedMs + (rawFrames[rawFrames.length - 1]?.t ?? 0) * 1000
   const totalSeconds = Math.max(0, (endMs - originMs) / 1000)
   const originT = (originMs - startedMs) / 1000
@@ -58,7 +83,13 @@ export function buildTabView(
     ...f,
     t: Math.max(0, f.t - originT),
   }))
-  return { frames, events, totalSeconds }
+  return {
+    frames,
+    events,
+    totalSeconds,
+    hasFullSnapshot,
+    incompleteUntilMs,
+  }
 }
 
 export interface TargetSeek {
@@ -78,17 +109,17 @@ export function targetSeekForFrame(
   const targetFrames = input.frames.filter(
     (candidate) => candidate.targetId === targetId,
   )
+  const targetView = buildTabView(input, targetId)
   if (frame.targetId == null) {
-    const targetEvents = input.eventsForTarget(targetId)
     const originT =
-      targetEvents.length > 0
-        ? ((targetEvents[0]?.ts ?? input.startedAtMs) - input.startedAtMs) /
+      targetView.events.length > 0
+        ? ((targetView.events[0]?.ts ?? input.startedAtMs) -
+            input.startedAtMs) /
           1000
         : (targetFrames[0]?.t ?? 0)
     return { targetId, seconds: Math.max(0, frame.t - originT) }
   }
   const targetFrameIndex = targetFrames.indexOf(frame)
-  const targetView = buildTabView(input, targetId)
   const shiftedFrame = targetView.frames[targetFrameIndex]
   return { targetId, seconds: shiftedFrame?.t ?? frame.t }
 }


### PR DESCRIPTION
## Summary

- replace probe-gated recording uploads with attempt-first delivery and bounded per-tab retry queues
- recover from dropped batches with stable batch IDs and fresh rrweb checkpoints
- show honest replay states for incomplete streams and tabs without a FullSnapshot

## Design

Recording POST outcomes now drive relay state. Transient failures retain batches in a 10 MB in-memory queue and retry every five seconds while preserving per-tab FIFO order. A confirmed 404 enters the ten-minute legacy interval, while every affected tab remains marked gapped so later recovery requests a FullSnapshot. The player starts at the first usable checkpoint and surfaces any omitted prefix.

## Test plan

- `bun run check`
- `bun run test`
- `bun run --filter @browseros/claw-app build`
- verified generated Chrome MV3 permissions and host permissions remain unchanged
- two adversarial review rounds; final round clean