### PR TITLE
feat(bos-build): prune orphaned resource families in clean

### DIFF
--- a/packages/browseros/bos_build/lib/testing.py
+++ b/packages/browseros/bos_build/lib/testing.py
@@ -218,6 +218,14 @@ class MockBrowserOSRoot:
             yaml.safe_dump(config, f, sort_keys=False, default_flow_style=False)
         return path
 
+    def write_download_config(self, config: Dict) -> Path:
+        """Write build/config/download_resources.yaml with the given mapping."""
+        path = self.root / "bos_build" / "config" / "download_resources.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            yaml.safe_dump(config, f, sort_keys=False, default_flow_style=False)
+        return path
+
     def write_gn_flags(self, platform: str, build_type: str, content: str) -> Path:
         """Write build/config/gn/flags.{platform}.{build_type}.gn."""
         path = self.root / "bos_build" / "config" / "gn" / f"flags.{platform}.{build_type}.gn"

--- a/packages/browseros/bos_build/steps/setup/clean.py
+++ b/packages/browseros/bos_build/steps/setup/clean.py
@@ -3,14 +3,15 @@
 
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
-from ...lib.utils import run_command, log_info, log_success, safe_rmtree
+from ...lib.utils import run_command, log_info, log_success, log_warning, safe_rmtree
+from ..storage.download import managed_binary_families
 
 
 @step("clean", phase="setup")
 class CleanModule(Step):
     produces = []
     requires = []
-    description = "Clean build artifacts and reset git state"
+    description = "Clean build artifacts, reset git state, and prune orphaned resources"
 
     def validate(self, ctx: Context) -> None:
         if not ctx.chromium_src.exists():
@@ -29,6 +30,37 @@ class CleanModule(Step):
 
         log_info("\n🧹 Cleaning Sparkle build artifacts...")
         self._clean_sparkle(ctx)
+
+        log_info("\n🧹 Pruning orphaned resource binaries...")
+        self._prune_orphan_binary_families(ctx)
+
+    def _prune_orphan_binary_families(self, ctx: Context) -> None:
+        """Remove resources/binaries/<family> dirs the download config no longer lists.
+
+        Retired families linger on persistent runners with stale per-arch
+        metadata (the retired browseros_claw_server dir failed a BrowserClaw
+        universal merge, run 29882827339). Only immediate child directories
+        are pruned; loose files and family contents are left alone.
+        """
+        binaries_dir = ctx.root_dir / "resources" / "binaries"
+        if not binaries_dir.is_dir():
+            return
+
+        config_path = ctx.get_download_resources_config()
+        families = managed_binary_families(config_path)
+        if not families:
+            # Fail safe: an empty set means the managed families are unknown
+            # (missing/malformed config), never that everything is an orphan.
+            log_warning(
+                f"No managed resource families found in {config_path}; "
+                "skipping orphan pruning"
+            )
+            return
+
+        for entry in sorted(binaries_dir.iterdir()):
+            if entry.is_dir() and entry.name not in families:
+                safe_rmtree(entry)
+                log_success(f"Removed orphaned resource family: {entry.name}")
 
     def _clean_sparkle(self, ctx: Context) -> None:
         sparkle_dir = ctx.get_sparkle_dir()

--- a/packages/browseros/bos_build/steps/setup/clean_test.py
+++ b/packages/browseros/bos_build/steps/setup/clean_test.py
@@ -70,5 +70,95 @@ class CleanExecuteTest(unittest.TestCase):
                 clean.CleanModule().execute(ctx)
 
 
