### PR TITLE
fix(browserclaw): avoid double-closing CDP windows

### DIFF
--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-tabs.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-tabs.ts
@@ -283,9 +283,10 @@ export const tabsCases: ContractCase[] = [
       )
       const windowId = Number(created.match(/\b(\d+)\b/)?.[1])
       ctx.record('windows:create-returns-id', Number.isFinite(windowId))
-      // Closing this hidden window crashes BrowserClaw on the macOS CI runner
-      // (BrowserClaw-2026-07-21-023231/024222.ips fault in -[NSWindow _close]).
-      // This case asserts creation; run teardown owns the hidden-window cleanup.
+      expectOk(
+        await ctx.mcp.callTool('windows', { action: 'close', windowId }),
+        'windows close hidden',
+      )
     },
   },
   {

--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
@@ -704,7 +704,9 @@ index 30bd52d09c3fc..5ef348c475174 100644
 +  if (!bwi) {
 +    return Response::ServerError("Browser window not found");
 +  }
-+  bwi->GetTabStripModel()->CloseAllTabs();
++  // BrowserWindow::Close owns the full Browser/TabStripModel teardown. Calling
++  // CloseAllTabs() first can synchronously start native-window destruction; a
++  // second close against the same BrowserWindowInterface crashes on macOS.
 +  bwi->GetWindow()->Close();
 +  return Response::Success();
 +}


### PR DESCRIPTION
## Summary
- Fix BrowserClaw custom CDP `Browser.closeWindow` to avoid calling `CloseAllTabs()` before native window close. The failing nightly crash reports faulted in `-[NSWindow _close]` immediately after a contract `windows close`; the old command could start teardown by closing the last tab and then close the same native window again.
- Restore the hidden-window close in the claw-mcp contract so the next signed nightly proves the browser-side close path instead of preserving a workaround.

## Evidence
- Run 29823571808 failed after `windows: activate` passed, then cascaded with `CDP not connected`; local crash report `BrowserClaw-2026-07-21-051051.ips` shows `EXC_BAD_ACCESS` on the main thread in `-[NSWindow _close]` at the same timestamp.
- `/Users/shadowfax/code/chromium-release/src/chrome/browser/devtools/protocol/browser_handler.cc` currently contains the old double-close sequence this patch replaces.

## Verification
- `git diff --check`
- `cd packages/browseros && uv run browseros dev doctor --feature cdp-api`
- `cd packages/browseros-agent && bun test --test-name-pattern 'windows:' contracts/claw-mcp/tests/cross-server.test.ts` (syntax harness only here: no `BROWSEROS_BINARY`, so Bun skips contract cases)

## Next
After merge, dispatch `nightly-browserclaw.yml` on main and verify the signed DMG contract suite goes green with Rust server staging/signing.