### PR TITLE
fix(claw): keep agent tabs open for inspection

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
@@ -13,8 +13,8 @@ Shared with other agents:
   tabs action="list" shows yours vs other agents' vs the user's.
 - Rename your session early with name_session using a 2-3 word task label;
   tabs group as <client>/<name>.
-- Work in your own tabs and close them when done; touch a tab you don't own
-  only when the user points you at it.
+- Work in your own tabs; touch a tab you don't own only when the user points
+  you at it.
 - The user oversees this browser from the BrowserClaw cockpit (live view,
   audit, replay).
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -453,14 +453,18 @@ mod tests {
             info.instructions.as_deref(),
             Some(BROWSERCLAW_MCP_INSTRUCTIONS)
         );
-        assert!(info.instructions.as_deref().is_some_and(|instructions| {
-            instructions.contains("BrowserClaw — the browser for agents")
-        }));
-        assert!(info.instructions.as_deref().is_some_and(|instructions| {
-            instructions.contains(
-                "- Rename your session early with name_session using a 2-3 word task label;\n  tabs group as <client>/<name>."
-            )
-        }));
+        let instructions = info
+            .instructions
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("BrowserClaw instructions missing"))?;
+        assert!(instructions.contains("BrowserClaw — the browser for agents"));
+        assert!(instructions.contains(
+            "- Rename your session early with name_session using a 2-3 word task label;\n  tabs group as <client>/<name>."
+        ));
+        assert!(instructions.contains(
+            "- Work in your own tabs; touch a tab you don't own only when the user points\n  you at it."
+        ));
+        assert!(!instructions.contains("close them when done"));
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/config.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/config.rs
@@ -10,7 +10,7 @@ use std::{
 
 const DEFAULT_SERVER_PORT: u16 = 9200;
 const DEFAULT_CDP_PORT: u16 = 49337;
-const DEFAULT_SESSION_IDLE_MS: u64 = 5 * 60 * 1000;
+const DEFAULT_SESSION_IDLE_MS: u64 = 30 * 60 * 1000;
 const DEFAULT_SESSION_RETENTION_MS: u64 = 2 * 60 * 60 * 1000;
 const DEFAULT_SESSION_SWEEP_INTERVAL_MS: u64 = 60 * 1000;
 const DEFAULT_REPLAY_RETENTION_DAYS: u64 = 7;
@@ -370,14 +370,14 @@ mod tests {
             (
                 "garbage",
                 "-500",
-                Duration::from_millis(300_000),
+                Duration::from_secs(30 * 60),
                 Duration::from_millis(7_200_000),
                 Duration::from_millis(60_000),
             ),
             (
                 "0",
                 "0x10",
-                Duration::from_millis(300_000),
+                Duration::from_secs(30 * 60),
                 Duration::from_millis(7_200_000),
                 Duration::from_millis(60_000),
             ),
@@ -419,7 +419,7 @@ mod tests {
             &config_path,
             &ConfigEnv::with_vars(BTreeMap::new(), home.clone()),
         )?;
-        assert_eq!(cfg.session_idle, Duration::from_millis(300_000));
+        assert_eq!(cfg.session_idle, Duration::from_secs(30 * 60));
         assert_eq!(cfg.session_retention, Duration::from_millis(7_200_000));
         assert_eq!(cfg.session_sweep_interval, Duration::from_millis(60_000));
         Ok(())


### PR DESCRIPTION
## Summary
- remove the BrowserClaw initialize instruction that tells agents to close task-owned tabs when work completes
- extend the Rust MCP session idle fallback from 5 to 30 minutes while preserving environment overrides and retained-group timing
- cover the served prompt wording and default/fallback behavior with focused tests

## Design
The change stays at the two policy sources: `BROWSERCLAW_MCP_INSTRUCTIONS` controls agent behavior, and `DEFAULT_SESSION_IDLE_MS` controls the Rust server fallback. Explicit tab closing remains available, and the retention and sweep defaults are unchanged.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p claw-server-rust`
- [x] `cargo clippy -p claw-server-rust --all-targets -- -D warnings`
