### PR TITLE
fix(claw): handle CORS preflight before route dispatch

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
@@ -80,6 +80,7 @@ pub fn router(state: AppState) -> Router<AppState> {
                 .layer(middleware::from_fn(mcp_request_hygiene)),
         )
         .fallback(route_fallback)
+        .layer(middleware::from_fn(options_preflight))
 }
 
 pub(super) fn error(
@@ -132,6 +133,13 @@ async fn mcp_request_hygiene(req: Request, next: Next) -> Response {
         if !is_json {
             return AppError::unsupported_media_type("unsupported content type").into_response();
         }
+    }
+    next.run(req).await
+}
+
+async fn options_preflight(req: Request, next: Next) -> Response {
+    if *req.method() == Method::OPTIONS {
+        return StatusCode::NO_CONTENT.into_response();
     }
     next.run(req).await
 }

--- a/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
@@ -35,6 +35,10 @@ use tokio::sync::{Notify, broadcast};
 use tokio_util::sync::CancellationToken;
 use tower::ServiceExt;
 
+const BROWSERCLAW_EXTENSION_ORIGIN: &str = "chrome-extension://pjimfkbpehlcllblajnpfamdfjhhlgkc";
+const EXPECTED_ALLOW_METHODS: &str = "GET,POST,PUT,PATCH,DELETE,OPTIONS";
+const EXPECTED_ALLOW_HEADERS: &str = "accept,content-type,authorization,mcp-session-id,mcp-protocol-version,last-event-id,x-recording-batch-id,x-recording-tab-id,x-recording-document-id,x-recording-has-gap";
+
 struct TestApp {
     router: Router,
     state: AppState,
@@ -294,6 +298,28 @@ fn json_body(bytes: &[u8]) -> anyhow::Result<Value> {
     Ok(serde_json::from_slice(bytes)?)
 }
 
+fn assert_permissive_cors(headers: &HeaderMap) {
+    assert_eq!(
+        headers
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|value| value.to_str().ok()),
+        Some("*")
+    );
+    assert_eq!(
+        headers
+            .get(header::ACCESS_CONTROL_ALLOW_METHODS)
+            .and_then(|value| value.to_str().ok()),
+        Some(EXPECTED_ALLOW_METHODS)
+    );
+    assert_eq!(
+        headers
+            .get(header::ACCESS_CONTROL_ALLOW_HEADERS)
+            .and_then(|value| value.to_str().ok()),
+        Some(EXPECTED_ALLOW_HEADERS)
+    );
+    assert!(headers.contains_key("x-request-id"));
+}
+
 fn session_item<'a>(body: &'a Value, session_id: &str) -> anyhow::Result<&'a Value> {
     body["items"]
         .as_array()
@@ -311,6 +337,203 @@ fn live_session(session_id: &str) -> Arc<Session> {
         ConversationIdentity::new("codex", "research-browserclaw".to_string()),
         tokio::time::Instant::now(),
     )
