### PR TITLE
fix(app): disable PostHog session replay in the side panel

### DIFF
--- a/packages/browseros-agent/apps/app/lib/analytics/posthog.ts
+++ b/packages/browseros-agent/apps/app/lib/analytics/posthog.ts
@@ -2,12 +2,20 @@ import posthog from 'posthog-js'
 import 'posthog-js/dist/posthog-recorder'
 import { env } from '../env'
 
+// Session replay mirrors the whole DOM continuously. The side panel is a
+// long-lived, unvirtualized streaming chat that never reloads, so the
+// recorder's node mirror grows until the renderer OOMs (issue #1972).
+// Disable replay there; keep it for the shorter-lived full-page contexts.
+const isSidePanel =
+  typeof window !== 'undefined' &&
+  window.location.pathname.includes('sidepanel')
+
 if (env.VITE_PUBLIC_POSTHOG_KEY && env.VITE_PUBLIC_POSTHOG_HOST) {
   posthog.init(env.VITE_PUBLIC_POSTHOG_KEY, {
     api_host: env.VITE_PUBLIC_POSTHOG_HOST,
     person_profiles: 'identified_only',
     disable_external_dependency_loading: true,
-    disable_session_recording: false,
+    disable_session_recording: isSidePanel,
     capture_pageview: true,
     autocapture: true,
     session_recording: {


### PR DESCRIPTION
## Problem

The Assistant side panel grows to multiple GB of memory during active use, eventually triggering a Chrome renderer OOM that auto-closes the panel and interrupts the task (#1972).

The side panel is a long-lived surface: it never navigates or reloads, its message list is not virtualized, and streaming re-renders the transcript token by token. PostHog's rrweb session recording keeps an in-memory mirror of every DOM node it has seen plus a buffered stream of incremental mutations, so on this surface its footprint only grows for the lifetime of the panel. Input masking does not shrink the retained DOM mirror.

## Change

Disable PostHog session replay for the side panel only, keyed off the entrypoint pathname. The shorter-lived full-page app, new tab, and settings contexts (served from `app.html`) keep session replay unchanged. Event capture, autocapture, and pageviews are untouched everywhere; only the rrweb DOM recorder is turned off in the panel.

## Notes

- Single-surface change in the analytics init; no behavior change to product features.
- There is no manual `startSessionRecording()` call anywhere, so the init flag is the sole control for replay.
- This targets the largest, lowest-risk contributor to the panel's memory growth. Retained conversation/tool-output state and per-token history serialization are separate follow-ups.

## Validation

- `apps/app` typecheck passes (after GraphQL codegen).
- Biome clean on the changed file.