### PR TITLE
refactor(claw-server-rust): typed per-family route modules

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/agents.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/agents.rs
@@ -1,0 +1,46 @@
+use super::wire::WireJson;
+use crate::{AppState, ids::ConvoId};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct CancelOutcome {
+    cancelled: usize,
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'static str>,
+}
+
+pub(super) async fn cancel(
+    State(state): State<AppState>,
+    Path(agent_id): Path<String>,
+) -> Response {
+    let cancelled = state
+        .sessions
+        .cancel_by_convo(&ConvoId::from(agent_id.as_str()))
+        .await;
+    if cancelled == 0 {
+        // claw-app parses this 404 body as a CancelAgentResult (idle state,
+        // not a failure), so it must keep the TS shape, not `{"error":...}`.
+        return (
+            StatusCode::NOT_FOUND,
+            WireJson(CancelOutcome {
+                cancelled: 0,
+                ok: false,
+                reason: Some("no active dispatches for this agent"),
+            }),
+        )
+            .into_response();
+    }
+    tracing::info!(%agent_id, cancelled, "cancelled in-flight dispatches for agent");
+    WireJson(CancelOutcome {
+        cancelled,
+        ok: true,
+        reason: None,
+    })
+    .into_response()
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/audit.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/audit.rs
@@ -1,0 +1,111 @@
+use super::wire::WireJson;
+use crate::{
+    AppState,
+    error::{AppError, AppResult},
+    services::audit::{
+        ListDispatchesQuery, ListDispatchesResult, ListTasksQuery, ListTasksResult, TaskDetail,
+        TaskStatus,
+    },
+};
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderValue, header},
+    response::IntoResponse,
+};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct DispatchesQuery {
+    agent_id: Option<String>,
+    session_id: Option<String>,
+    cursor: Option<i64>,
+    limit: Option<i64>,
+}
+
+pub(super) async fn dispatches(
+    State(state): State<AppState>,
+    Query(query): Query<DispatchesQuery>,
+) -> AppResult<WireJson<ListDispatchesResult>> {
+    validate_limit(query.limit, 500)?;
+    let result = state
+        .audit
+        .list_dispatches(ListDispatchesQuery {
+            agent_id: query.agent_id,
+            session_id: query.session_id,
+            cursor: query.cursor,
+            limit: query.limit,
+        })
+        .await?;
+    Ok(WireJson(result))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct TasksQuery {
+    agent_id: Option<String>,
+    status: Option<TaskStatus>,
+    site: Option<String>,
+    search: Option<String>,
+    since: Option<i64>,
+    cursor: Option<i64>,
+    limit: Option<i64>,
+}
+
+pub(super) async fn tasks(
+    State(state): State<AppState>,
+    Query(query): Query<TasksQuery>,
+) -> AppResult<WireJson<ListTasksResult>> {
+    validate_limit(query.limit, 100)?;
+    let result = state
+        .audit
+        .list_tasks(ListTasksQuery {
+            agent_id: query.agent_id,
+            status: query.status,
+            site: query.site,
+            search: query.search,
+            since: query.since,
+            cursor: query.cursor,
+            limit: query.limit,
+        })
+        .await?;
+    Ok(WireJson(result))
+}
+
+pub(super) async fn task_detail(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> AppResult<WireJson<TaskDetail>> {
+    let task = state
+        .audit
+        .get_task(&session_id)
+        .await?
+        .ok_or_else(|| AppError::not_found("not found"))?;
+    Ok(WireJson(task))
+}
+
+pub(super) async fn screenshot(
+    State(state): State<AppState>,
+    Path(dispatch_id): Path<String>,
+) -> AppResult<impl IntoResponse> {
+    let bytes = state.screenshots.read(&dispatch_id).await?;
+    Ok((
+        [
+            (header::CONTENT_TYPE, HeaderValue::from_static("image/jpeg")),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=86400, immutable"),
+            ),
+        ],
+        bytes,
+    ))
+}
+
+fn validate_limit(limit: Option<i64>, cap: i64) -> AppResult<()> {
+    if let Some(limit) = limit
+        && (limit <= 0 || limit > cap)
+    {
+        return Err(AppError::bad_request("limit out of range"));
+    }
+    Ok(())
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/connections.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/connections.rs
@@ -1,0 +1,43 @@
+use super::wire::WireJson;
+use crate::{
+    AppState,
+    error::AppResult,
+    services::harness::{ConnectionState, Harness},
+};
+use axum::extract::{Path, State};
+use serde::Serialize;
+use std::str::FromStr;
+
+#[derive(Debug, Serialize)]
+pub(super) struct ConnectionsResponse {
+    connections: Vec<ConnectionState>,
+}
+
+pub(super) async fn list(
+    State(state): State<AppState>,
+) -> AppResult<WireJson<ConnectionsResponse>> {
+    Ok(WireJson(ConnectionsResponse {
+        connections: state.harness.list_browseros_connections().await?,
+    }))
+}
+
+pub(super) async fn connect(
+    State(state): State<AppState>,
+    Path(harness): Path<String>,
+) -> AppResult<WireJson<ConnectionState>> {
+    let harness = Harness::from_str(&harness)?;
+    let result = state
+        .harness
+        .connect_browseros(harness, &state.config.public_mcp_url())
+        .await?;
+    Ok(WireJson(result))
+}
+
+pub(super) async fn disconnect(
+    State(state): State<AppState>,
+    Path(harness): Path<String>,
+) -> AppResult<WireJson<ConnectionState>> {
+    let harness = Harness::from_str(&harness)?;
+    let result = state.harness.disconnect_browseros(harness).await?;
+    Ok(WireJson(result))
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
@@ -1,63 +1,53 @@
-use crate::{
-    AppState,
-    error::{AppError, AppResult},
-    ids::ConvoId,
-    mcp::streamable_http_service,
-    services::{
-        audit::{ListDispatchesQuery, ListTasksQuery, TaskStatus},
-        harness::Harness,
-        recordings::RecordingEventInput,
-        tab_activity::EnrichedTabRecord,
-    },
-    tabs::hex_for_slug,
-};
+mod agents;
+mod audit;
+mod connections;
+mod replay;
+mod system;
+mod tabs;
+mod wire;
+
+use crate::{AppState, error::AppError, mcp::streamable_http_service};
 use axum::{
-    Json, Router,
-    body::to_bytes,
-    extract::{Path, Query, Request, State},
+    Router,
+    extract::Request,
     http::{HeaderValue, Method, StatusCode, header},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
-use serde::Deserialize;
-use serde_json::{Value, json};
-use std::{collections::HashMap, str::FromStr, time::Instant};
+use std::time::Instant;
 use tracing::{Instrument, info_span};
 use ulid::Ulid;
 
-const MAX_RECORDING_BODY_BYTES: usize = 8 * 1024 * 1024;
-const MAX_SAFE_TAB_ID: i64 = 9_007_199_254_740_991;
-
 pub fn router(state: AppState) -> Router<AppState> {
     Router::new()
-        .route("/system/health", get(system_health))
-        .route("/system/shutdown", post(system_shutdown))
-        .route("/system/version", get(system_version))
-        .route("/system/url", get(system_url))
+        .route("/system/health", get(system::health))
+        .route("/system/shutdown", post(system::shutdown))
+        .route("/system/version", get(system::version))
+        .route("/system/url", get(system::url))
         .route(
             "/system/telemetry",
-            get(system_telemetry).post(system_telemetry_consent),
+            get(system::telemetry).post(system::telemetry_consent),
         )
-        .route("/agents/{agent_id}/cancel", post(agents_cancel))
-        .route("/tabs/activity", get(tabs_activity))
-        .route("/connections", get(connections_list))
-        .route("/connections/{harness}/connect", post(connections_connect))
+        .route("/agents/{agent_id}/cancel", post(agents::cancel))
+        .route("/tabs/activity", get(tabs::activity))
+        .route("/connections", get(connections::list))
+        .route("/connections/{harness}/connect", post(connections::connect))
         .route(
             "/connections/{harness}/disconnect",
-            post(connections_disconnect),
+            post(connections::disconnect),
         )
-        .route("/audit/dispatches", get(audit_dispatches))
-        .route("/audit/tasks", get(audit_tasks))
-        .route("/audit/tasks/{session_id}", get(audit_task_detail))
-        .route("/audit/screenshot/{dispatch_id}", get(audit_screenshot))
-        .route("/recordings/health", get(recordings_health))
+        .route("/audit/dispatches", get(audit::dispatches))
+        .route("/audit/tasks", get(audit::tasks))
+        .route("/audit/tasks/{session_id}", get(audit::task_detail))
+        .route("/audit/screenshot/{dispatch_id}", get(audit::screenshot))
+        .route("/recordings/health", get(replay::recordings_health))
         .route(
             "/recordings/tabs/{tab_id}/events",
-            post(recordings_post_events),
+            post(replay::post_recording_events),
         )
-        .route("/audit/replays/{session_id}", get(audit_replay_get))
-        .route("/audit/replays/{session_id}/meta", get(audit_replay_meta))
+        .route("/audit/replays/{session_id}", get(replay::get))
+        .route("/audit/replays/{session_id}/meta", get(replay::meta))
         .nest_service(
             "/mcp",
             Router::new()
@@ -151,360 +141,4 @@ async fn route_fallback(request: Request) -> StatusCode {
     } else {
         StatusCode::NOT_FOUND
     }
-}
-
-async fn system_health(State(state): State<AppState>) -> Json<Value> {
-    let cdp = state.browser.state();
-    Json(json!({
-        "status": "ok",
-        "cdp": cdp,
-        "sessions": {
-            "count": state.sessions.count().await
-        }
-    }))
-}
-
-async fn system_shutdown(State(state): State<AppState>) -> AppResult<Json<Value>> {
-    let drained = state.sessions.shutdown().await?;
-    state.audit.drain_claim_writes().await;
-    state.recordings.close().await;
-    state.screencast.stop();
-    state.browser.stop();
-    if let Some(tx) = state.shutdown.lock().await.take() {
-        let _ = tx.send(());
-    }
-    Ok(Json(json!({ "status": "ok", "drainedSessions": drained })))
-}
-
-async fn system_version() -> Json<Value> {
-    Json(json!({
-        "name": env!("CARGO_PKG_NAME"),
-        "version": env!("CARGO_PKG_VERSION"),
-    }))
-}
-
-async fn system_url(State(state): State<AppState>) -> Json<Value> {
-    Json(json!({ "url": state.config.local_server_url() }))
-}
-
-async fn system_telemetry(State(state): State<AppState>) -> Json<Value> {
-    Json(json!(state.telemetry.get_state().await))
-}
-
-#[derive(Debug, Deserialize)]
-struct TelemetryConsent {
-    consent: bool,
-}
-
-async fn system_telemetry_consent(
-    State(state): State<AppState>,
-    Json(input): Json<TelemetryConsent>,
-) -> Json<Value> {
-    Json(json!(state.telemetry.set_consent(input.consent).await))
-}
-
-async fn agents_cancel(State(state): State<AppState>, Path(agent_id): Path<String>) -> Response {
-    let cancelled = state
-        .sessions
-        .cancel_by_convo(&ConvoId::from(agent_id.as_str()))
-        .await;
-    if cancelled == 0 {
-        // claw-app parses this 404 body as a CancelAgentResult (idle state,
-        // not a failure), so it must keep the TS shape, not `{"error":...}`.
-        return (
-            StatusCode::NOT_FOUND,
-            Json(json!({
-                "ok": false,
-                "cancelled": 0,
-                "reason": "no active dispatches for this agent",
-            })),
-        )
-            .into_response();
-    }
-    tracing::info!(%agent_id, cancelled, "cancelled in-flight dispatches for agent");
-    Json(json!({ "ok": true, "cancelled": cancelled })).into_response()
-}
-
-async fn tabs_activity(State(state): State<AppState>) -> AppResult<Json<Value>> {
-    state.screencast.note_read();
-    let profiles = state.agents.list_profiles().await?;
-    let live_sessions = state.sessions.snapshot().await;
-    let sessions_by_agent_id = live_sessions
-        .iter()
-        .map(|session| (session.convo_id().as_str(), session))
-        .collect::<HashMap<_, _>>();
-    let tabs = state.tab_activity.snapshot().await;
-    let mut enriched = Vec::with_capacity(tabs.len());
-    for record in tabs {
-        let session = sessions_by_agent_id.get(record.agent_id.as_str()).copied();
-        let profile = session
-            .and_then(|session| session.agent().profile_id())
-            .and_then(|profile_id| {
-                profiles
-                    .iter()
-                    .find(|profile| profile.id == profile_id.as_str())
-            });
-        enriched.push(EnrichedTabRecord {
-            agent_label: profile
-                .map(|profile| profile.name.clone())
-                .or_else(|| session.map(|session| session.agent().label().to_string()))
-                .unwrap_or_else(|| record.slug.clone()),
-            harness: profile.map(|profile| profile.harness.to_string()),
-            color: Some(hex_for_slug(&record.slug).to_string()),
-            screencast: state.screencast.frame_for(record.page_id).await,
-            record,
-        });
-    }
-    Ok(Json(json!({ "tabs": enriched })))
-}
-
-async fn connections_list(State(state): State<AppState>) -> AppResult<Json<Value>> {
-    Ok(Json(json!({
-        "connections": state.harness.list_browseros_connections().await?
-    })))
-}
-
-async fn connections_connect(
-    State(state): State<AppState>,
-    Path(harness): Path<String>,
-) -> AppResult<Json<Value>> {
-    let harness = Harness::from_str(&harness)?;
-    let result = state
-        .harness
-        .connect_browseros(harness, &state.config.public_mcp_url())
-        .await?;
-    Ok(Json(serde_json::to_value(result)?))
-}
-
-async fn connections_disconnect(
-    State(state): State<AppState>,
-    Path(harness): Path<String>,
-) -> AppResult<Json<Value>> {
-    let harness = Harness::from_str(&harness)?;
-    let result = state.harness.disconnect_browseros(harness).await?;
-    Ok(Json(serde_json::to_value(result)?))
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct DispatchesQuery {
-    agent_id: Option<String>,
-    session_id: Option<String>,
-    cursor: Option<i64>,
-    limit: Option<i64>,
-}
-
-async fn audit_dispatches(
-    State(state): State<AppState>,
-    Query(query): Query<DispatchesQuery>,
-) -> AppResult<Json<Value>> {
-    validate_limit(query.limit, 500)?;
-    let result = state
-        .audit
-        .list_dispatches(ListDispatchesQuery {
-            agent_id: query.agent_id,
-            session_id: query.session_id,
-            cursor: query.cursor,
-            limit: query.limit,
-        })
-        .await?;
-    Ok(Json(serde_json::to_value(result)?))
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct TasksQuery {
-    agent_id: Option<String>,
-    status: Option<TaskStatus>,
-    site: Option<String>,
-    search: Option<String>,
-    since: Option<i64>,
-    cursor: Option<i64>,
-    limit: Option<i64>,
-}
-
-async fn audit_tasks(
-    State(state): State<AppState>,
-    Query(query): Query<TasksQuery>,
-) -> AppResult<Json<Value>> {
-    validate_limit(query.limit, 100)?;
-    let result = state
-        .audit
-        .list_tasks(ListTasksQuery {
-            agent_id: query.agent_id,
-            status: query.status,
-            site: query.site,
-            search: query.search,
-            since: query.since,
-            cursor: query.cursor,
-            limit: query.limit,
-        })
-        .await?;
-    Ok(Json(serde_json::to_value(result)?))
-}
-
-async fn audit_task_detail(
-    State(state): State<AppState>,
-    Path(session_id): Path<String>,
-) -> AppResult<Json<Value>> {
-    let task = state
-        .audit
-        .get_task(&session_id)
-        .await?
-        .ok_or_else(|| AppError::not_found("not found"))?;
-    Ok(Json(serde_json::to_value(task)?))
-}
-
-async fn audit_screenshot(
-    State(state): State<AppState>,
-    Path(dispatch_id): Path<String>,
-) -> AppResult<impl IntoResponse> {
-    let bytes = state.screenshots.read(&dispatch_id).await?;
-    Ok((
-        [
-            (header::CONTENT_TYPE, HeaderValue::from_static("image/jpeg")),
-            (
-                header::CACHE_CONTROL,
-                HeaderValue::from_static("public, max-age=86400, immutable"),
-            ),
-        ],
-        bytes,
-    ))
-}
-
-async fn recordings_health() -> Json<Value> {
-    Json(json!({ "ok": true }))
-}
-
-async fn recordings_post_events(
-    State(state): State<AppState>,
-    Path(tab_id): Path<String>,
-    request: Request,
-) -> Response {
-    if request
-        .headers()
-        .get(header::CONTENT_LENGTH)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<usize>().ok())
-        .is_some_and(|length| length > MAX_RECORDING_BODY_BYTES)
-    {
-        return StatusCode::PAYLOAD_TOO_LARGE.into_response();
-    }
-    let batch_id = request
-        .headers()
-        .get("x-recording-batch-id")
-        .and_then(|value| value.to_str().ok())
-        .map(str::to_owned);
-    let bytes = match to_bytes(request.into_body(), MAX_RECORDING_BODY_BYTES + 1).await {
-        Ok(bytes) if bytes.len() <= MAX_RECORDING_BODY_BYTES => bytes,
-        Ok(_) | Err(_) => return StatusCode::PAYLOAD_TOO_LARGE.into_response(),
-    };
-    let tab_id = tab_id
-        .chars()
-        .all(|ch| ch.is_ascii_digit())
-        .then(|| tab_id.parse::<i64>().ok())
-        .flatten()
-        .filter(|tab_id| *tab_id <= MAX_SAFE_TAB_ID);
-    let target_id = match tab_id {
-        Some(tab_id) => {
-            let browser = state.browser.state();
-            state
-                .tab_targets
-                .resolve(tab_id, state.browser.session().await, browser.epoch)
-                .await
-        }
-        None => None,
-    };
-    let (Some(tab_id), Some(target_id)) = (tab_id, target_id) else {
-        return Json(json!({
-            "ok": false,
-            "reason": "unknown tab",
-            "accepted": 0,
-        }))
-        .into_response();
-    };
-    let events = String::from_utf8_lossy(&bytes)
-        .lines()
-        .filter_map(parse_recording_event)
-        .collect::<Vec<_>>();
-    if events.is_empty() {
-        return Json(json!({ "ok": true, "accepted": 0 })).into_response();
-    }
-    let appended = match state
-        .recordings
-        .append_batch_with_id(&target_id, tab_id, &events, batch_id.as_deref())
-        .await
-    {
-        Ok(appended) => appended,
-        Err(error) => {
-            tracing::warn!(tab_id, target_id, error = %error, "recording batch append failed");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({
-                    "ok": false,
-                    "reason": "append failed",
-                    "accepted": 0,
-                })),
-            )
-                .into_response();
-        }
-    };
-    if !appended {
-        return Json(json!({ "ok": true, "accepted": 0 })).into_response();
-    }
-    Json(json!({ "ok": true, "accepted": events.len() })).into_response()
-}
-
-fn parse_recording_event(line: &str) -> Option<RecordingEventInput> {
-    if line.trim().is_empty() {
-        return None;
-    }
-    let value = serde_json::from_str::<Value>(line).ok()?;
-    let event = value.as_object()?;
-    Some(RecordingEventInput {
-        ts: event.get("ts")?.as_i64()?,
-        event_type: event.get("type").cloned(),
-        data: event.get("data").cloned(),
-    })
-}
-
-async fn audit_replay_get(
-    State(state): State<AppState>,
-    Path(session_id): Path<String>,
-) -> AppResult<Response> {
-    let events = state.replays.read_session(&session_id).await?;
-    if events.is_empty() {
-        return Ok((
-            StatusCode::NOT_FOUND,
-            Json(json!({
-                "ok": false,
-                "reason": "no replay for this session",
-            })),
-        )
-            .into_response());
-    }
-    let mut body = String::new();
-    for event in events {
-        body.push_str(&serde_json::to_string(&event)?);
-        body.push('\n');
-    }
-    Ok(([(header::CONTENT_TYPE, "application/x-ndjson")], body).into_response())
-}
-
-async fn audit_replay_meta(
-    State(state): State<AppState>,
-    Path(session_id): Path<String>,
-) -> AppResult<Json<Value>> {
-    Ok(Json(serde_json::to_value(
-        state.replays.meta(&session_id).await?,
-    )?))
-}
-
-fn validate_limit(limit: Option<i64>, cap: i64) -> AppResult<()> {
-    if let Some(limit) = limit
-        && (limit <= 0 || limit > cap)
-    {
-        return Err(AppError::bad_request("limit out of range"));
-    }
-    Ok(())
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/replay.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/replay.rs
@@ -1,0 +1,177 @@
+use super::wire::WireJson;
+use crate::{
+    AppState,
+    error::AppResult,
+    services::{recordings::RecordingEventInput, replays::ReplayMeta},
+};
+use axum::{
+    body::to_bytes,
+    extract::{Path, Request, State},
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+use serde_json::Value;
+
+const MAX_RECORDING_BODY_BYTES: usize = 8 * 1024 * 1024;
+const MAX_SAFE_TAB_ID: i64 = 9_007_199_254_740_991;
+
+#[derive(Debug, Serialize)]
+pub(super) struct RecordingHealthResponse {
+    ok: bool,
+}
+
+pub(super) async fn recordings_health() -> WireJson<RecordingHealthResponse> {
+    WireJson(RecordingHealthResponse { ok: true })
+}
+
+#[derive(Debug, Serialize)]
+struct RecordEventsOutcome {
+    accepted: usize,
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'static str>,
+}
+
+pub(super) async fn post_recording_events(
+    State(state): State<AppState>,
+    Path(tab_id): Path<String>,
+    request: Request,
+) -> Response {
+    if request
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<usize>().ok())
+        .is_some_and(|length| length > MAX_RECORDING_BODY_BYTES)
+    {
+        return StatusCode::PAYLOAD_TOO_LARGE.into_response();
+    }
+    let batch_id = request
+        .headers()
+        .get("x-recording-batch-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let bytes = match to_bytes(request.into_body(), MAX_RECORDING_BODY_BYTES + 1).await {
+        Ok(bytes) if bytes.len() <= MAX_RECORDING_BODY_BYTES => bytes,
+        Ok(_) | Err(_) => return StatusCode::PAYLOAD_TOO_LARGE.into_response(),
+    };
+    let tab_id = tab_id
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+        .then(|| tab_id.parse::<i64>().ok())
+        .flatten()
+        .filter(|tab_id| *tab_id <= MAX_SAFE_TAB_ID);
+    let target_id = match tab_id {
+        Some(tab_id) => {
+            let browser = state.browser.state();
+            state
+                .tab_targets
+                .resolve(tab_id, state.browser.session().await, browser.epoch)
+                .await
+        }
+        None => None,
+    };
+    let (Some(tab_id), Some(target_id)) = (tab_id, target_id) else {
+        return WireJson(RecordEventsOutcome {
+            accepted: 0,
+            ok: false,
+            reason: Some("unknown tab"),
+        })
+        .into_response();
+    };
+    let events = String::from_utf8_lossy(&bytes)
+        .lines()
+        .filter_map(parse_recording_event)
+        .collect::<Vec<_>>();
+    if events.is_empty() {
+        return WireJson(RecordEventsOutcome {
+            accepted: 0,
+            ok: true,
+            reason: None,
+        })
+        .into_response();
+    }
+    let appended = match state
+        .recordings
+        .append_batch_with_id(&target_id, tab_id, &events, batch_id.as_deref())
+        .await
+    {
+        Ok(appended) => appended,
+        Err(error) => {
+            tracing::warn!(tab_id, target_id, error = %error, "recording batch append failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                WireJson(RecordEventsOutcome {
+                    accepted: 0,
+                    ok: false,
+                    reason: Some("append failed"),
+                }),
+            )
+                .into_response();
+        }
+    };
+    if !appended {
+        return WireJson(RecordEventsOutcome {
+            accepted: 0,
+            ok: true,
+            reason: None,
+        })
+        .into_response();
+    }
+    WireJson(RecordEventsOutcome {
+        accepted: events.len(),
+        ok: true,
+        reason: None,
+    })
+    .into_response()
+}
+
+fn parse_recording_event(line: &str) -> Option<RecordingEventInput> {
+    if line.trim().is_empty() {
+        return None;
+    }
+    let value = serde_json::from_str::<Value>(line).ok()?;
+    let event = value.as_object()?;
+    Some(RecordingEventInput {
+        ts: event.get("ts")?.as_i64()?,
+        event_type: event.get("type").cloned(),
+        data: event.get("data").cloned(),
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct ReplayUnavailableResponse {
+    ok: bool,
+    reason: &'static str,
+}
+
+pub(super) async fn get(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> AppResult<Response> {
+    let events = state.replays.read_session(&session_id).await?;
+    if events.is_empty() {
+        return Ok((
+            StatusCode::NOT_FOUND,
+            WireJson(ReplayUnavailableResponse {
+                ok: false,
+                reason: "no replay for this session",
+            }),
+        )
+            .into_response());
+    }
+    let mut body = String::new();
+    for event in events {
+        body.push_str(&serde_json::to_string(&event)?);
+        body.push('\n');
+    }
+    Ok(([(header::CONTENT_TYPE, "application/x-ndjson")], body).into_response())
+}
+
+pub(super) async fn meta(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> AppResult<WireJson<ReplayMeta>> {
+    Ok(WireJson(state.replays.meta(&session_id).await?))
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/system.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/system.rs
@@ -1,0 +1,95 @@
+use super::wire::WireJson;
+use crate::{
+    AppState,
+    error::AppResult,
+    services::{browser::BrowserConnectionState, telemetry::TelemetryState},
+};
+use axum::{Json, extract::State};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct HealthResponse {
+    cdp: BrowserConnectionState,
+    sessions: SessionCountResponse,
+    status: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct SessionCountResponse {
+    count: usize,
+}
+
+pub(super) async fn health(State(state): State<AppState>) -> WireJson<HealthResponse> {
+    WireJson(HealthResponse {
+        cdp: state.browser.state(),
+        sessions: SessionCountResponse {
+            count: state.sessions.count().await,
+        },
+        status: "ok",
+    })
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ShutdownResponse {
+    drained_sessions: usize,
+    status: &'static str,
+}
+
+pub(super) async fn shutdown(
+    State(state): State<AppState>,
+) -> AppResult<WireJson<ShutdownResponse>> {
+    let drained = state.sessions.shutdown().await?;
+    state.audit.drain_claim_writes().await;
+    state.recordings.close().await;
+    state.screencast.stop();
+    state.browser.stop();
+    if let Some(tx) = state.shutdown.lock().await.take() {
+        let _ = tx.send(());
+    }
+    Ok(WireJson(ShutdownResponse {
+        drained_sessions: drained,
+        status: "ok",
+    }))
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct VersionResponse {
+    name: &'static str,
+    version: &'static str,
+}
+
+pub(super) async fn version() -> WireJson<VersionResponse> {
+    WireJson(VersionResponse {
+        name: env!("CARGO_PKG_NAME"),
+        version: env!("CARGO_PKG_VERSION"),
+    })
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct UrlResponse {
+    url: String,
+}
+
+pub(super) async fn url(State(state): State<AppState>) -> WireJson<UrlResponse> {
+    WireJson(UrlResponse {
+        url: state.config.local_server_url(),
+    })
+}
+
+pub(super) async fn telemetry(State(state): State<AppState>) -> WireJson<TelemetryState> {
+    WireJson(state.telemetry.get_state().await)
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct TelemetryConsent {
+    consent: bool,
+}
+
+pub(super) async fn telemetry_consent(
+    State(state): State<AppState>,
+    Json(input): Json<TelemetryConsent>,
+) -> WireJson<TelemetryState> {
+    WireJson(state.telemetry.set_consent(input.consent).await)
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/tabs.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/tabs.rs
@@ -1,0 +1,47 @@
+use super::wire::WireJson;
+use crate::{
+    AppState, error::AppResult, services::tab_activity::EnrichedTabRecord, tabs::hex_for_slug,
+};
+use axum::extract::State;
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Serialize)]
+pub(super) struct TabsActivityResponse {
+    tabs: Vec<EnrichedTabRecord>,
+}
+
+pub(super) async fn activity(
+    State(state): State<AppState>,
+) -> AppResult<WireJson<TabsActivityResponse>> {
+    state.screencast.note_read();
+    let profiles = state.agents.list_profiles().await?;
+    let live_sessions = state.sessions.snapshot().await;
+    let sessions_by_agent_id = live_sessions
+        .iter()
+        .map(|session| (session.convo_id().as_str(), session))
+        .collect::<HashMap<_, _>>();
+    let tabs = state.tab_activity.snapshot().await;
+    let mut enriched = Vec::with_capacity(tabs.len());
+    for record in tabs {
+        let session = sessions_by_agent_id.get(record.agent_id.as_str()).copied();
+        let profile = session
+            .and_then(|session| session.agent().profile_id())
+            .and_then(|profile_id| {
+                profiles
+                    .iter()
+                    .find(|profile| profile.id == profile_id.as_str())
+            });
+        enriched.push(EnrichedTabRecord {
+            agent_label: profile
+                .map(|profile| profile.name.clone())
+                .or_else(|| session.map(|session| session.agent().label().to_string()))
+                .unwrap_or_else(|| record.slug.clone()),
+            harness: profile.map(|profile| profile.harness.to_string()),
+            color: Some(hex_for_slug(&record.slug).to_string()),
+            screencast: state.screencast.frame_for(record.page_id).await,
+            record,
+        });
+    }
+    Ok(WireJson(TabsActivityResponse { tabs: enriched }))
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/wire.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/wire.rs
@@ -1,0 +1,25 @@
+use axum::{
+    Json,
+    response::{IntoResponse, Response},
+};
+use serde::{Serialize, Serializer, ser::Error as _};
+
+/// Serializes through `Value` so typed handlers keep lexicographic object-key order on the wire.
+pub(super) struct WireJson<T>(pub T);
+
+impl<T: Serialize> Serialize for WireJson<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serde_json::to_value(&self.0)
+            .map_err(S::Error::custom)?
+            .serialize(serializer)
+    }
+}
+
+impl<T: Serialize> IntoResponse for WireJson<T> {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}


### PR DESCRIPTION
## Summary
- keep the complete axum route table and middleware in `routes/mod.rs`
- move handlers and typed request/response DTOs into six endpoint-family modules
- remove dynamic JSON response blobs while preserving response bytes through the typed wire adapter

## Design
The route table remains the single-screen API surface, while `system`, `agents`, `tabs`, `connections`, `audit`, and `replay` own their handlers and boundary DTOs. Existing service DTOs stay with their subsystems. `WireJson<T>` retains the previous sorted `serde_json::Value` serialization path so the refactor does not reorder object keys on the wire.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build -p claw-server-rust`
- [x] `cargo test -p claw-server-rust`
- [x] `cargo clippy -p claw-server-rust --all-targets -- -D warnings`
- [x] no `json!` or `Json<Value>` remains under `src/routes`
- [x] `bun run check` (exits 0 with existing unrelated Biome/Fallow warnings)
- [x] `bun run test`
- [x] context-free adversarial diff review: clean
