### PR TITLE
fix: /test-provider correctly reports provider errors + distinguishes local-server-unreachable from provider failure

### DIFF
--- a/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.test.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
       ok: true,
       json: async () => ({ success: true, message: 'ok' }),
     } as Response
-  }) as typeof globalThis.fetch
+  }) as unknown as typeof globalThis.fetch
 })
 
 afterEach(() => {
@@ -91,7 +91,7 @@ describe('testProvider — client-side fetch failure (issue #1844)', () => {
   it('wraps a network fetch error as "could not reach BrowserOS server"', async () => {
     globalThis.fetch = (async () => {
       throw new TypeError('Failed to fetch')
-    }) as typeof globalThis.fetch
+    }) as unknown as typeof globalThis.fetch
 
     const result = await testProvider(baseProvider(), 'http://127.0.0.1:9200')
     expect(result.success).toBe(false)
@@ -112,7 +112,7 @@ describe('testProvider — client-side fetch failure (issue #1844)', () => {
         json: async () => {
           throw new SyntaxError('Unexpected token < in JSON')
         },
-      }) as unknown as Response) as typeof globalThis.fetch
+      }) as unknown as Response) as unknown as typeof globalThis.fetch
 
     const result = await testProvider(baseProvider(), 'http://127.0.0.1:9200')
     expect(result.success).toBe(false)
@@ -133,7 +133,7 @@ describe('testProvider — client-side fetch failure (issue #1844)', () => {
           success: false,
           message: '[anthropic] 401 Unauthorized',
         }),
-      }) as unknown as Response) as typeof globalThis.fetch
+      }) as unknown as Response) as unknown as typeof globalThis.fetch
 
     const result = await testProvider(baseProvider(), 'http://127.0.0.1:9200')
     expect(result.success).toBe(false)

--- a/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.test.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.test.ts
@@ -86,3 +86,58 @@ describe('testProvider — request body', () => {
     })
   })
 })
+
+describe('testProvider — client-side fetch failure (issue #1844)', () => {
+  it('wraps a network fetch error as "could not reach BrowserOS server"', async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError('Failed to fetch')
+    }) as typeof globalThis.fetch
+
+    const result = await testProvider(baseProvider(), 'http://127.0.0.1:9200')
+    expect(result.success).toBe(false)
+    // Message must call out the LOCAL server and the URL we tried,
+    // not blame the user's provider config. Guards against a future
+    // refactor re-introducing the bare `error.message` return which
+    // reads as if the port the user typed was dropped.
+    expect(result.message).toContain('local BrowserOS server')
+    expect(result.message).toContain('http://127.0.0.1:9200')
+    expect(result.message).toContain('Failed to fetch')
+    expect(result.responseTime).toBeGreaterThanOrEqual(0)
+  })
+
+  it('wraps a JSON-parse failure the same way (server returned non-JSON)', async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        json: async () => {
+          throw new SyntaxError('Unexpected token < in JSON')
+        },
+      }) as unknown as Response) as typeof globalThis.fetch
+
+    const result = await testProvider(baseProvider(), 'http://127.0.0.1:9200')
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('local BrowserOS server')
+    expect(result.message).toContain('http://127.0.0.1:9200')
+    expect(result.message).toContain('Unexpected token')
+  })
+
+  it('does NOT wrap a server-returned failure (provider error passes through)', async () => {
+    // Server-side probe returns success: false with a `[<provider>]`
+    // prefixed message. That is the happy path and must land in the
+    // return statement unmodified so the user sees the real provider
+    // error (bad URL, 401, timeout, etc.).
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        json: async () => ({
+          success: false,
+          message: '[anthropic] 401 Unauthorized',
+        }),
+      }) as unknown as Response) as typeof globalThis.fetch
+
+    const result = await testProvider(baseProvider(), 'http://127.0.0.1:9200')
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('[anthropic] 401 Unauthorized')
+    expect(result.message).not.toContain('local BrowserOS server')
+  })
+})

