### PR TITLE
docs(rust): narrow persistence contracts

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
@@ -1,5 +1,5 @@
-//! Durable recording index. Each non-empty accepted document batch atomically commits stream
-//! metadata, NDJSON payload, and its durable dedupe identity.
+//! Durable recording index. Each newly accepted non-empty document batch commits stream metadata,
+//! NDJSON payload, and its durable dedupe identity in one transaction.
 
 use crate::{
     clock::now_epoch_ms,
@@ -28,7 +28,7 @@ pub struct RecordingIndex {
 
 pub struct AppendDocumentBatch<'a> {
     pub document_id: &'a str,
-    /// Chrome tab id permanently bound to the document by its first persisted batch.
+    /// Chrome tab id permanently bound to the document by its first persisted non-empty batch.
     pub tab_id: i64,
     /// Best-effort target attribution: a later persisted batch may fill an initial absence but
     /// never replace a stored target id.
@@ -39,9 +39,8 @@ pub struct AppendDocumentBatch<'a> {
     pub size_bytes: i64,
     pub event_count: i64,
     pub batch_id: &'a str,
-    /// Gap evidence from the recorder or server-dropped malformed lines. When the batch is
-    /// persisted, the gap is sticky for the document stream and makes any replay selecting it
-    /// incomplete.
+    /// On a newly accepted non-empty batch, recorder gap evidence or malformed lines dropped by the
+    /// server become sticky for the document stream; any replay selecting that stream is incomplete.
     pub has_gap: bool,
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/session_tabs.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/session_tabs.rs
@@ -1,5 +1,5 @@
-//! Durable session-to-browser ownership windows. Asynchronous legacy-target and tab claim/release
-//! mutations share one FIFO writer so their observed lifecycle order reaches SQLite unchanged.
+//! Durable session-to-browser ownership windows. Enqueued legacy-target and tab claim/release
+//! mutations share one FIFO writer, preserving their observed order at the SQLite boundary.
 
 use crate::{
     clock::now_epoch_ms,

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
@@ -108,7 +108,7 @@ impl AppRuntime {
                 )))
             }
         };
-        // Session teardown enqueues final ownership-release attempts, which are drained before
+        // Session teardown enqueues final ownership releases; wait for the FIFO barrier before
         // shutdown returns.
         self.state.session_tabs.drain_writes().await;
         self.state.recordings.close().await;

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
@@ -23,9 +23,11 @@ pub struct ReplayEvent {
 pub struct ReplaySegmentMeta {
     pub document_id: String,
     pub target_id: Option<String>,
-    /// Lower bound in Unix-epoch milliseconds, clipped to the session's tab-ownership window.
+    /// Lower bound in Unix-epoch milliseconds, clipped to the envelope of this session's matching
+    /// tab-ownership windows.
     pub first_event_at: i64,
-    /// Upper bound in Unix-epoch milliseconds, clipped to the session's tab-ownership window.
+    /// Upper bound in Unix-epoch milliseconds, clipped to the envelope of this session's matching
+    /// tab-ownership windows.
     pub last_event_at: i64,
     pub size_bytes: i64,
     pub event_count: i64,


### PR DESCRIPTION
## Summary
- qualify FIFO docs to enqueued lifecycle mutations
- condition recording persistence semantics on newly accepted non-empty batches
- describe replay bounds as the envelope of matching ownership windows
- avoid promising database-write success from the shutdown barrier

Follow-up precision correction to #1966. Comment-only; no behavior changes.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- exact wording from independent review
