### PR TITLE
fix(browserclaw): stop closed session previews

### DIFF
--- a/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.test.ts
@@ -74,6 +74,7 @@ describe('useLiveSessions', () => {
       'live',
     ])
     expect(useLiveSessions.getOptions().refetchInterval).toBe(1500)
+    expect(useLiveSessions.getOptions().refetchIntervalInBackground).toBe(true)
 
     expect(await useLiveSessions.fetcher(undefined)).toBe(response)
     expect(listSessions).toHaveBeenCalledWith({ status: 'live' })

--- a/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
@@ -72,6 +72,7 @@ export const useLiveSessions = createQuery<SessionList>({
   fetcher: async () =>
     (await apiClient()).listSessions({ status: SessionStatus.Live }),
   refetchInterval: 1500,
+  refetchIntervalInBackground: true,
 })
 
 export const useSessionDetail = createQuery<


### PR DESCRIPTION
## Summary
- keep the authoritative live-session snapshot polling while Cockpit is backgrounded
- let Running now remove closed-session cards so the existing `MiniScreencast` unmount cleanup stops preview polling
- cover the background-refetch query contract

## Design
Use TanStack Query's background interval refetch option on `useLiveSessions`. Session membership remains owned by the live collection; `MiniScreencast` does not gain duplicate liveness state or another backend request.

## Test plan
- [x] `bun test apps/claw-app/modules/api/audit.hooks.test.ts`
- [x] `bun run --filter @browseros/claw-app typecheck`
- [x] `bunx biome check apps/claw-app/modules/api/audit.hooks.ts apps/claw-app/modules/api/audit.hooks.test.ts`
- [x] all 34 claw-app test files with the baseline alias resolver setting temporarily restored

Baseline note: the default full claw-app runner is already red on `origin/main` after #1928 removed `baseUrl`; 12 unrelated test files cannot resolve `@/…` aliases. Restoring that setting only for verification makes all 34 files pass. This PR leaves that unrelated config repair out of scope.