### PR TITLE
feat(skills): add write-internal-docs skill

### DIFF
--- a/.claude/skills/write-internal-docs/SKILL.md
+++ b/.claude/skills/write-internal-docs/SKILL.md
@@ -125,21 +125,24 @@ Sweep the whole clone for drift — from inside it:
 CLONE="${TMPDIR:-/tmp}/internal-docs-<slug>"
 [ -d "$CLONE/.git" ] || { echo "work clone missing: $CLONE"; exit 1; }
 cd "$CLONE"
-# Index entries, with commented-out placeholders stripped first
-sed '/<!--/,/-->/d' README.md | grep -o '([a-z-]*/[^)]*\.md)' | tr -d '()' | sort > /tmp/indexed.txt
+IDX="${TMPDIR:-/tmp}/internal-docs-<slug>-index.txt"
+# Index entries, with commented-out placeholders stripped first. Per-line strip on
+# purpose: a range delete (sed '/<!--/,/-->/d') swallows live entries between
+# non-adjacent comment lines.
+sed 's/<!--.*-->//' README.md | grep -o '([a-z-]*/[^)]*\.md)' | tr -d '()' | sort > "$IDX"
 # 1. Dead links: live index entries pointing at files that do not exist
-while read -r f; do [ -f "$f" ] || echo "dead: $f"; done < /tmp/indexed.txt
+while read -r f; do [ -f "$f" ] || echo "dead: $f"; done < "$IDX"
 # 2. Docs on disk missing from the index
