### PR TITLE
fix(app): throttle execution-history writes and drop base64 from steps

### DIFF
--- a/packages/browseros-agent/apps/app/lib/execution-history/normalize.test.ts
+++ b/packages/browseros-agent/apps/app/lib/execution-history/normalize.test.ts
@@ -89,6 +89,34 @@ describe('normalizeExecutionSteps', () => {
     expect(completed.steps[0]?.completedAt).toBe(completedTimestamp)
   })
 
+  it('does not retain tool input or output payloads in step records', () => {
+    const normalized = normalizeExecutionSteps({
+      assistantMessage: createAssistantMessage([
+        asMessagePart({
+          type: 'tool-screenshot',
+          toolCallId: 'tool-1',
+          state: 'output-available',
+          input: { fullPage: true },
+          output: {
+            content: [
+              {
+                type: 'image',
+                data: 'BASE64_SCREENSHOT',
+                mimeType: 'image/png',
+              },
+            ],
+          },
+        }),
+      ]),
+      nowIso: '2026-03-26T10:00:00.000Z',
+    })
+
+    const step = normalized.steps[0]
+    expect(step?.input).toBeUndefined()
+    expect(step?.output).toBeUndefined()
+    expect(JSON.stringify(normalized)).not.toContain('BASE64_SCREENSHOT')
+  })
+
   it('uses a compact preview for completed tool output', () => {
     const normalized = normalizeExecutionSteps({
       assistantMessage: createAssistantMessage([

--- a/packages/browseros-agent/apps/app/lib/execution-history/normalize.ts
+++ b/packages/browseros-agent/apps/app/lib/execution-history/normalize.ts
@@ -96,6 +96,10 @@ function createStepRecord(
   existingStep?: ExecutionStepRecord,
 ): ExecutionStepRecord {
   const state = part.state as ExecutionStepState
+  // Deliberately omit `input`/`output`: nothing renders them, and tool
+  // results carry inline base64 screenshots that otherwise pile up in the
+  // history store and get re-serialized on every write (#1972). previewText
+  // and the counts are enough for the step summary.
   return {
     id: part.toolCallId,
     toolName: getToolName(part),
@@ -103,8 +107,6 @@ function createStepRecord(
     state,
     startedAt: existingStep?.startedAt ?? nowIso,
     completedAt: getCompletedAt(existingStep, state, nowIso),
-    input: part.input,
-    output: 'output' in part ? part.output : undefined,
     errorText: 'errorText' in part ? part.errorText : undefined,
     previewText: getPreviewText(part),
     approval: getApproval(part),

--- a/packages/browseros-agent/apps/app/lib/execution-history/task-change-key.test.ts
+++ b/packages/browseros-agent/apps/app/lib/execution-history/task-change-key.test.ts
@@ -71,4 +71,11 @@ describe('taskChangeKey', () => {
     expect(taskChangeKey(running)).not.toBe(taskChangeKey(completed))
     expect(taskChangeKey(running)).not.toBe(taskChangeKey(withPreview))
   })
+
+  it('distinguishes two tasks in the same state by id', () => {
+    const first = task({ id: 'task-1' })
+    const second = task({ id: 'task-2' })
+
+    expect(taskChangeKey(first)).not.toBe(taskChangeKey(second))
+  })
 })

--- a/packages/browseros-agent/apps/app/lib/execution-history/task-change-key.test.ts
+++ b/packages/browseros-agent/apps/app/lib/execution-history/task-change-key.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test'
+import { taskChangeKey } from './task-change-key'
+import type { ExecutionStepRecord, ExecutionTaskRecord } from './types'
+
+function step(
+  overrides: Partial<ExecutionStepRecord> = {},
+): ExecutionStepRecord {
+  return {
+    id: 'step-1',
+    toolName: 'screenshot',
+    order: 0,
+    state: 'input-available',
+    startedAt: '2026-03-26T10:00:00.000Z',
+    previewText: 'Action running',
+    ...overrides,
+  }
+}
+
+function task(
+  overrides: Partial<ExecutionTaskRecord> = {},
+): ExecutionTaskRecord {
+  return {
+    id: 'task-1',
+    conversationId: 'conv-1',
+    promptText: 'do the thing',
+    startedAt: '2026-03-26T10:00:00.000Z',
+    status: 'running',
+    actionCount: 0,
+    approvalCount: 0,
+    deniedCount: 0,
+    errorCount: 0,
+    steps: [],
+    ...overrides,
+  }
+}
+
+describe('taskChangeKey', () => {
+  it('is stable for tasks that differ only in unread payloads', () => {
+    const a = task({ steps: [step({ output: { big: 'A'.repeat(1000) } })] })
+    const b = task({ steps: [step({ output: { big: 'B'.repeat(1000) } })] })
+
+    expect(taskChangeKey(a)).toBe(taskChangeKey(b))
+  })
+
+  it('changes when a new step is added', () => {
+    const before = task({ steps: [step()] })
+    const after = task({ steps: [step(), step({ id: 'step-2', order: 1 })] })
+
+    expect(taskChangeKey(before)).not.toBe(taskChangeKey(after))
+  })
+
+  it('changes when the last step transitions state', () => {
+    const running = task({ steps: [step({ state: 'input-available' })] })
+    const done = task({
+      steps: [
+        step({
+          state: 'output-available',
+          previewText: 'Completed successfully',
+        }),
+      ],
+    })
+
+    expect(taskChangeKey(running)).not.toBe(taskChangeKey(done))
+  })
+
+  it('changes when the task status or preview changes', () => {
+    const running = task()
+    const completed = task({ status: 'completed', completedAt: 'x' })
+    const withPreview = task({ responsePreview: 'partial answer' })
+
+    expect(taskChangeKey(running)).not.toBe(taskChangeKey(completed))
+    expect(taskChangeKey(running)).not.toBe(taskChangeKey(withPreview))
+  })
+})

--- a/packages/browseros-agent/apps/app/lib/execution-history/task-change-key.ts
+++ b/packages/browseros-agent/apps/app/lib/execution-history/task-change-key.ts
@@ -1,14 +1,17 @@
 import type { ExecutionTaskRecord } from './types'
 
 /**
- * Cheap change detector for a task: covers step progress, counts, status, and
- * the streamed preview without serializing tool input/output payloads. Used to
- * skip redundant writes instead of `JSON.stringify`-ing the whole task (which,
- * with base64 tool results, was a per-token cost, #1972).
+ * Cheap change detector for a task: covers task identity, step progress,
+ * counts, status, and the streamed preview without serializing tool
+ * input/output payloads. Used to skip redundant writes instead of
+ * `JSON.stringify`-ing the whole task (which, with base64 tool results, was a
+ * per-token cost, #1972). Including the id keeps keys distinct across tasks so
+ * one task's saved state never dedupes another's write.
  */
 export function taskChangeKey(task: ExecutionTaskRecord): string {
   const lastStep = task.steps[task.steps.length - 1]
   return [
+    task.id,
     task.status,
     task.steps.length,
     lastStep?.id ?? '',

--- a/packages/browseros-agent/apps/app/lib/execution-history/task-change-key.ts
+++ b/packages/browseros-agent/apps/app/lib/execution-history/task-change-key.ts
@@ -1,0 +1,25 @@
+import type { ExecutionTaskRecord } from './types'
+
+/**
+ * Cheap change detector for a task: covers step progress, counts, status, and
+ * the streamed preview without serializing tool input/output payloads. Used to
+ * skip redundant writes instead of `JSON.stringify`-ing the whole task (which,
+ * with base64 tool results, was a per-token cost, #1972).
+ */
+export function taskChangeKey(task: ExecutionTaskRecord): string {
+  const lastStep = task.steps[task.steps.length - 1]
+  return [
+    task.status,
+    task.steps.length,
+    lastStep?.id ?? '',
+    lastStep?.state ?? '',
+    lastStep?.previewText ?? '',
+    task.actionCount,
+    task.approvalCount,
+    task.deniedCount,
+    task.errorCount,
+    task.assistantMessageId ?? '',
+    task.completedAt ?? '',
+    task.responsePreview ?? '',
+  ].join('|')
+}

--- a/packages/browseros-agent/apps/app/modules/chat/execution-history-tracker.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/execution-history-tracker.hooks.ts
@@ -66,7 +66,7 @@ const WRITE_THROTTLE_MS = 400
 export function useExecutionHistoryTracker() {
   const activeTaskRef = useRef<ExecutionTaskRecord | null>(null)
   const lastSavedKeyRef = useRef('')
-  const pendingWriteRef = useRef<ExecutionTaskRecord | null>(null)
+  const pendingWritesRef = useRef<Map<string, ExecutionTaskRecord>>(new Map())
   const writeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const writingRef = useRef(false)
 
@@ -74,11 +74,16 @@ export function useExecutionHistoryTracker() {
     if (writingRef.current) return
     writingRef.current = true
     try {
-      while (pendingWriteRef.current) {
-        const task = pendingWriteRef.current
-        pendingWriteRef.current = null
+      while (pendingWritesRef.current.size > 0) {
+        const next = pendingWritesRef.current.entries().next().value
+        if (!next) break
+        const [taskId, task] = next
+        pendingWritesRef.current.delete(taskId)
         try {
           await upsertConversationExecutionTask(task)
+          // Advance the dedupe marker only after a successful write so a
+          // transient failure is retried by the next persist, not skipped.
+          lastSavedKeyRef.current = taskChangeKey(task)
         } catch (error) {
           sentry.captureException(error, {
             extra: {
@@ -102,14 +107,15 @@ export function useExecutionHistoryTracker() {
     void drainWrites()
   }, [drainWrites])
 
-  // Coalesce storage writes: keep only the newest pending task and write at
-  // most one at a time. A streamed turn produces a task update per token, and
-  // each write is a full read/modify/write of the whole history store, so
-  // during streaming they are batched behind a short timer; terminal updates
-  // flush immediately (#1972).
+  // Coalesce storage writes newest-per-task and write at most one at a time. A
+  // streamed turn produces a task update per token, and each write is a full
+  // read/modify/write of the whole history store, so during streaming they are
+  // batched behind a short timer; terminal updates flush immediately (#1972).
+  // Keying by task id means a queued terminal write is never dropped when the
+  // next turn's task queues before it drains.
   const scheduleWrite = useCallback(
     (task: ExecutionTaskRecord, immediate: boolean) => {
-      pendingWriteRef.current = task
+      pendingWritesRef.current.set(task.id, task)
       if (immediate) {
         flushWrites()
         return
@@ -127,9 +133,7 @@ export function useExecutionHistoryTracker() {
     (task: ExecutionTaskRecord, options?: { immediate?: boolean }) => {
       activeTaskRef.current = task
       const immediate = options?.immediate ?? task.status !== 'running'
-      const key = taskChangeKey(task)
-      if (!immediate && key === lastSavedKeyRef.current) return
-      lastSavedKeyRef.current = key
+      if (!immediate && taskChangeKey(task) === lastSavedKeyRef.current) return
       scheduleWrite(task, immediate)
     },
     [scheduleWrite],
@@ -138,7 +142,6 @@ export function useExecutionHistoryTracker() {
   const startTask = useCallback(
     (input: StartExecutionTaskInput) => {
       const task = createTask(input)
-      lastSavedKeyRef.current = ''
       persistTask(task, { immediate: true })
       return task.id
     },
@@ -208,11 +211,13 @@ export function useExecutionHistoryTracker() {
     flushWrites()
   }, [flushWrites])
 
+  // Flush (not just cancel) on unmount so a task still sitting in the throttle
+  // window is persisted when the panel closes mid-turn, rather than dropped.
   useEffect(
     () => () => {
-      if (writeTimerRef.current) clearTimeout(writeTimerRef.current)
+      flushWrites()
     },
-    [],
+    [flushWrites],
   )
 
   return {

--- a/packages/browseros-agent/apps/app/modules/chat/execution-history-tracker.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/execution-history-tracker.hooks.ts
@@ -1,10 +1,11 @@
 import type { ChatStatus, UIMessage } from 'ai'
-import { useCallback, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import {
   getResponsePreview,
   normalizeExecutionSteps,
 } from '@/lib/execution-history/normalize'
 import { upsertConversationExecutionTask } from '@/lib/execution-history/storage'
+import { taskChangeKey } from '@/lib/execution-history/task-change-key'
 import type {
   ExecutionTaskRecord,
   ExecutionTaskStatus,
@@ -60,44 +61,92 @@ function getFinishedStatus(
   return 'completed'
 }
 
+const WRITE_THROTTLE_MS = 400
+
 export function useExecutionHistoryTracker() {
   const activeTaskRef = useRef<ExecutionTaskRecord | null>(null)
-  const lastSavedHashRef = useRef('')
-  const writeQueueRef = useRef(Promise.resolve())
+  const lastSavedKeyRef = useRef('')
+  const pendingWriteRef = useRef<ExecutionTaskRecord | null>(null)
+  const writeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const writingRef = useRef(false)
 
-  const persistTask = useCallback((task: ExecutionTaskRecord) => {
-    const taskHash = JSON.stringify(task)
-    if (taskHash === lastSavedHashRef.current) return
-
-    activeTaskRef.current = task
-    writeQueueRef.current = writeQueueRef.current
-      .then(async () => {
-        await upsertConversationExecutionTask(task)
-        lastSavedHashRef.current = taskHash
-      })
-      .catch((error) => {
-        sentry.captureException(error, {
-          extra: {
-            message: 'Failed to persist execution history task',
-            conversationId: task.conversationId,
-            taskId: task.id,
-          },
-        })
-      })
+  const drainWrites = useCallback(async () => {
+    if (writingRef.current) return
+    writingRef.current = true
+    try {
+      while (pendingWriteRef.current) {
+        const task = pendingWriteRef.current
+        pendingWriteRef.current = null
+        try {
+          await upsertConversationExecutionTask(task)
+        } catch (error) {
+          sentry.captureException(error, {
+            extra: {
+              message: 'Failed to persist execution history task',
+              conversationId: task.conversationId,
+              taskId: task.id,
+            },
+          })
+        }
+      }
+    } finally {
+      writingRef.current = false
+    }
   }, [])
+
+  const flushWrites = useCallback(() => {
+    if (writeTimerRef.current) {
+      clearTimeout(writeTimerRef.current)
+      writeTimerRef.current = null
+    }
+    void drainWrites()
+  }, [drainWrites])
+
+  // Coalesce storage writes: keep only the newest pending task and write at
+  // most one at a time. A streamed turn produces a task update per token, and
+  // each write is a full read/modify/write of the whole history store, so
+  // during streaming they are batched behind a short timer; terminal updates
+  // flush immediately (#1972).
+  const scheduleWrite = useCallback(
+    (task: ExecutionTaskRecord, immediate: boolean) => {
+      pendingWriteRef.current = task
+      if (immediate) {
+        flushWrites()
+        return
+      }
+      if (writeTimerRef.current) return
+      writeTimerRef.current = setTimeout(() => {
+        writeTimerRef.current = null
+        void drainWrites()
+      }, WRITE_THROTTLE_MS)
+    },
+    [drainWrites, flushWrites],
+  )
+
+  const persistTask = useCallback(
+    (task: ExecutionTaskRecord, options?: { immediate?: boolean }) => {
+      activeTaskRef.current = task
+      const immediate = options?.immediate ?? task.status !== 'running'
+      const key = taskChangeKey(task)
+      if (!immediate && key === lastSavedKeyRef.current) return
+      lastSavedKeyRef.current = key
+      scheduleWrite(task, immediate)
+    },
+    [scheduleWrite],
+  )
 
   const startTask = useCallback(
     (input: StartExecutionTaskInput) => {
       const task = createTask(input)
-      lastSavedHashRef.current = ''
-      persistTask(task)
+      lastSavedKeyRef.current = ''
+      persistTask(task, { immediate: true })
       return task.id
     },
     [persistTask],
   )
 
   const syncFromMessages = useCallback(
-    (messages: UIMessage[], _status: ChatStatus) => {
+    (messages: UIMessage[], status: ChatStatus) => {
       const activeTask = activeTaskRef.current
       if (!activeTask) return
 
@@ -109,19 +158,22 @@ export function useExecutionHistoryTracker() {
         nowIso: new Date().toISOString(),
       })
 
-      persistTask({
-        ...activeTask,
-        promptMessageId: activeTask.promptMessageId ?? promptMessage?.id,
-        assistantMessageId:
-          normalized.assistantMessageId ?? activeTask.assistantMessageId,
-        responsePreview:
-          getResponsePreview(assistantMessage) || activeTask.responsePreview,
-        actionCount: normalized.actionCount,
-        approvalCount: normalized.approvalCount,
-        deniedCount: normalized.deniedCount,
-        errorCount: normalized.errorCount,
-        steps: normalized.steps,
-      })
+      persistTask(
+        {
+          ...activeTask,
+          promptMessageId: activeTask.promptMessageId ?? promptMessage?.id,
+          assistantMessageId:
+            normalized.assistantMessageId ?? activeTask.assistantMessageId,
+          responsePreview:
+            getResponsePreview(assistantMessage) || activeTask.responsePreview,
+          actionCount: normalized.actionCount,
+          approvalCount: normalized.approvalCount,
+          deniedCount: normalized.deniedCount,
+          errorCount: normalized.errorCount,
+          steps: normalized.steps,
+        },
+        { immediate: status === 'ready' || status === 'error' },
+      )
     },
     [persistTask],
   )
@@ -144,7 +196,7 @@ export function useExecutionHistoryTracker() {
           : activeTask.responsePreview,
       }
 
-      persistTask(nextTask)
+      persistTask(nextTask, { immediate: true })
       activeTaskRef.current = null
     },
     [persistTask],
@@ -152,8 +204,16 @@ export function useExecutionHistoryTracker() {
 
   const clearActiveTask = useCallback(() => {
     activeTaskRef.current = null
-    lastSavedHashRef.current = ''
-  }, [])
+    lastSavedKeyRef.current = ''
+    flushWrites()
+  }, [flushWrites])
+
+  useEffect(
+    () => () => {
+      if (writeTimerRef.current) clearTimeout(writeTimerRef.current)
+    },
+    [],
+  )
 
   return {
     startTask,


### PR DESCRIPTION
## Problem

The execution-history tracker (which records a per-conversation task/step summary of each turn) ran on every streamed token. For each token it:
- copied the tool result into a step record, and on the default provider path those results carry inline base64 screenshots;
- `JSON.stringify`-ed the entire task to dedupe against the last save; and
- triggered a full read/modify/write of the whole history store (it re-serializes every conversation's history under one key).

On a screenshot-heavy turn that means allocations proportional to the entire accumulated payload on every token, which spikes the renderer heap and contributes to the side panel OOM (#1972). The step `output`/`input` fields are not rendered anywhere today, so all of that cost buys nothing user-visible.

## Change

- **Drop payloads from step records.** `createStepRecord` no longer stores `input`/`output`; `previewText` and the counts already describe the step. This removes base64 from the history store entirely.
- **Replace the per-token `JSON.stringify` dedupe with a cheap change key** over step progress, counts, status, and the streamed preview (no payload serialization). Extracted as a pure, unit-tested helper.
- **Coalesce and throttle writes.** Keep a single newest-wins pending write with at most one in-flight, batched behind a short timer while streaming. Terminal status, turn finish, and conversation reset flush immediately, and the timer is cleared on unmount.

The active task is still updated synchronously on every sync, so `finishTask` always persists the final steps; only the storage write cadence changes.

## Why it is safe

- Nothing reads `ExecutionStepRecord.input`/`output`: the only external consumer of the history store is conversation cleanup (`removeConversationExecutionHistory`). Step summaries (tool name, state, counts, preview, timings) are unchanged.
- Final state is never dropped: syncs keep the in-memory task current, and terminal/finish writes flush immediately.

## Validation

- New unit tests: step records no longer retain `input`/`output` (and the serialized task contains no base64), plus change-key coverage (stable across unread-payload differences, changes on new step / state transition / status / preview). Existing normalize tests still pass.
- `apps/app` typecheck passes (after GraphQL codegen); Biome clean on the changed files.