### PR TITLE
fix(codex): drive BrowserOS tools instead of Codex's bundled in-app browser

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/prompt.ts
+++ b/packages/browseros-agent/apps/server/src/agent/prompt.ts
@@ -173,6 +173,7 @@ function getAcpToolNamespace(
   if (!options?.acpMode) return ''
   return `<acp_tool_namespace>
 You are running through BrowserOS as an ACP-powered agent. The browser tools listed in capabilities reach you over MCP as \`mcp.browseros.<name>\`, so \`navigate\` is \`mcp.browseros.navigate\`, \`act\` is \`mcp.browseros.act\`, \`snapshot\` is \`mcp.browseros.snapshot\`, and so on. Your workspace filesystem is a separate surface from the browser tabs; editing files in the workspace does not change web page content, and reading pages over the browser tools does not touch your workspace. Prefer the BrowserOS MCP tools over your own built-in file, shell, or fetch tools for any browser or web task.
+BrowserOS via \`mcp.browseros.*\` is the only browser you have and the only browser you may drive. For every web or browser action (opening a URL, navigating, clicking, typing, filling forms, scraping, or taking a screenshot, whether the target is a remote site or the current tab) use the \`mcp.browseros.*\` tools. Do not use any bundled or in-app browser (a \`browser\` plugin, a \`control-in-app-browser\` skill, a \`node_repl\` browser bridge, or any "in-app browser" surface), Playwright, chrome-devtools, a headless fetcher, or the system Chrome. If a browser tool call fails, retry through \`mcp.browseros.*\`; never fall back to another browser.
 </acp_tool_namespace>`
 }
 

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -13,7 +13,6 @@ import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import type { LanguageModel } from 'ai'
 import { buildAcpxProvider } from '../lib/agents/acpx-provider/buildAcpxProvider'
