### PR TITLE
feat(claw-server): proxy port as source of truth + boot URL self-heal

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/config.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/config.rs
@@ -212,12 +212,20 @@ impl Config {
         })
     }
 
+    /// Base URL external tools should reach BrowserClaw at: the Chrome-assigned
+    /// proxy port when present (the source of truth), else the direct server
+    /// port (dev, where the proxy is unavailable).
     #[must_use]
-    pub fn public_mcp_url(&self) -> String {
+    pub fn public_base_url(&self) -> String {
         format!(
-            "http://127.0.0.1:{}/mcp",
+            "http://127.0.0.1:{}",
             self.proxy_port.unwrap_or(self.server_port)
         )
+    }
+
+    #[must_use]
+    pub fn public_mcp_url(&self) -> String {
+        format!("{}/mcp", self.public_base_url())
     }
 
     #[must_use]
@@ -347,6 +355,8 @@ mod tests {
         assert_eq!(cfg.replay_retention_days, 7);
         assert!(cfg.browserclaw_dir.ends_with("browserclaw"));
         assert_eq!(cfg.public_mcp_url(), "http://127.0.0.1:9200/mcp");
+        // No proxy configured (dev): falls back to the direct server port.
+        assert_eq!(cfg.public_base_url(), "http://127.0.0.1:9200");
         Ok(())
     }
 
@@ -519,6 +529,8 @@ mod tests {
         assert_eq!(cfg.proxy_port, Some(9444));
         assert!(cfg.browserclaw_dir.ends_with(".browserclaw-dev"));
         assert_eq!(cfg.public_mcp_url(), "http://127.0.0.1:9444/mcp");
+        // Proxy configured: the source of truth is the proxy port.
+        assert_eq!(cfg.public_base_url(), "http://127.0.0.1:9444");
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -128,14 +128,17 @@ async fn serve_with_boot_task(
     // or dev port (config port 0) is still published correctly.
     let bound = listener.local_addr().unwrap_or(addr);
     info!(%bound, "claw-server-rust listening");
-    // Publish the live server URL for external discovery (the Codex and Claude
-    // Desktop plugins). Fire-and-forget: a best-effort disk write must never
-    // gate the listener from accepting connections, since a stalled FUSE /
-    // network / container-mounted browserclaw_dir could otherwise leave the
-    // socket bound but never served. Mirrors the archived TS server, which
-    // deliberately did not await writeRuntimeFile for the same reason.
+    // Publish the canonical MCP URL for external discovery (the Codex and Claude
+    // Desktop plugins). This is the proxy port (the source of truth), falling
+    // back to the direct server port in dev where the proxy is unavailable, so
+    // runtime.json matches what the cockpit and connected agents advertise.
+    // Fire-and-forget: a best-effort disk write must never gate the listener
+    // from accepting connections, since a stalled FUSE / network /
+    // container-mounted browserclaw_dir could otherwise leave the socket bound
+    // but never served. Mirrors the archived TS server, which deliberately did
+    // not await writeRuntimeFile for the same reason.
     let runtime_dir = config.browserclaw_dir.clone();
-    let runtime_url = format!("http://{bound}");
+    let runtime_url = config.public_base_url();
     tokio::spawn(async move {
         claw_server_rust::runtime_file::write_runtime_file(&runtime_dir, &runtime_url).await;
     });
@@ -169,6 +172,21 @@ async fn ready_after<T, E>(
 }
 
 async fn heal_boot_config(state: &AppState) {
+    // Re-point every connected agent at the current canonical URL first (the
+    // proxy port may have moved on this app launch), then repair any config
+    // that still drifted from the now-current manifest spec.
+    match state
+        .harness
+        .migrate_connected_urls(&state.config.public_mcp_url())
+        .await
+    {
+        Ok(outcome) => info!(
+            migrated = outcome.migrated,
+            failed = outcome.failed,
+            "re-synced connected MCP agents to the current URL"
+        ),
+        Err(err) => error!(error = %err, "MCP URL migration failed"),
+    }
     match state.harness.run_integrity_scan().await {
         Ok(outcome) => info!(
             verified = outcome.verified,

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -138,7 +138,14 @@ async fn serve_with_boot_task(
     // but never served. Mirrors the archived TS server, which deliberately did
     // not await writeRuntimeFile for the same reason.
     let runtime_dir = config.browserclaw_dir.clone();
-    let runtime_url = config.public_base_url();
+    // The proxy port is the advertised endpoint. Without a proxy (dev) publish
+    // the ACTUAL bound port, which stays correct even when the config requested
+    // an OS-assigned port (server_port == 0) that public_base_url would render
+    // as an unreachable `:0`.
+    let runtime_url = match config.proxy_port {
+        Some(proxy) => format!("http://127.0.0.1:{proxy}"),
+        None => format!("http://{bound}"),
+    };
     tokio::spawn(async move {
         claw_server_rust::runtime_file::write_runtime_file(&runtime_dir, &runtime_url).await;
     });

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
@@ -327,9 +327,10 @@ impl HarnessService {
 
     /// Re-links every connected harness to `target_mcp_url`. Called on boot so a
     /// proxy-port change (native re-resolves ports at app launch) re-points all
-    /// already-connected agents at the new URL. A no-op when the manifest
-    /// already records `target_mcp_url`; per-harness failures are isolated so
-    /// one unwritable config never blocks the rest.
+    /// already-connected agents at the new URL. Harnesses already on the URL are
+    /// verified without rewriting their config (relink is write-on-change);
+    /// per-harness failures are isolated so one unwritable config never blocks
+    /// the rest.
     pub async fn migrate_connected_urls(
         &self,
         target_mcp_url: &str,
@@ -652,32 +653,17 @@ fn tildify_home_path(path: Option<&Path>, home_dir: &Path) -> Option<String> {
     }
 }
 
-/// Reads the canonical URL currently recorded for BrowserClaw in the manifest,
-/// from whichever transport spec it was last linked with. `None` when no entry
-/// exists or the URL cannot be recovered.
-fn manifest_server_url(manager: &Manager, workspace_dir: &Path) -> Option<String> {
-    with_legacy_manifest_migration(workspace_dir, || manager.list())
-        .ok()?
-        .into_iter()
-        .find(|server| server.name == BROWSEROS_MCP_SERVER_NAME)
-        .and_then(|server| match server.spec {
-            McpServerSpec::Http { url, .. } | McpServerSpec::Sse { url, .. } => Some(url),
-            // The stdio shape is `mcp-remote <url>`.
-            McpServerSpec::Stdio { args, .. } => args.into_iter().nth(1),
-        })
-}
-
 fn migrate_connected_urls(
     manager: &Manager,
     workspace_dir: &Path,
     target_mcp_url: &str,
 ) -> Result<UrlMigrationOutcome, ManagerError> {
-    // Nothing to do when the recorded URL already matches: every connected
-    // agent was last linked to it, so re-writing would only churn config files.
-    if manifest_server_url(manager, workspace_dir).as_deref() == Some(target_mcp_url) {
-        return Ok(UrlMigrationOutcome::default());
-    }
-
+    // Always re-link every connected agent rather than short-circuiting on the
+    // manifest URL. A partial migration (crash after some agents relinked but
+    // before the rest) leaves the manifest already pointing at the target while
+    // stale agents keep the old port; a manifest-level skip would strand them,
+    // and the integrity scan only checks server-name presence, not the URL.
+    // relink is write-on-change, so agents already on the target aren't rewritten.
     let links = with_legacy_manifest_migration(workspace_dir, || {
         manager.list_links(ListLinksFilter {
             server_names: Some(vec![BROWSEROS_MCP_SERVER_NAME.to_string()]),

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
@@ -123,6 +123,12 @@ pub struct IntegrityScanOutcome {
     pub failed: usize,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UrlMigrationOutcome {
+    pub migrated: usize,
+    pub failed: usize,
+}
+
 #[derive(Clone)]
 pub struct HarnessService {
     manager: Manager,
@@ -317,6 +323,26 @@ impl HarnessService {
         tokio::task::spawn_blocking(move || run_integrity_scan(&manager, &workspace_dir))
             .await?
             .map_err(manager_app_error)
+    }
+
+    /// Re-links every connected harness to `target_mcp_url`. Called on boot so a
+    /// proxy-port change (native re-resolves ports at app launch) re-points all
+    /// already-connected agents at the new URL. A no-op when the manifest
+    /// already records `target_mcp_url`; per-harness failures are isolated so
+    /// one unwritable config never blocks the rest.
+    pub async fn migrate_connected_urls(
+        &self,
+        target_mcp_url: &str,
+    ) -> AppResult<UrlMigrationOutcome> {
+        let _guard = self.mutex.lock().await;
+        let manager = self.manager.clone();
+        let workspace_dir = self.workspace_dir.clone();
+        let target = target_mcp_url.to_string();
+        tokio::task::spawn_blocking(move || {
+            migrate_connected_urls(&manager, &workspace_dir, &target)
+        })
+        .await?
+        .map_err(manager_app_error)
     }
 
     fn failure(
@@ -624,6 +650,68 @@ fn tildify_home_path(path: Option<&Path>, home_dir: &Path) -> Option<String> {
         Ok(relative) => Some(format!("~/{}", relative.display())),
         Err(_) => Some(path.display().to_string()),
     }
+}
+
+/// Reads the canonical URL currently recorded for BrowserClaw in the manifest,
+/// from whichever transport spec it was last linked with. `None` when no entry
+/// exists or the URL cannot be recovered.
+fn manifest_server_url(manager: &Manager, workspace_dir: &Path) -> Option<String> {
+    with_legacy_manifest_migration(workspace_dir, || manager.list())
+        .ok()?
+        .into_iter()
+        .find(|server| server.name == BROWSEROS_MCP_SERVER_NAME)
+        .and_then(|server| match server.spec {
+            McpServerSpec::Http { url, .. } | McpServerSpec::Sse { url, .. } => Some(url),
+            // The stdio shape is `mcp-remote <url>`.
+            McpServerSpec::Stdio { args, .. } => args.into_iter().nth(1),
+        })
+}
+
+fn migrate_connected_urls(
+    manager: &Manager,
+    workspace_dir: &Path,
+    target_mcp_url: &str,
+) -> Result<UrlMigrationOutcome, ManagerError> {
+    // Nothing to do when the recorded URL already matches: every connected
+    // agent was last linked to it, so re-writing would only churn config files.
+    if manifest_server_url(manager, workspace_dir).as_deref() == Some(target_mcp_url) {
+        return Ok(UrlMigrationOutcome::default());
+    }
+
+    let links = with_legacy_manifest_migration(workspace_dir, || {
+        manager.list_links(ListLinksFilter {
+            server_names: Some(vec![BROWSEROS_MCP_SERVER_NAME.to_string()]),
+            agents: None,
+        })
+    })?;
+
+    let mut outcome = UrlMigrationOutcome::default();
+    for link in links {
+        let agent = link.agent;
+        let spec = match spec_for(agent, target_mcp_url) {
+            Ok(spec) => spec,
+            Err(error) => {
+                outcome.failed += 1;
+                tracing::warn!(agent = %agent, error = %error, "URL migration: spec build failed");
+                continue;
+            }
+        };
+        match relink_managed_server(
+            manager,
+            workspace_dir,
+            BROWSEROS_MCP_SERVER_NAME,
+            agent,
+            spec,
+            true,
+        ) {
+            Ok(_) => outcome.migrated += 1,
+            Err(error) => {
+                outcome.failed += 1;
+                tracing::warn!(agent = %agent, error = %error, "URL migration: relink failed");
+            }
+        }
+    }
+    Ok(outcome)
 }
 
 fn manager_app_error(error: ManagerError) -> AppError {

--- a/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
@@ -224,10 +224,23 @@ async fn run_connections_case() -> anyhow::Result<()> {
         NEW_MCP_URL
     );
 
-    // Idempotent: re-running with the same URL is a no-op (nothing to rewrite).
-    let noop = service.migrate_connected_urls(NEW_MCP_URL).await?;
-    assert_eq!(noop.migrated, 0);
-    assert_eq!(noop.failed, 0);
+    // Regression: a crash mid-migration can leave the manifest already at the
+    // target while some agent configs are still stale. Re-running must repair
+    // the straggler, not short-circuit on the manifest URL. Simulate it by
+    // reverting one agent's config to a stale port with the manifest untouched.
+    const STALE_MCP_URL: &str = "http://127.0.0.1:8888/mcp";
+    fs::write(
+        claude_path,
+        format!(r#"{{"mcpServers":{{"BrowserClaw":{{"type":"http","url":"{STALE_MCP_URL}"}}}}}}"#),
+    )?;
+    let repaired = service.migrate_connected_urls(NEW_MCP_URL).await?;
+    assert_eq!(repaired.migrated, 3);
+    assert_eq!(repaired.failed, 0);
+    let claude_json: Value = serde_json::from_str(&fs::read_to_string(claude_path)?)?;
+    assert_eq!(
+        claude_json["mcpServers"]["BrowserClaw"]["url"], NEW_MCP_URL,
+        "a straggler left on a stale port is repaired, not skipped"
+    );
 
     // Restore the original URL so the rest of this scenario is unaffected.
     let restored = service.migrate_connected_urls(MCP_URL).await?;

--- a/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
@@ -198,6 +198,40 @@ async fn run_connections_case() -> anyhow::Result<()> {
             .collect::<Vec<_>>(),
         [Harness::ClaudeCode, Harness::Codex, Harness::Zed]
     );
+
+    // Proxy port moved on this launch: migrating re-links every connected
+    // harness to the new URL and rewrites their config files + the manifest.
+    const NEW_MCP_URL: &str = "http://127.0.0.1:9999/mcp";
+    let migrated = service.migrate_connected_urls(NEW_MCP_URL).await?;
+    assert_eq!(migrated.migrated, 3);
+    assert_eq!(migrated.failed, 0);
+
+    let claude_json: Value = serde_json::from_str(&fs::read_to_string(claude_path)?)?;
+    assert_eq!(
+        claude_json["mcpServers"]["BrowserClaw"]["url"], NEW_MCP_URL,
+        "claude config re-pointed to the new URL"
+    );
+    let codex_toml: toml::Value =
+        toml::from_str(&fs::read_to_string(path_for(&paths, AgentId::Codex)?)?)?;
+    assert_eq!(
+        codex_toml["mcp_servers"]["BrowserClaw"]["url"].as_str(),
+        Some(NEW_MCP_URL)
+    );
+    let zed_json: Value =
+        serde_json::from_str(&fs::read_to_string(path_for(&paths, AgentId::Zed)?)?)?;
+    assert_eq!(
+        zed_json["context_servers"]["BrowserClaw"]["url"],
+        NEW_MCP_URL
+    );
+
+    // Idempotent: re-running with the same URL is a no-op (nothing to rewrite).
+    let noop = service.migrate_connected_urls(NEW_MCP_URL).await?;
+    assert_eq!(noop.migrated, 0);
+    assert_eq!(noop.failed, 0);
+
+    // Restore the original URL so the rest of this scenario is unaffected.
+    let restored = service.migrate_connected_urls(MCP_URL).await?;
+    assert_eq!(restored.migrated, 3);
     assert_eq!(configured[0].message, "Configured in Claude Code.");
 
     fs::write(claude_path, "{\"mcpServers\":{}}")?;


### PR DESCRIPTION
## What

Implements the finalized MCP port handling for claw-server, per the team decision:

1. **Proxy port is the source of truth.** `runtime.json` now publishes the canonical MCP URL (`config.public_base_url()` = the Chrome-assigned proxy port), matching what the cockpit "connect" flows and every connected agent already advertise, instead of the raw sidecar port.
2. **Self-heal on proxy-port change.** On boot, every already-connected harness is re-linked to the current URL, so when the native layer re-resolves the proxy port on app launch, all agents get the new URL and `runtime.json` reflects it.
3. **Dev fallback.** When the proxy port is unavailable (dev), `public_base_url()` falls back to the direct server port — the same `proxy_port.unwrap_or(server_port)` rule `public_mcp_url()` already uses.

## Changes

- `config.rs`: add `public_base_url()` (proxy port, dev-fallback to server port); `public_mcp_url()` now builds on it so the two can't drift.
- `main.rs`: `runtime.json` boot write switches from the bound server port to `public_base_url()` (still spawned/fire-and-forget so a stalled mount can't block `axum::serve`). `heal_boot_config` runs the URL migration before the existing integrity scan.
- `services/harness.rs`: add `HarnessService::migrate_connected_urls(url)` — re-links every connected harness (enumerated via `list_links`) to `url`, reusing the existing `relink_managed_server` restore-on-failure primitive. No-op when the manifest already records the URL; per-harness failures are isolated. This restores the boot URL migration (`migrateMcpUrls`) that the TS→Rust rewrite dropped.

## Design notes

- **Boot-triggered, not runtime-watched.** The native `BrowserOSServerManager` resolves ports at app launch and writes them into the sidecar's `config.json`; the Rust server reads `config.proxy_port` fresh each boot. So "port changed → update runtime.json + re-link agents" happens naturally in the boot path.
- **Crash-safe without a marker.** The URL migration updates the manifest + configs; the integrity scan that runs immediately after repairs any config that still drifted from the (now-current) manifest spec. Together they converge even on a partial/crashed migration.
- **No native changes.** Port resolution and the proxy stay native and are consumed as-is.

## Validation

- `cargo test -p claw-server-rust`: all green (incl. a new migration case in `tests/connections.rs` asserting the 3 connected agents' config files + manifest are re-pointed to the new URL, the re-run is a no-op, and `public_base_url` proxy/dev-fallback in `config.rs`).
- `cargo clippy --all-targets`, `cargo fmt --check`: clean.
