### PR TITLE
fix(browserclaw): restore contract suite and patch length

### DIFF
--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -247,6 +247,65 @@ jobs:
             --notes-file "$notes_file" \
             "${files[@]}"
 
+      # Runs after the artifact is uploaded and the prerelease is published,
+      # so a red suite pings Slack (below) without blocking the nightly
+      # build. Mounts the just-built DMG and drives both claw servers'
+      # /mcp against that real browser.
+      - name: Run claw-mcp cross-server contract suite
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          if ! command -v cargo >/dev/null 2>&1; then
+            echo "::error::cargo is required to build claw-server-rust for the claw-mcp contract suite; install the Rust toolchain on this runner"
+            exit 1
+          fi
+
+          agent_root="$BROWSEROS_REPO/packages/browseros-agent"
+          dmgs=("$BROWSEROS_REPO"/packages/browseros/releases/"$VERSION"/BrowserClaw_*.dmg)
+          if [ "${#dmgs[@]}" -eq 0 ]; then
+            echo "::error::No BrowserClaw DMG found to test"
+            exit 1
+          fi
+
+          mount_point="$(mktemp -d)"
+          exe=""
+          cleanup() {
+            # Reap only the browser launched from this mounted DMG before
+            # releasing the mount, so concurrent contract runs are not killed.
+            if [ -n "$exe" ]; then
+              pkill -f "$exe" 2>/dev/null || true
+            fi
+            hdiutil detach "$mount_point" -quiet 2>/dev/null \
+              || hdiutil detach "$mount_point" -force -quiet 2>/dev/null || true
+            rmdir "$mount_point" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          hdiutil attach "${dmgs[0]}" -nobrowse -readonly -mountpoint "$mount_point"
+
+          app="$(/usr/bin/find "$mount_point" -maxdepth 1 -name '*.app' -print -quit)"
+          if [ -z "$app" ]; then
+            echo "::error::No .app bundle inside the mounted DMG"
+            exit 1
+          fi
+          # Resolve the real entrypoint via CFBundleExecutable rather than the
+          # first file in MacOS/, which could be a helper binary.
+          exe_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app/Contents/Info.plist" 2>/dev/null || true)"
+          exe="$app/Contents/MacOS/$exe_name"
+          if [ -z "$exe_name" ] || [ ! -x "$exe" ]; then
+            echo "::error::Could not resolve the BrowserClaw executable inside the DMG"
+            exit 1
+          fi
+          echo "Testing against $exe"
+
+          cd "$agent_root"
+          BROWSEROS_BINARY="$exe" \
+          BROWSEROS_TEST_HEADLESS=true \
+            bun contracts/claw-mcp/tests/run.ts
+
       - name: Slack failure ping
         if: ${{ failure() }}
         env:

--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
@@ -611,7 +611,7 @@ index 30bd52d09c3fc..5ef348c475174 100644
  Response BrowserHandler::GetWindowBounds(
      int window_id,
      std::unique_ptr<protocol::Browser::Bounds>* out_bounds) {
-@@ -297,3 +850,812 @@ protocol::Response BrowserHandler::AddPrivacySandboxEnrollmentOverride(
+@@ -297,3 +850,813 @@ protocol::Response BrowserHandler::AddPrivacySandboxEnrollmentOverride(
        net::SchemefulSite(url_to_add));
    return Response::Success();
  }


### PR DESCRIPTION
## Summary
- update the stored `browser_handler.cc` hunk length from `+812` to `+813` so the generated Chromium source keeps the final `MoveTabGroup` closing brace
- restore the `Run claw-mcp cross-server contract suite` nightly step that mounts the signed DMG and drives both claw servers through `contracts/claw-mcp/tests/run.ts`

## Verification
- `git diff --check`
- `uv run browseros dev doctor --feature cdp-api` from `packages/browseros`
- applied the stored `browser_handler.cc` patch to a clean Chromium base copied from `git show HEAD:...` and inspected generated `MoveTabGroup` through its closing brace
- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/nightly-browserclaw.yml\")"`

## Nightly context
- Follow-up for failed workflow_dispatch run 29844434547: build failed at `browser_handler.cc:1661:30: expected }` because the generated hunk was truncated.
- Also reverses #1924 for this workflow because this task requires a signed DMG verified by the cross-server contract suite.
