### PR TITLE
fix(claw): tell agents to copy a foreign tab's URL into their own tab

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
@@ -11,10 +11,10 @@ installed BrowserClaw precisely so they don't have to keep asking.
 Shared with other agents:
 - Open your own tab with tabs action="new". Pages you don't own are rejected —
   tabs action="list" shows yours vs other agents' vs the user's.
+- If the user points you at a tab you don't own, open its URL with
+  tabs action="new" and work on that copy; leave the original untouched.
 - Rename your session early with name_session using a 2-3 word task label;
   tabs group as <client>/<name>.
-- Work in your own tabs; touch a tab you don't own only when the user points
-  you at it.
 - The user oversees this browser from the BrowserClaw cockpit (live view,
   audit, replay).
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -462,8 +462,9 @@ mod tests {
             "- Rename your session early with name_session using a 2-3 word task label;\n  tabs group as <client>/<name>."
         ));
         assert!(instructions.contains(
-            "- Work in your own tabs; touch a tab you don't own only when the user points\n  you at it."
+            "- If the user points you at a tab you don't own, open its URL with\n  tabs action=\"new\" and work on that copy; leave the original untouched."
         ));
+        assert!(!instructions.contains("touch a tab"));
         assert!(!instructions.contains("close them when done"));
         Ok(())
     }


### PR DESCRIPTION
## Summary
- The BrowserClaw initialize prompt told agents to "touch" a user-pointed foreign tab — a vague verb naming no operation, and one the page-ownership guard rejects anyway.
- Replace it with the one action that works: open the tab's URL with `tabs action="new"` and work on the owned copy, leaving the original untouched.
- Drop the "Work in your own tabs" clause — the adjacent bullet's "Pages you don't own are rejected" already carries that meaning, so the ownership rule keeps a single authoritative home.

## Design
Applied the writing-great-skills predictability lens to the prompt: encode one explicit branch (user points at an unowned tab → owned copy via `tabs action="new"`), name only operations that exist (no fictional `duplicate` action), and co-locate the branch beside the ownership bullet. The served-prompt test locks in the new wording and asserts the ambiguous "touch a tab" phrasing is gone.

## Test plan
- [x] `cargo test -p claw-server-rust initialize_info_uses_browserclaw_branding_and_prompt` — passes
- [x] Full `cargo test -p claw-server-rust` — 176 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)