-import { materializeCodexBrowserlessHome } from '../lib/agents/host-acp/codex-home'
 import {
   DANGEROUS_ALLOW_MODE_CANDIDATES,
   isHostAcpAdapter,
@@ -90,10 +89,19 @@ function expandHomeToken(path: string): string {
 async function codexBrowserlessEnv(): Promise<
   Record<string, string> | undefined
 > {
-  const codexHome = await materializeCodexBrowserlessHome({
-    browserosDir: getBrowserosDir(),
-  })
-  return codexHome ? { CODEX_HOME: codexHome } : undefined
+  try {
+    // Loaded lazily so the overlay's fs-heavy module stays out of the
+    // factory's static import graph (it is only needed for codex chats).
+    const { materializeCodexBrowserlessHome } = await import(
+      '../lib/agents/host-acp/codex-home'
+    )
+    const codexHome = await materializeCodexBrowserlessHome({
+      browserosDir: getBrowserosDir(),
+    })
+    return codexHome ? { CODEX_HOME: codexHome } : undefined
+  } catch {
+    return undefined
+  }
 }
 
 function resolveAcpAgentId(config: ResolvedAgentConfig): string {
@@ -170,9 +178,13 @@ async function createAcpLanguageModel(
     // Codex ships a bundled in-app browser plugin that competes with the
     // BrowserOS MCP tools for browser tasks; point it at an overlay
     // CODEX_HOME that disables that plugin so BrowserOS is the only
-    // browser. Falls back to the real home when the overlay can't build.
+    // browser. Only built for the codex adapter when codex is the agent
+    // actually being spawned, and falls back to the real home if the
+    // overlay cannot be built.
     const extraEnv =
-      builtIn === 'codex' ? await codexBrowserlessEnv() : undefined
+      builtIn === 'codex' && agentId === 'codex'
+        ? await codexBrowserlessEnv()
+        : undefined
     const launcher = resolveAcpSpawnCommand({
       agentType: builtIn,
       browserosDir: getBrowserosDir(),

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -13,6 +13,7 @@ import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import type { LanguageModel } from 'ai'
 import { buildAcpxProvider } from '../lib/agents/acpx-provider/buildAcpxProvider'
+import { materializeCodexBrowserlessHome } from '../lib/agents/host-acp/codex-home'
 import {
   DANGEROUS_ALLOW_MODE_CANDIDATES,
   isHostAcpAdapter,
@@ -86,6 +87,15 @@ function expandHomeToken(path: string): string {
   return path.replace(/^\$HOME(?=\/|$)/, homedir())
 }
 
+async function codexBrowserlessEnv(): Promise<
+  Record<string, string> | undefined
+> {
+  const codexHome = await materializeCodexBrowserlessHome({
+    browserosDir: getBrowserosDir(),
+  })
+  return codexHome ? { CODEX_HOME: codexHome } : undefined
+}
+
 function resolveAcpAgentId(config: ResolvedAgentConfig): string {
   if (config.provider === LLM_PROVIDERS.ACP_CUSTOM) {
     if (!config.acpAgentId) {
@@ -157,10 +167,17 @@ async function createAcpLanguageModel(
   // pinned version range for both tiers instead of falling through to
   // whatever range acpx happens to ship.
   for (const builtIn of ['claude', 'codex'] as const) {
+    // Codex ships a bundled in-app browser plugin that competes with the
+    // BrowserOS MCP tools for browser tasks; point it at an overlay
+    // CODEX_HOME that disables that plugin so BrowserOS is the only
+    // browser. Falls back to the real home when the overlay can't build.
+    const extraEnv =
+      builtIn === 'codex' ? await codexBrowserlessEnv() : undefined
     const launcher = resolveAcpSpawnCommand({
       agentType: builtIn,
       browserosDir: getBrowserosDir(),
       resourcesDir: config.resourcesDir,
+      extraEnv,
     })
     if (launcher) {
       agentRegistryOverrides[builtIn] = launcher.command

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/codex-home.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/codex-home.ts
@@ -122,7 +122,13 @@ export async function materializeCodexBrowserlessHome(input: {
     const target = join(input.browserosDir, 'acpx-state', 'codex-home-no-iab')
     await mkdir(target, { recursive: true })
 
-    await syncSymlinkFarm(source, target)
+    if (!(await syncSymlinkFarm(source, target))) {
+      logger.error(
+        'Incomplete Codex home overlay (a required symlink failed); ' +
+          'using real home so Codex keeps its auth and settings',
+      )
+      return null
+    }
     const wrote = await writeBrowserlessConfig(source, target)
     return wrote ? target : null
   } catch (error) {
@@ -136,21 +142,31 @@ export async function materializeCodexBrowserlessHome(input: {
   }
 }
 
-/** Failsafe 1: converge the overlay's symlinks to mirror `source`. */
-async function syncSymlinkFarm(source: string, target: string): Promise<void> {
+/**
+ * Failsafe 1: converge the overlay's symlinks to mirror `source`. Returns
+ * false when any required link could not be created, so the caller falls
+ * back to the real home rather than handing Codex an incomplete overlay.
+ */
+async function syncSymlinkFarm(
+  source: string,
+  target: string,
+): Promise<boolean> {
   const sourceEntries = await readdir(source)
   const keep = new Set<string>()
+  let allOk = true
   for (const name of sourceEntries) {
     if (name === CONFIG_FILE) continue
     keep.add(name)
-    await ensureSymlink(join(source, name), join(target, name))
+    if (!(await ensureSymlink(join(source, name), join(target, name)))) {
+      allOk = false
+    }
   }
 
   let targetEntries: string[]
   try {
     targetEntries = await readdir(target)
   } catch {
-    return
+    return allOk
   }
   for (const name of targetEntries) {
     if (name === CONFIG_FILE || keep.has(name)) continue
@@ -159,27 +175,42 @@ async function syncSymlinkFarm(source: string, target: string): Promise<void> {
       await unlink(linkPath).catch(() => undefined)
     }
   }
+  return allOk
 }
 
+/**
+ * Ensure `linkPath` is a symlink to `sourcePath`. Returns true on success,
+ * including the benign case where a concurrent session created the same
+ * link first (EEXIST already pointing at the right target). Returns false
+ * on a genuine failure.
+ */
 async function ensureSymlink(
   sourcePath: string,
   linkPath: string,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const info = await lstat(linkPath).catch(() => null)
     if (info?.isSymbolicLink()) {
       const current = await readlink(linkPath).catch(() => null)
-      if (current === sourcePath) return
+      if (current === sourcePath) return true
       await unlink(linkPath)
     } else if (info) {
       await rm(linkPath, { recursive: true, force: true })
     }
     await symlink(sourcePath, linkPath)
+    return true
   } catch (error) {
-    logger.debug('Skipped a Codex home overlay symlink', {
+    // A concurrent session may have created the same link between our
+    // lstat and symlink; that is not a failure if it points where we want.
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      const current = await readlink(linkPath).catch(() => null)
+      if (current === sourcePath) return true
+    }
+    logger.warn('Failed to create a Codex home overlay symlink', {
       linkPath,
       error: error instanceof Error ? error.message : String(error),
     })
+    return false
   }
 }
 
@@ -188,9 +219,16 @@ async function writeBrowserlessConfig(
   source: string,
   target: string,
 ): Promise<boolean> {
-  const sourceText = await readFile(join(source, CONFIG_FILE), 'utf8').catch(
-    () => '',
-  )
+  // A missing config.toml is a valid empty config; any other read error
+  // (permissions, I/O) must propagate so the caller falls back to the real
+  // home instead of writing an overlay that drops the user's settings.
+  let sourceText: string
+  try {
+    sourceText = await readFile(join(source, CONFIG_FILE), 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    sourceText = ''
+  }
   const editedText = disableInAppBrowserPlugin(sourceText)
   if (!verifyBrowserDisabled(sourceText, editedText)) {
     logger.error(

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/codex-home.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/codex-home.ts
@@ -1,0 +1,247 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Builds a CODEX_HOME overlay for the acpx chat path that disables Codex's
+ * bundled in-app browser plugin (`browser@openai-bundled`), so a browser
+ * task is driven through the BrowserOS MCP tools instead of Codex's own
+ * in-app browser. The overlay symlinks every real `~/.codex` entry except
+ * `config.toml`, which is regenerated with the plugin disabled. Two
+ * failsafes keep it resilient: the symlink farm re-syncs to `~/.codex` on
+ * every call (new files picked up, removed ones pruned), and the config
+ * edit is committed only if a real TOML round-trip proves it changed
+ * exactly the one field and nothing else.
+ */
+
+import { randomUUID } from 'node:crypto'
+import {
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  readlink,
+  rename,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { basename, dirname, join } from 'node:path'
+import { logger } from '../../logger'
+
+export const IN_APP_BROWSER_PLUGIN_KEY = 'browser@openai-bundled'
+
+const PLUGIN_TABLE_HEADER = `[plugins."${IN_APP_BROWSER_PLUGIN_KEY}"]`
+const CONFIG_FILE = 'config.toml'
+
+/**
+ * Pure textual transform: return `configToml` with the in-app browser
+ * plugin disabled, touching only its `[plugins."browser@openai-bundled"]`
+ * table and leaving everything else byte-for-byte. Idempotent.
+ */
+export function disableInAppBrowserPlugin(configToml: string): string {
+  const lines = configToml.split('\n')
+  const headerIndex = lines.findIndex(
+    (line) => line.trim() === PLUGIN_TABLE_HEADER,
+  )
+
+  if (headerIndex === -1) {
+    const prefix =
+      configToml.length === 0 || configToml.endsWith('\n') ? '' : '\n'
+    return `${configToml}${prefix}\n${PLUGIN_TABLE_HEADER}\nenabled = false\n`
+  }
+
+  // Scan the table body until the next table/array header or EOF.
+  for (let i = headerIndex + 1; i < lines.length; i++) {
+    const trimmed = lines[i]?.trim() ?? ''
+    if (trimmed.startsWith('[')) break
+    if (/^enabled\s*=/.test(trimmed)) {
+      lines[i] = 'enabled = false'
+      return lines.join('\n')
+    }
+  }
+
+  // Table present but no `enabled` key: insert one right after the header.
+  lines.splice(headerIndex + 1, 0, 'enabled = false')
+  return lines.join('\n')
+}
+
+/**
+ * True when `editedText` is exactly `sourceText` with only the in-app
+ * browser plugin's `enabled` set to `false`. Uses a real TOML round-trip
+ * so a config-format change can never slip a corrupt overlay through.
+ * Returns false (never throws) when either side fails to parse.
+ */
+export function verifyBrowserDisabled(
+  sourceText: string,
+  editedText: string,
+): boolean {
+  let srcObj: Record<string, unknown>
+  let outObj: Record<string, unknown>
+  try {
+    srcObj = Bun.TOML.parse(sourceText) as Record<string, unknown>
+    outObj = Bun.TOML.parse(editedText) as Record<string, unknown>
+  } catch {
+    return false
+  }
+
+  const expected = structuredClone(srcObj)
+  if (!expected.plugins) expected.plugins = {}
+  const plugins = expected.plugins as Record<string, Record<string, unknown>>
+  plugins[IN_APP_BROWSER_PLUGIN_KEY] = {
+    ...(plugins[IN_APP_BROWSER_PLUGIN_KEY] ?? {}),
+    enabled: false,
+  }
+
+  const outPlugins = outObj.plugins as
+    | Record<string, Record<string, unknown>>
+    | undefined
+  return (
+    outPlugins?.[IN_APP_BROWSER_PLUGIN_KEY]?.enabled === false &&
+    deepEqual(outObj, expected)
+  )
+}
+
+/**
+ * Materialize (or refresh) the CODEX_HOME overlay with the in-app browser
+ * disabled. Returns the overlay path, or null on any failure so the caller
+ * falls back to the real `~/.codex`. Never throws; never writes a partial
+ * or corrupt config.
+ */
+export async function materializeCodexBrowserlessHome(input: {
+  browserosDir: string
+  sourceCodexHome?: string
+}): Promise<string | null> {
+  try {
+    const source =
+      input.sourceCodexHome?.trim() ||
+      process.env.CODEX_HOME?.trim() ||
+      join(homedir(), '.codex')
+    const target = join(input.browserosDir, 'acpx-state', 'codex-home-no-iab')
+    await mkdir(target, { recursive: true })
+
+    await syncSymlinkFarm(source, target)
+    const wrote = await writeBrowserlessConfig(source, target)
+    return wrote ? target : null
+  } catch (error) {
+    logger.warn(
+      'Failed to materialize browserless Codex home; using real home',
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+    )
+    return null
+  }
+}
+
+/** Failsafe 1: converge the overlay's symlinks to mirror `source`. */
+async function syncSymlinkFarm(source: string, target: string): Promise<void> {
+  const sourceEntries = await readdir(source)
+  const keep = new Set<string>()
+  for (const name of sourceEntries) {
+    if (name === CONFIG_FILE) continue
+    keep.add(name)
+    await ensureSymlink(join(source, name), join(target, name))
+  }
+
+  let targetEntries: string[]
+  try {
+    targetEntries = await readdir(target)
+  } catch {
+    return
+  }
+  for (const name of targetEntries) {
+    if (name === CONFIG_FILE || keep.has(name)) continue
+    const linkPath = join(target, name)
+    if (await isSymlink(linkPath)) {
+      await unlink(linkPath).catch(() => undefined)
+    }
+  }
+}
+
+async function ensureSymlink(
+  sourcePath: string,
+  linkPath: string,
+): Promise<void> {
+  try {
+    const info = await lstat(linkPath).catch(() => null)
+    if (info?.isSymbolicLink()) {
+      const current = await readlink(linkPath).catch(() => null)
+      if (current === sourcePath) return
+      await unlink(linkPath)
+    } else if (info) {
+      await rm(linkPath, { recursive: true, force: true })
+    }
+    await symlink(sourcePath, linkPath)
+  } catch (error) {
+    logger.debug('Skipped a Codex home overlay symlink', {
+      linkPath,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/** Failsafe 2: write the overlay config only if the edit round-trips clean. */
+async function writeBrowserlessConfig(
+  source: string,
+  target: string,
+): Promise<boolean> {
+  const sourceText = await readFile(join(source, CONFIG_FILE), 'utf8').catch(
+    () => '',
+  )
+  const editedText = disableInAppBrowserPlugin(sourceText)
+  if (!verifyBrowserDisabled(sourceText, editedText)) {
+    logger.error(
+      'Codex config.toml did not round-trip after disabling the in-app ' +
+        'browser plugin; leaving CODEX_HOME unset to avoid a corrupt overlay',
+    )
+    return false
+  }
+  await writeFileAtomic(join(target, CONFIG_FILE), editedText)
+  return true
+}
+
+async function writeFileAtomic(path: string, content: string): Promise<void> {
+  const temporaryPath = join(
+    dirname(path),
+    `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`,
+  )
+  try {
+    await writeFile(temporaryPath, content, 'utf8')
+    await rename(temporaryPath, path)
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined)
+    throw error
+  }
+}
+
+async function isSymlink(path: string): Promise<boolean> {
+  try {
+    return (await lstat(path)).isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (typeof a !== typeof b) return false
+  if (a === null || b === null) return a === b
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false
+    }
+    return a.every((item, index) => deepEqual(item, b[index]))
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const aObj = a as Record<string, unknown>
+    const bObj = b as Record<string, unknown>
+    const aKeys = Object.keys(aObj)
+    const bKeys = Object.keys(bObj)
+    if (aKeys.length !== bKeys.length) return false
+    return aKeys.every((key) => key in bObj && deepEqual(aObj[key], bObj[key]))
+  }
+  return false
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/launcher.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/launcher.ts
@@ -31,6 +31,12 @@ export interface ResolveAcpSpawnCommandInput {
   env?: NodeJS.ProcessEnv
   resourcesDir?: string | null
   platform?: NodeJS.Platform
+  /**
+   * Extra env baked into the spawn command for this adapter (e.g. a
+   * `CODEX_HOME` overlay that disables Codex's bundled in-app browser).
+   * Merged into both the bundled-Bun and npx-fallback commands.
+   */
+  extraEnv?: Record<string, string>
   /** Injected for tests; production callers leave it unset. */
   resolveBundledBun?: typeof resolveBundledBun
 }
@@ -59,14 +65,23 @@ export function resolveAcpSpawnCommand(
     return {
       command: wrapCommandWithEnv(
         `${quoteAcpCommandToken(bunPath)} x --bun --silent --package ${quoteAcpCommandToken(config.acpPackageSpec)} ${quoteAcpCommandToken(config.acpBin)}`,
-        withBundledBunAcpAdapterEnv({
-          bunPath,
-          browserosDir: input.browserosDir,
-          env: input.env,
-          platform: input.platform,
-        }),
+        {
+          ...withBundledBunAcpAdapterEnv({
+            bunPath,
+            browserosDir: input.browserosDir,
+            env: input.env,
+            platform: input.platform,
+          }),
+          ...input.extraEnv,
+        },
       ),
       source: 'bundled-bun',
+    }
+  }
+  if (input.extraEnv && Object.keys(input.extraEnv).length > 0) {
+    return {
+      command: wrapCommandWithEnv(config.acpCommand, input.extraEnv),
+      source: 'host-npx-fallback',
     }
   }
   return { command: config.acpCommand, source: 'host-npx-fallback' }

--- a/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/codex-home.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/codex-home.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  disableInAppBrowserPlugin,
+  IN_APP_BROWSER_PLUGIN_KEY,
+  verifyBrowserDisabled,
+} from '../../../../src/lib/agents/host-acp/codex-home'
+
+function browserEnabled(toml: string): unknown {
+  const parsed = Bun.TOML.parse(toml) as {
+    plugins?: Record<string, { enabled?: unknown }>
+  }
+  return parsed.plugins?.[IN_APP_BROWSER_PLUGIN_KEY]?.enabled
+}
+
+describe('disableInAppBrowserPlugin', () => {
+  it('flips an existing enabled = true to false', () => {
+    const src = `model = "gpt-5.5"\n\n[plugins."browser@openai-bundled"]\nenabled = true\n`
+    const out = disableInAppBrowserPlugin(src)
+    expect(browserEnabled(out)).toBe(false)
+    expect(out).toContain('model = "gpt-5.5"')
+  })
+
+  it('is idempotent when already disabled', () => {
+    const src = `[plugins."browser@openai-bundled"]\nenabled = false\n`
+    expect(disableInAppBrowserPlugin(src)).toBe(
+      disableInAppBrowserPlugin(disableInAppBrowserPlugin(src)),
+    )
+    expect(browserEnabled(disableInAppBrowserPlugin(src))).toBe(false)
+  })
+
+  it('inserts enabled = false when the table has no enabled key', () => {
+    const src = `[plugins."browser@openai-bundled"]\nother = 1\n`
+    const out = disableInAppBrowserPlugin(src)
+    expect(browserEnabled(out)).toBe(false)
+    expect(Bun.TOML.parse(out)).toMatchObject({
+      plugins: { [IN_APP_BROWSER_PLUGIN_KEY]: { other: 1 } },
+    })
+  })
+
+  it('appends the table when it is absent', () => {
+    const src = `model = "gpt-5.5"\n`
+    const out = disableInAppBrowserPlugin(src)
+    expect(browserEnabled(out)).toBe(false)
+  })
+
+  it('appends the table for empty input', () => {
+    expect(browserEnabled(disableInAppBrowserPlugin(''))).toBe(false)
+  })
+
+  it('does not leak into a following table', () => {
+    const src = `[plugins."browser@openai-bundled"]\n\n[other]\nenabled = true\n`
+    const out = disableInAppBrowserPlugin(src)
+    const parsed = Bun.TOML.parse(out) as {
+      plugins: Record<string, { enabled: unknown }>
+      other: { enabled: unknown }
+    }
+    expect(parsed.plugins[IN_APP_BROWSER_PLUGIN_KEY].enabled).toBe(false)
+    expect(parsed.other.enabled).toBe(true)
+  })
+
+  it('only touches the target table, preserving siblings', () => {
+    const src = `[plugins."documents@openai-primary-runtime"]\nenabled = true\n\n[plugins."browser@openai-bundled"]\nenabled = true\n`
+    const parsed = Bun.TOML.parse(disableInAppBrowserPlugin(src)) as {
+      plugins: Record<string, { enabled: unknown }>
+    }
+    expect(parsed.plugins['documents@openai-primary-runtime'].enabled).toBe(
+      true,
+    )
+    expect(parsed.plugins[IN_APP_BROWSER_PLUGIN_KEY].enabled).toBe(false)
+  })
+})
+
+describe('verifyBrowserDisabled', () => {
+  it('accepts an edit that only disables the plugin', () => {
+    const src = `model = "gpt-5.5"\n\n[plugins."browser@openai-bundled"]\nenabled = true\n`
+    expect(verifyBrowserDisabled(src, disableInAppBrowserPlugin(src))).toBe(
+      true,
+    )
+  })
+
+  it('rejects an edit that changes an unrelated field', () => {
+    const src = `model = "gpt-5.5"\n\n[plugins."browser@openai-bundled"]\nenabled = true\n`
+    const tampered = `model = "gpt-5.6"\n\n[plugins."browser@openai-bundled"]\nenabled = false\n`
+    expect(verifyBrowserDisabled(src, tampered)).toBe(false)
+  })
+
+  it('rejects when the edit did not disable the plugin', () => {
+    const src = `[plugins."browser@openai-bundled"]\nenabled = true\n`
+    expect(verifyBrowserDisabled(src, src)).toBe(false)
+  })
+
+  it('rejects when the edited text is invalid TOML', () => {
+    const src = `[plugins."browser@openai-bundled"]\nenabled = true\n`
+    expect(verifyBrowserDisabled(src, 'not = = valid toml [')).toBe(false)
+  })
+
+  it('rejects when the source is invalid TOML', () => {
+    expect(verifyBrowserDisabled('broken = = [', 'anything')).toBe(false)
+  })
+
+  it('round-trips a realistic multi-plugin config', () => {
+    const src = [
+      'model = "gpt-5.5"',
+      'notify = ["a", "b"]',
+      '',
+      '[plugins."documents@openai-primary-runtime"]',
+      'enabled = true',
+      '',
+      '[plugins."browser@openai-bundled"]',
+      'enabled = true',
+      '',
+      '[shell_environment_policy.set]',
+      'BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"',
+      '',
+    ].join('\n')
+    const out = disableInAppBrowserPlugin(src)
+    expect(verifyBrowserDisabled(src, out)).toBe(true)
+    expect(browserEnabled(out)).toBe(false)
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/codex-home.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/codex-home.test.ts
@@ -3,10 +3,22 @@
  * Copyright 2025 BrowserOS
  */
 
-import { describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   disableInAppBrowserPlugin,
   IN_APP_BROWSER_PLUGIN_KEY,
+  materializeCodexBrowserlessHome,
   verifyBrowserDisabled,
 } from '../../../../src/lib/agents/host-acp/codex-home'
 
@@ -121,5 +133,122 @@ describe('verifyBrowserDisabled', () => {
     const out = disableInAppBrowserPlugin(src)
     expect(verifyBrowserDisabled(src, out)).toBe(true)
     expect(browserEnabled(out)).toBe(false)
+  })
+})
+
+describe('materializeCodexBrowserlessHome', () => {
+  let root: string
+  let source: string
+  let browserosDir: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'codex-home-test-'))
+    source = join(root, 'codex')
+    browserosDir = join(root, 'browseros')
+    await mkdir(source, { recursive: true })
+    await mkdir(browserosDir, { recursive: true })
+    await writeFile(join(source, 'auth.json'), '{"token":"x"}')
+    await mkdir(join(source, 'plugins'))
+    await writeFile(
+      join(source, 'config.toml'),
+      `model = "gpt-5.5"\n\n[plugins."browser@openai-bundled"]\nenabled = true\n`,
+    )
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  async function overlayConfig(target: string): Promise<string> {
+    return readFile(join(target, 'config.toml'), 'utf8')
+  }
+
+  it('disables the plugin and symlinks the rest of the home', async () => {
+    const target = await materializeCodexBrowserlessHome({
+      browserosDir,
+      sourceCodexHome: source,
+    })
+    expect(target).not.toBeNull()
+    const config = await overlayConfig(target as string)
+    expect(browserEnabled(config)).toBe(false)
+    expect(config).toContain('model = "gpt-5.5"')
+    // real state is symlinked, config.toml is a real file
+    expect(
+      (await lstat(join(target as string, 'auth.json'))).isSymbolicLink(),
+    ).toBe(true)
+    expect(
+      (await lstat(join(target as string, 'config.toml'))).isSymbolicLink(),
+    ).toBe(false)
+  })
+
+  it('treats a missing config.toml as an empty config (ENOENT)', async () => {
+    await rm(join(source, 'config.toml'))
+    const target = await materializeCodexBrowserlessHome({
+      browserosDir,
+      sourceCodexHome: source,
+    })
+    expect(target).not.toBeNull()
+    expect(browserEnabled(await overlayConfig(target as string))).toBe(false)
+  })
+
+  it('falls back (null) when config.toml exists but is unreadable', async () => {
+    await chmod(join(source, 'config.toml'), 0o000)
+    // Skip when the runner can still read it (e.g. running as root).
+    const stillReadable = await readFile(join(source, 'config.toml'), 'utf8')
+      .then(() => true)
+      .catch(() => false)
+    await chmod(join(source, 'config.toml'), 0o600)
+    if (stillReadable) return
+    await chmod(join(source, 'config.toml'), 0o000)
+    const target = await materializeCodexBrowserlessHome({
+      browserosDir,
+      sourceCodexHome: source,
+    })
+    await chmod(join(source, 'config.toml'), 0o600)
+    expect(target).toBeNull()
+  })
+
+  it('self-heals: picks up new source entries and prunes removed ones', async () => {
+    const first = await materializeCodexBrowserlessHome({
+      browserosDir,
+      sourceCodexHome: source,
+    })
+    expect(first).not.toBeNull()
+    const target = first as string
+
+    await writeFile(join(source, 'newfile.json'), '{}')
+    await rm(join(source, 'auth.json'))
+    const second = await materializeCodexBrowserlessHome({
+      browserosDir,
+      sourceCodexHome: source,
+    })
+    expect(second).toBe(target)
+    expect((await lstat(join(target, 'newfile.json'))).isSymbolicLink()).toBe(
+      true,
+    )
+    await expect(lstat(join(target, 'auth.json'))).rejects.toThrow()
+  })
+
+  it('is idempotent across repeated calls', async () => {
+    const a = await materializeCodexBrowserlessHome({
+      browserosDir,
+      sourceCodexHome: source,
+    })
+    const b = await materializeCodexBrowserlessHome({
+      browserosDir,
+      sourceCodexHome: source,
+    })
+    expect(a).toBe(b)
+    expect(browserEnabled(await overlayConfig(b as string))).toBe(false)
+  })
+
+  it('does not mutate the real config.toml', async () => {
+    await materializeCodexBrowserlessHome({
+      browserosDir,
+      sourceCodexHome: source,
+    })
+    expect(
+      browserEnabled(await readFile(join(source, 'config.toml'), 'utf8')),
+    ).toBe(true)
   })
 })

--- a/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/launcher.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/launcher.test.ts
@@ -156,3 +156,40 @@ describe('resolveAcpSpawnCommand', () => {
     expect(split.args).toContain(WINDOWS_BUN_PATH)
   })
 })
+
+describe('resolveAcpSpawnCommand extraEnv', () => {
+  it('bakes extraEnv into the bundled-bun command env prefix', () => {
+    const out = resolveAcpSpawnCommand({
+      agentType: 'codex',
+      resourcesDir: '/fake/resources',
+      resolveBundledBun: stubBunPresent,
+      extraEnv: { CODEX_HOME: '/overlay/codex-home' },
+    })
+    expect(out?.source).toBe('bundled-bun')
+    const split = splitCommandLikeAcpx(out?.command ?? '')
+    expect(split.command).toBe('env')
+    expect(split.args).toContain('CODEX_HOME=/overlay/codex-home')
+  })
+
+  it('wraps the npx fallback command with extraEnv', () => {
+    const out = resolveAcpSpawnCommand({
+      agentType: 'codex',
+      resolveBundledBun: stubBunMissing,
+      extraEnv: { CODEX_HOME: '/overlay/codex-home' },
+    })
+    expect(out?.source).toBe('host-npx-fallback')
+    const split = splitCommandLikeAcpx(out?.command ?? '')
+    expect(split.command).toBe('env')
+    expect(split.args).toContain('CODEX_HOME=/overlay/codex-home')
+    expect(out?.command).toContain(HOST_ACP_ADAPTER_CONFIG.codex.acpCommand)
+  })
+
+  it('leaves the npx fallback command unchanged when extraEnv is absent', () => {
+    const out = resolveAcpSpawnCommand({
+      agentType: 'codex',
+      resolveBundledBun: stubBunMissing,
+    })
+    expect(out?.source).toBe('host-npx-fallback')
+    expect(out?.command).toBe(HOST_ACP_ADAPTER_CONFIG.codex.acpCommand)
+  })
+})


### PR DESCRIPTION
## Problem

When BrowserOS drives Codex through the ACP chat path, Codex sometimes reaches for its own bundled in-app browser plugin (`browser@openai-bundled`, exposed as the `control-in-app-browser` skill and a `node_repl` bridge) instead of the BrowserOS MCP browser tools. It only falls back to `mcp.browseros.*` after that bridge fails. The behavior is intermittent: the plugin's own manifest instructs the model to use the in-app browser for "open, navigate, click, type, screenshot ... the current in-app browser tab", which competes directly with the BrowserOS tools.

Root cause: the chat path spawns Codex against the real `~/.codex`, where that plugin is enabled, and the ACP prompt only steered Codex away from its "file, shell, or fetch tools", never its in-app browser.

## Fix

Two layers so BrowserOS is the only browser Codex can reach:

1. Spawn Codex with a `CODEX_HOME` overlay that disables the in-app browser plugin. The overlay symlinks every real `~/.codex` entry except `config.toml`, which is regenerated with `[plugins."browser@openai-bundled"] enabled = false`. Verified with `codex debug prompt-input`: the in-app browser skill and node_repl bridge disappear from the model-visible prompt while every other plugin stays intact. The user's real `~/.codex` is never modified.
2. Reinforce the ACP system prompt to route every browser action through `mcp.browseros.*` and never fall back to an in-app browser, Playwright, chrome-devtools, or the system Chrome.

## Resilience

The overlay is built to survive future changes to `~/.codex`:

- The symlink farm re-syncs on every session: entries added under `~/.codex` are picked up automatically and removed ones are pruned, so there is no hard-coded file list.
- The `config.toml` edit is validated by a real TOML round-trip (`Bun.TOML.parse`). It is written only when the parse proves the edit changed exactly the one plugin field and nothing else. If the config format ever changes in a way the edit cannot handle, the overlay is not written, an error is logged, and Codex falls back to the real home rather than crashing or writing a corrupt config.

## Validation

- New unit tests for the config transform and the round-trip verifier (including format-change and corruption-rejection cases), plus launcher `extraEnv` coverage. `bun test tests/lib/agents/host-acp` green.
- `apps/server` typecheck clean.
- Manual: materialized the overlay against a real `~/.codex` and confirmed via `codex debug prompt-input` that the in-app browser is gone and other plugins remain.
