### PR TITLE
feat(claw-server): add release-safe version contract

### DIFF
--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -6,7 +6,7 @@ name: "Release: BrowserClaw Server (Rust)"
 on:
   push:
     tags:
-      - "claw-server-rust/v*"
+      - "claw-server/v*"
   workflow_dispatch:
     inputs:
       version:
@@ -281,6 +281,18 @@ jobs:
           cargo build --release --locked --target "$RUST_TARGET" \
             -p claw-server-rust \
             --bin browseros-claw-server-rs
+
+      - name: Verify stamped binary version
+        shell: bash
+        working-directory: packages/browseros-agent
+        run: |
+          set -euo pipefail
+          BINARY_PATH="target/$RUST_TARGET/release/browseros-claw-server-rs$BINARY_EXT"
+          ACTUAL_VERSION="$("$BINARY_PATH" --version)"
+          if [ "$ACTUAL_VERSION" != "$VERSION" ]; then
+            echo "::error::Expected $VERSION from $BINARY_PATH, got: $ACTUAL_VERSION" >&2
+            exit 1
+          fi
 
       - name: Package artifact zip
         id: package

--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "claw-server-rust"
-version = "0.1.0"
+version = "0.0.13"
 dependencies = [
  "agent-mcp-manager",
  "anyhow",

--- a/packages/browseros-agent/apps/claw-server-rust/Cargo.toml
+++ b/packages/browseros-agent/apps/claw-server-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claw-server-rust"
-version = "0.1.0"
+version = "0.0.13"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/system.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/system.rs
@@ -1,4 +1,4 @@
-use crate::AppState;
+use crate::{AppState, VERSION};
 use axum::{Json, extract::State};
 use claw_api::models::{
     HealthResponse, ShutdownResponse, SystemCapabilities, SystemInfo,
@@ -21,7 +21,7 @@ pub(super) async fn shutdown(State(state): State<AppState>) -> Json<ShutdownResp
 pub(super) async fn info(State(state): State<AppState>) -> Json<SystemInfo> {
     let mut info = SystemInfo::new(
         "BrowserClaw".to_string(),
-        env!("CARGO_PKG_VERSION").to_string(),
+        VERSION.to_string(),
         state.config.local_server_url(),
     );
     let mut capabilities = SystemCapabilities::new();

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AppState,
+    AppState, VERSION,
     api::mcp::{
         dispatch::{ToolCall, ToolIdentity, dispatch_tool_call, linked_cancel_token},
         effects::audit::record_local_tool_dispatch,
@@ -259,7 +259,7 @@ impl Drop for ClawMcpService {
 impl ServerHandler for ClawMcpService {
     fn get_info(&self) -> InitializeResult {
         let capabilities = ServerCapabilities::builder().enable_tools().build();
-        let mut implementation = Implementation::new(SERVER_NAME, env!("CARGO_PKG_VERSION"));
+        let mut implementation = Implementation::new(SERVER_NAME, VERSION);
         implementation.title = Some(SERVER_TITLE.to_string());
         InitializeResult::new(capabilities)
             .with_server_info(implementation)
@@ -448,6 +448,7 @@ mod tests {
         let service = ClawMcpService::new(call.state);
         let info = service.get_info();
         assert_eq!(info.server_info.name, SERVER_NAME);
+        assert_eq!(info.server_info.version, VERSION);
         assert_eq!(info.server_info.title.as_deref(), Some(SERVER_TITLE));
         assert_eq!(
             info.instructions.as_deref(),

--- a/packages/browseros-agent/apps/claw-server-rust/src/config.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/config.rs
@@ -20,10 +20,36 @@ const DEV_BROWSERCLAW_DIR_NAME: &str = ".browserclaw-dev";
 #[derive(Debug, Parser)]
 #[command(name = "browseros-claw-server-rs")]
 pub struct Cli {
+    #[arg(long, conflicts_with_all = ["config", "stdio"], help = "Print version")]
+    version: bool,
+    #[arg(long, required_unless_present = "version")]
+    config: Option<PathBuf>,
     #[arg(long)]
-    pub config: PathBuf,
-    #[arg(long)]
-    pub stdio: bool,
+    stdio: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CliAction {
+    Version,
+    Run { config: PathBuf, stdio: bool },
+}
+
+impl Cli {
+    #[must_use]
+    pub fn parse_action() -> CliAction {
+        Self::parse().into_action()
+    }
+
+    fn into_action(self) -> CliAction {
+        match (self.version, self.config) {
+            (true, None) => CliAction::Version,
+            (false, Some(config)) => CliAction::Run {
+                config,
+                stdio: self.stdio,
+            },
+            _ => unreachable!("Clap enforces version and run argument constraints"),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -257,9 +283,45 @@ fn clean_string(value: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Config, ConfigEnv};
+    use super::{Cli, CliAction, Config, ConfigEnv};
+    use clap::{Parser, error::ErrorKind};
     use std::{collections::BTreeMap, fs, path::PathBuf, time::Duration};
     use tempfile::tempdir;
+
+    #[test]
+    fn version_action_does_not_require_config() -> anyhow::Result<()> {
+        let cli = Cli::try_parse_from(["browseros-claw-server-rs", "--version"])?;
+        assert_eq!(cli.into_action(), CliAction::Version);
+        Ok(())
+    }
+
+    #[test]
+    fn run_action_requires_config() -> anyhow::Result<()> {
+        let Err(error) = Cli::try_parse_from(["browseros-claw-server-rs"]) else {
+            anyhow::bail!("run mode parsed without --config");
+        };
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+        Ok(())
+    }
+
+    #[test]
+    fn version_action_rejects_run_flags() -> anyhow::Result<()> {
+        for args in [
+            &["browseros-claw-server-rs", "--version", "--stdio"][..],
+            &[
+                "browseros-claw-server-rs",
+                "--version",
+                "--config",
+                "sidecar.json",
+            ],
+        ] {
+            let Err(error) = Cli::try_parse_from(args) else {
+                anyhow::bail!("version mode accepted run-only arguments: {args:?}");
+            };
+            assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+        }
+        Ok(())
+    }
 
     #[test]
     fn parses_sidecar_defaults_and_browserclaw_dir_override() -> anyhow::Result<()> {

--- a/packages/browseros-agent/apps/claw-server-rust/src/lib.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/lib.rs
@@ -11,5 +11,7 @@ pub mod services;
 pub mod storage;
 pub mod telemetry;
 
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub use app::{AppState, build_router};
 pub use runtime::{AppRuntime, ShutdownHandle};

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -1,11 +1,18 @@
 use anyhow::Context;
 use axum::Router;
-use clap::Parser;
 use claw_server_rust::{
-    AppRuntime, AppState, ShutdownHandle, api::mcp::browser_mcp_service, build_router, config::Cli,
+    AppRuntime, AppState, ShutdownHandle, VERSION,
+    api::mcp::browser_mcp_service,
+    build_router,
+    config::{Cli, CliAction},
 };
 use rmcp::{serve_server, transport::stdio};
-use std::{future::Future, io, net::SocketAddr, sync::Arc};
+use std::{
+    future::Future,
+    io::{self, Write},
+    net::SocketAddr,
+    sync::Arc,
+};
 use tokio::net::TcpListener;
 use tracing::{error, info};
 use tracing_appender::non_blocking::WorkerGuard;
@@ -13,12 +20,18 @@ use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitEx
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let cli = Cli::parse();
-    let config = Arc::new(claw_server_rust::config::Config::load(&cli.config)?);
+    let (config_path, stdio_mode) = match Cli::parse_action() {
+        CliAction::Version => {
+            writeln!(io::stdout().lock(), "{VERSION}")?;
+            return Ok(());
+        }
+        CliAction::Run { config, stdio } => (config, stdio),
+    };
+    let config = Arc::new(claw_server_rust::config::Config::load(config_path)?);
     let _guard = init_tracing(config.clone())?;
     let state = AppState::new(config.clone()).await?;
     let mut runtime = AppRuntime::start(state);
-    let run_result = run(&mut runtime, config, cli.stdio).await;
+    let run_result = run(&mut runtime, config, stdio_mode).await;
     let shutdown_result = runtime.shutdown().await;
     match (run_result, shutdown_result) {
         (Ok(()), Ok(())) => Ok(()),

--- a/packages/browseros-agent/apps/claw-server-rust/tests/version_cli.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/version_cli.rs
@@ -1,0 +1,27 @@
+use claw_server_rust::VERSION;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn version_output_is_exact_and_side_effect_free() -> anyhow::Result<()> {
+    let root = tempdir()?;
+    let state_dir = root.path().join("browserclaw-state");
+    let output = Command::new(env!("CARGO_BIN_EXE_browseros-claw-server-rs"))
+        .arg("--version")
+        .env("BROWSERCLAW_DIR", &state_dir)
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "version command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, format!("{VERSION}\n").as_bytes());
+    assert!(
+        output.stderr.is_empty(),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!state_dir.exists());
+    Ok(())
+}

--- a/packages/browseros-agent/scripts/release/prepare-claw-server-rust-release.sh
+++ b/packages/browseros-agent/scripts/release/prepare-claw-server-rust-release.sh
@@ -2,12 +2,12 @@
 set -euo pipefail
 
 # Resolve a BrowserClaw server GitHub Release from the Rust crate version while
-# preserving the established claw-server-rust tag identity.
+# continuing the shipped BrowserClaw product tag sequence.
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 exec "$script_dir/prepare-server-bundle-release.sh" \
   --release-name "BrowserClaw Server (Rust)" \
-  --component-name "claw server rust" \
-  --tag-prefix "claw-server-rust/v" \
+  --component-name "claw server" \
+  --tag-prefix "claw-server/v" \
   --cargo-toml "packages/browseros-agent/apps/claw-server-rust/Cargo.toml" \
   "$@"

--- a/packages/browseros-agent/scripts/release/prepare-claw-server-rust-release.test.ts
+++ b/packages/browseros-agent/scripts/release/prepare-claw-server-rust-release.test.ts
@@ -120,24 +120,27 @@ async function prepare(
 }
 
 describe('prepare-claw-server-rust-release', () => {
-  it('creates a manual tag from the requested version', async () => {
-    const { dir, bareDir } = await initFixture('0.1.0')
+  it('continues the product sequence despite the historical Rust tag', async () => {
+    const { dir, bareDir } = await initFixture('0.0.12')
     try {
+      await tag(dir, 'claw-server/v0.0.12')
+      await tag(dir, 'claw-server-rust/v0.1.0')
+      await mustRun(dir, ['git', 'push', 'origin', '--tags'])
       const mainBefore = await revParse(bareDir, 'refs/heads/main')
 
       const result = await prepare(dir, {
         eventName: 'workflow_dispatch',
-        requestedVersion: '0.1.1',
+        requestedVersion: '0.0.13',
       })
 
       expect(result.code, result.stderr || result.stdout).toBe(0)
       expect(parseOutput(result.stdout)).toMatchObject({
-        version: '0.1.1',
-        tag: 'claw-server-rust/v0.1.1',
+        version: '0.0.13',
+        tag: 'claw-server/v0.0.13',
         release_sha: mainBefore,
-        previous_tag: '',
+        previous_tag: 'claw-server/v0.0.12',
       })
-      expect(await revParse(bareDir, 'claw-server-rust/v0.1.1^{commit}')).toBe(
+      expect(await revParse(bareDir, 'claw-server/v0.0.13^{commit}')).toBe(
         mainBefore,
       )
     } finally {
@@ -147,7 +150,7 @@ describe('prepare-claw-server-rust-release', () => {
   })
 
   it('derives a workflow_call release version from Cargo.toml', async () => {
-    const { dir, bareDir } = await initFixture('0.1.0')
+    const { dir, bareDir } = await initFixture('0.0.13')
     try {
       const releaseSha = await revParse(dir, 'HEAD')
 
@@ -157,11 +160,11 @@ describe('prepare-claw-server-rust-release', () => {
 
       expect(result.code, result.stderr || result.stdout).toBe(0)
       expect(parseOutput(result.stdout)).toMatchObject({
-        version: '0.1.0',
-        tag: 'claw-server-rust/v0.1.0',
+        version: '0.0.13',
+        tag: 'claw-server/v0.0.13',
         release_sha: releaseSha,
       })
-      expect(await revParse(bareDir, 'claw-server-rust/v0.1.0^{commit}')).toBe(
+      expect(await revParse(bareDir, 'claw-server/v0.0.13^{commit}')).toBe(
         releaseSha,
       )
     } finally {
@@ -171,7 +174,7 @@ describe('prepare-claw-server-rust-release', () => {
   })
 
   it('derives a workflow_dispatch release version from Cargo.toml when omitted', async () => {
-    const { dir, bareDir } = await initFixture('0.1.0')
+    const { dir, bareDir } = await initFixture('0.0.13')
     try {
       const releaseSha = await revParse(dir, 'HEAD')
 
@@ -181,11 +184,11 @@ describe('prepare-claw-server-rust-release', () => {
 
       expect(result.code, result.stderr || result.stdout).toBe(0)
       expect(parseOutput(result.stdout)).toMatchObject({
-        version: '0.1.0',
-        tag: 'claw-server-rust/v0.1.0',
+        version: '0.0.13',
+        tag: 'claw-server/v0.0.13',
         release_sha: releaseSha,
       })
-      expect(await revParse(bareDir, 'claw-server-rust/v0.1.0^{commit}')).toBe(
+      expect(await revParse(bareDir, 'claw-server/v0.0.13^{commit}')).toBe(
         releaseSha,
       )
     } finally {
@@ -194,24 +197,25 @@ describe('prepare-claw-server-rust-release', () => {
     }
   })
 
-  it('resolves pushed Rust tags and previous tags', async () => {
-    const { dir, bareDir } = await initFixture('0.1.0')
+  it('resolves pushed product tags and previous tags', async () => {
+    const { dir, bareDir } = await initFixture('0.0.12')
     try {
+      await tag(dir, 'claw-server/v0.0.12')
       await tag(dir, 'claw-server-rust/v0.1.0')
-      await commitCargoToml(dir, '0.1.1')
-      await tag(dir, 'claw-server-rust/v0.1.1')
+      await commitCargoToml(dir, '0.0.13')
+      await tag(dir, 'claw-server/v0.0.13')
       await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
 
       const result = await prepare(dir, {
         eventName: 'push',
-        refName: 'claw-server-rust/v0.1.1',
+        refName: 'claw-server/v0.0.13',
       })
 
       expect(result.code, result.stderr || result.stdout).toBe(0)
       expect(parseOutput(result.stdout)).toMatchObject({
-        version: '0.1.1',
-        tag: 'claw-server-rust/v0.1.1',
-        previous_tag: 'claw-server-rust/v0.1.0',
+        version: '0.0.13',
+        tag: 'claw-server/v0.0.13',
+        previous_tag: 'claw-server/v0.0.12',
       })
     } finally {
       rmSync(dir, { recursive: true, force: true })

--- a/packages/browseros-agent/scripts/release/prepare-claw-server-rust-release.test.ts
+++ b/packages/browseros-agent/scripts/release/prepare-claw-server-rust-release.test.ts
@@ -116,6 +116,8 @@ async function prepare(
     options.refName ?? 'main',
     '--requested-version',
     options.requestedVersion ?? '',
+    '--release-ref',
+    'HEAD',
   ])
 }
 

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -29,9 +29,10 @@ function createGithubReleaseStep(): string {
 }
 
 describe('release-claw-server-rust workflow', () => {
-  it('uses the Rust claw tag trigger and workflow_call contract', () => {
+  it('uses the BrowserClaw product tag trigger and workflow_call contract', () => {
     expect(workflow).toContain('name: "Release: BrowserClaw Server (Rust)"')
-    expect(workflow).toContain('"claw-server-rust/v*"')
+    expect(workflow).toContain('"claw-server/v*"')
+    expect(workflow).not.toContain('"claw-server-rust/v*"')
     expect(workflow).toContain('workflow_call:')
     expect(workflow).toContain('ref:')
     expect(workflow).toContain(
@@ -73,6 +74,25 @@ describe('release-claw-server-rust workflow', () => {
     )
     expect(workflow).not.toContain('wine')
     expect(workflow).not.toContain('patch-windows-exe')
+  })
+
+  it('validates the stamped target binary version before packaging', () => {
+    const verifyStart = workflow.indexOf(
+      '- name: Verify stamped binary version',
+    )
+    const packageStart = workflow.indexOf('- name: Package artifact zip')
+    expect(verifyStart).toBeGreaterThanOrEqual(0)
+    expect(packageStart).toBeGreaterThan(verifyStart)
+
+    const step = workflow.slice(verifyStart, packageStart)
+    expect(step).toContain(
+      'BINARY_PATH="target/$RUST_TARGET/release/browseros-claw-server-rs$BINARY_EXT"',
+    )
+    expect(step).toContain('ACTUAL_VERSION="$("$BINARY_PATH" --version)"')
+    expect(step).toContain('if [ "$ACTUAL_VERSION" != "$VERSION" ]; then')
+    expect(step).toContain(
+      '::error::Expected $VERSION from $BINARY_PATH, got: $ACTUAL_VERSION',
+    )
   })
 
   it('packages and validates artifact-compatible Rust resource zips', () => {


### PR DESCRIPTION
## Summary
- add a terminal `--version` action that prints only the Cargo package version and never enters BrowserClaw startup
- set the checked-in Rust package to `0.0.13` and share that metadata across CLI, HTTP system info, and MCP initialization
- continue Rust releases on `claw-server/v` and verify every stamped matrix binary before packaging

## Design
Clap projects validated arguments into an explicit `Version` or `Run` action, keeping optional config confined to parsing while run mode always receives a concrete path. The release workflow retains manifest and lockfile stamping, then executes the target-specific binary and compares its output with the requested release version before staging.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p claw-server-rust --locked`
- [x] `cargo clippy -p claw-server-rust --locked --all-targets -- -D warnings`
- [x] focused Bun release helper and workflow tests
- [x] `bun run typecheck`
- [x] `actionlint` and `shellcheck` on the changed release files
- [x] context-free adversarial diff review: clean