-find setup features architecture designs -name '*.md' 2>/dev/null | sort | comm -13 /tmp/indexed.txt -
+find setup features architecture designs -name '*.md' 2>/dev/null | sort | comm -13 "$IDX" -
 # 3. Misfiled docs: read anything whose filename or frontmatter suggests the wrong dir
 ```
 
 Interpret before acting:
 
 - Commented-out index lines are placeholders the maintainers left on purpose — the `sed` excludes them; never delete or uncomment them.
-- A doc whose parent directory's own `README.md` is in the index (e.g. `architecture/rust-port/*`) is subtree-indexed, not drift. Skip it.
+- A doc with any ancestor directory whose own `README.md` is in the index (e.g. everything under `architecture/rust-port/`, including its `reference/` subdir) is subtree-indexed, not drift. Skip it.
 - The doc this run is adding is not yet indexed by design — its line lands in Step 7. Skip it.
-- What remains is real drift: add the missing index line, repoint or remove the dead link, `git mv` the misfiled doc and fix its entry.
+- What remains is real drift: add the missing index line, repoint or remove the dead link, `git mv` the misfiled doc and fix its entry. A moved doc's `.html` sibling and its `(html)` index link move with it.
 
 Commit tidy changes here, separate from the doc, so the reviewer sees them apart. No findings → no commit:
 
@@ -165,9 +168,10 @@ Then commit the doc (tidy changes were committed in Step 6) and open the PR:
 ```bash
 CLONE="${TMPDIR:-/tmp}/internal-docs-<slug>"
 [ -d "$CLONE/.git" ] || { echo "work clone missing: $CLONE"; exit 1; }
-git -C "$CLONE" add "<dir>/<file>.md" "<dir>/<file>.html" README.md
-git -C "$CLONE" commit -m "docs(<type>): <slug>"
-git -C "$CLONE" push -u origin "docs/<slug>"
+cd "$CLONE"
+git add "<dir>/<file>.md" "<dir>/<file>.html" README.md
+git commit -m "docs(<type>): <slug>"
+git push -u origin "docs/<slug>"
 gh pr create -R browseros-ai/internal-docs --base main --head "docs/<slug>" \
   --title "docs(<type>): <slug>" \
   --body "<summary, source branch, related OSS PR, tidy-pass findings if any>"

--- a/.claude/skills/write-internal-docs/SKILL.md
+++ b/.claude/skills/write-internal-docs/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: write-internal-docs
+description: Write a doc into the private internal-docs repo as Markdown plus a rendered HTML sibling, tidy the repo's structure and index, and open a PR to browseros-ai/internal-docs.
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+disable-model-invocation: true
+---
+
+# Write Internal Docs
+
+Write a new doc for `.internal-docs/` (private repo `browseros-ai/internal-docs`), as Markdown plus a self-contained HTML sibling, and open a PR. Companion to `ask-internal`: that skill reads internal-docs, this one writes it.
+
+**Announce at start:** "I'm using the write-internal-docs skill to draft and land an internal doc."
+
+## Hard rules — never do these
+
+- NEVER write inside the user's `.internal-docs/` checkout. All writes happen in a tmp clone.
+- NEVER push to internal-docs `main`. Feature branch + PR only.
+- NEVER touch the OSS repo's `.gitmodules` or submodule pointer. The sync workflow moves it after merge.
+- NEVER `git add -A` or `git add .` in the tmp clone. Specific paths only.
+- NEVER fabricate content for empty template sections. Empty stays empty.
+- NEVER hand-edit an `.html` sibling. The `.md` is the source of truth; regenerate the HTML from it.
+- NEVER cite a file or line number you have not actually read.
+
+## Voice rules
+
+Every sentence of doc output follows these. Step 4 enforces them.
+
+- Lead with the point. First sentence answers "what is this?"
+- Concrete nouns. Name files, functions, commands. Not "the system".
+- Short sentences, average under 20 words. Active voice. No em dashes.
+- Banned words: delve, crucial, robust, comprehensive, nuanced, multifaceted, furthermore, moreover, additionally, pivotal, landscape, tapestry, underscore, foster, showcase, intricate, vibrant, fundamental, significant, leverage, utilize.
+- No filler intros ("This document describes..."). Start with the substance.
+- Feature notes: body 60 lines max. Architecture and design docs have no cap.
+
+## Workflow
+
+### Step 0: Pre-flight
+
+```bash
+if git submodule status .internal-docs 2>/dev/null | grep -q '^-'; then
+  echo "internal-docs submodule not initialized. Run: git submodule update --init .internal-docs"
+  exit 0
+fi
+[ -d .internal-docs ] && [ -n "$(ls -A .internal-docs 2>/dev/null)" ] || {
+  echo ".internal-docs/ missing or empty. Submodule not configured?"; exit 0; }
+gh auth status >/dev/null 2>&1 || { echo "gh not authenticated. Run: gh auth login"; exit 0; }
+```
+
+**Done when:** submodule present and `gh` authenticated, or the skill stopped with the fix command.
+
+### Step 1: Scope the doc
+
+Establish four facts. Take them from the user's invocation; derive what you can before asking.
+
+1. **Subject** — a stated topic, or the current branch's diff (`git diff main...HEAD --stat` plus the PR body) when invoked from a feature branch with no topic.
+2. **Type and target dir** — `setup/` (runbook), `features/` (shipped feature), `architecture/` (cross-cutting subsystem), `designs/` (decision or RFC). Branch heuristics: `feat/*` → features, `rfc/*`/`design/*` → designs. Unclear → ask one question.
+3. **Slug** — short kebab-case. Features and designs get a date prefix: `YYYY-MM-<slug>.md`.
+4. **Owner** — GitHub handle, default `gh api user --jq .login`.
+
+**Done when:** all four are stated and the target path (`<dir>/<file>.md`) is printed.
+
+### Step 2: Zoom out
+
+Before drafting, go up one layer of abstraction. Map the territory the doc covers: the relevant modules, their callers, and how data flows between them, in the project's domain vocabulary. Read the real files; tie every named module to a path.
+
+This map becomes the doc's first body section, before any detail. A reader who knows nothing about the area gets the shape first, then zooms in.
+
+**Done when:** you can draw the map (ASCII or mermaid, plus 2-4 sentences) and every box in it names a real path you read.
+
+### Step 3: Draft the Markdown
+
+Read the matching template from `.internal-docs/_templates/` (`feature-note.md`, `architecture-note.md`, `design-spec.md`; setup runbooks follow the shape of existing `setup/` docs). Fill it:
+
+- The zoom-out map from Step 2 leads the body, as the first section after the frontmatter (for feature notes, it opens "How it works").
+- Every factual claim cites `path/to/file.ts:line` you actually read.
+- Sections with nothing real to say stay empty.
+
+**Done when:** the draft matches the template's sections, opens with the map, and every claim carries a citation.
+
+### Step 4: Voice check
+
+Scan the draft against the voice rules: em dashes, banned words, sentence length, filler intros, the 60-line cap for feature notes. Rewrite offending sentences in place, max 3 passes. Still failing after 3 → stop and report which rules are violated.
+
+**Done when:** a scan finds zero violations, or the failure is reported.
+
+### Step 5: Clone, write, render HTML
+
+Work in a tmp clone so the user's checkout stays clean:
+
+```bash
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+git clone -b main git@github.com:browseros-ai/internal-docs.git "$TMP"
+git -C "$TMP" checkout -b "docs/<slug>"
+```
+
+Write the approved `.md` into the clone at the Step 1 path. Then render its sibling `<same-path>.html`:
+
+1. Read `reference/html-template.html` from this skill's folder.
+2. Convert the Markdown body to HTML — with `pandoc` if installed (`pandoc -f gfm -t html <doc>.md`), by hand otherwise.
+3. Fill the template's `{{TITLE}}`, `{{SOURCE_MD}}`, and `{{BODY}}` slots. Keep it self-contained: no external URLs, scripts, or fonts.
+
+Update the clone's `README.md` index — one line under the matching section:
+
+```markdown
+- [<Title>](<dir>/<file>.md) ([html](<dir>/<file>.html)): <one-line hook>
+```
+
+**Done when:** `.md`, `.html`, and the index line exist in the clone, and the `.html` contains no `http` reference except links that were in the doc body itself.
+
+### Step 6: Tidy pass
+
+Now sweep the whole clone for drift. Three checks:
+
+```bash
+# 1. Index drift: docs on disk missing from the README index
+comm -13 <(grep -o '([a-z-]*/[^)]*\.md)' README.md | tr -d '()' | sort) \
+         <(find setup features architecture designs -name '*.md' 2>/dev/null | sort)
+# 2. Dead links: index entries pointing at files that do not exist
+grep -o '([a-z-]*/[^)]*\.md)' README.md | tr -d '()' | while read -r f; do [ -f "$f" ] || echo "dead: $f"; done
+# 3. Misfiled docs: read anything the filename or frontmatter suggests is in the wrong dir
+```
+
+For each finding, fix it: add the missing index line, delete or repoint the dead link, `git mv` the misfiled doc and update its index entry. No findings → skip the commit. Reorg changes go in their own `chore(docs): tidy structure and index` commit, separate from the new doc, so the reviewer sees doc vs reorg apart.
+
+**Done when:** all three checks ran and every finding is either fixed in the clone or listed for the PR body as deliberately left.
+
+### Step 7: Open the PR
+
+```bash
+git -C "$TMP" add "<dir>/<file>.md" "<dir>/<file>.html" README.md   # plus tidy-pass paths
+git -C "$TMP" commit -m "docs(<type>): <slug>"
+git -C "$TMP" push -u origin "docs/<slug>"
+gh pr create -R browseros-ai/internal-docs --base main --head "docs/<slug>" \
+  --title "docs(<type>): <slug>" \
+  --body "<summary, source branch, related OSS PR, tidy-pass findings if any>"
+```
+
+**Done when:** the PR URL is printed.
+
+### Step 8: Completion status
+
+Report one of:
+
+- **DONE** — md + html written, index updated, PR opened. Print the PR URL.
+- **DONE_WITH_CONCERNS** — PR opened, but list concerns (voice check needed 3 passes, tidy findings left unfixed, citations uncertain).
+- **BLOCKED** — pre-flight failed, auth failed, or template missing. State exactly what unblocks.
+
+## Common Mistakes
+
+**Drafting before zooming out**
+- **Problem:** The doc dives into one function's details; a newcomer can't place it.
+- **Fix:** Step 2 is not optional. Map first, then draft.
+
+**Editing the HTML instead of the Markdown**
+- **Problem:** The two siblings diverge; the next regeneration silently reverts the edit.
+- **Fix:** Edit the `.md`, re-run Step 5's render.
+
+**Touching `.internal-docs/` directly**
+- **Problem:** User's submodule HEAD moves; the parent repo shows a dirty state.
+- **Fix:** All writes go through the tmp clone.
+
+**Tidy pass bundled into the doc commit**
+- **Problem:** Reviewer can't separate the new doc from moves and index fixes.
+- **Fix:** Two commits: `docs(<type>): <slug>` and `chore(docs): tidy structure and index`.

--- a/.claude/skills/write-internal-docs/SKILL.md
+++ b/.claude/skills/write-internal-docs/SKILL.md
@@ -7,16 +7,17 @@ disable-model-invocation: true
 
 # Write Internal Docs
 
-Write a new doc for `.internal-docs/` (private repo `browseros-ai/internal-docs`), as Markdown plus a self-contained HTML sibling, and open a PR. Companion to `ask-internal`: that skill reads internal-docs, this one writes it.
+Write a doc for `.internal-docs/` (private repo `browseros-ai/internal-docs`), as Markdown plus a self-contained HTML sibling, and open a PR. The subject is whatever the user names ("/write-internal-docs nightly signing") or, on a feature branch with no topic, the branch's diff. Companion to `ask-internal`: that skill reads internal-docs, this one writes it. Supersedes the older personal `document-internal` flow.
 
 **Announce at start:** "I'm using the write-internal-docs skill to draft and land an internal doc."
 
 ## Hard rules — never do these
 
-- NEVER write inside the user's `.internal-docs/` checkout. All writes happen in a tmp clone.
+- NEVER write inside the user's `.internal-docs/` checkout. All writes happen in the work clone.
 - NEVER push to internal-docs `main`. Feature branch + PR only.
 - NEVER touch the OSS repo's `.gitmodules` or submodule pointer. The sync workflow moves it after merge.
-- NEVER `git add -A` or `git add .` in the tmp clone. Specific paths only.
+- NEVER `git add -A` or `git add .` in the work clone. Specific paths only.
+- NEVER run a clone-touching command without the guard `[ -d "$CLONE/.git" ]` — a missing clone must fail loudly, not fall through to the OSS repo.
 - NEVER fabricate content for empty template sections. Empty stays empty.
 - NEVER hand-edit an `.html` sibling. The `.md` is the source of truth; regenerate the HTML from it.
 - NEVER cite a file or line number you have not actually read.
@@ -32,6 +33,16 @@ Every sentence of doc output follows these. Step 4 enforces them.
 - No filler intros ("This document describes..."). Start with the substance.
 - Feature notes: body 60 lines max. Architecture and design docs have no cap.
 
+## The work clone
+
+Shell state does not survive between Bash calls, so the clone lives at a deterministic path that every snippet re-derives — never `mktemp`, never a cleanup `trap` (it would fire when the first call exits and delete the clone mid-workflow):
+
+```bash
+CLONE="${TMPDIR:-/tmp}/internal-docs-<slug>"
+```
+
+Substitute the literal slug. Every later snippet starts with this line plus the guard `[ -d "$CLONE/.git" ] || { echo "work clone missing: $CLONE"; exit 1; }`. Cleanup is an explicit `rm -rf "$CLONE"` in Step 8, never automatic.
+
 ## Workflow
 
 ### Step 0: Pre-flight
@@ -44,17 +55,19 @@ fi
 [ -d .internal-docs ] && [ -n "$(ls -A .internal-docs 2>/dev/null)" ] || {
   echo ".internal-docs/ missing or empty. Submodule not configured?"; exit 0; }
 gh auth status >/dev/null 2>&1 || { echo "gh not authenticated. Run: gh auth login"; exit 0; }
+git ls-remote git@github.com:browseros-ai/internal-docs.git HEAD >/dev/null 2>&1 || {
+  echo "Cannot reach internal-docs over SSH. Check your keys: ssh -T git@github.com"; exit 0; }
 ```
 