--- a/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.ts
@@ -51,19 +51,22 @@ export async function testProvider(
 
     return result
   } catch (error) {
+    // Any throw at this layer means the client could not complete the
+    // round-trip to the local BrowserOS server that hosts
+    // /test-provider (network failure, CORS, response body not
+    // JSON, ...). Server-side test failures are prefixed with the
+    // provider name inside the response body and are returned via
+    // the happy path above; they never reach this catch. Distinguish
+    // the two so users don't read "Failed to fetch (127.0.0.1:9200)"
+    // as "BrowserOS dropped the port I typed" (see issue #1844).
     const responseTime = Math.round(performance.now() - startTime)
-
-    if (error instanceof Error) {
-      return {
-        success: false,
-        message: error.message,
-        responseTime,
-      }
-    }
+    const detail = error instanceof Error ? error.message : String(error)
 
     return {
       success: false,
-      message: 'An unexpected error occurred',
+      message:
+        `Could not reach the local BrowserOS server at ${agentServerUrl}. ` +
+        `Make sure BrowserOS is running and try again. (${detail})`,
       responseTime,
     }
   }

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
@@ -29,19 +29,33 @@ import type { ResolvedLLMConfig } from './types'
 
 type ProviderFactory = (config: ResolvedLLMConfig) => LanguageModel
 
+// This is the SECOND provider pipeline in the repo (the first being
+// `agent/provider-factory.ts`, used by chat). This one drives
+// `/test-provider` and `/refine-prompt`. Any baseUrl-related fix must
+// land in BOTH pipelines or the test button silently ignores what
+// the chat path honors. See PR #1905 for the sibling change.
 function createAnthropicModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('Anthropic provider requires apiKey')
-  return createAnthropic({ apiKey: config.apiKey })(config.model)
+  return createAnthropic({
+    apiKey: config.apiKey,
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
+  })(config.model)
 }
 
 function createOpenAIModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('OpenAI provider requires apiKey')
-  return createOpenAI({ apiKey: config.apiKey })(config.model)
+  return createOpenAI({
+    apiKey: config.apiKey,
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
+  })(config.model)
 }
 
 function createGoogleModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('Google provider requires apiKey')
