### PR TITLE
fix(browserclaw): keep hidden CDP windows headless

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
@@ -229,7 +229,7 @@ index 30bd52d09c3fc..5ef348c475174 100644
 +                                    bool hidden,
 +                                    bool activate) {
 +  if (hidden) {
-+    window->ShowInactive();
++    // Headless Browser windows must stay unshown.
 +    return;
 +  }
 +  if (activate) {
@@ -687,8 +687,9 @@ index 30bd52d09c3fc..5ef348c475174 100644
 +  GURL navigate_url = url.has_value() ? GURL(url.value()) : GURL();
 +  chrome::AddTabAt(browser, navigate_url, -1, true);
 +
-+  browser->window()->Show();
-+
++  if (!want_hidden) {
++    browser->window()->Show();
++  }
 +  BrowserWindowInterface* bwi = GetBrowserWindowInterface(
 +      browser->session_id().id());
 +  if (!bwi) {


### PR DESCRIPTION
## Summary
- keep BrowserClaw hidden/headless CDP Browser windows out of the Show/ShowInactive lifecycle
- route window creation through the visibility helper so visible windows still show/activate while hidden windows remain unshown
- addresses the macOS crash that drops CDP immediately after `windows: create opens a hidden window` in nightly contract runs

## Verification
- `git diff --check`
- `uv run browseros dev doctor --feature cdp-api` from `packages/browseros`
- applied the stored `browser_handler.cc` patch to a clean Chromium base copied from `git show HEAD:...` and inspected generated source