-**Done when:** submodule present and `gh` authenticated, or the skill stopped with the fix command.
+**Done when:** submodule present, `gh` authenticated, and SSH reaches internal-docs — or the skill stopped with the fix command.
 
 ### Step 1: Scope the doc
 
 Establish four facts. Take them from the user's invocation; derive what you can before asking.
 
-1. **Subject** — a stated topic, or the current branch's diff (`git diff main...HEAD --stat` plus the PR body) when invoked from a feature branch with no topic.
+1. **Subject** — the specific thing the user named, or the current branch's diff (`git diff main...HEAD --stat` plus the PR body) when invoked from a feature branch with no topic. For a named subject, research it first: grep the codebase and `.internal-docs/`, read the files that own it. If a doc on it already exists, this run updates that doc instead of creating a twin.
 2. **Type and target dir** — `setup/` (runbook), `features/` (shipped feature), `architecture/` (cross-cutting subsystem), `designs/` (decision or RFC). Branch heuristics: `feat/*` → features, `rfc/*`/`design/*` → designs. Unclear → ask one question.
-3. **Slug** — short kebab-case. Features and designs get a date prefix: `YYYY-MM-<slug>.md`.
+3. **Filename** — short kebab-case slug. Features prefix `YYYY-MM-`, designs prefix `YYYY-MM-DD-` (matches the existing tree).
 4. **Owner** — GitHub handle, default `gh api user --jq .login`.
 
 **Done when:** all four are stated and the target path (`<dir>/<file>.md`) is printed.
