### PR TITLE
fix(claw): classify recovered session status

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/db/audit_log.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/audit_log.rs
@@ -24,6 +24,7 @@ use url::Url;
 pub use crate::db::entities::tool_dispatches::Model as ToolDispatchRow;
 
 const ARGS_JSON_MAX: usize = 4096;
+const SUSTAINED_ERROR_TAIL: usize = 3;
 
 #[derive(Clone)]
 pub struct AuditLog {
@@ -80,9 +81,9 @@ pub struct SessionScreenshotRow {
     pub tool_name: String,
 }
 
-/// Status derived from persisted dispatches and the session end event. Any dispatch error or an
-/// `errored` end is `Failed`; a `closed` end without errors is `Done`; all other materialized tasks
-/// are `Live`.
+/// Status derived from persisted dispatches and the session end event. Active and cancelled
+/// sessions keep lifecycle precedence; completed browser work fails only after three consecutive
+/// final tool errors. Sessions without browser work retain their explicit end status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TaskStatus {
@@ -573,7 +574,7 @@ async fn recompute_task<C: ConnectionTrait>(conn: &C, session_id: &str) -> AppRe
         .filter(|row| result_is_error(row.result_meta.as_deref()))
         .count() as i64;
     let end_event = end.clone().map(SessionEndEvent::from);
-    let status = derive_status(error_count, end_event.as_ref());
+    let status = derive_status(&dispatches, end_event.as_ref());
     let tool_sequence: Vec<String> = dispatches.iter().map(|row| row.tool_name.clone()).collect();
     let screenshot_ids: Vec<i64> = dispatches
         .iter()
@@ -660,12 +661,23 @@ async fn query_end<C: ConnectionTrait>(
         .await?)
 }
 
