### PR TITLE
fix(claw): use session duration for human time saved

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
@@ -17,6 +17,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0008_add_task_token_estimates::Migration),
             Box::new(m0009_rebase_screenshot_baseline::Migration),
             Box::new(m0010_sum_session_efficiency_durations::Migration),
+            Box::new(m0011_use_session_durations_for_efficiency::Migration),
         ]
     }
 }
@@ -275,6 +276,150 @@ mod m0010_sum_session_efficiency_durations {
                     ("saturated".to_owned(), i64::MAX, 3)
                 ]
             );
+            Ok(())
+        }
+    }
+}
+
+mod m0011_use_session_durations_for_efficiency {
+    use super::*;
+    use sea_orm_migration::sea_orm::{DbBackend, Statement};
+
+    const SOURCE_EFFICIENCY_ESTIMATOR_VERSION: i64 = 3;
+    const EFFICIENCY_ESTIMATOR_VERSION: i64 = 4;
+
+    pub struct Migration;
+
+    impl MigrationName for Migration {
+        fn name(&self) -> &str {
+            "m0011_use_session_durations_for_efficiency"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for Migration {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            // Retained projections can outlive tasks, and session IDs can be reused. The end
+            // timestamp and dispatch count identify the task materialized from the same audit rows.
+            manager
+                .get_connection()
+                .execute(Statement::from_sql_and_values(
+                    DbBackend::Sqlite,
+                    r#"
+                    UPDATE session_efficiency_stats
+                    SET active_duration_ms = MAX((
+                            SELECT task.duration_ms
+                            FROM tasks AS task
+                            WHERE task.session_id = session_efficiency_stats.session_id
+                                AND task.ended_at = session_efficiency_stats.ended_at
+                                AND task.dispatch_count = session_efficiency_stats.dispatch_count
+                        ), 0),
+                        efficiency_estimator_version = ?
+                    WHERE efficiency_estimator_version = ?
+                        AND EXISTS (
+                            SELECT 1
+                            FROM tasks AS task
+                            WHERE task.session_id = session_efficiency_stats.session_id
+                                AND task.ended_at = session_efficiency_stats.ended_at
+                                AND task.dispatch_count = session_efficiency_stats.dispatch_count
+                        )
+                    "#,
+                    [
+                        EFFICIENCY_ESTIMATOR_VERSION.into(),
+                        SOURCE_EFFICIENCY_ESTIMATOR_VERSION.into(),
+                    ],
+                ))
+                .await?;
+            Ok(())
+        }
+
+        async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+            // Retained audit history cannot reconstruct the old summed-tool duration.
+            Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use sea_orm_migration::sea_orm::{
+            ConnectionTrait, Database as SeaDatabase, DatabaseConnection, DbBackend, Statement,
+        };
+
+        async fn insert_projection(
+            connection: &DatabaseConnection,
+            session_id: &str,
+            ended_at: i64,
+            dispatch_count: i64,
+        ) -> Result<(), DbErr> {
+            connection
+                .execute_unprepared(&format!(
+                    "INSERT INTO session_efficiency_stats VALUES ('{session_id}', {ended_at}, {dispatch_count}, 900, 0, 0, 0, 3, 0)"
+                ))
+                .await?;
+            Ok(())
+        }
+
+        async fn insert_task(
+            connection: &DatabaseConnection,
+            session_id: &str,
+            ended_at: i64,
+            dispatch_count: i64,
+            duration_ms: i64,
+        ) -> Result<(), DbErr> {
+            connection
+                .execute_unprepared(&format!(
+                    "INSERT INTO tasks (session_id, agent_id, slug, agent_label, title, started_at, ended_at, duration_ms, dispatch_count, tool_sequence_json, status, error_count, cursor_id, has_screenshots, updated_at) VALUES ('{session_id}', 'agent', 'agent', 'Agent', 'Session', 0, {ended_at}, {duration_ms}, {dispatch_count}, '[]', 'done', 0, 0, 0, 0)"
+                ))
+                .await?;
+            Ok(())
+        }
+
+        async fn projection(
+            connection: &DatabaseConnection,
+            session_id: &str,
+        ) -> Result<(i64, i64), DbErr> {
+            let row = connection
+                .query_one(Statement::from_string(
+                    DbBackend::Sqlite,
+                    format!(
+                        "SELECT active_duration_ms, efficiency_estimator_version FROM session_efficiency_stats WHERE session_id = '{session_id}'"
+                    ),
+                ))
+                .await?
+                .ok_or_else(|| DbErr::RecordNotFound(session_id.to_owned()))?;
+            Ok((
+                row.try_get("", "active_duration_ms")?,
+                row.try_get("", "efficiency_estimator_version")?,
+            ))
+        }
+
+        #[tokio::test]
+        async fn upgrade_uses_only_matching_task_durations() -> anyhow::Result<()> {
+            let connection = SeaDatabase::connect("sqlite::memory:").await?;
+            super::super::Migrator::up(&connection, Some(10)).await?;
+
+            insert_projection(&connection, "matching", 10, 2).await?;
+            insert_task(&connection, "matching", 10, 2, 1_234).await?;
+
+            insert_projection(&connection, "negative", 20, 1).await?;
+            insert_task(&connection, "negative", 20, 1, -5).await?;
+
+            insert_projection(&connection, "end-mismatch", 30, 1).await?;
+            insert_task(&connection, "end-mismatch", 31, 1, 300).await?;
+
+            insert_projection(&connection, "count-mismatch", 40, 2).await?;
+            insert_task(&connection, "count-mismatch", 40, 1, 400).await?;
+
+            insert_projection(&connection, "absent-task", 50, 1).await?;
+
+            super::super::Migrator::up(&connection, None).await?;
+
+            assert_eq!(projection(&connection, "matching").await?, (1_234, 4));
+            assert_eq!(projection(&connection, "negative").await?, (0, 4));
+            assert_eq!(projection(&connection, "end-mismatch").await?, (900, 3));
+            assert_eq!(projection(&connection, "count-mismatch").await?, (900, 3));
+            assert_eq!(projection(&connection, "absent-task").await?, (900, 3));
             Ok(())
         }
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
@@ -273,7 +273,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 10);
+        assert_eq!(migrations.len(), 11);
         assert_eq!(
             migrations[0].try_get::<String>("", "version")?,
             "m0001_baseline"
@@ -313,6 +313,10 @@ mod tests {
         assert_eq!(
             migrations[9].try_get::<String>("", "version")?,
             "m0010_sum_session_efficiency_durations"
+        );
+        assert_eq!(
+            migrations[10].try_get::<String>("", "version")?,
+            "m0011_use_session_durations_for_efficiency"
         );
         Ok(())
     }
@@ -355,7 +359,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations ORDER BY version".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 10);
+        assert_eq!(migrations.len(), 11);
         assert_eq!(
             migrations
                 .iter()
@@ -378,7 +382,7 @@ mod tests {
             .await?
             .ok_or_else(|| anyhow::anyhow!("migration count missing"))?
             .try_get::<i64>("", "count")?;
-        assert_eq!(migration_count, 10);
+        assert_eq!(migration_count, 11);
         Ok(())
     }
 
@@ -514,7 +518,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 10);
+        assert_eq!(migrations.len(), 11);
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
@@ -490,6 +490,7 @@ mod tests {
         }));
         state.session_efficiency = session_efficiency;
         state.sessions = sessions;
+        let audit_log = state.audit_log.clone();
         let session = state
             .sessions
             .mint_with_id(
@@ -517,6 +518,11 @@ mod tests {
             .await;
 
         AppRuntime::start(state).shutdown().await?;
+        let task_duration_ms = audit_log
+            .get_task_summary("shutdown-session")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("task summary missing"))?
+            .duration_ms;
         assert_eq!(analytics.shutdown_calls_for_testing(), 1);
         let mut captured = Vec::new();
         while let Ok(request) = requests.try_recv() {
@@ -551,14 +557,14 @@ mod tests {
                 "kind": "closed",
                 "client_name": "codex",
                 "dispatch_count": 1,
-                "active_duration_ms": 5,
+                "active_duration_ms": task_duration_ms,
                 "tool_input_token_estimate": 1,
                 "tool_output_token_estimate": 0,
                 "browserclaw_token_estimate": 1,
                 "screenshot_baseline_token_estimate": 3_000,
                 "screenshot_first_token_estimate": 3_001,
                 "raw_token_savings_estimate": 3_000,
-                "efficiency_estimator_version": 3,
+                "efficiency_estimator_version": 4,
                 "screenshot_baseline_width": 1_920,
                 "screenshot_baseline_height": 1_080,
                 "screenshot_tokens_per_dispatch": 3_000,

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/session_efficiency.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/session_efficiency.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::warn;
 
-pub const EFFICIENCY_ESTIMATOR_VERSION: i64 = 3;
+pub const EFFICIENCY_ESTIMATOR_VERSION: i64 = 4;
 pub const SCREENSHOT_BASELINE_WIDTH: usize = 1920;
 pub const SCREENSHOT_BASELINE_HEIGHT: usize = 1080;
 const DAY_MS: i64 = 24 * 60 * 60 * 1000;
@@ -215,16 +215,19 @@ fn calculate_session_efficiency(
 
     let mut tool_input_token_estimate = 0_i64;
     let mut tool_output_token_estimate = 0_i64;
-    let mut active_duration_ms = 0_i64;
     for dispatch in &source.dispatches {
         tool_input_token_estimate =
             tool_input_token_estimate.saturating_add(dispatch.tool_input_token_estimate.max(0));
         tool_output_token_estimate =
             tool_output_token_estimate.saturating_add(dispatch.tool_output_token_estimate.max(0));
-        active_duration_ms =
-            active_duration_ms.saturating_add(dispatch.duration_ms.unwrap_or_default().max(0));
     }
 
+    let started_at = source
+        .start
+        .as_ref()
+        .map(|start| start.created_at)
+        .unwrap_or(source.dispatches[0].created_at);
+    let active_duration_ms = source.end.created_at.saturating_sub(started_at).max(0);
     let dispatch_count = i64::try_from(source.dispatches.len()).unwrap_or(i64::MAX);
     Some(session_efficiency_stats::Model {
         session_id: source.session_id.clone(),
@@ -465,7 +468,7 @@ mod tests {
     }
 
     #[test]
-    fn calculator_sums_overlapping_dispatch_durations() -> anyhow::Result<()> {
+    fn calculator_uses_elapsed_session_duration() -> anyhow::Result<()> {
         let source = source(vec![
             dispatch(1, 1_000, Some(500), 10, 100, 1),
             dispatch(2, 1_200, Some(400), 20, 200, 1),
@@ -476,41 +479,46 @@ mod tests {
         assert_eq!(stats.session_id, "session");
         assert_eq!(stats.ended_at, 10_000);
         assert_eq!(stats.dispatch_count, 2);
-        assert_eq!(stats.active_duration_ms, 900);
+        assert_eq!(stats.active_duration_ms, 10_000);
         assert_eq!(stats.tool_input_token_estimate, 30);
         assert_eq!(stats.tool_output_token_estimate, 300);
         assert_eq!(stats.screenshot_baseline_token_estimate, 6_000);
-        assert_eq!(stats.efficiency_estimator_version, 3);
+        assert_eq!(stats.efficiency_estimator_version, 4);
         assert_eq!(stats.computed_at, 12_000);
         Ok(())
     }
 
     #[test]
-    fn calculator_ignores_gaps_and_treats_missing_and_negative_durations_as_zero()
-    -> anyhow::Result<()> {
-        let source = source(vec![
+    fn calculator_uses_first_dispatch_when_start_is_missing() -> anyhow::Result<()> {
+        let mut source = source(vec![
             dispatch(1, 100, None, i64::MAX, i64::MAX, 1),
             dispatch(2, 200, Some(-10), 1, 1, 1),
         ]);
+        source.start = None;
 
         let stats = calculate_session_efficiency(&source, 300)
             .ok_or_else(|| anyhow::anyhow!("eligible session was skipped"))?;
-        assert_eq!(stats.active_duration_ms, 0);
+        assert_eq!(stats.active_duration_ms, 9_900);
         assert_eq!(stats.tool_input_token_estimate, i64::MAX);
         assert_eq!(stats.tool_output_token_estimate, i64::MAX);
         Ok(())
     }
 
     #[test]
-    fn calculator_saturates_the_dispatch_duration_sum() -> anyhow::Result<()> {
-        let source = source(vec![
+    fn calculator_clamps_a_start_after_the_end_to_zero() -> anyhow::Result<()> {
+        let mut source = source(vec![
             dispatch(1, 100, Some(i64::MAX), 0, 0, 1),
             dispatch(2, 200, Some(1), 0, 0, 1),
         ]);
+        source
+            .start
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("source start missing"))?
+            .created_at = 10_001;
 
         let stats = calculate_session_efficiency(&source, 300)
             .ok_or_else(|| anyhow::anyhow!("eligible session was skipped"))?;
-        assert_eq!(stats.active_duration_ms, i64::MAX);
+        assert_eq!(stats.active_duration_ms, 0);
         Ok(())
     }
 
@@ -713,6 +721,11 @@ mod tests {
         audit
             .record_session_end("negative", "errored", None)
             .await?;
+        let task_duration_ms = audit
+            .get_task_summary("negative")
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("task summary missing"))?
+            .duration_ms;
 
         let (left, right) = tokio::join!(
             service.finalize_session_at("negative", 1),
@@ -730,14 +743,14 @@ mod tests {
                     "kind": "errored",
                     "client_name": "claude-code",
                     "dispatch_count": 1,
-                    "active_duration_ms": 10,
+                    "active_duration_ms": task_duration_ms,
                     "tool_input_token_estimate": 30,
                     "tool_output_token_estimate": 4_000,
                     "browserclaw_token_estimate": 4_030,
                     "screenshot_baseline_token_estimate": 3_000,
                     "screenshot_first_token_estimate": 3_030,
                     "raw_token_savings_estimate": -1_000,
-                    "efficiency_estimator_version": 3,
+                    "efficiency_estimator_version": 4,
                     "screenshot_baseline_width": 1_920,
                     "screenshot_baseline_height": 1_080,
                     "screenshot_tokens_per_dispatch": 3_000,

--- a/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
@@ -690,6 +690,13 @@ async fn canonical_cockpit_stats_maps_no_data_and_measured_windows() -> anyhow::
         .audit_log
         .record_session_end("stats-session", "closed", None)
         .await?;
+    let task_duration_ms = app
+        .state
+        .audit_log
+        .get_task_summary("stats-session")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("task summary missing"))?
+        .duration_ms;
     assert!(
         app.state
             .session_efficiency
@@ -711,7 +718,7 @@ async fn canonical_cockpit_stats_maps_no_data_and_measured_windows() -> anyhow::
         "browserClawTokenEstimate": 2_001,
         "screenshotFirstTokenEstimate": 3_001,
         "rawTokenSavingsEstimate": 1_000,
-        "humanTimeSavedMs": 5,
+        "humanTimeSavedMs": task_duration_ms,
         "sessionCount": 1,
         "toolCallCount": 1,
     });


### PR DESCRIPTION
## Summary
- define human time saved as the elapsed duration of each completed, measured session
- preserve token estimates, eligibility, aggregation windows, session counts, and tool-call counts
- backfill reconstructable version-3 projections from their matching activity-card task durations

## Design
The efficiency projection now uses the same lifecycle start, first-dispatch fallback, end timestamp, and nonnegative elapsed-duration semantics as activity cards. Formula version 4 distinguishes the new meaning. Migration 11 updates only version-3 rows whose task matches on session ID, end timestamp, and dispatch count, leaving retained or reused history untouched.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p claw-server-rust`
- [x] `cargo clippy -p claw-server-rust --all-targets -- -D warnings`
- [x] Open a consistent copy of the development database with the new migrator and verify both measured rows total `701245ms` at version 4
- [x] Query the copied database through `/api/v1/cockpit/stats` and verify `humanTimeSavedMs: 701245`, 2 sessions, and 37 tool calls
