### PR TITLE
fix(browseros-core): deserialize backendDOMNodeId so refs mint

### DIFF
--- a/packages/browseros-agent/crates/browseros-core/src/observer.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer.rs
@@ -379,6 +379,7 @@ struct RuntimeEvalResult {
 #[derive(Debug, Deserialize)]
 struct RemoteValue {
     value: Option<Value>,
+    #[serde(rename = "objectId")]
     object_id: Option<String>,
 }
 
@@ -673,7 +674,7 @@ fn name_of(node: &AxNode) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_ref_entry;
+    use super::{RemoteValue, resolve_ref_entry};
     use crate::{
         BrowserSession, BrowserSessionHooks, CoreError, ProtocolSession,
         connection::CdpConnection,
@@ -773,6 +774,17 @@ mod tests {
                 .then(|| children.iter().map(|child| (*child).to_string()).collect()),
             ..AxNode::default()
         }
+    }
+
+    #[test]
+    fn runtime_remote_value_deserializes_object_id() -> Result<(), serde_json::Error> {
+        let value: RemoteValue = serde_json::from_value(json!({
+            "type": "object",
+            "objectId": "-6404171882913021072.1.1"
+        }))?;
+
+        assert_eq!(value.object_id.as_deref(), Some("-6404171882913021072.1.1"));
+        Ok(())
     }
 
     #[tokio::test]

--- a/packages/browseros-agent/crates/browseros-core/src/snapshot/ax_types.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/snapshot/ax_types.rs
@@ -33,7 +33,7 @@ pub struct AxNode {
     pub properties: Option<Vec<AxProperty>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub child_ids: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "backendDOMNodeId", skip_serializing_if = "Option::is_none")]
     pub backend_dom_node_id: Option<i64>,
 }
 

--- a/packages/browseros-agent/crates/browseros-core/tests/data/get-full-ax-tree.json
+++ b/packages/browseros-agent/crates/browseros-core/tests/data/get-full-ax-tree.json
@@ -1,0 +1,54 @@
+{
+  "nodes": [
+    {
+      "nodeId": "1",
+      "ignored": false,
+      "role": { "type": "internalRole", "value": "RootWebArea" },
+      "name": { "type": "computedString", "value": "Checkout" },
+      "childIds": ["2"],
+      "backendDOMNodeId": 1
+    },
+    {
+      "nodeId": "2",
+      "ignored": false,
+      "role": { "type": "role", "value": "main" },
+      "name": { "type": "computedString", "value": "Checkout" },
+      "childIds": ["3", "4", "5"],
+      "backendDOMNodeId": 2
+    },
+    {
+      "nodeId": "3",
+      "ignored": false,
+      "role": { "type": "role", "value": "paragraph" },
+      "name": { "type": "computedString", "value": "Review your order" },
+      "backendDOMNodeId": 3
+    },
+    {
+      "nodeId": "4",
+      "ignored": false,
+      "role": { "type": "role", "value": "button" },
+      "name": { "type": "computedString", "value": "Place order" },
+      "properties": [
+        {
+          "name": "focusable",
+          "value": { "type": "booleanOrUndefined", "value": true }
+        }
+      ],
+      "backendDOMNodeId": 101
+    },
+    {
+      "nodeId": "5",
+      "ignored": false,
+      "role": { "type": "role", "value": "textbox" },
+      "name": { "type": "computedString", "value": "Promo code" },
+      "value": { "type": "string", "value": "SAVE20" },
+      "properties": [
+        {
+          "name": "editable",
+          "value": { "type": "token", "value": "plaintext" }
+        }
+      ],
+      "backendDOMNodeId": 102
+    }
+  ]
+}

