### PR TITLE
fix(agent): reconcile aliased skill targets by identity

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
@@ -166,6 +166,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
         fs::read_to_string(shared_skill.join("SKILL.md"))?,
         "managed skill v1\n"
     );
+    let shared_target_path = fs::canonicalize(parent(&shared_skill)?)?.join("browserclaw");
     let skill_manifest_path = browserclaw_dir.join("harness-integrations/skills.json");
     let skill_manifest: Value = serde_json::from_str(&fs::read_to_string(&skill_manifest_path)?)?;
     let shared_record = skill_manifest["targets"]
@@ -173,7 +174,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
         .and_then(|targets| {
             targets
                 .iter()
-                .find(|target| target["targetPath"] == shared_skill.display().to_string())
+                .find(|target| target["targetPath"] == shared_target_path.display().to_string())
         })
         .ok_or_else(|| anyhow::anyhow!("missing shared skill target"))?;
     assert_eq!(shared_record["consumers"], json!(["codex", "zed"]));
@@ -336,7 +337,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
         .and_then(|targets| {
             targets
                 .iter()
-                .find(|target| target["targetPath"] == shared_skill.display().to_string())
+                .find(|target| target["targetPath"] == shared_target_path.display().to_string())
         })
         .ok_or_else(|| anyhow::anyhow!("missing shared skill target after Codex disconnect"))?;
     assert_eq!(shared_record["consumers"], json!(["zed"]));

