### PR TITLE
docs(core): document screenshot capture contract

### DIFF
--- a/packages/browseros-agent/crates/browseros-core/src/screenshot/mod.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/screenshot/mod.rs
@@ -53,9 +53,8 @@ pub struct ScreenshotCaptureOptions {
     pub clip: Option<Viewport>,
 }
 
-/// Coordinates in the returned image's capture space. Viewport captures are
-/// viewport-relative and apply the clip scale; full-page captures include the
-/// current scroll offsets before projection.
+/// Viewport boxes are viewport-relative and apply the clip scale. Full-page
+/// boxes add the sampled scroll offsets when that best-effort read succeeds.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScreenshotAnnotationBox {
     pub x: i64,

--- a/packages/browseros-agent/crates/browseros-core/src/screenshot/mod.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/screenshot/mod.rs
@@ -53,6 +53,9 @@ pub struct ScreenshotCaptureOptions {
     pub clip: Option<Viewport>,
 }
 
+/// Coordinates in the returned image's capture space. Viewport captures are
+/// viewport-relative and apply the clip scale; full-page captures include the
+/// current scroll offsets before projection.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScreenshotAnnotationBox {
     pub x: i64,
@@ -644,6 +647,8 @@ where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = Result<T, CoreError>>,
 {
+    // Plain captures share this protocol-session lock because annotated capture
+    // temporarily overlays the DOM; overlap could include that overlay in a plain image.
     let mutex = screenshot_mutex(page_session);
     let _guard = mutex.lock().await;
     task().await


### PR DESCRIPTION
## Summary
- document the coordinate basis and best-effort full-page projection of screenshot annotation boxes
- explain why plain and annotated captures share the same protocol-session lock

## Verification
- `cargo fmt --all --check`
- `cargo test -p browseros-core` (65 tests plus doc tests)
- `git diff --check`
- independent Codex fresh-eyes review: PASS

Comment-only; no behavior or API changes.
