### PR TITLE
fix(browseros-core): treat select as semantic input

### DIFF
--- a/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/form.html
+++ b/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/form.html
@@ -3,6 +3,26 @@
   <head>
     <meta charset="utf-8" />
     <title>Form fixture</title>
+    <style>
+      .styled-select {
+        position: relative;
+        display: inline-block;
+      }
+      .styled-select select {
+        width: 12rem;
+        height: 2rem;
+      }
+      .styled-select-prompt {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        padding: 0 0.5rem;
+        background: white;
+        border: 1px solid #777;
+        pointer-events: auto;
+      }
+    </style>
   </head>
   <body>
     <h1>Form fixture</h1>
@@ -12,12 +32,15 @@
       <label>Bio <textarea id="bio" name="bio"></textarea></label>
       <label>
         Color
-        <select id="color" name="color">
-          <option value="">Pick a color</option>
-          <option value="red">Red</option>
-          <option value="green">Green</option>
-          <option value="blue">Blue</option>
-        </select>
+        <span class="styled-select">
+          <select id="color" name="color">
+            <option value="">Pick a color</option>
+            <option value="red">Red</option>
+            <option value="green">Green</option>
+            <option value="blue">Blue</option>
+          </select>
+          <span class="styled-select-prompt" aria-hidden="true">Pick a color</span>
+        </span>
       </label>
       <label><input id="subscribe" name="subscribe" type="checkbox" /> Subscribe</label>
       <fieldset>
@@ -43,6 +66,14 @@
       })
       document.getElementById('apply').addEventListener('click', () => {
         result.textContent = 'applied'
+      })
+      const color = document.getElementById('color')
+      const colorPrompt = document.querySelector('.styled-select-prompt')
+      let colorChanges = 0
+      color.addEventListener('change', () => {
+        colorChanges += 1
+        color.dataset.changeCount = String(colorChanges)
+        colorPrompt.textContent = color.selectedOptions[0].textContent.trim()
       })
     </script>
   </body>

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-act.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-act.ts
@@ -477,7 +477,8 @@ export const actCases: ContractCase[] = [
     },
   },
   {
-    name: 'act: select picks a valid option and rejects an invalid one',
+    name: 'act: select updates a covered styled native select semantically',
+    smoke: true,
     async run(ctx) {
       const page = await ctx.openPage(ctx.fixture('/form.html'))
       const snap = await snapshot(ctx, page)
@@ -491,13 +492,17 @@ export const actCases: ContractCase[] = [
         }),
         'act select valid',
       )
