### PR TITLE
docs(core): document page identity

### DIFF
--- a/packages/browseros-agent/crates/browseros-core/src/types.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/types.rs
@@ -1,3 +1,7 @@
+//! `PageId` is BrowserOS's process-local handle for tools and page ownership. It remains stable
+//! when a live Chrome tab is rebound, while the tab's `TargetId` and attached `SessionId`
+//! protocol incarnations may change.
+
 use serde::{Deserialize, Serialize};
 use std::{fmt, hash::Hash};
 


### PR DESCRIPTION
## Summary
- document BrowserOS's process-local page handle
- distinguish stable `PageId` ownership from replaceable CDP target/session incarnations

## Design
The identity-domain comment lives at the core type surface so tools and host consumers share one authoritative definition.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test -p browseros-core`
- [x] `git diff --check`
- [x] independent Codex comment-quality review
