### PR TITLE
docs(claw-app): restore api module commentary lost in #1892 migration

### DIFF
--- a/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
@@ -3,7 +3,16 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Canonical session queries and dispatch-artifact URL helpers.
+ * Session audit surface for the cockpit and audit screens.
+ *
+ * useSessions        paginated session list (homepage + audit screen),
+ *                    polled so live runs advance in place
+ * useSessionDetail   one session's summary + full dispatch list;
+ *                    polls only while the session is live
+ *
+ * taskScreenshotUrl builds the absolute URL to the binary screenshot
+ * route so an <img src> can render the persisted JPEG without going
+ * through the JSON client.
  */
 
 import type {
@@ -17,6 +26,8 @@ import { useEffect, useState } from 'react'
 import { createInfiniteQuery, createQuery } from 'react-query-kit'
 import { apiBaseUrl, apiClient, resolveApiBaseUrl } from './client'
 
+// The screens speak task-*; the contract speaks session-*. Aliased here
+// so call sites keep their vocabulary while the shapes stay canonical.
 export type ToolDispatchRow = Dispatch
 export type TaskStatus = SessionStatus
 export type TaskSummary = SessionSummary
@@ -64,6 +75,7 @@ export const useSessionDetail = createQuery<
     query.state.data?.session.status === 'live' ? 3000 : false,
 })
 