-fn derive_status(error_count: i64, end: Option<&SessionEndEvent>) -> TaskStatus {
-    match end.map(|event| event.kind.as_str()) {
-        Some("cancelled") => TaskStatus::Cancelled,
-        Some("errored") => TaskStatus::Failed,
-        Some("closed") if error_count == 0 => TaskStatus::Done,
-        _ if error_count > 0 => TaskStatus::Failed,
+fn derive_status(dispatches: &[ToolDispatchRow], end: Option<&SessionEndEvent>) -> TaskStatus {
+    let Some(end) = end else {
+        return TaskStatus::Live;
+    };
+    match end.kind.as_str() {
+        "cancelled" => TaskStatus::Cancelled,
+        "errored" if dispatches.is_empty() => TaskStatus::Failed,
+        "closed" if dispatches.is_empty() => TaskStatus::Done,
+        "closed" | "errored"
+            if dispatches.len() >= SUSTAINED_ERROR_TAIL
+                && dispatches[dispatches.len() - SUSTAINED_ERROR_TAIL..]
+                    .iter()
+                    .all(|row| result_is_error(row.result_meta.as_deref())) =>
+        {
+            TaskStatus::Failed
+        }
+        "closed" | "errored" => TaskStatus::Done,
         _ => TaskStatus::Live,
     }
 }
@@ -828,9 +840,12 @@ mod tests {
             .record_tool_dispatch(dispatch("a1", "https://alpha.example.com", false))
             .await?;
         audit.record_session_end("a1", "closed", None).await?;
-        audit
-            .record_tool_dispatch(dispatch("b1", "https://beta.example.com", true))
-            .await?;
+        for _ in 0..3 {
+            audit
+                .record_tool_dispatch(dispatch("b1", "https://beta.example.com", true))
+                .await?;
+        }
+        audit.record_session_end("b1", "closed", None).await?;
         let done = audit
             .list_tasks(ListTasksQuery {
                 status: Some(TaskStatus::Done),
@@ -851,6 +866,105 @@ mod tests {
             .await?;
         assert_eq!(failed.tasks.len(), 1);
         assert_eq!(failed.tasks[0].session_id, "b1");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn completed_session_recovers_after_tool_error() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = AuditLog::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
+        audit
+            .record_tool_dispatch(dispatch("recovered", "https://example.com", true))
+            .await?;
+        audit
+            .record_tool_dispatch(dispatch("recovered", "https://example.com", false))
+            .await?;
+        audit
+            .record_session_end("recovered", "errored", None)
+            .await?;
+
+        let summary = audit
+            .get_task_summary("recovered")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("recovered task missing"))?;
+        assert_eq!(summary.status, TaskStatus::Done);
+        assert_eq!(summary.error_count, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn completed_session_failure_requires_three_error_tail() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = AuditLog::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
+        for (session_id, error_tail) in [("two-errors", 2), ("three-errors", 3)] {
+            audit
+                .record_tool_dispatch(dispatch(session_id, "https://example.com", false))
+                .await?;
+            for _ in 0..error_tail {
+                audit
+                    .record_tool_dispatch(dispatch(session_id, "https://example.com", true))
+                    .await?;
+            }
+            audit.record_session_end(session_id, "closed", None).await?;
+        }
+
+        let two_errors = audit
+            .get_task_summary("two-errors")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("two-error task missing"))?;
+        assert_eq!(two_errors.status, TaskStatus::Done);
+        assert_eq!(two_errors.error_count, 2);
+
+        let three_errors = audit
+            .get_task_summary("three-errors")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("three-error task missing"))?;
+        assert_eq!(three_errors.status, TaskStatus::Failed);
+        assert_eq!(three_errors.error_count, 3);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn active_session_stays_live_after_three_error_tail() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = AuditLog::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
+        for _ in 0..3 {
+            audit
+                .record_tool_dispatch(dispatch("active", "https://example.com", true))
+                .await?;
+        }
+
+        let summary = audit
+            .get_task_summary("active")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("active task missing"))?;
+        assert_eq!(summary.status, TaskStatus::Live);
+        assert_eq!(summary.error_count, 3);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn zero_dispatch_tasks_keep_end_event_status() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = AuditLog::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
+        for (session_id, kind) in [("empty-closed", "closed"), ("empty-errored", "errored")] {
+            audit
+                .record_session_start(session_id, "agent", "agent", "Agent", "client", "1")
+                .await?;
+            audit.record_session_end(session_id, kind, None).await?;
+        }
+
+        let closed = audit
+            .get_task_summary("empty-closed")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("empty closed task missing"))?;
+        assert_eq!(closed.status, TaskStatus::Done);
+
+        let errored = audit
+            .get_task_summary("empty-errored")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("empty errored task missing"))?;
+        assert_eq!(errored.status, TaskStatus::Failed);
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
@@ -11,7 +11,272 @@ impl MigratorTrait for Migrator {
             Box::new(m0002_add_recordings_and_claims::Migration),
             Box::new(m0003_document_recordings_and_tab_ownership::Migration),
             Box::new(m0004_atomic_recording_payloads::Migration),
+            Box::new(m0005_reclassify_task_status::Migration),
         ]
+    }
+}
+
+mod m0005_reclassify_task_status {
+    use super::*;
+
+    pub struct Migration;
+
+    impl MigrationName for Migration {
+        fn name(&self) -> &str {
+            "m0005_reclassify_task_status"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for Migration {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            // Task status is a persisted projection, so completed rows must be reclassified when
+            // its semantics change instead of waiting for another dispatch that will never arrive.
+            manager
+                .get_connection()
+                .execute_unprepared(
+                    r#"
+                    WITH first_ends AS (
+                        SELECT session_id, kind
+                        FROM (
+                            SELECT
+                                session_id,
+                                kind,
+                                ROW_NUMBER() OVER (
+                                    PARTITION BY session_id
+                                    ORDER BY id ASC
+                                ) AS position
+                            FROM agent_session_ends
+                        )
+                        WHERE position = 1
+                    ),
+                    dispatch_tails AS (
+                        SELECT
+                            session_id,
+                            COUNT(*) AS dispatch_count,
+                            SUM(
+                                CASE WHEN json_valid(result_meta) THEN
+                                    CASE WHEN
+                                        json_extract(result_meta, '$.isError') = 1
+                                        AND COALESCE(
+                                            json_extract(result_meta, '$.cancelled'),
+                                            0
+                                        ) != 1
+                                    THEN 1 ELSE 0 END
+                                ELSE 0 END
+                            ) AS error_count
+                        FROM (
+                            SELECT
+                                session_id,
+                                result_meta,
+                                ROW_NUMBER() OVER (
+                                    PARTITION BY session_id
+                                    ORDER BY id DESC
+                                ) AS position
+                            FROM tool_dispatches
+                        )
+                        WHERE position <= 3
+                        GROUP BY session_id
+                    )
+                    UPDATE tasks
+                    SET status = CASE
+                        WHEN NOT EXISTS (
+                            SELECT 1 FROM first_ends
+                            WHERE first_ends.session_id = tasks.session_id
+                        ) THEN 'live'
+                        WHEN (
+                            SELECT kind FROM first_ends
+                            WHERE first_ends.session_id = tasks.session_id
+                        ) = 'cancelled' THEN 'cancelled'
+                        WHEN dispatch_count = 0 AND (
+                            SELECT kind FROM first_ends
+                            WHERE first_ends.session_id = tasks.session_id
+                        ) = 'errored' THEN 'failed'
+                        WHEN dispatch_count = 0 AND (
+                            SELECT kind FROM first_ends
+                            WHERE first_ends.session_id = tasks.session_id
+                        ) = 'closed' THEN 'done'
+                        WHEN (
+                            SELECT kind FROM first_ends
+                            WHERE first_ends.session_id = tasks.session_id
+                        ) IN ('closed', 'errored') AND EXISTS (
+                            SELECT 1 FROM dispatch_tails
+                            WHERE dispatch_tails.session_id = tasks.session_id
+                                AND dispatch_tails.dispatch_count = 3
+                                AND dispatch_tails.error_count = 3
+                        ) THEN 'failed'
+                        WHEN (
+                            SELECT kind FROM first_ends
+                            WHERE first_ends.session_id = tasks.session_id
+                        ) IN ('closed', 'errored') THEN 'done'
+                        ELSE 'live'
+                    END
+                    "#,
+                )
+                .await?;
+            Ok(())
+        }
+
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .get_connection()
+                .execute_unprepared(
+                    r#"
+                    WITH first_ends AS (
+                        SELECT session_id, kind
+                        FROM (
+                            SELECT
+                                session_id,
+                                kind,
+                                ROW_NUMBER() OVER (
+                                    PARTITION BY session_id
+                                    ORDER BY id ASC
+                                ) AS position
+                            FROM agent_session_ends
+                        )
+                        WHERE position = 1
+                    )
+                    UPDATE tasks
+                    SET status = CASE
+                        WHEN (
+                            SELECT kind FROM first_ends
+                            WHERE first_ends.session_id = tasks.session_id
+                        ) = 'cancelled' THEN 'cancelled'
+                        WHEN (
+                            SELECT kind FROM first_ends
+                            WHERE first_ends.session_id = tasks.session_id
+                        ) = 'errored' THEN 'failed'
+                        WHEN (
+                            SELECT kind FROM first_ends
+                            WHERE first_ends.session_id = tasks.session_id
+                        ) = 'closed' AND error_count = 0 THEN 'done'
+                        WHEN error_count > 0 THEN 'failed'
+                        ELSE 'live'
+                    END
+                    "#,
+                )
+                .await?;
+            Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use sea_orm_migration::sea_orm::{
+            ConnectionTrait, Database as SeaDatabase, DatabaseConnection, DbBackend, Statement,
+        };
+
+        struct PreviousMigrator;
+
+        #[async_trait::async_trait]
+        impl MigratorTrait for PreviousMigrator {
+            fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+                vec![
+                    Box::new(super::super::m0001_baseline::Migration),
+                    Box::new(super::super::m0002_add_recordings_and_claims::Migration),
+                    Box::new(super::super::m0003_document_recordings_and_tab_ownership::Migration),
+                    Box::new(super::super::m0004_atomic_recording_payloads::Migration),
+                ]
+            }
+        }
+
+        async fn insert_legacy_task(
+            connection: &DatabaseConnection,
+            session_id: &str,
+            results: &[bool],
+            end_kind: Option<&str>,
+        ) -> Result<(), DbErr> {
+            for (index, is_error) in results.iter().enumerate() {
+                let result_meta = format!(
+                    r#"{{"isError":{},"cancelled":false}}"#,
+                    if *is_error { "true" } else { "false" }
+                );
+                connection
+                    .execute_unprepared(&format!(
+                        "INSERT INTO tool_dispatches (created_at, agent_id, slug, agent_label, session_id, tool_name, result_meta, has_screenshot) VALUES ({index}, 'agent', 'agent', 'Agent', '{session_id}', 'navigate', '{result_meta}', 0)"
+                    ))
+                    .await?;
+            }
+            if let Some(kind) = end_kind {
+                connection
+                    .execute_unprepared(&format!(
+                        "INSERT INTO agent_session_ends (created_at, session_id, kind) VALUES (100, '{session_id}', '{kind}')"
+                    ))
+                    .await?;
+            }
+            let error_count = results.iter().filter(|is_error| **is_error).count();
+            let old_status = match end_kind {
+                Some("cancelled") => "cancelled",
+                Some("errored") => "failed",
+                Some("closed") if error_count == 0 => "done",
+                _ if error_count > 0 => "failed",
+                _ => "live",
+            };
+            let ended_at = end_kind.map_or_else(|| "NULL".to_string(), |_| "100".to_string());
+            connection
+                .execute_unprepared(&format!(
+                    "INSERT INTO tasks (session_id, agent_id, slug, agent_label, title, started_at, ended_at, duration_ms, dispatch_count, tool_sequence_json, status, error_count, cursor_id, has_screenshots, updated_at) VALUES ('{session_id}', 'agent', 'agent', 'Agent', 'Session', 0, {ended_at}, 100, {}, '[]', '{old_status}', {error_count}, {}, 0, 100)",
+                    results.len(),
+                    results.len()
+                ))
+                .await?;
+            Ok(())
+        }
+
+        async fn status_of(
+            connection: &DatabaseConnection,
+            session_id: &str,
+        ) -> Result<String, DbErr> {
+            connection
+                .query_one(Statement::from_string(
+                    DbBackend::Sqlite,
+                    format!("SELECT status FROM tasks WHERE session_id = '{session_id}'"),
+                ))
+                .await?
+                .ok_or_else(|| DbErr::RecordNotFound(session_id.to_string()))?
+                .try_get("", "status")
+        }
+
+        #[tokio::test]
+        async fn upgrade_reclassifies_existing_task_statuses() -> anyhow::Result<()> {
+            let connection = SeaDatabase::connect("sqlite::memory:").await?;
+            PreviousMigrator::up(&connection, None).await?;
+            for (session_id, results, end_kind) in [
+                ("recovered", vec![true, false], Some("errored")),
+                ("two-errors", vec![false, true, true], Some("closed")),
+                (
+                    "three-errors",
+                    vec![false, true, true, true],
+                    Some("closed"),
+                ),
+                ("active", vec![true, true, true], None),
+                ("empty-closed", vec![], Some("closed")),
+                ("empty-errored", vec![], Some("errored")),
+                ("cancelled", vec![true, true, true], Some("cancelled")),
+            ] {
+                insert_legacy_task(&connection, session_id, &results, end_kind).await?;
+            }
+
+            assert_eq!(status_of(&connection, "recovered").await?, "failed");
+            assert_eq!(status_of(&connection, "two-errors").await?, "failed");
+            assert_eq!(status_of(&connection, "active").await?, "failed");
+
+            super::super::Migrator::up(&connection, None).await?;
+
+            for (session_id, status) in [
+                ("recovered", "done"),
+                ("two-errors", "done"),
+                ("three-errors", "failed"),
+                ("active", "live"),
+                ("empty-closed", "done"),
+                ("empty-errored", "failed"),
+                ("cancelled", "cancelled"),
+            ] {
+                assert_eq!(status_of(&connection, session_id).await?, status);
+            }
+            Ok(())
+        }
     }
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
@@ -203,7 +203,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 4);
+        assert_eq!(migrations.len(), 5);
         assert_eq!(
             migrations[0].try_get::<String>("", "version")?,
             "m0001_baseline"
@@ -219,6 +219,10 @@ mod tests {
         assert_eq!(
             migrations[3].try_get::<String>("", "version")?,
             "m0004_atomic_recording_payloads"
+        );
+        assert_eq!(
+            migrations[4].try_get::<String>("", "version")?,
+            "m0005_reclassify_task_status"
         );
         Ok(())
     }
@@ -349,7 +353,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 4);
+        assert_eq!(migrations.len(), 5);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- classify completed sessions as failed only when their final three non-cancelled tool calls all error
- preserve live and cancellation precedence, historical error counts, and the canonical API status consumed by Audit and Cockpit
- reclassify existing persisted session rows on upgrade so recovered historical work is corrected immediately

## Design
The Rust audit task projection now derives status from the ordered dispatch tail plus the first session end event. A one-time data migration applies the same rule to existing task rows, keeping server-side status filters and every UI consumer on one canonical value.

## Test plan
- [x] `cargo test -p claw-server-rust db::audit_log::tests --lib`
- [x] `cargo test -p claw-server-rust db --lib`
- [x] `bun run fmt:rust`
- [x] `bun run lint:rust`
- [x] `bun run test:rust`
- [x] `bun run codegen:claw-api:check`
- [x] `bun run test:claw-api-contract`
- [x] `bun run test`

## Baseline note
- `bun run check` currently stops on two pre-existing `noUnsafeOptionalChaining` errors in `apps/server/tests/lib/agents/acpx-runtime.test.ts`; this branch does not modify that file.