### PR TITLE
fix(app): drop retained base64 screenshots from side panel chat state

### DIFF
--- a/packages/browseros-agent/apps/app/modules/chat/chat-session-persistence.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session-persistence.ts
@@ -1,4 +1,5 @@
 import type { ChatStatus, UIMessage } from 'ai'
+import { stripImageToolOutputs } from './tool-output-strip'
 
 export function didStreamingTurnFinish(
   previousStatus: ChatStatus,
@@ -10,5 +11,7 @@ export function didStreamingTurnFinish(
 }
 
 export function getPersistableMessages(messages: UIMessage[]) {
-  return messages.filter((message) => message.parts?.length > 0)
+  return stripImageToolOutputs(
+    messages.filter((message) => message.parts?.length > 0),
+  )
 }

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -52,6 +52,7 @@ import { useExecutionHistoryTracker } from './execution-history-tracker.hooks'
 import { useNotifyActiveTab } from './notify-active-tab.hooks'
 import { useRemoteConversationSave } from './remote-conversation-save.hooks'
 import { toLlmProviderConfig } from './sidepanel-chat-targets'
+import { stripImageToolOutputs } from './tool-output-strip'
 
 const getLastMessageText = (messages: UIMessage[]) => {
   const lastMessage = messages[messages.length - 1]
@@ -427,13 +428,19 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     },
   })
 
