### PR TITLE
fix(ci): stabilize claw-mcp browser contract setup

### DIFF
--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-tabs.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-tabs.ts
@@ -1,7 +1,8 @@
 /**
  * tabs (6), tab_groups (6) and windows (5) cases. Page/window handles
- * these cases open are cleaned up per case; group effects are observed
- * through the tools themselves (`tab_groups list` is the read-back).
+ * these cases open are cleaned up per case when that is part of the
+ * behavior under test; group effects are observed through the tools
+ * themselves (`tab_groups list` is the read-back).
  */
 
 import type { ContractCase } from './cases'
@@ -58,14 +59,15 @@ export const tabsCases: ContractCase[] = [
     name: 'tabs: active reports the focused page',
     async run(ctx) {
       const page = await ctx.openPage(ctx.fixture('/form.html'))
-      const text = expectOk(
-        await ctx.mcp.callTool('tabs', { action: 'active' }),
-        'tabs active',
-      )
-      ctx.record(
-        'tabs:active-reports-page',
-        text.includes('/form.html') || text.includes(`${page}`),
-      )
+      let text = ''
+      await waitUntil(async () => {
+        text = expectOk(
+          await ctx.mcp.callTool('tabs', { action: 'active' }),
+          'tabs active',
+        )
+        return text.includes('/form.html') || text.includes(`${page}`)
+      }, 'active tab to report the focused form page')
+      ctx.record('tabs:active-reports-page', true)
     },
   },
   {
@@ -281,7 +283,9 @@ export const tabsCases: ContractCase[] = [
       )
       const windowId = Number(created.match(/\b(\d+)\b/)?.[1])
       ctx.record('windows:create-returns-id', Number.isFinite(windowId))
-      await ctx.mcp.callTool('windows', { action: 'close', windowId })
+      // Closing this hidden window crashes BrowserClaw on the macOS CI runner
+      // (BrowserClaw-2026-07-21-023231/024222.ips fault in -[NSWindow _close]).
+      // This case asserts creation; run teardown owns the hidden-window cleanup.
     },
   },
   {

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cross-server.test.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cross-server.test.ts
@@ -125,7 +125,11 @@ function makeContext(run: ServerRun): CaseContext {
     fixture: (path) => pair.primary.url(path),
     fixture2: (path) => pair.secondary.url(path),
     async openPage(url, session = run.mcp) {
-      const result = await session.callTool('tabs', { action: 'new', url })
+      const result = await session.callTool('tabs', {
+        action: 'new',
+        url,
+        background: false,
+      })
       if (result.isError) {
         throw new Error(`tabs new failed: ${textOf(result)}`)
       }


### PR DESCRIPTION
## Summary
- Stop closing the hidden window created by the `windows: create` contract case; BrowserClaw crash reports from the self-hosted macOS runner (`BrowserClaw-2026-07-21-023231.ips` and `024222.ips`) show SIGSEGV on the main thread in `-[NSWindow _close]` immediately after that cleanup.
- Make the contract `openPage()` helper request foreground tabs explicitly (`background: false`) so `tabs: active` asserts a focused page instead of depending on tool defaults.
- Keep the active-tab case as a readiness assertion: it waits for the focused page to be observable and still fails if it never appears.

## Verification
- `git diff --check`
- Focused signed-DMG contract check: `BROWSEROS_BINARY=<BrowserClaw 0.47.22 DMG mount> BROWSEROS_TEST_HEADLESS=true bun test --test-name-pattern 'tabs: active' contracts/claw-mcp/tests/cross-server.test.ts` -> 2 pass, 0 fail
- Full signed-DMG contract suite: `BROWSEROS_BINARY=<BrowserClaw 0.47.22 DMG mount> BROWSEROS_TEST_HEADLESS=true bun contracts/claw-mcp/tests/run.ts` -> 205 pass, 0 fail
