### PR TITLE
fix(claw): raise recording ingest limit to 16 MiB

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
@@ -55,12 +55,11 @@ pub fn router(state: AppState) -> Router<AppState> {
             "/api/v1/sessions/{session_id}/recording/events",
             get(replay::download_events)
                 .post(recordings::append_legacy_events)
-                .layer(DefaultBodyLimit::max(RECORDING_INGEST_MAX_BYTES)),
+                .layer(DefaultBodyLimit::disable()),
         )
         .route(
             "/api/v1/recordings/events",
-            post(recordings::append_document_events)
-                .layer(DefaultBodyLimit::max(RECORDING_INGEST_MAX_BYTES)),
+            post(recordings::append_document_events).layer(DefaultBodyLimit::disable()),
         )
         .route(
             "/api/v1/dispatches/{dispatch_id}/screenshot",

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
@@ -26,7 +26,7 @@ mod sessions;
 mod settings;
 mod system;
 
-pub(super) const RECORDING_INGEST_MAX_BYTES: usize = 4 * 1024 * 1024;
+pub(super) const RECORDING_INGEST_MAX_BYTES: usize = 16 * 1024 * 1024;
 
 pub fn router(state: AppState) -> Router<AppState> {
     Router::new()
@@ -55,11 +55,12 @@ pub fn router(state: AppState) -> Router<AppState> {
             "/api/v1/sessions/{session_id}/recording/events",
             get(replay::download_events)
                 .post(recordings::append_legacy_events)
-                .layer(DefaultBodyLimit::disable()),
+                .layer(DefaultBodyLimit::max(RECORDING_INGEST_MAX_BYTES)),
         )
         .route(
             "/api/v1/recordings/events",
-            post(recordings::append_document_events).layer(DefaultBodyLimit::disable()),
+            post(recordings::append_document_events)
+                .layer(DefaultBodyLimit::max(RECORDING_INGEST_MAX_BYTES)),
         )
         .route(
             "/api/v1/dispatches/{dispatch_id}/screenshot",

--- a/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
@@ -697,6 +697,34 @@ async fn canonical_sessions_cancel_and_recordings() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn recording_ingest_accepts_bodies_larger_than_ten_mebibytes() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let headers = [
+        ("x-recording-tab-id", "101"),
+        (
+            "x-recording-document-id",
+            "33D25F3CF060E81B14070BC356FF1871",
+        ),
+        ("x-recording-batch-id", "large-batch"),
+    ];
+    let body = format!("{{\"ts\":100}}\n{}", " ".repeat(10 * 1024 * 1024));
+
+    let (status, _, bytes) = request_with_headers(
+        &app.router,
+        "POST",
+        "/api/v1/recordings/events",
+        Some("application/x-ndjson"),
+        &headers,
+        body,
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json_body(&bytes)?, json!({ "accepted": 1 }));
+    Ok(())
+}
+
 struct LiveFixture {
     primary: Arc<Session>,
     second: Arc<Session>,

--- a/packages/browseros-agent/packages/shared/src/constants/browserclaw.test.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/browserclaw.test.ts
@@ -17,7 +17,7 @@ describe('BrowserClaw runtime constants', () => {
   })
 
   test('preserves recording ingest ceilings', () => {
-    expect(RECORDING_INGEST_MAX_BYTES).toBe(4 * 1024 * 1024)
+    expect(RECORDING_INGEST_MAX_BYTES).toBe(16 * 1024 * 1024)
     expect(RECORDING_INGEST_FALLBACK_MAX_BYTES).toBe(2 * 1024 * 1024)
   })
 

--- a/packages/browseros-agent/packages/shared/src/constants/limits.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/limits.ts
@@ -6,7 +6,7 @@
  * Centralized limits and thresholds.
  */
 
-export const RECORDING_INGEST_MAX_BYTES = 4 * 1024 * 1024
+export const RECORDING_INGEST_MAX_BYTES = 16 * 1024 * 1024
 /** Aggregate target used until a server explicitly advertises a larger ceiling. */
 export const RECORDING_INGEST_FALLBACK_MAX_BYTES = 2 * 1024 * 1024
 


### PR DESCRIPTION
## Summary
- raise the shared recording ingest ceiling from 4 MiB to 16 MiB
- keep the Rust and TypeScript canonical servers, advertised capability, and recorder aligned
- cover Rust ingestion with a real request larger than 10 MiB

## Design
Keep the route-scoped Axum limit and raise the shared ceiling uniformly. Removing the Rust layer alone would restore Axum's 2 MiB default if deleted outright, or break cross-server contract parity if disabled; an unbounded String extractor would also allow unbounded allocation.

## Test plan
- [x] cargo fmt --all --check
- [x] cargo check --locked -p claw-server-rust --all-targets
- [x] cargo test --locked -p claw-server-rust
- [x] bun test packages/shared/src/constants/browserclaw.test.ts
- [x] bunx biome check packages/shared/src/constants/limits.ts packages/shared/src/constants/browserclaw.test.ts
- [x] bun run test:claw-api-contract