--- a/packages/browseros-agent/crates/browseros-core/tests/snapshot_cdp_fixture.rs
+++ b/packages/browseros-agent/crates/browseros-core/tests/snapshot_cdp_fixture.rs
@@ -1,0 +1,70 @@
+use browseros_core::snapshot::{
+    AxNode, RefMap, RenderOptions, SnapshotMode, SnapshotOptions, apply_snapshot_options,
+    render_snapshot,
+};
+use serde::Deserialize;
+
+const GET_FULL_AX_TREE: &str = include_str!("data/get-full-ax-tree.json");
+
+#[derive(Deserialize)]
+struct AxTreeResult {
+    nodes: Vec<AxNode>,
+}
+
+fn fixture() -> Result<AxTreeResult, serde_json::Error> {
+    serde_json::from_str(GET_FULL_AX_TREE)
+}
+
+#[test]
+fn cdp_ax_tree_deserializes_backend_dom_node_ids() -> Result<(), serde_json::Error> {
+    let result = fixture()?;
+    let button = result.nodes.iter().find(|node| node.node_id == "4");
+    let textbox = result.nodes.iter().find(|node| node.node_id == "5");
+
+    assert_eq!(button.and_then(|node| node.backend_dom_node_id), Some(101));
+    assert_eq!(textbox.and_then(|node| node.backend_dom_node_id), Some(102));
+    Ok(())
+}
+
+#[test]
+fn cdp_ax_tree_mints_refs_retained_by_interactive_mode() -> Result<(), serde_json::Error> {
+    let result = fixture()?;
+    let mut refs = RefMap::new();
+    let mut render_options = RenderOptions {
+        refs: &mut refs,
+        frame_id: None,
+        document_id: None,
+        cursor_hits: None,
+        base_depth: 0,
+    };
+
+    let full = render_snapshot(&result.nodes, &mut render_options).text;
+    assert_eq!(
+        full,
+        [
+            "- main \"Checkout\"",
+            "  - paragraph \"Review your order\"",
+            "  - button \"Place order\" [ref=e1]",
+            "  - textbox \"Promo code\" [ref=e2]: \"SAVE20\"",
+        ]
+        .join("\n")
+    );
+
+    let interactive = apply_snapshot_options(
+        &full,
+        SnapshotOptions {
+            mode: SnapshotMode::Interactive,
+            depth: None,
+        },
+    );
+    assert_eq!(
+        interactive,
+        [
+            "- main \"Checkout\"",
+            "  - button \"Place order\" [ref=e1]",
+            "  - textbox \"Promo code\" [ref=e2]: \"SAVE20\"",
+        ]
+        .join("\n")
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- map CDP's exact `backendDOMNodeId` wire key into `AxNode.backend_dom_node_id`, restoring refs for semantic interactive elements
- map `Runtime.evaluate`'s `objectId` into the cursor-augmentation response, restoring refs and `[cursor=pointer]` for non-ARIA click targets
- parse a realistic `Accessibility.getFullAXTree` JSON fixture through the public render pipeline and assert button/textbox refs survive interactive mode

## Verified root cause

The original diagnosis was correct for semantic refs: `#[serde(rename_all = "camelCase")]` mapped `backend_dom_node_id` to `backendDomNodeId`, but CDP sends `backendDOMNodeId`. Before changing production code, the new deserialization test failed with `left: None`, `right: Some(101)`.

The live Rust-server smoke found one additional wire bug in the same path. Cursor scanning successfully located the synthetic pointer target, but `RemoteValue.object_id` had no `objectId` mapping, so `DOM.describeNode` was never reached. Its focused CDP-shaped test also failed `None` versus the expected object handle before the explicit rename.

No ref semantics, role tables, interactive filtering, or output formatting changed.

## Snapshot before / after

Before, the fixture's full snapshot had controls but no handles, and interactive mode reduced to its first ancestor line:

```text
- main "Checkout"
  - paragraph "Review your order"
  - button "Place order"
  - textbox "Promo code": "SAVE20"

# mode="interactive"
- main "Checkout"
```

After, the fixture and a live `claw-server-rust` smoke retain real controls; the live page also exercises cursor augmentation:

```text
- heading "AX smoke" [level=1]
- button "Run smoke" [ref=e1]
  - textbox "Query" [ref=e2]
- generic [ref=e3] [cursor=pointer]
```

## Audit

Manual CDP response structs in `browseros-core` were checked against the pinned protocol JSON. `backendDOMNodeId` is the only represented name with a preserved `DOM`/`URL`/`CSS`/`HTML` initialism. The live smoke additionally caught the missing ordinary camelCase `objectId` mapping described above; both corrections have direct deserialization assertions.

## Test plan

- [x] pre-fix `cdp_ax_tree_deserializes_backend_dom_node_ids` fails `None` vs `Some(101)`
- [x] pre-fix `runtime_remote_value_deserializes_object_id` fails `None` vs the CDP object handle
- [x] `cargo test -p browseros-core -p browseros-mcp -p claw-server-rust`
- [x] `cargo clippy -p browseros-core -p browseros-mcp -p claw-server-rust --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `bun run check` (exit 0; existing unrelated Biome/Fallow warnings remain)
- [x] `bun run test`
- [x] live `claw-server-rust` stdio MCP smoke against BrowserOS CDP 9421; background test page closed afterward
