### PR TITLE
fix(app): make custom model IDs discoverable in the provider picker

### DIFF
--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -96,6 +96,9 @@ function showsStandardModelField(type: ProviderType): boolean {
   return !isAcpProviderType(type)
 }
 
+/** Window assumed for any model the bundled catalog cannot size. */
+const DEFAULT_CONTEXT_WINDOW = 128000
+
 function defaultReasoningEffort(type?: ProviderType) {
   return type === 'chatgpt-pro' ? 'medium' : 'high'
 }
@@ -211,7 +214,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
       modelId: initialValues?.modelId || '',
       apiKey: initialValues?.apiKey || '',
       supportsImages: initialValues?.supportsImages ?? false,
-      contextWindow: initialValues?.contextWindow || 128000,
+      contextWindow: initialValues?.contextWindow || DEFAULT_CONTEXT_WINDOW,
       temperature: initialValues?.temperature ?? 0.2,
       resourceName: initialValues?.resourceName || '',
       accessKeyId: initialValues?.accessKeyId || '',
@@ -325,16 +328,17 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
 
   useEffect(() => {
     if (initialValues?.id) return
+    if (!watchedModelId) return
 
-    if (watchedModelId) {
-      const contextLength = getModelContextLength(
-        watchedType as ProviderType,
-        watchedModelId,
-      )
-      if (contextLength) {
-        form.setValue('contextWindow', contextLength)
-      }
-    }
+    // A custom model has no catalog entry, so fall back to the default rather
+    // than keeping whatever the previously selected model left behind: picking
+    // gpt-5.5 and then pasting an 8k local model would otherwise save a
+    // 1M-token window and overflow it on the first long chat.
+    const contextLength = getModelContextLength(
+      watchedType as ProviderType,
+      watchedModelId,
+    )
+    form.setValue('contextWindow', contextLength || DEFAULT_CONTEXT_WINDOW)
   }, [watchedModelId, watchedType, form, initialValues?.id])
 
   useEffect(() => {
@@ -348,7 +352,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
         modelId: initialValues.modelId || '',
         apiKey: initialValues.apiKey || '',
         supportsImages: initialValues.supportsImages ?? false,
-        contextWindow: initialValues.contextWindow || 128000,
+        contextWindow: initialValues.contextWindow || DEFAULT_CONTEXT_WINDOW,
         temperature: initialValues.temperature ?? 0.2,
         resourceName: initialValues.resourceName || '',
         accessKeyId: initialValues.accessKeyId || '',
@@ -373,7 +377,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
         modelId: '',
         apiKey: '',
         supportsImages: false,
-        contextWindow: 128000,
+        contextWindow: DEFAULT_CONTEXT_WINDOW,
         temperature: 0.2,
         resourceName: '',
         accessKeyId: '',

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -72,8 +72,7 @@ import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
 import { useAcpProbe } from '@/modules/llm-providers/acp-probe.hooks'
 import {
   getIncompleteCatalogHint,
-  normalizeModelId,
-  shouldOfferCustomModel,
+  getModelPickerRows,
 } from './model-picker.helpers'
 import { getModelContextLength, getModelsForProvider } from './models'
 import {
@@ -291,12 +290,11 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     [modelInfoList],
   )
 
-  const filteredModels = modelSearch
-    ? modelFuse.search(modelSearch).map((r) => r.item)
-    : modelInfoList
-
-  const customModelId = normalizeModelId(modelSearch)
-  const showCustomEntry = shouldOfferCustomModel(modelSearch, modelInfoList)
+  const { customModelId, models: filteredModels } = getModelPickerRows(
+    modelSearch,
+    modelInfoList,
+    (query) => modelFuse.search(query).map((r) => r.item),
+  )
 
   const commitModelId = (modelId: string, contextLength?: number) => {
     form.setValue('modelId', modelId)
@@ -1059,7 +1057,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                               }}
                             />
                             <CommandList ref={modelListRef}>
-                              {showCustomEntry && (
+                              {customModelId !== null && (
                                 <CommandGroup forceMount>
                                   <CommandItem
                                     forceMount

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -14,7 +14,6 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   Command,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
@@ -71,6 +70,11 @@ import { cn } from '@/lib/utils'
 import { useAgentServerUrl } from '@/modules/browseros/agent-server-url.hooks'
 import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
 import { useAcpProbe } from '@/modules/llm-providers/acp-probe.hooks'
+import {
+  getIncompleteCatalogHint,
+  normalizeModelId,
+  shouldOfferCustomModel,
+} from './model-picker.helpers'
 import { getModelContextLength, getModelsForProvider } from './models'
 import {
   isCredentiallessProviderType,
@@ -291,8 +295,20 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     ? modelFuse.search(modelSearch).map((r) => r.item)
     : modelInfoList
 
-  const showCustomEntry =
-    modelSearch && !filteredModels.some((m) => m.modelId === modelSearch)
+  const customModelId = normalizeModelId(modelSearch)
+  const showCustomEntry = shouldOfferCustomModel(modelSearch, modelInfoList)
+
+  const commitModelId = (modelId: string, contextLength?: number) => {
+    form.setValue('modelId', modelId)
+    track(MODEL_SELECTED_EVENT, {
+      provider_type: watchedType,
+      model_id: modelId,
+      ...(contextLength === undefined ? {} : { context_window: contextLength }),
+      is_custom_model: !modelInfoList.some((m) => m.modelId === modelId),
+    })
+    setModelPickerOpen(false)
+    setModelSearch('')
+  }
 
   const handleTypeChange = (newType: ProviderType) => {
     form.setValue('type', newType)
@@ -470,6 +486,11 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   const providerName = providerTemplate?.name
   const setupGuideText = setupGuideLabel(
     watchedType as ProviderType,
+    providerName,
+  )
+  const modelCatalogHint = getIncompleteCatalogHint(
+    watchedType as ProviderType,
+    modelInfoList.length,
     providerName,
   )
 
@@ -1017,7 +1038,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                             )}
                           >
                             <span className="truncate">
-                              {field.value || 'Select a model...'}
+                              {field.value || 'Select or paste a model ID'}
                             </span>
                             <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                           </button>
@@ -1028,7 +1049,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                         >
                           <Command shouldFilter={false}>
                             <CommandInput
-                              placeholder="Search models..."
+                              placeholder="Search or paste a model ID..."
                               value={modelSearch}
                               onValueChange={(v) => {
                                 setModelSearch(v)
@@ -1036,48 +1057,24 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                                   modelListRef.current?.scrollTo(0, 0)
                                 })
                               }}
-                              onKeyDown={(e) => {
-                                if (e.key === 'Enter' && modelSearch) {
-                                  e.preventDefault()
-                                  e.stopPropagation()
-                                  form.setValue('modelId', modelSearch)
-                                  track(MODEL_SELECTED_EVENT, {
-                                    provider_type: watchedType,
-                                    model_id: modelSearch,
-                                    is_custom_model: !modelInfoList.some(
-                                      (m) => m.modelId === modelSearch,
-                                    ),
-                                  })
-                                  setModelPickerOpen(false)
-                                  setModelSearch('')
-                                }
-                              }}
                             />
                             <CommandList ref={modelListRef}>
-                              <CommandEmpty>
-                                No models found. Press Enter to use &quot;
-                                {modelSearch}&quot;
-                              </CommandEmpty>
                               {showCustomEntry && (
                                 <CommandGroup forceMount>
                                   <CommandItem
                                     forceMount
-                                    value={`custom:${modelSearch}`}
-                                    onSelect={() => {
-                                      form.setValue('modelId', modelSearch)
-                                      track(MODEL_SELECTED_EVENT, {
-                                        provider_type: watchedType,
-                                        model_id: modelSearch,
-                                        is_custom_model: true,
-                                      })
-                                      setModelPickerOpen(false)
-                                      setModelSearch('')
-                                    }}
+                                    value={`custom:${customModelId}`}
+                                    onSelect={() =>
+                                      commitModelId(customModelId)
+                                    }
                                   >
                                     <span className="flex-1 truncate">
-                                      {modelSearch}
+                                      Use &quot;{customModelId}&quot;
                                     </span>
-                                    {field.value === modelSearch && (
+                                    <span className="ml-2 shrink-0 rounded-md bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground uppercase tracking-wide">
+                                      Custom
+                                    </span>
+                                    {field.value === customModelId && (
                                       <Check className="ml-2 h-4 w-4 shrink-0" />
                                     )}
                                   </CommandItem>
@@ -1089,19 +1086,12 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                                     <CommandItem
                                       key={model.modelId}
                                       value={model.modelId}
-                                      onSelect={() => {
-                                        form.setValue('modelId', model.modelId)
-                                        track(MODEL_SELECTED_EVENT, {
-                                          provider_type: watchedType,
-                                          model_id: model.modelId,
-                                          context_window: model.contextLength,
-                                          is_custom_model: !modelInfoList.some(
-                                            (m) => m.modelId === model.modelId,
-                                          ),
-                                        })
-                                        setModelPickerOpen(false)
-                                        setModelSearch('')
-                                      }}
+                                      onSelect={() =>
+                                        commitModelId(
+                                          model.modelId,
+                                          model.contextLength,
+                                        )
+                                      }
                                     >
                                       <span className="flex-1 truncate">
                                         {model.modelId}
@@ -1121,9 +1111,19 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                                 </CommandGroup>
                               )}
                             </CommandList>
+                            {/* cmdk re-selects the first item on every
+                                keystroke, so the free-form row above is what
+                                Enter commits until the user arrows away. */}
+                            <p className="border-border border-t px-3 py-2 text-[11px] text-muted-foreground">
+                              Model not listed? Type or paste its exact ID, then
+                              press Enter.
+                            </p>
                           </Command>
                         </PopoverContent>
                       </Popover>
+                    )}
+                    {modelCatalogHint && (
+                      <FormDescription>{modelCatalogHint}</FormDescription>
                     )}
                     <FormMessage />
                   </FormItem>

--- a/packages/browseros-agent/apps/app/screens/ai-settings/model-picker.helpers.test.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/model-picker.helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import Fuse from 'fuse.js'
+import { getProviderTemplate } from '../../lib/llm-providers/providerTemplates'
 import type { ProviderType } from '../../lib/llm-providers/types'
 import {
   getIncompleteCatalogHint,
@@ -81,8 +82,13 @@ describe('servesUserLoadedModels', () => {
 
 describe('getIncompleteCatalogHint', () => {
   it('warns that a local runtime catalog is only a sample', () => {
-    expect(getIncompleteCatalogHint('lmstudio', 3, 'LM Studio')).toContain(
-      'LM Studio lists only common models',
+    // Names the provider off the same template the dialog passes in, so this
+    // asserts the sentence users actually read rather than echoing back a
+    // literal the call site never produces.
+    const providerName = getProviderTemplate('lmstudio')?.name
+
+    expect(getIncompleteCatalogHint('lmstudio', 3, providerName)).toBe(
+      `${providerName} lists only common models — paste the exact ID of any model you have loaded.`,
     )
   })
 

--- a/packages/browseros-agent/apps/app/screens/ai-settings/model-picker.helpers.test.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/model-picker.helpers.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  getIncompleteCatalogHint,
+  normalizeModelId,
+  servesUserLoadedModels,
+  shouldOfferCustomModel,
+} from './model-picker.helpers'
+import { getModelsForProvider, type ModelInfo } from './models'
+
+const catalog: ModelInfo[] = [
+  { modelId: 'openai/gpt-oss-20b', contextLength: 131072 },
+  { modelId: 'qwen/qwen3-coder-30b', contextLength: 262144 },
+]
+
+describe('normalizeModelId', () => {
+  it('strips whitespace picked up when pasting from provider UIs', () => {
+    expect(normalizeModelId('  qwen/qwen3-coder-30b\n')).toBe(
+      'qwen/qwen3-coder-30b',
+    )
+  })
+
+  it('reduces whitespace-only input to the empty string', () => {
+    expect(normalizeModelId('   ')).toBe('')
+  })
+})
+
+describe('shouldOfferCustomModel', () => {
+  it('offers an unlisted model ID', () => {
+    expect(shouldOfferCustomModel('openai/gpt-oss-120b', catalog)).toBe(true)
+  })
+
+  it('does not offer a model the catalog already lists', () => {
+    expect(shouldOfferCustomModel('qwen/qwen3-coder-30b', catalog)).toBe(false)
+  })
+
+  it('does not duplicate a listed model that was pasted with whitespace', () => {
+    expect(shouldOfferCustomModel(' qwen/qwen3-coder-30b ', catalog)).toBe(
+      false,
+    )
+  })
+
+  it('offers nothing until the user types something usable', () => {
+    expect(shouldOfferCustomModel('', catalog)).toBe(false)
+    expect(shouldOfferCustomModel('  ', catalog)).toBe(false)
+  })
+
+  it('offers free-form entry when the provider has no catalog at all', () => {
+    expect(shouldOfferCustomModel('llama3.2', [])).toBe(true)
+  })
+})
+
+describe('servesUserLoadedModels', () => {
+  it('covers the endpoints that serve locally loaded or proxied models', () => {
+    expect(servesUserLoadedModels('lmstudio')).toBe(true)
+    expect(servesUserLoadedModels('ollama')).toBe(true)
+    expect(servesUserLoadedModels('openai-compatible')).toBe(true)
+  })
+
+  it('excludes providers whose catalog is authoritative', () => {
+    expect(servesUserLoadedModels('anthropic')).toBe(false)
+    expect(servesUserLoadedModels('openai')).toBe(false)
+  })
+})
+
+describe('getIncompleteCatalogHint', () => {
+  it('warns that a local runtime catalog is only a sample', () => {
+    expect(getIncompleteCatalogHint('lmstudio', 3, 'LM Studio')).toContain(
+      'LM Studio lists only common models',
+    )
+  })
+
+  it('stays silent for providers with an authoritative catalog', () => {
+    expect(getIncompleteCatalogHint('anthropic', 12, 'Anthropic')).toBeNull()
+  })
+
+  it('stays silent when the field already renders as free-form input', () => {
+    expect(getIncompleteCatalogHint('ollama', 0, 'Ollama')).toBeNull()
+  })
+
+  it('falls back to a generic subject when the provider has no display name', () => {
+    expect(getIncompleteCatalogHint('lmstudio', 3)).toContain('This provider')
+  })
+})
+
+describe('LM Studio model catalog', () => {
+  // Regression guard for the bug report: LM Studio ships a handful of
+  // models.dev entries, so the picker must never present that list as the
+  // complete set of what the endpoint can serve.
+  it('is short enough that free-form entry has to stay discoverable', () => {
+    const models = getModelsForProvider('lmstudio')
+
+    expect(models.length).toBeGreaterThan(0)
+    expect(
+      getIncompleteCatalogHint('lmstudio', models.length, 'LM Studio'),
+    ).not.toBeNull()
+    expect(shouldOfferCustomModel('qwen/qwen3-vl-8b', models)).toBe(true)
+  })
+})

--- a/packages/browseros-agent/apps/app/screens/ai-settings/model-picker.helpers.test.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/model-picker.helpers.test.ts
@@ -1,11 +1,28 @@
 import { describe, expect, it } from 'bun:test'
+import Fuse from 'fuse.js'
+import type { ProviderType } from '../../lib/llm-providers/types'
 import {
   getIncompleteCatalogHint,
+  getModelPickerRows,
   normalizeModelId,
   servesUserLoadedModels,
   shouldOfferCustomModel,
 } from './model-picker.helpers'
 import { getModelsForProvider, type ModelInfo } from './models'
+
+// Mirrors NewProviderDialog's Fuse setup so these tests exercise the real
+// ranking the picker sees, not an idealized substring match.
+function pickerRows(providerType: ProviderType, search: string) {
+  const models = getModelsForProvider(providerType)
+  const fuse = new Fuse(models, {
+    keys: ['modelId'],
+    threshold: 0.4,
+    distance: 100,
+  })
+  return getModelPickerRows(search, models, (query) =>
+    fuse.search(query).map((r) => r.item),
+  )
+}
 
 const catalog: ModelInfo[] = [
   { modelId: 'openai/gpt-oss-20b', contextLength: 131072 },
@@ -79,6 +96,67 @@ describe('getIncompleteCatalogHint', () => {
 
   it('falls back to a generic subject when the provider has no display name', () => {
     expect(getIncompleteCatalogHint('lmstudio', 3)).toContain('This provider')
+  })
+})
+
+describe('getModelPickerRows', () => {
+  it('offers the free-form row for an unlisted ID', () => {
+    const rows = pickerRows('lmstudio', 'mistralai/magistral-small-2509')
+
+    expect(rows.customModelId).toBe('mistralai/magistral-small-2509')
+  })
+
+  it('ranks a pasted catalog ID above its longer near-matches', () => {
+    // A trailing space used to reach Fuse verbatim, where the padded pattern
+    // scored better against `gpt-5.5` than against the exact `gpt-5` — and
+    // with no custom row to outrank it, Enter saved the wrong model.
+    for (const search of ['gpt-5 ', ' gpt-5', 'gpt-5\n', 'gpt-5\t']) {
+      const rows = pickerRows('openai', search)
+
+      expect(rows.customModelId).toBeNull()
+      expect(rows.models[0]?.modelId).toBe('gpt-5')
+    }
+  })
+
+  it('still resolves a catalog ID padded on both sides', () => {
+    // ` o3 ` matched nothing at all, emptying a list whose trimmed form is a
+    // direct hit and leaving Enter with no row to commit.
+    const rows = pickerRows('openai', '  o3  ')
+
+    expect(rows.customModelId).toBeNull()
+    expect(rows.models[0]?.modelId).toBe('o3')
+  })
+
+  it('shows the whole catalog before the user types', () => {
+    const rows = pickerRows('lmstudio', '')
+
+    expect(rows.customModelId).toBeNull()
+    expect(rows.models).toEqual(getModelsForProvider('lmstudio'))
+  })
+
+  it('always leaves a row for Enter to commit, which is why there is no empty state', () => {
+    const providers: ProviderType[] = [
+      'lmstudio',
+      'openai',
+      'anthropic',
+      'google',
+      'openrouter',
+    ]
+
+    for (const providerType of providers) {
+      for (const model of getModelsForProvider(providerType)) {
+        for (const search of [model.modelId, ` ${model.modelId} `]) {
+          const rows = pickerRows(providerType, search)
+
+          expect(
+            rows.models.length + (rows.customModelId ? 1 : 0),
+          ).toBeGreaterThan(0)
+        }
+      }
+
+      const rows = pickerRows(providerType, 'definitely-not-a-real-model')
+      expect(rows.customModelId).toBe('definitely-not-a-real-model')
+    }
   })
 })
 

--- a/packages/browseros-agent/apps/app/screens/ai-settings/model-picker.helpers.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/model-picker.helpers.ts
@@ -1,0 +1,58 @@
+import type { ProviderType } from '../../lib/llm-providers/types'
+import type { ModelInfo } from './models'
+
+/**
+ * Endpoints that serve whatever the user has loaded or proxied locally, so the
+ * bundled models.dev catalog is only ever a stale sample of what they can
+ * actually reach. Free-form entry is the primary path for these — LM Studio
+ * ships three catalog entries and users read that as the complete list.
+ */
+const USER_LOADED_MODEL_PROVIDERS: ReadonlySet<ProviderType> = new Set([
+  'lmstudio',
+  'ollama',
+  'openai-compatible',
+])
+
+export function servesUserLoadedModels(providerType: ProviderType): boolean {
+  return USER_LOADED_MODEL_PROVIDERS.has(providerType)
+}
+
+/**
+ * Model IDs are usually pasted out of a provider's UI or docs and arrive with
+ * surrounding whitespace, which the provider's API then rejects as unknown.
+ */
+export function normalizeModelId(raw: string): string {
+  return raw.trim()
+}
+
+/**
+ * True when the search text is a usable model ID the catalog doesn't already
+ * offer, meaning the picker must surface it as an explicit free-form choice.
+ * Matched against the whole catalog rather than the fuzzy-filtered view so an
+ * exact hit never renders twice.
+ */
+export function shouldOfferCustomModel(
+  search: string,
+  catalog: readonly ModelInfo[],
+): boolean {
+  const modelId = normalizeModelId(search)
+  if (!modelId) return false
+  return !catalog.some((model) => model.modelId === modelId)
+}
+
+/**
+ * Guidance rendered under the Model field. Scoped to providers that show a
+ * catalog they cannot actually vouch for: a short list reads as authoritative,
+ * which is how LM Studio users concluded their loaded models were unsupported.
+ * A provider with no catalog already renders a free-form input, and a cloud
+ * catalog is authoritative, so both get null and stay uncluttered.
+ */
+export function getIncompleteCatalogHint(
+  providerType: ProviderType,
+  catalogSize: number,
+  providerName?: string,
+): string | null {
+  if (catalogSize === 0) return null
+  if (!servesUserLoadedModels(providerType)) return null
+  return `${providerName ?? 'This provider'} lists only common models — paste the exact ID of any model you have loaded.`
+}

--- a/packages/browseros-agent/apps/app/screens/ai-settings/model-picker.helpers.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/model-picker.helpers.ts
@@ -40,6 +40,39 @@ export function shouldOfferCustomModel(
   return !catalog.some((model) => model.modelId === modelId)
 }
 
+export interface ModelPickerRows {
+  /** Free-form row to offer, or null when the catalog already covers the ID. */
+  customModelId: string | null
+  /** Catalog rows to render for the current query. */
+  models: readonly ModelInfo[]
+}
+
+/**
+ * Rows the picker renders for the current search text.
+ *
+ * Both the fuzzy query and the free-form decision run on the *trimmed* ID, and
+ * they have to agree. Letting them diverge is what makes a stray pasted space
+ * dangerous: `Fuse` scores a padded `gpt-5 ` higher against the longer
+ * `gpt-5.5` than against the exact `gpt-5`, so Enter would silently save a
+ * different model, and a doubly-padded ` o3 ` matches nothing at all while the
+ * trimmed form is a catalog hit, leaving the list empty with no row to commit.
+ *
+ * Guarantees at least one row, which is why the picker needs no empty state:
+ * an exact catalog ID always scores 0 and ranks itself first, and anything else
+ * is by definition a custom ID.
+ */
+export function getModelPickerRows(
+  search: string,
+  catalog: readonly ModelInfo[],
+  fuzzySearch: (query: string) => readonly ModelInfo[],
+): ModelPickerRows {
+  const modelId = normalizeModelId(search)
+  return {
+    customModelId: shouldOfferCustomModel(search, catalog) ? modelId : null,
+    models: modelId ? fuzzySearch(modelId) : catalog,
+  }
+}
+
 /**
  * Guidance rendered under the Model field. Scoped to providers that show a
  * catalog they cannot actually vouch for: a short list reads as authoritative,


### PR DESCRIPTION
## Problem

> when you select LM Studio it doesnt show up with the model list just 3 pre defined ones

The Model combobox renders a bundled models.dev snapshot as if it were the provider's live catalog. LM Studio has exactly three entries there, so anyone running their own loaded models reads that list as "unsupported" and gives up.

Free-form entry already worked — but nothing said so. The trigger read "Select a model...", the search read "Search models...", and the custom row rendered as a bare ID indistinguishable from a catalog entry. The one hint that existed (`CommandEmpty`'s "Press Enter to use …") was unreachable dead code: the custom row always mounts, so cmdk's item count is never zero.

Expanding the preset list would not fix this — no static catalog can know which models a local endpoint has loaded.

## Changes

- **Placeholders** say what is actually possible: `Select or paste a model ID` on the trigger, `Search or paste a model ID...` in the search box.
- **Persistent popover footer** spells out the gesture: *Model not listed? Type or paste its exact ID, then press Enter.*
- **Free-form row** reads `Use "<id>"` with a `CUSTOM` badge, pinned above the catalog.
- **In-place hint** under the field for LM Studio / Ollama / OpenAI-compatible only — the catalogs that are knowingly incomplete. Providers with an authoritative catalog stay uncluttered.
- Picker row derivation moved to `model-picker.helpers.ts` (`getModelPickerRows`) with unit tests driven by the real Fuse config over the shipped catalogs.

## Bugs fixed along the way

- **Enter ignored the highlighted item.** The `onKeyDown` interception called `stopPropagation()`, so cmdk never got to select. Typing `qwen`, arrowing down to `qwen/qwen3-coder-30b`, and pressing Enter saved the literal string `qwen`. Removing the interception lets cmdk select normally — and because cmdk re-selects the first item on every keystroke, the free-form row still wins Enter while typing, even when a fuzzy near-match is listed. It also restores cmdk's IME-composition guard, which the hand-rolled handler lacked.
- **Pasted IDs were stored untrimmed**, so `  openai/gpt-oss-120b  ` reached the provider verbatim and came back rejected.
- **A pasted ID with a stray space selected the wrong model.** Trimming what got committed while leaving the Fuse query on the raw text made the two halves of the picker disagree: `gpt-5 ` scored better against `gpt-5.5` than against the exact `gpt-5`, so Enter silently saved a different model and logged it as a deliberate pick. The same root cause emptied the list for `  o3  ` — a direct catalog hit once trimmed — leaving Enter with nothing to commit and no way out but deleting the whitespace by hand. Both derivations now run on the trimmed ID.
- **The context window carried over onto custom models.** The autofill effect only wrote when the catalog could size the model, so selecting `gpt-5.5` and then pasting an 8k local model saved a 1M-token window. Custom models now take the 128k default. This one predates the branch, but free-form entry was a hidden affordance before and is the promoted path now, so it is newly reachable by design.

The whitespace fix is also what makes dropping the empty state sound: an exact catalog ID scores 0 and ranks itself first, and anything else is by definition custom, so there is always at least one row.

## Verification

`bun run check` clean on the touched files; `bun run test` → 2222 pass, 0 fail. Two adversarial review passes; every finding above the cosmetic line is fixed in-branch.

Driven against the running extension over CDP (`scripts/dev/inspect-ui.ts`):

| Flow | Result |
| --- | --- |
| LM Studio → type unlisted ID → Enter | commits the custom ID, picker closes |
| …with a fuzzy near-match listed (`qwen/qwen3-coder-30b` vs `…-30b-instruct-mlx`) | custom row stays selected, custom ID wins |
| Type → ArrowDown → Enter | commits the highlighted catalog model + autofills context window (was broken) |
| Mouse-click a catalog model | commits, context window → 262144 |
| Paste `"  openai/gpt-oss-120b  "` | stored trimmed |
| Paste `"gpt-5 "` | commits `gpt-5` @ 400K (was `gpt-5.5`) |
| Paste `"  o3  "` | commits `o3` (was an empty list, Enter a no-op) |
| `gpt-5.5` (1.05M) → paste custom ID | context window resets to 128K (was 1,050,000) |
| Anthropic (authoritative catalog) | no hint rendered, 18 models + footer |
