### PR TITLE
fix: accept Chrome recording document IDs

### DIFF
--- a/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/recorder/recordings-relay.test.ts
@@ -10,6 +10,15 @@ import {
 } from './recordings-relay'
 
 const serverBaseUrl = 'http://127.0.0.1:9511'
+const documentIds = {
+  retrying: '33D25F3CF060E81B14070BC356FF1871',
+  restart: '8395FF2EF4A1D8579F1917B3B54ADECE',
+  oldSidecar: '9E84CDCAB8762569B5B109D125F60147',
+  gap: 'A18F47A71C2B7DEF81230123456789AC',
+  evicted: 'B18F47A71C2B7DEF81230123456789AD',
+  retained: 'C18F47A71C2B7DEF81230123456789AE',
+  oversized: 'D18F47A71C2B7DEF81230123456789AF',
+} as const
 
 function createMemoryOutbox(): RecordingOutbox & {
   batches: StoredRecordingBatch[]
@@ -132,8 +141,8 @@ describe('createRecordingsRelay', () => {
       warn: () => {},
     })
 
-    await relay.post(42, 'document-a', 'first')
-    await relay.post(42, 'document-a', 'second')
+    await relay.post(42, documentIds.retrying, 'first')
+    await relay.post(42, documentIds.retrying, 'second')
 
     expect(outbox.batches.map((batch) => batch.ndjson)).toEqual([
       'first',
@@ -152,7 +161,7 @@ describe('createRecordingsRelay', () => {
     expect(successful[0]).toMatchObject({
       url: `${serverBaseUrl}/api/v1/recordings/events`,
       tabId: '42',
-      documentId: 'document-a',
+      documentId: documentIds.retrying,
       sessionId: '',
       pageId: '',
       targetId: '',
@@ -176,7 +185,7 @@ describe('createRecordingsRelay', () => {
         1 as unknown as ReturnType<typeof globalThis.setTimeout>,
       warn: () => {},
     })
-    await firstRelay.post(7, 'document-restart', 'persisted')
+    await firstRelay.post(7, documentIds.restart, 'persisted')
 
     let resumedId = ''
     const resumedRelay = createRecordingsRelay({
@@ -216,7 +225,7 @@ describe('createRecordingsRelay', () => {
       warn: () => {},
     })
 
-    await relay.post(1, 'document-old-sidecar', 'queued')
+    await relay.post(1, documentIds.oldSidecar, 'queued')
     expect(postedBodies).toEqual([])
     expect(outbox.batches).toHaveLength(1)
 
@@ -243,10 +252,10 @@ describe('createRecordingsRelay', () => {
     })
     relay.onTabRecoveredAfterLoss((tabId) => recoveredTabs.push(tabId))
 
-    await relay.post(12, 'document-gap', 'checkpoint', true)
+    await relay.post(12, documentIds.gap, 'checkpoint', true)
 
     expect(gapHeader).toBe('true')
-    expect(outbox.gaps.has('document-gap')).toBe(false)
+    expect(outbox.gaps.has(documentIds.gap)).toBe(false)
     expect(recoveredTabs).toEqual([12])
   })
 
@@ -267,15 +276,15 @@ describe('createRecordingsRelay', () => {
     })
 
     const batchBytes = Math.floor(RECORDINGS_QUEUE_MAX_BYTES * 0.6)
-    await relay.post(1, 'document-one', 'a'.repeat(batchBytes))
-    await relay.post(2, 'document-two', 'b'.repeat(batchBytes))
+    await relay.post(1, documentIds.evicted, 'a'.repeat(batchBytes))
+    await relay.post(2, documentIds.retained, 'b'.repeat(batchBytes))
 
     expect(
       outbox.batches.reduce((sum, batch) => sum + batch.bytes, 0),
     ).toBeLessThanOrEqual(RECORDINGS_QUEUE_MAX_BYTES)
-    expect(outbox.gaps.has('document-one')).toBe(true)
+    expect(outbox.gaps.has(documentIds.evicted)).toBe(true)
     expect(
-      outbox.batches.every((batch) => batch.documentId !== 'document-one'),
+      outbox.batches.every((batch) => batch.documentId !== documentIds.evicted),
     ).toBe(true)
   })
 
@@ -294,11 +303,11 @@ describe('createRecordingsRelay', () => {
       warn: () => {},
     })
 
-    await relay.post(5, 'document-large', 'x'.repeat(101))
-    expect(outbox.gaps.has('document-large')).toBe(true)
-    await relay.post(5, 'document-large', 'small')
+    await relay.post(5, documentIds.oversized, 'x'.repeat(101))
+    expect(outbox.gaps.has(documentIds.oversized)).toBe(true)
+    await relay.post(5, documentIds.oversized, 'small')
 
     expect(gapHeaders).toEqual(['true'])
-    expect(outbox.gaps.has('document-large')).toBe(false)
+    expect(outbox.gaps.has(documentIds.oversized)).toBe(false)
   })
 })

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/api_v1/sessions.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/api_v1/sessions.rs
@@ -22,7 +22,7 @@ use claw_api::models::{
     SessionSummary,
 };
 use std::{collections::HashMap, sync::Arc};
-use uuid::{Uuid, Variant};
+use uuid::Uuid;
 
 #[derive(Default)]
 struct SessionQuery {
@@ -225,7 +225,7 @@ pub(super) async fn append_document_events(
     let document_id = required_header(&request_id, &headers, "x-recording-document-id")?;
     let batch_id = required_header(&request_id, &headers, "x-recording-batch-id")?;
     let gap_header = gap_header(&request_id, &headers)?;
-    if !is_document_uuid(&document_id) {
+    if !is_chrome_document_id(&document_id) {
         return Err(error(
             &request_id,
             StatusCode::BAD_REQUEST,
@@ -452,12 +452,8 @@ fn gap_header(request_id: &RequestId, headers: &HeaderMap) -> Result<bool, Canon
     }
 }
 
-fn is_document_uuid(value: &str) -> bool {
-    Uuid::parse_str(value).is_ok_and(|uuid| {
-        value.len() == 36
-            && uuid.get_variant() == Variant::RFC4122
-            && (1..=8).contains(&uuid.get_version_num())
-    })
+fn is_chrome_document_id(value: &str) -> bool {
+    value.len() == 32 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn positive_recording_header(

--- a/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
@@ -408,13 +408,36 @@ async fn canonical_sessions_cancel_and_recordings() -> anyhow::Result<()> {
     );
     app.state.audit.drain_claim_writes().await;
 
+    for document_id in [
+        "33D25F3CF060E81B14070BC356FF187",
+        "33D25F3CF060E81B14070BC356FF187Z",
+        "018f47a7-1c2b-7def-8123-0123456789ab",
+    ] {
+        let malformed_headers = [
+            ("x-recording-tab-id", "101"),
+            ("x-recording-document-id", document_id),
+            ("x-recording-batch-id", "malformed-document"),
+        ];
+        let (status, _, bytes) = request_with_headers(
+            &app.router,
+            "POST",
+            "/api/v1/recordings/events",
+            Some("application/x-ndjson"),
+            &malformed_headers,
+            "{\"ts\":50}\n",
+        )
+        .await?;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(json_body(&bytes)?["code"], "invalid_request");
+    }
+
     let events =
         "{\"ts\":100,\"data\":{\"id\":\"seven-a\"}}\n{\"ts\":200,\"data\":{\"id\":\"seven-b\"}}\n";
     let recording_headers = [
         ("x-recording-tab-id", "101"),
         (
             "x-recording-document-id",
-            "018f47a7-1c2b-7def-8123-0123456789ab",
+            "33D25F3CF060E81B14070BC356FF1871",
         ),
         ("x-recording-batch-id", "batch-7"),
     ];
@@ -446,7 +469,7 @@ async fn canonical_sessions_cancel_and_recordings() -> anyhow::Result<()> {
         ("x-recording-tab-id", "102"),
         (
             "x-recording-document-id",
-            "018f47a7-1c2b-7def-8123-0123456789ac",
+            "8395FF2EF4A1D8579F1917B3B54ADECE",
         ),
         ("x-recording-batch-id", "batch-8"),
     ];
@@ -510,8 +533,8 @@ async fn canonical_sessions_cancel_and_recordings() -> anyhow::Result<()> {
     );
     let events = String::from_utf8(bytes)?;
     assert_eq!(events.matches("session-live").count(), 3);
-    assert!(events.contains("018f47a7-1c2b-7def-8123-0123456789ab"));
-    assert!(events.contains("018f47a7-1c2b-7def-8123-0123456789ac"));
+    assert!(events.contains("33D25F3CF060E81B14070BC356FF1871"));
+    assert!(events.contains("8395FF2EF4A1D8579F1917B3B54ADECE"));
     let seven_a = events
         .find("seven-a")
         .ok_or_else(|| anyhow::anyhow!("missing first target-7 event"))?;
@@ -534,7 +557,7 @@ async fn canonical_sessions_cancel_and_recordings() -> anyhow::Result<()> {
         ("x-recording-tab-id", "101"),
         (
             "x-recording-document-id",
-            "018f47a7-1c2b-7def-8123-0123456789ad",
+            "9E84CDCAB8762569B5B109D125F60147",
         ),
         ("x-recording-batch-id", "batch-late"),
     ];

--- a/packages/browseros-agent/apps/claw-server/src/routes/api-v1/index.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/api-v1/index.ts
@@ -166,7 +166,7 @@ export function createCanonicalApiRoute(deps: CanonicalApiDependencies) {
     const hasGap = recordingGap(c.req.header('x-recording-has-gap'))
     if (
       tabId === null ||
-      !isUuid(documentId) ||
+      !isChromeDocumentId(documentId) ||
       batchId.length === 0 ||
       hasGap === null
     ) {
@@ -296,10 +296,8 @@ function recordingGap(raw: string | undefined): boolean | null {
   return null
 }
 
-function isUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-    value,
-  )
+function isChromeDocumentId(value: string): boolean {
+  return /^[0-9a-f]{32}$/i.test(value)
 }
 
 function apiError(

--- a/packages/browseros-agent/apps/claw-server/tests/routes/api-v1.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/routes/api-v1.test.ts
@@ -254,7 +254,7 @@ describe('canonical TypeScript API', () => {
       headers: {
         'content-type': 'application/x-ndjson',
         'x-recording-tab-id': '101',
-        'x-recording-document-id': '018f47a7-1c2b-7def-8123-0123456789ab',
+        'x-recording-document-id': '33D25F3CF060E81B14070BC356FF1871',
         'x-recording-batch-id': 'batch-1',
       },
       body: '{"ts":1}\n{"ts":2}\n',
@@ -264,7 +264,7 @@ describe('canonical TypeScript API', () => {
     expect(append).toHaveBeenCalledWith(
       {
         tabId: 101,
-        documentId: '018f47a7-1c2b-7def-8123-0123456789ab',
+        documentId: '33D25F3CF060E81B14070BC356FF1871',
       },
       '{"ts":1}\n{"ts":2}\n',
       'batch-1',
@@ -279,12 +279,39 @@ describe('canonical TypeScript API', () => {
       headers: {
         'content-type': 'application/x-ndjson',
         'x-recording-tab-id': '101',
-        'x-recording-document-id': '018f47a7-1c2b-7def-8123-0123456789ac',
+        'x-recording-document-id': '8395FF2EF4A1D8579F1917B3B54ADECE',
         'x-recording-batch-id': 'batch-ended',
       },
       body: '{"ts":3}\n',
     })
     expect(stillAccepted.status).toBe(200)
+  })
+
+  it('rejects malformed Chrome recording document IDs', async () => {
+    const append = mock(async () => ({ accepted: 1 }))
+    const app = createCanonicalApiRoute(
+      dependencies({ appendRecordingEvents: append }),
+    )
+
+    for (const documentId of [
+      '33D25F3CF060E81B14070BC356FF187',
+      '33D25F3CF060E81B14070BC356FF187Z',
+      '018f47a7-1c2b-7def-8123-0123456789ab',
+    ]) {
+      const response = await request(app, '/api/v1/recordings/events', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-ndjson',
+          'x-recording-tab-id': '101',
+          'x-recording-document-id': documentId,
+          'x-recording-batch-id': 'malformed-document',
+        },
+        body: '{"ts":1}\n',
+      })
+      expect(response.status).toBe(400)
+      expect(await response.json()).toMatchObject({ code: 'invalid_request' })
+    }
+    expect(append).not.toHaveBeenCalled()
   })
 
   it('rejects recording ingest from web-page origins before preflight', async () => {
@@ -312,7 +339,7 @@ describe('canonical TypeScript API', () => {
           origin: 'https://attacker.example',
           'content-type': 'application/x-ndjson',
           'x-recording-tab-id': '101',
-          'x-recording-document-id': '018f47a7-1c2b-7def-8123-0123456789ab',
+          'x-recording-document-id': '33D25F3CF060E81B14070BC356FF1871',
           'x-recording-batch-id': 'hostile-batch',
         },
         body: '{"ts":1}\n',
@@ -371,7 +398,7 @@ describe('canonical TypeScript API', () => {
     const headers = {
       'content-type': 'application/x-ndjson',
       'x-recording-tab-id': '101',
-      'x-recording-document-id': '018f47a7-1c2b-7def-8123-0123456789ab',
+      'x-recording-document-id': '33D25F3CF060E81B14070BC356FF1871',
       'x-recording-batch-id': 'batch-boundary',
     }
 

--- a/packages/browseros-agent/apps/claw-server/tests/services/recordings.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/recordings.test.ts
@@ -18,8 +18,8 @@ import {
   type RecordingStore,
 } from '../../src/services/recordings'
 
-const documentA = '018f47a7-1c2b-7def-8123-0123456789ab'
-const documentB = '018f47a7-1c2b-7def-8123-0123456789ac'
+const documentA = '33D25F3CF060E81B14070BC356FF1871'
+const documentB = '8395FF2EF4A1D8579F1917B3B54ADECE'
 let dir: string
 let store: RecordingStore
 

--- a/packages/browseros-agent/apps/claw-server/tests/services/replays.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/replays.test.ts
@@ -14,9 +14,9 @@ import {
 } from '../../src/services/recordings'
 import { createReplayService } from '../../src/services/replays'
 
-const firstDocument = '018f47a7-1c2b-7def-8123-0123456789ab'
-const secondDocument = '018f47a7-1c2b-7def-8123-0123456789ac'
-const otherDocument = '018f47a7-1c2b-7def-8123-0123456789ad'
+const firstDocument = '33D25F3CF060E81B14070BC356FF1871'
+const secondDocument = '8395FF2EF4A1D8579F1917B3B54ADECE'
+const otherDocument = '9E84CDCAB8762569B5B109D125F60147'
 let dir: string
 let store: RecordingStore
 

--- a/packages/browseros-agent/contracts/claw-api/parameters.yaml
+++ b/packages/browseros-agent/contracts/claw-api/parameters.yaml
@@ -39,9 +39,10 @@ RecordingDocumentId:
   name: X-Recording-Document-Id
   in: header
   required: true
+  description: Opaque 32-character hexadecimal document token supplied by Chrome.
   schema:
     type: string
-    format: uuid
+    pattern: '^[0-9A-Fa-f]{32}$'
 RecordingBatchId:
   name: X-Recording-Batch-Id
   in: header

--- a/packages/browseros-agent/contracts/claw-api/tests/cases.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/cases.ts
@@ -137,7 +137,7 @@ export const contractCases: ContractCase[] = [
         '{"type":2,"data":{},"ts":100}\n{"type":3,"data":{},"ts":200}\n'
       const request = {
         xRecordingTabId: 101,
-        xRecordingDocumentId: '018f47a7-1c2b-7def-8123-0123456789ab',
+        xRecordingDocumentId: '33D25F3CF060E81B14070BC356FF1871',
         xRecordingBatchId: 'contract-batch-1',
         body,
       }
@@ -153,7 +153,7 @@ export const contractCases: ContractCase[] = [
             tabId: 101,
             segments: [
               {
-                documentId: '018f47a7-1c2b-7def-8123-0123456789ab',
+                documentId: '33D25F3CF060E81B14070BC356FF1871',
                 hasGap: false,
               },
             ],
@@ -168,6 +168,28 @@ export const contractCases: ContractCase[] = [
         'application/x-ndjson',
       )
       expect((await response.text()).trim().split('\n')).toHaveLength(2)
+    },
+  },
+  {
+    name: 'recording ingest rejects malformed Chrome document IDs',
+    async run({ api }) {
+      for (const [index, documentId] of [
+        '33D25F3CF060E81B14070BC356FF187',
+        '33D25F3CF060E81B14070BC356FF187Z',
+        '018f47a7-1c2b-7def-8123-0123456789ab',
+      ].entries()) {
+        await expectApiError(
+          () =>
+            api.appendRecordingEvents({
+              xRecordingTabId: 101,
+              xRecordingDocumentId: documentId,
+              xRecordingBatchId: `contract-malformed-${index.toString()}`,
+              body: '{"ts":125,"type":3,"data":{}}\n',
+            }),
+          400,
+          'invalid_request',
+        )
+      }
     },
   },
   {
@@ -192,7 +214,7 @@ export const contractCases: ContractCase[] = [
           origin: 'https://attacker.example',
           'content-type': 'application/x-ndjson',
           'x-recording-tab-id': '101',
-          'x-recording-document-id': '018f47a7-1c2b-7def-8123-0123456789ab',
+          'x-recording-document-id': '33D25F3CF060E81B14070BC356FF1871',
           'x-recording-batch-id': 'hostile-contract-batch',
         },
         body: '{"ts":150,"type":3,"data":{}}\n',
@@ -206,7 +228,7 @@ export const contractCases: ContractCase[] = [
           origin: 'chrome-extension://pjimfkbpehlcllblajnpfamdfjhhlgkc',
           'content-type': 'application/x-ndjson',
           'x-recording-tab-id': '101',
-          'x-recording-document-id': '018f47a7-1c2b-7def-8123-0123456789b0',
+          'x-recording-document-id': '8395FF2EF4A1D8579F1917B3B54ADECE',
           'x-recording-batch-id': 'trusted-contract-batch',
         },
         body: '{"ts":250,"type":3,"data":{}}\n',
@@ -222,7 +244,7 @@ export const contractCases: ContractCase[] = [
       expect(
         await api.appendRecordingEvents({
           xRecordingTabId: 101,
-          xRecordingDocumentId: '018f47a7-1c2b-7def-8123-0123456789ac',
+          xRecordingDocumentId: '9E84CDCAB8762569B5B109D125F60147',
           xRecordingBatchId: 'contract-boundary',
           body: accepted,
         }),
@@ -232,7 +254,7 @@ export const contractCases: ContractCase[] = [
         () =>
           api.appendRecordingEvents({
             xRecordingTabId: 101,
-            xRecordingDocumentId: '018f47a7-1c2b-7def-8123-0123456789ad',
+            xRecordingDocumentId: 'A18F47A71C2B7DEF81230123456789AC',
             xRecordingBatchId: 'contract-over-limit',
             body: recordingLineOfBytes(RECORDING_INGEST_MAX_BYTES + 1, 401),
           }),
@@ -243,7 +265,7 @@ export const contractCases: ContractCase[] = [
       expect(
         await api.appendRecordingEvents({
           xRecordingTabId: 101,
-          xRecordingDocumentId: '018f47a7-1c2b-7def-8123-0123456789ae',
+          xRecordingDocumentId: 'B18F47A71C2B7DEF81230123456789AD',
           xRecordingBatchId: 'contract-after-over-limit',
           body: '{"ts":402,"type":3,"data":{}}',
         }),
@@ -314,7 +336,7 @@ export const contractCases: ContractCase[] = [
       expect(
         await api.appendRecordingEvents({
           xRecordingTabId: 101,
-          xRecordingDocumentId: '018f47a7-1c2b-7def-8123-0123456789af',
+          xRecordingDocumentId: 'C18F47A71C2B7DEF81230123456789AE',
           xRecordingBatchId: 'contract-ended-independent',
           body: '{"ts":300,"type":3,"data":{}}\n',
         }),

--- a/packages/browseros-agent/contracts/claw-api/tests/server-adapters.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/server-adapters.ts
@@ -125,7 +125,7 @@ export async function startTypeScriptServer(): Promise<ContractServer> {
                       lastEventAt: 402,
                       segments: [
                         {
-                          documentId: '018f47a7-1c2b-7def-8123-0123456789ab',
+                          documentId: '33D25F3CF060E81B14070BC356FF1871',
                           targetId: 'target-7',
                           firstEventAt: 100,
                           lastEventAt: 200,


### PR DESCRIPTION
## Summary
- accept Chrome's opaque 32-character hexadecimal document IDs in both claw servers
- replace the RFC UUID OpenAPI constraint and align recording, replay, relay, and cross-server fixtures with Chromium's producer format
- reject malformed lengths, non-hex tokens, and RFC UUID values with the canonical HTTP 400 response

## Design
The shared contract and both server handlers validate the same exact ASCII hex shape while passing the original token through unchanged. Existing recording retry and gap semantics are untouched.

## Test plan
- [x] `bun test apps/claw-app/modules/recorder/recordings-relay.test.ts`
- [x] `bun test apps/claw-server/tests/routes/api-v1.test.ts`
- [x] `bun test apps/claw-server/tests/services/recordings.test.ts apps/claw-server/tests/services/replays.test.ts`
- [x] `cargo test -p claw-server-rust --test canonical_routes canonical_sessions_cancel_and_recordings`
- [x] `bun run test:claw-api-contract`
- [x] `bun run codegen:claw-api:check`
- [x] TypeScript typechecks, Biome, `cargo fmt --all --check`, and Rust clippy
