### PR TITLE
fix: cap automatic action settling at 50ms

### DIFF
--- a/packages/browseros-agent/crates/browseros-core/src/settle.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/settle.rs
@@ -236,6 +236,7 @@ mod tests {
     use super::{SettleOutcome, wait_for_action_settle};
     use crate::{
         BrowserSession, BrowserSessionHooks, CoreError, SessionId, connection::CdpConnection,
+        timeouts,
     };
     use browseros_cdp::{CdpError, CdpEvent};
     use futures_util::future::BoxFuture;
@@ -430,14 +431,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn settle_respects_budget_cap() -> Result<(), CoreError> {
+    async fn automatic_settle_respects_50ms_total_budget() -> Result<(), CoreError> {
         let (session, page_id) = harness(VecDeque::from([1, 2, 3]), VecDeque::new()).await?;
-        let budget = Duration::from_millis(320);
+        let budget = timeouts::ACTION_SETTLE_DEFAULT_TIMEOUT;
+        assert_eq!(budget, Duration::from_millis(50));
         let start = Instant::now();
         let outcome = wait_for_action_settle(&session.pages, page_id, budget).await;
         assert_eq!(outcome, SettleOutcome::BudgetExpired);
         assert!(start.elapsed() >= budget);
-        assert!(start.elapsed() < Duration::from_millis(500));
+        assert!(start.elapsed() < Duration::from_millis(150));
         Ok(())
     }
 

--- a/packages/browseros-agent/crates/browseros-core/src/timeouts.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/timeouts.rs
@@ -14,7 +14,9 @@ pub const WAIT_FOR_LOAD_TIMEOUT: Duration = Duration::from_secs(30);
 pub const WAIT_FOR_LOAD_POLL: Duration = Duration::from_millis(150);
 pub const NEW_PAGE_READY_ATTEMPTS: usize = 30;
 pub const NEW_PAGE_READY_POLL: Duration = Duration::from_millis(100);
-pub const ACTION_SETTLE_DEFAULT_TIMEOUT: Duration = Duration::from_millis(2_000);
+/// Total automatic post-action settle budget, deliberately short to keep agent actions responsive.
+/// Callers awaiting slower asynchronous page changes should use the explicit `wait` tool.
+pub const ACTION_SETTLE_DEFAULT_TIMEOUT: Duration = Duration::from_millis(50);
 pub const ACTION_SETTLE_NAVIGATION_DETECT: Duration = Duration::from_millis(150);
 pub const ACTION_SETTLE_NAVIGATION_POLL: Duration = Duration::from_millis(50);
 pub const ACTION_SETTLE_DOM_QUIET: Duration = Duration::from_millis(100);


### PR DESCRIPTION
## Summary
- cap automatic post-action settling at 50ms total before diff or snapshot capture
- document the intentional responsiveness tradeoff and direct slower asynchronous changes to the explicit `wait` tool
- pin the automatic default and total-budget behavior in the focused settle test

## Design
Keep the existing single-deadline settle pipeline unchanged and reduce only its automatic default budget. This preserves one total cap across navigation detection, load waiting, DOM quiet, and CDP calls without tuning unrelated timeouts.

## Test plan
- [x] `cargo fmt --package browseros-core --package browseros-mcp --check`
- [x] `cargo test --package browseros-core --package browseros-mcp`