### PR TITLE
docs(cdp): clarify connection epoch

### DIFF
--- a/packages/browseros-agent/crates/browseros-cdp/src/client.rs
+++ b/packages/browseros-agent/crates/browseros-cdp/src/client.rs
@@ -159,6 +159,8 @@ impl CdpClient {
         self.inner.connected.load(Ordering::SeqCst)
     }
 
+    /// Identifies this client's WebSocket incarnation. Each successfully installed socket
+    /// advances it so consumers can invalidate and reseed connection-scoped state.
     #[must_use]
     pub fn epoch(&self) -> u64 {
         self.inner.epoch.load(Ordering::SeqCst)


### PR DESCRIPTION
## Summary
- document the CDP client's WebSocket incarnation counter
- explain why consumers use epoch changes to invalidate and reseed connection-scoped state

## Design
The comment sits on the public epoch getter, where the advancement rule is owned, and avoids duplicating reconnect policy in downstream consumers.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test -p browseros-cdp`
- [x] `git diff --check`
- [x] independent Codex comment-quality review
