### PR TITLE
feat(claw): add session usage analytics

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/analytics/events.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/analytics/events.rs
@@ -5,11 +5,22 @@
 //! fixed tokens here before the delivery service ever sees it.
 
 use serde_json::{Map, Value};
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::OnceLock,
+};
 
 const CLIENT_NAME: &str = "client_name";
 const HARNESS: &str = "harness";
 const KIND: &str = "kind";
+const TOOL_NAME: &str = "tool_name";
+const DISPATCH_COUNT: &str = "dispatch_count";
+const DISTINCT_TOOL_COUNT: &str = "distinct_tool_count";
+const MAX_CONCURRENT_USED_SESSIONS: &str = "max_concurrent_used_sessions";
+const TOTAL_DURATION_MS: &str = "total_duration_ms";
+const MAX_DURATION_MS: &str = "max_duration_ms";
+
+pub(crate) const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
 const KNOWN_CLIENTS: [&str; 14] = [
     "claude-desktop",
@@ -41,30 +52,60 @@ pub(crate) const HARNESS_VALUES: [&str; 7] = [
 pub(crate) const END_KIND_VALUES: [&str; 2] = ["closed", "errored"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RequiredProperty {
+enum PropertyKind {
     ClientName,
     Harness,
-    Kind,
+    EndKind,
+    ToolName,
+    UnsignedInteger,
 }
 
-impl RequiredProperty {
-    const fn name(self) -> &'static str {
-        match self {
-            Self::ClientName => CLIENT_NAME,
-            Self::Harness => HARNESS,
-            Self::Kind => KIND,
-        }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PropertyDefinition {
+    name: &'static str,
+    kind: PropertyKind,
+}
+
+impl PropertyDefinition {
+    const fn new(name: &'static str, kind: PropertyKind) -> Self {
+        Self { name, kind }
     }
 
     fn normalize(self, value: &Value) -> Option<Value> {
-        let raw = value.as_str()?;
-        match self {
-            Self::ClientName => Some(Value::String(bucket_client_name(raw))),
-            Self::Harness if HARNESS_VALUES.contains(&raw) => Some(Value::String(raw.to_string())),
-            Self::Kind if END_KIND_VALUES.contains(&raw) => Some(Value::String(raw.to_string())),
-            Self::Harness | Self::Kind => None,
+        match self.kind {
+            PropertyKind::ClientName => Some(Value::String(bucket_client_name(value.as_str()?))),
+            PropertyKind::Harness => normalize_token(value, &HARNESS_VALUES),
+            PropertyKind::EndKind => normalize_token(value, &END_KIND_VALUES),
+            PropertyKind::ToolName => {
+                let raw = value.as_str()?;
+                known_tool_names()
+                    .contains(raw)
+                    .then(|| Value::String(raw.to_string()))
+            }
+            PropertyKind::UnsignedInteger => value
+                .as_u64()
+                .filter(|value| *value <= MAX_SAFE_INTEGER)
+                .map(Value::from),
         }
     }
+}
+
+fn normalize_token(value: &Value, accepted: &[&str]) -> Option<Value> {
+    let raw = value.as_str()?;
+    accepted
+        .contains(&raw)
+        .then(|| Value::String(raw.to_string()))
+}
+
+fn known_tool_names() -> &'static HashSet<&'static str> {
+    static KNOWN_TOOL_NAMES: OnceLock<HashSet<&'static str>> = OnceLock::new();
+    KNOWN_TOOL_NAMES.get_or_init(|| {
+        browseros_mcp::catalog()
+            .into_iter()
+            .map(|tool| tool.name)
+            .chain(std::iter::once("name_session"))
+            .collect()
+    })
 }
 
 /// One catalog entry. Its private fields and constructor prevent producers from
@@ -72,12 +113,12 @@ impl RequiredProperty {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventDefinition {
     name: &'static str,
-    required: &'static [RequiredProperty],
+    properties: &'static [PropertyDefinition],
 }
 
 impl EventDefinition {
-    const fn new(name: &'static str, required: &'static [RequiredProperty]) -> Self {
-        Self { name, required }
+    const fn new(name: &'static str, properties: &'static [PropertyDefinition]) -> Self {
+        Self { name, properties }
     }
 
     #[must_use]
@@ -86,22 +127,19 @@ impl EventDefinition {
     }
 
     #[must_use]
-    pub fn required_property_names(self) -> &'static [&'static str] {
-        match self.required {
-            [] => &[],
-            [RequiredProperty::ClientName] => &[CLIENT_NAME],
-            [RequiredProperty::Harness] => &[HARNESS],
-            [RequiredProperty::Kind] => &[KIND],
-            _ => &[],
-        }
+    pub fn property_names(self) -> Vec<&'static str> {
+        self.properties
+            .iter()
+            .map(|property| property.name)
+            .collect()
     }
 
     pub(crate) fn sanitize(self, properties: &Value) -> Option<Value> {
         let input = properties.as_object()?;
         let mut output = Map::new();
-        for required in self.required {
-            let value = input.get(required.name())?;
-            output.insert(required.name().to_string(), required.normalize(value)?);
+        for property in self.properties {
+            let value = input.get(property.name)?;
+            output.insert(property.name.to_string(), property.normalize(value)?);
         }
         Some(Value::Object(output))
     }
@@ -110,35 +148,63 @@ impl EventDefinition {
         self,
         properties: &HashMap<String, Value>,
     ) -> bool {
-        self.required.iter().all(|required| {
-            let Some(current) = properties.get(required.name()) else {
+        self.properties.iter().all(|property| {
+            let Some(current) = properties.get(property.name) else {
                 return false;
             };
-            required.normalize(current).as_ref() == Some(current)
+            property.normalize(current).as_ref() == Some(current)
         })
     }
 
     pub(crate) fn allows_property(self, key: &str) -> bool {
-        self.required.iter().any(|required| required.name() == key)
+        self.properties.iter().any(|property| property.name == key)
     }
 }
 
 pub const SERVER_STARTED: EventDefinition = EventDefinition::new("server_started", &[]);
-pub const AGENT_SESSION_STARTED: EventDefinition =
-    EventDefinition::new("agent_session_started", &[RequiredProperty::ClientName]);
-pub const AGENT_SESSION_ENDED: EventDefinition =
-    EventDefinition::new("agent_session_ended", &[RequiredProperty::Kind]);
-pub const HARNESS_CONNECTED: EventDefinition =
-    EventDefinition::new("harness_connected", &[RequiredProperty::Harness]);
-pub const HARNESS_DISCONNECTED: EventDefinition =
-    EventDefinition::new("harness_disconnected", &[RequiredProperty::Harness]);
+pub const AGENT_SESSION_STARTED: EventDefinition = EventDefinition::new(
+    "agent_session_started",
+    &[PropertyDefinition::new(
+        CLIENT_NAME,
+        PropertyKind::ClientName,
+    )],
+);
+pub const AGENT_SESSION_ENDED: EventDefinition = EventDefinition::new(
+    "agent_session_ended",
+    &[
+        PropertyDefinition::new(KIND, PropertyKind::EndKind),
+        PropertyDefinition::new(CLIENT_NAME, PropertyKind::ClientName),
+        PropertyDefinition::new(DISPATCH_COUNT, PropertyKind::UnsignedInteger),
+        PropertyDefinition::new(DISTINCT_TOOL_COUNT, PropertyKind::UnsignedInteger),
+        PropertyDefinition::new(MAX_CONCURRENT_USED_SESSIONS, PropertyKind::UnsignedInteger),
+    ],
+);
+pub const HARNESS_CONNECTED: EventDefinition = EventDefinition::new(
+    "harness_connected",
+    &[PropertyDefinition::new(HARNESS, PropertyKind::Harness)],
+);
+pub const HARNESS_DISCONNECTED: EventDefinition = EventDefinition::new(
+    "harness_disconnected",
+    &[PropertyDefinition::new(HARNESS, PropertyKind::Harness)],
+);
+pub const AGENT_SESSION_TOOL_USAGE: EventDefinition = EventDefinition::new(
+    "agent_session_tool_usage",
+    &[
+        PropertyDefinition::new(CLIENT_NAME, PropertyKind::ClientName),
+        PropertyDefinition::new(TOOL_NAME, PropertyKind::ToolName),
+        PropertyDefinition::new(DISPATCH_COUNT, PropertyKind::UnsignedInteger),
+        PropertyDefinition::new(TOTAL_DURATION_MS, PropertyKind::UnsignedInteger),
+        PropertyDefinition::new(MAX_DURATION_MS, PropertyKind::UnsignedInteger),
+    ],
+);
 
-pub const ALL: [EventDefinition; 5] = [
+pub const ALL: [EventDefinition; 6] = [
     SERVER_STARTED,
     AGENT_SESSION_STARTED,
     AGENT_SESSION_ENDED,
     HARNESS_CONNECTED,
     HARNESS_DISCONNECTED,
+    AGENT_SESSION_TOOL_USAGE,
 ];
 
 pub(crate) fn by_wire_name(name: &str) -> Option<EventDefinition> {
@@ -187,14 +253,36 @@ mod tests {
 
     #[test]
     fn catalog_pins_wire_names_and_required_properties() {
+        assert_eq!(ALL.len(), 6);
         assert_eq!(
-            ALL.map(|definition| (definition.name(), definition.required_property_names())),
+            ALL.map(EventDefinition::name),
             [
-                (SERVER_STARTED.name(), &[][..]),
-                (AGENT_SESSION_STARTED.name(), &["client_name"][..]),
-                (AGENT_SESSION_ENDED.name(), &["kind"][..]),
-                (HARNESS_CONNECTED.name(), &["harness"][..]),
-                (HARNESS_DISCONNECTED.name(), &["harness"][..]),
+                SERVER_STARTED.name(),
+                AGENT_SESSION_STARTED.name(),
+                AGENT_SESSION_ENDED.name(),
+                HARNESS_CONNECTED.name(),
+                HARNESS_DISCONNECTED.name(),
+                AGENT_SESSION_TOOL_USAGE.name(),
+            ]
+        );
+        assert_eq!(
+            AGENT_SESSION_ENDED.property_names(),
+            vec![
+                "kind",
+                "client_name",
+                "dispatch_count",
+                "distinct_tool_count",
+                "max_concurrent_used_sessions",
+            ]
+        );
+        assert_eq!(
+            AGENT_SESSION_TOOL_USAGE.property_names(),
+            vec![
+                "client_name",
+                "tool_name",
+                "dispatch_count",
+                "total_duration_ms",
+                "max_duration_ms",
             ]
         );
     }
@@ -269,8 +357,20 @@ mod tests {
         }
         for kind in END_KIND_VALUES {
             assert_eq!(
-                AGENT_SESSION_ENDED.sanitize(&json!({ "kind": kind })),
-                Some(json!({ "kind": kind }))
+                AGENT_SESSION_ENDED.sanitize(&json!({
+                    "kind": kind,
+                    "client_name": "Codex",
+                    "dispatch_count": 0,
+                    "distinct_tool_count": 0,
+                    "max_concurrent_used_sessions": 0,
+                })),
+                Some(json!({
+                    "kind": kind,
+                    "client_name": "codex",
+                    "dispatch_count": 0,
+                    "distinct_tool_count": 0,
+                    "max_concurrent_used_sessions": 0,
+                }))
             );
         }
 
@@ -280,10 +380,106 @@ mod tests {
                 None
             );
             assert_eq!(
-                AGENT_SESSION_ENDED.sanitize(&json!({ "kind": invalid })),
+                AGENT_SESSION_ENDED.sanitize(&json!({
+                    "kind": invalid,
+                    "client_name": "Codex",
+                    "dispatch_count": 0,
+                    "distinct_tool_count": 0,
+                    "max_concurrent_used_sessions": 0,
+                })),
                 None
             );
         }
+    }
+
+    #[test]
+    fn session_usage_schemas_accept_only_known_tools_and_safe_aggregates() {
+        assert_eq!(
+            AGENT_SESSION_TOOL_USAGE.sanitize(&json!({
+                "client_name": "Claude Code",
+                "tool_name": "navigate",
+                "dispatch_count": 3,
+                "total_duration_ms": 810,
+                "max_duration_ms": 420,
+                "url": "https://private.example",
+                "arguments": { "prompt": "private" },
+                "result": "private",
+            })),
+            Some(json!({
+                "client_name": "claude-code",
+                "tool_name": "navigate",
+                "dispatch_count": 3,
+                "total_duration_ms": 810,
+                "max_duration_ms": 420,
+            }))
+        );
+        assert_eq!(
+            AGENT_SESSION_TOOL_USAGE.sanitize(&json!({
+                "client_name": "Codex",
+                "tool_name": "name_session",
+                "dispatch_count": 1,
+                "total_duration_ms": 12,
+                "max_duration_ms": 12,
+            })),
+            Some(json!({
+                "client_name": "codex",
+                "tool_name": "name_session",
+                "dispatch_count": 1,
+                "total_duration_ms": 12,
+                "max_duration_ms": 12,
+            }))
+        );
+
+        for tool_name in ["unknown", "https://private.example", "user@example.com"] {
+            assert_eq!(
+                AGENT_SESSION_TOOL_USAGE.sanitize(&json!({
+                    "client_name": "Codex",
+                    "tool_name": tool_name,
+                    "dispatch_count": 1,
+                    "total_duration_ms": 12,
+                    "max_duration_ms": 12,
+                })),
+                None
+            );
+        }
+
+        for invalid in [json!(-1), json!(1.5), json!(MAX_SAFE_INTEGER + 1)] {
+            assert_eq!(
+                AGENT_SESSION_TOOL_USAGE.sanitize(&json!({
+                    "client_name": "Codex",
+                    "tool_name": "navigate",
+                    "dispatch_count": invalid,
+                    "total_duration_ms": 12,
+                    "max_duration_ms": 12,
+                })),
+                None
+            );
+        }
+        assert_eq!(
+            AGENT_SESSION_TOOL_USAGE.sanitize(&json!({
+                "client_name": "Codex",
+                "tool_name": "navigate",
+                "dispatch_count": 1,
+                "total_duration_ms": MAX_SAFE_INTEGER,
+                "max_duration_ms": MAX_SAFE_INTEGER,
+            })),
+            Some(json!({
+                "client_name": "codex",
+                "tool_name": "navigate",
+                "dispatch_count": 1,
+                "total_duration_ms": MAX_SAFE_INTEGER,
+                "max_duration_ms": MAX_SAFE_INTEGER,
+            }))
+        );
+        assert_eq!(
+            AGENT_SESSION_TOOL_USAGE.sanitize(&json!({
+                "client_name": "Codex",
+                "tool_name": "navigate",
+                "dispatch_count": 1,
+                "total_duration_ms": 12,
+            })),
+            None
+        );
     }
 
     #[test]

--- a/packages/browseros-agent/apps/claw-server-rust/src/analytics/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/analytics/service.rs
@@ -321,7 +321,9 @@ fn final_allowlist(mut event: Event) -> Option<Event> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analytics::events::{AGENT_SESSION_STARTED, SERVER_STARTED};
+    use crate::analytics::events::{
+        AGENT_SESSION_STARTED, AGENT_SESSION_TOOL_USAGE, SERVER_STARTED,
+    };
     use axum::{Router, body::Bytes, routing::any};
     use serde_json::json;
     use tempfile::tempdir;
@@ -406,6 +408,63 @@ mod tests {
                 "$process_person_profile": false,
                 "$geoip_disable": true,
                 "$is_server": true
+            })
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn aggregate_wire_payload_survives_both_allowlists_without_content() -> anyhow::Result<()>
+    {
+        let directory = tempdir()?;
+        let stable_id = "2e087632-1f4e-4ee7-b8bb-cf8ad53e91a8";
+        persist_state(
+            &state_path(directory.path()),
+            &AnalyticsState {
+                distinct_id: stable_id.to_string(),
+                enabled: true,
+            },
+        )
+        .await?;
+        let (host, mut requests, endpoint) = local_endpoint().await?;
+        let service =
+            AnalyticsService::new_with_config(directory.path(), test_config(host, true)).await?;
+
+        service.capture(
+            AGENT_SESSION_TOOL_USAGE,
+            json!({
+                "client_name": "Claude Code",
+                "tool_name": "navigate",
+                "dispatch_count": 3,
+                "total_duration_ms": 810,
+                "max_duration_ms": 420,
+                "url": "https://private.example",
+                "arguments": { "prompt": "private" },
+                "result": "private",
+            }),
+        );
+        service.shutdown().await;
+
+        let body = tokio::time::timeout(Duration::from_secs(2), requests.recv())
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("local endpoint closed before capture"))?;
+        endpoint.abort();
+        let event = &body["batch"][0];
+        assert_eq!(event["event"], AGENT_SESSION_TOOL_USAGE.name());
+        assert_eq!(event["distinct_id"], stable_id);
+        assert_eq!(
+            event["properties"],
+            json!({
+                "client_name": "claude-code",
+                "tool_name": "navigate",
+                "dispatch_count": 3,
+                "total_duration_ms": 810,
+                "max_duration_ms": 420,
+                "server_version": env!("CARGO_PKG_VERSION"),
+                "os_platform": events::platform_token(),
+                "$process_person_profile": false,
+                "$geoip_disable": true,
+                "$is_server": true,
             })
         );
         Ok(())

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/effects/tab_groups.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/effects/tab_groups.rs
@@ -939,6 +939,7 @@ mod tests {
                 label: "Codex".to_string(),
             },
             ConversationIdentity::new("codex", "agile-alpaca".to_string()),
+            "Codex".to_string(),
             tokio::time::Instant::now(),
         );
         let key = session.convo_id().clone();

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/effects/tabs_list_view.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/effects/tabs_list_view.rs
@@ -170,6 +170,7 @@ mod tests {
                 label: "Cowork".to_string(),
             },
             crate::identity::ConversationIdentity::new("other", "bright-beaver".to_string()),
+            "Codex".to_string(),
             tokio::time::Instant::now(),
         );
         call.state

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/naming.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/naming.rs
@@ -56,6 +56,7 @@ mod tests {
                 label: "Claude Code".to_string(),
             },
             ConversationIdentity::new("claude-code", "agile-alpaca".to_string()),
+            "Codex".to_string(),
             tokio::time::Instant::now(),
         );
         assert_eq!(desired_group_title(&session).await, "claude/agile-alpaca");

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -28,7 +28,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
-    time::Instant,
+    time::Instant as StdInstant,
 };
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -95,8 +95,12 @@ impl ClawMcpService {
         tools
     }
 
-    async fn call_name_session(&self, started: StartedSession, raw_args: &Value) -> CallToolResult {
-        let started_at = Instant::now();
+    async fn call_name_session(
+        &self,
+        started: &StartedSession,
+        raw_args: &Value,
+    ) -> CallToolResult {
+        let started_at = StdInstant::now();
         let rename = match rename_session(Some(started.session.as_ref()), raw_args).await {
             Ok(rename) => rename,
             Err(message) => {
@@ -319,48 +323,76 @@ impl ServerHandler for ClawMcpService {
             .unwrap_or_else(|| Value::Object(JsonObject::new()));
         let started = self.learn_session_from_request(&context).await?;
         started.session.touch(tokio::time::Instant::now()).await;
-        if is_name_session {
-            return Ok(self.call_name_session(started, &raw_args).await);
-        }
-        let Some(tool_index) = tool_index else {
-            return Err(McpError::method_not_found::<CallToolRequestMethod>());
+        started.session.mark_used();
+        let concurrent_used_sessions = self.state.sessions.used_count().await.max(1);
+        let tool_started_at = tokio::time::Instant::now();
+        let tool_name = request.name.to_string();
+
+        let result = if is_name_session {
+            Ok(self.call_name_session(&started, &raw_args).await)
+        } else {
+            let Some(tool_index) = tool_index else {
+                unreachable!("catalog tool was validated before session resolution");
+            };
+            let browser_session = self.state.browser.session().await;
+            let ownership_key = started.session.convo_id().clone();
+            let default_tab_group_id = self
+                .state
+                .sessions
+                .ownership()
+                .tab_group_ref(&ownership_key)
+                .await;
+            let dispatch_cancel = CancellationToken::new();
+            let cancel = linked_cancel_token(
+                started.session.child_token(),
+                context.ct.clone(),
+                dispatch_cancel.clone(),
+            );
+            let identity = ToolIdentity {
+                session: started.session.clone(),
+                agent: started.session.agent().clone(),
+                ownership_key,
+                agent_label: started.agent_label,
+            };
+            let call = ToolCall::new(
+                self.catalog.clone(),
+                tool_index,
+                raw_args,
+                started.session.id().clone(),
+                Some(identity),
+                browser_session,
+                cancel,
+                context.ct.clone(),
+                dispatch_cancel,
+                default_tab_group_id,
+                self.state.clone(),
+                self.output_files.clone(),
+            );
+            dispatch_tool_call(call).await
         };
-        let browser_session = self.state.browser.session().await;
-        let ownership_key = started.session.convo_id().clone();
-        let default_tab_group_id = self
-            .state
-            .sessions
-            .ownership()
-            .tab_group_ref(&ownership_key)
-            .await;
-        let dispatch_cancel = CancellationToken::new();
-        let cancel = linked_cancel_token(
-            started.session.child_token(),
-            context.ct.clone(),
-            dispatch_cancel.clone(),
-        );
-        let identity = ToolIdentity {
-            session: started.session.clone(),
-            agent: started.session.agent().clone(),
-            ownership_key,
-            agent_label: started.agent_label,
-        };
-        let call = ToolCall::new(
-            self.catalog.clone(),
-            tool_index,
-            raw_args,
-            started.session.id().clone(),
-            Some(identity),
-            browser_session,
-            cancel,
-            context.ct.clone(),
-            dispatch_cancel,
-            default_tab_group_id,
-            self.state.clone(),
-            self.output_files.clone(),
-        );
-        dispatch_tool_call(call).await
+
+        finish_tool_call(
+            started.session.as_ref(),
+            &tool_name,
+            tool_started_at,
+            concurrent_used_sessions,
+            result,
+        )
+        .await
     }
+}
+
+async fn finish_tool_call(
+    session: &Session,
+    tool_name: &str,
+    started_at: tokio::time::Instant,
+    concurrent_used_sessions: usize,
+    result: Result<CallToolResult, McpError>,
+) -> Result<CallToolResult, McpError> {
+    session
+        .record_tool_usage(tool_name, started_at.elapsed(), concurrent_used_sessions)
+        .await;
+    result
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -441,8 +473,78 @@ fn session_id_from_extensions(extensions: &rmcp::model::Extensions) -> Option<Se
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::identity::ConversationIdentity;
     use rmcp::handler::server::ServerHandler;
     use serde_json::json;
+
+    fn usage_session() -> Arc<Session> {
+        Session::new(
+            SessionId::new("usage-session"),
+            ClientIdentity::Ephemeral {
+                slug: "codex".to_string(),
+                label: "Codex".to_string(),
+            },
+            ConversationIdentity::new("codex", "usage-test".to_string()),
+            "Codex".to_string(),
+            tokio::time::Instant::now(),
+        )
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn completed_browser_tool_success_is_recorded_and_returned_unchanged() {
+        let session = usage_session();
+        assert_eq!(session.usage_snapshot().await.dispatch_count, 0);
+        let result = CallToolResult::success(vec![rmcp::model::ContentBlock::text("ok")]);
+        let expected = result.clone();
+        let started_at = tokio::time::Instant::now();
+        tokio::time::advance(std::time::Duration::from_millis(40)).await;
+
+        let returned = finish_tool_call(session.as_ref(), "tabs", started_at, 2, Ok(result)).await;
+
+        assert_eq!(returned, Ok(expected));
+        let snapshot = session.usage_snapshot().await;
+        assert_eq!(snapshot.dispatch_count, 1);
+        assert_eq!(snapshot.max_concurrent_used_sessions, 2);
+        assert_eq!(snapshot.tools[0].tool_name, "tabs");
+        assert_eq!(snapshot.tools[0].total_duration_ms, 40);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn completed_local_tool_error_result_is_recorded_and_returned_unchanged() {
+        let session = usage_session();
+        let result = CallToolResult::error(vec![rmcp::model::ContentBlock::text("invalid")]);
+        let expected = result.clone();
+        let started_at = tokio::time::Instant::now();
+        tokio::time::advance(std::time::Duration::from_millis(12)).await;
+
+        let returned =
+            finish_tool_call(session.as_ref(), "name_session", started_at, 1, Ok(result)).await;
+
+        assert_eq!(returned, Ok(expected));
+        let snapshot = session.usage_snapshot().await;
+        assert_eq!(snapshot.dispatch_count, 1);
+        assert_eq!(snapshot.tools[0].tool_name, "name_session");
+        assert_eq!(snapshot.tools[0].max_duration_ms, 12);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn completed_protocol_error_is_recorded_and_returned_unchanged() {
+        let session = usage_session();
+        let error = McpError::internal_error("dispatch failed", None);
+        let expected = error.clone();
+        let started_at = tokio::time::Instant::now();
+        tokio::time::advance(std::time::Duration::from_millis(7)).await;
+
+        let returned =
+            finish_tool_call(session.as_ref(), "navigate", started_at, 3, Err(error)).await;
+
+        assert_eq!(returned, Err(expected));
+        let snapshot = session.usage_snapshot().await;
+        assert_eq!(snapshot.dispatch_count, 1);
+        assert_eq!(snapshot.max_concurrent_used_sessions, 3);
+        assert_eq!(snapshot.tools[0].tool_name, "navigate");
+        assert_eq!(snapshot.tools[0].total_duration_ms, 7);
+    }
 
     #[tokio::test]
     async fn initialize_info_uses_browserclaw_branding_and_prompt() -> anyhow::Result<()> {

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/test_support.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/test_support.rs
@@ -36,6 +36,7 @@ pub async fn tool_call(tool_name: &str, raw_args: Value) -> anyhow::Result<ToolC
             label: "Codex".to_string(),
         },
         ConversationIdentity::new("codex", "agile-alpaca".to_string()),
+        "Codex".to_string(),
         tokio::time::Instant::now(),
     );
     state.sessions.insert_for_testing(session.clone()).await;

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
@@ -238,6 +238,7 @@ mod tests {
                     label: "Agent".to_string(),
                 },
                 ConversationIdentity::new("agent", "shutdown-label".to_string()),
+                "Codex".to_string(),
                 Instant::now(),
             ))
             .await;
@@ -308,6 +309,7 @@ mod tests {
                 label: "Agent".to_string(),
             },
             ConversationIdentity::new("agent", "stuck-label".to_string()),
+            "Codex".to_string(),
             Instant::now(),
         );
         sessions.insert_for_testing(session.clone()).await;

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
@@ -153,7 +153,7 @@ mod tests {
         services::sessions::{Session, Sessions},
     };
     use axum::{Router, body::Bytes, routing::any};
-    use serde_json::Value;
+    use serde_json::{Value, json};
     use std::{future::pending, sync::Arc, time::Duration};
     use tempfile::tempdir;
     use tokio::{
@@ -251,6 +251,21 @@ mod tests {
         assert_eq!(
             request["batch"][0]["event"],
             events::AGENT_SESSION_ENDED.name()
+        );
+        assert_eq!(
+            request["batch"][0]["properties"],
+            json!({
+                "kind": "closed",
+                "client_name": "codex",
+                "dispatch_count": 0,
+                "distinct_tool_count": 0,
+                "max_concurrent_used_sessions": 0,
+                "server_version": env!("CARGO_PKG_VERSION"),
+                "os_platform": events::platform_token(),
+                "$process_person_profile": false,
+                "$geoip_disable": true,
+                "$is_server": true,
+            })
         );
         endpoint.abort();
         Ok(())

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/manager.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/manager.rs
@@ -183,7 +183,13 @@ impl Sessions {
             reserved_keys.insert(identity.convo_id().clone());
             identity
         };
-        let session = Session::new(id.clone(), agent, identity, Instant::now());
+        let session = Session::new(
+            id.clone(),
+            agent,
+            identity,
+            client.name.clone(),
+            Instant::now(),
+        );
         let audit_result = self
             .audit_log
             .record_session_start(
@@ -195,15 +201,13 @@ impl Sessions {
                 client.version.as_str(),
             )
             .await;
-        self.finish_mint(id, session, client.name, audit_result)
-            .await
+        self.finish_mint(id, session, audit_result).await
     }
 
     async fn finish_mint(
         &self,
         id: SessionId,
         session: Arc<Session>,
-        client_name: String,
         audit_result: AppResult<()>,
     ) -> AppResult<Arc<Session>> {
         if let Err(error) = audit_result {
@@ -213,7 +217,7 @@ impl Sessions {
         self.sessions.write().await.insert(id, session.clone());
         self.analytics.capture(
             events::AGENT_SESSION_STARTED,
-            json!({ "client_name": client_name }),
+            json!({ "client_name": session.client_name() }),
         );
         Ok(session)
     }
@@ -254,6 +258,15 @@ impl Sessions {
 
     pub async fn count(&self) -> usize {
         self.sessions.read().await.len()
+    }
+
+    pub async fn used_count(&self) -> usize {
+        self.sessions
+            .read()
+            .await
+            .values()
+            .filter(|session| session.is_used())
+            .count()
     }
 
     pub async fn cancel_by_convo(&self, convo_id: &ConvoId) -> usize {
@@ -538,6 +551,7 @@ mod tests {
                 label: "A1".to_string(),
             },
             ConversationIdentity::new("a1", "agile-alpaca".to_string()),
+            "Codex".to_string(),
             Instant::now(),
         );
         registry.insert_for_testing(session).await;
@@ -570,6 +584,7 @@ mod tests {
                 label: "Agent".to_string(),
             },
             ConversationIdentity::new("agent", "agile-alpaca".to_string()),
+            "Codex".to_string(),
             Instant::now(),
         );
         registry.insert_for_testing(session.clone()).await;
@@ -619,6 +634,48 @@ mod tests {
             )
             .await?;
         assert!(registry.lookup(session.id()).await.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn used_count_excludes_initialize_only_sessions() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let (audit_log, session_tabs) = repositories(&dir).await?;
+        let registry = Sessions::new(
+            audit_log,
+            session_tabs,
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+            Duration::from_secs(1),
+        );
+        let first = Session::new(
+            SessionId::new("first"),
+            ClientIdentity::Ephemeral {
+                slug: "agent".to_string(),
+                label: "Agent".to_string(),
+            },
+            ConversationIdentity::new("agent", "first-label".to_string()),
+            "Codex".to_string(),
+            Instant::now(),
+        );
+        let second = Session::new(
+            SessionId::new("second"),
+            ClientIdentity::Ephemeral {
+                slug: "agent".to_string(),
+                label: "Agent".to_string(),
+            },
+            ConversationIdentity::new("agent", "second-label".to_string()),
+            "Codex".to_string(),
+            Instant::now(),
+        );
+        registry.insert_for_testing(first.clone()).await;
+        registry.insert_for_testing(second.clone()).await;
+
+        assert_eq!(registry.used_count().await, 0);
+        first.mark_used();
+        assert_eq!(registry.used_count().await, 1);
+        second.mark_used();
+        assert_eq!(registry.used_count().await, 2);
         Ok(())
     }
 
@@ -685,6 +742,7 @@ mod tests {
                 label: "Agent".to_string(),
             },
             ConversationIdentity::new("agent", "failed-start-label".to_string()),
+            "Codex".to_string(),
             Instant::now(),
         );
         registry
@@ -697,7 +755,6 @@ mod tests {
                 .finish_mint(
                     failed_start.id().clone(),
                     failed_start.clone(),
-                    "Codex".to_string(),
                     Err(crate::error::AppError::Internal("audit failed".to_string())),
                 )
                 .await
@@ -713,6 +770,7 @@ mod tests {
                 label: "Agent".to_string(),
             },
             ConversationIdentity::new("agent", "failed-end-label".to_string()),
+            "Codex".to_string(),
             Instant::now(),
         );
         assert!(
@@ -754,6 +812,7 @@ mod tests {
                         label: "Agent".to_string(),
                     },
                     ConversationIdentity::new("agent", format!("{id}-label")),
+                    "Codex".to_string(),
                     Instant::now(),
                 ))
                 .await;
@@ -768,6 +827,7 @@ mod tests {
                     label: "Agent".to_string(),
                 },
                 ConversationIdentity::new("agent", "shutdown-label".to_string()),
+                "Codex".to_string(),
                 Instant::now(),
             ))
             .await;
@@ -845,6 +905,7 @@ mod tests {
                 label: "Agent".to_string(),
             },
             ConversationIdentity::new("agent", "transport-close-label".to_string()),
+            "Codex".to_string(),
             Instant::now(),
         );
         registry.insert_for_testing(session.clone()).await;
@@ -969,6 +1030,7 @@ mod tests {
                 label: "Codex".to_string(),
             },
             ConversationIdentity::new("codex", "agile-alpaca".to_string()),
+            "Codex".to_string(),
             Instant::now(),
         );
         let key = session.convo_id().clone();
@@ -1069,6 +1131,7 @@ mod tests {
                 label: "Codex".to_string(),
             },
             ConversationIdentity::new("codex", "agile-alpaca".to_string()),
+            "Codex".to_string(),
             Instant::now(),
         );
         let key = session.convo_id().clone();
@@ -1127,6 +1190,7 @@ mod tests {
                 label: "Codex".to_string(),
             },
             ConversationIdentity::new("codex", "agile-alpaca".to_string()),
+            "Codex".to_string(),
             Instant::now(),
         );
         registry.insert_for_testing(session.clone()).await;
@@ -1191,6 +1255,7 @@ mod tests {
                 label: "Codex".to_string(),
             },
             ConversationIdentity::new("codex", "agile-alpaca".to_string()),
+            "Codex".to_string(),
             Instant::now(),
         );
         registry.insert_for_testing(session.clone()).await;

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/manager.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/manager.rs
@@ -390,6 +390,7 @@ impl Sessions {
         kind: &str,
         audit_result: AppResult<()>,
     ) -> AppResult<()> {
+        let usage = session.usage_snapshot().await;
         let key = session.convo_id().clone();
         self.retained.write().await.insert(
             key.clone(),
@@ -400,8 +401,28 @@ impl Sessions {
         if let Some(hook) = self.retained_group_hook.get() {
             hook(self.ownership.clone(), key, RetainedGroupAction::Collapse).await;
         }
-        self.analytics
-            .capture(events::AGENT_SESSION_ENDED, json!({ "kind": kind }));
+        for tool in usage.tools.iter().filter(|tool| tool.dispatch_count > 0) {
+            self.analytics.capture(
+                events::AGENT_SESSION_TOOL_USAGE,
+                json!({
+                    "client_name": usage.client_name.as_str(),
+                    "tool_name": tool.tool_name.as_str(),
+                    "dispatch_count": tool.dispatch_count,
+                    "total_duration_ms": tool.total_duration_ms,
+                    "max_duration_ms": tool.max_duration_ms,
+                }),
+            );
+        }
+        self.analytics.capture(
+            events::AGENT_SESSION_ENDED,
+            json!({
+                "kind": kind,
+                "client_name": usage.client_name.as_str(),
+                "dispatch_count": usage.dispatch_count,
+                "distinct_tool_count": usage.distinct_tool_count,
+                "max_concurrent_used_sessions": usage.max_concurrent_used_sessions,
+            }),
+        );
         audit_result?;
         Ok(())
     }
@@ -715,7 +736,90 @@ mod tests {
                     events::AGENT_SESSION_STARTED,
                     json!({ "client_name": "Claude Code" }),
                 ),
-                (events::AGENT_SESSION_ENDED, json!({ "kind": "closed" }),),
+                (
+                    events::AGENT_SESSION_ENDED,
+                    json!({
+                        "kind": "closed",
+                        "client_name": "Claude Code",
+                        "dispatch_count": 0,
+                        "distinct_tool_count": 0,
+                        "max_concurrent_used_sessions": 0,
+                    }),
+                ),
+            ]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn used_session_emits_sorted_tool_summaries_before_its_end_event() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let (audit_log, session_tabs) = repositories(&dir).await?;
+        let analytics = Arc::new(RecordingAnalytics::default());
+        let registry = Sessions::new_with_analytics(
+            audit_log,
+            session_tabs,
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+            Duration::from_secs(1),
+            analytics.clone(),
+        );
+        let session = Session::new(
+            SessionId::new("used-session"),
+            ClientIdentity::Ephemeral {
+                slug: "agent".to_string(),
+                label: "Agent".to_string(),
+            },
+            ConversationIdentity::new("agent", "used-label".to_string()),
+            "Codex".to_string(),
+            Instant::now(),
+        );
+        session
+            .record_tool_usage("navigate", Duration::from_millis(100), 1)
+            .await;
+        session
+            .record_tool_usage("tabs", Duration::from_millis(20), 2)
+            .await;
+        session
+            .record_tool_usage("navigate", Duration::from_millis(50), 2)
+            .await;
+        registry.insert_for_testing(session.clone()).await;
+
+        assert!(registry.remove(session.id(), "closed", None).await?);
+        assert!(!registry.remove(session.id(), "closed", None).await?);
+        assert_eq!(
+            analytics.snapshot(),
+            vec![
+                (
+                    events::AGENT_SESSION_TOOL_USAGE,
+                    json!({
+                        "client_name": "Codex",
+                        "tool_name": "navigate",
+                        "dispatch_count": 2,
+                        "total_duration_ms": 150,
+                        "max_duration_ms": 100,
+                    }),
+                ),
+                (
+                    events::AGENT_SESSION_TOOL_USAGE,
+                    json!({
+                        "client_name": "Codex",
+                        "tool_name": "tabs",
+                        "dispatch_count": 1,
+                        "total_duration_ms": 20,
+                        "max_duration_ms": 20,
+                    }),
+                ),
+                (
+                    events::AGENT_SESSION_ENDED,
+                    json!({
+                        "kind": "closed",
+                        "client_name": "Codex",
+                        "dispatch_count": 3,
+                        "distinct_tool_count": 2,
+                        "max_concurrent_used_sessions": 2,
+                    }),
+                ),
             ]
         );
         Ok(())
@@ -785,7 +889,16 @@ mod tests {
         );
         assert_eq!(
             analytics.snapshot(),
-            vec![(events::AGENT_SESSION_ENDED, json!({ "kind": "errored" }),)]
+            vec![(
+                events::AGENT_SESSION_ENDED,
+                json!({
+                    "kind": "errored",
+                    "client_name": "Codex",
+                    "dispatch_count": 0,
+                    "distinct_tool_count": 0,
+                    "max_concurrent_used_sessions": 0,
+                }),
+            )]
         );
         Ok(())
     }
@@ -936,7 +1049,16 @@ mod tests {
         assert_eq!(shutdown_task.await??, 0);
         assert_eq!(
             analytics.snapshot(),
-            vec![(events::AGENT_SESSION_ENDED, json!({ "kind": "closed" }))]
+            vec![(
+                events::AGENT_SESSION_ENDED,
+                json!({
+                    "kind": "closed",
+                    "client_name": "Codex",
+                    "dispatch_count": 0,
+                    "distinct_tool_count": 0,
+                    "max_concurrent_used_sessions": 0,
+                }),
+            )]
         );
         Ok(())
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/mod.rs
@@ -1,6 +1,7 @@
 mod manager;
 mod session;
 mod tab_ownership;
+mod usage;
 
 pub use manager::{RetainedGroupAction, RetainedGroupHook, Sessions};
 pub use session::Session;

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/session.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/session.rs
@@ -1,3 +1,4 @@
+use super::usage::{SessionUsageSnapshot, UsageTracker};
 use crate::{
     identity::{ClientIdentity, ConversationIdentity},
     ids::{ConvoId, DispatchId, SessionId},
@@ -13,6 +14,7 @@ pub struct Session {
     id: SessionId,
     agent: ClientIdentity,
     identity: ConversationIdentity,
+    usage: UsageTracker,
     active_dispatches: Mutex<BTreeMap<DispatchId, CancellationToken>>,
     cancel: CancellationToken,
     last_activity: Mutex<Instant>,
@@ -24,12 +26,14 @@ impl Session {
         id: SessionId,
         agent: ClientIdentity,
         identity: ConversationIdentity,
+        client_name: String,
         now: Instant,
     ) -> Arc<Self> {
         Arc::new(Self {
             id,
             agent,
             identity,
+            usage: UsageTracker::new(client_name),
             active_dispatches: Mutex::new(BTreeMap::new()),
             cancel: CancellationToken::new(),
             last_activity: Mutex::new(now),
@@ -54,6 +58,35 @@ impl Session {
     #[must_use]
     pub fn generated_label(&self) -> &str {
         self.identity.generated_label()
+    }
+
+    #[must_use]
+    pub fn client_name(&self) -> &str {
+        self.usage.client_name()
+    }
+
+    pub fn mark_used(&self) {
+        self.usage.mark_used();
+    }
+
+    #[must_use]
+    pub fn is_used(&self) -> bool {
+        self.usage.is_used()
+    }
+
+    pub async fn record_tool_usage(
+        &self,
+        tool_name: &str,
+        elapsed: Duration,
+        concurrent_used_sessions: usize,
+    ) {
+        self.usage
+            .record(tool_name, elapsed, concurrent_used_sessions)
+            .await;
+    }
+
+    pub(crate) async fn usage_snapshot(&self) -> SessionUsageSnapshot {
+        self.usage.snapshot().await
     }
 
     pub async fn label(&self) -> String {

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/usage.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/sessions/usage.rs
@@ -1,0 +1,182 @@
+use crate::analytics::events::MAX_SAFE_INTEGER;
+use std::{
+    collections::BTreeMap,
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionUsageSnapshot {
+    pub(crate) client_name: String,
+    pub(crate) dispatch_count: u64,
+    pub(crate) distinct_tool_count: u64,
+    pub(crate) max_concurrent_used_sessions: u64,
+    pub(crate) tools: Vec<ToolUsageSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolUsageSnapshot {
+    pub(crate) tool_name: String,
+    pub(crate) dispatch_count: u64,
+    pub(crate) total_duration_ms: u64,
+    pub(crate) max_duration_ms: u64,
+}
+
+pub(crate) struct UsageTracker {
+    client_name: String,
+    used: AtomicBool,
+    state: Mutex<UsageState>,
+}
+
+#[derive(Default)]
+struct UsageState {
+    dispatch_count: u64,
+    max_concurrent_used_sessions: u64,
+    tools: BTreeMap<String, ToolUsage>,
+}
+
+#[derive(Default)]
+struct ToolUsage {
+    dispatch_count: u64,
+    total_duration_ms: u64,
+    max_duration_ms: u64,
+}
+
+impl UsageTracker {
+    pub(crate) fn new(client_name: String) -> Self {
+        Self {
+            client_name,
+            used: AtomicBool::new(false),
+            state: Mutex::new(UsageState::default()),
+        }
+    }
+
+    pub(crate) fn client_name(&self) -> &str {
+        &self.client_name
+    }
+
+    pub(crate) fn mark_used(&self) {
+        self.used.store(true, Ordering::Relaxed);
+    }
+
+    pub(crate) fn is_used(&self) -> bool {
+        self.used.load(Ordering::Relaxed)
+    }
+
+    pub(crate) async fn record(
+        &self,
+        tool_name: &str,
+        elapsed: Duration,
+        concurrent_used_sessions: usize,
+    ) {
+        self.mark_used();
+        let elapsed_ms = capped_u128(elapsed.as_millis());
+        let concurrent_used_sessions = capped_u128(concurrent_used_sessions as u128);
+        let mut state = self.state.lock().await;
+        state.dispatch_count = capped_add(state.dispatch_count, 1);
+        state.max_concurrent_used_sessions = state
+            .max_concurrent_used_sessions
+            .max(concurrent_used_sessions);
+        let tool = state.tools.entry(tool_name.to_string()).or_default();
+        tool.dispatch_count = capped_add(tool.dispatch_count, 1);
+        tool.total_duration_ms = capped_add(tool.total_duration_ms, elapsed_ms);
+        tool.max_duration_ms = tool.max_duration_ms.max(elapsed_ms);
+    }
+
+    pub(crate) async fn snapshot(&self) -> SessionUsageSnapshot {
+        let state = self.state.lock().await;
+        SessionUsageSnapshot {
+            client_name: self.client_name.clone(),
+            dispatch_count: state.dispatch_count,
+            distinct_tool_count: capped_u128(state.tools.len() as u128),
+            max_concurrent_used_sessions: state.max_concurrent_used_sessions,
+            tools: state
+                .tools
+                .iter()
+                .map(|(tool_name, usage)| ToolUsageSnapshot {
+                    tool_name: tool_name.clone(),
+                    dispatch_count: usage.dispatch_count,
+                    total_duration_ms: usage.total_duration_ms,
+                    max_duration_ms: usage.max_duration_ms,
+                })
+                .collect(),
+        }
+    }
+}
+
+fn capped_add(current: u64, increment: u64) -> u64 {
+    current.saturating_add(increment).min(MAX_SAFE_INTEGER)
+}
+
+fn capped_u128(value: u128) -> u64 {
+    value.min(u128::from(MAX_SAFE_INTEGER)) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analytics::events::MAX_SAFE_INTEGER;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn untouched_tracker_has_a_zero_use_snapshot() {
+        let tracker = UsageTracker::new("Codex".to_string());
+
+        assert!(!tracker.is_used());
+        assert_eq!(
+            tracker.snapshot().await,
+            SessionUsageSnapshot {
+                client_name: "Codex".to_string(),
+                dispatch_count: 0,
+                distinct_tool_count: 0,
+                max_concurrent_used_sessions: 0,
+                tools: Vec::new(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn tracker_aggregates_calls_in_deterministic_tool_order() {
+        let tracker = UsageTracker::new("Codex".to_string());
+
+        tracker
+            .record("navigate", Duration::from_millis(120), 1)
+            .await;
+        tracker.record("tabs", Duration::from_millis(30), 2).await;
+        tracker
+            .record("navigate", Duration::from_millis(80), 2)
+            .await;
+
+        assert!(tracker.is_used());
+        assert_eq!(
+            tracker.snapshot().await,
+            SessionUsageSnapshot {
+                client_name: "Codex".to_string(),
+                dispatch_count: 3,
+                distinct_tool_count: 2,
+                max_concurrent_used_sessions: 2,
+                tools: vec![
+                    ToolUsageSnapshot {
+                        tool_name: "navigate".to_string(),
+                        dispatch_count: 2,
+                        total_duration_ms: 200,
+                        max_duration_ms: 120,
+                    },
+                    ToolUsageSnapshot {
+                        tool_name: "tabs".to_string(),
+                        dispatch_count: 1,
+                        total_duration_ms: 30,
+                        max_duration_ms: 30,
+                    },
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn numeric_helpers_cap_at_the_analytics_boundary() {
+        assert_eq!(capped_add(MAX_SAFE_INTEGER - 1, 10), MAX_SAFE_INTEGER);
+        assert_eq!(capped_u128(u128::MAX), MAX_SAFE_INTEGER);
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
@@ -333,6 +333,7 @@ fn live_session(session_id: &str) -> Arc<Session> {
             label: "Codex".to_string(),
         },
         ConversationIdentity::new("codex", "research-browserclaw".to_string()),
+        "Codex".to_string(),
         tokio::time::Instant::now(),
     )
 }
@@ -998,6 +999,7 @@ async fn seed_live_fixture(app: &TestApp) -> anyhow::Result<LiveFixture> {
             label: "Claude Code".to_string(),
         },
         ConversationIdentity::new("claude-code", "waiting-for-first-tool".to_string()),
+        "Codex".to_string(),
         tokio::time::Instant::now(),
     );
     for session in [&primary, &second, &zero_tab] {
@@ -1068,6 +1070,7 @@ fn profiled_session(session_id: &str, name: &str) -> Arc<Session> {
             label: "Codex".to_string(),
         },
         ConversationIdentity::new("codex", name.to_string()),
+        "Codex".to_string(),
         tokio::time::Instant::now(),
     )
 }

--- a/packages/browseros-agent/apps/claw-server-rust/tests/dependency_boundaries.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/dependency_boundaries.rs
@@ -154,6 +154,7 @@ fn analytics_catalog_and_sdk_have_single_source_boundaries()
         "server_started",
         "agent_session_started",
         "agent_session_ended",
+        "agent_session_tool_usage",
         "harness_connected",
         "harness_disconnected",
     ];
@@ -190,7 +191,7 @@ fn analytics_catalog_and_sdk_have_single_source_boundaries()
         );
     }
     assert_eq!(sdk_locations, ["analytics/service.rs"]);
-    assert_eq!(claw_server_rust::analytics::events::ALL.len(), 5);
+    assert_eq!(claw_server_rust::analytics::events::ALL.len(), 6);
     Ok(())
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -1003,6 +1003,7 @@ async fn canonical_live_sessions_enrich_through_profile_identity() -> anyhow::Re
             label: "Stored Agent".to_string(),
         },
         ConversationIdentity::new("mcp", "agile-alpaca".to_string()),
+        "Codex".to_string(),
         tokio::time::Instant::now(),
     );
     let ephemeral_session =
@@ -1341,6 +1342,7 @@ fn test_session(session_id: SessionId, agent_id: &str, slug: &str) -> Arc<Sessio
             label: slug.to_string(),
         },
         ConversationIdentity::new(slug, generated_label),
+        "Codex".to_string(),
         tokio::time::Instant::now(),
     )
 }


### PR DESCRIPTION
## Summary
- enrich session-end analytics with real tool dispatch counts, harness identity, and observed used-session concurrency
- emit one privacy-safe aggregate per distinct recognized tool with bounded total and maximum duration
- enforce the six-event catalog, closed tool names, safe integers, and double allowlisting at the analytics boundary

## Design
A session-owned in-memory tracker records each recognized `tools/call` once at the common completion boundary. Exactly-once teardown snapshots deterministic aggregates, emits sorted per-tool summaries, then emits the enriched terminal session event; no per-dispatch analytics, identifiers, content, or persistence are added.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p claw-server-rust --locked`
- [x] `cargo clippy -p claw-server-rust --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `bun run test:claw-api-contract`
