### PR TITLE
feat(browserclaw): bundle rust claw server in nightly

### DIFF
--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -147,10 +147,11 @@ jobs:
           cd "$agent_root"
           bun ci
           bun scripts/build/server.ts --target=darwin-arm64 --ci
-          bun scripts/build/claw-server.ts --target=darwin-arm64 --no-upload
+          scripts/build/claw-server-rust-local.sh \
+            --target=darwin-arm64 \
+            --agent-root "$agent_root" \
+            --browseros-root "$browseros_root"
           bun scripts/build/claw-onboard.ts --ci
-          # Rust alternative: run scripts/build/claw-server-rust-local.sh here
-          # and flip copy_resources.yaml/download_resources.yaml.
 
           cd "$browseros_root"
           AGENT_ROOT="$agent_root" BROWSEROS_ROOT="$browseros_root" uv run python - <<'PY'
@@ -170,12 +171,6 @@ jobs:
               (
                   agent_root / "dist/prod/claw-onboard/browseros-claw-onboard-resources.zip",
                   browseros_root / "resources/binaries/browseros_claw_onboard",
-              ),
-              (
-                  agent_root
-                  / "dist/prod/claw-server/browseros-claw-server-resources-darwin-arm64.zip",
-                  browseros_root
-                  / "resources/binaries/browseros_claw_server/darwin-arm64",
               ),
           ]
 

--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -291,6 +291,7 @@ jobs:
           rust_target = os.environ["RUST_TARGET"]
           binary_ext = os.environ["BINARY_EXT"]
           binary_name = f"browseros-claw-server-rs{binary_ext}"
+          runtime_binary_name = f"browseros-claw-server{binary_ext}"
           binary_path = agent / "target" / rust_target / "release" / binary_name
           if not binary_path.is_file():
               raise SystemExit(f"Missing compiled binary: {binary_path}")
@@ -299,7 +300,7 @@ jobs:
           stage_root = dist_root / target
           if stage_root.exists():
               shutil.rmtree(stage_root)
-          staged_binary = stage_root / "resources/bin" / binary_name
+          staged_binary = stage_root / "resources/bin" / runtime_binary_name
           staged_binary.parent.mkdir(parents=True, exist_ok=True)
           shutil.copy2(binary_path, staged_binary)
           if binary_ext != ".exe":
@@ -359,7 +360,7 @@ jobs:
           zip_path = Path(os.environ["ZIP_PATH"])
           target = os.environ["BROWSEROS_TARGET"]
           binary_ext = os.environ["BINARY_EXT"]
-          expected = f"resources/bin/browseros-claw-server-rs{binary_ext}"
+          expected = f"resources/bin/browseros-claw-server{binary_ext}"
           with tempfile.TemporaryDirectory() as tmp:
               destination = Path(tmp) / target
               extracted = extract_artifact_zip(zip_path, destination)

--- a/packages/browseros-agent/apps/claw-server-rust/src/browser/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/browser/mod.rs
@@ -68,7 +68,11 @@ impl BrowserService {
     }
 
     pub async fn session(&self) -> Option<Arc<browseros_core::BrowserSession>> {
-        self.session.read().await.clone()
+        self.session
+            .read()
+            .await
+            .clone()
+            .filter(|session| session.is_connected())
     }
 
     pub async fn wait_for_initial_attempt(&self) {
@@ -221,5 +225,108 @@ impl BrowserService {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use browseros_cdp::{CdpError, CdpEvent, SessionId};
+    use browseros_core::{BrowserSession, BrowserSessionHooks, CdpConnection};
+    use futures_util::future::BoxFuture;
+    use serde_json::Value;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+    use tempfile::TempDir;
+    use tokio::sync::broadcast;
+
+    struct TestConnection {
+        connected: AtomicBool,
+        events: broadcast::Sender<CdpEvent>,
+    }
+
+    impl TestConnection {
+        fn new(connected: bool) -> Arc<Self> {
+            let (events, _) = broadcast::channel(1);
+            Arc::new(Self {
+                connected: AtomicBool::new(connected),
+                events,
+            })
+        }
+    }
+
+    impl CdpConnection for TestConnection {
+        fn send<'a>(
+            &'a self,
+            _method: &'a str,
+            _params: Value,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<Value, CdpError>> {
+            Box::pin(async { Ok(serde_json::json!({})) })
+        }
+
+        fn send_raw_json<'a>(
+            &'a self,
+            _method: &'a str,
+            _params_json: &'a str,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<String, CdpError>> {
+            Box::pin(async { Ok("{}".to_string()) })
+        }
+
+        fn events(&self) -> broadcast::Receiver<CdpEvent> {
+            self.events.subscribe()
+        }
+
+        fn is_connected(&self) -> bool {
+            self.connected.load(Ordering::SeqCst)
+        }
+
+        fn connection_epoch(&self) -> u64 {
+            1
+        }
+    }
+
+    async fn service() -> anyhow::Result<(Arc<BrowserService>, TempDir)> {
+        let root = tempfile::tempdir()?;
+        let audit = Arc::new(
+            crate::capture::audit::AuditService::open(root.path().join("audit.sqlite")).await?,
+        );
+        let sessions = crate::sessions::Sessions::new(
+            audit.clone(),
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+        );
+        Ok((
+            BrowserService::new(0, sessions.ownership(), TabTargetMap::new(audit)),
+            root,
+        ))
+    }
+
+    #[tokio::test]
+    async fn session_filters_stored_disconnected_browser_session() -> anyhow::Result<()> {
+        let (service, _root) = service().await?;
+        let connection = TestConnection::new(false);
+        let browser = BrowserSession::new(connection, BrowserSessionHooks::default());
+
+        service.set_session_for_testing(browser).await;
+
+        assert!(service.session().await.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn session_returns_stored_connected_browser_session() -> anyhow::Result<()> {
+        let (service, _root) = service().await?;
+        let connection = TestConnection::new(true);
+        let browser = BrowserSession::new(connection, BrowserSessionHooks::default());
+
+        service.set_session_for_testing(browser).await;
+
+        assert!(service.session().await.is_some());
+        Ok(())
     }
 }

--- a/packages/browseros-agent/scripts/build/claw-server-rust-local.sh
+++ b/packages/browseros-agent/scripts/build/claw-server-rust-local.sh
@@ -20,13 +20,25 @@ while [ "$#" -gt 0 ]; do
       target="${2:?--target requires a value}"
       shift 2
       ;;
+    --target=*)
+      target="${1#*=}"
+      shift
+      ;;
     --agent-root)
       agent_root="${2:?--agent-root requires a value}"
       shift 2
       ;;
