### PR TITLE
feat(claw): show total tokens consumed on Audit surfaces

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
@@ -10,7 +10,7 @@ import { useLocation, useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import type { TaskDetail } from '@/modules/api/audit.hooks'
 import { useReplayMetadata } from '@/modules/api/replay.hooks'
-import { formatDuration } from '@/screens/audit/audit.helpers'
+import { formatDuration, formatTokensFull } from '@/screens/audit/audit.helpers'
 import { AgentDot } from './AgentDot'
 import { StatusBadge } from './StatusBadge'
 
@@ -99,6 +99,21 @@ export function TaskHeader({ detail }: TaskHeaderProps) {
           <div>
             <dt className="text-ink-3">Tools</dt>
             <dd className="font-mono text-ink-2">{task.dispatchCount}</dd>
+          </div>
+          <div>
+            <dt className="text-ink-3">Tokens</dt>
+            <dd
+              className="font-mono text-ink-2"
+              title={
+                task.tokenUsage
+                  ? `${task.tokenUsage.inputTokenEstimate.toLocaleString()} in · ${task.tokenUsage.outputTokenEstimate.toLocaleString()} out`
+                  : undefined
+              }
+            >
+              {task.tokenUsage
+                ? formatTokensFull(task.tokenUsage.totalTokenEstimate)
+                : '—'}
+            </dd>
           </div>
           <div className="col-span-2">
             <dt className="text-ink-3">Site</dt>

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
@@ -69,6 +69,11 @@ const sampleTask: TaskSummary = {
   status: 'done',
   errorCount: 0,
   latestScreenshotId: 7,
+  tokenUsage: {
+    inputTokenEstimate: 4200,
+    outputTokenEstimate: 8100,
+    totalTokenEstimate: 12300,
+  },
 }
 
 describe('Audit screen', () => {
@@ -119,6 +124,24 @@ describe('Audit screen', () => {
     // DONE is the silent default in the editorial cockpit; the row's
     // identity carries state (LIVE / FAILED / STOPPED render inline dots), so
     // no visible 'Done' text renders here anymore.
+  })
+
+  it('renders a compact token total for measured sessions', () => {
+    dataOverride = { ...baseData, tasks: [sampleTask] }
+    const html = renderApp()
+    expect(html).toContain('12.3k')
+    // Exact count surfaces on hover.
+    expect(html).toContain('12,300 tokens')
+  })
+
+  it('renders an em dash for sessions without measured token usage', () => {
+    dataOverride = {
+      ...baseData,
+      tasks: [{ ...sampleTask, tokenUsage: undefined }],
+    }
+    const html = renderApp()
+    expect(html).toContain('Token usage not measured')
+    expect(html).not.toContain('12.3k')
   })
 
   it('renders the Load older tasks button when hasNextPage is true', () => {

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
@@ -75,9 +75,12 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
   {
     id: 'tokens',
     header: 'Tokens',
-    // Unmeasured sessions sort as 0 so they sink to the bottom of a token sort.
-    accessorFn: (t) => t.tokenUsage?.totalTokenEstimate ?? 0,
+    // Unmeasured sessions have no total; returning undefined + `sortUndefined: 'last'`
+    // sinks them to the bottom in BOTH sort directions instead of masquerading as 0
+    // (which would surface them first on an ascending sort).
+    accessorFn: (t) => t.tokenUsage?.totalTokenEstimate,
     cell: ({ row }) => <TokensCell task={row.original} />,
+    sortUndefined: 'last',
     sortingFn: 'basic',
     enableSorting: true,
   },

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
@@ -6,6 +6,8 @@ import {
   abbreviateSequence,
   formatDuration,
   formatRelative,
+  formatTokensCompact,
+  formatTokensFull,
 } from './audit.helpers'
 
 /**
@@ -71,6 +73,15 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
     enableSorting: true,
   },
   {
+    id: 'tokens',
+    header: 'Tokens',
+    // Unmeasured sessions sort as 0 so they sink to the bottom of a token sort.
+    accessorFn: (t) => t.tokenUsage?.totalTokenEstimate ?? 0,
+    cell: ({ row }) => <TokensCell task={row.original} />,
+    sortingFn: 'basic',
+    enableSorting: true,
+  },
+  {
     id: 'duration',
     header: 'Dur.',
     accessorFn: (t) => t.durationMs,
@@ -114,10 +125,38 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
  */
 export const NUMERIC_COLUMN_IDS = new Set([
   'tools',
+  'tokens',
   'duration',
   'when',
   'chevron',
 ])
+
+/**
+ * Session token consumption. Shows a compact total ("12.3k") with the exact
+ * count on hover; renders an em dash for legacy/unmeasured sessions whose wire
+ * payload omits `tokenUsage`.
+ */
+function TokensCell({ task }: { task: TaskSummary }) {
+  const usage = task.tokenUsage
+  if (!usage) {
+    return (
+      <span
+        className="font-mono text-[11.5px] text-ink-4 tabular-nums"
+        title="Token usage not measured for this session"
+      >
+        —
+      </span>
+    )
+  }
+  return (
+    <span
+      className="font-mono text-[11.5px] text-ink-2 tabular-nums"
+      title={`${formatTokensFull(usage.totalTokenEstimate)} tokens`}
+    >
+      {formatTokensCompact(usage.totalTokenEstimate)}
+    </span>
+  )
+}
 
 function LiveInlineChip() {
   return (

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.helpers.ts
@@ -73,6 +73,25 @@ export function formatDuration(ms: number): string {
   return `${hours}h ${remMin}m`
 }
 
+const TOKEN_COMPACT_FORMAT = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  compactDisplay: 'short',
+  maximumFractionDigits: 1,
+})
+const TOKEN_WHOLE_FORMAT = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0,
+})
+
+/** Compact token count for dense rows: `948`, `12.3k`, `1.2m` (lowercase suffix). */
+export function formatTokensCompact(tokens: number): string {
+  return TOKEN_COMPACT_FORMAT.format(Math.max(0, tokens)).toLowerCase()
+}
+
+/** Grouped exact token count for the detail card: `12,345`. */
+export function formatTokensFull(tokens: number): string {
+  return TOKEN_WHOLE_FORMAT.format(Math.max(0, tokens))
+}
+
 /**
  * Short trail of tool names with an ellipsis when the sequence is
  * longer than `cap`. Mirrors the abbreviated trail shown on each

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.test.tsx
@@ -56,6 +56,11 @@ const sampleTask: TaskDetail = {
     status: 'done',
     errorCount: 0,
     latestScreenshotId: 20,
+    tokenUsage: {
+      inputTokenEstimate: 4200,
+      outputTokenEstimate: 8100,
+      totalTokenEstimate: 12300,
+    },
   },
   dispatches: [
     {
@@ -117,6 +122,26 @@ describe('TaskDetailPage', () => {
     expect(html).toContain('Screenshots')
     expect(html).toContain('Open final URL')
     expect(html).not.toContain('/audit/screenshot/2')
+  })
+
+  it('renders the total token consumption on the summary card', () => {
+    dataOverride = { ...baseData, detail: sampleTask }
+    const html = render()
+    expect(html).toContain('Tokens')
+    expect(html).toContain('12,300')
+  })
+
+  it('renders an em dash when the session has no measured token usage', () => {
+    dataOverride = {
+      ...baseData,
+      detail: {
+        ...sampleTask,
+        session: { ...sampleTask.session, tokenUsage: undefined },
+      },
+    }
+    const html = render()
+    expect(html).toContain('Tokens')
+    expect(html).not.toContain('12,300')
   })
 
   it('renders no-screenshots placeholder when there are none', () => {

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/sessions.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/sessions.rs
@@ -23,7 +23,7 @@ use axum::{
 };
 use claw_api::models::{
     CancelSessionResponse, Dispatch, SessionBrowserTab, SessionDetail, SessionList, SessionStatus,
-    SessionSummary,
+    SessionSummary, SessionTokenUsage,
 };
 use std::{collections::HashMap, sync::Arc};
 
@@ -196,6 +196,7 @@ async fn contract_summary(task: TaskSummary, live: Option<&Arc<Session>>) -> Ses
         Some(session) => session.label().await,
         None => task.title.clone(),
     };
+    let token_usage = contract_token_usage(&task);
     let mut summary = SessionSummary::new(
         task.session_id,
         task.slug,
@@ -214,6 +215,7 @@ async fn contract_summary(task: TaskSummary, live: Option<&Arc<Session>>) -> Ses
     summary.site = task.site;
     summary.ended_at = task.ended_at;
     summary.latest_screenshot_id = task.last_screenshot_dispatch_id;
+    summary.token_usage = token_usage;
     summary
 }
 
@@ -227,6 +229,7 @@ fn contract_live_projection(projection: LiveSessionProjection) -> SessionSummary
         name,
         live,
     } = projection;
+    let token_usage = contract_token_usage(&task);
     let mut summary = SessionSummary::new(
         task.session_id,
         task.slug,
@@ -245,8 +248,28 @@ fn contract_live_projection(projection: LiveSessionProjection) -> SessionSummary
     summary.site = task.site;
     summary.ended_at = task.ended_at;
     summary.latest_screenshot_id = task.last_screenshot_dispatch_id;
+    summary.token_usage = token_usage;
     summary.live = Some(Box::new(contract_live_state(live)));
     summary
+}
+
+/// Builds the session's token-consumption DTO from the materialized totals, clamped into the
+/// JavaScript-safe range the contract promises. Returns `None` for legacy/unmeasured sessions so
+/// the wire omits the field entirely instead of reporting a misleading zero.
+fn contract_token_usage(task: &TaskSummary) -> Option<Box<SessionTokenUsage>> {
+    if !task.tokens_measured {
+        return None;
+    }
+    let input = js_safe_token_estimate(task.tool_input_token_estimate);
+    let output = js_safe_token_estimate(task.tool_output_token_estimate);
+    let total = js_safe_token_estimate(input.saturating_add(output));
+    Some(Box::new(SessionTokenUsage::new(input, output, total)))
+}
+
+/// Clamps a token total into `[0, 2^53-1]` so it survives a round trip through a JavaScript client.
+fn js_safe_token_estimate(value: i64) -> i64 {
+    const JS_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
+    value.clamp(0, JS_SAFE_INTEGER)
 }
 
 fn contract_live_state(projection: LiveStateProjection) -> claw_api::models::LiveSessionState {

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/audit_log.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/audit_log.rs
@@ -7,6 +7,7 @@ use crate::{
             prelude::{AgentSessionEnds, AgentSessionStarts, Tasks, ToolDispatches},
             tasks, tool_dispatches,
         },
+        session_efficiency_stats::ELIGIBLE_TOKEN_ESTIMATOR_VERSION,
     },
     error::AppResult,
     ids::DispatchId,
@@ -141,6 +142,12 @@ pub struct TaskSummary {
     pub last_screenshot_dispatch_id: Option<i64>,
     pub cursor_id: i64,
     pub has_screenshots: bool,
+    /// Session totals of the per-dispatch semantic token estimates, trustworthy only when
+    /// `tokens_measured`. `tokens_measured` is true iff the session has dispatches and every one
+    /// carries token-estimator v1; legacy/unmeasured sessions leave it false and the sums at 0.
+    pub tool_input_token_estimate: i64,
+    pub tool_output_token_estimate: i64,
+    pub tokens_measured: bool,
 }
 
 impl From<tasks::Model> for TaskSummary {
@@ -164,6 +171,9 @@ impl From<tasks::Model> for TaskSummary {
             last_screenshot_dispatch_id: model.last_screenshot_dispatch_id,
             cursor_id: model.cursor_id,
             has_screenshots: model.has_screenshots,
+            tool_input_token_estimate: model.tool_input_token_estimate,
+            tool_output_token_estimate: model.tool_output_token_estimate,
+            tokens_measured: model.tokens_measured,
         }
     }
 }
@@ -600,6 +610,19 @@ async fn recompute_task<C: ConnectionTrait>(conn: &C, session_id: &str) -> AppRe
         .map(|row| row.id)
         .collect();
     let last_screenshot_dispatch_id = screenshot_ids.last().copied();
+    // Materialize the live-updating token totals so the audit surfaces read one field instead of
+    // re-summing dispatches. `tokens_measured` matches the efficiency projection's eligibility, so a
+    // legacy/unmeasured session reports absent rather than a misleading zero downstream.
+    let tokens_measured = !dispatches.is_empty()
+        && dispatches
+            .iter()
+            .all(|row| row.token_estimator_version == ELIGIBLE_TOKEN_ESTIMATOR_VERSION);
+    let tool_input_token_estimate = dispatches.iter().fold(0i64, |total, row| {
+        total.saturating_add(row.tool_input_token_estimate.max(0))
+    });
+    let tool_output_token_estimate = dispatches.iter().fold(0i64, |total, row| {
+        total.saturating_add(row.tool_output_token_estimate.max(0))
+    });
     Tasks::insert(tasks::ActiveModel {
         session_id: Set(session_id.to_owned()),
         agent_id: Set(agent_id),
@@ -617,6 +640,9 @@ async fn recompute_task<C: ConnectionTrait>(conn: &C, session_id: &str) -> AppRe
         last_screenshot_dispatch_id: Set(last_screenshot_dispatch_id),
         cursor_id: Set(cursor_id),
         has_screenshots: Set(!screenshot_ids.is_empty()),
+        tool_input_token_estimate: Set(tool_input_token_estimate),
+        tool_output_token_estimate: Set(tool_output_token_estimate),
+        tokens_measured: Set(tokens_measured),
         updated_at: Set(now_epoch_ms()),
     })
     .on_conflict(
@@ -637,6 +663,9 @@ async fn recompute_task<C: ConnectionTrait>(conn: &C, session_id: &str) -> AppRe
                 tasks::Column::LastScreenshotDispatchId,
                 tasks::Column::CursorId,
                 tasks::Column::HasScreenshots,
+                tasks::Column::ToolInputTokenEstimate,
+                tasks::Column::ToolOutputTokenEstimate,
+                tasks::Column::TokensMeasured,
                 tasks::Column::UpdatedAt,
             ])
             .to_owned(),
@@ -867,6 +896,45 @@ mod tests {
             .await?
             .ok_or_else(|| anyhow::anyhow!("task missing"))?;
         assert_eq!(task.dispatch_count, 2);
+        assert!(task.tokens_measured);
+        assert_eq!(task.tool_input_token_estimate, 68);
+        assert_eq!(task.tool_output_token_estimate, 112);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn task_summary_reports_unmeasured_for_any_legacy_dispatch() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = AuditLog::new(Database::open(dir.path().join(DATABASE_FILENAME)).await?);
+        // One v1 dispatch alone measures cleanly.
+        audit
+            .record_tool_dispatch(dispatch("solo-v1", "https://one.example.com", false))
+            .await?;
+        let measured = audit
+            .get_task_summary("solo-v1")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("task missing"))?;
+        assert!(measured.tokens_measured);
+        assert_eq!(measured.tool_input_token_estimate, 11);
+        assert_eq!(measured.tool_output_token_estimate, 22);
+
+        // A single unmeasured (v0) dispatch taints the whole session, and a negative per-dispatch
+        // estimate never drags the materialized total below zero.
+        audit
+            .record_tool_dispatch(dispatch("mixed", "https://one.example.com", false))
+            .await?;
+        let mut legacy = dispatch("mixed", "https://two.example.com", false);
+        legacy.token_estimator_version = 0;
+        legacy.tool_input_token_estimate = -5;
+        legacy.tool_output_token_estimate = 7;
+        audit.record_tool_dispatch(legacy).await?;
+        let mixed = audit
+            .get_task_summary("mixed")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("mixed task missing"))?;
+        assert!(!mixed.tokens_measured);
+        assert_eq!(mixed.tool_input_token_estimate, 11);
+        assert_eq!(mixed.tool_output_token_estimate, 29);
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/entities/tasks.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/entities/tasks.rs
@@ -20,6 +20,12 @@ pub struct Model {
     pub last_screenshot_dispatch_id: Option<i64>,
     pub cursor_id: i64,
     pub has_screenshots: bool,
+    /// Session totals of the per-dispatch semantic token estimates. Meaningful only when
+    /// `tokens_measured`; otherwise the session predates measurement and these are 0.
+    pub tool_input_token_estimate: i64,
+    pub tool_output_token_estimate: i64,
+    /// True iff the session has dispatches and every one carries token-estimator v1.
+    pub tokens_measured: bool,
     pub updated_at: i64,
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
@@ -14,7 +14,212 @@ impl MigratorTrait for Migrator {
             Box::new(m0005_reclassify_task_status::Migration),
             Box::new(m0006_add_tool_token_estimates::Migration),
             Box::new(m0007_add_session_efficiency_stats::Migration),
+            Box::new(m0008_add_task_token_estimates::Migration),
         ]
+    }
+}
+
+mod m0008_add_task_token_estimates {
+    use super::*;
+
+    pub struct Migration;
+
+    impl MigrationName for Migration {
+        fn name(&self) -> &str {
+            "m0008_add_task_token_estimates"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for Migration {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            // Zero/false defaults preserve existing rows; the backfill below refines them.
+            for column in ["tool_input_token_estimate", "tool_output_token_estimate"] {
+                if !manager.has_column("tasks", column).await? {
+                    manager
+                        .alter_table(
+                            Table::alter()
+                                .table(Alias::new("tasks"))
+                                .add_column(
+                                    ColumnDef::new(Alias::new(column))
+                                        .big_integer()
+                                        .not_null()
+                                        .default(0),
+                                )
+                                .to_owned(),
+                        )
+                        .await?;
+                }
+            }
+            if !manager.has_column("tasks", "tokens_measured").await? {
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(Alias::new("tasks"))
+                            .add_column(
+                                ColumnDef::new(Alias::new("tokens_measured"))
+                                    .boolean()
+                                    .not_null()
+                                    .default(false),
+                            )
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+            // Backfill the materialized per-session totals from the source dispatches. `tokens_measured`
+            // mirrors the efficiency projection's eligibility: a session counts only when it has
+            // dispatches and every one carries token-estimator v1 (0 is legacy/unmeasured). The version
+            // literal is the value frozen at this migration, not a runtime constant.
+            manager
+                .get_connection()
+                .execute_unprepared(
+                    r#"
+                    UPDATE tasks SET
+                        tool_input_token_estimate = COALESCE((
+                            SELECT SUM(MAX(d.tool_input_token_estimate, 0))
+                            FROM tool_dispatches d
+                            WHERE d.session_id = tasks.session_id
+                        ), 0),
+                        tool_output_token_estimate = COALESCE((
+                            SELECT SUM(MAX(d.tool_output_token_estimate, 0))
+                            FROM tool_dispatches d
+                            WHERE d.session_id = tasks.session_id
+                        ), 0),
+                        tokens_measured = CASE
+                            WHEN EXISTS (
+                                SELECT 1 FROM tool_dispatches d
+                                WHERE d.session_id = tasks.session_id
+                            )
+                            AND NOT EXISTS (
+                                SELECT 1 FROM tool_dispatches d
+                                WHERE d.session_id = tasks.session_id
+                                  AND d.token_estimator_version != 1
+                            )
+                            THEN 1 ELSE 0 END
+                    "#,
+                )
+                .await?;
+            Ok(())
+        }
+
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            for column in [
+                "tokens_measured",
+                "tool_output_token_estimate",
+                "tool_input_token_estimate",
+            ] {
+                if manager.has_column("tasks", column).await? {
+                    manager
+                        .alter_table(
+                            Table::alter()
+                                .table(Alias::new("tasks"))
+                                .drop_column(Alias::new(column))
+                                .to_owned(),
+                        )
+                        .await?;
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use sea_orm_migration::sea_orm::{
+            ConnectionTrait, Database as SeaDatabase, DatabaseConnection, DbBackend, Statement,
+        };
+
+        struct PreviousMigrator;
+
+        #[async_trait::async_trait]
+        impl MigratorTrait for PreviousMigrator {
+            fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+                vec![
+                    Box::new(super::super::m0001_baseline::Migration),
+                    Box::new(super::super::m0002_add_recordings_and_claims::Migration),
+                    Box::new(super::super::m0003_document_recordings_and_tab_ownership::Migration),
+                    Box::new(super::super::m0004_atomic_recording_payloads::Migration),
+                    Box::new(super::super::m0005_reclassify_task_status::Migration),
+                    Box::new(super::super::m0006_add_tool_token_estimates::Migration),
+                    Box::new(super::super::m0007_add_session_efficiency_stats::Migration),
+                ]
+            }
+        }
+
+        async fn insert_dispatch(
+            conn: &DatabaseConnection,
+            session_id: &str,
+            input_tokens: i64,
+            output_tokens: i64,
+            version: i64,
+        ) -> Result<(), DbErr> {
+            conn.execute_unprepared(&format!(
+                "INSERT INTO tool_dispatches (created_at, agent_id, slug, agent_label, session_id, tool_name, has_screenshot, tool_input_token_estimate, tool_output_token_estimate, token_estimator_version) VALUES (0, 'agent', 'agent', 'Agent', '{session_id}', 'navigate', 0, {input_tokens}, {output_tokens}, {version})"
+            ))
+            .await?;
+            Ok(())
+        }
+
+        async fn insert_task(
+            conn: &DatabaseConnection,
+            session_id: &str,
+            dispatch_count: i64,
+        ) -> Result<(), DbErr> {
+            conn.execute_unprepared(&format!(
+                "INSERT INTO tasks (session_id, agent_id, slug, agent_label, title, started_at, duration_ms, dispatch_count, tool_sequence_json, status, error_count, cursor_id, has_screenshots, updated_at) VALUES ('{session_id}', 'agent', 'agent', 'Agent', 'Session', 0, 0, {dispatch_count}, '[]', 'done', 0, 0, 0, 0)"
+            ))
+            .await?;
+            Ok(())
+        }
+
+        async fn token_row(
+            conn: &DatabaseConnection,
+            session_id: &str,
+        ) -> Result<(i64, i64, bool), DbErr> {
+            let row = conn
+                .query_one(Statement::from_string(
+                    DbBackend::Sqlite,
+                    format!(
+                        "SELECT tool_input_token_estimate, tool_output_token_estimate, tokens_measured FROM tasks WHERE session_id = '{session_id}'"
+                    ),
+                ))
+                .await?
+                .ok_or_else(|| DbErr::RecordNotFound(session_id.to_string()))?;
+            Ok((
+                row.try_get("", "tool_input_token_estimate")?,
+                row.try_get("", "tool_output_token_estimate")?,
+                row.try_get("", "tokens_measured")?,
+            ))
+        }
+
+        #[tokio::test]
+        async fn backfill_sums_tokens_and_marks_only_all_v1_sessions() -> anyhow::Result<()> {
+            let conn = SeaDatabase::connect("sqlite::memory:").await?;
+            PreviousMigrator::up(&conn, None).await?;
+
+            insert_task(&conn, "measured", 2).await?;
+            insert_dispatch(&conn, "measured", 10, 100, 1).await?;
+            insert_dispatch(&conn, "measured", 20, 200, 1).await?;
+
+            insert_task(&conn, "legacy", 1).await?;
+            insert_dispatch(&conn, "legacy", 0, 0, 0).await?;
+
+            // One legacy dispatch taints the session, but the sums still count every dispatch.
+            insert_task(&conn, "mixed", 2).await?;
+            insert_dispatch(&conn, "mixed", 5, 5, 1).await?;
+            insert_dispatch(&conn, "mixed", 5, 5, 0).await?;
+
+            insert_task(&conn, "empty", 0).await?;
+
+            super::super::Migrator::up(&conn, None).await?;
+
+            assert_eq!(token_row(&conn, "measured").await?, (30, 300, true));
+            assert_eq!(token_row(&conn, "legacy").await?, (0, 0, false));
+            assert_eq!(token_row(&conn, "mixed").await?, (10, 10, false));
+            assert_eq!(token_row(&conn, "empty").await?, (0, 0, false));
+            Ok(())
+        }
     }
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
@@ -245,6 +245,27 @@ mod tests {
             Some(1)
         );
 
+        let task_columns = db
+            .connection()
+            .query_all(Statement::from_string(
+                DbBackend::Sqlite,
+                "PRAGMA table_info(tasks)".to_string(),
+            ))
+            .await?
+            .into_iter()
+            .map(|row| row.try_get::<String>("", "name"))
+            .collect::<Result<HashSet<_>, sea_orm::DbErr>>()?;
+        for column in [
+            "tool_input_token_estimate",
+            "tool_output_token_estimate",
+            "tokens_measured",
+        ] {
+            assert!(
+                task_columns.contains(column),
+                "missing tasks column {column}"
+            );
+        }
+
         let migrations = db
             .connection()
             .query_all(Statement::from_string(
@@ -252,7 +273,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 7);
+        assert_eq!(migrations.len(), 8);
         assert_eq!(
             migrations[0].try_get::<String>("", "version")?,
             "m0001_baseline"
@@ -322,7 +343,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations ORDER BY version".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 7);
+        assert_eq!(migrations.len(), 8);
         assert_eq!(
             migrations
                 .iter()
@@ -345,7 +366,7 @@ mod tests {
             .await?
             .ok_or_else(|| anyhow::anyhow!("migration count missing"))?
             .try_get::<i64>("", "count")?;
-        assert_eq!(migration_count, 7);
+        assert_eq!(migration_count, 8);
         Ok(())
     }
 
@@ -481,7 +502,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 7);
+        assert_eq!(migrations.len(), 8);
         Ok(())
     }
 

--- a/packages/browseros-agent/contracts/claw-api/fixtures/session-detail.json
+++ b/packages/browseros-agent/contracts/claw-api/fixtures/session-detail.json
@@ -10,6 +10,11 @@
     "toolSequence": ["navigate", "snapshot"],
     "status": "live",
     "errorCount": 0,
+    "tokenUsage": {
+      "inputTokenEstimate": 120,
+      "outputTokenEstimate": 480,
+      "totalTokenEstimate": 600
+    },
     "latestScreenshotId": 42
   },
   "dispatches": [

--- a/packages/browseros-agent/contracts/claw-api/fixtures/session-list.json
+++ b/packages/browseros-agent/contracts/claw-api/fixtures/session-list.json
@@ -14,6 +14,11 @@
       "toolSequence": ["navigate", "snapshot"],
       "status": "live",
       "errorCount": 0,
+      "tokenUsage": {
+        "inputTokenEstimate": 120,
+        "outputTokenEstimate": 480,
+        "totalTokenEstimate": 600
+      },
       "live": {
         "state": "active",
         "browserTabs": [

--- a/packages/browseros-agent/contracts/claw-api/openapi.yaml
+++ b/packages/browseros-agent/contracts/claw-api/openapi.yaml
@@ -100,6 +100,8 @@ components:
       $ref: ./schemas/sessions.yaml#/LiveSessionState
     SessionBrowserTab:
       $ref: ./schemas/sessions.yaml#/SessionBrowserTab
+    SessionTokenUsage:
+      $ref: ./schemas/sessions.yaml#/SessionTokenUsage
     SessionSummary:
       $ref: ./schemas/sessions.yaml#/SessionSummary
     SessionList:

--- a/packages/browseros-agent/contracts/claw-api/schemas/sessions.yaml
+++ b/packages/browseros-agent/contracts/claw-api/schemas/sessions.yaml
@@ -54,6 +54,32 @@ LiveSessionState:
       type: array
       items:
         $ref: '#/SessionBrowserTab'
+SessionTokenUsage:
+  type: object
+  additionalProperties: false
+  required: [inputTokenEstimate, outputTokenEstimate, totalTokenEstimate]
+  description: >-
+    Estimated token consumption of a session's MCP tool traffic, summed across
+    every dispatch. Totals are JavaScript-safe integers.
+  properties:
+    inputTokenEstimate:
+      type: integer
+      format: int64
+      minimum: 0
+      maximum: 9007199254740991
+      description: Estimated tokens for tool inputs (name + compact arguments), summed across dispatches.
+    outputTokenEstimate:
+      type: integer
+      format: int64
+      minimum: 0
+      maximum: 9007199254740991
+      description: Estimated tokens for tool outputs (result content), summed across dispatches.
+    totalTokenEstimate:
+      type: integer
+      format: int64
+      minimum: 0
+      maximum: 9007199254740991
+      description: inputTokenEstimate + outputTokenEstimate — the session's total estimated token consumption.
 SessionSummary:
   type: object
   additionalProperties: false
@@ -113,6 +139,14 @@ SessionSummary:
       type: integer
       format: int64
       minimum: 1
+    tokenUsage:
+      allOf:
+        - $ref: '#/SessionTokenUsage'
+      description: >-
+        Estimated token consumption of this session's tool traffic, summed
+        across all dispatches and refreshed live as they land. Present only when
+        the session has dispatches and every one carries token-estimator v1;
+        absent for legacy or otherwise unmeasured sessions.
     live:
       allOf:
         - $ref: '#/LiveSessionState'

--- a/packages/browseros-agent/contracts/claw-api/tests/schema.test.ts
+++ b/packages/browseros-agent/contracts/claw-api/tests/schema.test.ts
@@ -96,6 +96,26 @@ describe('session visual API schema', () => {
     expect(schemas.SessionSummary?.properties).not.toHaveProperty(
       retiredLatestScreenshotKey,
     )
+    // Optional token-consumption totals: present on the summary shape, never required
+    // (absent for legacy/unmeasured sessions), each a JavaScript-safe unsigned integer.
+    const unsignedInteger = {
+      type: 'integer',
+      format: 'int64',
+      minimum: 0,
+      maximum: 9_007_199_254_740_991,
+    }
+    expect(schemas.SessionSummary?.properties).toHaveProperty('tokenUsage')
+    expect(schemas.SessionSummary?.required ?? []).not.toContain('tokenUsage')
+    expect(schemas.SessionTokenUsage?.required).toEqual([
+      'inputTokenEstimate',
+      'outputTokenEstimate',
+      'totalTokenEstimate',
+    ])
+    expect(schemas.SessionTokenUsage?.properties).toMatchObject({
+      inputTokenEstimate: unsignedInteger,
+      outputTokenEstimate: unsignedInteger,
+      totalTokenEstimate: unsignedInteger,
+    })
     expect(schemas.SessionBrowserTab?.properties).not.toHaveProperty(
       retiredPreviewTimestampKey,
     )

--- a/packages/browseros-agent/crates/claw-api/src/generated/sessions.rs
+++ b/packages/browseros-agent/crates/claw-api/src/generated/sessions.rs
@@ -247,6 +247,9 @@ pub struct SessionSummary {
     pub error_count: i64,
     #[serde(rename = "latestScreenshotId", skip_serializing_if = "Option::is_none")]
     pub latest_screenshot_id: Option<i64>,
+    /// Estimated token consumption of this session's tool traffic, summed across all dispatches and refreshed live as they land. Present only when the session has dispatches and every one carries token-estimator v1; absent for legacy or otherwise unmeasured sessions.
+    #[serde(rename = "tokenUsage", skip_serializing_if = "Option::is_none")]
+    pub token_usage: Option<Box<models::SessionTokenUsage>>,
     /// Present only on summaries returned by an explicit `status=live` list query.
     #[serde(rename = "live", skip_serializing_if = "Option::is_none")]
     pub live: Option<Box<models::LiveSessionState>>,
@@ -282,7 +285,37 @@ impl SessionSummary {
             status,
             error_count,
             latest_screenshot_id: None,
+            token_usage: None,
             live: None,
+        }
+    }
+}
+
+/// SessionTokenUsage : Estimated token consumption of a session's MCP tool traffic, summed across every dispatch. Totals are JavaScript-safe integers.
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionTokenUsage {
+    /// Estimated tokens for tool inputs (name + compact arguments), summed across dispatches.
+    #[serde(rename = "inputTokenEstimate")]
+    pub input_token_estimate: i64,
+    /// Estimated tokens for tool outputs (result content), summed across dispatches.
+    #[serde(rename = "outputTokenEstimate")]
+    pub output_token_estimate: i64,
+    /// inputTokenEstimate + outputTokenEstimate — the session's total estimated token consumption.
+    #[serde(rename = "totalTokenEstimate")]
+    pub total_token_estimate: i64,
+}
+
+impl SessionTokenUsage {
+    /// Estimated token consumption of a session's MCP tool traffic, summed across every dispatch. Totals are JavaScript-safe integers.
+    pub fn new(
+        input_token_estimate: i64,
+        output_token_estimate: i64,
+        total_token_estimate: i64,
+    ) -> SessionTokenUsage {
+        SessionTokenUsage {
+            input_token_estimate,
+            output_token_estimate,
+            total_token_estimate,
         }
     }
 }

--- a/packages/browseros-agent/packages/claw-api-client/src/generated/openapi.ts
+++ b/packages/browseros-agent/packages/claw-api-client/src/generated/openapi.ts
@@ -400,6 +400,24 @@ export interface components {
       toolCount: number
       recentTools: components['schemas']['ToolEvent'][]
     }
+    /** @description Estimated token consumption of a session's MCP tool traffic, summed across every dispatch. Totals are JavaScript-safe integers. */
+    SessionTokenUsage: {
+      /**
+       * Format: int64
+       * @description Estimated tokens for tool inputs (name + compact arguments), summed across dispatches.
+       */
+      inputTokenEstimate: number
+      /**
+       * Format: int64
+       * @description Estimated tokens for tool outputs (result content), summed across dispatches.
+       */
+      outputTokenEstimate: number
+      /**
+       * Format: int64
+       * @description inputTokenEstimate + outputTokenEstimate — the session's total estimated token consumption.
+       */
+      totalTokenEstimate: number
+    }
     SessionSummary: {
       sessionId: string
       profileId?: string
@@ -423,6 +441,8 @@ export interface components {
       errorCount: number
       /** Format: int64 */
       latestScreenshotId?: number
+      /** @description Estimated token consumption of this session's tool traffic, summed across all dispatches and refreshed live as they land. Present only when the session has dispatches and every one carries token-estimator v1; absent for legacy or otherwise unmeasured sessions. */
+      tokenUsage?: components['schemas']['SessionTokenUsage']
       /** @description Present only on summaries returned by an explicit `status=live` list query. */
       live?: components['schemas']['LiveSessionState']
     }

--- a/packages/browseros-agent/packages/claw-api/src/generated/models/sessions.ts
+++ b/packages/browseros-agent/packages/claw-api/src/generated/models/sessions.ts
@@ -315,11 +315,43 @@ export interface SessionSummary {
      */
     latestScreenshotId?: number;
     /**
+     * Estimated token consumption of this session's tool traffic, summed across all dispatches and refreshed live as they land. Present only when the session has dispatches and every one carries token-estimator v1; absent for legacy or otherwise unmeasured sessions.
+     * @type {SessionTokenUsage}
+     * @memberof SessionSummary
+     */
+    tokenUsage?: SessionTokenUsage;
+    /**
      * Present only on summaries returned by an explicit `status=live` list query.
      * @type {LiveSessionState}
      * @memberof SessionSummary
      */
     live?: LiveSessionState;
+}
+
+/**
+ * Estimated token consumption of a session's MCP tool traffic, summed across every dispatch. Totals are JavaScript-safe integers.
+ * @export
+ * @interface SessionTokenUsage
+ */
+export interface SessionTokenUsage {
+    /**
+     * Estimated tokens for tool inputs (name + compact arguments), summed across dispatches.
+     * @type {number}
+     * @memberof SessionTokenUsage
+     */
+    inputTokenEstimate: number;
+    /**
+     * Estimated tokens for tool outputs (result content), summed across dispatches.
+     * @type {number}
+     * @memberof SessionTokenUsage
+     */
+    outputTokenEstimate: number;
+    /**
+     * inputTokenEstimate + outputTokenEstimate — the session's total estimated token consumption.
+     * @type {number}
+     * @memberof SessionTokenUsage
+     */
+    totalTokenEstimate: number;
 }
 
 /**


### PR DESCRIPTION
## What

Show **total tokens consumed** on both Audit surfaces:

- **Session list** — a compact `Tokens` column beside `Actions` (e.g. `12.3k`, exact count on hover), right-aligned to preserve the table's numeric density.
- **Session detail** — a `Tokens` entry on the summary card beside `Tools` (grouped exact count, e.g. `12,345`; input/output breakdown on hover).

<img><!-- screenshots: Audit session-detail card + session-list row --></img>

## One shared meaning

**Total tokens consumed** = Σ over the session's dispatches of `inputTokenEstimate + outputTokenEstimate` — the semantic MCP tool traffic in+out. This is the same quantity as the cockpit efficiency band's `browserClawTokenEstimate` (screenshot-baseline is a what-if metric and is deliberately excluded). Both surfaces read the **one** field.

## How it flows (canonical OpenAPI path)

Per-dispatch token estimates already persist on `tool_dispatches`. This change:

1. **Materializes** the per-session totals onto the `tasks` table (migration `m0008`, backfilled from existing dispatches). `recompute_task` refreshes them on **every** dispatch, so the total is **live** — not dependent on the post-teardown `session_efficiency_stats` projection.
2. Exposes an **optional** `SessionSummary.tokenUsage { inputTokenEstimate, outputTokenEstimate, totalTokenEstimate }` (JS-safe integers) in the hand-authored OpenAPI spec, regenerated into the Rust/TS DTOs + typed client via `bun run codegen:claw-api`.
3. Maps domain → DTO in `contract_summary` **and** the `status=live` `contract_live_projection` path.

## Coherent states

| State | Behavior |
|---|---|
| Live | running total, recomputed each dispatch |
| Ended | final materialized total |
| Legacy / unmeasured | `tokenUsage` **absent** on the wire → UI shows `—` |
| Loading / error | existing skeleton / error states (unchanged) |

A session is *measured* iff it has ≥1 dispatch and every dispatch carries token-estimator v1 — mirroring the durable efficiency projection's eligibility, so the two never disagree.

## Tests

- **Backend**: `recompute_task` sums + `tokens_measured` (measured, mixed-legacy, non-negative clamp); `m0008` backfill (all-v1 vs legacy vs mixed vs dispatch-less); fresh-schema + migration-count bookkeeping updated.
- **Contract**: `schema.test.ts` locks `SessionTokenUsage` shape + optional `tokenUsage`; shared fixtures exercise present + absent; Rust `contract_fixtures` round-trips.
- **UI**: list compact render + em dash; detail card render + em dash.

Verified: `cargo test -p claw-server-rust` (227 pass) & `-p claw-api`, `cargo fmt`/`clippy`, `bun run codegen:claw-api:check`, `bun run test:claw-api-contract`, `bun run typecheck` (all packages), the Audit/TaskDetail suites, and biome on all touched files.

> Notes (both pre-existing, unrelated to this change):
> - `bun run check` reports 2 biome errors in `apps/server/tests/lib/agents/acpx-runtime.test.ts` — present verbatim on `main`.
> - The `claw-app` bun-test wrapper shows non-deterministic `@/`-alias module-resolution failures across many untouched files (e.g. `@/components/audit/ScreenshotLightbox`); it reproduces *worse* on the parent commit (31/40 vs 19/40). `bun run typecheck` (same tsconfig `paths`) is deterministic and green, and the Audit/TaskDetail suites pass when the runner resolves the alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