-      const value = await evalIn(
+      const selectedState = await evalIn(
         ctx,
         page,
-        'return document.getElementById("color").value',
+        'const select = document.getElementById("color"); return JSON.stringify({value: select.value, changes: Number(select.dataset.changeCount), prompt: document.querySelector(".styled-select-prompt").textContent})',
       )
-      if (!value.includes('green')) {
-        throw new Error(`select did not apply: ${value}`)
+      if (
+        !selectedState.includes('"value":"green"') ||
+        !selectedState.includes('"changes":1') ||
+        !selectedState.includes('"prompt":"Green"')
+      ) {
+        throw new Error(`select did not apply semantically: ${selectedState}`)
       }
       const invalid = await ctx.mcp.callTool('act', {
         page,
@@ -505,8 +510,21 @@ export const actCases: ContractCase[] = [
         ref,
         value: 'chartreuse',
       })
-      ctx.record('act:select-valid-and-invalid', {
+      const missingState = await evalIn(
+        ctx,
+        page,
+        'const select = document.getElementById("color"); return JSON.stringify({value: select.value, changes: Number(select.dataset.changeCount)})',
+      )
+      if (
+        !missingState.includes('"value":"green"') ||
+        !missingState.includes('"changes":1')
+      ) {
+        throw new Error(`missing option changed select state: ${missingState}`)
+      }
+      ctx.record('act:styled-select-semantics', {
         validApplied: true,
+        changeBubbledOnce: true,
+        missingLeftStateUnchanged: true,
         invalidRejected: invalid.isError === true,
       })
     },

--- a/packages/browseros-agent/crates/browseros-core/src/input/mod.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/input/mod.rs
@@ -285,12 +285,8 @@ impl Input {
         value: &str,
     ) -> Result<Option<String>, CoreError> {
         let resolved = self.observer.resolve_ref(ref_id).await?;
-        self.select_backend_node_with_session(
-            &resolved.session,
-            InputTarget::from_ref_entry(&resolved.entry),
-            value,
-        )
-        .await
+        self.select_backend_node_with_session(&resolved.session, resolved.backend_node_id, value)
+            .await
     }
 
     pub async fn select_backend_node(
@@ -301,12 +297,8 @@ impl Input {
         self.with_page_session_retry(|session| {
             let value = value.to_string();
             async move {
-                self.select_backend_node_with_session(
-                    &session,
-                    InputTarget::from_backend_node(backend_node_id),
-                    &value,
-                )
-                .await
+                self.select_backend_node_with_session(&session, backend_node_id, &value)
+                    .await
             }
         })
         .await
@@ -315,16 +307,13 @@ impl Input {
     async fn select_backend_node_with_session(
         &self,
         session: &ProtocolSession,
-        target: InputTarget,
+        backend_node_id: i64,
         value: &str,
     ) -> Result<Option<String>, CoreError> {
-        scroll_into_view(session, target.backend_node_id).await;
-        if let Ok(point) = get_element_center(session, target.backend_node_id).await {
-            self.check_click_point(session, &target, point).await?;
-        }
+        scroll_into_view(session, backend_node_id).await;
         let selected = call_on_element(
             session,
-            target.backend_node_id,
+            backend_node_id,
             SELECT_OPTION_FN,
             Some(vec![json!(value)]),
         )
@@ -553,12 +542,17 @@ mod tests {
 
     struct HarnessState {
         hit_test: HitTestResponse,
+        hit_test_calls: usize,
         mouse_events: usize,
         select_calls: usize,
+        select_result: Option<&'static str>,
+        select_semantics_preserved: bool,
     }
 
     struct HarnessConnection {
         state: Mutex<HarnessState>,
+        target_role: &'static str,
+        target_name: &'static str,
     }
 
     impl HarnessConnection {
@@ -573,6 +567,20 @@ mod tests {
             match self.state.lock() {
                 Ok(state) => state.select_calls,
                 Err(_err) => 0,
+            }
+        }
+
+        fn hit_test_calls(&self) -> usize {
+            match self.state.lock() {
+                Ok(state) => state.hit_test_calls,
+                Err(_err) => 0,
+            }
+        }
+
+        fn select_semantics_preserved(&self) -> bool {
+            match self.state.lock() {
+                Ok(state) => state.select_semantics_preserved,
+                Err(_err) => false,
             }
         }
     }
@@ -606,7 +614,9 @@ mod tests {
                             }
                         }
                     })),
-                    "Accessibility.getFullAXTree" => Ok(json!({ "nodes": ax_tree() })),
+                    "Accessibility.getFullAXTree" => Ok(json!({
+                        "nodes": ax_tree(self.target_role, self.target_name)
+                    })),
                     "Runtime.evaluate" => Ok(json!({ "result": { "value": [] } })),
                     "DOM.resolveNode" => Ok(json!({ "object": { "objectId": "target-object" } })),
                     "DOM.getContentQuads" => Ok(json!({
@@ -655,7 +665,10 @@ mod tests {
                 .unwrap_or_default();
             if function.contains("elementFromPoint") {
                 let response = match self.state.lock() {
-                    Ok(state) => state.hit_test,
+                    Ok(mut state) => {
+                        state.hit_test_calls += 1;
+                        state.hit_test
+                    }
                     Err(_err) => HitTestResponse::Error,
                 };
                 return match response {
@@ -672,11 +685,15 @@ mod tests {
             if function.contains("return this.checked") {
                 return Ok(json!({ "result": { "value": false } }));
             }
-            if function.contains("this.options") {
-                if let Ok(mut state) = self.state.lock() {
-                    state.select_calls += 1;
-                }
-                return Ok(json!({ "result": { "value": "Choice" } }));
+            if function.contains("this.options")
+                && let Ok(mut state) = self.state.lock()
+            {
+                state.select_calls += 1;
+                state.select_semantics_preserved = function.contains(
+                    "this.options[i].value===val||this.options[i].textContent.trim()===val",
+                ) && function.contains("this.selectedIndex=i")
+                    && function.contains("this.dispatchEvent(new Event('change',{bubbles:true}))");
+                return Ok(json!({ "result": { "value": state.select_result } }));
             }
             Ok(json!({ "result": { "value": null } }))
         }
@@ -685,12 +702,33 @@ mod tests {
     async fn input_harness(
         hit_test: HitTestResponse,
     ) -> Result<(Arc<HarnessConnection>, Input, Ref), CoreError> {
+        input_harness_for_target(hit_test, "button", "Submit", Some("Choice")).await
+    }
+
+    async fn select_input_harness(
+        hit_test: HitTestResponse,
+        select_result: Option<&'static str>,
+    ) -> Result<(Arc<HarnessConnection>, Input, Ref), CoreError> {
+        input_harness_for_target(hit_test, "combobox", "Sort by:", select_result).await
+    }
+
+    async fn input_harness_for_target(
+        hit_test: HitTestResponse,
+        target_role: &'static str,
+        target_name: &'static str,
+        select_result: Option<&'static str>,
+    ) -> Result<(Arc<HarnessConnection>, Input, Ref), CoreError> {
         let connection = Arc::new(HarnessConnection {
             state: Mutex::new(HarnessState {
                 hit_test,
+                hit_test_calls: 0,
                 mouse_events: 0,
                 select_calls: 0,
+                select_result,
+                select_semantics_preserved: false,
             }),
+            target_role,
+            target_name,
         });
         let session = BrowserSession::new(connection.clone(), BrowserSessionHooks::default());
         let pages = session.pages.list().await?;
@@ -719,18 +757,18 @@ mod tests {
         })
     }
 
-    fn ax_tree() -> Vec<AxNode> {
+    fn ax_tree(target_role: &str, target_name: &str) -> Vec<AxNode> {
         vec![
             AxNode {
                 node_id: "root".to_string(),
                 role: Some(AxValue::role("RootWebArea")),
-                child_ids: Some(vec!["button".to_string()]),
+                child_ids: Some(vec!["target".to_string()]),
                 ..AxNode::default()
             },
             AxNode {
-                node_id: "button".to_string(),
-                role: Some(AxValue::role("button")),
-                name: Some(AxValue::string("Submit")),
+                node_id: "target".to_string(),
+                role: Some(AxValue::role(target_role)),
+                name: Some(AxValue::string(target_name)),
                 backend_dom_node_id: Some(10),
                 ..AxNode::default()
             },
@@ -798,25 +836,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn select_option_reports_covered_ref_before_selection() -> Result<(), CoreError> {
-        let (connection, input, ref_id) =
-            input_harness(HitTestResponse::Blocked("dialog#privacy")).await?;
+    async fn semantic_select_ignores_pointer_occlusion_but_click_stays_blocked()
+    -> Result<(), CoreError> {
+        let (connection, input, ref_id) = select_input_harness(
+            HitTestResponse::Blocked("span.a-dropdown-prompt"),
+            Some("Price: Low to High"),
+        )
+        .await?;
 
-        let result = input.select_option(&ref_id, "Choice").await;
+        let selected = input.select_option(&ref_id, "price-asc-rank").await?;
 
-        assert!(matches!(result, Err(CoreError::ElementCovered { .. })));
-        assert_eq!(connection.select_calls(), 0);
+        assert_eq!(selected.as_deref(), Some("Price: Low to High"));
+        assert_eq!(connection.select_calls(), 1);
+        assert_eq!(connection.hit_test_calls(), 0);
+        assert_eq!(connection.mouse_events(), 0);
+        assert!(connection.select_semantics_preserved());
+
+        let click_result = input.click(&ref_id, ClickOptions::default()).await;
+        match click_result {
+            Err(CoreError::ElementCovered { target, blocker }) => {
+                assert_eq!(target.ref_id, Some(Ref("e1".to_string())));
+                assert_eq!(target.role.as_deref(), Some("combobox"));
+                assert_eq!(target.name.as_deref(), Some("Sort by:"));
+                assert_eq!(blocker, "span.a-dropdown-prompt");
+            }
+            other => {
+                return Err(CoreError::Message(format!(
+                    "expected ElementCovered, got {other:?}"
+                )));
+            }
+        }
+        assert_eq!(connection.hit_test_calls(), 1);
+        assert_eq!(connection.mouse_events(), 0);
         Ok(())
     }
 
     #[tokio::test]
-    async fn select_option_proceeds_when_point_is_clear() -> Result<(), CoreError> {
-        let (connection, input, ref_id) = input_harness(HitTestResponse::Clear).await?;
+    async fn semantic_select_returns_none_for_missing_option() -> Result<(), CoreError> {
+        let (connection, input, ref_id) =
+            select_input_harness(HitTestResponse::Clear, None).await?;
 
-        let selected = input.select_option(&ref_id, "Choice").await?;
+        let selected = input.select_option(&ref_id, "missing").await?;
 
-        assert_eq!(selected.as_deref(), Some("Choice"));
+        assert_eq!(selected, None);
         assert_eq!(connection.select_calls(), 1);
+        assert_eq!(connection.hit_test_calls(), 0);
+        assert!(connection.select_semantics_preserved());
         Ok(())
     }
 }

--- a/packages/browseros-agent/crates/browseros-core/tests/captured_cdp_fixture.rs
+++ b/packages/browseros-agent/crates/browseros-core/tests/captured_cdp_fixture.rs
@@ -30,10 +30,9 @@ fn captured_dir() -> PathBuf {
 fn captured_pages() -> Vec<(String, PathBuf)> {
     let mut pages = Vec::new();
     let dir = captured_dir();
-    let entries = fs::read_dir(&dir)
-        .unwrap_or_else(|err| panic!("read {}: {err}", dir.display()));
+    let entries = fs::read_dir(&dir).unwrap_or_else(|err| panic!("read {}: {err}", dir.display()));
     for entry in entries {
-        let entry = entry.expect("dir entry");
+        let entry = entry.unwrap_or_else(|err| panic!("read dir entry: {err}"));
         let ax = entry.path().join("get-full-ax-tree.json");
         if ax.is_file() {
             let name = entry.file_name().to_string_lossy().into_owned();
@@ -45,8 +44,8 @@ fn captured_pages() -> Vec<(String, PathBuf)> {
 }
 
 fn load_nodes(path: &Path) -> Vec<AxNode> {
-    let raw = fs::read_to_string(path)
-        .unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+    let raw =
+        fs::read_to_string(path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
     let result: AxTreeResult = serde_json::from_str(&raw)
         .unwrap_or_else(|err| panic!("deserialize {}: {err}", path.display()));
     result.nodes
@@ -112,7 +111,9 @@ fn interactive_captured_pages_mint_refs() {
 #[test]
 fn captured_frame_trees_and_describe_nodes_are_valid_json() {
     for (name, ax_path) in captured_pages() {
-        let dir = ax_path.parent().expect("page dir");
+        let dir = ax_path
+            .parent()
+            .unwrap_or_else(|| panic!("missing parent for {}", ax_path.display()));
         for companion in ["get-frame-tree.json", "describe-node.json"] {
             let path = dir.join(companion);
             let raw = fs::read_to_string(&path)


### PR DESCRIPTION
## Summary
- remove physical click hit-testing from Rust semantic select while preserving ref resolution and scrolling
- keep click and hover blocker protection intact, including the same covered combobox regression
- add real-browser cross-server coverage for styled native select success, bubbling change, and missing-option behavior

## Design
Rust select now follows the same semantic DOM path as TypeScript: resolve the target, scroll it into view, and execute the existing option-selection function. Pointer actions retain their existing center hit-test and mouse-dispatch path; geometry classification is unchanged.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p browseros-core -p browseros-mcp --all-targets -- -D warnings`
- [x] `cargo test -p browseros-core -p browseros-mcp`
- [x] `BROWSEROS_BINARY=/Applications/BrowserClaw.app/Contents/MacOS/BrowserClaw bun run test:claw-mcp-smoke`
- [x] `bun run check`
- [x] `bun run test`