### PR TITLE
ci(claw-api): enforce codegen drift and server conformance

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,6 +6,7 @@ on:
       - main
       - feat/claw-server-bootstrap
     paths:
+      - ".github/workflows/code-quality.yml"
       - "packages/browseros-agent/**"
 
 jobs:
@@ -62,6 +63,73 @@ jobs:
 
       - name: Run Typecheck
         run: bun run typecheck
+
+  claw-api-codegen:
+    name: runner / Claw API generated code
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: packages/browseros-agent
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Rustfmt
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add rustfmt
+
+      - name: Check Claw API generated code
+        run: bun run codegen:claw-api:check
+
+  claw-api-contract:
+    name: runner / Claw API conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: packages/browseros-agent
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Restore Cargo cache
+        uses: actions/cache@v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/browseros-agent/target
+          key: ${{ runner.os }}-claw-api-cargo-${{ hashFiles('packages/browseros-agent/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-claw-api-cargo-
+
+      - name: Install dependencies
+        run: bun ci
+
+      - name: Run Claw API contract tests
+        run: bun run test:claw-api-contract
 
   fallow:
     name: runner / Fallow

--- a/packages/browseros-agent/contracts/claw-api/tests/server-adapters.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/server-adapters.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
 import type { CanonicalApiDependencies } from '../../../apps/claw-server/src/routes/api-v1'
@@ -198,6 +198,9 @@ export async function startRustServer(): Promise<ContractServer> {
   await portProbe.stop(true)
   if (port === undefined) throw new Error('failed to allocate a test port')
   const dataDir = await mkdtemp(resolve(tmpdir(), 'claw-contract-rust-'))
+  const homeDir = resolve(dataDir, 'home')
+  // Exercise harness detection and Codex linking without touching host MCP config.
+  await mkdir(resolve(homeDir, '.codex'), { recursive: true })
   const process = Bun.spawn({
     cmd: [
       resolve(root, 'target/debug/examples/contract-server'),
@@ -205,6 +208,15 @@ export async function startRustServer(): Promise<ContractServer> {
       dataDir,
     ],
     cwd: root,
+    env: {
+      ...globalThis.process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      XDG_CONFIG_HOME: resolve(homeDir, '.config'),
+      CLAUDE_CONFIG_DIR: homeDir,
+      APPDATA: resolve(homeDir, 'AppData', 'Roaming'),
+      LOCALAPPDATA: resolve(homeDir, 'AppData', 'Local'),
+    },
     stdout: 'pipe',
     stderr: 'pipe',
   })

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -65,7 +65,7 @@
     "gen:cdp": "bun --env-file=.env.development scripts/codegen/cdp-protocol.ts",
     "codegen:claw-api": "bun scripts/codegen/claw-api.ts",
     "codegen:claw-api:check": "bun scripts/codegen/claw-api.ts --check",
-    "test:claw-api-contract": "bun test contracts/claw-api/tests/cross-server.test.ts",
+    "test:claw-api-contract": "cargo build --locked -p claw-server-rust --example contract-server && bun test contracts/claw-api/tests/cross-server.test.ts",
     "env:examples": "bun scripts/env/generate-examples.ts",
     "env:examples:check": "bun scripts/env/generate-examples.ts --check",
     "env:migrate": "bun scripts/env/migrate-local.ts",

--- a/packages/browseros-agent/scripts/run-test-suite.ts
+++ b/packages/browseros-agent/scripts/run-test-suite.ts
@@ -33,6 +33,10 @@ const testSuites = {
       argv: [bun, 'run', 'test'],
     },
     {
+      label: 'claw API contract tests',
+      argv: [bun, 'run', 'test:claw-api-contract'],
+    },
+    {
       label: 'agent tests',
       cwd: resolve(projectRoot, 'apps/app'),
       argv: [bun, 'run', 'test'],


### PR DESCRIPTION
## Summary

- add independently blocking generated-code drift and cross-server conformance jobs to Code Quality for BrowserOS-agent pull requests
- prebuild the locked Rust contract example before Bun starts scenario timeouts, then include the existing contract command in `test:all`
- restore Cargo state with the repository's cache action convention and make workflow-only edits trigger the gates
- isolate contract-fixture harness discovery from host config so clean CI runners and developer machines exercise the same connection lifecycle

## Design

CI delegates to the existing `codegen:claw-api:check` and `test:claw-api-contract` commands so local and pull-request enforcement share one implementation. The gates are separate jobs so Docker codegen and Cargo-backed conformance run in parallel and report distinct failures. `bun run test` now includes both server implementations; `bun run check` remains the daemon-free lint, typecheck, and Fallow pipeline, with Docker drift available locally as `bun run codegen:claw-api:check` and mandatory in CI.

## Test plan

- [x] `actionlint .github/workflows/code-quality.yml`
- [x] `bun run codegen:claw-api:check`
- [x] temporarily rename `HealthResponse.status` without regeneration and confirm the drift check fails; regenerate and confirm it passes
- [x] temporarily return a malformed TypeScript health payload and confirm conformance fails; restore it and confirm all 30 TypeScript/Rust executions pass
- [x] `bun run check` (passes with the existing warning inventory)
- [x] `bun run test`
