### PR TITLE
fix(ci): pass server build secrets to nightly staging steps

### DIFF
--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -139,6 +139,12 @@ jobs:
         env:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
           CLAW_POSTHOG_KEY: ${{ secrets.CLAW_POSTHOG_KEY }}
+          # server.ts --ci inlines these (REQUIRED_PROD_VARS); placeholders
+          # otherwise — see the matching block in nightly-browseros.yml.
+          BROWSEROS_CONFIG_URL: ${{ secrets.BROWSEROS_CONFIG_URL }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          AGENT_RUNNER_JWT_SECRET: ${{ secrets.AGENT_RUNNER_JWT_SECRET }}
         run: |
           set -euo pipefail
           agent_root="$BROWSEROS_REPO/packages/browseros-agent"

--- a/.github/workflows/nightly-browseros.yml
+++ b/.github/workflows/nightly-browseros.yml
@@ -259,6 +259,14 @@ jobs:
       - name: Stage BrowserOS nightly resources
         env:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          # The server build inlines these at compile time (REQUIRED_PROD_VARS in
+          # scripts/build/server/descriptor.ts); without them --ci substitutes
+          # browseros.invalid placeholders and the shipped server cannot reach
+          # the BrowserOS config/credits API.
+          BROWSEROS_CONFIG_URL: ${{ secrets.BROWSEROS_CONFIG_URL }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          AGENT_RUNNER_JWT_SECRET: ${{ secrets.AGENT_RUNNER_JWT_SECRET }}
         run: |
           set -euo pipefail
           agent_root="$BROWSEROS_REPO/packages/browseros-agent"


### PR DESCRIPTION
Nightlies have shipped `browseros_server` with the `https://browseros.invalid/...` placeholder config URL since the per-product nightlies began staging the server locally with `bun scripts/build/server.ts --ci` (~Jul 6-8): the staging steps never passed `REQUIRED_PROD_VARS` (`scripts/build/server/descriptor.ts`), so the `--ci` placeholder defaults got inlined into the binary. Result: the default `browseros` provider and credits endpoints cannot connect in nightly builds (BYO-key providers unaffected). PostHog/Sentry are placeholder too.

Mirrors `release-server.yml`: pass `BROWSEROS_CONFIG_URL`, `POSTHOG_API_KEY`, `SENTRY_DSN`, `AGENT_RUNNER_JWT_SECRET` (all existing repo secrets) to both nightly staging steps.

Found while validating the chromium-151 nightly (#1900) — verified fixed by re-running the nightly on that branch with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZ3u9Dc57DL56JCsZy8uCg