### PR TITLE
chore(ts): migrate the agent monorepo to the TypeScript 7.0.2 native compiler

### DIFF
--- a/packages/browseros-agent/README.md
+++ b/packages/browseros-agent/README.md
@@ -150,6 +150,8 @@ bun run lint:fix              # Auto-fix
 bun run typecheck             # TypeScript check
 ```
 
+`bun run typecheck` runs the native TypeScript 7 compiler (`tsc` from `typescript@7`, the Go-native build). Unlike an editor's bundled classic TypeScript, the native compiler does not implicitly include every `@types/*` package it finds — each tsconfig must list its ambient type packages in `compilerOptions.types` (the root tsconfig defaults to `["node", "bun"]`). A new package that omits this may look green in the editor but fail `bun run typecheck` in CI with "Cannot find name 'Bun' / 'process'"; add the needed names to its `types` array. For editor parity with CI, install your editor's native TypeScript 7 support.
+
 `build:server` now emits artifacts under `dist/prod/server/<target>/` and zip files under `dist/prod/server/`.
 
 Direct server build script options:

--- a/packages/browseros-agent/apps/app/package.json
+++ b/packages/browseros-agent/apps/app/package.json
@@ -10,9 +10,9 @@
     "build:dev": "bun --env-file=../../.env.development wxt build --mode development",
     "zip": "wxt zip",
     "test": "bun run ../../scripts/run-bun-test.ts ./apps/app",
-    "compile": "bun --env-file=../../.env.development wxt prepare && tsgo --noEmit",
+    "compile": "bun --env-file=../../.env.development wxt prepare && tsc --noEmit",
     "lint": "bunx @biomejs/biome check",
-    "typecheck": "bun --env-file=../../.env.development wxt prepare && tsgo --noEmit",
+    "typecheck": "bun --env-file=../../.env.development wxt prepare && tsc --noEmit",
     "lint:fix": "bunx @biomejs/biome check --write --unsafe",
     "clean:cache": "rm -rf node_modules/.cache && rm -rf .output/ && rm -rf .wxt/",
     "codegen": "bun --env-file=../../.env.development graphql-codegen --config codegen.ts",
@@ -108,7 +108,6 @@
     "@wxt-dev/module-react": "^1.2.2",
     "lefthook": "^2.1.10",
     "tailwindcss": "^4.3.1",
-    "typescript": "^5.9.3",
     "wxt": "^0.20.27"
   },
   "trustedDependencies": [

--- a/packages/browseros-agent/apps/claw-app/fonts.d.ts
+++ b/packages/browseros-agent/apps/claw-app/fonts.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Ambient declarations for the bare `@fontsource-variable/*` side-effect
+ * imports in the cockpit (see entrypoints/newtab/main.tsx). These packages
+ * ship CSS only and carry no type declarations; their `exports["."]` maps to
+ * the variable-font stylesheet, so they are imported by package name rather
+ * than by a `.css` path (the weighted `@fontsource/*` imports use `.css`
+ * paths and are covered by the bundler's `*.css` module type).
+ *
+ * The native TypeScript 7 compiler rejects a side-effect import of a module
+ * with no type declaration (TS2882), unlike classic tsc which accepted any
+ * resolvable package. Declaring them as untyped side-effect modules satisfies
+ * the checker without changing what the bundler ships.
+ */
+declare module '@fontsource-variable/schibsted-grotesk'
+declare module '@fontsource-variable/jetbrains-mono'

--- a/packages/browseros-agent/apps/claw-app/package.json
+++ b/packages/browseros-agent/apps/claw-app/package.json
@@ -70,7 +70,6 @@
     "linkedom": "^0.18.13",
     "serve": "^14.2.6",
     "tailwindcss": "^4.1.17",
-    "typescript": "^5.9.2",
     "wxt": "^0.20.27"
   }
 }

--- a/packages/browseros-agent/apps/claw-app/tsconfig.json
+++ b/packages/browseros-agent/apps/claw-app/tsconfig.json
@@ -4,7 +4,6 @@
     "types": ["chrome", "bun"],
     "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     }

