### PR TITLE
docs(core): explain snapshot reference semantics

### DIFF
--- a/packages/browseros-agent/crates/browseros-core/src/observer.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer.rs
@@ -87,6 +87,8 @@ impl Observer {
         options: SnapshotOptions,
     ) -> Result<SnapshotResult, CoreError> {
         let result = self.capture().await?;
+        // Options filter only the returned presentation; commit keeps the full
+        // capture as the next diff baseline.
         let text = apply_snapshot_options(&result.text, options);
         self.commit(result.clone()).await;
         Ok(SnapshotResult {

--- a/packages/browseros-agent/crates/browseros-core/src/snapshot/diff.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/snapshot/diff.rs
@@ -4,6 +4,8 @@ pub struct SnapshotDiff {
     pub added: usize,
     pub removed: usize,
     pub changed: bool,
+    /// When true, `text` is the full current snapshot for a known URL change, not a line diff.
+    /// `added` and `removed` are zero so MCP formats or spills it as a snapshot.
     pub url_changed: bool,
     pub before_url: Option<String>,
     pub after_url: Option<String>,

--- a/packages/browseros-agent/crates/browseros-core/src/snapshot/diff.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/snapshot/diff.rs
@@ -4,8 +4,8 @@ pub struct SnapshotDiff {
     pub added: usize,
     pub removed: usize,
     pub changed: bool,
-    /// When true, `text` is the full current snapshot for a known URL change, not a line diff.
-    /// `added` and `removed` are zero so MCP formats or spills it as a snapshot.
+    /// When true, `text` is the full current snapshot for a known URL change, not a line diff,
+    /// and `added` and `removed` are zero.
     pub url_changed: bool,
     pub before_url: Option<String>,
     pub after_url: Option<String>,

--- a/packages/browseros-agent/crates/browseros-core/src/snapshot/refs.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/snapshot/refs.rs
@@ -4,6 +4,8 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+/// Document identity synthesized for snapshot refs as `frame_id:loader_id`, not a raw CDP field.
+/// A change starts fresh stable-ref assignment for that document scope.
 pub type DocumentId = String;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12,6 +14,8 @@ pub struct RefEntry {
     pub backend_node_id: i64,
     pub role: String,
     pub name: String,
+    /// Zero-based occurrence among nodes with the same frame, role, and name in the latest capture.
+    /// Recomputed per snapshot and used only to recover a ref whose backend node id went stale.
     pub nth: usize,
     pub frame_id: Option<FrameId>,
 }


### PR DESCRIPTION
## Summary
- preserve the full snapshot as the next diff baseline even when returned output is filtered
- document synthesized document scope and capture-local stale-ref recovery metadata
- define the URL-change full-snapshot result shape

## Design
The comments sit on the producer boundaries that own each invariant, avoiding duplicate explanations in MCP consumers.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test -p browseros-core`
- [x] `git diff --check`
- [x] independent Codex review, one wording correction, final PASS
