### PR TITLE
chore: restore comments on claw servers and API contract surfaces

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/examples/contract-server.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/examples/contract-server.rs
@@ -1,3 +1,10 @@
+//! Contract-testable claw-server-rust: the full router over real app
+//! state seeded with one live and one ended session, no browser or CDP
+//! required. The cross-server contract suite
+//! (`contracts/claw-api/tests`) builds and spawns this binary to run
+//! the shared cases against the Rust implementation; it can also be run
+//! by hand: `cargo run --example contract-server <port> <data-dir>`.
+
 use axum::Router;
 use browseros_core::TargetId;
 use claw_server_rust::{

--- a/packages/browseros-agent/apps/claw-server-rust/src/capture/screencast.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/capture/screencast.rs
@@ -109,7 +109,8 @@ impl ScreencastService {
         self.inner.lock().await.frames.get(&page_id).cloned()
     }
 
-    /// Record a `/tabs/activity` read for the idle governor.
+    /// Record a tab-listing read (`/tabs/activity` or `/api/v1/tabs`)
+    /// for the idle governor.
     pub fn note_read(&self) {
         self.last_read_ms.store(now_epoch_ms(), Ordering::Relaxed);
     }
@@ -235,6 +236,8 @@ impl ScreencastService {
         .await;
     }
 
+    /// Public so integration tests can seed preview frames; production
+    /// frames arrive via `store_capture` from the poller.
     pub async fn cache_frame(&self, page_id: u32, frame: ScreencastFrame) {
         let mut inner = self.inner.lock().await;
         inner.frames.remove(&page_id);

--- a/packages/browseros-agent/apps/claw-server-rust/src/error.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/error.rs
@@ -115,9 +115,19 @@ impl IntoResponse for AppError {
 
 pub type AppResult<T> = Result<T, AppError>;
 
+/// Server-minted id for one HTTP request — never read from an inbound
+/// header. The `request_context` middleware creates it, stores it as a
+/// request extension, and echoes it back as `x-request-id`; canonical
+/// error bodies embed it so a reported failure can be tied to its
+/// request span in the logs.
 #[derive(Clone, Debug)]
 pub struct RequestId(pub String);
 
+/// The canonical routes' error dialect: the contract's `ApiError`
+/// envelope (`code` / `message` / `requestId`), as opposed to the
+/// legacy `{ "error": … }` body `AppError` renders. Handlers on the
+/// canonical surface must fail through this type so error responses
+/// stay in-contract.
 pub struct CanonicalError {
     status: StatusCode,
     body: ApiError,

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/api_v1/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/api_v1/mod.rs
@@ -1,3 +1,11 @@
+//! Canonical contract routes: the Rust implementation of the shared
+//! BrowserClaw OpenAPI contract (`contracts/claw-api`), speaking the
+//! generated `claw_api` types end to end. The TS claw-server implements
+//! the same surface, and the cross-server contract suite runs the same
+//! cases against both. Besides `/api/v1/*` the contract also owns
+//! `/system/health` and `/system/shutdown`; the pre-contract
+//! diagnostics stay in `routes::system`.
+
 use crate::{
     AppState,
     error::{AppError, CanonicalError, RequestId},

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/api_v1/sessions.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/api_v1/sessions.rs
@@ -58,6 +58,10 @@ pub(super) async fn list(
         .await
         .map_err(|source| internal(&request_id, source))?;
     let live = live_sessions(&state).await;
+    // profile_id lives on the live session's agent, not in the audit
+    // store, so a profileId filter can only match live sessions — and
+    // it applies after pagination, so a filtered page may come back
+    // short rather than backfilled.
     let mut items = Vec::with_capacity(result.tasks.len());
     for task in result.tasks {
         let session = live.get(task.session_id.as_str());
@@ -142,6 +146,8 @@ pub(super) async fn recording(
         .meta(&session_id)
         .await
         .map_err(|source| internal(&request_id, source))?;
+    // page_ids = tabs still claimed by this session whose targets have
+    // recorded events — the per-tab views a replay can offer.
     let target_ids = metadata
         .targets
         .iter()
@@ -241,6 +247,11 @@ pub(super) async fn append_events(
     let page_id = positive_recording_header(&request_id, &headers, "x-recording-page-id")?;
     let target_id = recording_target_header(&request_id, &headers)?;
     let events = parse_recording_events(&body);
+    // Batches are pinned to the (tab, page, target) incarnation the
+    // recorder captured them from. Any drift — the tab reclaimed by
+    // another session, a navigation that swapped the target — makes the
+    // batch undeliverable rather than attributing its events to the
+    // wrong replay; the 409 tells the recorder to drop its association.
     let Some(target) = state.tab_activity.snapshot().await.into_iter().find(|tab| {
         tab.session_id == session_id
             && tab.tab_id == tab_id
@@ -270,6 +281,8 @@ pub(super) async fn append_events(
     Ok(Json(AppendRecordingEventsResponse::new(accepted)))
 }
 
+/// Tolerant parse of recorder-supplied NDJSON: lines that are not JSON
+/// or lack an integer `ts` are dropped, never fatal.
 fn parse_recording_events(body: &str) -> Vec<RecordingEventInput> {
     body.lines()
         .filter_map(|line| {
@@ -360,6 +373,8 @@ async fn live_sessions(state: &AppState) -> HashMap<String, Arc<Session>> {
 }
 
 async fn contract_summary(task: TaskSummary, live: Option<&Arc<Session>>) -> SessionSummary {
+    // A live session can still rename itself, so prefer its current
+    // label; once ended, the audited title is all that remains.
     let name = match live {
         Some(session) => session.label().await,
         None => task.title.clone(),

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/api_v1/system.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/api_v1/system.rs
@@ -9,10 +9,14 @@ use claw_api::models::{
     HealthResponse, ShutdownResponse, SystemInfo, TelemetryState, UpdateTelemetryRequest,
 };
 
+// The contract's health is pure liveness: `status` is a single-variant
+// enum, so a reachable server can only answer "ok".
 pub(super) async fn health() -> Json<HealthResponse> {
     Json(HealthResponse::default())
 }
 
+// Only signals; the runtime's shutdown owner drains sessions and stops
+// the process.
 pub(super) async fn shutdown(State(state): State<AppState>) -> Json<ShutdownResponse> {
     state.shutdown.request();
     Json(ShutdownResponse::default())

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/api_v1/tabs.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/api_v1/tabs.rs
@@ -18,6 +18,8 @@ pub(super) async fn list(
     Extension(request_id): Extension<RequestId>,
     State(state): State<AppState>,
 ) -> Result<Json<TabList>, CanonicalError> {
+    // Wakes the screencast idle governor so previews keep refreshing
+    // while anyone is watching the tab list.
     state.screencast.note_read();
     let profiles = state
         .agents
@@ -38,6 +40,9 @@ pub(super) async fn list(
                     .iter()
                     .find(|profile| profile.id == profile_id.as_str())
             });
+        // Label preference: profile name, then the live agent's label,
+        // then the recorded slug — the only identity that survives once
+        // the session ends.
         let label = profile
             .map(|profile| profile.name.clone())
             .or_else(|| {
@@ -109,6 +114,8 @@ pub(super) async fn preview(
             "internal server error",
         )
     })?;
+    // An empty cached frame is treated as missing, not as an error —
+    // the client's fallback is the same either way.
     if bytes.is_empty() {
         return Err(error(
             &request_id,
@@ -117,6 +124,7 @@ pub(super) async fn preview(
             "tab preview not found",
         ));
     }
+    // Superseded by the next screencast frame — never serve from cache.
     Ok(jpeg_response(bytes, "private, max-age=0, must-revalidate"))
 }
 
@@ -127,6 +135,7 @@ pub(super) async fn screenshot(
 ) -> Result<Response, CanonicalError> {
     let dispatch_id = positive_i64(&request_id, &dispatch_id, "dispatchId")?;
     match state.screenshots.read(&dispatch_id.to_string()).await {
+        // Written once at capture time — safe to cache hard.
         Ok(bytes) => Ok(jpeg_response(bytes, "public, max-age=86400, immutable")),
         Err(source) if source.status() == StatusCode::NOT_FOUND => Err(error(
             &request_id,

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/system.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/system.rs
@@ -1,6 +1,6 @@
 //! Pre-contract `/system/*` diagnostics that remain outside the
 //! canonical surface. `/system/health` and `/system/shutdown` belong to
-//! the contract now and live in `routes::api_v1`.
+//! the contract and live in `routes::api_v1`.
 
 use super::wire::WireJson;
 use crate::{AppState, telemetry::TelemetryState};

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/system.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/system.rs
@@ -1,3 +1,7 @@
+//! Pre-contract `/system/*` diagnostics that remain outside the
+//! canonical surface. `/system/health` and `/system/shutdown` belong to
+//! the contract now and live in `routes::api_v1`.
+
 use super::wire::WireJson;
 use crate::{AppState, telemetry::TelemetryState};
 use axum::{Json, extract::State};

--- a/packages/browseros-agent/apps/claw-server-rust/src/sessions/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/sessions/mod.rs
@@ -183,6 +183,8 @@ impl Sessions {
         cancelled
     }
 
+    /// `None` when the session is not live; `Some(n)` aborts its active
+    /// dispatches and reports how many there were.
     pub async fn cancel_by_session(&self, session_id: &SessionId) -> Option<usize> {
         let session = self.lookup(session_id).await?;
         Some(session.cancel_active_dispatches().await)

--- a/packages/browseros-agent/apps/claw-server-rust/src/tabs/activity.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/tabs/activity.rs
@@ -22,6 +22,13 @@ pub struct ToolEvent {
 #[serde(rename_all = "camelCase")]
 pub struct TabActivityRecord {
     pub target_id: String,
+    // tab_id and session_id are skipped because this struct serializes
+    // as the legacy `/tabs/activity` wire shape, which stays frozen;
+    // the canonical `/api/v1/tabs` reads both fields in-process. tab_id
+    // is the browser tab id — the join key between recorder batches
+    // (which only know tab ids) and CDP-side state; session_id is the
+    // MCP session currently claiming the tab, which recording ingest
+    // checks before accepting a batch.
     #[serde(skip)]
     pub tab_id: i64,
     pub page_id: u32,

--- a/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
@@ -1,3 +1,9 @@
+//! In-process coverage of the canonical contract routes: drives the
+//! full router over seeded app state via tower, no network or browser.
+//! The TS twin is claw-server's `tests/routes/api-v1.test.ts`; the
+//! cross-server suite in `contracts/claw-api/tests` layers real-HTTP
+//! parity checks on top of both.
+
 use axum::{
     Router,
     body::{Body, to_bytes},

--- a/packages/browseros-agent/apps/claw-server-rust/tests/support/contract_fixtures.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/support/contract_fixtures.rs
@@ -1,3 +1,8 @@
+//! Deserializes every shared golden fixture from
+//! `contracts/claw-api/fixtures` through the generated `claw_api`
+//! models. The TS suite round-trips the same files, so a fixture that
+//! passes both proves the two type systems agree on the wire shape.
+
 use axum::{http::StatusCode, response::IntoResponse};
 use claw_api::models::{
     ApiError, AppendRecordingEventsResponse, CancelSessionResponse, Connection, ConnectionList,

--- a/packages/browseros-agent/apps/claw-server/src/lib/api-error.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/api-error.ts
@@ -1,5 +1,10 @@
 import type { ApiError } from '@browseros/claw-api'
 
+/**
+ * Error envelope for the canonical API surface. Route handlers and the
+ * server-level catch-all both funnel through here so error bodies stay
+ * in lockstep with the contract's `ApiError` schema.
+ */
 export function canonicalApiError(
   code: string,
   message: string,

--- a/packages/browseros-agent/apps/claw-server/src/lib/request-id.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/request-id.ts
@@ -1,5 +1,11 @@
 import type { Context, MiddlewareHandler } from 'hono'
 
+/**
+ * Per-request id for the canonical API surface. Minted server-side —
+ * never read from an inbound header — stored on the Hono context,
+ * echoed back as `x-request-id`, and embedded in canonical `ApiError`
+ * bodies so a reported failure can be tied to the exact request.
+ */
 export type RequestContextEnv = {
   Variables: {
     requestId: string

--- a/packages/browseros-agent/apps/claw-server/src/lib/tab-activity/registry.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/tab-activity/registry.ts
@@ -10,6 +10,12 @@
  * `GET /tabs/activity` to render the current view.
  *
  * Each record carries:
+ *   - `sessionId`: the MCP session currently claiming the tab. The
+ *     canonical `/api/v1/tabs` attributes the tab to it, and recording
+ *     ingest refuses batches whose claim has drifted from it.
+ *   - `tabId`: the browser tab id, kept alongside the CDP identifiers
+ *     because the recorder addresses tabs by tab id — it is the join
+ *     key between recorder batches and CDP-side state.
  *   - `firstToolAt`: when this agent first touched the tab (does not
  *     update on subsequent tool calls).
  *   - `lastToolAt` / `lastToolName`: the most recent dispatch.

--- a/packages/browseros-agent/apps/claw-server/src/routes/api-v1/index.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/api-v1/index.ts
@@ -29,6 +29,13 @@ export interface BinaryAsset {
   etag?: string
 }
 
+/**
+ * `live` — an MCP transport is still attached; `ended` — the transport
+ * is gone but audit history remains; `missing` — unknown id. The
+ * distinction drives the canonical status split: for an ended session,
+ * cancel answers 409 and recording ingest 410; both answer 404 for a
+ * missing one.
+ */
 export type SessionState = 'live' | 'ended' | 'missing'
 
 export interface CanonicalSessionQuery {
@@ -55,9 +62,13 @@ export interface CanonicalApiDependencies {
   listSessions(query: CanonicalSessionQuery): SessionList
   getSession(sessionId: string): SessionDetail | null
   getSessionState(sessionId: string): SessionState
+  /** Returns how many in-flight dispatches were aborted. */
   cancelSession(sessionId: string): number
+  /** Null means unknown session — a known session with no captured events still gets metadata (`hasData: false`). */
   getRecording(sessionId: string): RecordingMetadata | null
+  /** Full NDJSON stream. Null means unknown session; `''` means known but nothing captured yet. */
   downloadRecordingEvents(sessionId: string): Promise<string | null>
+  /** Null means the (tab, page, target) association no longer belongs to this session. */
   appendRecordingEvents(
     sessionId: string,
     association: RecordingAssociation,
@@ -144,6 +155,12 @@ export function createCanonicalApiRoute(deps: CanonicalApiDependencies) {
         'content-type must be application/x-ndjson',
       )
     }
+    // The recorder pins every batch to the (tab, page, target)
+    // incarnation it captured from. All three are required so a batch
+    // can never be attributed to a tab that was since reclaimed —
+    // appendRecordingEvents refuses (409) when the association no
+    // longer holds, and the recorder drops its cached association on
+    // any of 404/409/410.
     const tabId = positiveInteger(c.req.header('x-recording-tab-id') ?? '')
     const pageId = positiveInteger(c.req.header('x-recording-page-id') ?? '')
     const targetId = c.req.header('x-recording-target-id')
@@ -182,6 +199,7 @@ export function createCanonicalApiRoute(deps: CanonicalApiDependencies) {
     if (!asset) {
       return apiError(c, 404, 'preview_not_found', 'tab preview not found')
     }
+    // Superseded by the next screencast frame — never serve from cache.
     return binaryResponse(asset, 'private, max-age=0, must-revalidate')
   })
   app.get('/api/v1/dispatches/:dispatchId/screenshot', (c) => {
@@ -198,6 +216,7 @@ export function createCanonicalApiRoute(deps: CanonicalApiDependencies) {
         'dispatch screenshot not found',
       )
     }
+    // Written once at capture time — safe to cache hard.
     return binaryResponse(asset, 'public, max-age=86400, immutable')
   })
 
@@ -237,6 +256,8 @@ function binaryResponse(asset: BinaryAsset, cacheControl: string): Response {
     'cache-control': cacheControl,
   }
   if (asset.etag) headers.etag = `"${asset.etag}"`
+  // TS rejects `Uint8Array<ArrayBufferLike>` as BodyInit, so copy the
+  // bytes into a fresh ArrayBuffer the Response can own.
   const body = new ArrayBuffer(asset.bytes.byteLength)
   new Uint8Array(body).set(asset.bytes)
   return new Response(body, { headers })
@@ -305,6 +326,7 @@ function parseSessionQuery(
   }
 }
 
+/** `undefined` — param absent; `false` — present but not an integer in [minimum, maximum]. */
 function optionalInteger(
   raw: string | undefined,
   minimum: number,

--- a/packages/browseros-agent/apps/claw-server/src/routes/api-v1/production.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/api-v1/production.ts
@@ -2,6 +2,16 @@
  * @license
  * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Production wiring for the canonical API: adapts the server's existing
+ * services (audit task store, MCP identity service, replay + recording
+ * stores, screencast cache, harness connect) onto the
+ * implementation-neutral `CanonicalApiDependencies` seam. `createServer`
+ * mounts this by default; tests swap in fakes.
+ *
+ * Vocabulary bridge: a canonical *session* is what the audit services
+ * call a *task* (both keyed by MCP session id), and a canonical
+ * *dispatch* is one audited tool call.
  */
 
 import { existsSync, readFileSync } from 'node:fs'
@@ -68,6 +78,10 @@ export const canonicalApiDependencies: CanonicalApiDependencies = {
       ...(query.cursor !== undefined ? { cursor: query.cursor } : {}),
       ...(query.limit !== undefined ? { limit: query.limit } : {}),
     })
+    // Browser profiles are a BrowserOS-native concept: only the Rust
+    // server mints `profileId`, this server never does, so a profileId
+    // filter here matches nothing. The filter exists for parity with
+    // the contract's query surface.
     const items = result.tasks.map(sessionSummary)
     const filtered = query.profileId
       ? items.filter((item) => item.profileId === query.profileId)
@@ -82,6 +96,8 @@ export const canonicalApiDependencies: CanonicalApiDependencies = {
     return task ? sessionDetail(task) : null
   },
   getSessionState(sessionId) {
+    // Liveness comes from the MCP identity service (a transport is
+    // still attached); the audit store remembers ended sessions.
     if (identityService.getIdentity(sessionId)) return 'live'
     return getTask(sessionId) ? 'ended' : 'missing'
   },
@@ -93,6 +109,8 @@ export const canonicalApiDependencies: CanonicalApiDependencies = {
   getRecording(sessionId) {
     if (!knownSession(sessionId)) return null
     const metadata = replayService.getMeta(sessionId)
+    // pageIds = tabs still claimed by this session whose targets have
+    // recorded events — the per-tab views a replay can offer.
     const targetIds = new Set(metadata.targets.map((target) => target.targetId))
     const pageIds = tabActivityRegistry
       .snapshot()
@@ -198,6 +216,13 @@ export const canonicalApiDependencies: CanonicalApiDependencies = {
   },
 }
 
+/**
+ * A batch lands only while the recorder's (tab, page, target) claim
+ * still matches the live registry for that session. Any drift — the tab
+ * reclaimed by another session, a navigation that swapped the target —
+ * makes the batch undeliverable rather than attributing its events to
+ * the wrong replay. Exported for the route tests.
+ */
 export function recordingTargetFor(
   tabs: TabActivityRecord[],
   sessionId: string,
@@ -270,6 +295,7 @@ function connection(state: ConnectionState): Connection {
   }
 }
 
+/** Tolerant parse of recorder-supplied NDJSON: lines that aren't JSON or lack a finite `ts` are dropped, never fatal. */
 function parseRecordingEvents(ndjson: string): RecordingEventInput[] {
   const events: RecordingEventInput[] = []
   for (const line of ndjson.split('\n')) {

--- a/packages/browseros-agent/apps/claw-server/src/routes/tabs/index.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/tabs/index.ts
@@ -27,6 +27,8 @@ import {
 import { screencastCache } from '../../services/screencast-cache'
 import { resolveAgentDisplay } from './agent-display'
 
+// This route's wire shape predates sessionId/tabId and stays frozen;
+// the canonical `/api/v1/tabs` carries the full record.
 type LegacyTabActivityRecord = Omit<TabActivityRecord, 'sessionId' | 'tabId'>
 
 interface EnrichedTabRecord extends LegacyTabActivityRecord {

--- a/packages/browseros-agent/apps/claw-server/src/server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/server.ts
@@ -4,8 +4,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * Hono application composition for the standalone BrowserClaw server.
- * Callers create an isolated app instance so tests can inject lifecycle
- * hooks and the production entry point can own shutdown behavior.
+ * Two API generations mount side by side: the canonical surface
+ * implemented against the shared OpenAPI contract (generated
+ * `@browseros/claw-api` types — the same contract claw-server-rust
+ * implements), and the legacy route families that predate it. Callers
+ * create an isolated app instance so tests can inject lifecycle hooks
+ * and canonical dependencies; the production entry point owns shutdown
+ * behavior.
  */
 
 import type { MiddlewareHandler } from 'hono'
@@ -98,6 +103,11 @@ export function createServer(options: CreateServerOptions = {}) {
   // JSON body.
   app.onError((err, c) => {
     captureRouteError(err, c.req.path, c.req.method)
+    // Contract routes must fail in-contract: the canonical `ApiError`
+    // envelope with the request id, never the legacy `{ error }` shape.
+    // onError cannot tell which sub-router threw, so membership is by
+    // path — `/api/v1/*` plus the two `/system` endpoints the contract
+    // also owns.
     if (
       c.req.path.startsWith('/api/v1/') ||
       c.req.path === '/system/health' ||

--- a/packages/browseros-agent/apps/claw-server/tests/contract/fixtures.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/contract/fixtures.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Round-trips every shared contract fixture through the generated
+ * deserializers and back, asserting byte-for-byte JSON equality. The
+ * same fixtures feed the Rust server's `contract_fixtures` tests, so a
+ * fixture that survives both proves the two type systems agree on the
+ * wire shape.
+ */
+
 import { describe, expect, test } from 'bun:test'
 import {
   ApiErrorFromJSON,

--- a/packages/browseros-agent/apps/claw-server/tests/contract/fixtures.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/contract/fixtures.test.ts
@@ -1,9 +1,9 @@
 /**
  * Round-trips every shared contract fixture through the generated
- * deserializers and back, asserting byte-for-byte JSON equality. The
- * same fixtures feed the Rust server's `contract_fixtures` tests, so a
- * fixture that survives both proves the two type systems agree on the
- * wire shape.
+ * deserializers and back, asserting the JSON survives value-for-value.
+ * The same fixtures feed the Rust server's `contract_fixtures` tests,
+ * so a fixture that survives both proves the two type systems agree on
+ * the wire shape.
  */
 
 import { describe, expect, test } from 'bun:test'

--- a/packages/browseros-agent/contracts/claw-api/tests/cases.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/cases.ts
@@ -1,3 +1,15 @@
+/**
+ * The behavioral half of the contract: every case runs verbatim against
+ * both server implementations through the generated client, asserting
+ * observable wire behavior only — status codes, envelopes, headers —
+ * never anything implementation-specific. A case that passes on one
+ * server and fails on the other is by definition a contract violation.
+ *
+ * Cases assume the seeded world the adapters provide (a live and an
+ * ended session, tab 101 / page 7 / target-7, one screenshot). The
+ * `shutdown` case must stay last: it kills the server it runs against.
+ */
+
 import { expect } from 'bun:test'
 import {
   type ApiError,
@@ -11,6 +23,12 @@ export interface ContractCase {
   run(server: ContractServer): Promise<void>
 }
 
+// Legacy vocabulary the canonical surface must never leak (sessions
+// replaced agents/tasks/runs), and the inline-frame key the tab list
+// must not carry (binary travels via the preview/screenshot endpoints).
+// Spelled via concatenation so the forbidden names never appear
+// literally in contract sources — a plain grep for them across the
+// canonical surface should come up empty.
 const FORBIDDEN_IDENTITY_KEYS = ['agent', 'task', 'run'].map(
   (scope) => `${scope}Id`,
 )
@@ -62,6 +80,8 @@ export const contractCases: ContractCase[] = [
       for (const key of FORBIDDEN_IDENTITY_KEYS) {
         expect(serialized).not.toContain(key)
       }
+      // Absent optional fields are omitted entirely, never null — the
+      // reason both servers build responses field-conditionally.
       expect(JSON.stringify(detail)).not.toContain(':null')
     },
   },

--- a/packages/browseros-agent/contracts/claw-api/tests/cases.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/cases.ts
@@ -1,9 +1,10 @@
 /**
  * The behavioral half of the contract: every case runs verbatim against
- * both server implementations through the generated client, asserting
- * observable wire behavior only — status codes, envelopes, headers —
- * never anything implementation-specific. A case that passes on one
- * server and fails on the other is by definition a contract violation.
+ * both server implementations through the generated client (raw fetch
+ * where the client can't express the check), asserting observable wire
+ * behavior only — status codes, envelopes, headers — never anything
+ * implementation-specific. A case that passes on one server and fails
+ * on the other is by definition a contract violation.
  *
  * Cases assume the seeded world the adapters provide (a live and an
  * ended session, tab 101 / page 7 / target-7, one screenshot). The
@@ -27,8 +28,8 @@ export interface ContractCase {
 // replaced agents/tasks/runs), and the inline-frame key the tab list
 // must not carry (binary travels via the preview/screenshot endpoints).
 // Spelled via concatenation so the forbidden names never appear
-// literally in contract sources — a plain grep for them across the
-// canonical surface should come up empty.
+// literally in the contract package — a plain grep for them under
+// `contracts/claw-api` should come up empty.
 const FORBIDDEN_IDENTITY_KEYS = ['agent', 'task', 'run'].map(
   (scope) => `${scope}Id`,
 )

--- a/packages/browseros-agent/contracts/claw-api/tests/cross-server.test.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/cross-server.test.ts
@@ -1,8 +1,8 @@
 /**
  * Cross-server contract suite: runs every shared case against both
- * server implementations over real HTTP, through the generated client.
- * This is the gate that keeps claw-server and claw-server-rust
- * interchangeable behind the canonical API.
+ * server implementations over real HTTP. This is the gate that keeps
+ * claw-server and claw-server-rust interchangeable behind the canonical
+ * API.
  *
  * Each server boots lazily on the first case that needs it; the
  * `shutdown` case kills it, so it is torn down there rather than in

--- a/packages/browseros-agent/contracts/claw-api/tests/cross-server.test.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/cross-server.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Cross-server contract suite: runs every shared case against both
+ * server implementations over real HTTP, through the generated client.
+ * This is the gate that keeps claw-server and claw-server-rust
+ * interchangeable behind the canonical API.
+ *
+ * Each server boots lazily on the first case that needs it; the
+ * `shutdown` case kills it, so it is torn down there rather than in
+ * `afterAll` (which only covers early-exit paths).
+ */
+
 import { afterAll, describe, test } from 'bun:test'
 import { contractCases } from './cases'
 import {

--- a/packages/browseros-agent/contracts/claw-api/tests/server-adapters.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/server-adapters.ts
@@ -1,3 +1,16 @@
+/**
+ * Boots each implementation for the cross-server suite. The TypeScript
+ * server runs in-process: `createServer` with scripted
+ * `CanonicalApiDependencies`. The Rust server runs as the compiled
+ * `contract-server` example (claw-server-rust), which seeds real app
+ * state to the same shape.
+ *
+ * The fixtures here — `liveSession` / `endedSession`, tab 101 / page 7
+ * / target-7, dispatch 1 with its screenshot — must stay in lockstep
+ * with the Rust example's `seed()`: the cases assert the same values
+ * against both servers.
+ */
+
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'

--- a/packages/browseros-agent/scripts/codegen/claw-api.ts
+++ b/packages/browseros-agent/scripts/codegen/claw-api.ts
@@ -1,3 +1,19 @@
+/**
+ * Codegen for the canonical BrowserClaw API. Reads the OpenAPI spec at
+ * `contracts/claw-api/openapi.yaml` and emits both generated clients:
+ * the TypeScript fetch client into `packages/claw-api/src/generated`
+ * and the Rust DTOs into `crates/claw-api/src/generated`. Neither tree
+ * is ever hand-edited — change the spec, then regenerate with
+ * `bun run codegen:claw-api`.
+ *
+ * The generator runs in Docker with a pinned image and the output is
+ * normalized (trailing whitespace stripped, generated Rust run through
+ * rustfmt) so the emitted trees are byte-identical across machines.
+ * That determinism is what lets `--check` (`bun run
+ * codegen:claw-api:check`, the CI drift gate) compare a fresh
+ * generation against the committed trees byte for byte.
+ */
+
 import { spawnSync } from 'node:child_process'
 import {
   cpSync,
@@ -20,6 +36,8 @@ interface GeneratedTrees {
 }
 
 function runGenerator(outputRoot: string): GeneratedTrees {
+  // Run the container as the invoking user so the generated files on
+  // the bind mount aren't root-owned on Linux hosts.
   const mount = `${process.getuid?.() ?? 1000}:${process.getgid?.() ?? 1000}`
   const common = [
     'run',


### PR DESCRIPTION
## Summary
- Restores the commentary that #1892 (canonical BrowserClaw API contract) dropped in the server rewrites, and documents the new hand-written surfaces that shipped bare — comments-only, zero behavior change.
- claw-server (TS): rewritten `server.ts` header for today's two-generation composition, canonical error-envelope/onError rationale, `SessionState` + dependency-seam null semantics, recording batch-pinning gotcha, `profileId` asymmetry, cache-control decisions, `BodyInit` copy gotcha.
- claw-server-rust: `routes::api_v1` module doc, mirrored route semantics (profile filter post-pagination, association pinning, label fallback chain), `RequestId`/`CanonicalError` error-dialect docs, `#[serde(skip)]` legacy-wire rationale, shutdown-owner note, headers for `examples/contract-server.rs` and the canonical/fixture test crates.
- contracts + codegen: purpose docs for the cross-server suite (`cases.ts` / `server-adapters.ts` / `cross-server.test.ts`, incl. the TS↔Rust fixture-lockstep constraint and the no-`:null` wire rule) and for `scripts/codegen/claw-api.ts` (spec location, emitted trees, regen + `--check` drift gate).

## Design
Single curated pass, one subsystem per commit, each verified with its own toolchain. Removed comments were treated as raw material, not restored verbatim — several described deleted behavior (e.g. the old `AppType` hono-rpc story in `server.ts`). Every factual claim was traced to the implementation before being written down; an adversarial context-free review then re-verified all claims and its four accuracy findings were fixed. Generated trees (`crates/claw-api/src/generated`, `packages/claw-api/src/generated`) are untouched — if richer generated-client docs are wanted, the right lever is OpenAPI `description` fields flowing through codegen (deliberately not done here).

## Test plan
- [x] claw-server: `bun run typecheck` + `bun run test` (61 files, 0 fail)
- [x] claw-server-rust: `cargo clippy --all-targets -- -D warnings` + `cargo test` (156 tests pass)
- [x] contract suite: `bun run test:claw-api-contract` (30/30) and `bun run codegen:claw-api:check` (output current)
- [x] `git diff main...HEAD` audited comments-only (230 insertions, 3 deletions, all comment/blank lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)