--- a/packages/browseros-agent/apps/claw-onboard/package.json
+++ b/packages/browseros-agent/apps/claw-onboard/package.json
@@ -35,7 +35,6 @@
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.0",
     "tailwindcss": "^4.1.17",
-    "typescript": "^5.9.2",
     "vite": "^7.3.6"
   }
 }

--- a/packages/browseros-agent/apps/claw-onboard/tsconfig.json
+++ b/packages/browseros-agent/apps/claw-onboard/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "allowJs": false,
-    "baseUrl": ".",
     "composite": false,
     "declaration": false,
     "declarationMap": false,

--- a/packages/browseros-agent/apps/claw-server/package.json
+++ b/packages/browseros-agent/apps/claw-server/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.5",
-    "drizzle-kit": "^0.31.10",
-    "typescript": "^5.9.2"
+    "drizzle-kit": "^0.31.10"
   }
 }

--- a/packages/browseros-agent/apps/server/package.json
+++ b/packages/browseros-agent/apps/server/package.json
@@ -101,8 +101,7 @@
     "async-mutex": "^0.5.0",
     "drizzle-kit": "^0.31.10",
     "pino-pretty": "^13.1.3",
-    "puppeteer": "^25.3.0",
-    "typescript": "^5.9.3"
+    "puppeteer": "^25.3.0"
   },
   "license": "AGPL-3.0-or-later"
 }

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -12,13 +12,12 @@
         "@sentry/cli": "^3.6.0",
         "@types/bun": "^1.3.14",
         "@types/node": "^24.13.3",
-        "@typescript/native-preview": "^7.0.0-dev.20260619.1",
         "commander": "^14.0.3",
         "fallow": "^2.104.0",
         "lefthook": "^2.1.10",
         "picocolors": "^1.1.1",
         "typedoc": "^0.28.20",
-        "typescript": "^5.9.3",
+        "typescript": "^7.0.2",
         "yaml": "2.9.0",
       },
     },
@@ -115,7 +114,6 @@
         "@wxt-dev/module-react": "^1.2.2",
         "lefthook": "^2.1.10",
         "tailwindcss": "^4.3.1",
-        "typescript": "^5.9.3",
         "wxt": "^0.20.27",
       },
     },
@@ -175,7 +173,6 @@
         "linkedom": "^0.18.13",
         "serve": "^14.2.6",
         "tailwindcss": "^4.1.17",
-        "typescript": "^5.9.2",
         "wxt": "^0.20.27",
       },
     },
@@ -203,7 +200,6 @@
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.0",
         "tailwindcss": "^4.1.17",
-        "typescript": "^5.9.2",
         "vite": "^7.3.6",
       },
     },