+}
+
+#[tokio::test]
+async fn trusted_recording_preflight_returns_cors_headers() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, headers, bytes) = request_with_headers(
+        &app.router,
+        "OPTIONS",
+        "/api/v1/recordings/events",
+        None,
+        &[
+            ("origin", BROWSERCLAW_EXTENSION_ORIGIN),
+            ("access-control-request-method", "POST"),
+            (
+                "access-control-request-headers",
+                "content-type,x-recording-batch-id,x-recording-tab-id,x-recording-document-id,x-recording-has-gap",
+            ),
+        ],
+        Body::empty(),
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    assert!(bytes.is_empty());
+    assert_permissive_cors(&headers);
+    Ok(())
+}
+
+#[tokio::test]
+async fn originless_preflight_to_exact_route_returns_cors_headers() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, headers, bytes) = request_with_headers(
+        &app.router,
+        "OPTIONS",
+        "/api/v1/system",
+        None,
+        &[
+            ("access-control-request-method", "GET"),
+            ("access-control-request-headers", "content-type"),
+        ],
+        Body::empty(),
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    assert!(bytes.is_empty());
+    assert_permissive_cors(&headers);
+    Ok(())
+}
+
+#[tokio::test]
+async fn null_origin_native_recording_preflight_is_trusted() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, headers, bytes) = request_with_headers(
+        &app.router,
+        "OPTIONS",
+        "/api/v1/recordings/events",
+        None,
+        &[
+            ("origin", "null"),
+            ("sec-fetch-site", "none"),
+            ("access-control-request-method", "POST"),
+            (
+                "access-control-request-headers",
+                "content-type,x-recording-batch-id,x-recording-tab-id,x-recording-document-id,x-recording-has-gap",
+            ),
+        ],
+        Body::empty(),
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    assert!(bytes.is_empty());
+    assert_permissive_cors(&headers);
+    Ok(())
+}
+
+#[tokio::test]
+async fn hostile_recording_preflight_remains_forbidden() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, headers, bytes) = request_with_headers(
+        &app.router,
+        "OPTIONS",
+        "/api/v1/recordings/events",
+        None,
+        &[
+            ("origin", "https://attacker.example"),
+            ("access-control-request-method", "POST"),
+            (
+                "access-control-request-headers",
+                "content-type,x-recording-batch-id,x-recording-tab-id,x-recording-document-id,x-recording-has-gap",
+            ),
+        ],
+        Body::empty(),
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(json_body(&bytes)?["code"], "forbidden");
+    assert!(!headers.contains_key(header::ACCESS_CONTROL_ALLOW_ORIGIN));
+    Ok(())
+}
+
+#[tokio::test]
+async fn hostile_recording_post_remains_forbidden() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, headers, bytes) = request_with_headers(
+        &app.router,
+        "POST",
+        "/api/v1/recordings/events",
+        Some("application/x-ndjson"),
+        &[
+            ("origin", "https://attacker.example"),
+            ("x-recording-tab-id", "101"),
+            (
+                "x-recording-document-id",
+                "33D25F3CF060E81B14070BC356FF1871",
+            ),
+            ("x-recording-batch-id", "hostile-test-batch"),
+        ],
+        "{\"ts\":150,\"type\":3,\"data\":{}}\n",
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(json_body(&bytes)?["code"], "forbidden");
+    assert!(!headers.contains_key(header::ACCESS_CONTROL_ALLOW_ORIGIN));
+    Ok(())
+}
+
+#[tokio::test]
+async fn unsupported_non_options_method_keeps_axum_allow_header() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, headers, bytes) = request(
+        &app.router,
+        "PUT",
+        "/api/v1/system",
+        Some("application/json"),
+        "{}",
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+    assert!(bytes.is_empty());
+    let allow = headers
+        .get(header::ALLOW)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    assert!(allow.split(',').any(|method| method.trim() == "GET"));
+    assert!(allow.split(',').any(|method| method.trim() == "HEAD"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_preflight_remains_no_content() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, headers, bytes) = request_with_headers(
+        &app.router,
+        "OPTIONS",
+        "/mcp",
+        None,
+        &[
+            ("origin", "https://example.com"),
+            ("access-control-request-method", "POST"),
+            ("access-control-request-headers", "content-type"),
+        ],
+        Body::empty(),
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    assert!(bytes.is_empty());
+    assert_permissive_cors(&headers);
+    Ok(())
+}
+
+#[tokio::test]
+async fn unknown_path_preflight_remains_no_content() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, headers, bytes) = request_with_headers(
+        &app.router,
+        "OPTIONS",
+        "/api/v1/not-a-route",
+        None,
+        &[
+            ("origin", "https://example.com"),
+            ("access-control-request-method", "POST"),
+            ("access-control-request-headers", "content-type"),
+        ],
+        Body::empty(),
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::NO_CONTENT);
+    assert!(bytes.is_empty());
+    assert_permissive_cors(&headers);
+    Ok(())
 }
 
 async fn seed_dispatch(app: &TestApp, session_id: &str) -> anyhow::Result<i64> {

--- a/packages/browseros-agent/contracts/claw-api/tests/cases.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/cases.ts
@@ -232,6 +232,42 @@ export const contractCases: ContractCase[] = [
     },
   },
   {
+    name: 'recording ingest accepts trusted preflight',
+    async run({ baseUrl }) {
+      const requestedHeaders = [
+        'content-type',
+        'x-recording-batch-id',
+        'x-recording-tab-id',
+        'x-recording-document-id',
+        'x-recording-has-gap',
+      ]
+      const response = await fetch(`${baseUrl}/api/v1/recordings/events`, {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'chrome-extension://pjimfkbpehlcllblajnpfamdfjhhlgkc',
+          'access-control-request-method': 'POST',
+          'access-control-request-headers': requestedHeaders.join(','),
+        },
+      })
+
+      expect(response.status).toBe(204)
+      expect(response.headers.get('access-control-allow-origin')).toBe('*')
+      expect(
+        response.headers
+          .get('access-control-allow-methods')
+          ?.split(',')
+          .map((method) => method.trim()),
+      ).toContain('POST')
+      const allowedHeaders = response.headers
+        .get('access-control-allow-headers')
+        ?.split(',')
+        .map((name) => name.trim().toLowerCase())
+      for (const name of requestedHeaders) {
+        expect(allowedHeaders).toContain(name)
+      }
+    },
+  },
+  {
     name: 'recording ingest rejects web origins',
     async run({ baseUrl }) {
       const path = `${baseUrl}/api/v1/recordings/events`


### PR DESCRIPTION
## Summary
- answer trusted and origin-less OPTIONS requests before exact Axum method routing returns 405
- preserve recording-ingest origin rejection and normal non-OPTIONS method semantics
- enforce the trusted recording preflight contract against both TypeScript and Rust servers

## Design
The canonical Rust HTTP router now has a minimal OPTIONS-only middleware inside the existing request-context layer. Request context remains responsible for origin trust, CORS headers, request IDs, and failure logging; non-OPTIONS requests continue through the existing route tree unchanged.

## Test plan
- [x] cargo test -p claw-server-rust --test canonical_routes -- --test-threads=1
- [x] cargo fmt --all --check
- [x] cargo test -p claw-server-rust
- [x] cargo clippy -p claw-server-rust --all-targets -- -D warnings
- [x] bun run test:claw-api-contract
- [x] live trusted/hostile preflight, system GET, and unsupported-method curl checks