@@ -85,52 +98,76 @@ Scan the draft against the voice rules: em dashes, banned words, sentence length
 
 ### Step 5: Clone, write, render HTML
 
-Work in a tmp clone so the user's checkout stays clean:
+Create the work clone (user's checkout stays clean):
 
 ```bash
-TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
-git clone -b main git@github.com:browseros-ai/internal-docs.git "$TMP"
-git -C "$TMP" checkout -b "docs/<slug>"
+CLONE="${TMPDIR:-/tmp}/internal-docs-<slug>"
+rm -rf "$CLONE"
+git clone -b main git@github.com:browseros-ai/internal-docs.git "$CLONE"
+git -C "$CLONE" checkout -b "docs/<slug>"
 ```
 
 Write the approved `.md` into the clone at the Step 1 path. Then render its sibling `<same-path>.html`:
 
 1. Read `reference/html-template.html` from this skill's folder.
-2. Convert the Markdown body to HTML — with `pandoc` if installed (`pandoc -f gfm -t html <doc>.md`), by hand otherwise.
-3. Fill the template's `{{TITLE}}`, `{{SOURCE_MD}}`, and `{{BODY}}` slots. Keep it self-contained: no external URLs, scripts, or fonts.
+2. Convert the Markdown body to HTML — with `pandoc` if installed (`pandoc -f gfm -t html <doc>.md`), by hand otherwise. Either way the YAML frontmatter is stripped from the body; it never renders.
+3. Fill the template's slots: `{{TITLE}}` from the frontmatter `title:`, `{{SOURCE_MD}}` with the md filename, `{{BODY}}` with the converted body. Keep it self-contained: no external URLs, scripts, or fonts.
 
-Update the clone's `README.md` index — one line under the matching section:
+The README index line comes later, in Step 7 — Step 6's tidy commit also touches `README.md`, and the new doc's index line must ride the doc commit, not the tidy commit.
+
+**Done when:** `.md` and `.html` exist in the clone, and the `.html` contains no `http` reference except links that were in the doc body itself.
+
+### Step 6: Tidy pass
+
+Sweep the whole clone for drift — from inside it:
+
+```bash
+CLONE="${TMPDIR:-/tmp}/internal-docs-<slug>"
+[ -d "$CLONE/.git" ] || { echo "work clone missing: $CLONE"; exit 1; }
+cd "$CLONE"
+# Index entries, with commented-out placeholders stripped first
+sed '/<!--/,/-->/d' README.md | grep -o '([a-z-]*/[^)]*\.md)' | tr -d '()' | sort > /tmp/indexed.txt
+# 1. Dead links: live index entries pointing at files that do not exist
+while read -r f; do [ -f "$f" ] || echo "dead: $f"; done < /tmp/indexed.txt
+# 2. Docs on disk missing from the index
+find setup features architecture designs -name '*.md' 2>/dev/null | sort | comm -13 /tmp/indexed.txt -
+# 3. Misfiled docs: read anything whose filename or frontmatter suggests the wrong dir
+```
+
+Interpret before acting:
+
+- Commented-out index lines are placeholders the maintainers left on purpose — the `sed` excludes them; never delete or uncomment them.
+- A doc whose parent directory's own `README.md` is in the index (e.g. `architecture/rust-port/*`) is subtree-indexed, not drift. Skip it.
+- The doc this run is adding is not yet indexed by design — its line lands in Step 7. Skip it.
+- What remains is real drift: add the missing index line, repoint or remove the dead link, `git mv` the misfiled doc and fix its entry.
+
+Commit tidy changes here, separate from the doc, so the reviewer sees them apart. No findings → no commit:
+
+```bash
+git -C "$CLONE" add <each tidied path> README.md
+git -C "$CLONE" commit -m "chore(docs): tidy structure and index"
+```
+
+**Done when:** all three checks ran from the clone and every finding is fixed in the tidy commit, skipped by the rules above, or listed for the PR body as deliberately left.
+
+### Step 7: Open the PR
+
+Add the new doc's line to the clone's `README.md` index, under the matching section:
 
 ```markdown
 - [<Title>](<dir>/<file>.md) ([html](<dir>/<file>.html)): <one-line hook>
 ```
 
-**Done when:** `.md`, `.html`, and the index line exist in the clone, and the `.html` contains no `http` reference except links that were in the doc body itself.
+The `(html)` link is this skill's addition to the index convention; older entries lack it, and the tidy pass backfills nothing — html siblings appear as docs get touched.
 
-### Step 6: Tidy pass
-
-Now sweep the whole clone for drift. Three checks:
+Then commit the doc (tidy changes were committed in Step 6) and open the PR:
 
 ```bash
-# 1. Index drift: docs on disk missing from the README index
-comm -13 <(grep -o '([a-z-]*/[^)]*\.md)' README.md | tr -d '()' | sort) \
-         <(find setup features architecture designs -name '*.md' 2>/dev/null | sort)
-# 2. Dead links: index entries pointing at files that do not exist
-grep -o '([a-z-]*/[^)]*\.md)' README.md | tr -d '()' | while read -r f; do [ -f "$f" ] || echo "dead: $f"; done
-# 3. Misfiled docs: read anything the filename or frontmatter suggests is in the wrong dir
-```
-
-For each finding, fix it: add the missing index line, delete or repoint the dead link, `git mv` the misfiled doc and update its index entry. No findings → skip the commit. Reorg changes go in their own `chore(docs): tidy structure and index` commit, separate from the new doc, so the reviewer sees doc vs reorg apart.
-
-**Done when:** all three checks ran and every finding is either fixed in the clone or listed for the PR body as deliberately left.
-
-### Step 7: Open the PR
-
-```bash
-git -C "$TMP" add "<dir>/<file>.md" "<dir>/<file>.html" README.md   # plus tidy-pass paths
-git -C "$TMP" commit -m "docs(<type>): <slug>"
-git -C "$TMP" push -u origin "docs/<slug>"
+CLONE="${TMPDIR:-/tmp}/internal-docs-<slug>"
+[ -d "$CLONE/.git" ] || { echo "work clone missing: $CLONE"; exit 1; }
+git -C "$CLONE" add "<dir>/<file>.md" "<dir>/<file>.html" README.md
+git -C "$CLONE" commit -m "docs(<type>): <slug>"
+git -C "$CLONE" push -u origin "docs/<slug>"
 gh pr create -R browseros-ai/internal-docs --base main --head "docs/<slug>" \
   --title "docs(<type>): <slug>" \
   --body "<summary, source branch, related OSS PR, tidy-pass findings if any>"
@@ -138,13 +175,15 @@ gh pr create -R browseros-ai/internal-docs --base main --head "docs/<slug>" \
 
 **Done when:** the PR URL is printed.
 
-### Step 8: Completion status
+### Step 8: Report and clean up
 
-Report one of:
+Remove the work clone (`rm -rf "$CLONE"`), then report exactly one of:
 
 - **DONE** — md + html written, index updated, PR opened. Print the PR URL.
 - **DONE_WITH_CONCERNS** — PR opened, but list concerns (voice check needed 3 passes, tidy findings left unfixed, citations uncertain).
 - **BLOCKED** — pre-flight failed, auth failed, or template missing. State exactly what unblocks.
+
+**Done when:** the clone is gone and exactly one status line is printed.
 
 ## Common Mistakes
 
@@ -158,8 +197,12 @@ Report one of:
 
 **Touching `.internal-docs/` directly**
 - **Problem:** User's submodule HEAD moves; the parent repo shows a dirty state.
-- **Fix:** All writes go through the tmp clone.
+- **Fix:** All writes go through the work clone.
+
+**Trusting the tidy greps raw**
+- **Problem:** Placeholder entries and subtree-indexed docs read as drift; the "fix" mangles the README.
+- **Fix:** Apply Step 6's interpretation rules before touching anything.
 
 **Tidy pass bundled into the doc commit**
 - **Problem:** Reviewer can't separate the new doc from moves and index fixes.
-- **Fix:** Two commits: `docs(<type>): <slug>` and `chore(docs): tidy structure and index`.
+- **Fix:** Two commits: `chore(docs): tidy structure and index` (Step 6), then `docs(<type>): <slug>` (Step 7).

--- a/.claude/skills/write-internal-docs/reference/html-template.html
+++ b/.claude/skills/write-internal-docs/reference/html-template.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<!--
+  Shell for the HTML sibling of an internal doc. write-internal-docs fills
+  {{TITLE}}, {{SOURCE_MD}} (relative path to the source .md), and {{BODY}}
+  (the converted Markdown body). Self-contained on purpose: no external
+  URLs, scripts, or fonts, so it renders offline from any checkout.
+  The .md is the source of truth; regenerate this file, never hand-edit it.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{TITLE}} · BrowserOS internal docs</title>
+<style>
+  :root {
+    --bg: #ffffff; --fg: #1a1f24; --muted: #57606a; --border: #d0d7de;
+    --code-bg: #f6f8fa; --link: #0a5ad2;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117; --fg: #e6edf3; --muted: #8b949e; --border: #30363d;
+      --code-bg: #161b22; --link: #539bf5;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0 auto; padding: 2.5rem 1.25rem 5rem; max-width: 46rem;
+    background: var(--bg); color: var(--fg);
+    font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  header.doc-meta {
+    color: var(--muted); font-size: 0.85rem; margin-bottom: 2rem;
+    padding-bottom: 0.75rem; border-bottom: 1px solid var(--border);
+  }
+  header.doc-meta a { color: var(--muted); }
+  h1 { font-size: 1.7rem; line-height: 1.25; margin: 0 0 1rem; }
+  h2 { font-size: 1.25rem; margin: 2rem 0 0.5rem; padding-top: 0.5rem; }
+  h3 { font-size: 1.05rem; margin: 1.5rem 0 0.5rem; }
+  a { color: var(--link); }
+  p, ul, ol { margin: 0.6rem 0; }
+  li { margin: 0.25rem 0; }
+  code {
+    font: 0.875em ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: var(--code-bg); border: 1px solid var(--border);
+    border-radius: 4px; padding: 0.1em 0.35em;
+  }
+  pre {
+    background: var(--code-bg); border: 1px solid var(--border);
+    border-radius: 6px; padding: 0.9rem 1rem; overflow-x: auto;
+  }
+  pre code { background: none; border: none; padding: 0; }
+  table { border-collapse: collapse; margin: 1rem 0; width: 100%; }
+  th, td { border: 1px solid var(--border); padding: 0.4rem 0.7rem; text-align: left; }
+  th { background: var(--code-bg); }
+  blockquote {
+    margin: 1rem 0; padding: 0.1rem 1rem; color: var(--muted);
+    border-left: 3px solid var(--border);
+  }
+  img { max-width: 100%; }
+  hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+</style>
+</head>
+<body>
+<header class="doc-meta">
+  Rendered from <a href="{{SOURCE_MD}}"><code>{{SOURCE_MD}}</code></a> — the Markdown is the source of truth.
+</header>
+{{BODY}}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New user-invoked skill `.claude/skills/write-internal-docs/` — the writing companion to `ask-internal`: drafts a doc for the private internal-docs repo from a user-named topic or the branch diff, and lands it via a work clone → `docs/<slug>` branch → PR to `browseros-ai/internal-docs`.
- Every doc ships as Markdown plus a self-contained HTML sibling (inline CSS, offline-renderable, generated from the md via `reference/html-template.html`), opens zoom-out-first (a map of modules/callers in domain vocabulary before details), and follows the internal-docs voice rules.
- Tidy pass sweeps the internal-docs clone for index drift, dead links, and misfiled docs, fixing real drift in a separate `chore(docs)` commit — with interpretation rules so commented-out placeholders and subtree-indexed docs (`architecture/rust-port/*`) aren't mangled.

## Design
Standalone repo skill (no dependency on personal skills); supersedes the personal `document-internal` flow. Because each Bash call runs in a fresh shell, the work clone lives at a deterministic slug-scoped path re-derived per snippet with `[ -d "$CLONE/.git" ]` guards — no `mktemp`, no cleanup traps (a trap would delete the clone after the first call). Hard safety rules: never the user's `.internal-docs/` checkout, never internal-docs `main`, never the submodule pointer, never `git add -A`.

## Test plan
- [x] 3-round adversarial review (context-free subagent); rounds 1-2 findings (clone lifecycle, tidy-pass cwd, sed range-delete, subtree rule, commit ordering) fixed and re-verified with read-only repros against the real internal-docs tree — round 3 verdict: clean
- [x] Frontmatter keys present; `reference/html-template.html` referenced and free of external URLs
- [ ] First real run: `/write-internal-docs <topic>` produces md+html+PR against internal-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)