### PR TITLE
fix(claw): stop cockpit saved-stats labels from overlapping

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/SavedStatsBand.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/SavedStatsBand.test.tsx
@@ -329,8 +329,8 @@ describe('SavedStatsBand', () => {
       container.querySelector('[data-stat="percentage"]')?.textContent,
     ).toBe('0%')
     expect(
-      container.querySelector('[data-used-marker]')?.getAttribute('style'),
-    ).toContain('left:0%')
+      container.querySelector('[data-used-fill]')?.getAttribute('style'),
+    ).toContain('width:0%')
 
     await selectTab('30 days')
     expect(
@@ -340,17 +340,65 @@ describe('SavedStatsBand', () => {
       container.querySelector('[data-stat="percentage"]')?.textContent,
     ).toBe('0%')
     expect(
-      container.querySelector('[data-used-marker]')?.getAttribute('style'),
-    ).toContain('left:100%')
+      container.querySelector('[data-used-fill]')?.getAttribute('style'),
+    ).toContain('width:100%')
 
     await selectTab('7 days')
     expect(
       container.querySelector('[data-stat="percentage"]')?.textContent,
     ).toBe('100%')
     expect(
-      container.querySelector('[data-used-marker]')?.getAttribute('style'),
-    ).toContain('left:50%')
+      container.querySelector('[data-used-fill]')?.getAttribute('style'),
+    ).toContain('width:50%')
     expect(value.allTime.rawTokenSavingsEstimate).toBe(-50)
