### PR TITLE
chore(claw-app): restore why-comments thinned by the canonical API migration

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.tsx
@@ -7,14 +7,37 @@ interface MiniScreencastProps {
   site: string
   live?: boolean
   pageId: number
+  /**
+   * Timestamp of the tab's newest capture. Its only job here is to make
+   * the preview URL unique per frame; undefined means the tab has never
+   * been captured, which renders the globe placeholder.
+   */
   previewCapturedAt?: number
+  /**
+   * Overrides the container sizing. Defaults to `h-[132px] w-full` for
+   * compact cards; AgentRunningCard passes `h-full w-full` so the frame
+   * fills its `flex-1` zone instead of clamping at 132px.
+   */
   className?: string
 }
 
 /**
- * Live card preview backed by the canonical binary JPEG route. The capture
- * timestamp changes the URL for each frame while `displayedSrc` keeps the old
- * decoded image painted until its replacement is ready.
+ * Card-top tile on the Running-now homepage cards. Renders the tab's
+ * latest capture from the canonical binary JPEG route; falls back to a
+ * tinted block with the site host and a small globe while there is no
+ * frame to show.
+ *
+ * Flicker-free frame swap: every `previewCapturedAt` tick yields a new
+ * preview URL, and swapping the visible `<img src>` directly would
+ * unload the old pixels the moment the attribute changes, briefly
+ * exposing the container backdrop between paints — the operator sees
+ * that as a flicker on every poll. So an off-screen `new Image()`
+ * fetches and decodes the next frame first, and `displayedSrc` only
+ * advances once the decode completes; the visible swap then hits the
+ * browser cache and paints without a gap.
+ *
+ * The `live` flag adds a pulsing dot top-right matching the design's
+ * running indicator.
  */
 export function MiniScreencast({
   site,
@@ -24,6 +47,8 @@ export function MiniScreencast({
   className,
 }: MiniScreencastProps) {
   const incomingSrc = useTabPreviewUrl(pageId, previewCapturedAt)
+  // `displayedSrc` is the src actually painted in the DOM. It only
+  // moves forward once the new frame has decoded successfully.
   const [displayedSrc, setDisplayedSrc] = useState<string | null>(incomingSrc)
 
   useEffect(() => {
@@ -32,6 +57,8 @@ export function MiniScreencast({
       return
     }
     if (incomingSrc === displayedSrc) return
+    // Pre-decode off-screen; if the fetch or decode fails, onload never
+    // fires and the previous frame stays painted until the next capture.
     let cancelled = false
     const image = new Image()
     image.onload = () => {
@@ -55,6 +82,10 @@ export function MiniScreencast({
           src={displayedSrc}
           alt={`Live view of ${site}`}
           className="h-full w-full object-cover"
+          // Catches bad bytes that slipped past the pre-decode gate
+          // (mainly on mount, where displayedSrc seeds straight from
+          // incomingSrc). Nulling falls back to the globe placeholder
+          // instead of the browser's broken-image icon.
           onError={() => setDisplayedSrc(null)}
         />
       ) : (
@@ -68,6 +99,8 @@ export function MiniScreencast({
           aria-hidden
           className={cn(
             'absolute top-2.5 right-2.5 size-2 animate-pulse-dot rounded-full bg-green',
+            // Translucent ring so the dot stays readable against busy
+            // live thumbnails.
             'ring-2 ring-bg-canvas/70',
           )}
         />

--- a/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.ts
@@ -36,7 +36,13 @@ interface QueuedBatch {
   batchId: string
   ndjson: string
   bytes: number
-  /** Pins retries to the session/page/target that produced these events. */
+  /**
+   * The session/page/target that produced these events, stamped from the
+   * tab's last known association at enqueue time (or on first successful
+   * tab lookup). A pinned batch whose association no longer matches the
+   * tab's live one is dropped rather than written into the session that
+   * now owns the tab.
+   */
   association?: TabAssociation
 }
 
@@ -51,6 +57,14 @@ const LEGACY_TTL_MS = 10 * 60_000
 const RETRY_INTERVAL_MS = 5_000
 const WARNING_INTERVAL_MS = 60_000
 
+/**
+ * Identity of the recording stream a tab's events belong to, as reported
+ * by the canonical tab listing. Chrome tab ids are reused when a tab is
+ * reattached to a new session, so this trio — not the tab id — decides
+ * where a batch may land: `sessionId` scopes the ingest URL, and the
+ * page/target ids travel as headers for the server to re-validate
+ * against its live registry (mismatch comes back as 409).
+ */
 interface TabAssociation {
   sessionId: string
   pageId: number
@@ -83,6 +97,9 @@ export function createRecordingsRelay(
   let queuedBatchCount = 0
   let retryTimer: TimerHandle | null = null
   let drainPromise: Promise<void> | null = null
+  // Last known association per tab id, kept so batches queued while the
+  // server is unreachable pin to the session that produced them, not to
+  // whichever session owns the tab once delivery resumes.
   const associations = new Map<number, TabAssociation>()
 
   function safeWarn(...args: unknown[]): void {
@@ -253,9 +270,15 @@ export function createRecordingsRelay(
         batch.association &&
         !associationsMatch(batch.association, association)
       ) {
+        // The tab has moved on (new session/page/target) since these
+        // events were recorded. Dropping beats leaking one session's
+        // events into another's replay; the drain loop marks the gap
+        // when it sees the unknown-tab outcome.
         return { kind: 'unknown-tab' }
       }
       batch.association = association
+      // Batches enqueued before the tab was first resolved carry no pin;
+      // they were recorded under this association, so stamp it now.
       for (const queuedBatch of queues.get(tabId) ?? []) {
         queuedBatch.association ??= association
       }
@@ -275,6 +298,9 @@ export function createRecordingsRelay(
         },
       )
       if ([404, 409, 410].includes(response.status)) {
+        // The pinned session cannot take these events any more: gone
+        // (404), association drifted server-side (409), or ended (410).
+        // Forget the association so the next batch re-resolves the tab.
         associations.delete(tabId)
         return { kind: 'unknown-tab' }
       }
@@ -286,6 +312,9 @@ export function createRecordingsRelay(
       }
       return { kind: 'success' }
     } catch (error) {
+      // Only the generated client throws ResponseError, so a 404 here is
+      // `listTabs` itself missing — a pre-canonical server. Back off via
+      // legacy mode instead of treating every tab as unknown.
       if (error instanceof ResponseError && error.response.status === 404) {
         return { kind: 'legacy' }
       }
@@ -301,6 +330,9 @@ export function createRecordingsRelay(
     }
     const previous = associations.get(tabId)
     if (previous && !associationsMatch(previous, association)) {
+      // The tab was reattached mid-recording; mark the gap so the next
+      // successful delivery fires the recovered listeners and the
+      // background re-checkpoints the new stream.
       gappedTabs.add(tabId)
     }
     associations.set(tabId, association)

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.ts
@@ -96,9 +96,9 @@ export interface AgentActivityRecord {
   /** Merged across all this agent's tabs, sorted by `at`, capped at MERGED_TRAIL_CAP. */
   recentTools: ToolEvent[]
   status: 'active' | 'idle'
-  /** The freshest tab in the group. Always present. */
+  /** The freshest tab in the group. Always present (a rollup with no tabs is impossible). */
   currentFocus: TabActivityRecord
-  /** All tabs in the group, newest activity first. */
+  /** All tabs in the group, newest activity first, so the popover reads chronologically. */
   tabs: TabActivityRecord[]
 }
 


### PR DESCRIPTION
## Summary

PR #1892 migrated claw-app to the canonical BrowserClaw client and, along the way, dropped or thinned the comments that carried non-obvious semantics in the UI layer. This restores them, rewritten for the code as it stands today (not verbatim — some old comments described removed behavior like base64 data-URL frames).

- **`components/cockpit/MiniScreencast.tsx`** — the flicker-free frame swap (off-screen `Image` pre-decode gates `displayedSrc`, so the visible `<img>` never blanks between poll ticks), the `onError` fallback to the globe placeholder, the `className` sizing-override contract (`h-[132px]` default vs `h-full` from AgentRunningCard), `previewCapturedAt` null-semantics, and the pulse-dot ring note.
- **`modules/recorder/recordings-relay.ts`** — documents the session-pinning invariants added in #1892 that shipped with a single one-liner: what a `TabAssociation` is and why the trio (not the reused Chrome tab id) decides where a batch lands, when batches get pinned, why a mismatched pin drops the batch instead of writing into the tab's new session, the 404/409/410 ingest verdicts, and why a `ResponseError` 404 means a pre-canonical server (legacy backoff) rather than a dead tab.
- **`screens/cockpit/cockpit.helpers.ts`** — restores the why on `currentFocus` ("always present" because a rollup with no tabs is impossible) and the popover-facing sort order of `tabs`.

Comments only — zero behavior change.

## Verification

- `bunx biome check` clean on all three files
- `bun run typecheck` green in `apps/claw-app`
- 47/47 tests pass across the three touched modules' suites
- Diff mechanically verified to contain only comment additions/edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)