### PR TITLE
fix(claw): hide tokens in audit list

### DIFF
--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
@@ -126,22 +126,19 @@ describe('Audit screen', () => {
     // no visible 'Done' text renders here anymore.
   })
 
-  it('renders a compact token total for measured sessions', () => {
-    dataOverride = { ...baseData, tasks: [sampleTask] }
-    const html = renderApp()
-    expect(html).toContain('12.3k')
-    // Exact count surfaces on hover.
-    expect(html).toContain('12,300 tokens')
-  })
-
-  it('renders an em dash for sessions without measured token usage', () => {
+  it('hides token usage from the task list', () => {
     dataOverride = {
       ...baseData,
-      tasks: [{ ...sampleTask, tokenUsage: undefined }],
+      tasks: [
+        sampleTask,
+        { ...sampleTask, sessionId: 'sess-2', tokenUsage: undefined },
+      ],
     }
     const html = renderApp()
-    expect(html).toContain('Token usage not measured')
+    expect(html).not.toContain('Tokens')
     expect(html).not.toContain('12.3k')
+    expect(html).not.toContain('12,300 tokens')
+    expect(html).not.toContain('Token usage not measured')
   })
 
   it('renders the Load older tasks button when hasNextPage is true', () => {

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
@@ -30,6 +30,9 @@ import {
   orderByLiveThenRecency,
 } from './audit.helpers'
 
+/** Keeps the implemented token column dormant without discarding its sorting and cell behavior. */
+const SHOW_TOKEN_USAGE_COLUMN = false
+
 /**
  * Editorial audit screen. Preserves the tanstack-table + shadcn
  * Table primitives (sortable headers, keyboard nav, infinite
@@ -82,7 +85,13 @@ export function Audit() {
         : [],
     [sortId, sortDesc],
   )
-  const state = useMemo(() => ({ sorting }), [sorting])
+  const state = useMemo(
+    () => ({
+      sorting,
+      columnVisibility: { tokens: SHOW_TOKEN_USAGE_COLUMN },
+    }),
+    [sorting],
+  )
 
   const table = useReactTable<TaskSummary>({
     data: orderedTasks,


### PR DESCRIPTION
## Summary
- hide the Tokens column from the Audit task list through TanStack column visibility
- preserve the existing token column implementation, sorting, formatting helpers, task-detail display, and backend data
- replace list rendering assertions with coverage that the header, values, and tooltips stay hidden

## Design
The Audit table controls the existing `tokens` column with one explicit `SHOW_TOKEN_USAGE_COLUMN` switch. The `ColumnDef` remains intact so restoring the list presentation is a one-line visibility change.

## Test plan
- [x] focused Audit screen tests
- [x] focused task-detail screen tests
- [x] claw-app typecheck
- [x] Biome check for touched files