### PR TITLE
fix(bos-build): scope universal skew guard to the product's server bundles

### DIFF
--- a/packages/browseros/bos_build/steps/compile/universal.py
+++ b/packages/browseros/bos_build/steps/compile/universal.py
@@ -15,6 +15,7 @@ from typing import Optional
 
 from ...core.context import Context
 from ...core.step import Step, ValidationError, step
+from ...products.server_binaries import server_bundles_for_product
 from ..package.merge import merge_architectures
 from ..storage.download import ARTIFACT_METADATA_NAME
 
@@ -34,22 +35,23 @@ def _read_artifact_metadata(path: Path) -> Optional[dict]:
     return data if isinstance(data, dict) else None
 
 
-def _assert_server_bundles_aligned(binaries_dir: Path) -> None:
-    """Fail if a family's darwin-arm64/-x64 bundles disagree on version.
+def _assert_server_bundles_aligned(root_dir: Path, product_id: str) -> None:
+    """Fail if a product bundle's darwin-arm64/-x64 versions disagree.
 
     The universal merge folds both arch server bundles into one app. A
     skewed pair (fresh arm64 vs stale x64) either trips the universalizer
     on differing non-Mach-O files or, for all-Mach-O bundles, silently
     ships mismatched server versions (BrowserClaw 0.47.11). A correct
     universal build re-downloads both dirs, so this only fires on stale