+  })
+
+  it('keeps both comparison labels outside the bounded bar at every ratio', async () => {
+    // The original overlap bug: both token labels were absolutely positioned
+    // inside the same overflow-hidden track and painted through each other in
+    // the mid-range. The fix moves them into a legend row that is a sibling of
+    // the bar, so no ratio can make them collide or clip. Assert the structural
+    // invariant that guarantees it — the track carries no text labels — across
+    // a low, mid, and full used ratio.
+    const value = stats({
+      allTime: statsWindow({
+        browserClawTokenEstimate: 63_200,
+        screenshotFirstTokenEstimate: 112_300,
+        rawTokenSavingsEstimate: 49_100,
+      }),
+      last30Days: statsWindow({
+        browserClawTokenEstimate: 2_000,
+        screenshotFirstTokenEstimate: 200_000,
+        rawTokenSavingsEstimate: 198_000,
+      }),
+      last7Days: statsWindow({
+        browserClawTokenEstimate: 500_000,
+        screenshotFirstTokenEstimate: 500_000,
+        rawTokenSavingsEstimate: 0,
+      }),
+    })
+    await render(value)
+
+    for (const label of ['All time', '30 days', '7 days']) {
+      await selectTab(label)
+      const track = container.querySelector('[data-budget-track]')
+      expect(track).not.toBeNull()
+      // Root-cause guard: nothing textual lives inside the bounded bar.
+      expect(track?.querySelector('[data-stat]')).toBeNull()
+      expect(track?.textContent?.trim()).toBe('')
+      // Both numbers still render, now in the legend, and no legend label is
+      // absolutely positioned (the property that let them overlap).
+      const browserclaw = container.querySelector(
+        '[data-stat="browserclaw-tokens"]',
+      )
+      const comparison = container.querySelector(
+        '[data-stat="comparison-tokens"]',
+      )
+      expect(browserclaw?.textContent?.trim().length).toBeGreaterThan(0)
+      expect(comparison?.textContent?.trim().length).toBeGreaterThan(0)
+      expect(browserclaw?.closest('[class*="absolute"]')).toBeNull()
+      expect(comparison?.closest('[class*="absolute"]')).toBeNull()
+    }
   })
 
   it('frames BrowserClaw against a screenshot-first agent', async () => {

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/SavedStatsBand.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/SavedStatsBand.tsx
@@ -1,7 +1,6 @@
 import type { CockpitStats, CockpitStatsWindow } from '@browseros/claw-api'
 import { useState } from 'react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { cn } from '@/lib/utils'
 
 export type { CockpitStats, CockpitStatsWindow } from '@browseros/claw-api'
 
@@ -130,23 +129,14 @@ function SavedStatsPanel({
           </div>
         </div>
 
-        <div
-          className="relative h-12 min-w-0 overflow-hidden rounded-xl bg-[repeating-linear-gradient(135deg,var(--color-card-tint),var(--color-card-tint)_9px,var(--color-card)_9px,var(--color-card)_10px)] shadow-[inset_0_0_0_1px_var(--color-border-2)]"
-          data-budget-track
-        >
-          <div
-            aria-hidden
-            className="absolute inset-y-0 left-0 rounded-r-sm rounded-l-xl bg-gradient-to-r from-accent to-accent-2 shadow-[0_2px_10px_color-mix(in_srgb,var(--color-accent)_45%,transparent)] transition-[width] duration-300 motion-reduce:transition-none"
-            style={{ width: `${usedRatio * 100}%` }}
-          />
-          <div
-            className={cn(
-              'absolute inset-y-0 z-10 flex items-center gap-2',
-              usedRatio > 0.7 && '-translate-x-full flex-row-reverse',
-            )}
-            data-used-marker
-            style={{ left: `${usedRatio * 100}%` }}
-          >
+        {/* Usage gauge. The full bar is what a screenshot-first agent would
+            spend; the accent fill is what BrowserClaw actually used. Both
+            numbers live in the legend row above the bar — never absolutely
+            positioned inside the bounded, overflow-hidden track — so they can
+            never overlap or clip, at any used/total ratio or label length. The
+            legend wraps to two lines before the labels would ever meet. */}
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
+          <span className="inline-flex items-center gap-1.5 whitespace-nowrap font-mono font-semibold text-[11px] text-accent-ink tracking-[0.04em]">
             <span className="relative size-2.5 shrink-0">
               <span
                 aria-hidden
@@ -158,19 +148,32 @@ function SavedStatsPanel({
                 className="absolute inset-0 rounded-full bg-accent ring-2 ring-card"
               />
             </span>
-            <span
-              className="whitespace-nowrap font-mono font-semibold text-[11px] text-accent-ink tracking-[0.04em]"
-              data-stat="browserclaw-tokens"
-            >
-              used {formatCompact(windowStats.browserClawTokenEstimate)}
+            used{' '}
+            <span className="tabular-nums" data-stat="browserclaw-tokens">
+              {formatCompact(windowStats.browserClawTokenEstimate)}
             </span>
-          </div>
-          <span className="absolute inset-y-0 right-3 z-10 flex max-w-[58%] items-center justify-end text-right font-mono text-[9px] text-ink-3 leading-3 tracking-[0.02em] sm:text-[11px] sm:leading-4 sm:tracking-[0.04em]">
+          </span>
+          <span className="font-mono text-[11px] text-ink-3 tracking-[0.04em]">
             a screenshot-first agent would spend{' '}
-            <span className="ml-1 tabular-nums" data-stat="comparison-tokens">
+            <span
+              className="text-ink-2 tabular-nums"
+              data-stat="comparison-tokens"
+            >
               {formatCompact(windowStats.screenshotFirstTokenEstimate)}
             </span>
           </span>
+        </div>
+
+        <div
+          aria-hidden
+          className="relative h-3 min-w-0 overflow-hidden rounded-full bg-[repeating-linear-gradient(135deg,var(--color-card-tint),var(--color-card-tint)_9px,var(--color-card)_9px,var(--color-card)_10px)] shadow-[inset_0_0_0_1px_var(--color-border-2)]"
+          data-budget-track
+        >
+          <div
+            className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-accent to-accent-2 shadow-[0_2px_10px_color-mix(in_srgb,var(--color-accent)_45%,transparent)] transition-[width] duration-300 motion-reduce:transition-none"
+            data-used-fill
+            style={{ width: `${usedRatio * 100}%` }}
+          />
         </div>
         <p className="mt-2.5 font-mono text-[10.5px] text-ink-4 tracking-[0.04em]">
           compact DOM &amp; tool responses instead of a screenshot per call


### PR DESCRIPTION
## Problem

The cockpit idle saved-stats band (#1990) absolutely positioned **both** token labels — `used <n>` and `a screenshot-first agent would spend <n>` — inside the same `overflow-hidden` budget track. `[data-used-marker]` started at `usedRatio*100%` and only flipped sides above `0.7`, while the comparison label stayed right-pinned with `max-w-[58%]`. Around the mid-range their text landed on the same pixels and painted through each other:

> `used 63.2K` overlapping `…would spend 112.3K` — the reported "weird thing".

## Fix

Lift both numbers out of the bounded bar into a **legend row above** the track:

- A `flex flex-wrap items-center justify-between` row — the two labels anchor to opposite ends and **wrap to two lines before they could ever meet**, so there is no ratio or label length that makes them collide.
- The track becomes a **pure gauge** (`aria-hidden`, no text): accent fill = what BrowserClaw used, striped remainder = what a screenshot-first agent would have spent. With no text inside, nothing can clip against `overflow-hidden` either.
- The pulsing "live" dot moves next to the `used` value and keeps its `motion-reduce:animate-none` behavior.

Meaning of the comparison, the cockpit's visual language (accent gradient, striped track, mono labels, theme tokens), and the stats/API contract are all unchanged. No efficiency-calculation or backend changes.

## Tests

- Replaced the old `[data-used-marker]` `left:%` assertions with `[data-used-fill]` `width:%` (same 0% / 100% / 50% cases).
- Added a regression test asserting the **structural invariant that guarantees no overlap** — the bounded bar carries no `[data-stat]` text and neither label is absolutely positioned — across low, mid (the 63.2K/112.3K bug case), and full ratios.

## Verification

- `SavedStatsBand` suite: **6 pass / 61 expect()**.
- `bun run typecheck`: clean (incl. `@browseros/claw-app`).
- `biome` on the changed files: clean.
- Visual: rendered the exact markup with real theme tokens at 0%, near-0%, mid (bug case), 80%, 100%, long 1.2M/1.5M labels, on desktop **and** narrow 360px — collision- and clip-free at every case, and the layout reads as intentional.

<sub>Note: raw `bun test` in this worktree can't resolve the `@/` alias after `wxt prepare` regenerated `.wxt` (a local bun/tsconfig quirk that hits the original file identically and does not affect CI); the suite passes with the alias resolving normally.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)