### PR TITLE
feat(app): gate sidepanel voice input controls

### DIFF
--- a/packages/browseros-agent/apps/app/lib/browseros/capabilities.test.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/capabilities.test.ts
@@ -67,6 +67,32 @@ describe('resolveStaticFeatureSupport', () => {
 })
 
 describe('resolveFeatureStaticSupport', () => {
+  it('gates voice input on alpha outside development', () => {
+    expect(
+      resolveFeatureStaticSupport({
+        feature: Feature.VOICE_INPUT_SUPPORT,
+        isDevelopment: true,
+        alphaFeaturesEnabled: false,
+      }),
+    ).toBe(true)
+
+    expect(
+      resolveFeatureStaticSupport({
+        feature: Feature.VOICE_INPUT_SUPPORT,
+        isDevelopment: false,
+        alphaFeaturesEnabled: false,
+      }),
+    ).toBe(false)
+
+    expect(
+      resolveFeatureStaticSupport({
+        feature: Feature.VOICE_INPUT_SUPPORT,
+        isDevelopment: false,
+        alphaFeaturesEnabled: true,
+      }),
+    ).toBe(true)
+  })
+
   it('gates Hermes support on alpha before server version checks', () => {
     expect(
       resolveFeatureStaticSupport({

--- a/packages/browseros-agent/apps/app/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/capabilities.ts
@@ -23,6 +23,7 @@ type FeatureConfig = {
 export enum Feature {
   // Unfinished UI surfaces behind an explicit alpha opt-in
   ALPHA_FEATURES_SUPPORT = 'ALPHA_FEATURES_SUPPORT',
+  VOICE_INPUT_SUPPORT = 'VOICE_INPUT_SUPPORT',
   // Inline chat in the new tab page
   NEWTAB_CHAT_SUPPORT = 'NEWTAB_CHAT_SUPPORT',
   // Vertical tabs preference and customization
@@ -54,6 +55,7 @@ export enum Feature {
  */
 const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.ALPHA_FEATURES_SUPPORT]: { requiresAlphaFlag: true },
+  [Feature.VOICE_INPUT_SUPPORT]: { requiresAlphaFlag: true },
   [Feature.NEWTAB_CHAT_SUPPORT]: { minBrowserOSVersion: '0.40.0.0' },
   [Feature.VERTICAL_TABS_SUPPORT]: { minBrowserOSVersion: '0.42.0.0' },
   [Feature.CHATGPT_PRO_SUPPORT]: { minServerVersion: '0.0.77' },

--- a/packages/browseros-agent/apps/app/lib/env.test.ts
+++ b/packages/browseros-agent/apps/app/lib/env.test.ts
@@ -3,8 +3,8 @@ import { parseBrowserOSApiUrl } from './browseros-api-url'
 import { parseAlphaFeaturesFlag } from './env'
 
 describe('parseAlphaFeaturesFlag', () => {
-  it('defaults alpha features on when unset', () => {
-    expect(parseAlphaFeaturesFlag(undefined)).toBe(true)
+  it('defaults alpha features off when unset', () => {
+    expect(parseAlphaFeaturesFlag(undefined)).toBe(false)
   })
 
   it('keeps explicit true enabled', () => {

--- a/packages/browseros-agent/apps/app/lib/env.ts
+++ b/packages/browseros-agent/apps/app/lib/env.ts
@@ -2,7 +2,7 @@ import { ZodError, z } from 'zod'
 import { parseBrowserOSApiUrl } from './browseros-api-url'
 
 export function parseAlphaFeaturesFlag(value: string | undefined): boolean {
-  return (value ?? 'true') === 'true'
+  return value === 'true'
 }
 
 const EnvSchema = z.object({

--- a/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatFooter.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatFooter.tsx
@@ -4,12 +4,14 @@ import { useEffect, useRef, useState } from 'react'
 import { AppSelector } from '@/components/elements/AppSelector'
 import { WorkspaceSelector } from '@/components/elements/workspace-selector'
 import { McpServerIcon } from '@/components/mcp/McpServerIcon'
+import { Feature } from '@/lib/browseros/capabilities'
 import { useMcpServers } from '@/lib/mcp/mcpServerStorage'
 import {
   type SelectedTextData,
   selectedTextStorage,
 } from '@/lib/selected-text/selectedTextStorage'
 import { cn } from '@/lib/utils'
+import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
 import type { ChatMode } from '@/modules/chat/chat-types'
 import { useGetUserMCPIntegrations } from '@/modules/mcp/user-integrations.hooks'
 import type { VoiceInputState } from '@/modules/voice/voice.hooks'
@@ -57,6 +59,8 @@ export const ChatFooter: FC<ChatFooterProps> = ({
   const { selectedFolder } = useWorkspace()
   const { servers: mcpServers } = useMcpServers()
   const { data: userMCPIntegrations } = useGetUserMCPIntegrations()
+  const { supports } = useCapabilities()
+  const supportsVoiceInput = supports(Feature.VOICE_INPUT_SUPPORT)
   const chatInputRef = useRef<ChatInputHandle>(null)
   const [selectionMap, setSelectionMap] = useState<
     Record<string, SelectedTextData>
@@ -219,11 +223,11 @@ export const ChatFooter: FC<ChatFooterProps> = ({
           </div>
         </div>
 
-        {voice?.error && (
+        {supportsVoiceInput && voice?.error && (
           <div className="mt-1 text-destructive text-xs">{voice.error}</div>
         )}
 
-        <VoiceModeArea voiceLoop={voiceLoop}>
+        <VoiceModeArea voiceLoop={supportsVoiceInput ? voiceLoop : undefined}>
           <ChatInput
             input={input}
             status={status}
@@ -235,8 +239,8 @@ export const ChatFooter: FC<ChatFooterProps> = ({
             selectedTabs={attachedTabs}
             onToggleTab={onToggleTab}
             onTabMentionOpenChange={setIsTabMentionOpen}
-            voice={voice}
-            onOpenVoiceMode={onOpenVoiceMode}
+            voice={supportsVoiceInput ? voice : undefined}
+            onOpenVoiceMode={supportsVoiceInput ? onOpenVoiceMode : undefined}
             ref={chatInputRef}
           />
         </VoiceModeArea>


### PR DESCRIPTION
## Summary
- add an alpha-gated `VOICE_INPUT_SUPPORT` capability and make alpha features opt-in when the env flag is omitted
- hide the side-panel voice-mode, dictation, voice error, and voice-mode area by withholding their existing props when unsupported
- preserve the voice implementation and the separate new-tab composer unchanged

## Design
The existing capabilities layer owns the build-time alpha toggle, while `ChatFooter` owns the presentation boundary for all side-panel voice props. With the capability disabled, `ChatInput` naturally uses its existing send-only rendering and spacing; with explicit alpha opt-in or development mode, the original voice props and behavior pass through unchanged.

## Test plan
- [x] `bun test apps/app/lib/env.test.ts apps/app/lib/browseros/capabilities.test.ts`
- [x] `bun run --filter @browseros/app typecheck`
- [x] `VITE_ALPHA_FEATURES=false bun run --filter @browseros/app build`
- [x] `bun run check`
- [x] `bun run test`
- [x] CDP snapshot + screenshot: production alpha-off side panel shows textarea and Send only with `pr-11` spacing
- [x] CDP snapshot + screenshot: development flag-on side panel restores Voice mode, Voice input, and Send
