### PR TITLE
fix(server): forward configured baseUrl for Anthropic, OpenAI, Google, OpenRouter, Azure factories

### DIFF
--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -889,6 +889,12 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
               <FormControl>
                 <Input placeholder="https://api.openai.com/v1" {...field} />
               </FormControl>
+              {watchedType === 'openai' && (
+                <FormDescription>
+                  If your custom endpoint doesn't work with OpenAI, try the
+                  OpenAI Compatible provider template instead.
+                </FormDescription>
+              )}
               <FormMessage />
             </FormItem>
           )}

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -278,18 +278,21 @@ function createAnthropicFactory(
   })
 }
 
-// OpenAI-specific: `baseUrl` is intentionally NOT forwarded here.
-// The SDK's default transport is the Responses API and almost every
-// OpenAI-shape proxy in the wild (MiniMax, LiteLLM, self-hosted
-// gateways) speaks Chat Completions instead, so silently threading
-// baseURL would swap one silent failure for another. The /mcp UI
-// shows a hint on the OpenAI Base URL field pointing users at the
-// "OpenAI Compatible" provider template for that case.
+// The SDK defaults to the Responses API; many OpenAI-shape proxies
+// only speak Chat Completions. The `NewProviderDialog` shows a hint
+// on the OpenAI Base URL field pointing users at the "OpenAI
+// Compatible" provider template for that case, so a proxy that fails
+// here has a documented next step. Users who point at a Responses-
+// compatible custom endpoint get the direct-forward behavior they
+// asked for.
 function createOpenAIFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('OpenAI provider requires apiKey')
-  return createOpenAI({ apiKey: config.apiKey })
+  return createOpenAI({
+    apiKey: config.apiKey,
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
+  })
 }
 
 function createGoogleFactory(

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -272,9 +272,19 @@ function createAnthropicFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('Anthropic provider requires apiKey')
-  return createAnthropic({ apiKey: config.apiKey })
+  return createAnthropic({
+    apiKey: config.apiKey,
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
+  })
 }
 
+// OpenAI-specific: `baseUrl` is intentionally NOT forwarded here.
+// The SDK's default transport is the Responses API and almost every
+// OpenAI-shape proxy in the wild (MiniMax, LiteLLM, self-hosted
+// gateways) speaks Chat Completions instead, so silently threading
+// baseURL would swap one silent failure for another. The /mcp UI
+// shows a hint on the OpenAI Base URL field pointing users at the
+// "OpenAI Compatible" provider template for that case.
 function createOpenAIFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
@@ -286,7 +296,10 @@ function createGoogleFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('Google provider requires apiKey')
-  return createGoogleGenerativeAI({ apiKey: config.apiKey })
+  return createGoogleGenerativeAI({
+    apiKey: config.apiKey,
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
+  })
 }
 
 function createOpenRouterFactory(
@@ -297,18 +310,27 @@ function createOpenRouterFactory(
     apiKey: config.apiKey,
     extraBody: { reasoning: {} },
     fetch: createOpenRouterCompatibleFetch(),
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
   })
 }
 
 function createAzureFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
-  if (!config.apiKey || !config.resourceName) {
-    throw new Error('Azure provider requires apiKey and resourceName')
+  // baseUrl and resourceName are mutually exclusive per the
+  // @ai-sdk/azure contract; the SDK ignores resourceName when
+  // baseURL is set. Accept either so users of custom Azure OpenAI
+  // gateways can point at a full URL directly. The UI copy already
+  // says "Overrides resource name if set".
+  if (!config.apiKey || (!config.resourceName && !config.baseUrl)) {
+    throw new Error(
+      'Azure provider requires apiKey and either resourceName or baseUrl',
+    )
   }
   return createAzure({
-    resourceName: config.resourceName,
     apiKey: config.apiKey,
+    ...(config.resourceName && { resourceName: config.resourceName }),
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
   })
 }
 

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-baseurl.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-baseurl.test.ts
@@ -3,14 +3,15 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Regression coverage: Anthropic / Google / OpenRouter / Azure factories
- * must forward a configured `baseUrl` as the SDK's `baseURL` option and
- * omit it when the field is unset so the SDK default endpoint stands.
+ * Regression coverage: every URL-configurable model-backed factory
+ * (Anthropic, OpenAI, Google, OpenRouter, Azure) must forward a
+ * configured `baseUrl` as the SDK's `baseURL` option and omit it
+ * when the field is unset so the SDK default endpoint stands.
  *
