### PR TITLE
fix(ci): isolate claw-mcp contract cleanup

### DIFF
--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -272,10 +272,13 @@ jobs:
           fi
 
           mount_point="$(mktemp -d)"
+          exe=""
           cleanup() {
-            # Reap any test browser the harness spawned before releasing the
-            # mount, so a cancel/timeout cannot orphan a process holding it.
-            pkill -f 'claw-mcp-browser-' 2>/dev/null || true
+            # Reap only the browser launched from this mounted DMG before
+            # releasing the mount, so concurrent contract runs are not killed.
+            if [ -n "$exe" ]; then
+              pkill -f "$exe" 2>/dev/null || true
+            fi
             hdiutil detach "$mount_point" -quiet 2>/dev/null \
               || hdiutil detach "$mount_point" -force -quiet 2>/dev/null || true
           }

--- a/packages/browseros-agent/contracts/claw-mcp/tests/browser.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/browser.ts
@@ -97,7 +97,9 @@ function launchArgs(cdpPort: number, userDataDir: string): string[] {
  */
 export async function launchBrowser(): Promise<BrowserHandle> {
   const binary = browserBinary()
-  const userDataDir = await mkdtemp(join(tmpdir(), 'claw-mcp-browser-'))
+  const userDataDir = await mkdtemp(
+    join(tmpdir(), 'browseros-contract-browser-'),
+  )
   const cdpPort = await findFreePort()
   const child = Bun.spawn({
     cmd: [binary, ...launchArgs(cdpPort, userDataDir)],


### PR DESCRIPTION
## Summary
- stop nightly claw-mcp cleanup from using the shared claw-mcp-browser process pattern
- kill only the BrowserClaw executable launched from the mounted DMG during cleanup
- move contract test profiles to a distinct browseros-contract-browser prefix so stale broad cleanup from other runs cannot hit new suites

## Verification
- git diff --check
- parsed .github/workflows/nightly-browserclaw.yml with PyYAML via uv
- BROWSEROS_BINARY=<signed BrowserClaw DMG executable> BROWSEROS_TEST_HEADLESS=true bun test --test-name-pattern 'windows:' contracts/claw-mcp/tests/cross-server.test.ts