### PR TITLE
docs(core): document input coordinate basis

### DIFF
--- a/packages/browseros-agent/crates/browseros-core/src/input/geometry.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/input/geometry.rs
@@ -105,6 +105,8 @@ struct Bounds {
     h: f64,
 }
 
+/// The point is in `session`'s coordinate basis. Dispatch input through the same
+/// session so OOPIF coordinates remain valid without a manual transform.
 pub async fn get_element_center(
     session: &ProtocolSession,
     backend_node_id: i64,


### PR DESCRIPTION
## Summary
- document that element-center points use the supplied protocol session's coordinate basis
- make the same-session dispatch requirement explicit for OOPIF input

## Verification
- `cargo fmt --all --check`
- `cargo test -p browseros-core` (65 tests plus doc tests, rerun after merging current main)
- `git diff --check`
- independent Codex fresh-eyes review: PASS

Comment-only; no behavior or API changes.
