### PR TITLE
fix(agent-mcp-manager): port recent TypeScript parity fixes

### DIFF
--- a/packages/browseros-agent/crates/agent-mcp-manager/src/catalog.rs
+++ b/packages/browseros-agent/crates/agent-mcp-manager/src/catalog.rs
@@ -529,13 +529,17 @@ pub fn resolve_agent_mcp_config_path(agent: AgentId, scope: AgentScope) -> Resul
     })
 }
 
+pub(crate) fn has_install_fingerprint(agent: AgentId) -> Result<bool, Error> {
+    let checks = selected_os_paths(&get_catalog_entry(agent).install_check_paths);
+    any_exists(checks)
+}
+
 /// Reports catalog install checks separately from config-path writability.
 pub fn detect_installed_agents() -> Result<Vec<AgentInfo>, Error> {
     CATALOG
         .iter()
         .map(|entry| {
-            let checks = selected_os_paths(&entry.install_check_paths);
-            let installed = any_exists(checks)?;
+            let installed = has_install_fingerprint(entry.id)?;
             let config_path = resolve_agent_mcp_config_path(entry.id, AgentScope::System).ok();
             Ok(AgentInfo {
                 id: entry.id,

--- a/packages/browseros-agent/crates/agent-mcp-manager/src/catalog.rs
+++ b/packages/browseros-agent/crates/agent-mcp-manager/src/catalog.rs
@@ -363,13 +363,19 @@ const OPENCODE: ClientConfig = ClientConfig {
             "$XDG_CONFIG_HOME/opencode",
             "$HOME/.config/opencode",
             "$HOME/.opencode",
+            "$HOME/.local/share/opencode",
         ],
         &[
             "$XDG_CONFIG_HOME/opencode",
             "$HOME/.config/opencode",
             "$HOME/.opencode",
+            "$HOME/.local/share/opencode",
         ],
-        &["$USERPROFILE\\.config\\opencode", "$USERPROFILE\\.opencode"],
+        &[
+            "$USERPROFILE\\.config\\opencode",
+            "$USERPROFILE\\.opencode",
+            "$USERPROFILE\\.local\\share\\opencode",
+        ],
     ),
     system_paths: paths(
         &[
@@ -431,9 +437,9 @@ const ANTIGRAVITY: ClientConfig = ClientConfig {
         &["$USERPROFILE\\.gemini\\antigravity"],
     ),
     system_paths: paths(
-        &["$HOME/.gemini/antigravity/mcp_config.json"],
-        &["$HOME/.gemini/antigravity/mcp_config.json"],
-        &["$USERPROFILE\\.gemini\\antigravity\\mcp_config.json"],
+        &["$HOME/.gemini/config/mcp_config.json"],
+        &["$HOME/.gemini/config/mcp_config.json"],
+        &["$USERPROFILE\\.gemini\\config\\mcp_config.json"],
     ),
     project_file: None,
     format: ConfigFormat::Json,
@@ -454,7 +460,7 @@ const ANTIGRAVITY: ClientConfig = ClientConfig {
         first_party: "https://antigravity.google/",
         smithery: Some(SMITHERY_URL),
         notes: Some(
-            "Google's Antigravity editor. Uses `serverUrl` for remote entries (matches Windsurf's convention).",
+            "Google's Antigravity editor. Config lives at `~/.gemini/config/mcp_config.json` (schema id: https://antigravity.google/schemas/mcp_config.json). Uses `serverUrl` for remote entries (matches Windsurf's convention).",
         ),
         verified: VERIFIED,
     },

--- a/packages/browseros-agent/crates/agent-mcp-manager/src/io.rs
+++ b/packages/browseros-agent/crates/agent-mcp-manager/src/io.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use crate::{
     AgentId, AgentScope, Error, ServerManifest,
-    catalog::{ensure_system_scope, resolve_agent_mcp_config_path},
+    catalog::{ensure_system_scope, has_install_fingerprint, resolve_agent_mcp_config_path},
     paths::path_exists,
 };
 
@@ -32,6 +32,20 @@ pub(crate) struct AgentFileState {
     pub(crate) raw_content: String,
     pub(crate) exists: bool,
     pub(crate) parent_exists: bool,
+    pub(crate) install_check_hit: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigPathSource {
+    Catalog,
+    Explicit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AgentPath {
+    agent: AgentId,
+    config_path: PathBuf,
+    source: ConfigPathSource,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -70,11 +84,18 @@ pub(crate) fn read_state(
     let mut paths = Vec::with_capacity(agents.len());
     for agent in agents {
         ensure_system_scope(*agent, scope)?;
-        let config_path = match overrides.get(agent) {
-            Some(path) => path.clone(),
-            None => resolve_agent_mcp_config_path(*agent, scope)?,
+        let (config_path, source) = match overrides.get(agent) {
+            Some(path) => (path.clone(), ConfigPathSource::Explicit),
+            None => (
+                resolve_agent_mcp_config_path(*agent, scope)?,
+                ConfigPathSource::Catalog,
+            ),
         };
-        paths.push((*agent, config_path));
+        paths.push(AgentPath {
+            agent: *agent,
+            config_path,
+            source,
+        });
     }
     snapshot_state(workspace_dir, manifest, &paths, scope)
 }
@@ -89,33 +110,47 @@ pub(crate) fn read_state_at_paths(
     for (agent, _) in paths {
         ensure_system_scope(*agent, scope)?;
     }
-    snapshot_state(workspace_dir, manifest, paths, scope)
+    let explicit_paths = paths
+        .iter()
+        .map(|(agent, config_path)| AgentPath {
+            agent: *agent,
+            config_path: config_path.clone(),
+            source: ConfigPathSource::Explicit,
+        })
+        .collect::<Vec<_>>();
+    snapshot_state(workspace_dir, manifest, &explicit_paths, scope)
 }
 
 fn snapshot_state(
     workspace_dir: &Path,
     manifest: ServerManifest,
-    paths: &[(AgentId, PathBuf)],
+    paths: &[AgentPath],
     scope: AgentScope,
 ) -> Result<State, Error> {
     let mut agent_files = Vec::with_capacity(paths.len());
-    for (agent, config_path) in paths {
-        let (raw_content, exists) = read_file_with_existence(config_path)?;
+    for path in paths {
+        let (raw_content, exists) = read_file_with_existence(&path.config_path)?;
         let parent_exists = if exists {
             true
         } else {
-            match config_path.parent() {
+            match path.config_path.parent() {
                 Some(parent) => path_exists(parent)?,
                 None => false,
             }
         };
+        let install_check_hit = path.source == ConfigPathSource::Catalog
+            && scope == AgentScope::System
+            && !exists
+            && !parent_exists
+            && has_install_fingerprint(path.agent)?;
         agent_files.push(AgentFileState {
-            agent: *agent,
+            agent: path.agent,
             scope,
-            config_path: config_path.clone(),
+            config_path: path.config_path.clone(),
             raw_content,
             exists,
             parent_exists,
+            install_check_hit,
         });
     }
     Ok(State {

--- a/packages/browseros-agent/crates/agent-mcp-manager/src/paths.rs
+++ b/packages/browseros-agent/crates/agent-mcp-manager/src/paths.rs
@@ -5,7 +5,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{AgentId, AgentScope, Error, PerOsPaths, catalog::resolve_agent_mcp_config_path};
+use crate::{
+    AgentId, AgentScope, Error, PerOsPaths,
+    catalog::{has_install_fingerprint, resolve_agent_mcp_config_path},
+};
 
 pub(crate) fn selected_os_paths(paths: &PerOsPaths) -> &'static [&'static str] {
     match env::consts::OS {
@@ -95,17 +98,21 @@ fn is_config_path_installed(config_path: &Path) -> Result<bool, Error> {
     }
 }
 
-/// Checks whether each agent's config file or its parent directory exists.
+/// Checks whether each agent has an install fingerprint or a writable config location.
 pub fn is_installed(agents: &[AgentId]) -> Result<BTreeMap<AgentId, bool>, Error> {
     let mut result = BTreeMap::new();
     for agent in agents {
         if result.contains_key(agent) {
             continue;
         }
-        let installed = match resolve_agent_mcp_config_path(*agent, AgentScope::System) {
-            Ok(config_path) => is_config_path_installed(&config_path)?,
-            Err(Error::UnresolvedConfigPath { .. }) => false,
-            Err(error) => return Err(error),
+        let installed = if has_install_fingerprint(*agent)? {
+            true
+        } else {
+            match resolve_agent_mcp_config_path(*agent, AgentScope::System) {
+                Ok(config_path) => is_config_path_installed(&config_path)?,
+                Err(Error::UnresolvedConfigPath { .. }) => false,
+                Err(error) => return Err(error),
+            }
         };
         result.insert(*agent, installed);
     }

--- a/packages/browseros-agent/crates/agent-mcp-manager/src/planner.rs
+++ b/packages/browseros-agent/crates/agent-mcp-manager/src/planner.rs
@@ -319,7 +319,7 @@ fn require_agent_file(
 }
 
 fn ensure_agent_installed(agent: AgentId, file: &AgentFileState) -> Result<(), Error> {
-    if file.exists || file.parent_exists {
+    if file.exists || file.parent_exists || file.install_check_hit {
         return Ok(());
     }
     Err(Error::AgentNotInstalled {
@@ -360,7 +360,10 @@ fn manifest_write_op(state: &State, manifest: &ServerManifest) -> Result<FsOp, E
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, path::PathBuf};
+    use std::{
+        collections::BTreeMap,
+        path::{Path, PathBuf},
+    };
 
     use super::{plan_disconnect, plan_link, plan_rescan, plan_unlink};
     use crate::{
@@ -391,6 +394,7 @@ mod tests {
                 raw_content: raw.to_string(),
                 exists: !raw.is_empty(),
                 parent_exists,
+                install_check_hit: false,
             }],
         }
     }
@@ -417,6 +421,17 @@ mod tests {
             plan_link(&state, &input, NOW),
             Err(Error::UnsupportedTransport { .. })
         ));
+    }
+
+    #[test]
+    fn install_fingerprint_allows_link_before_config_parent_exists() -> Result<(), Error> {
+        let mut state = state(AgentId::OpenCode, "", false);
+        state.agents[0].install_check_hit = true;
+        let planned = plan_link(&state, &link_input(AgentId::OpenCode), NOW)?;
+        assert!(planned.plan.ops.iter().any(|op| {
+            matches!(op, FsOp::WriteFile { path, .. } if path == Path::new("/tmp/ws/config.json"))
+        }));
+        Ok(())
     }
 
     #[test]

--- a/packages/browseros-agent/crates/agent-mcp-manager/tests/api.rs
+++ b/packages/browseros-agent/crates/agent-mcp-manager/tests/api.rs
@@ -1,4 +1,9 @@
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{
+    collections::BTreeMap,
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use agent_mcp_manager::{
     AgentId, AgentScope, DisconnectInput, Error, LinkInput, ListLinksFilter, Manager, McpServer,
@@ -317,6 +322,60 @@ fn recent_catalog_path_fixes_match_typescript() -> Result<(), Box<dyn std::error
         antigravity.system_paths.windows,
         &["$USERPROFILE\\.gemini\\config\\mcp_config.json"]
     );
+    Ok(())
+}
+
+#[test]
+fn opencode_install_fingerprint_drives_probe_and_default_link_gate()
+-> Result<(), Box<dyn std::error::Error>> {
+    const CHILD_HOME: &str = "AGENT_MCP_MANAGER_OPENCODE_TEST_HOME";
+    if let Some(home) = env::var_os(CHILD_HOME) {
+        return exercise_opencode_install_fingerprint(&PathBuf::from(home));
+    }
+
+    let root = tempdir()?;
+    let output = Command::new(env::current_exe()?)
+        .args([
+            "--exact",
+            "opencode_install_fingerprint_drives_probe_and_default_link_gate",
+            "--nocapture",
+        ])
+        .env(CHILD_HOME, root.path())
+        .env("HOME", root.path())
+        .env("USERPROFILE", root.path())
+        .env("XDG_CONFIG_HOME", root.path().join(".config"))
+        .output()?;
+    if !output.status.success() {
+        return Err(std::io::Error::other(format!(
+            "isolated OpenCode regression failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+fn exercise_opencode_install_fingerprint(home: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    fs::create_dir_all(home.join(".local/share/opencode"))?;
+    assert_eq!(
+        is_installed(&[AgentId::OpenCode])?.get(&AgentId::OpenCode),
+        Some(&true)
+    );
+
+    let manager = Manager::new(home.join("manager-workspace"));
+    manager.link(LinkInput::new(stdio_server("browseros"), AgentId::OpenCode))?;
+    let config_path = home.join(".config/opencode/opencode.json");
+    let config: Value = serde_json::from_str(&fs::read_to_string(&config_path)?)?;
+    assert_eq!(config["mcp"]["browseros"]["command"][0], "browseros-mcp");
+
+    let override_path = home.join("custom/missing/opencode.json");
+    let mut explicit = LinkInput::new(stdio_server("strict"), AgentId::OpenCode);
+    explicit.config_path = Some(override_path.clone());
+    assert!(matches!(
+        manager.link(explicit),
+        Err(Error::AgentNotInstalled { config_path, .. }) if config_path == override_path
+    ));
     Ok(())
 }
 

--- a/packages/browseros-agent/crates/agent-mcp-manager/tests/api.rs
+++ b/packages/browseros-agent/crates/agent-mcp-manager/tests/api.rs
@@ -261,6 +261,66 @@ fn malformed_manifest_is_never_silently_reset() -> Result<(), Box<dyn std::error
 }
 
 #[test]
+fn recent_catalog_path_fixes_match_typescript() -> Result<(), Box<dyn std::error::Error>> {
+    let opencode = resolve_agent_surface(AgentId::OpenCode, AgentScope::System)?.client;
+    assert_eq!(
+        opencode.install_check_paths.darwin,
+        &[
+            "$XDG_CONFIG_HOME/opencode",
+            "$HOME/.config/opencode",
+            "$HOME/.opencode",
+            "$HOME/.local/share/opencode",
+        ]
+    );
+    assert_eq!(
+        opencode.install_check_paths.linux,
+        &[
+            "$XDG_CONFIG_HOME/opencode",
+            "$HOME/.config/opencode",
+            "$HOME/.opencode",
+            "$HOME/.local/share/opencode",
+        ]
+    );
+    assert_eq!(
+        opencode.install_check_paths.windows,
+        &[
+            "$USERPROFILE\\.config\\opencode",
+            "$USERPROFILE\\.opencode",
+            "$USERPROFILE\\.local\\share\\opencode",
+        ]
+    );
+    assert_eq!(
+        opencode.system_paths.darwin,
+        &[
+            "$XDG_CONFIG_HOME/opencode/opencode.json",
+            "$HOME/.config/opencode/opencode.json",
+            "$XDG_CONFIG_HOME/opencode/opencode.jsonc",
+            "$HOME/.config/opencode/opencode.jsonc",
+            "$HOME/.opencode/opencode.jsonc",
+        ]
+    );
+
+    let antigravity = resolve_agent_surface(AgentId::Antigravity, AgentScope::System)?.client;
+    assert_eq!(
+        antigravity.install_check_paths.darwin,
+        &["$HOME/.gemini/antigravity"]
+    );
+    assert_eq!(
+        antigravity.system_paths.darwin,
+        &["$HOME/.gemini/config/mcp_config.json"]
+    );
+    assert_eq!(
+        antigravity.system_paths.linux,
+        &["$HOME/.gemini/config/mcp_config.json"]
+    );
+    assert_eq!(
+        antigravity.system_paths.windows,
+        &["$USERPROFILE\\.gemini\\config\\mcp_config.json"]
+    );
+    Ok(())
+}
+
+#[test]
 fn public_agent_helpers_expose_exactly_the_seven_harness_targets()
 -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(


### PR DESCRIPTION
## Summary
- sync the Rust catalog with the verified OpenCode install fingerprint and Antigravity config target fixes from the TypeScript package
- make `is_installed` and default-path `Manager::link` share the catalog install signal without weakening explicit `config_path` safety
- add focused catalog, planner, and isolated temporary-home regressions

## Design
The read layer records a crate-private install-fingerprint fact only for catalog-resolved system paths, then the pure planner consumes it beside existing file/parent facts. This keeps filesystem access out of planning, preserves the public API, and prevents an unrelated installed agent from authorizing arbitrary explicit-path creation.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p agent-mcp-manager --all-targets -- -D warnings`
- [x] `cargo test -p agent-mcp-manager` (23 unit + 13 integration)
- [x] `cargo test -p claw-server-rust --test connections`
- [x] TypeScript source package `bun run typecheck` + `bun run test` (142 tests)
- [x] workspace `bun run typecheck`
- [x] workspace `bun run fallow` (exit 0)

## Baseline notes
- `bun run check` reaches existing Biome errors in unrelated TypeScript files; this branch changes only `crates/agent-mcp-manager`.
- `bun run test` reaches two existing release-workflow snapshot failures unrelated to this Rust crate. All Rust/Claw API and target-package checks above pass.
