### PR TITLE
refactor: remove legacy recording ingest

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
@@ -53,9 +53,7 @@ pub fn router(state: AppState) -> Router<AppState> {
         )
         .route(
             "/api/v1/sessions/{session_id}/recording/events",
-            get(replay::download_events)
-                .post(recordings::append_legacy_events)
-                .layer(DefaultBodyLimit::max(RECORDING_INGEST_MAX_BYTES)),
+            get(replay::download_events),
         )
         .route(
             "/api/v1/recordings/events",
@@ -179,7 +177,7 @@ pub async fn request_context(mut req: Request, next: Next) -> Response {
             headers.insert(
                 header::ACCESS_CONTROL_ALLOW_HEADERS,
                 HeaderValue::from_static(
-                    "accept,content-type,authorization,mcp-session-id,mcp-protocol-version,last-event-id,x-recording-batch-id,x-recording-tab-id,x-recording-document-id,x-recording-has-gap,x-recording-page-id,x-recording-target-id",
+                    "accept,content-type,authorization,mcp-session-id,mcp-protocol-version,last-event-id,x-recording-batch-id,x-recording-tab-id,x-recording-document-id,x-recording-has-gap",
                 ),
             );
         }

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/recordings.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/recordings.rs
@@ -2,16 +2,14 @@ use super::{error, internal};
 use crate::{
     AppState,
     error::{CanonicalError, RequestId},
-    ids::SessionId,
     services::recordings::RecordingEventInput,
 };
 use axum::{
     Extension, Json,
-    extract::{Path, State, rejection::StringRejection},
+    extract::{State, rejection::StringRejection},
     http::{HeaderMap, StatusCode, header},
 };
 use claw_api::models::AppendRecordingEventsResponse;
-use uuid::Uuid;
 
 pub(super) async fn append_document_events(
     Extension(request_id): Extension<RequestId>,
@@ -50,86 +48,6 @@ pub(super) async fn append_document_events(
     } else {
         0
     })))
-}
-
-pub(super) async fn append_legacy_events(
-    Extension(request_id): Extension<RequestId>,
-    State(state): State<AppState>,
-    Path(session_id): Path<String>,
-    headers: HeaderMap,
-    body: Result<String, StringRejection>,
-) -> Result<Json<AppendRecordingEventsResponse>, CanonicalError> {
-    let body = recording_body(&request_id, body)?;
-    let session_key = SessionId::new(session_id.clone());
-    if !state.sessions.contains(&session_key).await {
-        let known = state
-            .audit_log
-            .get_task(&session_id)
-            .await
-            .map_err(|source| internal(&request_id, source))?
-            .is_some();
-        return Err(if known {
-            error(
-                &request_id,
-                StatusCode::GONE,
-                "session_ended",
-                "session has ended",
-            )
-        } else {
-            error(
-                &request_id,
-                StatusCode::NOT_FOUND,
-                "session_not_found",
-                "session not found",
-            )
-        });
-    }
-    require_ndjson(&request_id, &headers)?;
-    let tab_id = positive_recording_header(&request_id, &headers, "x-recording-tab-id")?;
-    let page_id = positive_recording_header(&request_id, &headers, "x-recording-page-id")?;
-    let target_id = recording_target_header(&request_id, &headers)?;
-    let parsed = parse_recording_events(&body);
-    // Batches are pinned to the (tab, page, target) incarnation the
-    // recorder captured them from. Any drift — the tab reclaimed by
-    // another session, a navigation that swapped the target — makes the
-    // batch undeliverable rather than attributing its events to the
-    // wrong replay; the 409 tells the recorder to drop its association.
-    let Some(target) = state.live_tab_activity().await.into_iter().find(|tab| {
-        tab.session_id == session_id
-            && tab.tab_id == tab_id
-            && i64::from(tab.page_id) == page_id
-            && tab.target_id == target_id
-    }) else {
-        return Err(error(
-            &request_id,
-            StatusCode::CONFLICT,
-            "recording_association_changed",
-            "recording tab association changed",
-        ));
-    };
-    let batch_id = headers
-        .get("x-recording-batch-id")
-        .and_then(|value| value.to_str().ok())
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-        .unwrap_or_else(|| Uuid::new_v4().to_string());
-    let appended = state
-        .recordings
-        .append_legacy_batch(
-            &target.target_id,
-            target.tab_id,
-            &parsed.events,
-            &batch_id,
-            parsed.dropped_lines > 0,
-        )
-        .await
-        .map_err(|source| internal(&request_id, source))?;
-    let accepted = if appended {
-        i64::try_from(parsed.events.len()).unwrap_or(i64::MAX)
-    } else {
-        0
-    };
-    Ok(Json(AppendRecordingEventsResponse::new(accepted)))
 }
 
 /// Tolerant parse of recorder-supplied NDJSON: lines that are not JSON