@@ -226,7 +222,6 @@
       "devDependencies": {
         "@types/bun": "^1.3.5",
         "drizzle-kit": "^0.31.10",
-        "typescript": "^5.9.2",
       },
     },
     "apps/server": {
@@ -277,7 +272,6 @@
         "drizzle-kit": "^0.31.10",
         "pino-pretty": "^13.1.3",
         "puppeteer": "^25.3.0",
-        "typescript": "^5.9.3",
       },
     },
     "packages/agent-mcp-manager": {
@@ -320,7 +314,6 @@
       "devDependencies": {
         "@types/bun": "^1.3.5",
         "@types/node": "^24.13.3",
-        "typescript": "^5.9.3",
       },
     },
     "packages/cdp-protocol": {
@@ -346,7 +339,6 @@
         "@remotion/renderer": "^4.0.400",
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.0",
-        "typescript": "^5.9.3",
       },
     },
     "packages/shared": {
@@ -1758,21 +1750,45 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260622.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260622.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260622.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260622.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260622.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260622.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260622.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260622.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-t4XoYz/Jr1Jt7wkaHwe4e/r3OcYgKxvL0dqfZsnBmqG8HsJ57VpOwd0PINU5b5umcb4g9akVto028L70lAJUpA=="],
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260622.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-g/fjmdh/i/ngSmUeWNHh98iuONzW+kUaqwZRaZCmGkssBJ6ZrJAsyg85cm1t4aK9ne5nNjbjNPzJFTZ+QNMSRw=="],
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260622.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-AqRrnPQCR+7j6u6uC6eQpacJ/btxZW6ktpWxPj7byoyk6kGSSgUb0YNcZ2Iao2brdbYw4LOxVcrVW4mP+K7sxg=="],
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260622.1", "", { "os": "linux", "cpu": "arm" }, "sha512-XnDHJZWFY2M8DCzxXj598Ql9op+zYpk6k5X3FYB4KeOXpdzjAke2H9wKW7UKeYfvPJyAgvyS+IapcvogCwx13A=="],
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260622.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-sxo7AlhQiX5J5WYWBxSBjJ02nA2kiO8j+K51fuF24nmbQRtSLjTa8/BimpYbBywTAsSps8vgnJjsLONf243HYw=="],
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260622.1", "", { "os": "linux", "cpu": "x64" }, "sha512-41TR69UuB1be2DmjcavcUMoFipIQNVpqsm1FvVCtGnscL41pDa/ijXHnSwzn7v8EbCgAI7hRUhRsPNPGY3OCKQ=="],
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260622.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-TMdYylCqBvQOVz6x5dT1HQ/49eLBijNE/uMGD2CA3YR4Hp4NkG+Rqg46NZiaO48D2+sjZws2uoNtPhfefN9IdA=="],
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260622.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ROz8ncFZsMC2nn8ClBZ3wLNXpea6BbdMYyNTWx8xYrikhOIgFlkmAdc10PA/MiOh78RraUbdWvwbXNe19He+iQ=="],
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
@@ -3852,7 +3868,7 @@
 
     "typedoc": ["typedoc@0.28.20", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.23.0", "lunr": "^2.3.9", "markdown-it": "^14.3.0", "minimatch": "^10.2.5", "yaml": "^2.9.0" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -88,13 +88,12 @@
     "@sentry/cli": "^3.6.0",
     "@types/bun": "^1.3.14",
     "@types/node": "^24.13.3",
-    "@typescript/native-preview": "^7.0.0-dev.20260619.1",
     "commander": "^14.0.3",
     "fallow": "^2.104.0",
     "lefthook": "^2.1.10",
     "picocolors": "^1.1.1",
     "typedoc": "^0.28.20",
-    "typescript": "^5.9.3",
+    "typescript": "^7.0.2",
     "yaml": "2.9.0"
   },
   "trustedDependencies": [

--- a/packages/browseros-agent/packages/build-server-tools/package.json
+++ b/packages/browseros-agent/packages/build-server-tools/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.5",
-    "@types/node": "^24.13.3",
-    "typescript": "^5.9.3"
+    "@types/node": "^24.13.3"
   }
 }

--- a/packages/browseros-agent/packages/onboarding-video/package.json
+++ b/packages/browseros-agent/packages/onboarding-video/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
-    "typescript": "^5.9.3",
     "@remotion/cli": "^4.0.490",
     "@remotion/bundler": "^4.0.400",
     "@remotion/renderer": "^4.0.400"

--- a/packages/browseros-agent/scripts/codegen/cdp-protocol.ts
+++ b/packages/browseros-agent/scripts/codegen/cdp-protocol.ts
@@ -9,11 +9,16 @@ import {
 } from './lib/protocol-api-emitter'
 import { parseProtocol } from './lib/protocol-parser'
 
-const PROTOCOL_PATH = process.env.CDP_PROTOCOL_JSON
-if (!PROTOCOL_PATH) {
-  console.error('Set CDP_PROTOCOL_JSON to the path of browser_protocol.json')
-  process.exit(1)
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    console.error(`Set ${name} to the path of browser_protocol.json`)
+    process.exit(1)
+  }
+  return value
 }