+/** Absolute URL for the persisted screenshot of one dispatch. */
 export function taskScreenshotUrl(
   dispatchId: number,
   baseUrl = apiBaseUrl(),
@@ -71,6 +83,11 @@ export function taskScreenshotUrl(
   return `${baseUrl}/api/v1/dispatches/${dispatchId}/screenshot`
 }
 
+/**
+ * Screenshot URL base that follows the BrowserOS server-port pref. The
+ * pref API is callback-based, so `taskScreenshotUrl`'s sync default
+ * cannot see it; components resolve the base here and pass it in.
+ */
 export function useTaskScreenshotBaseUrl(): string | null {
   const [baseUrl, setBaseUrl] = useState<string | null>(null)
 

--- a/packages/browseros-agent/apps/claw-app/modules/api/cancel.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/cancel.hooks.ts
@@ -3,7 +3,14 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Session-scoped cancellation for the cockpit Stop action.
+ * react-query-kit mutation backing the cockpit's Stop button. Hits
+ * `POST /api/v1/sessions/:sessionId/cancel`; the server aborts every
+ * in-flight tool dispatch on that MCP session and resolves with the
+ * count — `cancelled: 0` is a success meaning the session was idle.
+ * Missing or already-ended sessions come back 404/409, which the
+ * generated client throws as the mutation's error path. The session
+ * itself stays open: the agent's harness sees each cancelled dispatch
+ * as an isError tool result and is free to fire its next call.
  */
 
 import type { CancelSessionResponse } from '@browseros/claw-api'

--- a/packages/browseros-agent/apps/claw-app/modules/api/client.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/client.ts
@@ -3,9 +3,21 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Generated BrowserClaw API client with dynamic loopback URL resolution.
- * One client is cached per resolved URL so switching BrowserOS's managed
- * server port immediately moves subsequent requests to the new server.
+ * Generated BrowserClaw API client (`DefaultApi` from
+ * `@browseros/claw-api`); calls go over HTTP loopback to whichever
+ * port the claw server bound to.
+ *
+ * Base URL resolution order:
+ *   1. BrowserOS `browseros.server.server_port` pref
+ *   2. `?apiUrl=…` on window.location (dev launcher publishes this)
+ *   3. sessionStorage cache of (2)
+ *   4. VITE_BROWSEROS_CLAW_API_URL from the dev watcher
+ *   5. standalone BrowserClaw port on 127.0.0.1
+ *
+ * (1) comes from BrowserOS's callback-based pref API, so the full
+ * chain is async. `apiClient()` re-resolves on every call and swaps
+ * the cached client when the resolved URL changes, so a managed-port
+ * change moves subsequent requests to the new server without a reload.
  */
 
 import { Configuration, DefaultApi } from '@browseros/claw-api'
@@ -15,10 +27,18 @@ import {
 } from './browseros-ports'
 import { resolveApiBaseUrlFromSources } from './client.helpers'
 
+/**
+ * Sync resolution over the trusted local sources — steps 2-5 only; the
+ * BrowserOS pref is callback-based and needs `resolveApiBaseUrl`. For
+ * surfaces that embed the resolved base URL directly (eg. an
+ * `<img src>` to a binary screenshot route) rather than going through
+ * the JSON client.
+ */
 export function apiBaseUrl(): string {
   return resolveApiBaseUrlFromSources(apiBaseUrlSourcesFromWindow())
 }
 
+/** Full resolution, BrowserOS server-port pref included. */
 export async function resolveApiBaseUrl(): Promise<string> {
   return resolveBrowserOSServerBaseUrl(apiBaseUrlSourcesFromWindow())
 }

--- a/packages/browseros-agent/apps/claw-app/modules/api/connections.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/connections.hooks.ts
@@ -2,6 +2,10 @@
  * @license
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Per-harness Connect / Disconnect surface for the MCP page's harness
+ * cards. The list is polled so state changed outside the app (installs,
+ * hand-edited harness configs) shows up without a refresh.
  */
 
 import type { Connection, ConnectionList, Harness } from '@browseros/claw-api'

--- a/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
@@ -70,7 +70,7 @@ export interface UseReplayMetadataVariables {
   sessionId: string
 }
 
-/** Fetches the replay target index used by the CTA and tab picker. */
+/** Cheap metadata probe behind the "View Replay" CTA and page picker. */
 export async function fetchReplayMetadata({
   sessionId,
 }: UseReplayMetadataVariables): Promise<ReplayMetadata> {
@@ -107,7 +107,13 @@ function isReplayEvent(value: unknown): value is ReplayEvent {
   )
 }
 
-/** Fetches and parses one session's target-addressed NDJSON stream. */
+/**
+ * Fetches and parses one session's target-addressed NDJSON stream.
+ * Raw fetch rather than the generated client: the route serves
+ * `application/x-ndjson`, which the JSON-typed client cannot parse.
+ * 404 (nothing recorded) maps to an empty bundle so the viewer shows
+ * its empty state instead of an error.
+ */
 export async function fetchReplayEvents({
   sessionId,
 }: UseReplayEventsVariables): Promise<ReplayEventsBundle> {

--- a/packages/browseros-agent/apps/claw-app/modules/api/tabs.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/tabs.hooks.ts
@@ -3,7 +3,12 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Canonical live-tab query and binary preview URL helpers.
+ * Live-tab surface for the cockpit. `useTabs` polls the canonical tab
+ * registry so the homepage can render which tabs each agent has
+ * touched, how recently, and the tool sequence behind the current
+ * state. The preview helpers build URLs to the binary JPEG route for
+ * the per-tab screencast frames, loaded via <img src> because the
+ * generated client is JSON-only.
  */
 
 import type { Tab, TabList, ToolEvent } from '@browseros/claw-api'
@@ -20,6 +25,11 @@ export const useTabs = createQuery<TabList>({
   refetchInterval: 1500,
 })
 
+/**
+ * The server ignores `capturedAt`; the param exists to key the URL to
+ * one frame so an <img> notices a new capture and re-fetches instead
+ * of reusing the browser-cached image.
+ */
 export function tabPreviewUrl(
   pageId: number,
   previewCapturedAt: number,
@@ -28,6 +38,11 @@ export function tabPreviewUrl(
   return `${baseUrl}/api/v1/tabs/${pageId}/preview?capturedAt=${previewCapturedAt}`
 }
 
+/**
+ * Null until the base URL resolves, and whenever the tab has no
+ * captured frame yet (`previewCapturedAt` undefined); the screencast
+ * surfaces map null to their placeholder state.
+ */
 export function useTabPreviewUrl(
   pageId: number,
   previewCapturedAt?: number,


### PR DESCRIPTION
## Summary
- The canonical claw-api migration (#1892) replaced the `apps/claw-app/modules/api/` subsystem headers and why-comments with thin one-liners; this restores them, written against the code as it stands today (not verbatim restoration of pre-migration text).
- Comments-only diff — zero behavior change, verified mechanically (`git diff` contains no non-comment lines).

## Design
Each comment re-established only where the next reader can't recover the fact from the code: `client.ts` documents the 5-step base-URL resolution order and why the chain is async (BrowserOS's callback-based pref API) with the sync `apiBaseUrl` escape hatch for `<img src>` surfaces; `cancel.hooks.ts` documents the session-scoped cancel semantics (`cancelled: 0` is a legitimate idle success, 404/409 throw into the mutation error path, the session stays open for the harness); `tabs.hooks.ts` explains that the server ignores `capturedAt` — it exists purely to key the preview URL to a frame; `replay.hooks.ts` gets the raw-fetch-over-generated-client rationale (NDJSON, JSON-only client) plus a stale-vocabulary fix on `fetchReplayMetadata` (targets → pages); `audit.hooks.ts` and `connections.hooks.ts` get their surface headers back and a note on the task-*/session-* aliasing decision. Generated code under `packages/claw-api/src/generated/` untouched.

## Test plan
- [x] `bunx biome check apps/claw-app/modules/api/` — clean
- [x] `bun run typecheck` in `apps/claw-app` — clean
- [x] `git diff` mechanically verified comments-only
- [x] `bun test modules/api/` — 20 pass; the 2 failures in `client.helpers.test.ts` (cached-client leakage across tests) reproduce identically on `origin/main` at 9271e3cef and are unrelated to this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)