--- a/packages/browseros-agent/crates/harness-integrations/src/skills/reconciler.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/skills/reconciler.rs
@@ -79,7 +79,8 @@ impl SkillReconciler {
         for (target, target_consumers) in &plan.desired {
             let record_controls = records
                 .get(target)
-                .is_some_and(|record| record.skill_name == spec.name);
+                .is_some_and(|record| record.skill_name == spec.name)
+                && plan.manifest_controlled_targets.contains(target);
             let metadata = match fs::symlink_metadata(target) {
                 Ok(metadata) => Some(metadata),
                 Err(error) if error.kind() == ErrorKind::NotFound => None,
@@ -179,13 +180,15 @@ impl SkillReconciler {
             if plan.desired.contains_key(&target) {
                 continue;
             }
-            let record_controls = records
+            let record_matches_skill = records
                 .get(&target)
                 .is_some_and(|record| record.skill_name == spec.name);
-            if records.contains_key(&target) && !record_controls {
+            if records.contains_key(&target) && !record_matches_skill {
                 preserve_original_records.insert(target);
                 continue;
             }
+            let record_controls =
+                record_matches_skill && plan.manifest_controlled_targets.contains(&target);
             let metadata = match fs::symlink_metadata(&target) {
                 Ok(metadata) => Some(metadata),
                 Err(error) if error.kind() == ErrorKind::NotFound => None,
@@ -198,6 +201,10 @@ impl SkillReconciler {
                     continue;
                 }
             };
+            if metadata.is_none() && record_matches_skill {
+                records.remove(&target);
+                continue;
+            }
             let marker_controls = if record_controls {
                 false
             } else if metadata.as_ref().is_some_and(|value| value.is_dir()) {
@@ -270,6 +277,8 @@ struct ReconciliationPlan {
     desired: BTreeMap<PathBuf, BTreeSet<AgentId>>,
     records: BTreeMap<PathBuf, SkillManifestEntry>,
     original_records: BTreeMap<PathBuf, Vec<SkillManifestEntry>>,
+    /// Migrated aliases need a marker before they can control an existing destination.
+    manifest_controlled_targets: BTreeSet<PathBuf>,
     cleanup_targets: BTreeSet<PathBuf>,
 }
 
@@ -283,8 +292,12 @@ fn plan_reconciliation(
     let desired = desired_targets(consumers, &spec.name, environment, identity)?;
     let mut records = BTreeMap::<PathBuf, SkillManifestEntry>::new();
     let mut original_records = BTreeMap::<PathBuf, Vec<SkillManifestEntry>>::new();
+    let mut manifest_controlled_targets = BTreeSet::new();
     for original_entry in &original.targets {
         let target = identity(&original_entry.target_path)?;
+        if original_entry.target_path == target {
+            manifest_controlled_targets.insert(target.clone());
+        }
         original_records
             .entry(target.clone())
             .or_default()
@@ -343,6 +356,7 @@ fn plan_reconciliation(
         desired,
         records,
         original_records,
+        manifest_controlled_targets,
         cleanup_targets,
     })
 }
@@ -398,13 +412,20 @@ fn physical_skill_target(target: &Path) -> Result<PathBuf, Error> {
             ),
         )
     })?;
-    let mut ancestor = target.parent().map(Path::to_path_buf).ok_or_else(|| {
+    let root = target.parent().ok_or_else(|| {
         Error::io(
             "resolve filesystem identity for",
             target,
             std::io::Error::new(ErrorKind::InvalidInput, "skill target has no parent"),
         )
     })?;
+    let mut ancestor = if root.is_absolute() {
+        root.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| Error::io("resolve filesystem identity for", target, error))?
+            .join(root)
+    };
     let mut missing = Vec::new();
 
     loop {
@@ -725,6 +746,22 @@ mod tests {
             fs::canonicalize(root.path())?.join("missing/nested/skills/browserclaw")
         );
         assert!(!missing_root.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn relative_skill_roots_resolve_from_the_process_directory()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let target = Path::new("relative-home/.agents/skills/browserclaw");
+
+        let physical = physical_skill_target(target)?;
+
+        assert_eq!(
+            physical,
+            fs::canonicalize(std::env::current_dir()?)?
+                .join("relative-home/.agents/skills/browserclaw")
+        );
+        assert!(!Path::new("relative-home").exists());
         Ok(())
     }
 

--- a/packages/browseros-agent/crates/harness-integrations/src/skills/reconciler.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/skills/reconciler.rs
@@ -52,23 +52,39 @@ impl SkillReconciler {
         environment: &SkillEnvironment,
         mut replace: impl FnMut(&Path, &SkillSpec, &str) -> std::io::Result<()>,
     ) -> Result<SkillReconcileOutcome, Error> {
-        let original = read_manifest(&self.workspace_dir)?;
-        let mut records = original
-            .targets
-            .iter()
-            .cloned()
-            .map(|entry| (entry.target_path.clone(), entry))
-            .collect::<BTreeMap<_, _>>();
-        let desired_hash = content_hash(spec.content.as_bytes());
-        let desired = desired_targets(consumers, &spec.name, environment)?;
-        let mut outcome = SkillReconcileOutcome::default();
+        self.reconcile_with_identity(
+            spec,
+            consumers,
+            environment,
+            physical_skill_target,
+            &mut replace,
+        )
+    }
 
-        for (target, target_consumers) in &desired {
-            let record = records.get(target).cloned();
+    fn reconcile_with_identity(
+        &self,
+        spec: &SkillSpec,
+        consumers: &BTreeSet<AgentId>,
+        environment: &SkillEnvironment,
+        mut identity: impl FnMut(&Path) -> Result<PathBuf, Error>,
+        mut replace: impl FnMut(&Path, &SkillSpec, &str) -> std::io::Result<()>,
+    ) -> Result<SkillReconcileOutcome, Error> {
+        let original = read_manifest(&self.workspace_dir)?;
+        let plan = plan_reconciliation(&original, spec, consumers, environment, &mut identity)?;
+        let mut records = plan.records;
+        let desired_hash = content_hash(spec.content.as_bytes());
+        let mut outcome = SkillReconcileOutcome::default();
+        let mut preserve_original_records = BTreeSet::new();
+
+        for (target, target_consumers) in &plan.desired {
+            let record_controls = records
+                .get(target)
+                .is_some_and(|record| record.skill_name == spec.name);
             let metadata = match fs::symlink_metadata(target) {
                 Ok(metadata) => Some(metadata),
                 Err(error) if error.kind() == ErrorKind::NotFound => None,
                 Err(error) => {
+                    preserve_original_records.insert(target.clone());
                     outcome.warnings.push(SkillWarning {
                         target: target.clone(),
                         message: format!("Could not inspect managed skill target: {error}"),
@@ -80,6 +96,7 @@ impl SkillReconciler {
                 match read_marker(target) {
                     Ok(marker) => marker,
                     Err(error) => {
+                        preserve_original_records.insert(target.clone());
                         outcome.warnings.push(SkillWarning {
                             target: target.clone(),
                             message: error.to_string(),
@@ -93,7 +110,8 @@ impl SkillReconciler {
             let marker_controls = marker
                 .as_ref()
                 .is_some_and(|marker| marker.controls(&spec.name));
-            if metadata.is_some() && record.is_none() && !marker_controls {
+            if metadata.is_some() && !record_controls && !marker_controls {
+                preserve_original_records.insert(target.clone());
                 outcome.warnings.push(SkillWarning {
                     target: target.clone(),
                     message: format!(
@@ -115,6 +133,7 @@ impl SkillReconciler {
                 match read_content_hash(&target.join("SKILL.md")) {
                     Ok(hash) => hash,
                     Err(error) => {
+                        preserve_original_records.insert(target.clone());
                         outcome.warnings.push(SkillWarning {
                             target: target.clone(),
                             message: error.to_string(),
@@ -128,11 +147,9 @@ impl SkillReconciler {
             let marker_matches = marker.as_ref().is_some_and(|marker| {
                 marker.controls(&spec.name) && marker.content_hash == desired_hash
             });
-            let record_matches = record.as_ref().is_some_and(|record| record == &entry);
             let needs_replace = metadata.is_none()
                 || actual_hash.as_deref() != Some(desired_hash.as_str())
-                || !marker_matches
-                || (record.is_some() && !record_matches);
+                || !marker_matches;
 
             if needs_replace {
                 match replace(target, spec, &desired_hash) {
@@ -144,10 +161,13 @@ impl SkillReconciler {
                         }
                         records.insert(target.clone(), entry);
                     }
-                    Err(error) => outcome.warnings.push(SkillWarning {
-                        target: target.clone(),
-                        message: format!("Could not replace managed skill: {error}"),
-                    }),
+                    Err(error) => {
+                        preserve_original_records.insert(target.clone());
+                        outcome.warnings.push(SkillWarning {
+                            target: target.clone(),
+                            message: format!("Could not replace managed skill: {error}"),
+                        });
+                    }
                 }
             } else {
                 outcome.unchanged += 1;
@@ -155,23 +175,22 @@ impl SkillReconciler {
             }
         }
 
-        let mut cleanup_targets = records.keys().cloned().collect::<BTreeSet<_>>();
-        for agent in AgentId::ALL {
-            if resolve_harness_definition(agent).skill.is_some() {
-                cleanup_targets.insert(resolve_agent_skill_target(agent, &spec.name, environment)?);
-            }
-        }
-        for target in cleanup_targets {
-            if desired.contains_key(&target) {
+        for target in plan.cleanup_targets {
+            if plan.desired.contains_key(&target) {
                 continue;
             }
             let record_controls = records
                 .get(&target)
                 .is_some_and(|record| record.skill_name == spec.name);
+            if records.contains_key(&target) && !record_controls {
+                preserve_original_records.insert(target);
+                continue;
+            }
             let metadata = match fs::symlink_metadata(&target) {
                 Ok(metadata) => Some(metadata),
                 Err(error) if error.kind() == ErrorKind::NotFound => None,
                 Err(error) => {
+                    preserve_original_records.insert(target.clone());
                     outcome.warnings.push(SkillWarning {
                         target: target.clone(),
                         message: format!("Could not inspect stale managed skill: {error}"),
@@ -187,6 +206,7 @@ impl SkillReconciler {
                         .as_ref()
                         .is_some_and(|marker| marker.controls(&spec.name)),
                     Err(error) => {
+                        preserve_original_records.insert(target.clone());
                         outcome.warnings.push(SkillWarning {
                             target: target.clone(),
                             message: error.to_string(),
@@ -206,10 +226,13 @@ impl SkillReconciler {
                         outcome.removed += 1;
                         records.remove(&target);
                     }
-                    Err(error) => outcome.warnings.push(SkillWarning {
-                        target: target.clone(),
-                        message: format!("Could not remove managed skill: {error}"),
-                    }),
+                    Err(error) => {
+                        preserve_original_records.insert(target.clone());
+                        outcome.warnings.push(SkillWarning {
+                            target: target.clone(),
+                            message: format!("Could not remove managed skill: {error}"),
+                        });
+                    }
                 },
                 None => {
                     records.remove(&target);
@@ -217,15 +240,111 @@ impl SkillReconciler {
             }
         }
 
+        let mut targets = Vec::new();
+        for (target, record) in records {
+            if preserve_original_records.contains(&target)
+                && let Some(original_records) = plan.original_records.get(&target)
+            {
+                targets.extend(original_records.iter().cloned());
+                continue;
+            }
+            targets.push(record);
+        }
+        targets.sort_by(|left, right| {
+            left.target_path
+                .cmp(&right.target_path)
+                .then_with(|| left.skill_name.cmp(&right.skill_name))
+        });
         let next = SkillManifest {
             version: 1,
-            targets: records.into_values().collect(),
+            targets,
         };
         if next != original {
             write_manifest(&self.workspace_dir, &next)?;
         }
         Ok(outcome)
     }
+}
+
+struct ReconciliationPlan {
+    desired: BTreeMap<PathBuf, BTreeSet<AgentId>>,
+    records: BTreeMap<PathBuf, SkillManifestEntry>,
+    original_records: BTreeMap<PathBuf, Vec<SkillManifestEntry>>,
+    cleanup_targets: BTreeSet<PathBuf>,
+}
+
+fn plan_reconciliation(
+    original: &SkillManifest,
+    spec: &SkillSpec,
+    consumers: &BTreeSet<AgentId>,
+    environment: &SkillEnvironment,
+    identity: &mut impl FnMut(&Path) -> Result<PathBuf, Error>,
+) -> Result<ReconciliationPlan, Error> {
+    let desired = desired_targets(consumers, &spec.name, environment, identity)?;
+    let mut records = BTreeMap::<PathBuf, SkillManifestEntry>::new();
+    let mut original_records = BTreeMap::<PathBuf, Vec<SkillManifestEntry>>::new();
+    for original_entry in &original.targets {
+        let target = identity(&original_entry.target_path)?;
+        original_records
+            .entry(target.clone())
+            .or_default()
+            .push(original_entry.clone());
+
+        let mut entry = original_entry.clone();
+        entry.target_path = target.clone();
+        entry.consumers.sort();
+        entry.consumers.dedup();
+        if let Some(existing) = records.get_mut(&target) {
+            if existing.skill_name != entry.skill_name
+                || existing.content_hash != entry.content_hash
+            {
+                return Err(Error::Manifest {
+                    message: format!(
+                        "Skill manifest contains conflicting records for physical target {}.",
+                        target.display()
+                    ),
+                });
+            }
+            let consumers = existing
+                .consumers
+                .iter()
+                .chain(&entry.consumers)
+                .copied()
+                .collect::<BTreeSet<_>>();
+            existing.consumers = consumers.into_iter().collect();
+        } else {
+            records.insert(target, entry);
+        }
+    }
+
+    for target in desired.keys() {
+        if let Some(record) = records.get(target)
+            && record.skill_name != spec.name
+        {
+            return Err(Error::Manifest {
+                message: format!(
+                    "Skill manifest target {} belongs to skill {}; cannot reconcile {} there.",
+                    target.display(),
+                    record.skill_name,
+                    spec.name
+                ),
+            });
+        }
+    }
+
+    let mut cleanup_targets = records.keys().cloned().collect::<BTreeSet<_>>();
+    for agent in AgentId::ALL {
+        if resolve_harness_definition(agent).skill.is_some() {
+            let target = resolve_agent_skill_target(agent, &spec.name, environment)?;
+            cleanup_targets.insert(identity(&target)?);
+        }
+    }
+    Ok(ReconciliationPlan {
+        desired,
+        records,
+        original_records,
+        cleanup_targets,
+    })
 }
 
 /// Resolves one harness's preferred global directory for a named skill.
@@ -256,13 +375,70 @@ fn desired_targets(
     consumers: &BTreeSet<AgentId>,
     skill_name: &str,
     environment: &SkillEnvironment,
+    identity: &mut impl FnMut(&Path) -> Result<PathBuf, Error>,
 ) -> Result<BTreeMap<PathBuf, BTreeSet<AgentId>>, Error> {
     let mut targets = BTreeMap::<PathBuf, BTreeSet<AgentId>>::new();
     for consumer in consumers {
         let target = resolve_agent_skill_target(*consumer, skill_name, environment)?;
+        let target = identity(&target)?;
         targets.entry(target).or_default().insert(*consumer);
     }
     Ok(targets)
+}
+
+/// Follows aliases in the harness skill root without following the managed skill entry itself.
+fn physical_skill_target(target: &Path) -> Result<PathBuf, Error> {
+    let skill_name = target.file_name().ok_or_else(|| {
+        Error::io(
+            "resolve filesystem identity for",
+            target,
+            std::io::Error::new(
+                ErrorKind::InvalidInput,
+                "skill target has no final component",
+            ),
+        )
+    })?;
+    let mut ancestor = target.parent().map(Path::to_path_buf).ok_or_else(|| {
+        Error::io(
+            "resolve filesystem identity for",
+            target,
+            std::io::Error::new(ErrorKind::InvalidInput, "skill target has no parent"),
+        )
+    })?;
+    let mut missing = Vec::new();
+
+    loop {
+        match fs::symlink_metadata(&ancestor) {
+            Ok(_) => {
+                let mut physical_root = fs::canonicalize(&ancestor)
+                    .map_err(|error| Error::io("resolve filesystem identity for", target, error))?;
+                for component in missing.iter().rev() {
+                    physical_root.push(component);
+                }
+                physical_root.push(skill_name);
+                return Ok(physical_root);
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                let component = ancestor.file_name().map(ToOwned::to_owned).ok_or_else(|| {
+                    Error::io(
+                        "resolve filesystem identity for",
+                        target,
+                        std::io::Error::new(
+                            ErrorKind::NotFound,
+                            "no existing ancestor for skill root",
+                        ),
+                    )
+                })?;
+                missing.push(component);
+                if !ancestor.pop() {
+                    return Err(Error::io("resolve filesystem identity for", target, error));
+                }
+            }
+            Err(error) => {
+                return Err(Error::io("resolve filesystem identity for", target, error));
+            }
+        }
+    }
 }
 
 fn selected_paths(paths: &PerOsPaths, platform: TargetPlatform) -> &'static [&'static str] {
@@ -416,16 +592,141 @@ fn monotonic_nonce() -> u128 {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeSet, fs};
+    use std::{collections::BTreeSet, fs, path::Path};
 
     use tempfile::tempdir;
 
     use crate::{AgentId, SkillEnvironment, SkillSpec, TargetPlatform};
 
     use super::{
-        SkillReconciler, replace_managed_directory_with, resolve_agent_skill_target,
-        swap_directories_with,
+        SkillReconciler, physical_skill_target, replace_managed_directory,
+        replace_managed_directory_with, resolve_agent_skill_target, swap_directories_with,
     };
+
+    #[test]
+    fn identity_planning_groups_aliases_without_platform_symlinks()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let root = tempdir()?;
+        let home = root.path().join("home");
+        let state = root.path().join("state");
+        let environment = SkillEnvironment::new(&home, TargetPlatform::Linux);
+        let reconciler = SkillReconciler::new(&state);
+        let claude = resolve_agent_skill_target(AgentId::ClaudeCode, "browserclaw", &environment)?;
+        let agents = resolve_agent_skill_target(AgentId::Codex, "browserclaw", &environment)?;
+        let physical = home.join(".skills/browserclaw");
+        let identity = |target: &Path| {
+            Ok(if target == claude || target == agents {
+                physical.clone()
+            } else {
+                target.to_path_buf()
+            })
+        };
+        let spec = SkillSpec::new("browserclaw", "managed\n")?;
+
+        let installed = reconciler.reconcile_with_identity(
+            &spec,
+            &BTreeSet::from([AgentId::ClaudeCode]),
+            &environment,
+            identity,
+            replace_managed_directory,
+        )?;
+        assert_eq!(installed.installed, 1);
+        assert_eq!(installed.removed, 0);
+        let modified = fs::metadata(physical.join("SKILL.md"))?.modified()?;
+
+        let shared = reconciler.reconcile_with_identity(
+            &spec,
+            &BTreeSet::from([AgentId::ClaudeCode, AgentId::Codex]),
+            &environment,
+            |target| {
+                Ok(if target == claude || target == agents {
+                    physical.clone()
+                } else {
+                    target.to_path_buf()
+                })
+            },
+            replace_managed_directory,
+        )?;
+        assert_eq!(shared.unchanged, 1);
+        assert_eq!(
+            fs::metadata(physical.join("SKILL.md"))?.modified()?,
+            modified
+        );
+
+        let removed = reconciler.reconcile_with_identity(
+            &spec,
+            &BTreeSet::new(),
+            &environment,
+            |target| {
+                Ok(if target == claude || target == agents {
+                    physical.clone()
+                } else {
+                    target.to_path_buf()
+                })
+            },
+            replace_managed_directory,
+        )?;
+        assert_eq!(removed.removed, 1);
+        assert!(!physical.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn identity_failure_precedes_all_directory_mutation() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let root = tempdir()?;
+        let environment = SkillEnvironment::new(root.path().join("home"), TargetPlatform::Linux);
+        let reconciler = SkillReconciler::new(root.path().join("state"));
+        let spec = SkillSpec::new("browserclaw", "managed\n")?;
+        let mut identity_calls = 0;
+        let mut replace_calls = 0;
+
+        let error = reconciler
+            .reconcile_with_identity(
+                &spec,
+                &BTreeSet::from([AgentId::Cursor]),
+                &environment,
+                |target| {
+                    identity_calls += 1;
+                    if identity_calls == 3 {
+                        return Err(crate::Error::io(
+                            "resolve filesystem identity for",
+                            target,
+                            std::io::Error::other("injected identity failure"),
+                        ));
+                    }
+                    Ok(target.to_path_buf())
+                },
+                |_, _, _| {
+                    replace_calls += 1;
+                    Ok(())
+                },
+            )
+            .err()
+            .ok_or("identity failure unexpectedly reconciled")?;
+
+        assert!(error.to_string().contains("injected identity failure"));
+        assert_eq!(replace_calls, 0);
+        assert!(!root.path().join("state/skills.json").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn missing_skill_roots_are_planned_without_creating_directories()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let root = tempdir()?;
+        let missing_root = root.path().join("missing/nested/skills");
+        let target = missing_root.join("browserclaw");
+
+        let physical = physical_skill_target(&target)?;
+
+        assert_eq!(
+            physical,
+            fs::canonicalize(root.path())?.join("missing/nested/skills/browserclaw")
+        );
+        assert!(!missing_root.exists());
+        Ok(())
+    }
 
     #[test]
     fn failed_directory_swap_restores_the_previous_target() -> std::io::Result<()> {

--- a/packages/browseros-agent/crates/harness-integrations/tests/skills.rs
+++ b/packages/browseros-agent/crates/harness-integrations/tests/skills.rs
@@ -1,5 +1,8 @@
 use std::{collections::BTreeSet, fs, thread, time::Duration};
 
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
 use harness_integrations::{
     AgentId, SkillEnvironment, SkillReconciler, SkillSpec, TargetPlatform,
     resolve_agent_skill_target,
@@ -201,12 +204,244 @@ fn shared_consumers_keep_the_target_until_the_last_disconnect()
 
     let one_left =
         reconciler.reconcile(&spec("shared\n")?, &agents(&[AgentId::Zed]), &environment)?;
-    assert_eq!(one_left.updated, 1);
+    assert_eq!(one_left.unchanged, 1);
     assert!(target.exists());
 
     let removed = reconciler.reconcile(&spec("shared\n")?, &BTreeSet::new(), &environment)?;
     assert_eq!(removed.removed, 1);
     assert!(!target.exists());
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn aliased_harness_roots_share_one_physical_installation() -> Result<(), Box<dyn std::error::Error>>
+{
+    let root = tempdir()?;
+    let home = root.path().join("home");
+    let shared_root = home.join(".skills");
+    fs::create_dir_all(home.join(".claude"))?;
+    fs::create_dir_all(home.join(".agents"))?;
+    fs::create_dir_all(&shared_root)?;
+    symlink(&shared_root, home.join(".claude/skills"))?;
+    symlink(&shared_root, home.join(".agents/skills"))?;
+
+    let environment = SkillEnvironment::new(&home, TargetPlatform::Linux);
+    let state = root.path().join("state");
+    let reconciler = SkillReconciler::new(&state);
+    let physical_target = fs::canonicalize(&shared_root)?.join("browserclaw");
+
+    let installed = reconciler.reconcile(
+        &spec("shared\n")?,
+        &agents(&[AgentId::ClaudeCode]),
+        &environment,
+    )?;
+    assert_eq!(installed.installed, 1);
+    assert_eq!(installed.removed, 0);
+    assert!(installed.warnings.is_empty());
+    assert_eq!(
+        fs::read_to_string(physical_target.join("SKILL.md"))?,
+        "shared\n"
+    );
+
+    let manifest: Value = serde_json::from_str(&fs::read_to_string(state.join("skills.json"))?)?;
+    assert_eq!(manifest["targets"].as_array().map(Vec::len), Some(1));
+    assert_eq!(
+        manifest["targets"][0]["targetPath"],
+        physical_target.to_string_lossy().as_ref()
+    );
+    assert_eq!(
+        manifest["targets"][0]["consumers"],
+        serde_json::json!(["claude-code"])
+    );
+
+    let modified = fs::metadata(physical_target.join("SKILL.md"))?.modified()?;
+    thread::sleep(Duration::from_millis(20));
+    let shared = reconciler.reconcile(
+        &spec("shared\n")?,
+        &agents(&[AgentId::ClaudeCode, AgentId::Codex]),
+        &environment,
+    )?;
+    assert_eq!(shared.unchanged, 1);
+    assert_eq!(shared.updated, 0);
+    assert_eq!(
+        fs::metadata(physical_target.join("SKILL.md"))?.modified()?,
+        modified
+    );
+    let manifest: Value = serde_json::from_str(&fs::read_to_string(state.join("skills.json"))?)?;
+    assert_eq!(
+        manifest["targets"][0]["consumers"],
+        serde_json::json!(["claude-code", "codex"])
+    );
+
+    let one_left =
+        reconciler.reconcile(&spec("shared\n")?, &agents(&[AgentId::Codex]), &environment)?;
+    assert_eq!(one_left.unchanged, 1);
+    assert!(physical_target.exists());
+
+    fs::remove_file(state.join("skills.json"))?;
+    let marker_only = reconciler.reconcile(
+        &spec("shared\n")?,
+        &agents(&[AgentId::ClaudeCode]),
+        &environment,
+    )?;
+    assert_eq!(marker_only.unchanged, 1);
+    assert_eq!(marker_only.removed, 0);
+    assert!(physical_target.exists());
+
+    let removed = reconciler.reconcile(&spec("shared\n")?, &BTreeSet::new(), &environment)?;
+    assert_eq!(removed.removed, 1);
+    assert!(!physical_target.exists());
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn legacy_alias_records_migrate_and_conflicts_fail_before_mutation()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = tempdir()?;
+    let home = root.path().join("home");
+    let shared_root = home.join(".skills");
+    fs::create_dir_all(home.join(".claude"))?;
+    fs::create_dir_all(home.join(".agents"))?;
+    fs::create_dir_all(&shared_root)?;
+    symlink(&shared_root, home.join(".claude/skills"))?;
+    symlink(&shared_root, home.join(".agents/skills"))?;
+
+    let environment = SkillEnvironment::new(&home, TargetPlatform::Linux);
+    let state = root.path().join("state");
+    let manifest_path = state.join("skills.json");
+    let reconciler = SkillReconciler::new(&state);
+    let desired = agents(&[AgentId::ClaudeCode, AgentId::Codex]);
+    let physical_target = fs::canonicalize(&shared_root)?.join("browserclaw");
+    reconciler.reconcile(&spec("managed\n")?, &desired, &environment)?;
+
+    let mut manifest: Value = serde_json::from_str(&fs::read_to_string(&manifest_path)?)?;
+    let canonical_entry = manifest["targets"][0].clone();
+    manifest["targets"][0]["targetPath"] = Value::String(
+        home.join(".claude/skills/browserclaw")
+            .display()
+            .to_string(),
+    );
+    fs::write(&manifest_path, serde_json::to_vec_pretty(&manifest)?)?;
+    fs::remove_dir_all(&physical_target)?;
+
+    let repaired = reconciler.reconcile(&spec("managed\n")?, &desired, &environment)?;
+    assert_eq!(repaired.installed, 1);
+    let migrated: Value = serde_json::from_str(&fs::read_to_string(&manifest_path)?)?;
+    assert_eq!(migrated["targets"].as_array().map(Vec::len), Some(1));
+    assert_eq!(
+        migrated["targets"][0]["targetPath"],
+        physical_target.to_string_lossy().as_ref()
+    );
+
+    let modified = fs::metadata(physical_target.join("SKILL.md"))?.modified()?;
+    let mut duplicate_manifest = migrated.clone();
+    let mut claude_entry = canonical_entry.clone();
+    claude_entry["targetPath"] = Value::String(
+        home.join(".claude/skills/browserclaw")
+            .display()
+            .to_string(),
+    );
+    claude_entry["consumers"] = serde_json::json!(["claude-code"]);
+    let mut codex_entry = canonical_entry;
+    codex_entry["targetPath"] = Value::String(
+        home.join(".agents/skills/browserclaw")
+            .display()
+            .to_string(),
+    );
+    codex_entry["consumers"] = serde_json::json!(["codex"]);
+    duplicate_manifest["targets"] = Value::Array(vec![claude_entry, codex_entry]);
+    fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&duplicate_manifest)?,
+    )?;
+
+    thread::sleep(Duration::from_millis(20));
+    let collapsed = reconciler.reconcile(&spec("managed\n")?, &desired, &environment)?;
+    assert_eq!(collapsed.unchanged, 1);
+    assert_eq!(
+        fs::metadata(physical_target.join("SKILL.md"))?.modified()?,
+        modified
+    );
+    let collapsed_manifest: Value = serde_json::from_str(&fs::read_to_string(&manifest_path)?)?;
+    assert_eq!(
+        collapsed_manifest["targets"].as_array().map(Vec::len),
+        Some(1)
+    );
+
+    let mut conflicting_manifest = duplicate_manifest;
+    conflicting_manifest["targets"][1]["contentHash"] = Value::String("conflict".to_string());
+    let conflicting_bytes = serde_json::to_vec_pretty(&conflicting_manifest)?;
+    fs::write(&manifest_path, &conflicting_bytes)?;
+    let skill_before = fs::read(physical_target.join("SKILL.md"))?;
+
+    let error = reconciler
+        .reconcile(&spec("managed\n")?, &desired, &environment)
+        .err()
+        .ok_or("conflicting aliases unexpectedly reconciled")?;
+    assert!(error.to_string().contains("conflicting records"));
+    assert_eq!(fs::read(&manifest_path)?, conflicting_bytes);
+    assert_eq!(fs::read(physical_target.join("SKILL.md"))?, skill_before);
+    Ok(())
+}
+
+#[test]
+fn retargeted_root_installs_new_destination_and_removes_old_one()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = tempdir()?;
+    let state = root.path().join("state");
+    let reconciler = SkillReconciler::new(&state);
+    let home = root.path().join("home");
+    let old_root = root.path().join("old-claude");
+    let old_environment = SkillEnvironment::new(&home, TargetPlatform::Linux)
+        .with_variable("CLAUDE_CONFIG_DIR", &old_root);
+    let desired = agents(&[AgentId::ClaudeCode]);
+    reconciler.reconcile(&spec("managed\n")?, &desired, &old_environment)?;
+    let old_target = old_root.join("skills/browserclaw");
+    assert!(old_target.exists());
+
+    let new_root = root.path().join("new-claude");
+    let new_environment = SkillEnvironment::new(&home, TargetPlatform::Linux)
+        .with_variable("CLAUDE_CONFIG_DIR", &new_root);
+    let moved = reconciler.reconcile(&spec("managed\n")?, &desired, &new_environment)?;
+
+    assert_eq!(moved.installed, 1);
+    assert_eq!(moved.removed, 1);
+    assert!(!old_target.exists());
+    assert_eq!(
+        fs::read_to_string(new_root.join("skills/browserclaw/SKILL.md"))?,
+        "managed\n"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn foreign_final_symlink_is_not_followed_or_replaced() -> Result<(), Box<dyn std::error::Error>> {
+    let root = tempdir()?;
+    let home = root.path().join("home");
+    let skill_root = home.join(".claude/skills");
+    let foreign = root.path().join("foreign");
+    fs::create_dir_all(&skill_root)?;
+    fs::create_dir_all(&foreign)?;
+    fs::write(foreign.join("SKILL.md"), "foreign\n")?;
+    fs::write(foreign.join("keep.txt"), "keep\n")?;
+    let target = skill_root.join("browserclaw");
+    symlink(&foreign, &target)?;
+
+    let environment = SkillEnvironment::new(&home, TargetPlatform::Linux);
+    let reconciler = SkillReconciler::new(root.path().join("state"));
+    let outcome = reconciler.reconcile(
+        &spec("managed\n")?,
+        &agents(&[AgentId::ClaudeCode]),
+        &environment,
+    )?;
+
+    assert_eq!(outcome.warnings.len(), 1);
+    assert!(fs::symlink_metadata(&target)?.file_type().is_symlink());
+    assert_eq!(fs::read_to_string(foreign.join("SKILL.md"))?, "foreign\n");
+    assert_eq!(fs::read_to_string(foreign.join("keep.txt"))?, "keep\n");
     Ok(())
 }
 

--- a/packages/browseros-agent/crates/harness-integrations/tests/skills.rs
+++ b/packages/browseros-agent/crates/harness-integrations/tests/skills.rs
@@ -445,6 +445,56 @@ fn foreign_final_symlink_is_not_followed_or_replaced() -> Result<(), Box<dyn std
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn legacy_alias_record_does_not_claim_a_retargeted_foreign_destination()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = tempdir()?;
+    let home = root.path().join("home");
+    let claude_root = home.join(".claude");
+    let old_root = home.join("old-skills");
+    let new_root = home.join("new-skills");
+    fs::create_dir_all(&claude_root)?;
+    fs::create_dir_all(&old_root)?;
+    fs::create_dir_all(&new_root)?;
+    let alias = claude_root.join("skills");
+    symlink(&old_root, &alias)?;
+
+    let environment = SkillEnvironment::new(&home, TargetPlatform::Linux);
+    let state = root.path().join("state");
+    let manifest_path = state.join("skills.json");
+    let reconciler = SkillReconciler::new(&state);
+    let desired = agents(&[AgentId::ClaudeCode]);
+    reconciler.reconcile(&spec("managed\n")?, &desired, &environment)?;
+
+    let mut manifest: Value = serde_json::from_str(&fs::read_to_string(&manifest_path)?)?;
+    manifest["targets"][0]["targetPath"] =
+        Value::String(alias.join("browserclaw").display().to_string());
+    let legacy_manifest = serde_json::to_vec_pretty(&manifest)?;
+    fs::write(&manifest_path, &legacy_manifest)?;
+
+    fs::remove_file(&alias)?;
+    symlink(&new_root, &alias)?;
+    let foreign_target = new_root.join("browserclaw");
+    fs::create_dir_all(&foreign_target)?;
+    fs::write(foreign_target.join("SKILL.md"), "foreign\n")?;
+    fs::write(foreign_target.join("keep.txt"), "keep\n")?;
+
+    let outcome = reconciler.reconcile(&spec("managed\n")?, &desired, &environment)?;
+
+    assert_eq!(outcome.warnings.len(), 1);
+    assert_eq!(
+        fs::read_to_string(foreign_target.join("SKILL.md"))?,
+        "foreign\n"
+    );
+    assert_eq!(
+        fs::read_to_string(foreign_target.join("keep.txt"))?,
+        "keep\n"
+    );
+    assert_eq!(fs::read(&manifest_path)?, legacy_manifest);
+    Ok(())
+}
+
 #[test]
 fn foreign_targets_and_corrupt_manifests_are_preserved() -> Result<(), Box<dyn std::error::Error>> {
     let root = tempdir()?;

--- a/packages/browseros-agent/tools/dev/cmd/sidecar.go
+++ b/packages/browseros-agent/tools/dev/cmd/sidecar.go
@@ -6,10 +6,10 @@ import (
 	"browseros-dev/proc"
 )
 
-func writeServerSidecarConfig(path string, root string, executionDir string, p proc.Ports) error {
+func writeServerSidecarConfig(path string, resourcesDir string, executionDir string, p proc.Ports) error {
 	return proc.WriteSidecarConfig(path, proc.SidecarConfigOptions{
 		Ports:        p,
-		ResourcesDir: filepath.Join(root, "resources"),
+		ResourcesDir: resourcesDir,
 		ExecutionDir: executionDir,
 	})
 }

--- a/packages/browseros-agent/tools/dev/cmd/test.go
+++ b/packages/browseros-agent/tools/dev/cmd/test.go
@@ -114,7 +114,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 	proc.LogMsgf(proc.TagBrowser, "Created temp profile: %s", tempDir)
 
 	sidecarPath := filepath.Join(tempDir, "server-config.json")
-	if err := writeServerSidecarConfig(sidecarPath, root, tempDir, p); err != nil {
+	if err := writeServerSidecarConfig(sidecarPath, filepath.Join(root, "resources"), tempDir, p); err != nil {
 		cleanup()
 		return fmt.Errorf("writing server config: %w", err)
 	}

--- a/packages/browseros-agent/tools/dev/cmd/watch.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch.go
@@ -324,7 +324,7 @@ func startBrowserOSWatch(ctx context.Context, wg *sync.WaitGroup, root string, e
 		Restart: true,
 		Cmd:     []string{"bun", "--watch", "--env-file=../../.env.development", "src/index.ts", "--config", sidecarPath},
 		BeforeStart: func() error {
-			if err := writeServerSidecarConfig(sidecarPath, root, userDataDir, p); err != nil {
+			if err := writeServerSidecarConfig(sidecarPath, filepath.Join(root, "resources"), userDataDir, p); err != nil {
 				return err
 			}
 			return proc.KillPortAndWait(p.Server, 3*time.Second)
@@ -380,7 +380,7 @@ func clawServerProcConfig(root string, env []string, p proc.Ports, userDataDir s
 		Restart: true,
 		Cmd:     []string{"cargo", "run", "-p", "claw-server-rust", "--", "--config", sidecarPath},
 		BeforeStart: func() error {
-			if err := writeServerSidecarConfig(sidecarPath, root, userDataDir, p); err != nil {
+			if err := writeServerSidecarConfig(sidecarPath, filepath.Join(root, "apps/claw-server-rust/resources"), userDataDir, p); err != nil {
 				return err
 			}
 			return killPort(p.Server, 3*time.Second)

--- a/packages/browseros-agent/tools/dev/cmd/watch_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch_test.go
@@ -214,12 +214,19 @@ func TestClawRustServerProcConfigPassesSidecarAndDevEnv(t *testing.T) {
 			CDP    int `json:"cdp"`
 			Proxy  int `json:"proxy"`
 		} `json:"ports"`
+		Directories struct {
+			Resources string `json:"resources"`
+			Execution string `json:"execution"`
+		} `json:"directories"`
 	}
 	if err := json.Unmarshal(raw, &sidecar); err != nil {
 		t.Fatalf("parsing sidecar: %v", err)
 	}
 	if sidecar.Ports.Server != ports.Server || sidecar.Ports.CDP != ports.CDP || sidecar.Ports.Proxy != ports.Server {
 		t.Fatalf("expected sidecar ports server=%d cdp=%d proxy=%d, got %+v", ports.Server, ports.CDP, ports.Server, sidecar.Ports)
+	}
+	if sidecar.Directories.Resources != filepath.Join(root, "apps/claw-server-rust/resources") || sidecar.Directories.Execution != userDataDir {
+		t.Fatalf("unexpected sidecar directories: %+v", sidecar.Directories)
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/cmd/sidecar.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/sidecar.go
@@ -42,7 +42,7 @@ func dogfoodSidecarConfigPath(cfg config.Config) string {
 	return filepath.Join(cfg.DevUserDataDir, "server-config.json")
 }
 
-func writeDogfoodSidecarConfig(path string, cfg config.Config, agentRoot string) error {
+func writeDogfoodSidecarConfig(path string, cfg config.Config, resourcesDir string) error {
 	if cfg.Ports.Server == 0 || cfg.Ports.CDP == 0 {
 		return fmt.Errorf("dogfood sidecar ports require non-zero server and cdp values")
 	}
@@ -56,7 +56,7 @@ func writeDogfoodSidecarConfig(path string, cfg config.Config, agentRoot string)
 			Proxy:  cfg.Ports.Server,
 		},
 		Directories: dogfoodSidecarDirectories{
-			Resources: filepath.Join(agentRoot, "resources"),
+			Resources: resourcesDir,
 			Execution: cfg.BrowserOSDir,
 		},
 		Flags: dogfoodSidecarFlags{

--- a/packages/browseros-agent/tools/dogfood/cmd/sidecar_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/sidecar_test.go
@@ -9,36 +9,52 @@ import (
 	"browseros-dogfood/config"
 )
 
-func TestWriteDogfoodSidecarConfigWritesPortsAndDirectories(t *testing.T) {
-	cfg := config.Config{
-		DevUserDataDir: t.TempDir(),
-		BrowserOSDir:   "/tmp/browseros-dogfood",
-		Ports:          config.Ports{CDP: 9015, Server: 9115, Extension: 9315},
-	}
-	path := dogfoodSidecarConfigPath(cfg)
+func TestWriteDogfoodSidecarConfigUsesExplicitResourceDirectory(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		resourcesDir string
+	}{
+		{
+			name:         "BrowserOS",
+			resourcesDir: "/repo/packages/browseros-agent/resources",
+		},
+		{
+			name:         "BrowserClaw",
+			resourcesDir: "/repo/packages/browseros-agent/apps/claw-server-rust/resources",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := config.Config{
+				DevUserDataDir: t.TempDir(),
+				BrowserOSDir:   "/tmp/browseros-dogfood",
+				Ports:          config.Ports{CDP: 9015, Server: 9115, Extension: 9315},
+			}
+			path := dogfoodSidecarConfigPath(cfg)
 
-	if err := writeDogfoodSidecarConfig(path, cfg, "/repo/packages/browseros-agent"); err != nil {
-		t.Fatal(err)
-	}
+			if err := writeDogfoodSidecarConfig(path, cfg, test.resourcesDir); err != nil {
+				t.Fatal(err)
+			}
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var got map[string]any
-	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatal(err)
-	}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatal(err)
+			}
 
-	if path != filepath.Join(cfg.DevUserDataDir, "server-config.json") {
-		t.Fatalf("unexpected sidecar path: %s", path)
-	}
-	ports := got["ports"].(map[string]any)
-	if ports["server"] != float64(9115) || ports["cdp"] != float64(9015) || ports["proxy"] != float64(9115) {
-		t.Fatalf("unexpected ports: %#v", ports)
-	}
-	directories := got["directories"].(map[string]any)
-	if directories["resources"] != "/repo/packages/browseros-agent/resources" || directories["execution"] != "/tmp/browseros-dogfood" {
-		t.Fatalf("unexpected directories: %#v", directories)
+			if path != filepath.Join(cfg.DevUserDataDir, "server-config.json") {
+				t.Fatalf("unexpected sidecar path: %s", path)
+			}
+			ports := got["ports"].(map[string]any)
+			if ports["server"] != float64(9115) || ports["cdp"] != float64(9015) || ports["proxy"] != float64(9115) {
+				t.Fatalf("unexpected ports: %#v", ports)
+			}
+			directories := got["directories"].(map[string]any)
+			if directories["resources"] != test.resourcesDir || directories["execution"] != "/tmp/browseros-dogfood" {
+				t.Fatalf("unexpected directories: %#v", directories)
+			}
+		})
 	}
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -321,7 +321,7 @@ func startBrowserOSEnvironment(parent context.Context, cfg config.Config, agentR
 	runtimeEnv := serverRuntimeEnv(os.Environ(), cfg)
 	serverDir := filepath.Join(agentRoot, "apps/server")
 	sidecarPath := dogfoodSidecarConfigPath(cfg)
-	if err := writeDogfoodSidecarConfig(sidecarPath, cfg, agentRoot); err != nil {
+	if err := writeDogfoodSidecarConfig(sidecarPath, cfg, filepath.Join(agentRoot, "resources")); err != nil {
 		e.Stop()
 		e.Wait()
 		return nil, fmt.Errorf("write server config: %w", err)
@@ -367,7 +367,7 @@ func startClawEnvironment(parent context.Context, cfg config.Config, agentRoot s
 	}
 
 	sidecarPath := dogfoodSidecarConfigPath(cfg)
-	if err := writeDogfoodSidecarConfig(sidecarPath, cfg, agentRoot); err != nil {
+	if err := writeDogfoodSidecarConfig(sidecarPath, cfg, filepath.Join(agentRoot, "apps/claw-server-rust/resources")); err != nil {
 		e.Stop()
 		e.Wait()
 		return nil, fmt.Errorf("write Claw server config: %w", err)


### PR DESCRIPTION
## Summary
- reconcile managed BrowserClaw skills by physical skill-root identity so harness aliases share one safe installation
- migrate compatible schema-v1 records while preserving foreign destinations, including retargeted legacy aliases
- point BrowserClaw dev and dogfood launchers at the checked-in Rust app resource root

## Design
Catalog paths remain lexical and harness-native. The reconciler plans desired, recorded, and cleanup identities before mutation by canonicalizing the deepest existing ancestor of each parent skill root, then appending missing components and the un-followed final skill name. Only records already stored at physical identity retain manifest-only ownership; migrated aliases require the ownership marker before controlling an existing destination.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `go test ./...` in `tools/dev`
- [x] `go test ./...` in `tools/dogfood`
- [x] `git diff --check`