-    state left by a --from resume or --no-download flow. Families missing
-    either metadata file are skipped (older layouts, non-artifact dirs).
+    state left by a --from resume or --no-download flow. Only the merging
+    product's registered bundles are checked: retired families leave
+    orphaned resources/binaries dirs on persistent runners that downloads
+    never re-align (BrowserClaw 0.48.0), and other products' bundles
+    never enter this app. Bundles missing either metadata file are
+    skipped (older layouts, undownloaded dirs).
     """
-    if not binaries_dir.is_dir():
-        return
-    for family_dir in sorted(binaries_dir.iterdir()):
-        if not family_dir.is_dir():
-            continue
+    for bundle in server_bundles_for_product(product_id):
+        family_dir = root_dir / bundle.local_resources_root
         arm_meta = _read_artifact_metadata(
             family_dir / "darwin-arm64" / ARTIFACT_METADATA_NAME
         )
@@ -63,7 +65,7 @@ def _assert_server_bundles_aligned(binaries_dir: Path) -> None:
         if arm_version == x64_version:
             continue
         raise ValidationError(
-            f"Skewed '{family_dir.name}' server bundle: "
+            f"Skewed '{bundle.local_resources_root.name}' server bundle: "
             f"darwin-arm64 version {arm_version!r} "
             f"(generated {arm_meta.get('generatedAt', 'unknown')}) "
             f"!= darwin-x64 version {x64_version!r} "
@@ -106,7 +108,7 @@ class MergeUniversalModule(Step):
             app = _arch_app_path(ctx, arch)
             if not app.exists():
                 raise ValidationError(f"{arch} app not found (build it first): {app}")
-        _assert_server_bundles_aligned(ctx.root_dir / "resources" / "binaries")
+        _assert_server_bundles_aligned(ctx.root_dir, ctx.product.id)
 
     def execute(self, ctx: Context) -> None:
         arm64_app, x64_app = (

--- a/packages/browseros/bos_build/steps/compile/universal_test.py
+++ b/packages/browseros/bos_build/steps/compile/universal_test.py
@@ -187,7 +187,7 @@ class ServerBundleSkewTest(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "browseros_server"):
             universal._assert_server_bundles_aligned(self.root, "browseros")
 
-    def test_absent_x64_metadata_skips_family(self):
+    def test_absent_metadata_on_either_side_skips_family(self):
         self._write_bundle("browseros_server", "darwin-arm64", "0.0.10")
         # x64 dir exists but carries no metadata (partial/older layout).
         (
@@ -195,6 +195,10 @@ class ServerBundleSkewTest(unittest.TestCase):
         ).mkdir(parents=True)
 
         universal._assert_server_bundles_aligned(self.root, "browseros")  # no raise
+
+        self._write_bundle("browseros_claw_server_rust", "darwin-x64", "0.0.13")
+
+        universal._assert_server_bundles_aligned(self.root, "browserclaw")  # no raise
 
     def test_missing_binaries_dir_is_noop(self):
         universal._assert_server_bundles_aligned(self.root, "browseros")  # no raise

--- a/packages/browseros/bos_build/steps/compile/universal_test.py
+++ b/packages/browseros/bos_build/steps/compile/universal_test.py
@@ -110,14 +110,19 @@ class PreflightTest(MergeUniversalTestBase):
 class ServerBundleSkewTest(unittest.TestCase):
     """The merge-time guard against version-skewed per-arch server bundles."""
 
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+
     def _write_bundle(
         self,
-        family_dir: Path,
+        family: str,
         arch_dir: str,
         version: str,
         generated_at: str = "2026-01-01T00:00:00.000Z",
     ) -> None:
-        arch_path = family_dir / arch_dir
+        arch_path = self.root / "resources" / "binaries" / family / arch_dir
         arch_path.mkdir(parents=True)
         (arch_path / "artifact-metadata.json").write_text(
             json.dumps(
@@ -126,49 +131,74 @@ class ServerBundleSkewTest(unittest.TestCase):
         )
 
     def test_matching_versions_pass(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            binaries = Path(tmp)
-            family = binaries / "browseros_server"
-            self._write_bundle(family, "darwin-arm64", "0.0.10")
-            self._write_bundle(family, "darwin-x64", "0.0.10")
+        self._write_bundle("browseros_server", "darwin-arm64", "0.0.10")
+        self._write_bundle("browseros_server", "darwin-x64", "0.0.10")
 
-            universal._assert_server_bundles_aligned(binaries)  # no raise
+        universal._assert_server_bundles_aligned(self.root, "browseros")  # no raise
 
     def test_mismatched_versions_raise_with_both_versions_and_timestamps(self):
         # Mirrors the BrowserClaw 0.47.11 skew: fresh arm64 vs stale x64.
-        with tempfile.TemporaryDirectory() as tmp:
-            binaries = Path(tmp)
-            family = binaries / "browseros_claw_server"
-            self._write_bundle(
-                family, "darwin-arm64", "0.0.10", "2026-07-14T00:00:00.000Z"
-            )
-            self._write_bundle(
-                family, "darwin-x64", "0.0.3", "2026-06-30T00:00:00.000Z"
-            )
+        self._write_bundle(
+            "browseros_claw_server_rust",
+            "darwin-arm64",
+            "0.0.13",
+            "2026-07-14T00:00:00.000Z",
+        )
+        self._write_bundle(
+            "browseros_claw_server_rust",
+            "darwin-x64",
+            "0.0.3",
+            "2026-06-30T00:00:00.000Z",
+        )
 
-            with self.assertRaises(ValidationError) as caught:
-                universal._assert_server_bundles_aligned(binaries)
+        with self.assertRaises(ValidationError) as caught:
+            universal._assert_server_bundles_aligned(self.root, "browserclaw")
 
-            message = str(caught.exception)
-            self.assertIn("browseros_claw_server", message)
-            self.assertIn("0.0.10", message)
-            self.assertIn("0.0.3", message)
-            self.assertIn("2026-07-14T00:00:00.000Z", message)
-            self.assertIn("2026-06-30T00:00:00.000Z", message)
+        message = str(caught.exception)
+        self.assertIn("browseros_claw_server_rust", message)
+        self.assertIn("0.0.13", message)
+        self.assertIn("0.0.3", message)
+        self.assertIn("2026-07-14T00:00:00.000Z", message)
+        self.assertIn("2026-06-30T00:00:00.000Z", message)
+
+    def test_orphaned_family_skew_is_ignored(self):
+        # Mirrors run 29882827339: 'browseros_claw_server' was retired in
+        # #1948, so its dir lingers on persistent runners with skew that
+        # downloads can never re-align — it must not fail the merge.
+        self._write_bundle("browseros_claw_server", "darwin-arm64", "0.0.11")
+        self._write_bundle("browseros_claw_server", "darwin-x64", "0.0.12")
+        self._write_bundle("browseros_claw_server_rust", "darwin-arm64", "0.0.13")
+        self._write_bundle("browseros_claw_server_rust", "darwin-x64", "0.0.13")
+
+        universal._assert_server_bundles_aligned(self.root, "browserclaw")  # no raise
+
+    def test_skew_in_another_products_family_is_ignored(self):
+        # Nightlies routinely leave the claw arm64 bundle at "local"; that
+        # must never block a browseros merge — only the product's own
+        # families ship in its app.
+        self._write_bundle("browseros_claw_server_rust", "darwin-arm64", "local")
+        self._write_bundle("browseros_claw_server_rust", "darwin-x64", "0.0.13")
+
+        universal._assert_server_bundles_aligned(self.root, "browseros")  # no raise
+
+        self._write_bundle("browseros_server", "darwin-arm64", "0.0.10")
+        self._write_bundle("browseros_server", "darwin-x64", "0.0.9")
+
+        with self.assertRaisesRegex(ValidationError, "browseros_server"):
+            universal._assert_server_bundles_aligned(self.root, "browseros")
 
     def test_absent_x64_metadata_skips_family(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            binaries = Path(tmp)
-            family = binaries / "browseros_server"
-            self._write_bundle(family, "darwin-arm64", "0.0.10")
-            # x64 dir exists but carries no metadata (partial/older layout).
-            (family / "darwin-x64").mkdir(parents=True)
+        self._write_bundle("browseros_server", "darwin-arm64", "0.0.10")
+        # x64 dir exists but carries no metadata (partial/older layout).
+        (
+            self.root / "resources" / "binaries" / "browseros_server" / "darwin-x64"
+        ).mkdir(parents=True)
 
-            universal._assert_server_bundles_aligned(binaries)  # no raise
+        universal._assert_server_bundles_aligned(self.root, "browseros")  # no raise
 
     def test_missing_binaries_dir_is_noop(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            universal._assert_server_bundles_aligned(Path(tmp) / "absent")  # no raise
+        universal._assert_server_bundles_aligned(self.root, "browseros")  # no raise
+        universal._assert_server_bundles_aligned(self.root, "browserclaw")  # no raise
 
 
 class RegistrationTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- The merge_universal skew guard scanned **every** directory under `resources/binaries/`, so orphaned families — dirs left behind when a bundle is retired or renamed — failed the merge forever on persistent runners: no download/copy op manages them anymore, so nothing can ever re-align their per-arch metadata.
- BrowserClaw 0.48.0 universal (run [29882827339](https://github.com/browseros-ai/BrowserOS/actions/runs/29882827339), job 88809062699) hit exactly this: the guard tripped on `browseros_claw_server` — the TypeScript server family retired in #1948 — with arm64 `0.0.11` vs x64 `0.0.12`, while the actual shipping family (`browseros_claw_server_rust`) was fresh and aligned at `0.0.13` on both arches. Pure validation false positive; the merge never started.
- The guard now iterates `server_bundles_for_product(ctx.product.id)` and checks each bundle's `local_resources_root` — exactly the families that ship in the merging product's app.

## Design
Registry-scoped, not filesystem-scoped: the `ServerBundle` registry (`bos_build/products/server_binaries.py`) already drives download destinations, signing, and OTA, so it is the single source of truth for what enters an app. Product scoping is deliberate (`server_bundles_for_product`, not `all_server_bundles`): nightlies stage `version: "local"` arm64 bundles daily, and a browseros merge must not be blocked by claw-family skew (or vice versa) — only bundles whose `product_ids` include the merging product ship in that app. Skip-silently semantics for missing dirs/metadata, the error message shape, and genuine own-family skew detection (e.g. in `--from` resumes) are unchanged. Rejected: allowlists (second source of truth that rots the same way), parsing `download_resources.yaml` (wrong ownership boundary), pruning orphan dirs in the download step (risky vs nightly local-staging flows), special-casing `"local"` versions (that skew is genuine when the guard sees it).

## Test plan
- [x] Regression for run 29882827339: orphaned `browseros_claw_server` dir with mismatched versions is ignored for product browserclaw
- [x] Own-family skew still raises with family name, both versions, both generatedAt timestamps
- [x] Cross-product isolation: browseros ignores claw-family skew (incl. the nightly `"local"` case) but still raises on `browseros_server`
- [x] Matching versions pass; missing metadata on either arch side skips; missing binaries dir is a no-op
- [x] From `packages/browseros`: `uv run python -m unittest discover -s bos_build -t . -p "*_test.py"` — 726 tests OK · `uv run ruff check bos_build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)