- * OpenAI is intentionally excluded from this suite: `createOpenAIFactory`
- * does NOT forward baseUrl (the SDK's default Responses API transport
- * doesn't match what most OpenAI-shape proxies speak; users are routed
- * to the "OpenAI Compatible" provider template via a UI hint instead).
+ * The OpenAI branch also carries a UI hint in NewProviderDialog
+ * pointing users at the "OpenAI Compatible" provider template when
+ * a custom endpoint speaks Chat Completions instead of the default
+ * Responses API; that hint is a UX concern, not a factory concern.
  */
 
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
@@ -22,10 +23,17 @@ import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 // `provider-factory.ts` is imported below.
 const lastCallArgs: {
   anthropic: Record<string, unknown> | null
+  openai: Record<string, unknown> | null
   google: Record<string, unknown> | null
   openrouter: Record<string, unknown> | null
   azure: Record<string, unknown> | null
-} = { anthropic: null, google: null, openrouter: null, azure: null }
+} = {
+  anthropic: null,
+  openai: null,
+  google: null,
+  openrouter: null,
+  azure: null,
+}
 
 function fakeProvider(): (modelId: string) => unknown {
   const fn = (modelId: string) => ({ modelId })
@@ -35,6 +43,13 @@ function fakeProvider(): (modelId: string) => unknown {
 mock.module('@ai-sdk/anthropic', () => ({
   createAnthropic: (args: Record<string, unknown>) => {
     lastCallArgs.anthropic = args
+    return fakeProvider()
+  },
+}))
+
+mock.module('@ai-sdk/openai', () => ({
+  createOpenAI: (args: Record<string, unknown>) => {
+    lastCallArgs.openai = args
     return fakeProvider()
   },
 }))
@@ -71,6 +86,7 @@ const { createLanguageModel } = await import('../../src/agent/provider-factory')
 
 beforeEach(() => {
   lastCallArgs.anthropic = null
+  lastCallArgs.openai = null
   lastCallArgs.google = null
   lastCallArgs.openrouter = null
   lastCallArgs.azure = null
@@ -115,6 +131,33 @@ describe('createAnthropicFactory baseUrl handling', () => {
       baseUrl: '',
     })
     expect(lastCallArgs.anthropic).not.toHaveProperty('baseURL')
+  })
+})
+
+describe('createOpenAIFactory baseUrl handling', () => {
+  it('forwards a configured baseUrl as the SDK baseURL option', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.OPENAI,
+      model: 'gpt-4o',
+      apiKey: 'sk-openai-test',
+      baseUrl: 'https://gateway.internal/openai',
+    })
+    expect(lastCallArgs.openai).toMatchObject({
+      apiKey: 'sk-openai-test',
+      baseURL: 'https://gateway.internal/openai',
+    })
+  })
+
+  it('omits baseURL when baseUrl is unset (SDK default preserved)', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.OPENAI,
+      model: 'gpt-4o',
+      apiKey: 'sk-openai-test',
+    })
+    expect(lastCallArgs.openai).toEqual({ apiKey: 'sk-openai-test' })
+    expect(lastCallArgs.openai).not.toHaveProperty('baseURL')
   })
 })
 

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-baseurl.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-baseurl.test.ts
@@ -1,0 +1,239 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Regression coverage: Anthropic / Google / OpenRouter / Azure factories
+ * must forward a configured `baseUrl` as the SDK's `baseURL` option and
+ * omit it when the field is unset so the SDK default endpoint stands.
+ *
+ * OpenAI is intentionally excluded from this suite: `createOpenAIFactory`
+ * does NOT forward baseUrl (the SDK's default Responses API transport
+ * doesn't match what most OpenAI-shape proxies speak; users are routed
+ * to the "OpenAI Compatible" provider template via a UI hint instead).
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
+
+// Each SDK is mocked as a factory that records its args on
+// `lastCallArgs` and returns a callable stand-in for the language
+// model provider. Live in module scope so the mocks resolve before
+// `provider-factory.ts` is imported below.
+const lastCallArgs: {
+  anthropic: Record<string, unknown> | null
+  google: Record<string, unknown> | null
+  openrouter: Record<string, unknown> | null
+  azure: Record<string, unknown> | null
+} = { anthropic: null, google: null, openrouter: null, azure: null }
+
+function fakeProvider(): (modelId: string) => unknown {
+  const fn = (modelId: string) => ({ modelId })
+  return fn
+}
+
+mock.module('@ai-sdk/anthropic', () => ({
+  createAnthropic: (args: Record<string, unknown>) => {
+    lastCallArgs.anthropic = args
+    return fakeProvider()
+  },
+}))
+
+mock.module('@ai-sdk/google', () => ({
+  createGoogleGenerativeAI: (args: Record<string, unknown>) => {
+    lastCallArgs.google = args
+    return fakeProvider()
+  },
+}))
+
+mock.module('@openrouter/ai-sdk-provider', () => ({
+  createOpenRouter: (args: Record<string, unknown>) => {
+    lastCallArgs.openrouter = args
+    return fakeProvider()
+  },
+}))
+
+mock.module('@ai-sdk/azure', () => ({
+  createAzure: (args: Record<string, unknown>) => {
+    lastCallArgs.azure = args
+    return fakeProvider()
+  },
+}))
+
+// Stub the OpenRouter-compatible fetch helper so the factory does not
+// try to reach the network for tests that never invoke the returned
+// model. Same shape as production, minus side effects.
+mock.module('../../src/lib/openrouter-fetch', () => ({
+  createOpenRouterCompatibleFetch: () => globalThis.fetch,
+}))
+
+const { createLanguageModel } = await import('../../src/agent/provider-factory')
+
+beforeEach(() => {
+  lastCallArgs.anthropic = null
+  lastCallArgs.google = null
+  lastCallArgs.openrouter = null
+  lastCallArgs.azure = null
+})
+
+const CUSTOM_URL = 'https://api.minimax.io/anthropic'
+
+describe('createAnthropicFactory baseUrl handling', () => {
+  it('forwards a configured baseUrl as the SDK baseURL option', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.ANTHROPIC,
+      model: 'claude-sonnet-4-6',
+      apiKey: 'sk-anthropic-test',
+      baseUrl: CUSTOM_URL,
+    })
+    expect(lastCallArgs.anthropic).toMatchObject({
+      apiKey: 'sk-anthropic-test',
+      baseURL: CUSTOM_URL,
+    })
+  })
+
+  it('omits baseURL entirely when baseUrl is unset (SDK default preserved)', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.ANTHROPIC,
+      model: 'claude-sonnet-4-6',
+      apiKey: 'sk-anthropic-test',
+    })
+    expect(lastCallArgs.anthropic).toEqual({ apiKey: 'sk-anthropic-test' })
+    expect(lastCallArgs.anthropic).not.toHaveProperty('baseURL')
+  })
+
+  it('omits baseURL when baseUrl is an empty string', async () => {
+    // Form serialization can produce empty strings for cleared fields;
+    // the short-circuit guard must treat those the same as undefined.
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.ANTHROPIC,
+      model: 'claude-sonnet-4-6',
+      apiKey: 'sk-anthropic-test',
+      baseUrl: '',
+    })
+    expect(lastCallArgs.anthropic).not.toHaveProperty('baseURL')
+  })
+})
+
+describe('createGoogleFactory baseUrl handling', () => {
+  it('forwards a configured baseUrl as the SDK baseURL option', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.GOOGLE,
+      model: 'gemini-2.5-flash',
+      apiKey: 'goog-key',
+      baseUrl: 'https://gateway.internal/gemini',
+    })
+    expect(lastCallArgs.google).toMatchObject({
+      apiKey: 'goog-key',
+      baseURL: 'https://gateway.internal/gemini',
+    })
+  })
+
+  it('omits baseURL when baseUrl is unset', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.GOOGLE,
+      model: 'gemini-2.5-flash',
+      apiKey: 'goog-key',
+    })
+    expect(lastCallArgs.google).toEqual({ apiKey: 'goog-key' })
+  })
+})
+
+describe('createOpenRouterFactory baseUrl handling', () => {
+  it('forwards a configured baseUrl as the SDK baseURL option', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.OPENROUTER,
+      model: 'anthropic/claude-sonnet-4.5',
+      apiKey: 'or-key',
+      baseUrl: 'https://gateway.internal/openrouter',
+    })
+    expect(lastCallArgs.openrouter).toMatchObject({
+      apiKey: 'or-key',
+      baseURL: 'https://gateway.internal/openrouter',
+    })
+  })
+
+  it('omits baseURL when baseUrl is unset (SDK default endpoint preserved)', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.OPENROUTER,
+      model: 'anthropic/claude-sonnet-4.5',
+      apiKey: 'or-key',
+    })
+    expect(lastCallArgs.openrouter).not.toHaveProperty('baseURL')
+    // The rest of the OpenRouter-specific args (extraBody, fetch)
+    // still flow through unchanged.
+    expect(lastCallArgs.openrouter).toMatchObject({
+      apiKey: 'or-key',
+      extraBody: { reasoning: {} },
+    })
+  })
+})
+
+describe('createAzureFactory baseUrl handling', () => {
+  it('forwards a configured baseUrl as the SDK baseURL option alongside resourceName', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.AZURE,
+      model: 'gpt-4o',
+      apiKey: 'az-key',
+      resourceName: 'my-resource',
+      baseUrl: 'https://custom-gateway.example.com/openai',
+    })
+    // Both fields present; the SDK is documented to prefer baseURL
+    // when both are set, and our factory forwards whatever the user
+    // configured.
+    expect(lastCallArgs.azure).toMatchObject({
+      apiKey: 'az-key',
+      resourceName: 'my-resource',
+      baseURL: 'https://custom-gateway.example.com/openai',
+    })
+  })
+
+  it('accepts baseUrl without resourceName (custom Azure gateway)', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.AZURE,
+      model: 'gpt-4o',
+      apiKey: 'az-key',
+      baseUrl: 'https://custom-gateway.example.com/openai',
+    })
+    expect(lastCallArgs.azure).toMatchObject({
+      apiKey: 'az-key',
+      baseURL: 'https://custom-gateway.example.com/openai',
+    })
+    expect(lastCallArgs.azure).not.toHaveProperty('resourceName')
+  })
+
+  it('accepts resourceName without baseUrl (unchanged pre-fix behavior)', async () => {
+    await createLanguageModel({
+      conversationId: 'c1',
+      provider: LLM_PROVIDERS.AZURE,
+      model: 'gpt-4o',
+      apiKey: 'az-key',
+      resourceName: 'my-resource',
+    })
+    expect(lastCallArgs.azure).toMatchObject({
+      apiKey: 'az-key',
+      resourceName: 'my-resource',
+    })
+    expect(lastCallArgs.azure).not.toHaveProperty('baseURL')
+  })
+
+  it('throws when neither baseUrl nor resourceName is provided', async () => {
+    await expect(
+      createLanguageModel({
+        conversationId: 'c1',
+        provider: LLM_PROVIDERS.AZURE,
+        model: 'gpt-4o',
+        apiKey: 'az-key',
+      }),
+    ).rejects.toThrow(/apiKey and either resourceName or baseUrl/)
+  })
+})


