### PR TITLE
test: lock Rust recording reliability parity

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings.rs
@@ -170,6 +170,7 @@ impl RecordingStore {
             self.release_append_handle(target_id).await;
             result?;
             if let Some(batch_id) = batch_id {
+                // Remember only committed batches so a failed append remains retryable.
                 self.remember_accepted_batch_id(target_id, batch_id).await;
             }
             Ok(true)
@@ -694,20 +695,109 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deduplicates_recent_batch_ids_per_target() -> anyhow::Result<()> {
+    async fn deduplicates_accepted_batch_ids_independently_per_target() -> anyhow::Result<()> {
         let dir = tempdir()?;
         let (_, store) = store(dir.path()).await?;
         assert!(
             store
-                .append_batch_with_id("target-dedupe", 23, &[event(1, "first")], Some("batch-0"))
+                .append_batch_with_id("target-dedupe", 23, &[event(1, "first")], Some("batch-a"))
                 .await?
         );
+        let before_retry =
+            tokio::fs::read(dir.path().join("recordings/target-dedupe.ndjson")).await?;
         assert!(
             !store
-                .append_batch_with_id("target-dedupe", 23, &[event(1, "first")], Some("batch-0"))
+                .append_batch_with_id("target-dedupe", 23, &[event(1, "first")], Some("batch-a"))
                 .await?
         );
-        for index in 1..=BATCH_ID_LRU_CAPACITY {
+        assert_eq!(
+            tokio::fs::read(dir.path().join("recordings/target-dedupe.ndjson")).await?,
+            before_retry
+        );
+        assert!(
+            store
+                .append_batch_with_id("target-other", 24, &[event(1, "first")], Some("batch-a"))
+                .await?
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn appends_every_batch_without_a_batch_id() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let (_, store) = store(dir.path()).await?;
+        store
+            .append_batch("target-no-id", 23, &[event(1, "first")])
+            .await?;
+        store
+            .append_batch("target-no-id", 23, &[event(1, "first")])
+            .await?;
+
+        let text =
+            tokio::fs::read_to_string(dir.path().join("recordings/target-no-id.ndjson")).await?;
+        assert_eq!(text.lines().count(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn serializes_concurrent_retries_before_checking_the_batch_id() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let (_, store) = store(dir.path()).await?;
+        let events = [event(1, "first")];
+        let first = store.append_batch_with_id("target-concurrent", 23, &events, Some("batch-a"));
+        let second = store.append_batch_with_id("target-concurrent", 23, &events, Some("batch-a"));
+
+        let (first, second) = tokio::join!(first, second);
+        let mut results = [first?, second?];
+        results.sort_unstable();
+        assert_eq!(results, [false, true]);
+        let text =
+            tokio::fs::read_to_string(dir.path().join("recordings/target-concurrent.ndjson"))
+                .await?;
+        assert_eq!(text.lines().count(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn remembers_a_batch_id_only_after_append_succeeds() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let (_, store) = store(dir.path()).await?;
+        let recordings_path = dir.path().join("recordings");
+        tokio::fs::write(&recordings_path, b"not a directory").await?;
+
+        assert!(
+            store
+                .append_batch_with_id(
+                    "target-retry",
+                    23,
+                    &[event(1, "retry")],
+                    Some("batch-retry")
+                )
+                .await
+                .is_err()
+        );
+        tokio::fs::remove_file(&recordings_path).await?;
+
+        assert!(
+            store
+                .append_batch_with_id(
+                    "target-retry",
+                    23,
+                    &[event(1, "retry")],
+                    Some("batch-retry")
+                )
+                .await?
+        );
+        let text = tokio::fs::read_to_string(recordings_path.join("target-retry.ndjson")).await?;
+        assert_eq!(text.lines().count(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn evicts_the_least_recently_used_batch_id_after_256_entries() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let (_, store) = store(dir.path()).await?;
+        for index in 0..BATCH_ID_LRU_CAPACITY {
             let batch_id = format!("batch-{index}");
             assert!(
                 store
@@ -721,12 +811,32 @@ mod tests {
             );
         }
         assert!(
+            !store
+                .append_batch_with_id("target-dedupe", 23, &[event(1, "first")], Some("batch-0"))
+                .await?
+        );
+        assert!(
+            store
+                .append_batch_with_id(
+                    "target-dedupe",
+                    23,
+                    &[event(257, "next")],
+                    Some("batch-256")
+                )
+                .await?
+        );
+        assert!(
+            !store
+                .append_batch_with_id("target-dedupe", 23, &[event(1, "first")], Some("batch-0"))
+                .await?
+        );
+        assert!(
             store
                 .append_batch_with_id(
                     "target-dedupe",
                     23,
                     &[event(999, "evicted")],
-                    Some("batch-0")
+                    Some("batch-1")
                 )
                 .await?
         );

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings.rs
@@ -761,9 +761,15 @@ mod tests {
     #[tokio::test]
     async fn remembers_a_batch_id_only_after_append_succeeds() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let (_, store) = store(dir.path()).await?;
-        let recordings_path = dir.path().join("recordings");
-        tokio::fs::write(&recordings_path, b"not a directory").await?;
+        let (audit, store) = store(dir.path()).await?;
+        audit
+            .connection()
+            .execute_unprepared(
+                "CREATE TRIGGER fail_recording_catalog
+                 BEFORE INSERT ON tab_recordings
+                 BEGIN SELECT RAISE(FAIL, 'catalog unavailable'); END",
+            )
+            .await?;
 
         assert!(
             store
@@ -776,7 +782,12 @@ mod tests {
                 .await
                 .is_err()
         );
-        tokio::fs::remove_file(&recordings_path).await?;
+        let recording_path = dir.path().join("recordings/target-retry.ndjson");
+        assert_eq!(tokio::fs::read(&recording_path).await?, b"");
+        audit
+            .connection()
+            .execute_unprepared("DROP TRIGGER fail_recording_catalog")
+            .await?;
 
         assert!(
             store
@@ -788,8 +799,13 @@ mod tests {
                 )
                 .await?
         );
-        let text = tokio::fs::read_to_string(recordings_path.join("target-retry.ndjson")).await?;
+        let text = tokio::fs::read_to_string(recording_path).await?;
         assert_eq!(text.lines().count(), 1);
+        let row = TabRecordings::find_by_id("target-retry")
+            .one(audit.connection())
+            .await?
+            .unwrap_or_else(|| panic!("catalog row missing"));
+        assert_eq!(row.event_count, 1);
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/tab_targets.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/tab_targets.rs
@@ -17,7 +17,7 @@ use tokio::time::Instant;
 use tracing::warn;
 
 const NO_EPOCH: u64 = u64::MAX;
-const DESTROYED_TARGET_GRACE: Duration = Duration::from_secs(5 * 60);
+const GRACE_MS: u64 = 5 * 60 * 1_000;
 
 type TargetClaimReleaser = Arc<dyn Fn(String) -> BoxFuture<'static, AppResult<()>> + Send + Sync>;
 
@@ -40,8 +40,8 @@ impl TabIdentity {
 struct TargetMaps {
     target_by_tab: HashMap<i64, String>,
     tab_by_target: HashMap<String, i64>,
-    /// Chrome tab ids increase monotonically within a browser session, so live
-    /// entries cannot alias these destroyed entries.
+    /// Chrome never reuses tab ids within a browser session, so live entries
+    /// cannot alias these destroyed entries; lookups still prefer live.
     recently_destroyed: HashMap<i64, RecentlyDestroyed>,
 }
 
@@ -329,8 +329,9 @@ impl TabTargetMap {
 }
 
 fn prune_recently_destroyed(maps: &mut TargetMaps, now: Instant) {
-    maps.recently_destroyed
-        .retain(|_, entry| now.duration_since(entry.destroyed_at) < DESTROYED_TARGET_GRACE);
+    maps.recently_destroyed.retain(|_, entry| {
+        now.duration_since(entry.destroyed_at) < Duration::from_millis(GRACE_MS)
+    });
 }
 
 #[cfg(test)]
@@ -546,7 +547,7 @@ mod tests {
                 None
             })
             .await;
-        tokio::time::advance(super::DESTROYED_TARGET_GRACE).await;
+        tokio::time::advance(Duration::from_millis(super::GRACE_MS)).await;
         let after_grace = map
             .resolve_with(55, |_| async {
                 calls.fetch_add(1, Ordering::SeqCst);

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -230,7 +230,7 @@ async fn recordings_pipeline_ingests_and_replays_only_the_claimed_target() -> an
     let retry = Request::builder()
         .method("POST")
         .uri("/recordings/tabs/11/events")
-        .header("x-recording-batch-id", "batch-a")
+        .header("X-Recording-Batch-Id", "batch-a")
         .body(Body::from(first_body))?;
     let response = app.router.clone().oneshot(retry).await?;
     assert_eq!(response.status(), StatusCode::OK);


### PR DESCRIPTION
## Summary
- align the Rust destroyed-target grace constant with the TypeScript `GRACE_MS` contract and preserve the tab-id non-reuse invariant
- port the missing retry-dedupe matrix for target isolation, absent headers, concurrent retries, post-catalog failure recovery, and true LRU eviction at 257 entries
- verify mixed-case `X-Recording-Batch-Id` retries return the existing successful `accepted: 0` response without duplicate events

## Design
`21815a767` already contained both reliability mechanisms, so this keeps the shipped Rust implementation intact and adds the exact cross-port naming and regression contracts. Dedupe stays in the per-target serialized append boundary and remains in-memory; destroyed-target grace remains append-resolution-only while claims close immediately.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo build -p claw-server-rust`
- [x] `cargo clippy -p claw-server-rust`
- [x] `cargo test -p claw-server-rust`
- [x] `bun run check`
- [x] `bun run test`