+    --agent-root=*)
+      agent_root="${1#*=}"
+      shift
+      ;;
     --browseros-root)
       browseros_root="${2:?--browseros-root requires a value}"
       shift 2
+      ;;
+    --browseros-root=*)
+      browseros_root="${1#*=}"
+      shift
       ;;
     -h|--help)
       usage
@@ -61,6 +73,7 @@ else
 fi
 
 binary_name="browseros-claw-server-rs"
+runtime_binary_name="browseros-claw-server"
 cargo_target_dir="${CARGO_TARGET_DIR:-$agent_root/target}"
 binary_path="$cargo_target_dir/release/$binary_name"
 destination="$browseros_root/resources/binaries/browseros_claw_server_rust/$target"
@@ -78,6 +91,7 @@ export BROWSEROS_AGENT_ROOT="$agent_root"
 export BROWSEROS_ROOT="$browseros_root"
 export BROWSEROS_TARGET="$target"
 export BROWSEROS_RUST_BINARY="$binary_path"
+export BROWSEROS_RUST_RUNTIME_BINARY="$runtime_binary_name"
 
 uv run --project "$browseros_root" python <<'PY'
 import hashlib
@@ -95,12 +109,13 @@ from bos_build.steps.storage.download import extract_artifact_zip
 browseros_root = Path(os.environ["BROWSEROS_ROOT"])
 target = os.environ["BROWSEROS_TARGET"]
 binary_path = Path(os.environ["BROWSEROS_RUST_BINARY"])
+runtime_binary = os.environ["BROWSEROS_RUST_RUNTIME_BINARY"]
 destination = (
     browseros_root
     / "resources/binaries/browseros_claw_server_rust"
     / target
 )
-stage_binary = destination / "resources/bin/browseros-claw-server-rs"
+stage_binary = destination / "resources/bin" / runtime_binary
 
 if destination.exists():
     shutil.rmtree(destination)
@@ -146,7 +161,7 @@ with tempfile.TemporaryDirectory() as tmp:
     extracted_rel = sorted(
         path.relative_to(validate_destination).as_posix() for path in extracted
     )
