### PR TITLE
chore(claw): rename shared database file

### DIFF
--- a/docs/browserclaw/audit-and-replay.mdx
+++ b/docs/browserclaw/audit-and-replay.mdx
@@ -46,7 +46,7 @@ Use the scrubber to jump to any moment. Click any step on the right timeline to 
 
 Everything you see on these pages sits in one folder on your computer: **`~/.browserclaw/`** in your home directory.
 
-- `~/.browserclaw/audit.sqlite` is the database of tool calls, session starts, and session ends.
+- `~/.browserclaw/browserclaw.sqlite` is the shared database for audit history, tasks, sessions, recording indexes, tab claims, and tab ownership.
 - `~/.browserclaw/screenshots/` is a JPEG per screenshotted step.
 - `~/.browserclaw/replays/` is the recording data per session.
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/effects/tab_groups.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/effects/tab_groups.rs
@@ -492,7 +492,7 @@ const _: ToolEffect = apply;
 mod tests {
     use super::*;
     use crate::{
-        db::{AuditLog, Database, SessionTabLedger},
+        db::{AuditLog, DATABASE_FILENAME, Database, SessionTabLedger},
         identity::{ClientIdentity, ConversationIdentity},
         ids::SessionId as AppSessionId,
         services::sessions::{RetainedGroupAction, Sessions},
@@ -906,7 +906,7 @@ mod tests {
         let browser = BrowserSession::new(recorder.clone(), BrowserSessionHooks::default());
         assert_eq!(browser.pages.list().await?.len(), 2);
         let dir = tempfile::tempdir()?;
-        let database = Database::open(dir.path().join("audit.sqlite")).await?;
+        let database = Database::open(dir.path().join(DATABASE_FILENAME)).await?;
         let sessions = Sessions::new(
             Arc::new(AuditLog::new(database.clone())),
             Arc::new(SessionTabLedger::new(database)),

--- a/packages/browseros-agent/apps/claw-server-rust/src/app.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/app.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::http,
     config::Config,
-    db::{AuditLog, Database, RecordingIndex, SessionTabLedger},
+    db::{AuditLog, DATABASE_FILENAME, Database, RecordingIndex, SessionTabLedger},
     error::AppResult,
     runtime::ShutdownHandle,
     services::{
@@ -52,7 +52,7 @@ impl AppState {
     pub async fn new_with_home(config: Arc<Config>, home_dir: PathBuf) -> AppResult<Self> {
         tokio::fs::create_dir_all(&config.browserclaw_dir).await?;
         let store = JsonStore::new(config.browserclaw_dir.clone());
-        let database = Database::open(config.browserclaw_dir.join("audit.sqlite")).await?;
+        let database = Database::open(config.browserclaw_dir.join(DATABASE_FILENAME)).await?;
         let audit_log = Arc::new(AuditLog::new(database.clone()));
         let session_tabs = Arc::new(SessionTabLedger::new(database.clone()));
         let recording_index = Arc::new(RecordingIndex::new(database));
@@ -132,4 +132,43 @@ pub fn build_router(state: AppState) -> Router {
     http::router(state.clone())
         .with_state(state)
         .layer(middleware::from_fn(http::request_context))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppState;
+    use crate::{config::Config, db::DATABASE_FILENAME};
+    use std::{sync::Arc, time::Duration};
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn new_with_home_uses_browserclaw_database_without_touching_old_file()
+    -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let browserclaw_dir = dir.path().join("browserclaw");
+        tokio::fs::create_dir_all(&browserclaw_dir).await?;
+        let old_database = browserclaw_dir.join("audit.sqlite");
+        let old_contents = b"old database stays untouched";
+        tokio::fs::write(&old_database, old_contents).await?;
+        let config = Arc::new(Config {
+            server_port: 9200,
+            cdp_port: 49337,
+            proxy_port: None,
+            resources_dir: dir.path().join("resources"),
+            browserclaw_dir: browserclaw_dir.clone(),
+            session_idle: Duration::from_secs(300),
+            session_retention: Duration::from_secs(7_200),
+            session_sweep_interval: Duration::from_secs(60),
+            replay_retention_days: 7,
+            dev_mode: false,
+            auth_token: None,
+        });
+
+        let _state = AppState::new_with_home(config, dir.path().join("home")).await?;
+
+        assert_eq!(DATABASE_FILENAME, "browserclaw.sqlite");
+        assert!(browserclaw_dir.join(DATABASE_FILENAME).is_file());
+        assert_eq!(tokio::fs::read(old_database).await?, old_contents);
+        Ok(())
+    }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/audit_log.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/audit_log.rs
@@ -701,7 +701,7 @@ mod tests {
     use super::{
         AuditLog, DispatchResultSummary, ListTasksQuery, RecordToolDispatchInput, TaskStatus,
     };
-    use crate::db::Database;
+    use crate::db::{DATABASE_FILENAME, Database};
     use serde_json::json;
     use tempfile::tempdir;
 
@@ -736,7 +736,7 @@ mod tests {
     #[tokio::test]
     async fn migrations_and_dispatch_pagination_work() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let audit = AuditLog::new(Database::open(dir.path().join("audit.sqlite")).await?);
+        let audit = AuditLog::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
         assert!(
             audit
                 .list_dispatches(Default::default())
@@ -764,7 +764,7 @@ mod tests {
     #[tokio::test]
     async fn task_filters_compose_before_pagination() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let audit = AuditLog::new(Database::open(dir.path().join("audit.sqlite")).await?);
+        let audit = AuditLog::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
         audit
             .record_tool_dispatch(dispatch("a1", "https://alpha.example.com", false))
             .await?;
@@ -798,7 +798,7 @@ mod tests {
     #[tokio::test]
     async fn zero_dispatch_tasks_are_excluded_before_pagination() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let audit = AuditLog::new(Database::open(dir.path().join("audit.sqlite")).await?);
+        let audit = AuditLog::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
         for session_id in ["handshake-1", "handshake-2"] {
             audit
                 .record_session_start(session_id, "agent", "agent", "Agent", "client", "1")

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
@@ -1,10 +1,10 @@
 use sea_orm_migration::prelude::*;
 
-/// Applies the audit schema migrations.
-pub struct AuditMigrator;
+/// Applies the shared BrowserClaw database schema migrations.
+pub struct Migrator;
 
 #[async_trait::async_trait]
-impl MigratorTrait for AuditMigrator {
+impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
             Box::new(m0001_baseline::Migration),

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
@@ -12,7 +12,7 @@ pub use recording_index::{
 pub use session_tabs::SessionTabLedger;
 
 use crate::error::{AppError, AppResult, IoPath};
-use migration::AuditMigrator;
+use migration::Migrator;
 use sea_orm::{
     DatabaseConnection, DbErr, RuntimeErr, SqlxSqliteConnector,
     sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
@@ -24,15 +24,15 @@ use std::{
     time::Duration,
 };
 
+pub const DATABASE_FILENAME: &str = "browserclaw.sqlite";
+
 #[derive(Clone)]
 pub struct Database(DatabaseConnection);
 
 impl Database {
-    /// Opens and migrates the audit database.
+    /// Opens and migrates BrowserClaw's shared durable state database.
     pub async fn open(path: impl AsRef<Path>) -> AppResult<Self> {
-        open_and_migrate::<AuditMigrator>(path.as_ref())
-            .await
-            .map(Self)
+        open_and_migrate::<Migrator>(path.as_ref()).await.map(Self)
     }
 
     pub(in crate::db) fn connection(&self) -> &DatabaseConnection {
@@ -117,7 +117,10 @@ fn append_suffix(path: &Path, suffix: &str) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{AuditLog, Database, audit_log::ListDispatchesQuery};
+    use super::{
+        AuditLog, DATABASE_FILENAME, Database, append_suffix, audit_log::ListDispatchesQuery,
+        back_up_database,
+    };
     use sea_orm::{
         ConnectionTrait, DbBackend, Statement,
         sqlx::{
@@ -140,7 +143,7 @@ mod tests {
     #[tokio::test]
     async fn fresh_file_has_the_complete_baseline_schema() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let db = Database::open(dir.path().join("audit.sqlite")).await?;
+        let db = Database::open(dir.path().join(DATABASE_FILENAME)).await?;
         let objects = db
             .connection()
             .query_all(Statement::from_string(
@@ -223,7 +226,7 @@ mod tests {
     #[tokio::test]
     async fn ts_snapshot_upgrades_in_place_and_preserves_dispatches() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let path = dir.path().join("audit.sqlite");
+        let path = dir.path().join(DATABASE_FILENAME);
         let options = sqlite_options(&path);
         let mut conn = SqliteConnection::connect_with(&options).await?;
         for migration in [TS_0000, TS_0001, TS_0002] {
@@ -290,7 +293,7 @@ mod tests {
     #[tokio::test]
     async fn garbage_file_is_backed_up_and_recreated() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let path = dir.path().join("audit.sqlite");
+        let path = dir.path().join(DATABASE_FILENAME);
         let backup = path.with_extension("sqlite.bak");
         tokio::fs::write(&path, b"not a sqlite database").await?;
 
@@ -304,9 +307,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn database_backups_include_wal_and_shm_sidecars() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let path = dir.path().join(DATABASE_FILENAME);
+        for (source_suffix, contents) in [
+            ("", b"database".as_slice()),
+            ("-wal", b"wal".as_slice()),
+            ("-shm", b"shm".as_slice()),
+        ] {
+            tokio::fs::write(append_suffix(&path, source_suffix), contents).await?;
+        }
+
+        back_up_database(&path).await?;
+
+        for (source_suffix, backup_suffix, contents) in [
+            ("", ".bak", b"database".as_slice()),
+            ("-wal", ".bak-wal", b"wal".as_slice()),
+            ("-shm", ".bak-shm", b"shm".as_slice()),
+        ] {
+            assert!(!append_suffix(&path, source_suffix).exists());
+            assert_eq!(
+                tokio::fs::read(append_suffix(&path, backup_suffix)).await?,
+                contents
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn double_open_keeps_one_baseline_record() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let path = dir.path().join("audit.sqlite");
+        let path = dir.path().join(DATABASE_FILENAME);
         let first = Database::open(&path).await?;
         first.0.close().await?;
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/session_tabs.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/session_tabs.rs
@@ -554,7 +554,7 @@ async fn release_claims_for_target(
 mod tests {
     use super::{ClaimWrite, SessionTabLedger};
     use crate::db::{
-        Database,
+        DATABASE_FILENAME, Database,
         entities::prelude::{SessionTabs, TabClaims},
     };
     use sea_orm::EntityTrait;
@@ -563,7 +563,8 @@ mod tests {
     #[tokio::test]
     async fn queued_claim_mutations_preserve_lifecycle_order() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let ledger = SessionTabLedger::new(Database::open(dir.path().join("audit.sqlite")).await?);
+        let ledger =
+            SessionTabLedger::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
         ledger.enqueue_claim_target_for_session(
             "target-a".to_string(),
             "session-a".to_string(),
@@ -584,7 +585,8 @@ mod tests {
     #[tokio::test]
     async fn tab_claim_transfer_closes_the_prior_owner_at_the_boundary() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let ledger = SessionTabLedger::new(Database::open(dir.path().join("audit.sqlite")).await?);
+        let ledger =
+            SessionTabLedger::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
         ledger.enqueue_claim_tab_for_session(
             11,
             Some("target-a".to_string()),
@@ -613,7 +615,8 @@ mod tests {
     #[tokio::test]
     async fn queued_tab_release_preserves_the_observed_boundary() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let ledger = SessionTabLedger::new(Database::open(dir.path().join("audit.sqlite")).await?);
+        let ledger =
+            SessionTabLedger::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
         ledger.enqueue_claim_tab_for_session(
             11,
             Some("target-a".to_string()),

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/browser/connection.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/browser/connection.rs
@@ -292,7 +292,8 @@ mod tests {
 
     async fn service() -> anyhow::Result<(Arc<BrowserService>, TempDir)> {
         let root = tempfile::tempdir()?;
-        let database = crate::db::Database::open(root.path().join("audit.sqlite")).await?;
+        let database =
+            crate::db::Database::open(root.path().join(crate::db::DATABASE_FILENAME)).await?;
         let audit_log = Arc::new(crate::db::AuditLog::new(database.clone()));
         let session_tabs = Arc::new(crate::db::SessionTabLedger::new(database));
         let sessions = crate::services::sessions::Sessions::new(

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
@@ -358,14 +358,14 @@ fn sanitize_id(id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::{Database, RecordingIndex};
+    use crate::db::{DATABASE_FILENAME, Database, RecordingIndex};
     use tempfile::tempdir;
 
     async fn setup() -> anyhow::Result<(tempfile::TempDir, Arc<RecordingIndex>, Arc<RecordingStore>)>
     {
         let dir = tempdir()?;
         let index = Arc::new(RecordingIndex::new(
-            Database::open(dir.path().join("audit.sqlite")).await?,
+            Database::open(dir.path().join(DATABASE_FILENAME)).await?,
         ));
         let store = RecordingStore::new(
             dir.path().join("recordings"),

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
@@ -325,7 +325,7 @@ fn build_meta(entries: Vec<(i64, ReplaySegmentMeta)>) -> ReplayMeta {
 mod tests {
     use super::*;
     use crate::{
-        db::{Database, RecordingIndex},
+        db::{DATABASE_FILENAME, Database, RecordingIndex},
         services::recordings::RecordingEventInput,
     };
     use serde_json::json;
@@ -344,7 +344,7 @@ mod tests {
     async fn joins_tab_windows_across_document_targets_and_filters_exactly() -> anyhow::Result<()> {
         let dir = tempdir()?;
         let index = Arc::new(RecordingIndex::new(
-            Database::open(dir.path().join("audit.sqlite")).await?,
+            Database::open(dir.path().join(DATABASE_FILENAME)).await?,
         ));
         let recordings = RecordingStore::new(
             dir.path().join("recordings"),

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/manager.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/manager.rs
@@ -348,7 +348,7 @@ impl Sessions {
 mod tests {
     use super::{RetainedGroupAction, Session, Sessions};
     use crate::{
-        db::{AuditLog, Database, SessionTabLedger},
+        db::{AuditLog, DATABASE_FILENAME, Database, SessionTabLedger},
         identity::{ClientIdentity, ClientInfo, ConversationIdentity, generate_fun_name},
         ids::{ConvoId, SessionId},
     };
@@ -365,7 +365,7 @@ mod tests {
     async fn repositories(
         dir: &tempfile::TempDir,
     ) -> anyhow::Result<(Arc<AuditLog>, Arc<SessionTabLedger>)> {
-        let database = Database::open(dir.path().join("audit.sqlite")).await?;
+        let database = Database::open(dir.path().join(DATABASE_FILENAME)).await?;
         Ok((
             Arc::new(AuditLog::new(database.clone())),
             Arc::new(SessionTabLedger::new(database)),


### PR DESCRIPTION
## Summary
- rename the Rust Claw server shared SQLite file from `audit.sqlite` to `browserclaw.sqlite`
- centralize the filename as `db::DATABASE_FILENAME` and rename the whole-schema migrator to `Migrator`
- prove the clean break leaves old database files untouched while preserving full schema creation and path-derived recovery backups
- align shared-database fixtures and current BrowserClaw documentation

## Design
`db` owns the canonical filename alongside database opening, migrations, and recovery. `AppState` joins that constant onto `browserclaw_dir` and continues sharing one connection across audit, sessions/tasks, recordings, claims, and ownership. There is intentionally no fallback or filename/data migration: an existing `audit.sqlite` and its sidecars remain untouched, and BrowserClaw starts with a fresh `browserclaw.sqlite`. The existing SeaORM migration history remains the schema creation/evolution mechanism.

## Test plan
- [x] `cargo test -p claw-server-rust db::tests -- --test-threads=1`
- [x] `cargo test -p claw-server-rust app::tests -- --test-threads=1`
- [x] `cargo test -p claw-server-rust`
- [x] `cargo clippy -p claw-server-rust --all-targets -- -D warnings`
- [x] `bun run fmt:rust`
- [x] `bun run test:rust`
- [x] `bun run lint:rust`
- [x] focused search confirms the only current Rust `audit.sqlite` reference is the intentional clean-break sentinel