+class CleanPruneOrphanBinariesTest(unittest.TestCase):
+    """Pruning of resources/binaries/<family> dirs absent from the download config."""
+
+    MANAGED_CONFIG = {
+        "download_operations": [
+            {
+                "name": "Server arm64",
+                "destination": "resources/binaries/browseros_server/darwin-arm64",
+            },
+            {
+                "name": "Rust claw server arm64",
+                "destination": "resources/binaries/browseros_claw_server_rust/darwin-arm64",
+            },
+            {
+                "name": "Onboard",
+                "destination": "resources/binaries/browseros_claw_onboard",
+            },
+        ]
+    }
+
+    def _execute(self, ctx):
+        with mock.patch.object(clean, "run_command"):
+            clean.CleanModule().execute(ctx)
+
+    def test_prunes_orphan_and_keeps_managed_families_and_loose_files(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            root = MockBrowserOSRoot(Path(root_tmp))
+            root.write_download_config(self.MANAGED_CONFIG)
+            ctx = make_context(MockChromium(Path(chromium_tmp)), root)
+
+            binaries = root.root / "resources" / "binaries"
+            orphan = binaries / "browseros_claw_server"
+            (orphan / "darwin-arm64").mkdir(parents=True)
+            (orphan / "darwin-arm64" / "artifact-metadata.json").write_text("{}")
+
+            managed = binaries / "browseros_server" / "darwin-arm64"
+            managed.mkdir(parents=True)
+            (managed / "artifact-metadata.json").write_text("{}")
+
+            # Nightly-macos stages local bundles without artifact metadata;
+            # membership in the config alone must keep the family.
+            staged = binaries / "browseros_claw_server_rust" / "darwin-arm64"
+            staged.mkdir(parents=True)
+            (staged / "browseros_claw_server_rust").write_text("binary")
+
+            loose_file = binaries / "README.txt"
+            loose_file.write_text("not a family dir")
+
+            self._execute(ctx)
+
+            self.assertFalse(orphan.exists())
+            self.assertTrue(managed.exists())
+            self.assertTrue(staged.exists())
+            self.assertTrue(loose_file.exists())
+
+    def test_empty_managed_set_prunes_nothing(self):
+        # Fail-safe pin: a missing/unparseable config yields an empty managed
+        # set, which must mean "unknown — prune nothing", never "prune all".
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            root = MockBrowserOSRoot(Path(root_tmp))
+            ctx = make_context(MockChromium(Path(chromium_tmp)), root)
+            self.assertFalse(ctx.get_download_resources_config().exists())
+
+            orphan = root.root / "resources" / "binaries" / "browseros_claw_server"
+            orphan.mkdir(parents=True)
+
+            self._execute(ctx)
+
+            self.assertTrue(orphan.exists())
+
+    def test_missing_binaries_dir_is_tolerated(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            root = MockBrowserOSRoot(Path(root_tmp))
+            root.write_download_config(self.MANAGED_CONFIG)
+            ctx = make_context(MockChromium(Path(chromium_tmp)), root)
+
+            self._execute(ctx)
+
+            self.assertFalse((root.root / "resources" / "binaries").exists())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/browseros/bos_build/steps/storage/download.py
+++ b/packages/browseros/bos_build/steps/storage/download.py
@@ -187,6 +187,41 @@ def _clear_destination(dest_path: Path) -> None:
     dest_path.unlink()
 
 
+def managed_binary_families(config_path: Path) -> set[str]:
+    """Return the resource families download_resources.yaml manages.
+
+    A family is the first path component after resources/binaries/ in an
+    operation destination; destinations elsewhere are ignored. Returns an
+    empty set for a missing or malformed config — callers must treat empty
+    as "unknown", never as "nothing is managed".
+    """
+    try:
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError):
+        return set()
+
+    if not isinstance(config, dict):
+        return set()
+
+    operations = config.get("download_operations")
+    if not isinstance(operations, list):
+        return set()
+
+    families = set()
+    for op in operations:
+        if not isinstance(op, dict):
+            continue
+        destination = op.get("destination")
+        if not isinstance(destination, str):
+            continue
+        parts = PurePosixPath(destination).parts
+        if len(parts) >= 3 and parts[:2] == ("resources", "binaries"):
+            families.add(parts[2])
+
+    return families
+
+
 @step("download_resources", phase="prep")
 class DownloadResourcesModule(Step):
     """Download resources from Cloudflare R2 before build

--- a/packages/browseros/bos_build/steps/storage/download_test.py
+++ b/packages/browseros/bos_build/steps/storage/download_test.py
@@ -20,6 +20,7 @@ from bos_build.steps.storage.download import (
     ARTIFACT_METADATA_NAME,
     DownloadResourcesModule,
     extract_artifact_zip,
+    managed_binary_families,
 )
 
 
@@ -196,6 +197,70 @@ class ExtractArtifactZipTest(unittest.TestCase):
                 for relative_path, content in files.items()
             ],
         }
+
+
+class ManagedBinaryFamiliesTest(unittest.TestCase):
+    def test_collects_families_from_binaries_destinations(self) -> None:
+        # Arch-suffixed and family-root destinations both resolve to their
+        # family; destinations outside resources/binaries/ are ignored.
+        config = {
+            "download_operations": [
+                {
+                    "name": "Server arm64",
+                    "destination": "resources/binaries/browseros_server/darwin-arm64",
+                },
+                {
+                    "name": "Server x64",
+                    "destination": "resources/binaries/browseros_server/darwin-x64",
+                },
+                {
+                    "name": "Onboard",
+                    "destination": "resources/binaries/browseros_claw_onboard",
+                },
+                {
+                    "name": "Elsewhere",
+                    "destination": "resources/other/thing",
+                },
+            ]
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "download_resources.yaml"
+            config_path.write_text(yaml.safe_dump(config))
+
+            self.assertEqual(
+                {"browseros_server", "browseros_claw_onboard"},
+                managed_binary_families(config_path),
+            )
+
+    def test_missing_file_returns_empty_set(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing = Path(temp_dir) / "does-not-exist.yaml"
+            self.assertEqual(set(), managed_binary_families(missing))
+
+    def test_config_without_download_operations_returns_empty_set(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "download_resources.yaml"
+            config_path.write_text("some_other_key: true\n")
+            self.assertEqual(set(), managed_binary_families(config_path))
+
+    def test_malformed_yaml_returns_empty_set(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "download_resources.yaml"
+            config_path.write_text("download_operations: [unclosed\n")
+            self.assertEqual(set(), managed_binary_families(config_path))
+
+    def test_real_config_lists_current_families(self) -> None:
+        config_path = (
+            Path(__file__).resolve().parents[2] / "config" / "download_resources.yaml"
+        )
+        families = managed_binary_families(config_path)
+
+        self.assertIn("browseros_server", families)
+        self.assertIn("browseros_claw_server_rust", families)
+        self.assertIn("browseros_claw_onboard", families)
+        # Retired by #1948; its leftover dir is exactly what pruning removes.
+        self.assertNotIn("browseros_claw_server", families)
 
 
 class DownloadResourceConfigTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Retired `resources/binaries/<family>` dirs linger on persistent runners: the retired `browseros_claw_server` dir (TS server, retired by #1948) sat on the self-hosted mac runner with skewed per-arch metadata and failed the BrowserClaw 0.48.0 universal merge ([run 29882827339](https://github.com/browseros-ai/BrowserOS/actions/runs/29882827339)) until it was hand-deleted. #1977 made the `merge_universal` skew guard immune to orphans; this PR sweeps the fossils themselves so they can't accumulate again.

## Changes

- **`steps/storage/download.py`** — new module-level `managed_binary_families(config_path)`: parses `download_resources.yaml` (which owns the schema) and returns the set of family names appearing as the first path component after `resources/binaries/` in op destinations. Missing/malformed config → empty set.
- **`steps/setup/clean.py`** — `CleanModule.execute` now calls `_prune_orphan_binary_families`: removes immediate child **dirs** of `resources/binaries/` not in the managed set. Loose files survive, family contents are never recursed into (downloads clear+refresh their own destinations), missing dir is a no-op.
- **Fail-safe**: an empty managed set means "unknown" — warn and prune **nothing**. Empty must never mean "prune everything". Pinned by test.
- **`lib/testing.py`** — `MockBrowserOSRoot.write_download_config` fixture, mirroring `write_copy_config`.

## Why the download config (not the ServerBundle registry)

`browseros_claw_onboard` is a download destination but not a ServerBundle — registry-scoped pruning would delete it. The download config is exactly the artifact that loses a family's ops when it's retired, which is precisely when its dir becomes an orphan.

Lane behavior: the self-hosted mac release lane (`--preset release`) runs clean in run-1 prep of universal plans — pruning fires exactly where the incident happened. `nightly-macos` runs clean with downloads off after staging local bundles into three families that are all in the config, so they survive (covered by the metadata-less staged-family test). Warp lanes run `clean: false` on ephemeral workspaces — unaffected.

## Tests

- `download_test.py`: family extraction from mixed destinations (arch-suffixed + family-root, non-binaries ignored); missing file / no `download_operations` / malformed yaml → empty set; real config lists the three current families and not the retired `browseros_claw_server`.
- `clean_test.py`: orphan pruned while managed families (including one staged **without** `artifact-metadata.json`, mimicking nightly local staging) and loose files survive; missing `resources/binaries` tolerated; **empty managed set → orphan survives** (the fail-safe pin).
- Full `bos_build` suite: 734 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)