### PR TITLE
refactor(claw): move runtime file publisher into services

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/lib.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/lib.rs
@@ -8,7 +8,6 @@ pub mod error;
 pub mod identity;
 pub mod ids;
 pub mod runtime;
-pub mod runtime_file;
 pub mod services;
 pub mod storage;
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -146,7 +146,7 @@ async fn serve_with_boot_task(
         Some(proxy) => format!("http://127.0.0.1:{proxy}"),
         None => format!("http://{bound}"),
     };
-    tokio::spawn(async move {
+    runtime.spawn_task("runtime file publication", async move {
         claw_server_rust::services::runtime_file::write(&runtime_dir, &runtime_url).await;
     });
     let shutdown = runtime.state().shutdown;

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -147,7 +147,7 @@ async fn serve_with_boot_task(
         None => format!("http://{bound}"),
     };
     tokio::spawn(async move {
-        claw_server_rust::runtime_file::write_runtime_file(&runtime_dir, &runtime_url).await;
+        claw_server_rust::services::runtime_file::write(&runtime_dir, &runtime_url).await;
     });
     let shutdown = runtime.state().shutdown;
     runtime.spawn_task("MCP config integrity scan", boot_task);

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime_file.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime_file.rs
@@ -40,10 +40,10 @@ mod tests {
 
     #[tokio::test]
     async fn writes_url_and_cleans_up_temp() -> anyhow::Result<()> {
-        let dir = std::env::temp_dir().join(format!("claw-runtime-{}", std::process::id()));
-        let _ = fs::remove_dir_all(&dir).await;
+        let root = tempfile::tempdir()?;
+        let dir = root.path();
 
-        write_runtime_file(&dir, "http://127.0.0.1:9200").await;
+        write_runtime_file(dir, "http://127.0.0.1:9200").await;
 
         let raw = fs::read_to_string(dir.join("runtime.json")).await?;
         // Byte-for-byte identical to the archived TS writer's contract:
@@ -52,20 +52,30 @@ mod tests {
         // The atomic temp file must not survive the rename.
         assert!(!dir.join("runtime.json.tmp").exists());
 
-        fs::remove_dir_all(&dir).await?;
         Ok(())
     }
 
     #[tokio::test]
     async fn missing_parent_is_created() -> anyhow::Result<()> {
-        let base = std::env::temp_dir().join(format!("claw-runtime-nested-{}", std::process::id()));
-        let dir = base.join("state");
-        let _ = fs::remove_dir_all(&base).await;
+        let root = tempfile::tempdir()?;
+        let dir = root.path().join("state");
 
         write_runtime_file(&dir, "http://127.0.0.1:9201").await;
 
         assert!(dir.join("runtime.json").exists());
-        fs::remove_dir_all(&base).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn replaces_existing_runtime_file() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        let dir = root.path();
+
+        write_runtime_file(dir, "http://127.0.0.1:9200").await;
+        write_runtime_file(dir, "http://127.0.0.1:9201").await;
+
+        let raw = fs::read_to_string(dir.join("runtime.json")).await?;
+        assert_eq!(raw, "{\n  \"url\": \"http://127.0.0.1:9201\"\n}\n");
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/mod.rs
@@ -4,5 +4,6 @@ pub mod harness;
 pub mod profiles;
 pub mod recordings;
 pub mod replay;
+pub mod runtime_file;
 pub mod screenshots;
 pub mod sessions;

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/runtime_file.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/runtime_file.rs
@@ -13,7 +13,7 @@ const RUNTIME_FILE: &str = "runtime.json";
 
 /// Atomically write `{ "url": <url> }` to `<dir>/runtime.json`. Errors are
 /// logged and swallowed so this best-effort disk write can never fail boot.
-pub async fn write_runtime_file(dir: &Path, url: &str) {
+pub async fn write(dir: &Path, url: &str) {
     if let Err(err) = try_write(dir, url).await {
         warn!(
             error = %err,
@@ -43,7 +43,7 @@ mod tests {
         let root = tempfile::tempdir()?;
         let dir = root.path();
 
-        write_runtime_file(dir, "http://127.0.0.1:9200").await;
+        write(dir, "http://127.0.0.1:9200").await;
 
         let raw = fs::read_to_string(dir.join("runtime.json")).await?;
         // Byte-for-byte identical to the archived TS writer's contract:
@@ -60,7 +60,7 @@ mod tests {
         let root = tempfile::tempdir()?;
         let dir = root.path().join("state");
 
-        write_runtime_file(&dir, "http://127.0.0.1:9201").await;
+        write(&dir, "http://127.0.0.1:9201").await;
 
         assert!(dir.join("runtime.json").exists());
         Ok(())
@@ -71,8 +71,8 @@ mod tests {
         let root = tempfile::tempdir()?;
         let dir = root.path();
 
-        write_runtime_file(dir, "http://127.0.0.1:9200").await;
-        write_runtime_file(dir, "http://127.0.0.1:9201").await;
+        write(dir, "http://127.0.0.1:9200").await;
+        write(dir, "http://127.0.0.1:9201").await;
 
         let raw = fs::read_to_string(dir.join("runtime.json")).await?;
         assert_eq!(raw, "{\n  \"url\": \"http://127.0.0.1:9201\"\n}\n");

--- a/packages/browseros-agent/apps/claw-server-rust/tests/dependency_boundaries.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/dependency_boundaries.rs
@@ -275,13 +275,7 @@ fn classify(relative: &Path) -> Result<Layer, String> {
         [file]
             if matches!(
                 file.as_str(),
-                "clock.rs"
-                    | "config.rs"
-                    | "error.rs"
-                    | "ids.rs"
-                    | "lib.rs"
-                    | "runtime_file.rs"
-                    | "storage.rs"
+                "clock.rs" | "config.rs" | "error.rs" | "ids.rs" | "lib.rs" | "storage.rs"
             ) =>
         {
             Ok(Layer::Support)
@@ -318,8 +312,9 @@ fn crate_target(path: &[String], failures: &mut Vec<String>, display: &str) -> O
         "identity" => Some(Target::Identity),
         "app" | "runtime" => Some(Target::Composition),
         "AppState" => Some(Target::AppState),
-        "analytics" | "clock" | "config" | "error" | "ids" | "runtime_file" | "storage"
-        | "AppResult" => Some(Target::Support),
+        "analytics" | "clock" | "config" | "error" | "ids" | "storage" | "AppResult" => {
+            Some(Target::Support)
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- move the `runtime.json` publisher under the Rust Claw service layer and remove its root boundary exception
- preserve the exact filename, JSON bytes, atomic replacement, best-effort warning, and canonical URL selection
- register publication with `AppRuntime` so startup remains non-blocking while shutdown owns the task lifetime

## Design
Listener binding and advertised URL selection remain in `main.rs`, where the actual bound address and optional Chrome proxy port are available. The stateless service module owns only the runtime-file format and filesystem operation, while `AppRuntime::spawn_task` tracks the best-effort publication without awaiting it before `axum::serve`.

## Test plan
- [x] `bun run fmt:rust`
- [x] `cargo test -p claw-server-rust runtime_file`
- [x] `cargo test -p claw-server-rust --test dependency_boundaries`
- [x] `cargo test -p claw-server-rust --locked`
- [x] `bun run lint:rust`
- [x] `bun run test:rust`