+
+const PROTOCOL_PATH = requireEnv('CDP_PROTOCOL_JSON')
 const OUT_DIR = join(import.meta.dir, '../../packages/cdp-protocol')
 const GEN_DIR = join(OUT_DIR, 'src/generated')
 const DOMAINS_DIR = join(GEN_DIR, 'domains')

--- a/packages/browseros-agent/scripts/tsconfig.json
+++ b/packages/browseros-agent/scripts/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": ".",
     "types": ["bun"]
   },
-  "include": ["./**/*.ts", "./**/*.js"]
+  "include": ["./**/*.ts", "./**/*.js", "./**/*.mjs"]
 }

--- a/packages/browseros-agent/tsconfig.json
+++ b/packages/browseros-agent/tsconfig.json
@@ -23,7 +23,8 @@
     "useUnknownInCatchVariables": false,
     "composite": true,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "types": ["node", "bun"]
   },
   "references": [
     { "path": "./packages/agent-mcp-manager" },


### PR DESCRIPTION
## Summary

`typescript@7.0.2` (the Go-native compiler) is now the stable `latest` on npm. This migrates the whole `packages/browseros-agent` workspace onto it and retires the hybrid preview state (classic `typescript@5.9` for most packages + `@typescript/native-preview`'s `tsgo` for `apps/app`).

`bun run typecheck` is green across all 13 workspace packages on 7.0.2 — the WXT extensions (`app`, `claw-app`), the Remotion package, and the bun/Hono servers included.

## The one real gotcha

The root `tsconfig` set no `types` array and relied on classic TypeScript implicitly including every visible `@types/*`. The native compiler does **not** do that implicit auto-inclusion in this hoisted bun workspace, so packages without an explicit `types` array lost their ambient globals (`process`, `node:*`, `Bun`, `bun:test`, `bun:sqlite`) — dozens of spurious "Cannot find name" errors. `apps/app` was already green on the native preview only because it is a browser extension that never uses those globals.

Fix: a single root default `"types": ["node", "bun"]`, inherited by the seven packages that extend root without their own `types` (which already brought them from ~40/~16 native errors to zero). Packages that set their own `types` are unaffected.

## Commits (each keeps `bun run typecheck` green)

1. **`chore(ts): set an explicit root types default`** — the root `types` default; no-op on classic 5.9, makes every tsconfig native-ready.
2. **`chore(ts)!: adopt the TypeScript 7.0.2 native compiler`** — `typescript` ^5.9.3 → ^7.0.2; drop `@typescript/native-preview` and the seven redundant per-package `typescript` pins; `apps/app` `tsgo`→`tsc`; remove `baseUrl` from `claw-app`/`claw-onboard` (TS 7 removed the option, TS5102); two small `scripts/` fixes (`.mjs` in the include glob + a `requireEnv` helper so an env value types as `string`).
3. **`docs: note the native TypeScript 7 compiler`** — documents the explicit-`types` requirement so a future package doesn't look green in-editor but fail CI.

## What did NOT need changing

- **CI**: the typecheck job's `bun ci` pulls the native `typescript@7` platform binary from the lockfile automatically — the same mechanism `apps/app`'s `tsgo` already used. No workflow edit.
- **Editor**: the repo never pinned `typescript.tsdk`, and `typescript@7` ships no `tsserver`, so VS Code keeps using its bundled TypeScript for editing. Adding a `tsdk` pointer would break it; deliberately left alone.
- **Source behaviour**: this is a toolchain migration. The only `.ts` change is the `scripts/` codegen helper, which is behaviour-identical.

## Verification

- `bun run typecheck` → all 13 packages exit 0 on 7.0.2.
- `bun install --frozen-lockfile` → in sync (CI's `bun ci` will pass).
- `biome ci` unaffected (TypeScript-version-independent); changed files are biome-clean.
- No `tsc` emit and no `tsc -b` build-mode anywhere, so there are no output/declaration-parity concerns; every typecheck is `--noEmit`.