### PR TITLE
chore: disable model invocation for Claude skills

### DIFF
--- a/.claude/skills/ask-internal/SKILL.md
+++ b/.claude/skills/ask-internal/SKILL.md
@@ -2,6 +2,7 @@
 name: ask-internal
 description: Answer questions about BrowserOS internal stuff (setup, features, architecture, design decisions) by reading the private internal-docs submodule and the codebase. Use for "how do I X", "where is Y", "what is the deal with Z", or any question that mixes ops/setup knowledge with code knowledge. Can execute steps with per-command confirmation.
 allowed-tools: Bash, Read, Grep, Glob
+disable-model-invocation: true
 ---
 
 # Ask Internal

--- a/.claude/skills/write-docs/SKILL.md
+++ b/.claude/skills/write-docs/SKILL.md
@@ -2,6 +2,7 @@
 name: write-docs
 description: Write BrowserOS feature documentation. Use when the user wants to create or update documentation for a BrowserOS feature. This skill explores the codebase to understand features and writes concise Mintlify MDX docs.
 allowed-tools: Read, Grep, Glob, Bash, Task, Write, Edit
+disable-model-invocation: true
 ---
 
 # Write BrowserOS Documentation

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sup-writing-plans
 description: Use when you have a spec or requirements for a multi-step task, before touching code
+disable-model-invocation: true
 ---
 
 # Writing Plans


### PR DESCRIPTION
## Summary
- mark all three `.claude/skills/*/SKILL.md` files as unavailable for model invocation
- keep `disable-model-invocation: true` as the final YAML frontmatter key

## Design
This is a frontmatter-only change: each skill gets the same one-line key immediately before the closing delimiter, with no changes to skill content.

## Test plan
- [x] `rg -c '^disable-model-invocation: true$' .claude/skills/*/SKILL.md` returns 1 for every skill\n- [x] `git diff --check origin/main..HEAD`\n- [x] branch diff is exactly 3 insertions across 3 files