### PR TITLE
fix(app): gate new-tab voice controls

### DIFF
--- a/packages/browseros-agent/apps/app/screens/agent-command/ConversationInput.tsx
+++ b/packages/browseros-agent/apps/app/screens/agent-command/ConversationInput.tsx
@@ -1,13 +1,11 @@
 import {
   ArrowRight,
-  AudioLines,
   Bot,
   ChevronDown,
   FileText,
   Folder,
   Layers,
   Loader2,
-  Mic,
   Paperclip,
   Square,
   X,
@@ -30,13 +28,19 @@ import { McpServerIcon } from '@/components/mcp/McpServerIcon'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { type StagedAttachment, stageAttachments } from '@/lib/attachments'
+import { Feature } from '@/lib/browseros/capabilities'
 import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { ProviderType } from '@/lib/llm-providers/types'
 import { useMcpServers } from '@/lib/mcp/mcpServerStorage'
 import { cn } from '@/lib/utils'
+import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
 import { useGetUserMCPIntegrations } from '@/modules/mcp/user-integrations.hooks'
 import { useVoiceInput } from '@/modules/voice/voice.hooks'
 import { useWorkspace } from '@/modules/workspace/workspace.hooks'
+import {
+  ConversationVoiceControls,
+  resolveVoicePresentation,
+} from './ConversationVoiceControls'
 
 export interface ConversationInputSendInput {
   text: string
@@ -119,74 +123,6 @@ function StopButton({ onStop }: { onStop: () => void }) {
       className="h-8 w-8 flex-shrink-0 rounded-lg bg-destructive/10 text-destructive transition-colors hover:bg-destructive/15 hover:text-destructive"
     >
       <Square className="h-3.5 w-3.5 fill-current" />
-    </Button>
-  )
-}
-
-function VoiceModeEntryButton({ onClick }: { onClick: () => void }) {
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      onClick={onClick}
-      className="h-10 w-10 flex-shrink-0 rounded-xl text-muted-foreground transition-colors hover:text-foreground"
-      title="Open voice mode"
-      aria-label="Open voice mode"
-    >
-      <AudioLines className="h-5 w-5" />
-    </Button>
-  )
-}
-
-function VoiceButton({
-  isRecording,
-  isTranscribing,
-  onStart,
-  onStop,
-}: {
-  isRecording: boolean
-  isTranscribing: boolean
-  onStart: () => void
-  onStop: () => void
-}) {
-  if (isRecording) {
-    return (
-      <Button
-        type="button"
-        size="icon"
-        onClick={onStop}
-        className="h-10 w-10 flex-shrink-0 rounded-xl bg-red-600 text-white hover:bg-red-700"
-      >
-        <Square className="h-4 w-4" />
-      </Button>
-    )
-  }
-
-  if (isTranscribing) {
-    return (
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        disabled
-        className="h-10 w-10 flex-shrink-0 rounded-xl"
-      >
-        <Loader2 className="h-5 w-5 animate-spin" />
-      </Button>
-    )
-  }
-
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      onClick={onStart}
-      className="h-10 w-10 flex-shrink-0 rounded-xl text-muted-foreground transition-colors hover:text-foreground"
-      title="Voice input"
-    >
-      <Mic className="h-5 w-5" />
     </Button>
   )
 }