### PR DESCRIPTION
Fixes #1870.

## Summary

The AI settings dialog accepts a Base URL for the Anthropic, OpenAI, Google, OpenRouter, and Azure providers and round-trips the value through the persisted `LlmProviderConfig`, but `provider-factory.ts` never forwarded it to the underlying SDK. Custom endpoints (MiniMax's Anthropic-compatible API, LiteLLM, self-hosted OpenAI/Google/OpenRouter gateways, custom Azure OpenAI gateways) therefore silently resolved to each SDK's default endpoint and failed with a confusing "no output generated" error.

This PR threads `baseURL: config.baseUrl` through each of the five factories when the field is set, and keeps the SDK default when it is unset.

## Verified against each SDK's docs

| Package | Option | Source |
|---|---|---|
| `@ai-sdk/anthropic` | `baseURL: string` (default `https://api.anthropic.com/v1`) | https://ai-sdk.dev/providers/ai-sdk-providers/anthropic |
| `@ai-sdk/openai` | `baseURL: string` (default `https://api.openai.com/v1`) | https://ai-sdk.dev/providers/ai-sdk-providers/openai |
| `@ai-sdk/google` | `baseURL: string` (default `https://generativelanguage.googleapis.com/v1beta`) | https://ai-sdk.dev/providers/ai-sdk-providers/google |
| `@ai-sdk/azure` | `baseURL: string`; mutually exclusive with `resourceName` (SDK ignores resourceName when baseURL is set). Matches the UI copy "Overrides resource name if set". | https://ai-sdk.dev/providers/ai-sdk-providers/azure |
| `@openrouter/ai-sdk-provider@2.9.1` | `baseURL?: string` (legacy `baseUrl?` alias marked `@deprecated`) | shipped `.d.ts` in this project's `node_modules` |

## OpenAI Responses vs Chat Completions

`@ai-sdk/openai` defaults to the Responses API. Many OpenAI-shape proxies (MiniMax, LiteLLM, self-hosted gateways) only speak Chat Completions. The factory now forwards the user's `baseUrl` regardless; the OpenAI branch of the provider dialog gains a hint next to the Base URL field:

> If your custom endpoint doesn't work with OpenAI, try the OpenAI Compatible provider template instead.

That puts the choice in the user's hands: point at a Responses-compatible endpoint and it works direct; hit a Chat-Completions-only proxy and the visible next step is the existing "OpenAI Compatible" template.

## Files changed

- `packages/browseros-agent/apps/server/src/agent/provider-factory.ts` — five factories updated; Azure now accepts either `resourceName` or `baseUrl`.
- `packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx` — inline `FormDescription` on the OpenAI Base URL field.
- `packages/browseros-agent/apps/server/tests/agent/provider-factory-baseurl.test.ts` — new suite. 13 assertions across the five providers.

## Behavior preservation

- Users who never set Base URL see zero change: each factory omits the SDK option entirely when `config.baseUrl` is falsy.
- Empty-string Base URL (form serialization for cleared fields) treated same as unset (Anthropic test explicitly covers this).
- Azure's `resourceName`-only path is unchanged.
- OpenAI users see one new line of description text on the Base URL field.

## Test plan

- [x] `bun test tests/agent/provider-factory-baseurl.test.ts` in `apps/server` → 13/13 pass.
- [x] `bun test tests/agent` in `apps/server` → 314/314 pass.
- [x] `bun test screens/ai-settings/NewProviderDialog.test` in `apps/app` → 7/7 pass.
- [x] `bunx tsc --noEmit` clean in both `apps/server` and `apps/app` (app requires `NODE_OPTIONS='--max-old-space-size=8192'` due to a pre-existing repo-scale memory ceiling; unrelated to this PR).
- [x] `bunx @biomejs/biome check` clean.
- [ ] Manual smoke: configure an Anthropic provider with `https://api.minimax.io/anthropic` + a MiniMax key, click Test, confirm response comes through the custom endpoint.