-    expected = ["resources/bin/browseros-claw-server-rs"]
+    expected = [f"resources/bin/{runtime_binary}"]
     if extracted_rel != expected:
         raise SystemExit(
             f"Expected extracted files {expected}, got {extracted_rel}"

--- a/packages/browseros/bos_build/config/copy_resources.yaml
+++ b/packages/browseros/bos_build/config/copy_resources.yaml
@@ -183,104 +183,68 @@ copy_operations:
     os: ["windows"]
     arch: ["x64"]
 
-  # BrowserOS Claw Server resources - Bun ships by default.
-  # Rust alternative: comment the Bun blocks below and uncomment the matching
-  # Rust blocks to ship claw-server-rust; also flip download_resources.yaml and
-  # nightly-browserclaw.yml.
-  - name: "BrowserOS Claw Server Resources - macOS ARM64"
-    source: "resources/binaries/browseros_claw_server/darwin-arm64/resources"
+  # BrowserOS Claw Server resources - Rust ships by default. The optional
+  # rename keeps current CDN artifacts that still use the old -rs filename
+  # compatible until the next Rust server resource publish lands.
+  - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
+    source: "resources/binaries/browseros_claw_server_rust/darwin-arm64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
+    renames:
+      - from: "bin/browseros-claw-server-rs"
+        to: "bin/browseros-claw-server"
+        optional: true
     type: "directory"
     os: ["macos"]
     arch: ["arm64"]
 
-  # - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
-  #   source: "resources/binaries/browseros_claw_server_rust/darwin-arm64/resources"
-  #   destination: "chrome/browser/browseros/claw_server/resources"
-  #   clear_destination: true
-  #   renames:
-  #     - from: "bin/browseros-claw-server-rs"
-  #       to: "bin/browseros-claw-server"
-  #   type: "directory"
-  #   os: ["macos"]
-  #   arch: ["arm64"]
-
-  - name: "BrowserOS Claw Server Resources - macOS x64"
-    source: "resources/binaries/browseros_claw_server/darwin-x64/resources"
+  - name: "BrowserOS Claw Rust Server Resources - macOS x64"
+    source: "resources/binaries/browseros_claw_server_rust/darwin-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
+    renames:
+      - from: "bin/browseros-claw-server-rs"
+        to: "bin/browseros-claw-server"
+        optional: true
     type: "directory"
     os: ["macos"]
     arch: ["x64"]
 
-  # - name: "BrowserOS Claw Rust Server Resources - macOS x64"
-  #   source: "resources/binaries/browseros_claw_server_rust/darwin-x64/resources"
-  #   destination: "chrome/browser/browseros/claw_server/resources"
-  #   clear_destination: true
-  #   renames:
-  #     - from: "bin/browseros-claw-server-rs"
-  #       to: "bin/browseros-claw-server"
-  #   type: "directory"
-  #   os: ["macos"]
-  #   arch: ["x64"]
-
-  - name: "BrowserOS Claw Server Resources - Linux ARM64"
-    source: "resources/binaries/browseros_claw_server/linux-arm64/resources"
+  - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
+    source: "resources/binaries/browseros_claw_server_rust/linux-arm64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
+    renames:
+      - from: "bin/browseros-claw-server-rs"
+        to: "bin/browseros-claw-server"
+        optional: true
     type: "directory"
     os: ["linux"]
     arch: ["arm64"]
 
-  # - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
-  #   source: "resources/binaries/browseros_claw_server_rust/linux-arm64/resources"
-  #   destination: "chrome/browser/browseros/claw_server/resources"
-  #   clear_destination: true
-  #   renames:
-  #     - from: "bin/browseros-claw-server-rs"
-  #       to: "bin/browseros-claw-server"
-  #   type: "directory"
-  #   os: ["linux"]
-  #   arch: ["arm64"]
-
-  - name: "BrowserOS Claw Server Resources - Linux x64"
-    source: "resources/binaries/browseros_claw_server/linux-x64/resources"
+  - name: "BrowserOS Claw Rust Server Resources - Linux x64"
+    source: "resources/binaries/browseros_claw_server_rust/linux-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
+    renames:
+      - from: "bin/browseros-claw-server-rs"
+        to: "bin/browseros-claw-server"
+        optional: true
     type: "directory"
     os: ["linux"]
     arch: ["x64"]
 
-  # - name: "BrowserOS Claw Rust Server Resources - Linux x64"
-  #   source: "resources/binaries/browseros_claw_server_rust/linux-x64/resources"
-  #   destination: "chrome/browser/browseros/claw_server/resources"
-  #   clear_destination: true
-  #   renames:
-  #     - from: "bin/browseros-claw-server-rs"
-  #       to: "bin/browseros-claw-server"
-  #   type: "directory"
-  #   os: ["linux"]
-  #   arch: ["x64"]
-
-  - name: "BrowserOS Claw Server Resources - Windows x64"
-    source: "resources/binaries/browseros_claw_server/windows-x64/resources"
+  - name: "BrowserOS Claw Rust Server Resources - Windows x64"
+    source: "resources/binaries/browseros_claw_server_rust/windows-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     clear_destination: true
+    renames:
+      - from: "bin/browseros-claw-server-rs.exe"
+        to: "bin/browseros-claw-server.exe"
+        optional: true
     type: "directory"
     os: ["windows"]
     arch: ["x64"]
-
-  # - name: "BrowserOS Claw Rust Server Resources - Windows x64"
-  #   source: "resources/binaries/browseros_claw_server_rust/windows-x64/resources"
-  #   destination: "chrome/browser/browseros/claw_server/resources"
-  #   clear_destination: true
-  #   renames:
-  #     - from: "bin/browseros-claw-server-rs.exe"
-  #       to: "bin/browseros-claw-server.exe"
-  #   type: "directory"
-  #   os: ["windows"]
-  #   arch: ["x64"]
 
   # BrowserOS Claw onboarding static resources - platform-independent dist
   # downloaded from R2, feeds the onboarding grit pak built for every product

--- a/packages/browseros/bos_build/config/download_resources.yaml
+++ b/packages/browseros/bos_build/config/download_resources.yaml
@@ -22,7 +22,6 @@
 #   - Supported values: file, artifact_zip
 # R2 Path Structure:
 #   artifacts/server/latest/browseros-server-resources-{target}.zip
-#   claw-server/prod-resources/latest/browseros-claw-server-resources-{target}.zip
 #   claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-{target}.zip
 #   claw-onboard/prod-resources/latest/browseros-claw-onboard-resources.zip
 #
@@ -72,78 +71,42 @@ download_operations:
     arch: ["x64"]
 
   # BrowserOS Claw Server resource bundles - Platform & Architecture specific.
-  # Bun ships by default. Rust alternative: uncomment the Rust blocks below and
-  # flip copy_resources.yaml plus nightly-browserclaw.yml to ship claw-server-rust.
-  - name: "BrowserOS Claw Server Resources - macOS ARM64"
-    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip"
-    destination: "resources/binaries/browseros_claw_server/darwin-arm64"
+  # BrowserClaw now ships claw-server-rust; copy_resources.yaml normalizes
+  # the legacy -rs binary filename from existing CDN resources if present.
+  - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
+    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip"
+    destination: "resources/binaries/browseros_claw_server_rust/darwin-arm64"
     download_type: "artifact_zip"
     os: ["macos"]
     arch: ["arm64"]
 
-  - name: "BrowserOS Claw Server Resources - macOS x64"
-    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip"
-    destination: "resources/binaries/browseros_claw_server/darwin-x64"
+  - name: "BrowserOS Claw Rust Server Resources - macOS x64"
+    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-x64.zip"
+    destination: "resources/binaries/browseros_claw_server_rust/darwin-x64"
     download_type: "artifact_zip"
     os: ["macos"]
     arch: ["x64"]
 
-  - name: "BrowserOS Claw Server Resources - Linux ARM64"
-    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip"
-    destination: "resources/binaries/browseros_claw_server/linux-arm64"
+  - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
+    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-arm64.zip"
+    destination: "resources/binaries/browseros_claw_server_rust/linux-arm64"
     download_type: "artifact_zip"
     os: ["linux"]
     arch: ["arm64"]
 
-  - name: "BrowserOS Claw Server Resources - Linux x64"
-    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip"
-    destination: "resources/binaries/browseros_claw_server/linux-x64"
+  - name: "BrowserOS Claw Rust Server Resources - Linux x64"
+    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-x64.zip"
+    destination: "resources/binaries/browseros_claw_server_rust/linux-x64"
     download_type: "artifact_zip"
     os: ["linux"]
     arch: ["x64"]
 
-  - name: "BrowserOS Claw Server Resources - Windows x64"
-    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip"
-    destination: "resources/binaries/browseros_claw_server/windows-x64"
+  - name: "BrowserOS Claw Rust Server Resources - Windows x64"
+    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-windows-x64.zip"
+    destination: "resources/binaries/browseros_claw_server_rust/windows-x64"
     download_type: "artifact_zip"
     os: ["windows"]
     arch: ["x64"]
-
-  # Rust alternative resource bundles - uncomment only when shipping claw-server-rust.
-  # - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
-  #   r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip"
-  #   destination: "resources/binaries/browseros_claw_server_rust/darwin-arm64"
-  #   download_type: "artifact_zip"
-  #   os: ["macos"]
-  #   arch: ["arm64"]
-
-  # - name: "BrowserOS Claw Rust Server Resources - macOS x64"
-  #   r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-x64.zip"
-  #   destination: "resources/binaries/browseros_claw_server_rust/darwin-x64"
-  #   download_type: "artifact_zip"
-  #   os: ["macos"]
-  #   arch: ["x64"]
-
-  # - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
-  #   r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-arm64.zip"
-  #   destination: "resources/binaries/browseros_claw_server_rust/linux-arm64"
-  #   download_type: "artifact_zip"
-  #   os: ["linux"]
-  #   arch: ["arm64"]
-
-  # - name: "BrowserOS Claw Rust Server Resources - Linux x64"
-  #   r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-x64.zip"
-  #   destination: "resources/binaries/browseros_claw_server_rust/linux-x64"
-  #   download_type: "artifact_zip"
-  #   os: ["linux"]
-  #   arch: ["x64"]
-
-  # - name: "BrowserOS Claw Rust Server Resources - Windows x64"
-  #   r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-windows-x64.zip"
-  #   destination: "resources/binaries/browseros_claw_server_rust/windows-x64"
-  #   download_type: "artifact_zip"
-  #   os: ["windows"]
-  #   arch: ["x64"]
 
   # BrowserOS Claw onboarding static resources - platform-independent, feeds
   # the onboarding grit pak built for every product (no os/arch/product gate)

--- a/packages/browseros/bos_build/docs/nightly-macos-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-macos-ci.md
@@ -54,21 +54,7 @@ packages/browseros/resources/binaries/browseros_claw_onboard
 ```
 
 BrowserClaw stages the shared BrowserOS server bundle, the product-independent
-onboarding bundle, and the TypeScript/Bun Claw server bundle:
-
-```bash
-bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
-```
-
-and extracts it into
-`resources/binaries/browseros_claw_server/darwin-arm64`. The normal resources
-step then copies this root into Chromium; the bundled binary is already named
-`browseros-claw-server`.
-
-The Rust alternative remains available as a manual comment flip. To ship Rust,
-run this helper in `.github/workflows/nightly-browserclaw.yml` before the Python
-staging heredoc and flip the commented Rust blocks in
-`copy_resources.yaml`/`download_resources.yaml`:
+onboarding bundle, and the Rust Claw server bundle:
 
 ```bash
 packages/browseros-agent/scripts/build/claw-server-rust-local.sh \
@@ -77,10 +63,10 @@ packages/browseros-agent/scripts/build/claw-server-rust-local.sh \
   --browseros-root packages/browseros
 ```
 
-That helper builds the Rust server natively with Cargo and stages
-`resources/binaries/browseros_claw_server_rust/darwin-arm64`; the commented copy
-block renames `browseros-claw-server-rs` to the runtime name
-`browseros-claw-server`.
+The helper builds the Rust server natively with Cargo and stages
+`resources/binaries/browseros_claw_server_rust/darwin-arm64` with the runtime
+binary name `browseros-claw-server`. The normal resources step then copies this
+root into Chromium.
 
 ## Bundled Extensions
 
@@ -106,10 +92,10 @@ uv run browseros build --preset release --product <product> --arch <arch> \
   --chromium-src "$CHROMIUM_SRC"
 ```
 
-For BrowserClaw, `download_resources` fetches the active TypeScript/Bun Claw
-server bundle from `claw-server/prod-resources/latest/`. Rust resources come
-from `claw-server-rust/prod-resources/latest/` only when the commented Rust
-download/copy blocks are flipped intentionally.
+For BrowserClaw, `download_resources` fetches the active Rust Claw server bundle
+from `claw-server-rust/prod-resources/latest/`. The copy step normalizes legacy
+Rust resource zips that still contain `browseros-claw-server-rs` into the
+runtime filename `browseros-claw-server`.
 
 Release runs default to rebuilding the current version files without bumping
 them:

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -82,25 +82,20 @@ Server resources do not use that version. `release-server.yml` resolves
 
 The Rust Claw server lane publishes to a distinct CDN/R2 prefix:
 `claw-server-rust/prod-resources/{version,latest}/`. BrowserClaw browser builds
-ship the TypeScript/Bun server by default from `claw-server/prod-resources/latest/`.
-The Rust download entries in
-`packages/browseros/bos_build/config/download_resources.yaml` and the Rust copy
-entries in `packages/browseros/bos_build/config/copy_resources.yaml` are kept as
-commented alternatives. To ship Rust, uncomment the matching Rust blocks,
-comment the Bun blocks, and ensure the Rust workflow has already populated the
-matching R2 objects; the bos_build download step fails the whole Chromium build
-when a configured key is missing. The Rust copy blocks rename
-`browseros-claw-server-rs` to the runtime name `browseros-claw-server`.
+ship the Rust server by default from
+`claw-server-rust/prod-resources/latest/`. The bos_build download step fails the
+whole Chromium build when a configured key is missing. The Rust copy blocks
+normalize legacy resource zips that still contain `browseros-claw-server-rs` to
+the runtime name `browseros-claw-server`.
 BrowserClaw server OTA feeds (`appcast-claw-server*.xml`) remain pinned to the
 TypeScript/Bun server bundle until a separate feed migration changes them.
 
 `release-macos.yml` follows this release rule too: it does not build server
 resources from the checked-out `packages/browseros-agent` tree. Its browser
 build command leaves downloads enabled, so `download_resources` fetches the
-published BrowserOS server bundle, the active Bun BrowserClaw server bundle, and
-the onboarding bundle from R2 using the runner-local `packages/browseros/.env`
-R2 credentials. Flip the commented Rust blocks only when intentionally shipping
-the Rust server.
+published BrowserOS server bundle, the active Rust BrowserClaw server bundle,
+and the onboarding bundle from R2 using the runner-local
+`packages/browseros/.env` R2 credentials.
 
 The reusable nesting depth is `release-browseros.yml` or
 `release-browserclaw.yml` -> `release-linux.yml` or `release-windows.yml` ->

--- a/packages/browseros/bos_build/products/browserclaw/product.py
+++ b/packages/browseros/bos_build/products/browserclaw/product.py
@@ -20,6 +20,7 @@ BROWSERCLAW_PRODUCT = ProductDescriptor.define(
         (BROWSERCLAW_EXTENSION_ID, "BrowserClaw app"),
         (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
     ),
+    server_bundle_ids=("browserclaw-server-rust",),
 )
 
 BROWSERCLAW_SERVER_BUNDLE = ServerBundle(
@@ -46,9 +47,9 @@ BROWSERCLAW_SERVER_BUNDLE = ServerBundle(
     unsigned_artifact_base_name="browseros-claw-server-resources",
 )
 
-# Rust release/OTA metadata stays defined for release-claw-server-rust.yml.
-# It is not in SERVER_BUNDLES and ships only when the commented YAML blocks are
-# flipped by hand.
+# Rust browser-build metadata. BrowserClaw launches this through the existing
+# Chromium Claw server resource root with the canonical browseros-claw-server
+# runtime binary name.
 BROWSERCLAW_RUST_SERVER_BUNDLE = ServerBundle(
     id="browserclaw-server-rust",
     name="BrowserOS Claw Server (Rust)",

--- a/packages/browseros/bos_build/products/products_test.py
+++ b/packages/browseros/bos_build/products/products_test.py
@@ -87,7 +87,7 @@ EXPECTED_BROWSERCLAW = ProductDescriptor(
         (BROWSERCLAW_EXTENSION_ID, "BrowserClaw app"),
         (BROWSEROS_BUG_REPORTER_EXTENSION_ID, "BrowserOS bug reporter"),
     ),
-    server_bundle_ids=("browserclaw-server",),
+    server_bundle_ids=("browserclaw-server-rust",),
     mac=MacProductIdentity(
         bundle_id="com.browseros.BrowserClaw",
         dev_bundle_id="com.browseros.dev.BrowserClaw",

--- a/packages/browseros/bos_build/products/server_binaries.py
+++ b/packages/browseros/bos_build/products/server_binaries.py
@@ -105,6 +105,6 @@ def expected_windows_bundle_binary_paths(
 
 def _browser_build_server_bundles() -> Tuple[ServerBundle, ...]:
     from .browseros.product import BROWSEROS_SERVER_BUNDLE
-    from .browserclaw.product import BROWSERCLAW_SERVER_BUNDLE
+    from .browserclaw.product import BROWSERCLAW_RUST_SERVER_BUNDLE
 
-    return (BROWSEROS_SERVER_BUNDLE, BROWSERCLAW_SERVER_BUNDLE)
+    return (BROWSEROS_SERVER_BUNDLE, BROWSERCLAW_RUST_SERVER_BUNDLE)

--- a/packages/browseros/bos_build/products/server_binaries_test.py
+++ b/packages/browseros/bos_build/products/server_binaries_test.py
@@ -30,10 +30,10 @@ ENTITLEMENTS_DIR = Path(__file__).resolve().parents[2] / "resources" / "entitlem
 
 
 class MacosServerBinariesTest(unittest.TestCase):
-    def test_server_bundles_use_bun_for_browser_builds(self):
+    def test_server_bundles_use_rust_claw_for_browser_builds(self):
         self.assertEqual(
             all_server_bundles(),
-            (BROWSEROS_SERVER_BUNDLE, BROWSEROS_CLAW_SERVER_BUNDLE),
+            (BROWSEROS_SERVER_BUNDLE, BROWSERCLAW_RUST_SERVER_BUNDLE),
         )
 
     def test_server_bundles_have_separate_resource_roots(self):
@@ -96,7 +96,7 @@ class MacosServerBinariesTest(unittest.TestCase):
         )
         self.assertEqual(
             server_bundles_for_product("browserclaw"),
-            (BROWSEROS_CLAW_SERVER_BUNDLE,),
+            (BROWSERCLAW_RUST_SERVER_BUNDLE,),
         )
 
     def test_server_ota_bundles_stay_pinned_to_typescript_claw(self):

--- a/packages/browseros/bos_build/steps/resources/resources.py
+++ b/packages/browseros/bos_build/steps/resources/resources.py
@@ -182,9 +182,15 @@ def apply_renames(base: Path, renames) -> None:
             raise ValueError("rename entries must be mappings")
         src_rel = _safe_relative_path(rename.get("from"), "from")
         dst_rel = _safe_relative_path(rename.get("to"), "to")
+        optional = bool(rename.get("optional", False))
         src = base / src_rel
         dst = base / dst_rel
         if not src.is_file():
+            if optional and dst.is_file():
+                log_info(
+                    f"    ✓ Rename skipped; target already present: {dst_rel.as_posix()}"
+                )
+                continue
             raise FileNotFoundError(f"rename source not found: {src_rel.as_posix()}")
         dst.parent.mkdir(parents=True, exist_ok=True)
         if dst.exists():

--- a/packages/browseros/bos_build/steps/resources/resources_test.py
+++ b/packages/browseros/bos_build/steps/resources/resources_test.py
@@ -61,6 +61,65 @@ class CopyResourcesTest(unittest.TestCase):
         self.assertEqual((dest / "app.png").read_text(), "png-bytes")
         self.assertEqual((dest / "nested" / "small.png").read_text(), "small-bytes")
 
+    def test_optional_rename_skips_when_target_already_exists(self):
+        src_dir = self.root.root / "resources" / "server"
+        (src_dir / "bin").mkdir(parents=True)
+        (src_dir / "bin" / "browseros-claw-server").write_text("canonical")
+        self.root.write_copy_config(
+            {
+                "copy_operations": [
+                    {
+                        "name": "Rust Claw",
+                        "source": "resources/server",
+                        "destination": "chrome/server",
+                        "type": "directory",
+                        "renames": [
+                            {
+                                "from": "bin/browseros-claw-server-rs",
+                                "to": "bin/browseros-claw-server",
+                                "optional": True,
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        self.assertTrue(copy_resources_impl(self.ctx))
+
+        dest = self.chromium.src / "chrome" / "server" / "bin"
+        self.assertEqual((dest / "browseros-claw-server").read_text(), "canonical")
+
+    def test_optional_rename_normalizes_legacy_source(self):
+        src_dir = self.root.root / "resources" / "server"
+        (src_dir / "bin").mkdir(parents=True)
+        (src_dir / "bin" / "browseros-claw-server-rs").write_text("legacy")
+        self.root.write_copy_config(
+            {
+                "copy_operations": [
+                    {
+                        "name": "Rust Claw",
+                        "source": "resources/server",
+                        "destination": "chrome/server",
+                        "type": "directory",
+                        "renames": [
+                            {
+                                "from": "bin/browseros-claw-server-rs",
+                                "to": "bin/browseros-claw-server",
+                                "optional": True,
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        self.assertTrue(copy_resources_impl(self.ctx))
+
+        dest = self.chromium.src / "chrome" / "server" / "bin"
+        self.assertEqual((dest / "browseros-claw-server").read_text(), "legacy")
+        self.assertFalse((dest / "browseros-claw-server-rs").exists())
+
     def test_file_operation_copies_and_creates_parents(self):
         (self.root.root / "resources").mkdir(exist_ok=True)
         (self.root.root / "resources" / "logo.icns").write_text("icns")
@@ -308,21 +367,21 @@ class CopyResourcesTest(unittest.TestCase):
             / "bin"
             / "browseros-claw-server"
         )
-        claw_rust_dest = (
+        legacy_rust_dest = (
             self.chromium.src
             / "chrome"
             / "browser"
             / "browseros"
-            / "claw_server_rust"
+            / "claw_server"
             / "resources"
             / "bin"
             / "browseros-claw-server-rs"
         )
         self.assertEqual(browseros_dest.read_text(), "browseros")
-        self.assertEqual(claw_dest.read_text(), "claw")
-        self.assertFalse(claw_rust_dest.exists())
+        self.assertEqual(claw_dest.read_text(), "claw-rust")
+        self.assertFalse(legacy_rust_dest.exists())
 
-    def test_real_config_copies_bun_server_resources_for_browserclaw_by_default(
+    def test_real_config_copies_rust_server_resources_for_browserclaw_by_default(
         self,
     ):
         self.root.write_copy_config(self._real_copy_config())
@@ -355,9 +414,7 @@ class CopyResourcesTest(unittest.TestCase):
         (claw_source / "bin").mkdir(parents=True)
         (claw_source / "bin" / "browseros-claw-server").write_text("claw")
         (claw_rust_source / "bin").mkdir(parents=True)
-        (claw_rust_source / "bin" / "browseros-claw-server-rs").write_text(
-            "claw-rust"
-        )
+        (claw_rust_source / "bin" / "browseros-claw-server").write_text("claw-rust")
         stale_rust_file = (
             self.chromium.src
             / "chrome"
@@ -404,22 +461,22 @@ class CopyResourcesTest(unittest.TestCase):
             / "bin"
             / "browseros-claw-server"
         )
-        claw_rust_dest = (
+        legacy_rust_dest = (
             self.chromium.src
             / "chrome"
             / "browser"
             / "browseros"
-            / "claw_server_rust"
+            / "claw_server"
             / "resources"
             / "bin"
             / "browseros-claw-server-rs"
         )
         self.assertEqual(browseros_dest.read_text(), "browseros")
-        self.assertEqual(claw_dest.read_text(), "claw")
-        self.assertFalse(claw_rust_dest.exists())
+        self.assertEqual(claw_dest.read_text(), "claw-rust")
+        self.assertFalse(legacy_rust_dest.exists())
         self.assertFalse(stale_rust_file.exists())
 
-    def test_real_config_keeps_rust_claw_server_switch_block_commented(
+    def test_real_config_uses_rust_claw_server_resources(
         self,
     ):
         config_path = (
@@ -430,30 +487,21 @@ class CopyResourcesTest(unittest.TestCase):
         active_names = [op["name"] for op in config["copy_operations"]]
 
         self.assertIn(
-            "# BrowserOS Claw Server resources - Bun ships by default.",
+            "# BrowserOS Claw Server resources - Rust ships by default.",
             text,
         )
         self.assertIn(
-            "# Rust alternative: comment the Bun blocks below and uncomment the matching",
+            'optional: true',
             text,
         )
         self.assertIn(
-            '# - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"',
-            text,
-        )
-        self.assertIn(
-            '#     - from: "bin/browseros-claw-server-rs"',
-            text,
-        )
-        self.assertIn(
-            "BrowserOS Claw Server Resources - macOS ARM64",
-            active_names,
-        )
-        self.assertNotIn(
             "BrowserOS Claw Rust Server Resources - macOS ARM64",
             active_names,
         )
-        self.assertNotIn('#   product: "browserclaw"', text)
+        self.assertNotIn(
+            "BrowserOS Claw Server Resources - macOS ARM64",
+            active_names,
+        )
 
     def test_real_config_keeps_active_server_copy_resources_ungated(self):
         config = self._real_copy_config()
@@ -462,6 +510,7 @@ class CopyResourcesTest(unittest.TestCase):
             for op in config["copy_operations"]
             if op["name"].startswith("BrowserOS Server Resources")
             or op["name"].startswith("BrowserOS Claw Server Resources")
+            or op["name"].startswith("BrowserOS Claw Rust Server Resources")
         ]
 
         self.assertTrue(server_ops)

--- a/packages/browseros/bos_build/steps/sign/macos_test.py
+++ b/packages/browseros/bos_build/steps/sign/macos_test.py
@@ -231,6 +231,7 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
             op["destination"]
             for op in config["copy_operations"]
             if op["name"].startswith("BrowserOS Claw Server Resources")
+            or op["name"].startswith("BrowserOS Claw Rust Server Resources")
         }
         self.assertEqual(
             claw_destinations,

--- a/packages/browseros/bos_build/steps/storage/download_test.py
+++ b/packages/browseros/bos_build/steps/storage/download_test.py
@@ -211,9 +211,9 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "resources/binaries/browseros_server/darwin-arm64",
                     ),
                     (
-                        "BrowserOS Claw Server Resources - macOS ARM64",
-                        "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",
-                        "resources/binaries/browseros_claw_server/darwin-arm64",
+                        "BrowserOS Claw Rust Server Resources - macOS ARM64",
+                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
+                        "resources/binaries/browseros_claw_server_rust/darwin-arm64",
                     ),
                 ],
             ),
@@ -227,9 +227,9 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "resources/binaries/browseros_server/darwin-x64",
                     ),
                     (
-                        "BrowserOS Claw Server Resources - macOS x64",
-                        "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip",
-                        "resources/binaries/browseros_claw_server/darwin-x64",
+                        "BrowserOS Claw Rust Server Resources - macOS x64",
+                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-x64.zip",
+                        "resources/binaries/browseros_claw_server_rust/darwin-x64",
                     ),
                 ],
             ),
@@ -243,9 +243,9 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "resources/binaries/browseros_server/linux-arm64",
                     ),
                     (
-                        "BrowserOS Claw Server Resources - Linux ARM64",
-                        "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip",
-                        "resources/binaries/browseros_claw_server/linux-arm64",
+                        "BrowserOS Claw Rust Server Resources - Linux ARM64",
+                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-arm64.zip",
+                        "resources/binaries/browseros_claw_server_rust/linux-arm64",
                     ),
                 ],
             ),
@@ -259,9 +259,9 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "resources/binaries/browseros_server/linux-x64",
                     ),
                     (
-                        "BrowserOS Claw Server Resources - Linux x64",
-                        "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip",
-                        "resources/binaries/browseros_claw_server/linux-x64",
+                        "BrowserOS Claw Rust Server Resources - Linux x64",
+                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-x64.zip",
+                        "resources/binaries/browseros_claw_server_rust/linux-x64",
                     ),
                 ],
             ),
@@ -275,9 +275,9 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "resources/binaries/browseros_server/windows-x64",
                     ),
                     (
-                        "BrowserOS Claw Server Resources - Windows x64",
-                        "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip",
-                        "resources/binaries/browseros_claw_server/windows-x64",
+                        "BrowserOS Claw Rust Server Resources - Windows x64",
+                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-windows-x64.zip",
+                        "resources/binaries/browseros_claw_server_rust/windows-x64",
                     ),
                 ],
             ),
@@ -303,8 +303,8 @@ class DownloadResourceConfigTest(unittest.TestCase):
             [
                 "BrowserOS Server Resources - macOS ARM64",
                 "BrowserOS Server Resources - macOS x64",
-                "BrowserOS Claw Server Resources - macOS ARM64",
-                "BrowserOS Claw Server Resources - macOS x64",
+                "BrowserOS Claw Rust Server Resources - macOS ARM64",
+                "BrowserOS Claw Rust Server Resources - macOS x64",
                 "BrowserOS Claw Onboarding Resources",
             ],
             [op["name"] for op in filtered],
@@ -324,8 +324,8 @@ class DownloadResourceConfigTest(unittest.TestCase):
 
         self.assertIn("BrowserOS Server Resources - macOS ARM64", names)
         self.assertIn("BrowserOS Server Resources - macOS x64", names)
-        self.assertIn("BrowserOS Claw Server Resources - macOS ARM64", names)
-        self.assertIn("BrowserOS Claw Server Resources - macOS x64", names)
+        self.assertIn("BrowserOS Claw Rust Server Resources - macOS ARM64", names)
+        self.assertIn("BrowserOS Claw Rust Server Resources - macOS x64", names)
 
     def test_flat_multi_arch_plan_stays_arch_scoped(self) -> None:
         # Flat multi-arch (arm64, x64 without universal) plans a full
@@ -340,7 +340,7 @@ class DownloadResourceConfigTest(unittest.TestCase):
 
         self.assertIn("BrowserOS Server Resources - macOS ARM64", names)
         self.assertNotIn("BrowserOS Server Resources - macOS x64", names)
-        self.assertNotIn("BrowserOS Claw Server Resources - macOS x64", names)
+        self.assertNotIn("BrowserOS Claw Rust Server Resources - macOS x64", names)
 
     def test_real_config_includes_claw_onboard_resources_everywhere(self) -> None:
         # The onboarding dist is platform-independent and its grit pak is
@@ -378,7 +378,7 @@ class DownloadResourceConfigTest(unittest.TestCase):
                     ]
                     self.assertEqual([expected], actual)
 
-    def test_real_config_downloads_bun_claw_server_for_browserclaw(
+    def test_real_config_downloads_rust_claw_server_for_browserclaw(
         self,
     ) -> None:
         operations = self._real_download_operations()
@@ -398,9 +398,9 @@ class DownloadResourceConfigTest(unittest.TestCase):
                     "resources/binaries/browseros_server/darwin-arm64",
                 ),
                 (
-                    "BrowserOS Claw Server Resources - macOS ARM64",
-                    "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",
-                    "resources/binaries/browseros_claw_server/darwin-arm64",
+                    "BrowserOS Claw Rust Server Resources - macOS ARM64",
+                    "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
+                    "resources/binaries/browseros_claw_server_rust/darwin-arm64",
                 ),
             ],
             [
@@ -417,6 +417,7 @@ class DownloadResourceConfigTest(unittest.TestCase):
             for op in operations
             if op["name"].startswith("BrowserOS Server Resources")
             or op["name"].startswith("BrowserOS Claw Server Resources")
+            or op["name"].startswith("BrowserOS Claw Rust Server Resources")
         ]
 
         self.assertTrue(server_ops)
@@ -424,7 +425,7 @@ class DownloadResourceConfigTest(unittest.TestCase):
             with self.subTest(name=op["name"]):
                 self.assertNotIn("product", op)
 
-    def test_real_config_keeps_rust_claw_downloads_commented(self) -> None:
+    def test_real_config_uses_rust_claw_downloads(self) -> None:
         config_path = (
             Path(__file__).resolve().parents[2] / "config" / "download_resources.yaml"
         )
@@ -432,18 +433,18 @@ class DownloadResourceConfigTest(unittest.TestCase):
         operations = self._real_download_operations()
 
         self.assertIn(
-            "# Rust alternative resource bundles - uncomment only when shipping "
-            "claw-server-rust.",
+            "# BrowserClaw now ships claw-server-rust; copy_resources.yaml normalizes",
             text,
         )
         self.assertIn(
-            '# - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"',
+            "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
             text,
         )
-        self.assertNotIn(
+        self.assertIn(
             "BrowserOS Claw Rust Server Resources - macOS ARM64",
             [op["name"] for op in operations],
         )
+        self.assertNotIn("claw-server/prod-resources/latest/", text)
 
     def _real_download_operations(self) -> list[dict]:
         config_path = (


### PR DESCRIPTION
## Summary
- fix claw-server-rust so `BrowserService::session()` hides stored sessions whose CDP client is disconnected, preventing stale sessions from leaking into MCP tools as raw `CDP not connected` failures
- switch BrowserClaw browser-build server bundle resolution from the TypeScript Claw server bundle to `browserclaw-server-rust`
- update nightly BrowserClaw staging to build/stage the local Rust server as `resources/bin/browseros-claw-server`, preserving the signing runtime filename
- update published Rust resource packaging to emit the canonical runtime filename and keep copy-time optional renames for legacy `browseros-claw-server-rs` artifacts
- keep BrowserClaw server OTA bundle lookup pinned to the TypeScript bundle for now

## Verification
- `cargo test -p claw-server-rust session_`
- `cargo test -p claw-server-rust`
- `cargo clippy -p claw-server-rust --all-targets`
- `uv run python -m unittest bos_build.products.products_test bos_build.products.server_binaries_test bos_build.steps.resources.resources_test bos_build.steps.storage.download_test bos_build.steps.sign.macos_test`
- `scripts/build/claw-server-rust-local.sh --target=darwin-arm64 --agent-root=. --browseros-root=../browseros`
- `BROWSEROS_BINARY=<mounted BrowserClaw 0.47.21 executable> BROWSEROS_TEST_HEADLESS=true bun contracts/claw-mcp/tests/run.ts --smoke` (35 pass)
- `BROWSEROS_BINARY=<mounted BrowserClaw 0.47.21 executable> BROWSEROS_TEST_HEADLESS=true bun contracts/claw-mcp/tests/run.ts` (205 pass)
- `bash -n packages/browseros-agent/scripts/build/claw-server-rust-local.sh`
- `git diff --check`
- YAML parse check for touched workflow/resource files

## Watch
- The full `nightly-browserclaw.yml` workflow still needs a `workflow_dispatch` run after merge because this PR intentionally changes signed BrowserClaw bundling.