-  // Remove messages with empty parts (e.g. interrupted assistant responses)
-  // to prevent AI SDK validation errors on subsequent sends
+  // Two cleanups once a turn is no longer streaming: drop messages with
+  // empty parts (interrupted responses trip AI SDK validation on the next
+  // send), and strip retained base64 image tool outputs from older turns.
+  // Nothing renders those screenshots, but the AI SDK keeps every message
+  // resident, so they accumulate until the renderer OOMs (#1972). The latest
+  // message stays intact so the just-finished turn is untouched.
   useEffect(() => {
     if (status === 'streaming') return
-    if (messages.some((m) => !m.parts?.length)) {
-      setMessages(messages.filter((m) => m.parts?.length > 0))
-    }
+    const nonEmpty = messages.some((m) => !m.parts?.length)
+      ? messages.filter((m) => m.parts?.length > 0)
+      : messages
+    const cleaned = stripImageToolOutputs(nonEmpty, { keepLastMessage: true })
+    if (cleaned !== messages) setMessages(cleaned)
   }, [messages, status, setMessages])
 
   useNotifyActiveTab({

--- a/packages/browseros-agent/apps/app/modules/chat/tool-output-strip.test.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/tool-output-strip.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'bun:test'
+import type { UIMessage } from 'ai'
+import { OMITTED_IMAGE_TEXT, stripImageToolOutputs } from './tool-output-strip'
+
+type UIPart = UIMessage['parts'][number]
+
+function textPart(text: string): UIPart {
+  return { type: 'text', text } as UIPart
+}
+
+function screenshotToolPart(options?: {
+  data?: string
+  extraContent?: Array<Record<string, unknown>>
+  metadata?: Record<string, unknown>
+}): UIPart {
+  return {
+    type: 'tool-screenshot',
+    toolCallId: 'call-1',
+    state: 'output-available',
+    input: {},
+    output: {
+      content: [
+        {
+          type: 'image',
+          data: options?.data ?? 'BASE64_SCREENSHOT_DATA',
+          mimeType: 'image/png',
+        },
+        { type: 'text', text: 'took screenshot' },
+        ...(options?.extraContent ?? []),
+      ],
+      isError: false,
+      ...(options?.metadata ? { metadata: options.metadata } : {}),
+    },
+  } as UIPart
+}
+
+function assistantMessage(id: string, parts: UIPart[]): UIMessage {
+  return { id, role: 'assistant', parts }
+}
+
+describe('stripImageToolOutputs', () => {
+  it('replaces base64 image blocks with a text marker and keeps text blocks', () => {
+    const messages = [assistantMessage('a', [screenshotToolPart()])]
+
+    const result = stripImageToolOutputs(messages)
+    const output = (result[0].parts[0] as { output: { content: unknown[] } })
+      .output
+
+    expect(output.content).toEqual([
+      { type: 'text', text: OMITTED_IMAGE_TEXT },
+      { type: 'text', text: 'took screenshot' },
+    ])
+  })
+
+  it('preserves output metadata such as the active tab id', () => {
+    const messages = [
+      assistantMessage('a', [screenshotToolPart({ metadata: { tabId: 42 } })]),
+    ]
+
+    const result = stripImageToolOutputs(messages)
+    const output = (result[0].parts[0] as { output: { metadata?: unknown } })
+      .output
+
+    expect(output.metadata).toEqual({ tabId: 42 })
+  })
+
+  it('returns the same array reference when there is nothing to strip', () => {
+    const messages = [
+      assistantMessage('a', [textPart('hello'), textPart('world')]),
+    ]
+
+    expect(stripImageToolOutputs(messages)).toBe(messages)
+  })
+
+  it('leaves non-tool parts untouched', () => {
+    const messages = [
+      assistantMessage('a', [
+        { type: 'reasoning', text: 'thinking' } as UIPart,
+        textPart('answer'),
+      ]),
+    ]
+
+    expect(stripImageToolOutputs(messages)).toBe(messages)
+  })
+
+  it('keeps the last message intact when keepLastMessage is set', () => {
+    const older = assistantMessage('older', [screenshotToolPart()])
+    const latest = assistantMessage('latest', [screenshotToolPart()])
+
+    const result = stripImageToolOutputs([older, latest], {
+      keepLastMessage: true,
+    })
+
+    const olderOutput = (
+      result[0].parts[0] as { output: { content: unknown[] } }
+    ).output
+    const latestOutput = (
+      result[1].parts[0] as { output: { content: unknown[] } }
+    ).output
+
+    expect(olderOutput.content[0]).toEqual({
+      type: 'text',
+      text: OMITTED_IMAGE_TEXT,
+    })
+    expect(latestOutput.content[0]).toEqual({
+      type: 'image',
+      data: 'BASE64_SCREENSHOT_DATA',
+      mimeType: 'image/png',
+    })
+    expect(result[1]).toBe(latest)
+  })
+
+  it('does not throw on tool parts with non-object or missing output', () => {
+    const messages = [
+      assistantMessage('a', [
+        {
+          type: 'tool-run',
+          toolCallId: 'c',
+          state: 'input-available',
+          input: {},
+        } as UIPart,
+        {
+          type: 'dynamic-tool',
+          toolName: 'run',
+          toolCallId: 'd',
+          state: 'output-available',
+          input: {},
+          output: 'plain string',
+        } as UIPart,
+      ]),
+    ]
+
+    expect(() => stripImageToolOutputs(messages)).not.toThrow()
+    expect(stripImageToolOutputs(messages)).toBe(messages)
+  })
+})

--- a/packages/browseros-agent/apps/app/modules/chat/tool-output-strip.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/tool-output-strip.ts
@@ -1,0 +1,81 @@
+import type { UIMessage } from 'ai'
+
+type UIPart = UIMessage['parts'][number]
+
+export const OMITTED_IMAGE_TEXT = '[image omitted to conserve memory]'
+
+interface ToolResultContentBlock {
+  type?: string
+  text?: string
+  data?: string
+  mimeType?: string
+}
+
+interface ToolResultOutput {
+  content?: ToolResultContentBlock[]
+}
+
+function isToolPart(part: UIPart): boolean {
+  return part.type.startsWith('tool-') || part.type === 'dynamic-tool'
+}
+
+function stripImagesFromOutput(output: unknown): unknown {
+  if (!output || typeof output !== 'object') return output
+  const content = (output as ToolResultOutput).content
+  if (!Array.isArray(content)) return output
+  let changed = false
+  const nextContent = content.map((block) => {
+    if (block?.type === 'image' && typeof block.data === 'string') {
+      changed = true
+      return { type: 'text', text: OMITTED_IMAGE_TEXT }
+    }
+    return block
+  })
+  return changed
+    ? { ...(output as ToolResultOutput), content: nextContent }
+    : output
+}
+
+function stripPart(part: UIPart): UIPart {
+  if (!isToolPart(part)) return part
+  const output = (part as { output?: unknown }).output
+  if (output === undefined) return part
+  const nextOutput = stripImagesFromOutput(output)
+  if (nextOutput === output) return part
+  return { ...part, output: nextOutput } as UIPart
+}
+
+function stripMessage(message: UIMessage): UIMessage {
+  if (!message.parts?.length) return message
+  let changed = false
+  const parts = message.parts.map((part) => {
+    const next = stripPart(part)
+    if (next !== part) changed = true
+    return next
+  })
+  return changed ? { ...message, parts } : message
+}
+
+/**
+ * Replace retained base64 image blocks in tool-result outputs with a small
+ * text marker. Nothing in the side panel renders these images, but the AI
+ * SDK keeps every message resident for the whole session, so the screenshots
+ * pile up until the renderer runs out of memory (issue #1972). Returns the
+ * same array reference when there is nothing to strip so callers can skip a
+ * redundant state update. `keepLastMessage` leaves the most recent message
+ * untouched, used for in-memory trimming where the latest turn stays live.
+ */
+export function stripImageToolOutputs(
+  messages: UIMessage[],
+  options?: { keepLastMessage?: boolean },
+): UIMessage[] {
+  const keepLastIndex = options?.keepLastMessage ? messages.length - 1 : -1
+  let changed = false
+  const next = messages.map((message, index) => {
+    if (index === keepLastIndex) return message
+    const stripped = stripMessage(message)
+    if (stripped !== message) changed = true
+    return stripped
+  })
+  return changed ? next : messages
+}


### PR DESCRIPTION
## Problem

The Assistant side panel grows to multiple GB during active use and eventually OOMs the renderer, auto-closing the panel (#1972). One contributor is that the AI SDK keeps the entire conversation resident in memory for the whole session, and on the default provider path browser tool results carry inline base64 screenshots (structured image data). The side panel never renders those images (the chat only shows a tool label), so the screenshots accumulate in the tab's heap, in the resident set of recent conversations, and in persisted history, with nothing releasing them.

## Change

Add a small pure helper (`tool-output-strip.ts`) that replaces base64 image blocks inside tool-result outputs with a short text marker, preserving everything else (text blocks, `isError`, and output `metadata` such as the active tab id). It returns the same array reference when there is nothing to strip so callers can skip a redundant update.

Apply it in two places:
- When building the persistable messages for a conversation, so saved and reloaded history no longer carries screenshot bytes.
- After a turn settles (not while streaming), strip older messages in the live `useChat` state while leaving the latest turn intact.

## Why it is safe

- Nothing in the side panel renders tool-output images, so removing the bytes has no visible effect on the transcript. Non-image tool output, text, and metadata are untouched.
- Multi-turn context is unaffected: the client already sends only a bounded, text-only history plus the new message to the server, which keeps the working conversation state itself. The transcript is not the source of truth for context, so trimming retained outputs does not change what the model sees.
- The in-memory pass runs only when a turn is no longer streaming and keeps the most recent message intact, matching the existing empty-parts cleanup.

## Scope / notes

- This mainly helps the default / BYOK provider path, where tool outputs carry base64 inline. On ACP named-agent providers tool outputs are already text-only.
- User-attached images are out of scope here.

## Validation

- New unit tests for the helper (image stripping, metadata preservation, keep-last-message, identity when nothing to strip, non-object output). Existing persistence tests still pass.
- `apps/app` typecheck passes (after GraphQL codegen); Biome clean on the changed files.