@@ -393,6 +329,14 @@ export const ConversationInput: FC<ConversationInputProps> = ({
   const [isDragOver, setIsDragOver] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const voice = useVoiceInput()
+  const { supports } = useCapabilities()
+  const supportsVoiceInput = supports(Feature.VOICE_INPUT_SUPPORT)
+  const voicePresentation = resolveVoicePresentation({
+    enabled: supportsVoiceInput,
+    isRecording: voice.isRecording,
+    isTranscribing: voice.isTranscribing,
+    error: voice.error,
+  })
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const isConversation = variant === 'conversation'
 
@@ -437,11 +381,20 @@ export const ConversationInput: FC<ConversationInputProps> = ({
   })
 
   useEffect(() => {
-    if (voice.transcript && !voice.isTranscribing) {
+    if (
+      supportsVoiceInput &&
+      voice.transcript &&
+      !voicePresentation.isTranscribing
+    ) {
       setInput(voice.transcript)
       voice.clearTranscript()
     }
-  }, [voice.transcript, voice.isTranscribing, voice])
+  }, [
+    supportsVoiceInput,
+    voice.transcript,
+    voicePresentation.isTranscribing,
+    voice,
+  ])
 
   useEffect(() => {
     if (attachmentsEnabled) return
@@ -585,12 +538,12 @@ export const ConversationInput: FC<ConversationInputProps> = ({
               onPaste={handlePaste}
               rows={1}
               placeholder={
-                voice.isTranscribing
+                voicePresentation.isTranscribing
                   ? 'Transcribing...'
                   : (placeholder ??
                     `Message ${selectedProvider?.name ?? 'agent'}...`)
               }
-              disabled={disabled || voice.isTranscribing}
+              disabled={disabled || voicePresentation.isTranscribing}
               className={cn(
                 'resize-none border-none bg-transparent px-0 text-[15px] shadow-none focus-visible:ring-0 dark:bg-transparent',
                 '[field-sizing:fixed]',
@@ -602,26 +555,25 @@ export const ConversationInput: FC<ConversationInputProps> = ({
             />
           </div>
           {streaming && onStop ? <StopButton onStop={onStop} /> : null}
-          {onOpenVoiceMode ? (
-            <VoiceModeEntryButton onClick={onOpenVoiceMode} />
-          ) : null}
-          <VoiceButton
+          <ConversationVoiceControls
+            enabled={supportsVoiceInput}
             isRecording={voice.isRecording}
             isTranscribing={voice.isTranscribing}
-            onStart={() => {
+            onStartRecording={() => {
               void voice.startRecording()
             }}
-            onStop={() => {
+            onStopRecording={() => {
               void voice.stopRecording()
             }}
+            onOpenVoiceMode={onOpenVoiceMode}
           />
           <InputActionButton
             disabled={
               !hasContent ||
               isStaging ||
               !!disabled ||
-              voice.isRecording ||
-              voice.isTranscribing ||
+              voicePresentation.isRecording ||
+              voicePresentation.isTranscribing ||
               (streaming && !queueAware)
             }
             onClick={handleSend}
@@ -631,9 +583,9 @@ export const ConversationInput: FC<ConversationInputProps> = ({
             hasContent={hasContent}
           />
         </div>
-        {voice.error ? (
+        {voicePresentation.error ? (
           <div className="px-5 pb-2 text-destructive text-xs">
-            {voice.error}
+            {voicePresentation.error}
           </div>
         ) : null}
         <CalmContextControls

--- a/packages/browseros-agent/apps/app/screens/agent-command/ConversationVoiceControls.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/agent-command/ConversationVoiceControls.test.tsx
@@ -1,0 +1,104 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import { type ComponentProps, createElement, type FC } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type {
+  ConversationVoiceControlsProps,
+  VoicePresentationInput,
+} from './ConversationVoiceControls'
+
+type MockButtonProps = ComponentProps<'button'> & {
+  variant?: string
+  size?: string
+}
+
+mock.module('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: MockButtonProps) =>
+    createElement('button', { type: 'button', ...props }, children),
+}))
+
+type ResolveVoicePresentation = (input: VoicePresentationInput) => {
+  isRecording: boolean
+  isTranscribing: boolean
+  error: string | null
+}
+
+let ConversationVoiceControls: FC<ConversationVoiceControlsProps>
+let resolveVoicePresentation: ResolveVoicePresentation
+
+beforeAll(async () => {
+  const voiceControls = await import('./ConversationVoiceControls')
+  ConversationVoiceControls = voiceControls.ConversationVoiceControls
+  resolveVoicePresentation = voiceControls.resolveVoicePresentation
+})
+
+const callbacks = {
+  onStartRecording: () => {},
+  onStopRecording: () => {},
+  onOpenVoiceMode: () => {},
+}
+
+describe('ConversationVoiceControls', () => {
+  it('hides both voice actions when support is disabled', () => {
+    const html = renderToStaticMarkup(
+      createElement(ConversationVoiceControls, {
+        enabled: false,
+        isRecording: false,
+        isTranscribing: false,
+        ...callbacks,
+      }),
+    )
+
+    expect(html).toBe('')
+  })
+
+  it('shows voice mode and dictation when support is enabled', () => {
+    const html = renderToStaticMarkup(
+      createElement(ConversationVoiceControls, {
+        enabled: true,
+        isRecording: false,
+        isTranscribing: false,
+        ...callbacks,
+      }),
+    )
+
+    expect(html).toContain('aria-label="Open voice mode"')
+    expect(html).toContain('aria-label="Voice input"')
+  })
+})
+
+describe('resolveVoicePresentation', () => {
+  it('suppresses voice-derived input state while support is disabled', () => {
+    expect(
+      resolveVoicePresentation({
+        enabled: false,
+        isRecording: true,
+        isTranscribing: true,
+        error: 'Microphone permission denied',
+      }),
+    ).toEqual({
+      isRecording: false,
+      isTranscribing: false,
+      error: null,
+    })
+  })
+
+  it('preserves voice-derived input state while support is enabled', () => {
+    expect(
+      resolveVoicePresentation({
+        enabled: true,
+        isRecording: true,
+        isTranscribing: true,
+        error: 'Microphone permission denied',
+      }),
+    ).toEqual({
+      isRecording: true,
+      isTranscribing: true,
+      error: 'Microphone permission denied',
+    })
+  })
+})

--- a/packages/browseros-agent/apps/app/screens/agent-command/ConversationVoiceControls.tsx
+++ b/packages/browseros-agent/apps/app/screens/agent-command/ConversationVoiceControls.tsx
@@ -1,0 +1,102 @@
+import { AudioLines, Loader2, Mic, Square } from 'lucide-react'
+import type { FC } from 'react'
+import { Button } from '@/components/ui/button'
+
+export interface VoicePresentationInput {
+  enabled: boolean
+  isRecording: boolean
+  isTranscribing: boolean
+  error: string | null
+}
+
+export function resolveVoicePresentation({
+  enabled,
+  isRecording,
+  isTranscribing,
+  error,
+}: VoicePresentationInput): Omit<VoicePresentationInput, 'enabled'> {
+  if (!enabled) {
+    return {
+      isRecording: false,
+      isTranscribing: false,
+      error: null,
+    }
+  }
+
+  return { isRecording, isTranscribing, error }
+}
+
+export interface ConversationVoiceControlsProps {
+  enabled: boolean
+  isRecording: boolean
+  isTranscribing: boolean
+  onStartRecording: () => void
+  onStopRecording: () => void
+  onOpenVoiceMode?: () => void
+}
+
+export const ConversationVoiceControls: FC<ConversationVoiceControlsProps> = ({
+  enabled,
+  isRecording,
+  isTranscribing,
+  onStartRecording,
+  onStopRecording,
+  onOpenVoiceMode,
+}) => {
+  if (!enabled) return null
+
+  return (
+    <>
+      {onOpenVoiceMode ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onOpenVoiceMode}
+          className="h-10 w-10 flex-shrink-0 rounded-xl text-muted-foreground transition-colors hover:text-foreground"
+          title="Open voice mode"
+          aria-label="Open voice mode"
+        >
+          <AudioLines className="h-5 w-5" />
+        </Button>
+      ) : null}
+
+      {isRecording ? (
+        <Button
+          type="button"
+          size="icon"
+          onClick={onStopRecording}
+          className="h-10 w-10 flex-shrink-0 rounded-xl bg-red-600 text-white hover:bg-red-700"
+          title="Stop voice input"
+          aria-label="Stop voice input"
+        >
+          <Square className="h-4 w-4" />
+        </Button>
+      ) : isTranscribing ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          disabled
+          className="h-10 w-10 flex-shrink-0 rounded-xl"
+          title="Transcribing voice input"
+          aria-label="Transcribing voice input"
+        >
+          <Loader2 className="h-5 w-5 animate-spin" />
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onStartRecording}
+          className="h-10 w-10 flex-shrink-0 rounded-xl text-muted-foreground transition-colors hover:text-foreground"
+          title="Voice input"
+          aria-label="Voice input"
+        >
+          <Mic className="h-5 w-5" />
+        </Button>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- apply the existing voice capability to the shared new-tab composer
- hide voice controls, errors, and voice-derived input state when unsupported
- cover enabled and disabled rendering with focused tests

## Design
The shared ConversationInput boundary now resolves VOICE_INPUT_SUPPORT, matching the existing ChatFooter convention. A focused voice-controls component keeps both new-tab composer routes consistent and makes the gate states directly testable.

## Test plan
- [x] focused ConversationVoiceControls tests
- [x] app test suite
- [x] app and monorepo typecheck
- [x] repository lint and fallow checks
- [x] production agent extension build
- [x] CDP snapshot and screenshot with voice support enabled
- [x] CDP snapshot and screenshot with voice support disabled
