### PR TITLE
docs(mcp): clarify host metadata contracts

### DIFF
--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -87,6 +87,9 @@ impl ToolDef {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ToolMetadata {
+    /// Treats top-level `raw_args.page` as the authoritative dispatch page. The framework
+    /// uses it for page signals; the claw-server host uses it for pre-dispatch snapshots,
+    /// ownership guards, audit records, and tab-activity effects.
     pub accepts_page_arg: bool,
 }
 

--- a/packages/browseros-agent/crates/browseros-mcp/src/service.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/service.rs
@@ -80,6 +80,8 @@ pub struct BrowserMcpServiceOptions {
     pub instructions: Option<String>,
     pub defaults: BrowserToolDefaults,
     pub output_files: Option<OutputFileAccess>,
+    /// `false` suppresses only legacy untyped structured content. Content declared
+    /// by a tool's output schema is retained to preserve the advertised MCP contract.
     pub include_structured_content: Option<bool>,
     pub on_tool_execution_start: Option<BrowserToolLifecycleCallback>,
     pub on_tool_execution_end: Option<BrowserToolLifecycleCallback>,


### PR DESCRIPTION
## Summary
- document the host lifecycle consumers of page-argument metadata
- clarify that disabling structured content preserves schema-declared output

## Verification
- `cargo fmt --all --check`
- `cargo test -p browseros-mcp` (41 tests plus doc tests)
- `git diff --check`
- independent Codex fresh-eyes review: PASS

Comment-only; no behavior or API changes.
