### PR TITLE
fix(claw-server): write runtime.json with the live server URL on boot

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/lib.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod identity;
 pub mod ids;
 pub mod runtime;
+pub mod runtime_file;
 pub mod services;
 pub mod storage;
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -125,6 +125,13 @@ async fn serve_with_boot_task(
     };
     analytics.capture(events::SERVER_STARTED, json!({}));
     info!(%addr, "claw-server-rust listening");
+    // Publish the live server URL so external discovery (the Codex and Claude
+    // Desktop plugins) reads the current port instead of a stale file.
+    claw_server_rust::runtime_file::write_runtime_file(
+        &config.browserclaw_dir,
+        &config.local_server_url(),
+    )
+    .await;
     let shutdown = runtime.state().shutdown;
     runtime.spawn_task("MCP config integrity scan", boot_task);
     axum::serve(listener, app.into_make_service())

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -124,12 +124,15 @@ async fn serve_with_boot_task(
         Err(err) => return Err(err).context("failed to bind claw-server listener"),
     };
     analytics.capture(events::SERVER_STARTED, json!({}));
-    info!(%addr, "claw-server-rust listening");
+    // Use the ACTUAL bound address, not the requested port, so an OS-assigned
+    // or dev port (config port 0) is still published correctly.
+    let bound = listener.local_addr().unwrap_or(addr);
+    info!(%bound, "claw-server-rust listening");
     // Publish the live server URL so external discovery (the Codex and Claude
     // Desktop plugins) reads the current port instead of a stale file.
     claw_server_rust::runtime_file::write_runtime_file(
         &config.browserclaw_dir,
-        &config.local_server_url(),
+        &format!("http://{bound}"),
     )
     .await;
     let shutdown = runtime.state().shutdown;

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -128,13 +128,17 @@ async fn serve_with_boot_task(
     // or dev port (config port 0) is still published correctly.
     let bound = listener.local_addr().unwrap_or(addr);
     info!(%bound, "claw-server-rust listening");
-    // Publish the live server URL so external discovery (the Codex and Claude
-    // Desktop plugins) reads the current port instead of a stale file.
-    claw_server_rust::runtime_file::write_runtime_file(
-        &config.browserclaw_dir,
-        &format!("http://{bound}"),
-    )
-    .await;
+    // Publish the live server URL for external discovery (the Codex and Claude
+    // Desktop plugins). Fire-and-forget: a best-effort disk write must never
+    // gate the listener from accepting connections, since a stalled FUSE /
+    // network / container-mounted browserclaw_dir could otherwise leave the
+    // socket bound but never served. Mirrors the archived TS server, which
+    // deliberately did not await writeRuntimeFile for the same reason.
+    let runtime_dir = config.browserclaw_dir.clone();
+    let runtime_url = format!("http://{bound}");
+    tokio::spawn(async move {
+        claw_server_rust::runtime_file::write_runtime_file(&runtime_dir, &runtime_url).await;
+    });
     let shutdown = runtime.state().shutdown;
     runtime.spawn_task("MCP config integrity scan", boot_task);
     axum::serve(listener, app.into_make_service())

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime_file.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime_file.rs
@@ -46,8 +46,9 @@ mod tests {
         write_runtime_file(&dir, "http://127.0.0.1:9200").await;
 
         let raw = fs::read_to_string(dir.join("runtime.json")).await?;
-        let parsed: serde_json::Value = serde_json::from_str(&raw)?;
-        assert_eq!(parsed["url"], "http://127.0.0.1:9200");
+        // Byte-for-byte identical to the archived TS writer's contract:
+        // JSON.stringify({ url }, null, 2) + "\n".
+        assert_eq!(raw, "{\n  \"url\": \"http://127.0.0.1:9200\"\n}\n");
         // The atomic temp file must not survive the rename.
         assert!(!dir.join("runtime.json.tmp").exists());
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime_file.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime_file.rs
@@ -1,0 +1,70 @@
+//! Publishes the live claw-server URL to `<browserclaw_dir>/runtime.json` so
+//! external discovery (the Codex and Claude Desktop plugins) can read the
+//! current port without probing or scanning. Best-effort: a failed write logs
+//! a warning and never blocks startup.
+
+use std::path::Path;
+
+use serde_json::json;
+use tokio::fs;
+use tracing::warn;
+
+const RUNTIME_FILE: &str = "runtime.json";
+
+/// Atomically write `{ "url": <url> }` to `<dir>/runtime.json`. Errors are
+/// logged and swallowed so this best-effort disk write can never fail boot.
+pub async fn write_runtime_file(dir: &Path, url: &str) {
+    if let Err(err) = try_write(dir, url).await {
+        warn!(
+            error = %err,
+            path = %dir.join(RUNTIME_FILE).display(),
+            "runtime file write failed",
+        );
+    }
+}
+
+async fn try_write(dir: &Path, url: &str) -> std::io::Result<()> {
+    fs::create_dir_all(dir).await?;
+    let path = dir.join(RUNTIME_FILE);
+    let tmp = dir.join(format!("{RUNTIME_FILE}.tmp"));
+    let mut payload = serde_json::to_string_pretty(&json!({ "url": url }))
+        .unwrap_or_else(|_| format!("{{\n  \"url\": \"{url}\"\n}}"));
+    payload.push('\n');
+    fs::write(&tmp, &payload).await?;
+    fs::rename(&tmp, &path).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn writes_url_and_cleans_up_temp() -> anyhow::Result<()> {
+        let dir = std::env::temp_dir().join(format!("claw-runtime-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir).await;
+
+        write_runtime_file(&dir, "http://127.0.0.1:9200").await;
+
+        let raw = fs::read_to_string(dir.join("runtime.json")).await?;
+        let parsed: serde_json::Value = serde_json::from_str(&raw)?;
+        assert_eq!(parsed["url"], "http://127.0.0.1:9200");
+        // The atomic temp file must not survive the rename.
+        assert!(!dir.join("runtime.json.tmp").exists());
+
+        fs::remove_dir_all(&dir).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn missing_parent_is_created() -> anyhow::Result<()> {
+        let base = std::env::temp_dir().join(format!("claw-runtime-nested-{}", std::process::id()));
+        let dir = base.join("state");
+        let _ = fs::remove_dir_all(&base).await;
+
+        write_runtime_file(&dir, "http://127.0.0.1:9201").await;
+
+        assert!(dir.join("runtime.json").exists());
+        fs::remove_dir_all(&base).await?;
+        Ok(())
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/tests/dependency_boundaries.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/dependency_boundaries.rs
@@ -275,7 +275,13 @@ fn classify(relative: &Path) -> Result<Layer, String> {
         [file]
             if matches!(
                 file.as_str(),
-                "clock.rs" | "config.rs" | "error.rs" | "ids.rs" | "lib.rs" | "storage.rs"
+                "clock.rs"
+                    | "config.rs"
+                    | "error.rs"
+                    | "ids.rs"
+                    | "lib.rs"
+                    | "runtime_file.rs"
+                    | "storage.rs"
             ) =>
         {
             Ok(Layer::Support)
@@ -312,9 +318,8 @@ fn crate_target(path: &[String], failures: &mut Vec<String>, display: &str) -> O
         "identity" => Some(Target::Identity),
         "app" | "runtime" => Some(Target::Composition),
         "AppState" => Some(Target::AppState),
-        "analytics" | "clock" | "config" | "error" | "ids" | "storage" | "AppResult" => {
-            Some(Target::Support)
-        }
+        "analytics" | "clock" | "config" | "error" | "ids" | "runtime_file" | "storage"
+        | "AppResult" => Some(Target::Support),
         _ => None,
     }
 }


### PR DESCRIPTION
## Problem

The Codex and Claude Desktop BrowserClaw plugins discover the local MCP server by reading `~/.browserclaw/runtime.json` as their primary source. The TS→Rust rewrite of claw-server dropped the writer for that file (its only remaining implementation lives in `packages/archive/claw-server-ts`), so on current builds `runtime.json` is never refreshed. A stale file survives across runs, and when the bound port changes the plugins are pointed at a port the server is no longer on, so they fail to connect ("BrowserClaw isn't connected").

## Fix

Restore the writer in `claw-server-rust`. Immediately after the HTTP listener binds, atomically publish the live server URL:

```json
{ "url": "http://127.0.0.1:<server_port>" }
```

- New `runtime_file` module: `create_dir_all` → write `runtime.json.tmp` → `rename`, matching the crate's atomic-write idiom. Best-effort — a failed write logs a warning and never blocks startup.
- Hooked into `serve_with_boot_task` after a successful bind, so the file only ever reflects a server that actually came up.
- Writes `config.local_server_url()` (the server's real bound port), so the file always matches reality even as the port advances on conflict. The plugins re-run discovery on every spawn, so they follow it.

This restores the exact behavior the archived TS server had (`main.ts` published the bound URL via `writeRuntimeFile`), and its shape is identical to what the plugins already parse.

## Scope

This is the targeted fix for the plugin breakage today. The larger port/proxy redesign (single dynamic port, retire the native proxy, full boot-time re-link of every connected harness) is deliberately out of scope here and tracked separately — it spans the native BrowserOS Chromium-fork port manager and proxy.

## Validation

- `cargo check`, `cargo clippy --all-targets`, `cargo fmt --check`: clean.
- `cargo test --lib`: 170 passed (2 new writer tests covering the atomic write, the `{"url":...}` shape, temp-file cleanup, and parent-dir creation; no regressions).
