### PR TITLE
fix(claw-app): keep rrweb replay mounted in Strict Mode

### DIFF
--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.test.tsx
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { parseHTML } from 'linkedom'
+import { act, StrictMode } from 'react'
+import type { Root } from 'react-dom/client'
+import type { ReplayEvent } from '@/modules/api/replay.hooks'
+import type { ReplayPlayerHandle } from './ReplayViewport'
+
+interface ReplayerConfig {
+  root: HTMLElement
+}
+
+class FakeReplayer {
+  readonly marker: HTMLElement
+  destroyed = false
+
+  constructor(_events: unknown[], config: ReplayerConfig) {
+    this.marker = document.createElement('div')
+    this.marker.dataset.fakeReplayer = String(fakeReplayers.length + 1)
+    config.root.append(this.marker)
+    fakeReplayers.push(this)
+  }
+
+  pause(_ms?: number): void {}
+
+  play(_ms?: number): void {}
+
+  setConfig(_config: { speed: number }): void {}
+
+  getCurrentTime(): number {
+    return 0
+  }
+
+  destroy(): void {
+    this.destroyed = true
+    this.marker.remove()
+  }
+}
+
+const fakeReplayers: FakeReplayer[] = []
+
+mock.module('rrweb', () => ({ Replayer: FakeReplayer }))
+
+const globalDescriptors = new Map(
+  ['window', 'document', 'navigator', 'HTMLElement', 'Node', 'Event'].map(
+    (name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)],
+  ),
+)
+
+const events: ReplayEvent[] = [
+  {
+    sessionId: 'session-1',
+    targetId: 'target-a',
+    tabId: 1,
+    ts: 1_000,
+    type: 4,
+    data: { width: 1280, height: 720 },
+  },
+  {
+    sessionId: 'session-1',
+    targetId: 'target-a',
+    tabId: 1,
+    ts: 1_001,
+    type: 2,
+    data: {},
+  },
+]
+
+let root: Root | null
+let container: HTMLElement
+
+beforeEach(async () => {
+  fakeReplayers.length = 0
+  const dom = parseHTML(
+    '<!doctype html><html><body><div id="root"></div></body></html>',
+  )
+  const globals = {
+    window: dom.window,
+    document: dom.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+  }
+  for (const [name, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    })
+  }
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  })
+
+  container = dom.document.getElementById('root') as unknown as HTMLElement
+  const { createRoot } = await import('react-dom/client')
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  for (const [name, descriptor] of globalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor)
+    else Reflect.deleteProperty(globalThis, name)
+  }
+  Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
+})
+
+describe('ReplayViewport', () => {
+  it('owns one live Replayer across Strict Mode setup, replacement, and unmount', async () => {
+    const readyValues: Array<ReplayPlayerHandle | null> = []
+    const onPlayerReady = (handle: ReplayPlayerHandle | null): void => {
+      readyValues.push(handle)
+    }
+    const { ReplayViewport } = await import('./ReplayViewport')
+
+    await act(async () => {
+      root?.render(
+        <StrictMode>
+          <ReplayViewport
+            site="example.com"
+            frame={undefined}
+            events={events}
+            onPlayerReady={onPlayerReady}
+          />
+        </StrictMode>,
+      )
+    })
+
+    const canvas = container.querySelector('[data-replay-canvas]')
+    expect(canvas?.querySelectorAll('[data-fake-replayer]')).toHaveLength(1)
+    expect(fakeReplayers).toHaveLength(2)
+    expect(
+      fakeReplayers.filter((replayer) => !replayer.destroyed),
+    ).toHaveLength(1)
+    expect(readyValues.at(-1)).not.toBeNull()
+
+    const firstLiveReplayer = fakeReplayers.find(
+      (replayer) => !replayer.destroyed,
+    )
+    const replacementEvents = events.map((event) => ({
+      ...event,
+      targetId: 'target-b',
+    }))
+    await act(async () => {
+      root?.render(
+        <StrictMode>
+          <ReplayViewport
+            site="example.com"
+            frame={undefined}
+            events={replacementEvents}
+            onPlayerReady={onPlayerReady}
+          />
+        </StrictMode>,
+      )
+    })
+
+    expect(firstLiveReplayer?.destroyed).toBe(true)
+    expect(canvas?.querySelectorAll('[data-fake-replayer]')).toHaveLength(1)
+    expect(
+      fakeReplayers.filter((replayer) => !replayer.destroyed),
+    ).toHaveLength(1)
+
+    await act(async () => root?.unmount())
+    root = null
+
+    expect(fakeReplayers.every((replayer) => replayer.destroyed)).toBe(true)
+    expect(readyValues.at(-1)).toBeNull()
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -114,13 +114,10 @@ function readRecordedSize(events: readonly ReplayEvent[]): {
 /** Mounts rrweb's imperative Replayer and exposes the narrow playback handle. */
 function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
   const mountRef = useRef<HTMLDivElement>(null)
-  const lastEventsRef = useRef<readonly ReplayEvent[] | null>(null)
   useEffect(() => {
     const mount = mountRef.current
     if (!mount) return
     if (events.length < 2) return
-    if (lastEventsRef.current === events) return
-    lastEventsRef.current = events
 
     const rrwebEvents = events.map((e) => ({
       type: e.type,


### PR DESCRIPTION
## Summary
- make every `PlayerCanvas` Effect setup own a matching rrweb `Replayer` cleanup under React Strict Mode
- add a real `ReplayViewport` regression test for Strict Mode setup, target replacement, and unmount
- preserve the FullSnapshot gate, incomplete-recording UX, and both server replay contracts

## Design
Remove the redundant `lastEventsRef` equality guard and let the Effect dependency list control real event-array replacements. The regression test mocks only rrweb's imperative `Replayer`, renders the public viewport under `StrictMode`, and tracks live instances through setup, cleanup, replacement, and unmount.

## Test plan
- [x] focused Strict Mode test failed before the source fix and passes after it
- [x] neighboring replay tests
- [x] claw-app tests, typecheck, and lint
- [x] TypeScript recording and audit replay route tests
- [x] targeted and full claw-server-rust suites
- [x] repository `bun run check` and `bun run test`
- Optional GUI smoke not run: the only live dev runtime belonged to a separate checkout, so it could not exercise this branch
