### PR TITLE
docs(core): explain navigation readiness polling

### DIFF
--- a/packages/browseros-agent/crates/browseros-core/src/navigation.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/navigation.rs
@@ -98,6 +98,7 @@ async fn wait_for_load(
             ),
         )
         .await;
+        // Navigation can tear down the execution context; errors and timeouts mean not ready yet, so keep polling.
         if let Ok(Ok(result)) = result
             && result.result.value.as_ref().and_then(Value::as_str) == Some("complete")
         {


### PR DESCRIPTION
## Summary
- explain why readiness evaluation may fail during navigation
- preserve the bounded keep-polling decision at the exact error-swallowing branch

## Design
The local comment records the execution-context teardown gotcha without broadening the best-effort navigation contract.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test -p browseros-core`
- [x] `git diff --check`
- [x] independent Codex comment-quality review
