### PR TITLE
fix(browserclaw): keep browser handler patch length in sync

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
@@ -611,7 +611,7 @@ index 30bd52d09c3fc..5ef348c475174 100644
  Response BrowserHandler::GetWindowBounds(
      int window_id,
      std::unique_ptr<protocol::Browser::Bounds>* out_bounds) {
-@@ -297,3 +850,810 @@ protocol::Response BrowserHandler::AddPrivacySandboxEnrollmentOverride(
+@@ -297,3 +850,812 @@ protocol::Response BrowserHandler::AddPrivacySandboxEnrollmentOverride(
        net::SchemefulSite(url_to_add));
    return Response::Success();
  }


### PR DESCRIPTION
## Summary
- fix the inner Chromium patch hunk length after the Browser.closeWindow double-close change
- preserve the generated BrowserHandler::MoveTabGroup return/closing brace when the patch applies during the nightly build

## Verification
- git diff --check
- uv run browseros dev doctor --feature cdp-api
- applied the stored browser_handler.cc patch to a temporary Chromium base file and confirmed MoveTabGroup ends with return Response::Success(); and }