@@ -269,23 +187,4 @@ fn positive_recording_header(
             )
         })?;
     Ok(value)
-}
-
-fn recording_target_header(
-    request_id: &RequestId,
-    headers: &HeaderMap,
-) -> Result<String, CanonicalError> {
-    headers
-        .get("x-recording-target-id")
-        .and_then(|value| value.to_str().ok())
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-        .ok_or_else(|| {
-            error(
-                request_id,
-                StatusCode::BAD_REQUEST,
-                "invalid_request",
-                "recording tab, page, and target headers are required",
-            )
-        })
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
@@ -92,25 +92,6 @@ impl RecordingStore {
         result
     }
 
-    pub async fn append_legacy_batch(
-        &self,
-        target_id: &str,
-        tab_id: i64,
-        events: &[RecordingEventInput],
-        batch_id: &str,
-        has_gap: bool,
-    ) -> AppResult<bool> {
-        self.append_batch(
-            &legacy_document_id(target_id),
-            tab_id,
-            Some(target_id),
-            events,
-            batch_id,
-            has_gap,
-        )
-        .await
-    }
-
     async fn append_locked(
         &self,
         document_id: &str,

--- a/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
@@ -599,22 +599,22 @@ async fn canonical_sessions_cancel_and_recordings() -> anyhow::Result<()> {
     assert_eq!(metadata["complete"], true);
     assert_eq!(metadata["tabs"].as_array().map(Vec::len), Some(2));
 
-    let stale_headers = [
+    let legacy_headers = [
         ("x-recording-tab-id", "102"),
         ("x-recording-page-id", "8"),
-        ("x-recording-target-id", "target-7"),
+        ("x-recording-target-id", "target-8"),
     ];
     let (status, _, bytes) = request_with_headers(
         &app.router,
         "POST",
         "/api/v1/sessions/session-live/recording/events",
         Some("application/x-ndjson"),
-        &stale_headers,
-        "{\"ts\":175}\n",
+        &legacy_headers,
+        "{\"ts\":175,\"data\":{\"id\":\"legacy-write\"}}\n",
     )
     .await?;
-    assert_eq!(status, StatusCode::CONFLICT);
-    assert_eq!(json_body(&bytes)?["code"], "recording_association_changed");
+    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+    assert!(bytes.is_empty());
 
     let (status, headers, bytes) = request(
         &app.router,
@@ -633,6 +633,7 @@ async fn canonical_sessions_cancel_and_recordings() -> anyhow::Result<()> {
     );
     let events = String::from_utf8(bytes)?;
     assert_eq!(events.matches("session-live").count(), 3);
+    assert!(!events.contains("legacy-write"));
     assert!(events.contains("33D25F3CF060E81B14070BC356FF1871"));
     assert!(events.contains("8395FF2EF4A1D8579F1917B3B54ADECE"));
     let seven_a = events
@@ -681,8 +682,8 @@ async fn canonical_sessions_cancel_and_recordings() -> anyhow::Result<()> {
         "{\"ts\":300}\n",
     )
     .await?;
-    assert_eq!(status, StatusCode::GONE);
-    assert_eq!(json_body(&bytes)?["code"], "session_ended");
+    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+    assert!(bytes.is_empty());
 
     let (status, _, bytes) = request(
         &app.router,

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -1160,7 +1160,7 @@ async fn live_projection_filters_external_close_and_screencast_frame() -> anyhow
         .header("x-recording-target-id", "target-old")
         .body(Body::from("{\"ts\":1}\n"))?;
     let recording_response = app.router.clone().oneshot(recording_request).await?;
-    assert_eq!(recording_response.status(), StatusCode::CONFLICT);
+    assert_eq!(recording_response.status(), StatusCode::METHOD_NOT_ALLOWED);
 
     let (status, body) =
         request_json(&app.router, "GET", "/api/v1/sessions?status=live", None).await?;

--- a/packages/browseros-agent/apps/claw-server/src/routes/api-v1/index.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/api-v1/index.ts
@@ -32,9 +32,8 @@ export interface BinaryAsset {
 /**
  * `live` — an MCP transport is still attached; `ended` — the transport
  * is gone but audit history remains; `missing` — unknown id. The
- * distinction drives the canonical status split: for an ended session,
- * cancel answers 409 and recording ingest 410; both answer 404 for a
- * missing one.
+ * distinction drives cancellation semantics: ended sessions answer 409,
+ * while missing sessions answer 404.
  */
 export type SessionState = 'live' | 'ended' | 'missing'
 
@@ -47,12 +46,6 @@ export interface CanonicalSessionQuery {
   since?: number
   cursor?: number
   limit?: number
-}
-
-export interface RecordingAssociation {
-  tabId: number
-  pageId: number
-  targetId: string
 }
 
 export interface RecordingIdentity {
@@ -82,13 +75,6 @@ export interface CanonicalApiDependencies {
     batchId: string,
     hasGap: boolean,
   ): Promise<AppendRecordingEventsResponse>
-  /** Undocumented compatibility path for the already-shipped session-aware extension. */
-  appendLegacyRecordingEvents(
-    sessionId: string,
-    association: RecordingAssociation,
-    ndjson: string,
-    batchId?: string,
-  ): Promise<AppendRecordingEventsResponse | null>
   getSessionBrowserTabPreview(
     sessionId: string,
     browserTabId: number,
@@ -189,58 +175,6 @@ export function createCanonicalApiRoute(deps: CanonicalApiDependencies) {
       ),
     )
   })
-  app.post(
-    '/api/v1/sessions/:sessionId/recording/events',
-    recordingBodyLimit(),
-    async (c) => {
-      const sessionId = c.req.param('sessionId')
-      const state = deps.getSessionState(sessionId)
-      if (state === 'missing') {
-        return apiError(c, 404, 'session_not_found', 'session not found')
-      }
-      if (state === 'ended') {
-        return apiError(c, 410, 'session_ended', 'session has ended')
-      }
-      const contentType = c.req.header('content-type') ?? ''
-      if (!contentType.toLowerCase().startsWith('application/x-ndjson')) {
-        return apiError(
-          c,
-          400,
-          'invalid_request',
-          'content-type must be application/x-ndjson',
-        )
-      }
-      // Compatibility for recorder builds that pinned a batch to the live
-      // (tab, page, target) tuple. New recorders use the document-keyed route.
-      const tabId = positiveInteger(c.req.header('x-recording-tab-id') ?? '')
-      const pageId = positiveInteger(c.req.header('x-recording-page-id') ?? '')
-      const targetId = c.req.header('x-recording-target-id')
-      if (tabId === null || pageId === null || !targetId) {
-        return apiError(
-          c,
-          400,
-          'invalid_request',
-          'recording tab, page, and target headers are required',
-        )
-      }
-      const result = await deps.appendLegacyRecordingEvents(
-        sessionId,
-        { tabId, pageId, targetId },
-        await c.req.text(),
-        c.req.header('x-recording-batch-id'),
-      )
-      if (!result) {
-        return apiError(
-          c,
-          409,
-          'recording_association_changed',
-          'recording tab association changed',
-        )
-      }
-      return c.json(result)
-    },
-  )
-
   app.get(
     '/api/v1/sessions/:sessionId/browser-tabs/:browserTabId/preview',
     async (c) => {

--- a/packages/browseros-agent/apps/claw-server/src/routes/api-v1/production.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/api-v1/production.ts
@@ -26,10 +26,7 @@ import { CLAW_API_PORT_DEFAULT } from '@browseros/shared/constants/ports'
 import { getBrowserSession } from '../../lib/browser-session'
 import { logger } from '../../lib/logger'
 import { identityService } from '../../lib/mcp-session'
-import {
-  type TabActivityRecord,
-  tabActivityRegistry,
-} from '../../lib/tab-activity'
+import { tabActivityRegistry } from '../../lib/tab-activity'
 import { getTabTargetMap } from '../../lib/tab-targets'
 import { getLocalServerUrl } from '../../local-server-url'
 import {
@@ -65,7 +62,7 @@ import {
   type TaskDetail,
 } from '../../services/tasks'
 import { VERSION } from '../../version'
-import type { CanonicalApiDependencies, RecordingAssociation } from '.'
+import type { CanonicalApiDependencies } from '.'
 
 const sessionQueryService = createSessionQueryService({
   listConnectedIdentities: () => identityService.list(),
@@ -175,24 +172,6 @@ export const canonicalApiDependencies: CanonicalApiDependencies = {
     })
     return { accepted: appended ? parsed.events.length : 0 }
   },
-  async appendLegacyRecordingEvents(sessionId, association, ndjson, batchId) {
-    const parsed = parseRecordingEvents(ndjson)
-    const target = recordingTargetFor(
-      tabActivityRegistry.snapshot(),
-      sessionId,
-      association,
-    )
-    if (!target) return null
-    if (parsed.events.length === 0) return { accepted: 0 }
-    const appended = await recordingStore.appendLegacyBatch(
-      target.targetId,
-      target.tabId,
-      parsed.events,
-      batchId ?? crypto.randomUUID(),
-      parsed.droppedLines > 0,
-    )
-    return { accepted: appended ? parsed.events.length : 0 }
-  },
   async getSessionBrowserTabPreview(sessionId, browserTabId) {
     const frame = await sessionQueryService.getSessionBrowserTabPreview(
       sessionId,
@@ -219,27 +198,6 @@ export const canonicalApiDependencies: CanonicalApiDependencies = {
   async disconnectHarness(harness) {
     return connection(await disconnectBrowserosFromHarness(harness))
   },
-}
-
-/**
- * A batch lands only while the recorder's (tab, page, target) claim
- * still matches the live registry for that session. Any drift — the tab
- * reclaimed by another session, a navigation that swapped the target —
- * makes the batch undeliverable rather than attributing its events to
- * the wrong replay. Exported for the route tests.
- */
-export function recordingTargetFor(
-  tabs: TabActivityRecord[],
-  sessionId: string,
-  association: RecordingAssociation,
-): TabActivityRecord | undefined {
-  return tabs.find(
-    (tab) =>
-      tab.sessionId === sessionId &&
-      tab.tabId === association.tabId &&
-      tab.pageId === association.pageId &&
-      tab.targetId === association.targetId,
-  )
 }
 
 function knownSession(sessionId: string): boolean {

--- a/packages/browseros-agent/apps/claw-server/src/services/recordings.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/recordings.ts
@@ -51,13 +51,6 @@ export interface RetentionSweepResult {
 export interface RecordingStore {
   /** Returns false only when this document already durably accepted the batch. */
   appendBatch(input: AppendRecordingBatchInput): Promise<boolean>
-  appendLegacyBatch(
-    targetId: string,
-    tabId: number,
-    events: RecordingEventInput[],
-    batchId: string,
-    hasGap?: boolean,
-  ): Promise<boolean>
   readRange(
     documentId: string,
     from: number,
@@ -246,16 +239,6 @@ export function createRecordingStore(
   return {
     appendBatch(input) {
       return enqueue(input.documentId, () => append(input))
-    },
-    appendLegacyBatch(targetId, tabId, events, batchId, hasGap = false) {
-      return this.appendBatch({
-        documentId: legacyDocumentId(targetId),
-        tabId,
-        targetId,
-        events,
-        batchId,
-        hasGap,
-      })
     },
     readRange: readDocumentRange,
     async readLegacyRange(targetId, from, to) {

--- a/packages/browseros-agent/apps/claw-server/tests/routes/api-v1.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/routes/api-v1.test.ts
@@ -35,7 +35,6 @@ import {
   type CanonicalApiDependencies,
   createCanonicalApiRoute,
 } from '../../src/routes/api-v1'
-import { recordingTargetFor } from '../../src/routes/api-v1/production'
 import { createServer } from '../../src/server'
 import { recordToolDispatch } from '../../src/services/audit-log'
 
@@ -107,7 +106,6 @@ function dependencies(
     getRecording: () => recording,
     downloadRecordingEvents: async () => '',
     appendRecordingEvents: async () => ({ accepted: 2 }),
-    appendLegacyRecordingEvents: async () => ({ accepted: 2 }),
     getSessionBrowserTabPreview: async () => ({
       bytes: new Uint8Array([0xff, 0xd8]),
       etag: '111',
@@ -338,14 +336,14 @@ describe('canonical TypeScript API', () => {
     expect(await upload.json()).toMatchObject({ code: 'forbidden' })
   })
 
-  it('keeps the old session-scoped write as a compatibility route', async () => {
+  it('does not support session-scoped recording writes', async () => {
     const append = mock(async () => ({ accepted: 1 }))
-    const changed = createCanonicalApiRoute(
-      dependencies({ appendLegacyRecordingEvents: async () => null }),
+    const app = createCanonicalApiRoute(
+      dependencies({ appendRecordingEvents: append }),
     )
 
-    const changedResponse = await request(
-      changed,
+    const response = await request(
+      app,
       '/api/v1/sessions/session-live/recording/events',
       {
         method: 'POST',
@@ -358,24 +356,7 @@ describe('canonical TypeScript API', () => {
         body: '{"ts":1}\n',
       },
     )
-    expect(changedResponse.status).toBe(409)
-    expect(await changedResponse.json()).toMatchObject({
-      code: 'recording_association_changed',
-    })
-
-    const ended = createCanonicalApiRoute(
-      dependencies({
-        getSessionState: () => 'ended',
-        appendLegacyRecordingEvents: append,
-      }),
-    )
-    const rejected = await request(
-      ended,
-      '/api/v1/sessions/session-old/recording/events',
-      { method: 'POST', body: '{"ts":1}\n' },
-    )
-    expect(rejected.status).toBe(410)
-    expect(await rejected.json()).toMatchObject({ code: 'session_ended' })
+    expect(response.status).toBe(404)
     expect(append).not.toHaveBeenCalled()
   })
 
@@ -408,48 +389,6 @@ describe('canonical TypeScript API', () => {
       code: 'recording_payload_too_large',
     })
     expect(append).toHaveBeenCalledTimes(1)
-  })
-
-  it('selects the exact recording association in a multi-tab session', () => {
-    const first = {
-      targetId: 'target-7',
-      tabId: 101,
-      pageId: 7,
-      sessionId: 'session-live',
-      agentId: 'codex-one',
-      slug: 'codex',
-      url: 'https://one.example',
-      title: 'One',
-      firstToolAt: 1,
-      lastToolAt: 2,
-      lastToolName: 'snapshot',
-      toolCount: 1,
-      recentTools: [],
-      status: 'active' as const,
-    }
-    const second = {
-      ...first,
-      targetId: 'target-8',
-      tabId: 102,
-      pageId: 8,
-      url: 'https://two.example',
-      title: 'Two',
-    }
-
-    expect(
-      recordingTargetFor([first, second], 'session-live', {
-        tabId: 102,
-        pageId: 8,
-        targetId: 'target-8',
-      }),
-    ).toBe(second)
-    expect(
-      recordingTargetFor([first, second], 'session-live', {
-        tabId: 102,
-        pageId: 8,
-        targetId: 'target-7',
-      }),
-    ).toBeUndefined()
   })
 
   it('serves session-owned previews and immutable dispatch screenshots', async () => {

--- a/packages/browseros-agent/contracts/claw-api/tests/cases.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/cases.ts
@@ -172,6 +172,27 @@ export const contractCases: ContractCase[] = [
     },
   },
   {
+    name: 'session recording ingest is unsupported',
+    async run({ baseUrl, liveSessionId }) {
+      const path = `${baseUrl}/api/v1/sessions/${liveSessionId}/recording/events`
+      const before = await fetch(path).then((response) => response.text())
+      const response = await fetch(path, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-ndjson',
+          'x-recording-tab-id': '101',
+          'x-recording-page-id': '7',
+          'x-recording-target-id': 'target-7',
+        },
+        body: '{"ts":175,"data":{"id":"legacy-write"}}\n',
+      })
+      expect([404, 405]).toContain(response.status)
+      const after = await fetch(path).then((download) => download.text())
+      expect(after).toBe(before)
+      expect(after).not.toContain('legacy-write')
+    },
+  },
+  {
     name: 'recording ingest rejects malformed Chrome document IDs',
     async run({ api }) {
       for (const [index, documentId] of [

--- a/packages/browseros-agent/contracts/claw-api/tests/server-adapters.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/server-adapters.ts
@@ -226,19 +226,6 @@ export async function startTypeScriptServer(): Promise<ContractServer> {
         accepted: ndjson.split('\n').filter((line) => line.trim()).length,
       }
     },
-    async appendLegacyRecordingEvents(_sessionId, association, ndjson) {
-      if (
-        association.tabId !== 101 ||
-        association.pageId !== 7 ||
-        association.targetId !== 'target-7'
-      ) {
-        return null
-      }
-      recordingEvents += ndjson
-      return {
-        accepted: ndjson.split('\n').filter((line) => line.trim()).length,
-      }
-    },
     getSessionBrowserTabPreview: (sessionId, browserTabId) =>
       sessionId === primarySession.sessionId && browserTabId === 101
         ? { bytes: new Uint8Array([0xff, 0xd8]) }


### PR DESCRIPTION
## Summary
- remove the undocumented session-keyed recording POST from the TypeScript and Rust servers
- delete the dead legacy write adapters while retaining all historical recording readers and retention paths
- add shared contract coverage proving the removed method is unsupported and cannot mutate replay data

## Design
The session recording-events path remains a GET-only replay view. New capture continues through the document-keyed POST at /api/v1/recordings/events, so recorder identity stays separate from session-derived replay lookup. OpenAPI and generated DTOs are unchanged.

## Test plan
- [x] TypeScript route and recording-store suites
- [x] claw-server typecheck and changed-file Biome checks
- [x] Rust canonical routes, routes, full crate, fmt, and clippy gates
- [x] claw API codegen drift check
- [x] cross-server contract suite
- [x] workspace typecheck
