### PR TITLE
fix(claw-app): merge replay navigations by tab

### DIFF
--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -476,6 +476,28 @@ describe('Replay', () => {
       'this replay contains a known gap',
     )
   })
+
+  it("does not leak another tab's gap into the selected tab", async () => {
+    const partialReplay = replayData(events)
+    partialReplay.complete = false
+    const secondTab = partialReplay.tabs[1]
+    if (secondTab) {
+      secondTab.complete = false
+      const firstSegment = secondTab.segments[0]
+      if (firstSegment) firstSegment.hasGap = true
+    }
+    replayResult = { ...replayResult, replay: partialReplay }
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
+          <Replay />
+        </MemoryRouter>,
+      )
+    })
+
+    expect(container.textContent).not.toContain('Recording incomplete')
+  })
 })
 
 const { Replay } = await import('./Replay')

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -447,12 +447,18 @@ describe('Replay', () => {
     )
   })
 
-  it('does not hide a cataloged session gap behind a prefix warning', async () => {
+  it("keeps the selected tab's prefix warning when another tab has a gap", async () => {
     const partialReplay = replayData([
-      { ...events[0], ts: 500, type: 3 },
-      ...events.slice(0, 3),
+      { ...events[0], ts: 0, type: 3 },
+      ...events,
     ])
     partialReplay.complete = false
+    const secondTab = partialReplay.tabs[1]
+    if (secondTab) {
+      secondTab.complete = false
+      const firstSegment = secondTab.segments[0]
+      if (firstSegment) firstSegment.hasGap = true
+    }
     replayResult = { ...replayResult, replay: partialReplay }
 
     await act(async () => {
@@ -464,9 +470,11 @@ describe('Replay', () => {
     })
 
     expect(container.textContent).toContain(
-      'Recording incomplete — this replay contains a known gap',
+      'Recording incomplete — playback starts at 0:01',
     )
-    expect(container.textContent).not.toContain('playback starts at')
+    expect(container.textContent).not.toContain(
+      'this replay contains a known gap',
+    )
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -209,7 +209,7 @@ function replayData(replayEvents: readonly ReplayEvent[], tabOrder?: number[]) {
     frames,
     complete: true,
     tabs,
-    eventsForDocument: eventCatalog.eventsForDocument,
+    eventsForTab: eventCatalog.eventsForTab,
   }
 }
 
@@ -304,6 +304,11 @@ describe('Replay', () => {
         ?.getAttribute('data-player-documents'),
     ).toBe('document-a,document-a,document-a')
     expect(
+      [...container.querySelectorAll('[data-target-chip]')].map(
+        (chip) => chip.textContent,
+      ),
+    ).toEqual(['Tab 1', 'Tab 2'])
+    expect(
       container
         .querySelector('[data-playback-playing]')
         ?.getAttribute('data-playback-playing'),
@@ -355,7 +360,7 @@ describe('Replay', () => {
     ).toBe('0')
   })
 
-  it('offers navigation segments without merging their rrweb lifecycles', async () => {
+  it('merges navigation lifecycles into one tab-level replay', async () => {
     const navigationEvents: ReplayEvent[] = [
       ...events.slice(0, 3),
       ...events.slice(3).map((candidate) => ({
@@ -377,29 +382,16 @@ describe('Replay', () => {
       )
     })
 
-    expect(container.textContent).toContain('Navigation 1')
-    expect(container.textContent).toContain('Navigation 2')
+    expect(container.textContent).not.toContain('Navigation 1')
+    expect(container.textContent).not.toContain('Navigation 2')
     expect(
       container
         .querySelector('[data-player-documents]')
         ?.getAttribute('data-player-documents'),
-    ).toBe('document-a,document-a,document-a')
-
-    const secondNavigation = container.querySelector(
-      '[data-target-chip="document-b"]',
-    )
-    if (!secondNavigation) throw new Error('second navigation missing')
-    await act(async () => {
-      secondNavigation.dispatchEvent(
-        new window.Event('click', { bubbles: true }),
-      )
-    })
-
+    ).toBe('document-a,document-a,document-a,document-b,document-b,document-b')
     expect(
-      container
-        .querySelector('[data-player-documents]')
-        ?.getAttribute('data-player-documents'),
-    ).toBe('document-b,document-b,document-b')
+      container.querySelector('[data-target-chip="document-b"]'),
+    ).toBeNull()
   })
 
   it('slices orphan mutations and explains where visual playback starts', async () => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -447,15 +447,12 @@ describe('Replay', () => {
     )
   })
 
-  it('does not present a cataloged recording gap as complete', async () => {
-    const partialReplay = replayData(events.slice(0, 3))
+  it('does not hide a cataloged session gap behind a prefix warning', async () => {
+    const partialReplay = replayData([
+      { ...events[0], ts: 500, type: 3 },
+      ...events.slice(0, 3),
+    ])
     partialReplay.complete = false
-    const firstTab = partialReplay.tabs[0]
-    if (firstTab) {
-      firstTab.complete = false
-      const firstSegment = firstTab.segments[0]
-      if (firstSegment) firstSegment.hasGap = true
-    }
     replayResult = { ...replayResult, replay: partialReplay }
 
     await act(async () => {
@@ -469,6 +466,7 @@ describe('Replay', () => {
     expect(container.textContent).toContain(
       'Recording incomplete — this replay contains a known gap',
     )
+    expect(container.textContent).not.toContain('playback starts at')
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -24,40 +24,28 @@ export function Replay() {
   const { replay, isLoading, navigate } = useReplayData()
   const location = useLocation()
   const [selectedTabId, setSelectedTabId] = useState<number | null>(null)
-  const [selectedDocumentId, setSelectedDocumentId] = useState<string | null>(
-    null,
-  )
   const playerHandleRef = useRef<ReplayPlayerHandle | null>(null)
   const playbackTimeRef = useRef(0)
   const playbackSpeedRef = useRef(1)
   const playbackIsPlayingRef = useRef(true)
-  const pendingSegmentSeekRef = useRef<number | null>(null)
+  const pendingTabSeekRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (!replay) return
     const firstTab = replay.tabs[0]
     if (!firstTab) {
-      if (selectedTabId !== null || selectedDocumentId !== null) {
-        pendingSegmentSeekRef.current = 0
+      if (selectedTabId !== null) {
+        pendingTabSeekRef.current = 0
         setSelectedTabId(null)
-        setSelectedDocumentId(null)
       }
       return
     }
     const selectedTab = replay.tabs.find((tab) => tab.tabId === selectedTabId)
     if (!selectedTab) {
+      if (selectedTabId !== null) pendingTabSeekRef.current = 0
       setSelectedTabId(firstTab.tabId)
-      setSelectedDocumentId(firstTab.segments[0]?.documentId ?? null)
-      return
     }
-    if (
-      !selectedTab.segments.some(
-        (segment) => segment.documentId === selectedDocumentId,
-      )
-    ) {
-      setSelectedDocumentId(selectedTab.segments[0]?.documentId ?? null)
-    }
-  }, [replay, selectedDocumentId, selectedTabId])
+  }, [replay, selectedTabId])
 
   const tabViewInput = useMemo(
     () =>
@@ -65,7 +53,7 @@ export function Replay() {
         ? {
             frames: replay.frames,
             tabs: replay.tabs,
-            eventsForDocument: replay.eventsForDocument,
+            eventsForTab: replay.eventsForTab,
             startedAtMs: replay.startedAtMs,
           }
         : null,
@@ -73,10 +61,8 @@ export function Replay() {
   )
   const perTabView = useMemo(
     () =>
-      tabViewInput
-        ? buildTabView(tabViewInput, selectedTabId, selectedDocumentId)
-        : EMPTY_TAB_VIEW,
-    [selectedDocumentId, selectedTabId, tabViewInput],
+      tabViewInput ? buildTabView(tabViewInput, selectedTabId) : EMPTY_TAB_VIEW,
+    [selectedTabId, tabViewInput],
   )
 
   const playbackTotalSeconds = perTabView.hasFullSnapshot
@@ -135,64 +121,37 @@ export function Replay() {
     [playback.seek],
   )
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: target changes must flush pending seeks even when both targets have the same duration.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: tab changes must flush pending seeks even when consecutive tabs have the same duration.
   useEffect(() => {
-    const pendingSeconds = pendingSegmentSeekRef.current
+    const pendingSeconds = pendingTabSeekRef.current
     if (pendingSeconds === null) return
-    pendingSegmentSeekRef.current = null
+    pendingTabSeekRef.current = null
     seekTo(pendingSeconds)
-  }, [seekTo, selectedDocumentId, selectedTabId])
+  }, [seekTo, selectedTabId])
 
   const selectTab = useCallback(
     (value: string) => {
       const tabId = Number(value)
       if (!replay || !Number.isSafeInteger(tabId)) return
-      if (tabId === selectedTabId) {
-        seekTo(0)
-        return
-      }
-      pendingSegmentSeekRef.current = 0
-      const tab = replay.tabs.find((candidate) => candidate.tabId === tabId)
+      if (tabId === selectedTabId) return
+      pendingTabSeekRef.current = 0
       setSelectedTabId(tabId)
-      setSelectedDocumentId(tab?.segments[0]?.documentId ?? null)
     },
-    [replay, seekTo, selectedTabId],
-  )
-
-  const selectDocument = useCallback(
-    (documentId: string) => {
-      if (documentId === selectedDocumentId) {
-        seekTo(0)
-        return
-      }
-      pendingSegmentSeekRef.current = 0
-      setSelectedDocumentId(documentId)
-    },
-    [seekTo, selectedDocumentId],
+    [replay, selectedTabId],
   )
 
   const selectFrame = useCallback(
     (frame: ReplayFrame) => {
       if (!tabViewInput) return
-      const tabSeek = tabSeekForFrame(
-        tabViewInput,
-        selectedTabId,
-        selectedDocumentId,
-        frame,
-      )
-      if (
-        tabSeek.tabId !== null &&
-        (tabSeek.tabId !== selectedTabId ||
-          tabSeek.documentId !== selectedDocumentId)
-      ) {
-        pendingSegmentSeekRef.current = tabSeek.seconds
+      const tabSeek = tabSeekForFrame(tabViewInput, selectedTabId, frame)
+      if (tabSeek.tabId !== null && tabSeek.tabId !== selectedTabId) {
+        pendingTabSeekRef.current = tabSeek.seconds
         setSelectedTabId(tabSeek.tabId)
-        setSelectedDocumentId(tabSeek.documentId)
         return
       }
       seekTo(tabSeek.seconds)
     },
-    [seekTo, selectedDocumentId, selectedTabId, tabViewInput],
+    [seekTo, selectedTabId, tabViewInput],
   )
 
   const onPlayerReady = useCallback((handle: ReplayPlayerHandle | null) => {
@@ -239,8 +198,6 @@ export function Replay() {
           (frame) => frame.dispatchId === currentTabFrame.dispatchId,
         )
       : -1
-  const selectedTab = replay.tabs.find((tab) => tab.tabId === selectedTabId)
-
   const stats: { label: string; value: string }[] = [
     { label: 'Duration', value: replay.duration },
     { label: 'Steps', value: replay.steps },
@@ -299,21 +256,6 @@ export function Replay() {
               </TabsList>
             </Tabs>
           )}
-          {(selectedTab?.segments.length ?? 0) > 1 &&
-            selectedDocumentId !== null && (
-              <Tabs value={selectedDocumentId} onValueChange={selectDocument}>
-                <TabsList variant="line">
-                  {selectedTab?.segments.map((segment, idx) => (
-                    <TabsTrigger
-                      key={segment.documentId}
-                      value={segment.documentId}
-                    >
-                      Navigation {idx + 1}
-                    </TabsTrigger>
-                  ))}
-                </TabsList>
-              </Tabs>
-            )}
           {perTabView.incompleteUntilMs !== null && (
             <div
               role="status"

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -202,6 +202,8 @@ export function Replay() {
     { label: 'Duration', value: replay.duration },
     { label: 'Steps', value: replay.steps },
   ]
+  const incompleteStartsAtMs =
+    replay.complete === false ? null : perTabView.incompleteUntilMs
 
   return (
     <div className="flex h-screen min-h-0 flex-col bg-bg-canvas">
@@ -256,16 +258,16 @@ export function Replay() {
               </TabsList>
             </Tabs>
           )}
-          {perTabView.incompleteUntilMs !== null && (
+          {incompleteStartsAtMs !== null && (
             <div
               role="status"
               className="rounded-lg border border-amber/30 bg-amber-tint px-3 py-2 font-medium text-ink-2 text-xs"
             >
               Recording incomplete — playback starts at{' '}
-              {formatIncompleteOffset(perTabView.incompleteUntilMs)}
+              {formatIncompleteOffset(incompleteStartsAtMs)}
             </div>
           )}
-          {perTabView.incompleteUntilMs === null &&
+          {incompleteStartsAtMs === null &&
             (perTabView.knownIncomplete || replay.complete === false) && (
               <div
                 role="status"

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -202,8 +202,6 @@ export function Replay() {
     { label: 'Duration', value: replay.duration },
     { label: 'Steps', value: replay.steps },
   ]
-  const incompleteStartsAtMs =
-    replay.complete === false ? null : perTabView.incompleteUntilMs
 
   return (
     <div className="flex h-screen min-h-0 flex-col bg-bg-canvas">
@@ -258,16 +256,16 @@ export function Replay() {
               </TabsList>
             </Tabs>
           )}
-          {incompleteStartsAtMs !== null && (
+          {perTabView.incompleteUntilMs !== null && (
             <div
               role="status"
               className="rounded-lg border border-amber/30 bg-amber-tint px-3 py-2 font-medium text-ink-2 text-xs"
             >
               Recording incomplete — playback starts at{' '}
-              {formatIncompleteOffset(incompleteStartsAtMs)}
+              {formatIncompleteOffset(perTabView.incompleteUntilMs)}
             </div>
           )}
-          {incompleteStartsAtMs === null &&
+          {perTabView.incompleteUntilMs === null &&
             (perTabView.knownIncomplete || replay.complete === false) && (
               <div
                 role="status"

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -266,7 +266,7 @@ export function Replay() {
             </div>
           )}
           {perTabView.incompleteUntilMs === null &&
-            (perTabView.knownIncomplete || replay.complete === false) && (
+            perTabView.knownIncomplete && (
               <div
                 role="status"
                 className="rounded-lg border border-amber/30 bg-amber-tint px-3 py-2 font-medium text-ink-2 text-xs"

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -34,7 +34,7 @@ interface ReplayViewportProps {
   site: string
   /** The frame whose caption is currently displayed in the overlay. */
   frame: ReplayFrame | undefined
-  /** rrweb events for the currently selected document segment. */
+  /** Every playable document lifecycle in the selected tab. */
   events: readonly ReplayEvent[]
   /** Called when the rrweb Replayer mounts or is destroyed. */
   onPlayerReady: (handle: ReplayPlayerHandle | null) => void

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay-events.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay-events.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { ReplayEvent } from '@/modules/api/replay.hooks'
+import { buildReplayEventCatalog } from './replay-events'
+
+function event(ts: number, tabId: number, documentId: string): ReplayEvent {
+  return {
+    sessionId: 'session-1',
+    documentId,
+    targetId: `target-${tabId}`,
+    tabId,
+    type: 2,
+    data: {},
+    ts,
+  }
+}
+
+describe('buildReplayEventCatalog', () => {
+  it('indexes one stable chronological stream per Chrome tab', () => {
+    const events = [
+      event(1_000, 1, 'document-a'),
+      event(2_000, 1, 'document-a'),
+      event(3_000, 1, 'document-b'),
+      event(4_000, 2, 'document-c'),
+    ]
+    const catalog = buildReplayEventCatalog(events)
+
+    expect(catalog.eventsForTab(1).map(({ documentId }) => documentId)).toEqual(
+      ['document-a', 'document-a', 'document-b'],
+    )
+    expect(catalog.eventsForTab(2)).toEqual([events[3]])
+    expect(catalog.eventsForTab(1)).toBe(catalog.eventsForTab(1))
+    expect(catalog.eventsForTab(99)).toBe(catalog.eventsForTab(99))
+    expect(catalog.documentIdsForTab(1)).toEqual(['document-a', 'document-b'])
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay-events.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay-events.ts
@@ -16,9 +16,10 @@ export interface ReplayEventCatalog {
   tabIds: number[]
   documentIdsForTab: (tabId: number) => readonly string[]
   eventsForDocument: (documentId: string) => readonly ReplayEvent[]
+  eventsForTab: (tabId: number) => readonly ReplayEvent[]
 }
 
-/** Keeps each Chrome document in its own stable rrweb event array. */
+/** Keeps stable rrweb event arrays for both internal documents and visible tabs. */
 export function buildReplayEventCatalog(
   events: readonly ReplayEvent[],
 ): ReplayEventCatalog {
@@ -27,6 +28,7 @@ export function buildReplayEventCatalog(
       tabIds: [],
       documentIdsForTab: () => [],
       eventsForDocument: () => EMPTY_REPLAY_EVENTS,
+      eventsForTab: () => EMPTY_REPLAY_EVENTS,
     }
   }
 
@@ -34,11 +36,15 @@ export function buildReplayEventCatalog(
   const seenTabs = new Set<number>()
   const documentsByTab = new Map<number, string[]>()
   const eventsByDocument = new Map<string, ReplayEvent[]>()
+  const eventsByTab = new Map<number, ReplayEvent[]>()
   for (const event of events) {
     if (!seenTabs.has(event.tabId)) {
       seenTabs.add(event.tabId)
       tabIds.push(event.tabId)
     }
+    const tabEvents = eventsByTab.get(event.tabId)
+    if (tabEvents) tabEvents.push(event)
+    else eventsByTab.set(event.tabId, [event])
     const documentEvents = eventsByDocument.get(event.documentId)
     if (documentEvents) {
       documentEvents.push(event)
@@ -55,6 +61,7 @@ export function buildReplayEventCatalog(
     documentIdsForTab: (tabId) => documentsByTab.get(tabId) ?? [],
     eventsForDocument: (documentId) =>
       eventsByDocument.get(documentId) ?? EMPTY_REPLAY_EVENTS,
+    eventsForTab: (tabId) => eventsByTab.get(tabId) ?? EMPTY_REPLAY_EVENTS,
   }
 }
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -69,7 +69,7 @@ export interface ReplayData {
   frames: ReplayFrame[]
   complete: boolean | null
   tabs: ReplayTabData[]
-  eventsForDocument: (documentId: string) => readonly ReplayEvent[]
+  eventsForTab: (tabId: number) => readonly ReplayEvent[]
 }
 
 // `buildTabView` and the `TabView` shape live in `./tab-view.ts` so
@@ -172,7 +172,7 @@ function buildReplayData(
     frames,
     complete: metadata?.complete ?? null,
     tabs,
-    eventsForDocument: eventCatalog.eventsForDocument,
+    eventsForTab: eventCatalog.eventsForTab,
   }
 }
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
@@ -79,21 +79,68 @@ function makeInput(
   return {
     frames: [],
     tabs: [],
-    eventsForDocument: () => [],
+    eventsForTab: () => [],
     startedAtMs: 1_000_000,
     ...overrides,
   }
 }
 
 describe('buildTabView', () => {
-  it('returns empty without a selected tab and document', () => {
-    const view = buildTabView(makeInput(), null, null)
+  it('returns empty without a selected tab', () => {
+    const view = buildTabView(makeInput(), null)
     expect(view.events).toEqual([])
     expect(view.frames).toEqual([])
     expect(view.totalSeconds).toBe(0)
   })
 
-  it('keeps navigation documents in separate rrweb player inputs', () => {
+  it('merges every document lifecycle and action from one tab', () => {
+    const events = [
+      event(1_001_000, 'document-a', 1, 0),
+      event(1_001_001, 'document-a', 1, 4),
+      event(1_002_000, 'document-a', 1, 2),
+      event(1_003_000, 'document-a', 1, 3),
+      event(1_004_000, 'document-b', 1, 0),
+      event(1_004_001, 'document-b', 1, 4),
+      event(1_005_000, 'document-b', 1, 2),
+      event(1_006_000, 'document-b', 1, 3),
+      event(1_007_000, 'document-c', 2, 2),
+    ]
+    const catalog = buildReplayEventCatalog(events)
+    const input = makeInput({
+      frames: [frame(1, 1), frame(5, 1), frame(6, 2)],
+      tabs: [
+        tab(1, [
+          {
+            documentId: 'document-a',
+            firstEventAt: 1_001_000,
+            lastEventAt: 1_003_000,
+          },
+          {
+            documentId: 'document-b',
+            firstEventAt: 1_004_000,
+            lastEventAt: 1_006_000,
+          },
+        ]),
+      ],
+      eventsForTab: catalog.eventsForTab,
+    })
+
+    const view = buildTabView(input, 1)
+    expect(view.events.map(({ documentId }) => documentId)).toEqual([
+      'document-a',
+      'document-a',
+      'document-a',
+      'document-a',
+      'document-b',
+      'document-b',
+      'document-b',
+      'document-b',
+    ])
+    expect(view.frames.map(({ t }) => t)).toEqual([0, 4])
+    expect(view.totalSeconds).toBe(5)
+  })
+
+  it('keeps a merged tab event array stable across audit polling', () => {
     const events = [
       event(1_001_000, 'document-a'),
       event(1_002_000, 'document-a', 1, 3),
@@ -101,98 +148,42 @@ describe('buildTabView', () => {
       event(1_004_000, 'document-b', 1, 3),
     ]
     const catalog = buildReplayEventCatalog(events)
-    const input = makeInput({
-      tabs: [
-        tab(1, [
-          {
-            documentId: 'document-a',
-            firstEventAt: 1_001_000,
-            lastEventAt: 1_002_000,
-          },
-          {
-            documentId: 'document-b',
-            firstEventAt: 1_003_000,
-            lastEventAt: 1_004_000,
-          },
-        ]),
-      ],
-      eventsForDocument: catalog.eventsForDocument,
-    })
-
-    expect(
-      buildTabView(input, 1, 'document-a').events.map(
-        (candidate) => candidate.documentId,
-      ),
-    ).toEqual(['document-a', 'document-a'])
-    expect(
-      buildTabView(input, 1, 'document-b').events.map(
-        (candidate) => candidate.documentId,
-      ),
-    ).toEqual(['document-b', 'document-b'])
-  })
-
-  it('assigns tab captions to the nearest document ownership window', () => {
-    const input = makeInput({
-      frames: [frame(1, 1), frame(3, 1), frame(3, 2), frame(6, 1)],
-      tabs: [
-        tab(1, [
-          {
-            documentId: 'document-a',
-            firstEventAt: 1_002_000,
-            lastEventAt: 1_004_000,
-          },
-          {
-            documentId: 'document-b',
-            firstEventAt: 1_005_000,
-            lastEventAt: 1_007_000,
-          },
-        ]),
-      ],
-    })
-    const view = buildTabView(input, 1, 'document-a')
-
-    expect(view.frames).toHaveLength(2)
-    expect(view.frames.map((candidate) => candidate.t)).toEqual([0, 2])
-  })
-
-  it('keeps a document event array stable across audit polling', () => {
-    const catalog = buildReplayEventCatalog([
-      event(1_002_000, 'document-a'),
-      event(1_003_000, 'document-a', 1, 3),
-    ])
     const tabs = [
       tab(1, [
         {
           documentId: 'document-a',
-          firstEventAt: 1_002_000,
-          lastEventAt: 1_003_000,
+          firstEventAt: 1_001_000,
+          lastEventAt: 1_002_000,
+        },
+        {
+          documentId: 'document-b',
+          firstEventAt: 1_003_000,
+          lastEventAt: 1_004_000,
         },
       ]),
     ]
     const first = buildTabView(
       makeInput({
-        frames: [frame(2, 1)],
+        frames: [frame(1, 1)],
         tabs,
-        eventsForDocument: catalog.eventsForDocument,
+        eventsForTab: catalog.eventsForTab,
       }),
       1,
-      'document-a',
     )
     const afterAuditPoll = buildTabView(
       makeInput({
-        frames: [frame(2, 1), frame(3, 1)],
+        frames: [frame(1, 1), frame(2, 1)],
         tabs,
-        eventsForDocument: catalog.eventsForDocument,
+        eventsForTab: catalog.eventsForTab,
       }),
       1,
-      'document-a',
     )
 
     expect(afterAuditPoll.events).toBe(first.events)
     expect(afterAuditPoll.frames).not.toBe(first.frames)
   })
 
-  it('reuses the playable slice after leading orphan mutations', () => {
+  it('reuses the playable stream after leading orphan mutations', () => {
     const rawEvents = [
       event(1_001_000, 'document-a', 1, 3),
       event(1_004_000, 'document-a'),
@@ -208,18 +199,18 @@ describe('buildTabView', () => {
           },
         ]),
       ],
-      eventsForDocument: () => rawEvents,
+      eventsForTab: () => rawEvents,
     })
 
-    const first = buildTabView(input, 1, 'document-a')
-    const second = buildTabView(input, 1, 'document-a')
+    const first = buildTabView(input, 1)
+    const second = buildTabView(input, 1)
     expect(first.events.map(({ type }) => type)).toEqual([2, 3])
     expect(second.events).toBe(first.events)
     expect(first.incompleteUntilMs).toBe(3_000)
     expect(first.knownIncomplete).toBe(true)
   })
 
-  it('surfaces a cataloged gap even when the segment is playable', () => {
+  it('surfaces a cataloged gap even when the tab is playable', () => {
     const input = makeInput({
       tabs: [
         tab(1, [
@@ -231,13 +222,13 @@ describe('buildTabView', () => {
           },
         ]),
       ],
-      eventsForDocument: () => [
+      eventsForTab: () => [
         event(1_001_000, 'document-gap'),
         event(1_002_000, 'document-gap', 1, 3),
       ],
     })
 
-    expect(buildTabView(input, 1, 'document-gap').knownIncomplete).toBe(true)
+    expect(buildTabView(input, 1).knownIncomplete).toBe(true)
   })
 
   it('marks an event stream without a full snapshot as incomplete', () => {
@@ -251,14 +242,54 @@ describe('buildTabView', () => {
           },
         ]),
       ],
-      eventsForDocument: () => [
-        event(1_001_000, 'document-missing-snapshot', 1, 3),
-      ],
+      eventsForTab: () => [event(1_001_000, 'document-missing-snapshot', 1, 3)],
     })
 
-    const view = buildTabView(input, 1, 'document-missing-snapshot')
+    const view = buildTabView(input, 1)
     expect(view.hasFullSnapshot).toBe(false)
     expect(view.knownIncomplete).toBe(true)
+  })
+
+  it('omits an unplayable middle document and reports a middle gap', () => {
+    const events = [
+      event(1_001_000, 'document-a'),
+      event(1_002_000, 'document-a', 1, 3),
+      event(1_003_000, 'document-b', 1, 3),
+      event(1_004_000, 'document-c'),
+      event(1_005_000, 'document-c', 1, 3),
+    ]
+    const input = makeInput({
+      tabs: [
+        tab(1, [
+          {
+            documentId: 'document-a',
+            firstEventAt: 1_001_000,
+            lastEventAt: 1_002_000,
+          },
+          {
+            documentId: 'document-b',
+            firstEventAt: 1_003_000,
+            lastEventAt: 1_003_000,
+          },
+          {
+            documentId: 'document-c',
+            firstEventAt: 1_004_000,
+            lastEventAt: 1_005_000,
+          },
+        ]),
+      ],
+      eventsForTab: buildReplayEventCatalog(events).eventsForTab,
+    })
+
+    const view = buildTabView(input, 1)
+    expect(view.events.map(({ documentId }) => documentId)).toEqual([
+      'document-a',
+      'document-a',
+      'document-c',
+      'document-c',
+    ])
+    expect(view.knownIncomplete).toBe(true)
+    expect(view.incompleteUntilMs).toBeNull()
   })
 })
 
@@ -312,7 +343,7 @@ describe('catalog ordering', () => {
 })
 
 describe('tabSeekForFrame', () => {
-  it('switches tab and navigation segment using dispatch tab identity and time', () => {
+  it('switches tabs using dispatch tab identity and the tab clock', () => {
     const selectedFrame = frame(12, 2, { dispatchId: 22 })
     const events = [
       event(1_010_000, 'document-b', 2),
@@ -336,13 +367,45 @@ describe('tabSeekForFrame', () => {
           },
         ]),
       ],
-      eventsForDocument: buildReplayEventCatalog(events).eventsForDocument,
+      eventsForTab: buildReplayEventCatalog(events).eventsForTab,
     })
 
-    expect(tabSeekForFrame(input, 1, 'document-a', selectedFrame)).toEqual({
+    expect(tabSeekForFrame(input, 1, selectedFrame)).toEqual({
       tabId: 2,
-      documentId: 'document-b',
       seconds: 2,
+    })
+  })
+
+  it('does not reset the clock for an action after navigation', () => {
+    const selectedFrame = frame(12, 1, { dispatchId: 22 })
+    const events = [
+      event(1_001_000, 'document-a'),
+      event(1_005_000, 'document-a', 1, 3),
+      event(1_010_000, 'document-b'),
+      event(1_015_000, 'document-b', 1, 3),
+    ]
+    const input = makeInput({
+      frames: [selectedFrame],
+      tabs: [
+        tab(1, [
+          {
+            documentId: 'document-a',
+            firstEventAt: 1_001_000,
+            lastEventAt: 1_005_000,
+          },
+          {
+            documentId: 'document-b',
+            firstEventAt: 1_010_000,
+            lastEventAt: 1_015_000,
+          },
+        ]),
+      ],
+      eventsForTab: buildReplayEventCatalog(events).eventsForTab,
+    })
+
+    expect(tabSeekForFrame(input, 1, selectedFrame)).toEqual({
+      tabId: 1,
+      seconds: 11,
     })
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
@@ -250,8 +250,9 @@ describe('buildTabView', () => {
     expect(view.knownIncomplete).toBe(true)
   })
 
-  it('omits an unplayable middle document and reports a middle gap', () => {
+  it('reports a generic gap when omissions occur before and during playback', () => {
     const events = [
+      event(1_000_000, 'document-a', 1, 3),
       event(1_001_000, 'document-a'),
       event(1_002_000, 'document-a', 1, 3),
       event(1_003_000, 'document-b', 1, 3),
@@ -263,7 +264,7 @@ describe('buildTabView', () => {
         tab(1, [
           {
             documentId: 'document-a',
-            firstEventAt: 1_001_000,
+            firstEventAt: 1_000_000,
             lastEventAt: 1_002_000,
           },
           {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
@@ -32,6 +32,7 @@ const NO_VISUAL_EVENTS: readonly ReplayEvent[] = []
 interface PlayableTabStream {
   events: readonly ReplayEvent[]
   hasOmittedEvents: boolean
+  hasOmittedEventsAfterPlaybackStart: boolean
   incompleteUntilMs: number | null
 }
 
@@ -43,6 +44,7 @@ const playableTabStreams = new WeakMap<
 const EMPTY_PLAYABLE_TAB_STREAM: PlayableTabStream = {
   events: NO_VISUAL_EVENTS,
   hasOmittedEvents: false,
+  hasOmittedEventsAfterPlaybackStart: false,
   incompleteUntilMs: null,
 }
 
@@ -80,6 +82,9 @@ export function buildTabView(
     timingEvents.at(-1)?.ts ??
     input.startedAtMs + (rawFrames.at(-1)?.t ?? 0) * 1000
   const originT = (originMs - input.startedAtMs) / 1000
+  const hasCatalogedGap =
+    tab.complete === false ||
+    tab.segments.some((segment) => segment.hasGap || segment.legacy)
   return {
     frames: rawFrames.map((frame) => ({
       ...frame,
@@ -88,11 +93,11 @@ export function buildTabView(
     events: stream.events,
     totalSeconds: Math.max(0, (endMs - originMs) / 1000),
     hasFullSnapshot,
-    knownIncomplete:
-      tab.complete === false ||
-      tab.segments.some((segment) => segment.hasGap || segment.legacy) ||
-      stream.hasOmittedEvents,
-    incompleteUntilMs: stream.incompleteUntilMs,
+    knownIncomplete: hasCatalogedGap || stream.hasOmittedEvents,
+    incompleteUntilMs:
+      hasCatalogedGap || stream.hasOmittedEventsAfterPlaybackStart
+        ? null
+        : stream.incompleteUntilMs,
   }
 }
 
@@ -143,13 +148,18 @@ function playableTabStream(
   const hasOmittedEvents = [...documents.values()].some(
     (state) => state.firstSnapshotIndex === -1 || state.mutationBeforeSnapshot,
   )
+  let playbackStarted = false
+  let hasOmittedEventsAfterPlaybackStart = false
   const events = hasOmittedEvents
     ? rawEvents.filter((event, index) => {
         const state = documents.get(event.documentId)
-        if (!state || state.firstSnapshotIndex === -1) return false
-        return (
-          !state.mutationBeforeSnapshot || index >= state.firstSnapshotIndex
-        )
+        const playable =
+          state !== undefined &&
+          state.firstSnapshotIndex !== -1 &&
+          (!state.mutationBeforeSnapshot || index >= state.firstSnapshotIndex)
+        if (playable) playbackStarted = true
+        else if (playbackStarted) hasOmittedEventsAfterPlaybackStart = true
+        return playable
       })
     : rawEvents
   const firstRawAt = rawEvents[0]?.ts
@@ -157,6 +167,7 @@ function playableTabStream(
   const result = {
     events,
     hasOmittedEvents,
+    hasOmittedEventsAfterPlaybackStart,
     incompleteUntilMs:
       firstRawAt !== undefined &&
       firstPlayableAt !== undefined &&

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
@@ -5,11 +5,11 @@
  */
 
 import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
-import type { ReplaySegmentData, ReplayTabData } from './replay.data'
+import type { ReplayTabData } from './replay.data'
 
 export interface TabView {
   frames: ReplayFrame[]
-  /** Events from exactly one Chrome document lifecycle. */
+  /** Every playable document lifecycle from one Chrome tab. */
   events: readonly ReplayEvent[]
   totalSeconds: number
   hasFullSnapshot: boolean
@@ -28,61 +28,52 @@ export const EMPTY_TAB_VIEW: TabView = {
 }
 
 const NO_VISUAL_EVENTS: readonly ReplayEvent[] = []
-const playableEvents = new WeakMap<
+
+interface PlayableTabStream {
+  events: readonly ReplayEvent[]
+  hasOmittedEvents: boolean
+  incompleteUntilMs: number | null
+}
+
+const playableTabStreams = new WeakMap<
   readonly ReplayEvent[],
-  readonly ReplayEvent[]
+  PlayableTabStream
 >()
+
+const EMPTY_PLAYABLE_TAB_STREAM: PlayableTabStream = {
+  events: NO_VISUAL_EVENTS,
+  hasOmittedEvents: false,
+  incompleteUntilMs: null,
+}
+
+interface DocumentState {
+  firstSnapshotIndex: number
+  mutationBeforeSnapshot: boolean
+}
 
 export interface BuildTabViewInput {
   frames: ReplayFrame[]
   tabs: ReplayTabData[]
-  eventsForDocument: (documentId: string) => readonly ReplayEvent[]
+  eventsForTab: (tabId: number) => readonly ReplayEvent[]
   startedAtMs: number
 }
 
-/** Builds one navigation segment without merging independent rrweb documents. */
+/** Projects one continuous player and action clock for a persisted Chrome tab. */
 export function buildTabView(
   input: BuildTabViewInput,
   tabId: number | null,
-  documentId: string | null,
 ): TabView {
-  const segment = findSegment(input.tabs, tabId, documentId)
-  if (!segment || tabId === null) return EMPTY_TAB_VIEW
-  const rawEvents = input.eventsForDocument(segment.documentId)
-  const rawFrames = input.frames.filter((frame) => {
-    if (frame.tabId !== tabId) return false
-    const timestamp = input.startedAtMs + frame.t * 1000
-    const tabSegments =
-      input.tabs.find((candidate) => candidate.tabId === tabId)?.segments ?? []
-    return (
-      segmentForTimestamp(tabSegments, timestamp)?.documentId === documentId
-    )
-  })
+  if (tabId === null) return EMPTY_TAB_VIEW
+  const tab = input.tabs.find((candidate) => candidate.tabId === tabId)
+  if (!tab) return EMPTY_TAB_VIEW
+
+  const rawEvents = input.eventsForTab(tabId)
+  const stream = playableTabStream(rawEvents)
+  const rawFrames = input.frames.filter((frame) => frame.tabId === tabId)
   if (rawFrames.length === 0 && rawEvents.length === 0) return EMPTY_TAB_VIEW
 
-  const firstSnapshotIndex = rawEvents.findIndex((event) => event.type === 2)
-  const hasFullSnapshot = firstSnapshotIndex !== -1
-  const missingSnapshot = rawEvents.length > 0 && !hasFullSnapshot
-  const hasLeadingMutation =
-    firstSnapshotIndex > 0 &&
-    rawEvents.slice(0, firstSnapshotIndex).some((event) => event.type === 3)
-  let events: readonly ReplayEvent[]
-  if (!hasFullSnapshot) {
-    events = NO_VISUAL_EVENTS
-  } else if (hasLeadingMutation) {
-    const cached = playableEvents.get(rawEvents)
-    events = cached ?? rawEvents.slice(firstSnapshotIndex)
-    if (!cached) playableEvents.set(rawEvents, events)
-  } else {
-    events = rawEvents
-  }
-  const incompleteUntilMs = hasLeadingMutation
-    ? Math.max(
-        0,
-        (rawEvents[firstSnapshotIndex]?.ts ?? 0) - (rawEvents[0]?.ts ?? 0),
-      )
-    : null
-  const timingEvents = hasFullSnapshot ? events : rawEvents
+  const hasFullSnapshot = stream.events.some((event) => event.type === 2)
+  const timingEvents = hasFullSnapshot ? stream.events : rawEvents
   const originMs =
     timingEvents[0]?.ts ?? input.startedAtMs + (rawFrames[0]?.t ?? 0) * 1000
   const endMs =
@@ -94,77 +85,85 @@ export function buildTabView(
       ...frame,
       t: Math.max(0, frame.t - originT),
     })),
-    events,
+    events: stream.events,
     totalSeconds: Math.max(0, (endMs - originMs) / 1000),
     hasFullSnapshot,
     knownIncomplete:
-      segment.hasGap || segment.legacy || missingSnapshot || hasLeadingMutation,
-    incompleteUntilMs,
+      tab.complete === false ||
+      tab.segments.some((segment) => segment.hasGap || segment.legacy) ||
+      stream.hasOmittedEvents,
+    incompleteUntilMs: stream.incompleteUntilMs,
   }
 }
 
 export interface TabSeek {
   tabId: number | null
-  documentId: string | null
   seconds: number
 }
 
-/** Resolves an audit frame to its logical tab and navigation segment clock. */
+/** Resolves an audit frame to its persisted Chrome tab and continuous clock. */
 export function tabSeekForFrame(
   input: BuildTabViewInput,
   selectedTabId: number | null,
-  selectedDocumentId: string | null,
   frame: ReplayFrame,
 ): TabSeek {
   const tabId = frame.tabId ?? selectedTabId
-  if (tabId === null) {
-    return { tabId, documentId: selectedDocumentId, seconds: frame.t }
-  }
-  const tab = input.tabs.find((candidate) => candidate.tabId === tabId)
-  const timestamp = input.startedAtMs + frame.t * 1000
-  const segment =
-    segmentForTimestamp(tab?.segments ?? [], timestamp) ??
-    findSegment(input.tabs, tabId, selectedDocumentId)
-  if (!segment) return { tabId, documentId: null, seconds: frame.t }
-  const view = buildTabView(input, tabId, segment.documentId)
+  if (tabId === null) return { tabId, seconds: frame.t }
+
+  const view = buildTabView(input, tabId)
   const originMs =
-    view.events[0]?.ts ?? segment.firstEventAt ?? input.startedAtMs
+    view.events[0]?.ts ?? input.eventsForTab(tabId)[0]?.ts ?? input.startedAtMs
+  const timestamp = input.startedAtMs + frame.t * 1000
   return {
     tabId,
-    documentId: segment.documentId,
     seconds: Math.max(0, (timestamp - originMs) / 1000),
   }
 }
 
-function findSegment(
-  tabs: readonly ReplayTabData[],
-  tabId: number | null,
-  documentId: string | null,
-): ReplaySegmentData | undefined {
-  if (tabId === null || documentId === null) return undefined
-  return tabs
-    .find((tab) => tab.tabId === tabId)
-    ?.segments.find((segment) => segment.documentId === documentId)
-}
+function playableTabStream(
+  rawEvents: readonly ReplayEvent[],
+): PlayableTabStream {
+  if (rawEvents.length === 0) return EMPTY_PLAYABLE_TAB_STREAM
+  const cached = playableTabStreams.get(rawEvents)
+  if (cached) return cached
 
-function segmentForTimestamp(
-  segments: readonly ReplaySegmentData[],
-  timestamp: number,
-): ReplaySegmentData | undefined {
-  const overlapping = segments.find(
-    (segment) =>
-      timestamp >= segment.firstEventAt && timestamp <= segment.lastEventAt,
+  const documents = new Map<string, DocumentState>()
+  rawEvents.forEach((event, index) => {
+    const state = documents.get(event.documentId) ?? {
+      firstSnapshotIndex: -1,
+      mutationBeforeSnapshot: false,
+    }
+    if (state.firstSnapshotIndex === -1) {
+      if (event.type === 3) state.mutationBeforeSnapshot = true
+      if (event.type === 2) state.firstSnapshotIndex = index
+    }
+    documents.set(event.documentId, state)
+  })
+
+  const hasOmittedEvents = [...documents.values()].some(
+    (state) => state.firstSnapshotIndex === -1 || state.mutationBeforeSnapshot,
   )
-  if (overlapping) return overlapping
-  return [...segments].sort((left, right) => {
-    const leftDistance = Math.min(
-      Math.abs(timestamp - left.firstEventAt),
-      Math.abs(timestamp - left.lastEventAt),
-    )
-    const rightDistance = Math.min(
-      Math.abs(timestamp - right.firstEventAt),
-      Math.abs(timestamp - right.lastEventAt),
-    )
-    return leftDistance - rightDistance
-  })[0]
+  const events = hasOmittedEvents
+    ? rawEvents.filter((event, index) => {
+        const state = documents.get(event.documentId)
+        if (!state || state.firstSnapshotIndex === -1) return false
+        return (
+          !state.mutationBeforeSnapshot || index >= state.firstSnapshotIndex
+        )
+      })
+    : rawEvents
+  const firstRawAt = rawEvents[0]?.ts
+  const firstPlayableAt = events[0]?.ts
+  const result = {
+    events,
+    hasOmittedEvents,
+    incompleteUntilMs:
+      firstRawAt !== undefined &&
+      firstPlayableAt !== undefined &&
+      firstPlayableAt > firstRawAt
+        ? firstPlayableAt - firstRawAt
+        : null,
+  }
+  playableTabStreams.set(rawEvents, result)
+  return result
 }


### PR DESCRIPTION
## Summary

- group chronological rrweb document lifecycles by persisted Chrome `tabId`
- keep one playback/action clock per real browser tab and remove document-level Navigation controls
- retain `documentId` internally for snapshot safety, completeness checks, and stable replay inputs

## Design

The replay UI now projects a single continuous stream per Chrome tab while preserving document metadata as internal recording boundaries. True multi-tab selection remains unchanged, and completeness warnings are scoped to the selected tab.

## Test plan

- [x] Replay-focused Bun tests
- [x] Full claw-app test suite
- [x] Claw-app typecheck and development build
- [x] Full repository test suite
- [x] Root typecheck and Fallow
- [x] Biome on all touched files
- [x] `git diff --check`

`bun run check` still reports two pre-existing `noUnsafeOptionalChaining` diagnostics in unchanged `apps/server/tests/lib/agents/acpx-runtime.test.ts` (lines 160 and 203); the same diagnostics reproduce on `origin/main`.