### PR TITLE
chore: expose Claude skills to Codex

### DIFF
--- a/.agents/skills/ask-internal
+++ b/.agents/skills/ask-internal
@@ -1,0 +1,1 @@
+../../.claude/skills/ask-internal

--- a/.agents/skills/write-docs
+++ b/.agents/skills/write-docs
@@ -1,0 +1,1 @@
+../../.claude/skills/write-docs

--- a/.agents/skills/write-internal-docs
+++ b/.agents/skills/write-internal-docs
@@ -1,0 +1,1 @@
+../../.claude/skills/write-internal-docs

--- a/.agents/skills/writing-plans
+++ b/.agents/skills/writing-plans
@@ -1,0 +1,1 @@
+../../.claude/skills/writing-plans


### PR DESCRIPTION
## Summary
- expose all four repo-local Claude skills through Codex's supported `.agents/skills` discovery path
- keep `.claude/skills` as the single source of truth with relative skill-folder symlinks
- leave the existing skill frontmatter and unrelated worktree state unchanged

## Design
Each `.agents/skills/<folder>` entry is an individual relative symlink to the matching `.claude/skills/<folder>`. This follows Codex's documented repository discovery layout and explicit support for symlinked skill folders without relying on an undocumented symlinked discovery root.

## Test plan
- [x] verify each entry is a symlink with the exact expected relative target
- [x] verify every link resolves to the matching `.claude/skills/<folder>` directory
- [x] verify each resolved directory contains `SKILL.md`
- [x] run `git diff --check` and confirm the worktree is clean