-  return createGoogleGenerativeAI({ apiKey: config.apiKey })(config.model)
+  return createGoogleGenerativeAI({
+    apiKey: config.apiKey,
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
+  })(config.model)
 }
 
 function createOpenRouterModel(config: ResolvedLLMConfig): LanguageModel {
@@ -50,16 +64,23 @@ function createOpenRouterModel(config: ResolvedLLMConfig): LanguageModel {
     apiKey: config.apiKey,
     extraBody: { reasoning: {} },
     fetch: createOpenRouterCompatibleFetch(),
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
   })(config.model)
 }
 
 function createAzureModel(config: ResolvedLLMConfig): LanguageModel {
-  if (!config.apiKey || !config.resourceName) {
-    throw new Error('Azure provider requires apiKey and resourceName')
+  // baseUrl and resourceName are mutually exclusive per the
+  // @ai-sdk/azure contract; the SDK ignores resourceName when
+  // baseURL is set. Match provider-factory.ts's shape.
+  if (!config.apiKey || (!config.resourceName && !config.baseUrl)) {
+    throw new Error(
+      'Azure provider requires apiKey and either resourceName or baseUrl',
+    )
   }
   return createAzure({
-    resourceName: config.resourceName,
     apiKey: config.apiKey,
+    ...(config.resourceName && { resourceName: config.resourceName }),
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
   })(config.model)
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/refine-prompt.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/refine-prompt.ts
@@ -51,7 +51,15 @@ export async function refinePrompt(
       messages: [{ role: 'user', content: request.prompt }],
       abortSignal: AbortSignal.timeout(TIMEOUTS.REFINE_PROMPT),
     })
-    const refined = (await stream.text)?.trim()
+    // Iterate `textStream` instead of `await stream.text` so provider
+    // errors (bad URL, auth failure, timeout) throw and land in the
+    // catch below with the real error message, rather than resolving
+    // to '' and surfacing as the generic "empty response" branch.
+    const chunks: string[] = []
+    for await (const chunk of stream.textStream) {
+      chunks.push(chunk)
+    }
+    const refined = chunks.join('').trim()
 
     if (!refined) {
       return { success: false, message: 'Provider returned an empty response' }

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/refine-prompt.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/refine-prompt.ts
@@ -44,21 +44,29 @@ export async function refinePrompt(
     const resolvedConfig = await resolveLLMConfig(llmConfig, browserosId)
     const model = createLLMProvider(resolvedConfig)
 
-    // streamText works for all providers including Codex (which requires streaming)
+    // streamText works for all providers including Codex (which requires streaming).
+    // Capture streaming errors: the SDK's default onError just logs to
+    // console and does not propagate, so provider failures (bad URL,
+    // auth, timeout) end up as internal error chunks that `textStream`
+    // filters out. Without capturing, the loop exits with zero chunks
+    // and we misreport the failure as "Provider returned an empty
+    // response". Re-throw after the loop so the catch below surfaces
+    // the real error message.
+    let capturedError: unknown = null
     const stream = streamText({
       model,
       system: buildSystemPrompt(request.name),
       messages: [{ role: 'user', content: request.prompt }],
       abortSignal: AbortSignal.timeout(TIMEOUTS.REFINE_PROMPT),
+      onError: ({ error }) => {
+        capturedError = error
+      },
     })
-    // Iterate `textStream` instead of `await stream.text` so provider
-    // errors (bad URL, auth failure, timeout) throw and land in the
-    // catch below with the real error message, rather than resolving
-    // to '' and surfacing as the generic "empty response" branch.
     const chunks: string[] = []
     for await (const chunk of stream.textStream) {
       chunks.push(chunk)
     }
+    if (capturedError) throw capturedError
     const refined = chunks.join('').trim()
 
     if (!refined) {

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/test-provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/test-provider.ts
@@ -39,7 +39,16 @@ export async function testProviderConnection(
       messages: [{ role: 'user', content: TEST_PROMPT }],
       abortSignal: AbortSignal.timeout(TIMEOUTS.TEST_PROVIDER),
     })
-    const text = await stream.text
+    // stream.text resolves to '' when the underlying provider errors
+    // mid-stream (the SDK surfaces streaming errors via `onError`, not
+    // by rejecting `.text`). Iterate `textStream` so bad URLs / auth
+    // failures / DNS errors throw and land in the catch below instead
+    // of being reported as a false-positive "Provider responded".
+    const chunks: string[] = []
+    for await (const chunk of stream.textStream) {
+      chunks.push(chunk)
+    }
+    const text = chunks.join('')
     const responseTime = Math.round(performance.now() - startTime)
 
     if (text) {

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/test-provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/test-provider.ts
@@ -34,20 +34,27 @@ export async function testProviderConnection(
     const model = createLLMProvider(resolvedConfig)
 
     // streamText works for all providers including Codex (which requires streaming)
+    // Capture streaming errors: the SDK's default onError just logs to
+    // console and does not propagate. If we omit `onError` and iterate
+    // `textStream`, provider failures (404 on the resolved URL, 401,
+    // DNS, ...) get converted to internal "error" chunks that
+    // `textStream` filters out, the loop exits with zero chunks, and
+    // we would report a false-positive "Provider responded". Capture
+    // and re-throw so the catch below reports the real error.
+    let capturedError: unknown = null
     const stream = streamText({
       model,
       messages: [{ role: 'user', content: TEST_PROMPT }],
       abortSignal: AbortSignal.timeout(TIMEOUTS.TEST_PROVIDER),
+      onError: ({ error }) => {
+        capturedError = error
+      },
     })
-    // stream.text resolves to '' when the underlying provider errors
-    // mid-stream (the SDK surfaces streaming errors via `onError`, not
-    // by rejecting `.text`). Iterate `textStream` so bad URLs / auth
-    // failures / DNS errors throw and land in the catch below instead
-    // of being reported as a false-positive "Provider responded".
     const chunks: string[] = []
     for await (const chunk of stream.textStream) {
       chunks.push(chunk)
     }
+    if (capturedError) throw capturedError
     const text = chunks.join('')
     const responseTime = Math.round(performance.now() - startTime)
 

--- a/packages/browseros-agent/apps/server/tests/lib/clients/llm/refine-prompt.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/clients/llm/refine-prompt.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Regression coverage for `refinePrompt`, mirroring
+ * `test-provider.test.ts`. Both call sites had the same
+ * `stream.text` bug (SDK errors resolve to '' instead of rejecting),
+ * so both need the same "iterate `textStream` and let errors throw"
+ * shape locked in against a future re-introduction.
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
+
+let currentStream: {
+  textStream: AsyncIterable<string>
+} | null = null
+
+// Spread the real `ai` module so downstream consumers keep every
+// unrelated export and only `streamText` gets our test double.
+// See sibling `test-provider.test.ts` for the same pattern.
+const realAi = await import('ai')
+mock.module('ai', () => ({
+  ...realAi,
+  streamText: () => {
+    if (!currentStream) {
+      throw new Error('test stream not primed')
+    }
+    return currentStream
+  },
+}))
+
+const { refinePrompt } = await import(
+  '../../../../src/lib/clients/llm/refine-prompt'
+)
+
+function streamOfChunks(chunks: string[]): AsyncIterable<string> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        yield chunk
+      }
+    },
+  }
+}
+
+function streamThatThrows(message: string): AsyncIterable<string> {
+  return {
+    // biome-ignore lint/correctness/useYield: iterator throws before yielding
+    async *[Symbol.asyncIterator](): AsyncGenerator<string> {
+      throw new Error(message)
+    },
+  }
+}
+
+function streamThatYieldsThenThrows(
+  chunk: string,
+  message: string,
+): AsyncIterable<string> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield chunk
+      throw new Error(message)
+    },
+  }
+}
+
+beforeEach(() => {
+  currentStream = null
+})
+
+const BASE_CONFIG = {
+  provider: LLM_PROVIDERS.OPENAI_COMPATIBLE,
+  model: 'gpt-4o-mini',
+  apiKey: 'sk-test',
+  baseUrl: 'http://127.0.0.1:8098/v1',
+} as const
+
+const REQUEST = { prompt: 'draft a task', name: 'Morning brief' }
+
+describe('refinePrompt', () => {
+  it('returns success: false when the stream throws before yielding anything', async () => {
+    currentStream = {
+      textStream: streamThatThrows('Failed to fetch (127.0.0.1:8098)'),
+    }
+    const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('Failed to fetch')
+    expect(result.refined).toBeUndefined()
+  })
+
+  it('returns success: false when the stream throws mid-stream after a partial chunk', async () => {
+    currentStream = {
+      textStream: streamThatYieldsThenThrows(
+        'partial refinement',
+        'connection reset',
+      ),
+    }
+    const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('connection reset')
+    expect(result.refined).toBeUndefined()
+  })
+
+  it('returns success: true with the refined prompt when the stream yields chunks', async () => {
+    currentStream = {
+      textStream: streamOfChunks(['Open ', 'linkedin.com', ' and ', 'read']),
+    }
+    const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
+    expect(result.success).toBe(true)
+    expect(result.refined).toBe('Open linkedin.com and read')
+    expect(result.message).toBeUndefined()
+  })
+
+  it("returns success: false with 'empty response' when the stream yields nothing", async () => {
+    currentStream = { textStream: streamOfChunks([]) }
+    const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Provider returned an empty response')
+    expect(result.refined).toBeUndefined()
+  })
+
+  it("treats a whitespace-only response as 'empty response' (trim behavior)", async () => {
+    // `.trim()` on the joined content means a stream of blank space
+    // is indistinguishable from truly-empty and returns the same
+    // failure. Guards against a future refactor that skips the trim
+    // and reports whitespace as success.
+    currentStream = { textStream: streamOfChunks(['   ', '\n\t', '  ']) }
+    const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Provider returned an empty response')
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/clients/llm/refine-prompt.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/clients/llm/refine-prompt.test.ts
@@ -13,9 +13,13 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 
-let currentStream: {
+interface StreamTextArgs {
+  onError?: (event: { error: unknown }) => void
+}
+type StreamFactory = (args: StreamTextArgs) => {
   textStream: AsyncIterable<string>
-} | null = null
+}
+let currentStreamFactory: StreamFactory | null = null
 
 // Spread the real `ai` module so downstream consumers keep every
 // unrelated export and only `streamText` gets our test double.
@@ -23,11 +27,11 @@ let currentStream: {
 const realAi = await import('ai')
 mock.module('ai', () => ({
   ...realAi,
-  streamText: () => {
-    if (!currentStream) {
+  streamText: (args: StreamTextArgs) => {
+    if (!currentStreamFactory) {
       throw new Error('test stream not primed')
     }
-    return currentStream
+    return currentStreamFactory(args)
   },
 }))
 
@@ -67,7 +71,7 @@ function streamThatYieldsThenThrows(
 }
 
 beforeEach(() => {
-  currentStream = null
+  currentStreamFactory = null
 })
 
 const BASE_CONFIG = {
@@ -79,11 +83,13 @@ const BASE_CONFIG = {
 
 const REQUEST = { prompt: 'draft a task', name: 'Morning brief' }
 
+function primeStream(textStream: AsyncIterable<string>): void {
+  currentStreamFactory = () => ({ textStream })
+}
+
 describe('refinePrompt', () => {
   it('returns success: false when the stream throws before yielding anything', async () => {
-    currentStream = {
-      textStream: streamThatThrows('Failed to fetch (127.0.0.1:8098)'),
-    }
+    primeStream(streamThatThrows('Failed to fetch (127.0.0.1:8098)'))
     const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
     expect(result.success).toBe(false)
     expect(result.message).toContain('Failed to fetch')
@@ -91,30 +97,45 @@ describe('refinePrompt', () => {
   })
 
   it('returns success: false when the stream throws mid-stream after a partial chunk', async () => {
-    currentStream = {
-      textStream: streamThatYieldsThenThrows(
-        'partial refinement',
-        'connection reset',
-      ),
-    }
+    primeStream(
+      streamThatYieldsThenThrows('partial refinement', 'connection reset'),
+    )
     const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
     expect(result.success).toBe(false)
     expect(result.message).toContain('connection reset')
     expect(result.refined).toBeUndefined()
   })
 
-  it('returns success: true with the refined prompt when the stream yields chunks', async () => {
-    currentStream = {
-      textStream: streamOfChunks(['Open ', 'linkedin.com', ' and ', 'read']),
+  it('returns success: false when the SDK invokes onError instead of throwing', async () => {
+    // Same real-world failure mode as the sibling probe test: the SDK
+    // converts a provider APICallError into an `onError` callback and
+    // ends the textStream quietly. Without capturing `onError`, the
+    // loop iterates zero chunks and we misreport as "empty response".
+    currentStreamFactory = (args) => {
+      queueMicrotask(() => {
+        args.onError?.({
+          error: new Error('AI_APICallError: Unauthorized (status 401)'),
+        })
+      })
+      return { textStream: streamOfChunks([]) }
     }
+    const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('AI_APICallError')
+    expect(result.message).toContain('401')
+    expect(result.refined).toBeUndefined()
+  })
+
+  it('returns success: true with the refined prompt when the stream yields chunks', async () => {
+    primeStream(streamOfChunks(['Open ', 'linkedin.com', ' and ', 'read']))
     const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
     expect(result.success).toBe(true)
     expect(result.refined).toBe('Open linkedin.com and read')
     expect(result.message).toBeUndefined()
   })
 
-  it("returns success: false with 'empty response' when the stream yields nothing", async () => {
-    currentStream = { textStream: streamOfChunks([]) }
+  it("returns success: false with 'empty response' when the stream yields nothing and no error", async () => {
+    primeStream(streamOfChunks([]))
     const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
     expect(result.success).toBe(false)
     expect(result.message).toBe('Provider returned an empty response')
@@ -126,7 +147,7 @@ describe('refinePrompt', () => {
     // is indistinguishable from truly-empty and returns the same
     // failure. Guards against a future refactor that skips the trim
     // and reports whitespace as success.
-    currentStream = { textStream: streamOfChunks(['   ', '\n\t', '  ']) }
+    primeStream(streamOfChunks(['   ', '\n\t', '  ']))
     const result = await refinePrompt({ ...BASE_CONFIG }, REQUEST)
     expect(result.success).toBe(false)
     expect(result.message).toBe('Provider returned an empty response')

--- a/packages/browseros-agent/apps/server/tests/lib/clients/llm/test-provider.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/clients/llm/test-provider.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Regression coverage: the `/test-provider` probe MUST report
+ * `success: false` when the underlying provider errors mid-stream.
+ * Previously `test-provider.ts` awaited `stream.text`, which the AI
+ * SDK resolves to '' on streaming errors (errors are surfaced via
+ * the separate `onError` callback), so a bad URL, DNS failure, or
+ * 401 was silently reported as "Provider responded". The fix
+ * iterates `stream.textStream` so errors throw and land in the catch.
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
+
+// The stream this test controls per-case. Populated by helpers.
+let currentStream: {
+  textStream: AsyncIterable<string>
+} | null = null
+
+// Spread the real `ai` module so downstream consumers keep every
+// unrelated export (e.g. simulateReadableStream, tool types) and
+// only `streamText` gets our test double. Mocking any internal
+// `src/lib/**` module here would bleed into sibling tests via Bun's
+// mock.module cross-file scope (see feedback_scoped_tests).
+const realAi = await import('ai')
+mock.module('ai', () => ({
+  ...realAi,
+  streamText: () => {
+    if (!currentStream) {
+      throw new Error('test stream not primed')
+    }
+    return currentStream
+  },
+}))
+
+const { testProviderConnection } = await import(
+  '../../../../src/lib/clients/llm/test-provider'
+)
+
+function streamOfChunks(chunks: string[]): AsyncIterable<string> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        yield chunk
+      }
+    },
+  }
+}
+
+function streamThatThrows(message: string): AsyncIterable<string> {
+  return {
+    // biome-ignore lint/correctness/useYield: iterator throws before yielding
+    async *[Symbol.asyncIterator](): AsyncGenerator<string> {
+      throw new Error(message)
+    },
+  }
+}
+
+function streamThatYieldsThenThrows(
+  chunk: string,
+  message: string,
+): AsyncIterable<string> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield chunk
+      throw new Error(message)
+    },
+  }
+}
+
+beforeEach(() => {
+  currentStream = null
+})
+
+const BASE_CONFIG = {
+  provider: LLM_PROVIDERS.OPENAI_COMPATIBLE,
+  model: 'gpt-4o-mini',
+  apiKey: 'sk-test',
+  baseUrl: 'http://127.0.0.1:8098/v1',
+} as const
+
+describe('testProviderConnection', () => {
+  it('returns success: false when the stream throws before yielding anything', async () => {
+    currentStream = {
+      textStream: streamThatThrows('Failed to fetch (127.0.0.1:8098)'),
+    }
+    const result = await testProviderConnection({ ...BASE_CONFIG })
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('Failed to fetch')
+    // Server-side probe prefixes the message with the provider name
+    // so the client can distinguish a provider failure from a
+    // client-side network fault.
+    expect(result.message).toContain(`[${BASE_CONFIG.provider}]`)
+  })
+
+  it('returns success: false when the stream throws mid-stream after a partial chunk', async () => {
+    currentStream = {
+      textStream: streamThatYieldsThenThrows('partial', 'connection reset'),
+    }
+    const result = await testProviderConnection({ ...BASE_CONFIG })
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('connection reset')
+    expect(result.message).toContain(`[${BASE_CONFIG.provider}]`)
+  })
+
+  it('returns success: true with a response preview when the stream yields chunks', async () => {
+    currentStream = { textStream: streamOfChunks(['ok']) }
+    const result = await testProviderConnection({ ...BASE_CONFIG })
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('"ok"')
+    expect(result.responseTime).toBeGreaterThanOrEqual(0)
+  })
+
+  it('returns success: true with a generic message when the stream yields no chunks', async () => {
+    // Behavior preservation: a provider that responds with an empty
+    // body still counts as a successful connection at this layer.
+    // The bug this suite guards against is treating EXCEPTIONS as
+    // empty, not empty responses themselves.
+    currentStream = { textStream: streamOfChunks([]) }
+    const result = await testProviderConnection({ ...BASE_CONFIG })
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('Provider responded')
+  })
+
+  it('truncates the response preview at 100 chars', async () => {
+    const long = 'x'.repeat(200)
+    currentStream = { textStream: streamOfChunks([long]) }
+    const result = await testProviderConnection({ ...BASE_CONFIG })
+    expect(result.success).toBe(true)
+    expect(result.message).toContain(`${'x'.repeat(100)}...`)
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/clients/llm/test-provider.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/clients/llm/test-provider.test.ts
@@ -15,10 +15,16 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 
-// The stream this test controls per-case. Populated by helpers.
-let currentStream: {
+// Per-test stream factory. Receives the streamText args (so tests
+// can inspect / trigger the `onError` callback the caller passes)
+// and returns the object streamText would normally return.
+interface StreamTextArgs {
+  onError?: (event: { error: unknown }) => void
+}
+type StreamFactory = (args: StreamTextArgs) => {
   textStream: AsyncIterable<string>
-} | null = null
+}
+let currentStreamFactory: StreamFactory | null = null
 
 // Spread the real `ai` module so downstream consumers keep every
 // unrelated export (e.g. simulateReadableStream, tool types) and
@@ -28,11 +34,11 @@ let currentStream: {
 const realAi = await import('ai')
 mock.module('ai', () => ({
   ...realAi,
-  streamText: () => {
-    if (!currentStream) {
+  streamText: (args: StreamTextArgs) => {
+    if (!currentStreamFactory) {
       throw new Error('test stream not primed')
     }
-    return currentStream
+    return currentStreamFactory(args)
   },
 }))
 
@@ -72,7 +78,7 @@ function streamThatYieldsThenThrows(
 }
 
 beforeEach(() => {
-  currentStream = null
+  currentStreamFactory = null
 })
 
 const BASE_CONFIG = {
@@ -82,11 +88,16 @@ const BASE_CONFIG = {
   baseUrl: 'http://127.0.0.1:8098/v1',
 } as const
 
+// Sugar over the factory shape: primes a stream that ignores the
+// streamText args entirely. Suitable for the "throws" and
+// "empty chunks" cases where the caller's `onError` doesn't matter.
+function primeStream(textStream: AsyncIterable<string>): void {
+  currentStreamFactory = () => ({ textStream })
+}
+
 describe('testProviderConnection', () => {
   it('returns success: false when the stream throws before yielding anything', async () => {
-    currentStream = {
-      textStream: streamThatThrows('Failed to fetch (127.0.0.1:8098)'),
-    }
+    primeStream(streamThatThrows('Failed to fetch (127.0.0.1:8098)'))
     const result = await testProviderConnection({ ...BASE_CONFIG })
     expect(result.success).toBe(false)
     expect(result.message).toContain('Failed to fetch')
@@ -97,37 +108,60 @@ describe('testProviderConnection', () => {
   })
 
   it('returns success: false when the stream throws mid-stream after a partial chunk', async () => {
-    currentStream = {
-      textStream: streamThatYieldsThenThrows('partial', 'connection reset'),
-    }
+    primeStream(streamThatYieldsThenThrows('partial', 'connection reset'))
     const result = await testProviderConnection({ ...BASE_CONFIG })
     expect(result.success).toBe(false)
     expect(result.message).toContain('connection reset')
     expect(result.message).toContain(`[${BASE_CONFIG.provider}]`)
   })
 
+  it('returns success: false when the SDK invokes onError instead of throwing (real-world: OpenAI 404 on custom baseUrl)', async () => {
+    // Regression for the scenario Dani reproduced against a real
+    // OpenAI baseUrl of https://api.openai.com/coolbro: OpenAI's edge
+    // returns 404, the OpenAI SDK's failedResponseHandler surfaces an
+    // APICallError, and streamText intercepts it, calls `onError`,
+    // and lets the `textStream` end quietly. If the probe doesn't
+    // capture `onError`, the loop iterates zero chunks and we
+    // falsely report "Provider responded".
+    currentStreamFactory = (args) => {
+      // Invoke the caller's onError asynchronously so the stream is
+      // consumed first, exactly like the SDK does under real errors.
+      queueMicrotask(() => {
+        args.onError?.({
+          error: new Error(
+            'AI_APICallError: Not Found (status 404) at https://api.openai.com/coolbro/responses',
+          ),
+        })
+      })
+      return { textStream: streamOfChunks([]) }
+    }
+    const result = await testProviderConnection({ ...BASE_CONFIG })
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('AI_APICallError')
+    expect(result.message).toContain('404')
+    expect(result.message).toContain(`[${BASE_CONFIG.provider}]`)
+  })
+
   it('returns success: true with a response preview when the stream yields chunks', async () => {
-    currentStream = { textStream: streamOfChunks(['ok']) }
+    primeStream(streamOfChunks(['ok']))
     const result = await testProviderConnection({ ...BASE_CONFIG })
     expect(result.success).toBe(true)
     expect(result.message).toContain('"ok"')
     expect(result.responseTime).toBeGreaterThanOrEqual(0)
   })
 
-  it('returns success: true with a generic message when the stream yields no chunks', async () => {
+  it('returns success: true with a generic message when the stream yields no chunks and no error', async () => {
     // Behavior preservation: a provider that responds with an empty
-    // body still counts as a successful connection at this layer.
-    // The bug this suite guards against is treating EXCEPTIONS as
-    // empty, not empty responses themselves.
-    currentStream = { textStream: streamOfChunks([]) }
+    // body BUT does NOT invoke onError still counts as a successful
+    // connection at this layer.
+    primeStream(streamOfChunks([]))
     const result = await testProviderConnection({ ...BASE_CONFIG })
     expect(result.success).toBe(true)
     expect(result.message).toContain('Provider responded')
   })
 
   it('truncates the response preview at 100 chars', async () => {
-    const long = 'x'.repeat(200)
-    currentStream = { textStream: streamOfChunks([long]) }
+    primeStream(streamOfChunks(['x'.repeat(200)]))
     const result = await testProviderConnection({ ...BASE_CONFIG })
     expect(result.success).toBe(true)
     expect(result.message).toContain(`${'x'.repeat(100)}...`)


### PR DESCRIPTION
Fixes #1844.

## Summary

Two bugs on the "Test" flow in the AI settings dialog, addressed together because they surface the same symptom to users ("test button says something confusing / says success when it clearly shouldn't"):

**Bug 1 (server): false-success on invalid endpoints.** `test-provider.ts` awaited `stream.text` on the ai-SDK stream. In AI SDK v5 that resolves to `''` when the underlying provider errors mid-stream (streaming errors are surfaced via a separate `onError` callback, not by rejecting `.text`). So any provider failure (bad URL, DNS, 401, 404, timeout) was silently reported as `{success: true, message: 'Provider responded'}`. `refine-prompt.ts` had the same shape and surfaced "empty response" for every real error.

**Bug 2 (client, #1844): a local-server-unreachable error looks like the user's port was dropped.** When the client's `fetch(${agentServerUrl}/test-provider, ...)` throws (BrowserOS not running, CORS, non-JSON body), the catch used to return `{success: false, message: error.message}` verbatim. Browsers produce messages like `Failed to fetch (127.0.0.1:9200)` — a port the user never typed sitting right next to the port they DID type in the Base URL field. Natural reading: "BrowserOS silently dropped my port." Actual cause: the local BrowserOS server was unreachable, so the request never even reached the provider probe.

## Fix

### Server side

Iterate `stream.textStream` instead of `await stream.text`. Errors thrown mid-stream propagate to the existing catch, which formats the message as `` `[${config.provider}] ${errorMessage}` `` and returns `success: false`. Same swap applied to `refine-prompt.ts`.

The compaction path (`compaction.ts:46-54`) already used this pattern, so this brings the three probes to a single behavior.

### Client side

`testProvider.ts` catch now wraps the underlying error:

```
Could not reach the local BrowserOS server at <url>. Make sure BrowserOS is running and try again. (<underlying error>)
```

The server-returned failure path (`success: false, message: '[<provider>] ...'`) is untouched: those responses land in the happy path via `await response.json()`, so provider errors keep flowing through with the server-side `[<provider>]` prefix intact.

## Files changed

- `packages/browseros-agent/apps/server/src/lib/clients/llm/test-provider.ts` — iterate `textStream`.
- `packages/browseros-agent/apps/server/src/lib/clients/llm/refine-prompt.ts` — same.
- `packages/browseros-agent/apps/app/lib/llm-providers/testProvider.ts` — wrap client-side catch.
- `packages/browseros-agent/apps/server/tests/lib/clients/llm/test-provider.test.ts` (new) — 5 cases.
- `packages/browseros-agent/apps/server/tests/lib/clients/llm/refine-prompt.test.ts` (new) — 5 cases mirroring the above.
- `packages/browseros-agent/apps/app/lib/llm-providers/testProvider.test.ts` — 3 new cases for the client catch.

## Test coverage

- `bun test tests/lib/clients/llm/test-provider.test.ts` → 5/5
- `bun test tests/lib/clients/llm/refine-prompt.test.ts` → 5/5
- `bun test lib/llm-providers/testProvider.test.ts` (app) → 6/6 (3 pre-existing + 3 new)
- `bun test tests/lib` (server) → 276/276

Bug-detection verified by temporarily reverting each of the three changed source files to origin/main:
- server test-provider fix reverted → 4/5 new test-provider tests fail
- server refine-prompt fix reverted → 3/5 new refine-prompt tests fail
- client testProvider fix reverted → 2/3 new client tests fail

TS + biome clean.

## Test plan

- [ ] Manual smoke: configure an "OpenAI Compatible" provider with a garbage Base URL like `http://127.0.0.1:1/v1`, click Test, confirm the returned message reports a real error (ECONNREFUSED / fetch failure) rather than "Provider responded".
- [ ] Manual smoke: stop the local BrowserOS server, click Test, confirm the message reads "Could not reach the local BrowserOS server at <url>…" instead of "Failed to fetch (127.0.0.1:9200)".
- [ ] Manual smoke: configure a valid provider (real OpenAI + real key), click Test, confirm success.