### PR TITLE
perf(core): acquire snapshots concurrently

### DIFF
--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -335,6 +335,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/packages/browseros-agent/crates/browseros-cdp/protocol/browser_protocol.json
+++ b/packages/browseros-agent/crates/browseros-cdp/protocol/browser_protocol.json
@@ -205,6 +205,14 @@
         },
         { "name": "reload" },
         {
+          "name": "createIsolatedWorld",
+          "parameters": [
+            { "name": "frameId", "$ref": "FrameId" },
+            { "name": "worldName", "type": "string", "optional": true }
+          ],
+          "returns": [{ "name": "executionContextId", "type": "integer" }]
+        },
+        {
           "name": "getFrameTree",
           "returns": [{ "name": "frameTree", "$ref": "FrameTree" }]
         },

--- a/packages/browseros-agent/crates/browseros-cdp/protocol/browser_protocol.json
+++ b/packages/browseros-agent/crates/browseros-cdp/protocol/browser_protocol.json
@@ -205,14 +205,6 @@
         },
         { "name": "reload" },
         {
-          "name": "createIsolatedWorld",
-          "parameters": [
-            { "name": "frameId", "$ref": "FrameId" },
-            { "name": "worldName", "type": "string", "optional": true }
-          ],
-          "returns": [{ "name": "executionContextId", "type": "integer" }]
-        },
-        {
           "name": "getFrameTree",
           "returns": [{ "name": "frameTree", "$ref": "FrameTree" }]
         },

--- a/packages/browseros-agent/crates/browseros-cdp/protocol/js_protocol.json
+++ b/packages/browseros-agent/crates/browseros-cdp/protocol/js_protocol.json
@@ -22,6 +22,14 @@
           ]
         },
         {
+          "id": "PropertyDescriptor",
+          "type": "object",
+          "properties": [
+            { "name": "name", "type": "string" },
+            { "name": "value", "$ref": "RemoteObject", "optional": true }
+          ]
+        },
+        {
           "id": "CallArgument",
           "type": "object",
           "properties": [
@@ -123,6 +131,20 @@
               "name": "exceptionDetails",
               "$ref": "ExceptionDetails",
               "optional": true
+            }
+          ]
+        },
+        {
+          "name": "getProperties",
+          "parameters": [
+            { "name": "objectId", "type": "string" },
+            { "name": "ownProperties", "type": "boolean", "optional": true }
+          ],
+          "returns": [
+            {
+              "name": "result",
+              "type": "array",
+              "items": { "$ref": "PropertyDescriptor" }
             }
           ]
         },

--- a/packages/browseros-agent/crates/browseros-core/Cargo.toml
+++ b/packages/browseros-agent/crates/browseros-core/Cargo.toml
@@ -16,6 +16,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 base64.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/packages/browseros-agent/crates/browseros-core/src/assets/cursor-augment.js
+++ b/packages/browseros-agent/crates/browseros-core/src/assets/cursor-augment.js
@@ -1,6 +1,8 @@
 // biome-ignore-all lint: Injected ES5 asset mirrors the TypeScript browser-core runtime string.
 // biome-ignore format: Keep injected script byte-oriented and close to the TypeScript source.
-(function(markerAttribute){
+(function(markerAttribute,markerToken){
+  var document=this;
+  if(document.querySelector('['+markerAttribute+']'))return{collision:true,candidates:[]};
   var interactiveTags=new Set(['a','button','input','select','textarea','details','summary']);
   var interactiveRoles=new Set(['button','link','textbox','checkbox','radio','combobox','listbox',
     'menuitem','menuitemcheckbox','menuitemradio','option','searchbox','slider','spinbutton','switch','tab','treeitem']);
@@ -24,7 +26,7 @@
     }
     var rect=el.getBoundingClientRect();
     if(rect.width===0||rect.height===0)continue;
-    el.setAttribute(markerAttribute,String(i));
+    el.setAttribute(markerAttribute,markerToken+':'+String(i));
     var reasons=[];
     if(hasCursor)reasons.push('cursor:pointer');
     if(hasOnClick)reasons.push('onclick');
@@ -32,5 +34,5 @@
     if(editable)reasons.push('contenteditable');
     out.push({marker:String(i),reasons:reasons});
   }
-  return out;
-})(__BROWSEROS_CURSOR_MARKER__)
+  return{collision:false,candidates:out};
+})

--- a/packages/browseros-agent/crates/browseros-core/src/assets/cursor-augment.js
+++ b/packages/browseros-agent/crates/browseros-core/src/assets/cursor-augment.js
@@ -1,6 +1,6 @@
 // biome-ignore-all lint: Injected ES5 asset mirrors the TypeScript browser-core runtime string.
 // biome-ignore format: Keep injected script byte-oriented and close to the TypeScript source.
-(function(){
+(function(markerAttribute){
   var interactiveTags=new Set(['a','button','input','select','textarea','details','summary']);
   var interactiveRoles=new Set(['button','link','textbox','checkbox','radio','combobox','listbox',
     'menuitem','menuitemcheckbox','menuitemradio','option','searchbox','slider','spinbutton','switch','tab','treeitem']);
@@ -24,7 +24,7 @@
     }
     var rect=el.getBoundingClientRect();
     if(rect.width===0||rect.height===0)continue;
-    el.setAttribute('data-__bcid',String(i));
+    el.setAttribute(markerAttribute,String(i));
     var reasons=[];
     if(hasCursor)reasons.push('cursor:pointer');
     if(hasOnClick)reasons.push('onclick');
@@ -33,4 +33,4 @@
     out.push({marker:String(i),reasons:reasons});
   }
   return out;
-})()
+})(__BROWSEROS_CURSOR_MARKER__)

--- a/packages/browseros-agent/crates/browseros-core/src/assets/cursor-augment.js
+++ b/packages/browseros-agent/crates/browseros-core/src/assets/cursor-augment.js
@@ -1,3 +1,5 @@
+/* deepscan-disable UNUSED_EXPR */
+// CDP Runtime.callFunctionOn consumes the final expression as its functionDeclaration; it must remain uninvoked in this source asset.
 // biome-ignore-all lint: Injected ES5 asset mirrors the TypeScript browser-core runtime string.
 // biome-ignore format: Keep injected script byte-oriented and close to the TypeScript source.
 (function(markerAttribute,markerToken){

--- a/packages/browseros-agent/crates/browseros-core/src/frames.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/frames.rs
@@ -16,6 +16,7 @@ pub struct FrameTarget {
 
 pub struct FrameRegistry {
     cdp: Arc<dyn CdpConnection>,
+    connection_epoch: Mutex<u64>,
     oopif_sessions: Mutex<HashMap<FrameId, SessionId>>,
     same_process_sessions: Mutex<HashMap<FrameId, SessionId>>,
     page_sessions: Mutex<HashMap<PageId, SessionId>>,
@@ -24,8 +25,10 @@ pub struct FrameRegistry {
 impl FrameRegistry {
     #[must_use]
     pub fn new(cdp: Arc<dyn CdpConnection>) -> Arc<Self> {
+        let connection_epoch = cdp.connection_epoch();
         let registry = Arc::new(Self {
             cdp,
+            connection_epoch: Mutex::new(connection_epoch),
             oopif_sessions: Mutex::new(HashMap::new()),
             same_process_sessions: Mutex::new(HashMap::new()),
             page_sessions: Mutex::new(HashMap::new()),
@@ -40,6 +43,7 @@ impl FrameRegistry {
         page_id: PageId,
         session_id: SessionId,
     ) -> Result<(), CoreError> {
+        self.clear_sessions_from_prior_connection().await;
         self.page_sessions.lock().await.insert(page_id, session_id);
         let _ = page_session
             .send::<_, Value>(
@@ -60,6 +64,7 @@ impl FrameRegistry {
         frame_id: Option<FrameId>,
         same_process_parent: Option<&ProtocolSession>,
     ) -> Result<FrameTarget, CoreError> {
+        self.clear_sessions_from_prior_connection().await;
         let page_session_id = self
             .page_sessions
             .lock()
@@ -108,6 +113,20 @@ impl FrameRegistry {
         })
     }
 
+    async fn clear_sessions_from_prior_connection(&self) {
+        let current_epoch = self.cdp.connection_epoch();
+        let mut cached_epoch = self.connection_epoch.lock().await;
+        if *cached_epoch == current_epoch {
+            return;
+        }
+        // Flattened target session ids are scoped to one CDP websocket. A reconnect can reuse
+        // frame ids while every cached page, OOPIF, and inherited session id is already invalid.
+        self.oopif_sessions.lock().await.clear();
+        self.same_process_sessions.lock().await.clear();
+        self.page_sessions.lock().await.clear();
+        *cached_epoch = current_epoch;
+    }
+
     fn spawn_event_listener(registry: Arc<Self>) {
         let mut events = registry.cdp.events();
         tokio::spawn(async move {
@@ -143,6 +162,7 @@ impl FrameRegistry {
         if params.target_info.r#type != "iframe" {
             return;
         }
+        self.clear_sessions_from_prior_connection().await;
         let frame_id = FrameId(params.target_info.target_id);
         let session_id = SessionId::from(params.session_id);
         self.oopif_sessions
@@ -172,6 +192,7 @@ impl FrameRegistry {
     }
 
     async fn on_detached(&self, session_id: &SessionId) {
+        self.clear_sessions_from_prior_connection().await;
         self.oopif_sessions
             .lock()
             .await
@@ -190,10 +211,23 @@ mod tests {
     use browseros_cdp::{CdpError, CdpEvent};
     use futures_util::future::BoxFuture;
     use serde_json::{Value, json};
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    };
     use tokio::sync::broadcast;
 
-    struct NoopConnection;
+    struct NoopConnection {
+        epoch: AtomicU64,
+    }
+
+    impl Default for NoopConnection {
+        fn default() -> Self {
+            Self {
+                epoch: AtomicU64::new(1),
+            }
+        }
+    }
 
     impl CdpConnection for NoopConnection {
         fn send<'a>(
@@ -224,14 +258,14 @@ mod tests {
         }
 
         fn connection_epoch(&self) -> u64 {
-            1
+            self.epoch.load(Ordering::SeqCst)
         }
     }
 
     #[tokio::test]
     async fn same_process_child_inherits_and_caches_its_oopif_parent_session()
     -> Result<(), crate::CoreError> {
-        let cdp = Arc::new(NoopConnection);
+        let cdp = Arc::new(NoopConnection::default());
         let registry = FrameRegistry::new(cdp.clone());
         let page_id = PageId(1);
         registry
@@ -267,6 +301,54 @@ mod tests {
             cdp,
             SessionId::from("page-session".to_string())
         )));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reconnect_discards_inherited_sessions_from_the_prior_connection()
+    -> Result<(), crate::CoreError> {
+        let cdp = Arc::new(NoopConnection::default());
+        let registry = FrameRegistry::new(cdp.clone());
+        let page_id = PageId(1);
+        let child_id = FrameId("child".to_string());
+        let first_page_session = ProtocolSession::for_session(
+            cdp.clone(),
+            SessionId::from("page-session-1".to_string()),
+        );
+        registry
+            .register_page(
+                first_page_session,
+                page_id.clone(),
+                SessionId::from("page-session-1".to_string()),
+            )
+            .await?;
+        let first_parent = ProtocolSession::for_session(
+            cdp.clone(),
+            SessionId::from("oopif-session-1".to_string()),
+        );
+        let first_child = registry
+            .resolve_frame_target(page_id.clone(), Some(child_id.clone()), Some(&first_parent))
+            .await?;
+        assert!(first_child.session.same_session(&first_parent));
+
+        cdp.epoch.store(2, Ordering::SeqCst);
+        let second_page_session = ProtocolSession::for_session(
+            cdp.clone(),
+            SessionId::from("page-session-2".to_string()),
+        );
+        registry
+            .register_page(
+                second_page_session.clone(),
+                page_id.clone(),
+                SessionId::from("page-session-2".to_string()),
+            )
+            .await?;
+
+        let reconnected_child = registry
+            .resolve_frame_target(page_id, Some(child_id), None)
+            .await?;
+        assert!(reconnected_child.session.same_session(&second_page_session));
+        assert!(!reconnected_child.session.same_session(&first_parent));
         Ok(())
     }
 }

--- a/packages/browseros-agent/crates/browseros-core/src/frames.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/frames.rs
@@ -8,9 +8,9 @@ use tokio::sync::Mutex;
 pub struct FrameTarget {
     pub session: ProtocolSession,
     pub ax_params: Value,
-    /// Frame whose isolated world must host DOM cursor scanning. Root targets use their session's
-    /// default document; same-process and out-of-process children require an explicit frame.
-    pub runtime_frame_id: Option<FrameId>,
+    /// Root and OOPIF sessions already inspect the intended document. Same-process children share
+    /// the page session, so cursor acquisition must target their resolved document object instead.
+    pub cursor_uses_session_default: bool,
 }
 
 pub struct FrameRegistry {
@@ -67,20 +67,20 @@ impl FrameRegistry {
             return Ok(FrameTarget {
                 session: ProtocolSession::for_session(self.cdp.clone(), page_session_id),
                 ax_params: json!({}),
-                runtime_frame_id: None,
+                cursor_uses_session_default: true,
             });
         };
         if let Some(oopif) = self.oopif_sessions.lock().await.get(&frame_id).cloned() {
             return Ok(FrameTarget {
                 session: ProtocolSession::for_session(self.cdp.clone(), oopif),
                 ax_params: json!({}),
-                runtime_frame_id: Some(frame_id),
+                cursor_uses_session_default: true,
             });
         }
         Ok(FrameTarget {
             session: ProtocolSession::for_session(self.cdp.clone(), page_session_id),
             ax_params: json!({ "frameId": frame_id.0 }),
-            runtime_frame_id: Some(frame_id),
+            cursor_uses_session_default: false,
         })
     }
 

--- a/packages/browseros-agent/crates/browseros-core/src/frames.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/frames.rs
@@ -9,13 +9,15 @@ pub struct FrameTarget {
     pub session: ProtocolSession,
     pub ax_params: Value,
     /// Root and OOPIF sessions already inspect the intended document. Same-process children share
-    /// the page session, so cursor acquisition must target their resolved document object instead.
+    /// their nearest parent target session, so cursor acquisition must target the resolved child
+    /// Document object instead.
     pub cursor_uses_session_default: bool,
 }
 
 pub struct FrameRegistry {
     cdp: Arc<dyn CdpConnection>,
     oopif_sessions: Mutex<HashMap<FrameId, SessionId>>,
+    same_process_sessions: Mutex<HashMap<FrameId, SessionId>>,
     page_sessions: Mutex<HashMap<PageId, SessionId>>,
 }
 
@@ -25,6 +27,7 @@ impl FrameRegistry {
         let registry = Arc::new(Self {
             cdp,
             oopif_sessions: Mutex::new(HashMap::new()),
+            same_process_sessions: Mutex::new(HashMap::new()),
             page_sessions: Mutex::new(HashMap::new()),
         });
         Self::spawn_event_listener(registry.clone());
@@ -55,6 +58,7 @@ impl FrameRegistry {
         &self,
         page_id: PageId,
         frame_id: Option<FrameId>,
+        same_process_parent: Option<&ProtocolSession>,
     ) -> Result<FrameTarget, CoreError> {
         let page_session_id = self
             .page_sessions
@@ -77,8 +81,28 @@ impl FrameRegistry {
                 cursor_uses_session_default: true,
             });
         }
+        // A non-target frame shares its nearest parent target's CDP session, which may itself be
+        // an OOPIF. Cache that inheritance because later ref resolution knows the frame id but no
+        // longer has the capture-time parent target.
+        let inherited_session = same_process_parent
+            .and_then(ProtocolSession::session_id)
+            .cloned();
+        let session_id = if let Some(inherited_session) = inherited_session {
+            self.same_process_sessions
+                .lock()
+                .await
+                .insert(frame_id.clone(), inherited_session.clone());
+            inherited_session
+        } else {
+            self.same_process_sessions
+                .lock()
+                .await
+                .get(&frame_id)
+                .cloned()
+                .unwrap_or(page_session_id)
+        };
         Ok(FrameTarget {
-            session: ProtocolSession::for_session(self.cdp.clone(), page_session_id),
+            session: ProtocolSession::for_session(self.cdp.clone(), session_id),
             ax_params: json!({ "frameId": frame_id.0 }),
             cursor_uses_session_default: false,
         })
@@ -152,5 +176,97 @@ impl FrameRegistry {
             .lock()
             .await
             .retain(|_, existing| existing != session_id);
+        self.same_process_sessions
+            .lock()
+            .await
+            .retain(|_, existing| existing != session_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FrameRegistry;
+    use crate::{FrameId, PageId, ProtocolSession, SessionId, connection::CdpConnection};
+    use browseros_cdp::{CdpError, CdpEvent};
+    use futures_util::future::BoxFuture;
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+    use tokio::sync::broadcast;
+
+    struct NoopConnection;
+
+    impl CdpConnection for NoopConnection {
+        fn send<'a>(
+            &'a self,
+            _method: &'a str,
+            _params: Value,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<Value, CdpError>> {
+            Box::pin(async { Ok(json!({})) })
+        }
+
+        fn send_raw_json<'a>(
+            &'a self,
+            _method: &'a str,
+            _params_json: &'a str,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<String, CdpError>> {
+            Box::pin(async { Ok("{}".to_string()) })
+        }
+
+        fn events(&self) -> broadcast::Receiver<CdpEvent> {
+            let (_tx, rx) = broadcast::channel(1);
+            rx
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn connection_epoch(&self) -> u64 {
+            1
+        }
+    }
+
+    #[tokio::test]
+    async fn same_process_child_inherits_and_caches_its_oopif_parent_session()
+    -> Result<(), crate::CoreError> {
+        let cdp = Arc::new(NoopConnection);
+        let registry = FrameRegistry::new(cdp.clone());
+        let page_id = PageId(1);
+        registry
+            .page_sessions
+            .lock()
+            .await
+            .insert(page_id.clone(), SessionId::from("page-session".to_string()));
+        registry.oopif_sessions.lock().await.insert(
+            FrameId("oopif".to_string()),
+            SessionId::from("oopif-session".to_string()),
+        );
+        let oopif = registry
+            .resolve_frame_target(page_id.clone(), Some(FrameId("oopif".to_string())), None)
+            .await?;
+        let nested_id = FrameId("nested".to_string());
+
+        let nested = registry
+            .resolve_frame_target(
+                page_id.clone(),
+                Some(nested_id.clone()),
+                Some(&oopif.session),
+            )
+            .await?;
+        assert!(nested.session.same_session(&oopif.session));
+        assert_eq!(nested.ax_params, json!({"frameId": "nested"}));
+        assert!(!nested.cursor_uses_session_default);
+
+        let cached = registry
+            .resolve_frame_target(page_id, Some(nested_id), None)
+            .await?;
+        assert!(cached.session.same_session(&oopif.session));
+        assert!(!cached.session.same_session(&ProtocolSession::for_session(
+            cdp,
+            SessionId::from("page-session".to_string())
+        )));
+        Ok(())
     }
 }

--- a/packages/browseros-agent/crates/browseros-core/src/frames.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/frames.rs
@@ -8,6 +8,9 @@ use tokio::sync::Mutex;
 pub struct FrameTarget {
     pub session: ProtocolSession,
     pub ax_params: Value,
+    /// Frame whose isolated world must host DOM cursor scanning. Root targets use their session's
+    /// default document; same-process and out-of-process children require an explicit frame.
+    pub runtime_frame_id: Option<FrameId>,
 }
 
 pub struct FrameRegistry {
@@ -64,17 +67,20 @@ impl FrameRegistry {
             return Ok(FrameTarget {
                 session: ProtocolSession::for_session(self.cdp.clone(), page_session_id),
                 ax_params: json!({}),
+                runtime_frame_id: None,
             });
         };
         if let Some(oopif) = self.oopif_sessions.lock().await.get(&frame_id).cloned() {
             return Ok(FrameTarget {
                 session: ProtocolSession::for_session(self.cdp.clone(), oopif),
                 ax_params: json!({}),
+                runtime_frame_id: Some(frame_id),
             });
         }
         Ok(FrameTarget {
             session: ProtocolSession::for_session(self.cdp.clone(), page_session_id),
             ax_params: json!({ "frameId": frame_id.0 }),
+            runtime_frame_id: Some(frame_id),
         })
     }
 

--- a/packages/browseros-agent/crates/browseros-core/src/observer.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer.rs
@@ -138,7 +138,7 @@ impl Observer {
         let _page_session = self.pages.get_session(self.page_id.clone()).await?;
         let target = self
             .frames
-            .resolve_frame_target(self.page_id.clone(), entry.frame_id.clone())
+            .resolve_frame_target(self.page_id.clone(), entry.frame_id.clone(), None)
             .await?;
         let mut entry_for_resolution = entry.clone();
         let resolved =
@@ -248,7 +248,7 @@ impl Observer {
                 visited.push(frame_id.clone());
             }
 
-            let acquired = self.acquire_frame(frame_id, None, &context).await?;
+            let acquired = self.acquire_frame(frame_id, None, None, &context).await?;
             self.assemble_acquired_frame(acquired, refs, base_depth, visited, context)
                 .await
         })
@@ -1148,7 +1148,6 @@ mod tests {
                         }))
                     }
                     "Runtime.evaluate" => Ok(json!({ "result": { "value": [] } })),
-                    "Page.createIsolatedWorld" => Ok(json!({"executionContextId": 7})),
                     "Runtime.releaseObjectGroup" => Ok(json!({})),
                     "DOM.describeNode" => {
                         let frame_id = match params.get("backendNodeId").and_then(Value::as_i64) {
@@ -1244,7 +1243,6 @@ mod tests {
                         }))
                     }
                     "Runtime.evaluate" => Ok(json!({ "result": { "value": [] } })),
-                    "Page.createIsolatedWorld" => Ok(json!({"executionContextId": 7})),
                     "Runtime.releaseObjectGroup" => Ok(json!({})),
                     "DOM.describeNode" => {
                         let frame_id = params

--- a/packages/browseros-agent/crates/browseros-core/src/observer.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer.rs
@@ -180,7 +180,7 @@ impl Observer {
     fn capture_frame(
         &self,
         frame_id: Option<FrameId>,
-        mut refs: RefMap,
+        refs: RefMap,
         base_depth: usize,
         mut visited: Vec<FrameId>,
         context: CaptureContext,
@@ -193,12 +193,28 @@ impl Observer {
                 visited.push(frame_id.clone());
             }
 
+            let acquired = self.acquire_frame(frame_id, &context).await?;
+            self.assemble_acquired_frame(acquired, refs, base_depth, visited, context)
+                .await
+        })
+    }
+
+    fn assemble_acquired_frame(
+        &self,
+        acquired: AcquiredFrame,
+        mut refs: RefMap,
+        base_depth: usize,
+        visited: Vec<FrameId>,
+        context: CaptureContext,
+    ) -> BoxFuture<'_, Result<(String, RefMap), CoreError>> {
+        Box::pin(async move {
             let AcquiredFrame {
+                frame_id,
                 target,
                 nodes,
                 cursor_hits,
                 document_id,
-            } = self.acquire_frame(frame_id.clone(), &context).await?;
+            } = acquired;
             let mut render_opts = RenderOptions {
                 refs: &mut refs,
                 frame_id: frame_id.clone(),
@@ -219,19 +235,27 @@ impl Observer {
                     .map(ToString::to_string)
                     .collect::<Vec<_>>()
             };
-            for stitch in rendered.iframes.iter().rev() {
-                let child_frame_id =
-                    resolve_child_frame_id(&target.session, stitch.backend_node_id).await;
-                let Some(child_frame_id) = child_frame_id else {
+            let children = self
+                .acquire_child_frames(&target, &rendered.iframes, &visited, &context)
+                .await;
+            // `acquire_child_frames` restores original stitch order after unordered completion.
+            // Reverse it here because refs and line insertion have historically followed reverse
+            // iframe order; changing that would renumber stable public refs.
+            for child in children.into_iter().rev() {
+                let refs_before_child = refs.clone();
+                let Ok(acquired_child) = child.result else {
                     continue;
                 };
-                let refs_before_child = refs.clone();
+                let mut child_visited = visited.clone();
+                if let Some(child_frame_id) = &acquired_child.frame_id {
+                    child_visited.push(child_frame_id.clone());
+                }
                 let child_result = self
-                    .capture_frame(
-                        Some(child_frame_id),
+                    .assemble_acquired_frame(
+                        acquired_child,
                         refs.clone(),
-                        stitch.depth + 1,
-                        visited.clone(),
+                        child.stitch.depth + 1,
+                        child_visited,
                         context.clone(),
                     )
                     .await;
@@ -246,7 +270,7 @@ impl Observer {
                     }
                 };
                 if !child_text.is_empty() {
-                    lines.insert(stitch.line_index + 1, child_text);
+                    lines.insert(child.stitch.line_index + 1, child_text);
                 }
             }
             text = lines.join("\n");
@@ -474,25 +498,6 @@ async fn fetch_ax_tree(
     Ok(result.nodes)
 }
 
-async fn resolve_child_frame_id(
-    session: &ProtocolSession,
-    backend_node_id: i64,
-) -> Option<FrameId> {
-    let described = session
-        .send::<_, DescribeNodeResult>(
-            "DOM.describeNode",
-            json!({ "backendNodeId": backend_node_id, "depth": 1 }),
-        )
-        .await
-        .ok()?;
-    described
-        .node
-        .content_document
-        .and_then(|node| node.frame_id)
-        .or(described.node.frame_id)
-        .map(FrameId)
-}
-
 fn known_main_frame_changed(before: &MainFrameState, after: &MainFrameState) -> bool {
     if known_urls_differ(&before.url, &after.url) {
         return true;
@@ -595,9 +600,12 @@ mod tests {
     use serde_json::{Value, json};
     use std::{
         collections::HashSet,
-        sync::{Arc, Mutex},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
+        },
     };
-    use tokio::sync::broadcast;
+    use tokio::sync::{Notify, Semaphore, broadcast};
 
     struct MockConnection {
         live: HashSet<i64>,
@@ -890,6 +898,314 @@ mod tests {
         }
     }
 
+    struct SiblingConnection {
+        started: AtomicU8,
+        started_changed: Notify,
+        gates: [Arc<Semaphore>; 2],
+        completions: Mutex<Vec<usize>>,
+        completed: Notify,
+        fail_second_child: bool,
+        cycle_first_child: AtomicBool,
+        root_ax_reads: AtomicUsize,
+        main_loader: Mutex<String>,
+    }
+
+    impl SiblingConnection {
+        fn new(fail_second_child: bool) -> Self {
+            Self {
+                started: AtomicU8::new(0),
+                started_changed: Notify::new(),
+                gates: [Arc::new(Semaphore::new(0)), Arc::new(Semaphore::new(0))],
+                completions: Mutex::new(Vec::new()),
+                completed: Notify::new(),
+                fail_second_child,
+                cycle_first_child: AtomicBool::new(false),
+                root_ax_reads: AtomicUsize::new(0),
+                main_loader: Mutex::new("main-loader".to_string()),
+            }
+        }
+
+        async fn wait_for_both_children(&self) {
+            loop {
+                let notified = self.started_changed.notified();
+                if self.started.load(Ordering::SeqCst) == 0b11 {
+                    return;
+                }
+                notified.await;
+            }
+        }
+
+        async fn wait_for_completions(&self, target: usize) {
+            loop {
+                let notified = self.completed.notified();
+                if self
+                    .completions
+                    .lock()
+                    .map(|completions| completions.len())
+                    .unwrap_or_default()
+                    >= target
+                {
+                    return;
+                }
+                notified.await;
+            }
+        }
+    }
+
+    impl CdpConnection for SiblingConnection {
+        fn send<'a>(
+            &'a self,
+            method: &'a str,
+            params: Value,
+            _session: Option<&'a crate::SessionId>,
+        ) -> BoxFuture<'a, Result<Value, CdpError>> {
+            Box::pin(async move {
+                match method {
+                    "Browser.getTabs" => Ok(json!({
+                        "tabs": [tab_value("https://example.com/")]
+                    })),
+                    "Browser.getTabInfo" => Ok(json!({
+                        "tab": tab_value("https://example.com/")
+                    })),
+                    "Target.attachToTarget" => Ok(json!({ "sessionId": "session-1" })),
+                    "Page.enable"
+                    | "DOM.enable"
+                    | "Runtime.enable"
+                    | "Accessibility.enable"
+                    | "Runtime.runIfWaitingForDebugger"
+                    | "Target.setAutoAttach" => Ok(json!({})),
+                    "Page.getFrameTree" => {
+                        let loader_id = self
+                            .main_loader
+                            .lock()
+                            .map(|loader| loader.clone())
+                            .unwrap_or_else(|_error| "main-loader".to_string());
+                        Ok(json!({
+                            "frameTree": {
+                                "frame": {
+                                    "id": "main",
+                                    "loaderId": loader_id,
+                                    "url": "https://example.com/"
+                                },
+                                "childFrames": [
+                                    {
+                                        "frame": {
+                                            "id": "child-a",
+                                            "parentId": "main",
+                                            "loaderId": "loader-a",
+                                            "url": "https://example.com/a"
+                                        }
+                                    },
+                                    {
+                                        "frame": {
+                                            "id": "child-b",
+                                            "parentId": "main",
+                                            "loaderId": "loader-b",
+                                            "url": "https://example.com/b"
+                                        }
+                                    }
+                                ]
+                            }
+                        }))
+                    }
+                    "Accessibility.getFullAXTree" => {
+                        let frame_id = params.get("frameId").and_then(Value::as_str);
+                        let Some(index) = (match frame_id {
+                            Some("child-a") => Some(0),
+                            Some("child-b") => Some(1),
+                            _ => None,
+                        }) else {
+                            self.root_ax_reads.fetch_add(1, Ordering::SeqCst);
+                            return Ok(json!({
+                                "nodes": [
+                                    root_with(&["frame-a", "frame-b"]),
+                                    iframe_node("frame-a", 10),
+                                    iframe_node("frame-b", 20)
+                                ]
+                            }));
+                        };
+                        self.started.fetch_or(1 << index, Ordering::SeqCst);
+                        self.started_changed.notify_waiters();
+                        let permit =
+                            self.gates[index]
+                                .clone()
+                                .acquire_owned()
+                                .await
+                                .map_err(|error| CdpError::Protocol {
+                                    code: -1,
+                                    message: error.to_string(),
+                                })?;
+                        permit.forget();
+                        if let Ok(mut completions) = self.completions.lock() {
+                            completions.push(index);
+                        }
+                        self.completed.notify_waiters();
+                        if index == 1 && self.fail_second_child {
+                            return Err(CdpError::Protocol {
+                                code: -32000,
+                                message: "child capture failed".to_string(),
+                            });
+                        }
+                        if index == 0 && self.cycle_first_child.load(Ordering::SeqCst) {
+                            return Ok(json!({
+                                "nodes": [
+                                    root_with(&["cycle-a"]),
+                                    iframe_node("cycle-a", 10)
+                                ]
+                            }));
+                        }
+                        let (node_id, name, backend_id) = if index == 0 {
+                            ("button-a", "A", 101)
+                        } else {
+                            ("button-b", "B", 201)
+                        };
+                        Ok(json!({
+                            "nodes": [
+                                root_with(&[node_id]),
+                                ax_button(node_id, name, backend_id)
+                            ]
+                        }))
+                    }
+                    "Runtime.evaluate" => Ok(json!({ "result": { "value": [] } })),
+                    "Page.createIsolatedWorld" => Ok(json!({"executionContextId": 7})),
+                    "Runtime.releaseObjectGroup" => Ok(json!({})),
+                    "DOM.describeNode" => {
+                        let frame_id = match params.get("backendNodeId").and_then(Value::as_i64) {
+                            Some(10) => Some("child-a"),
+                            Some(20) => Some("child-b"),
+                            _ => None,
+                        };
+                        Ok(json!({
+                            "node": {
+                                "contentDocument": {
+                                    "frameId": frame_id
+                                }
+                            }
+                        }))
+                    }
+                    _ => Ok(json!({})),
+                }
+            })
+        }
+
+        fn send_raw_json<'a>(
+            &'a self,
+            _method: &'a str,
+            _params_json: &'a str,
+            _session: Option<&'a crate::SessionId>,
+        ) -> BoxFuture<'a, Result<String, CdpError>> {
+            Box::pin(async { Ok("{}".to_string()) })
+        }
+
+        fn events(&self) -> broadcast::Receiver<CdpEvent> {
+            let (_tx, rx) = broadcast::channel(1);
+            rx
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn connection_epoch(&self) -> u64 {
+            1
+        }
+    }
+
+    struct DepthConnection {
+        max_child_requested: AtomicUsize,
+    }
+
+    impl CdpConnection for DepthConnection {
+        fn send<'a>(
+            &'a self,
+            method: &'a str,
+            params: Value,
+            _session: Option<&'a crate::SessionId>,
+        ) -> BoxFuture<'a, Result<Value, CdpError>> {
+            Box::pin(async move {
+                match method {
+                    "Browser.getTabs" => Ok(json!({
+                        "tabs": [tab_value("https://example.com/")]
+                    })),
+                    "Browser.getTabInfo" => Ok(json!({
+                        "tab": tab_value("https://example.com/")
+                    })),
+                    "Target.attachToTarget" => Ok(json!({ "sessionId": "session-1" })),
+                    "Page.enable"
+                    | "DOM.enable"
+                    | "Runtime.enable"
+                    | "Accessibility.enable"
+                    | "Runtime.runIfWaitingForDebugger"
+                    | "Target.setAutoAttach" => Ok(json!({})),
+                    "Page.getFrameTree" => Ok(json!({
+                        "frameTree": depth_frame_tree()
+                    })),
+                    "Accessibility.getFullAXTree" => {
+                        let depth = params
+                            .get("frameId")
+                            .and_then(Value::as_str)
+                            .and_then(|frame_id| frame_id.strip_prefix("child-"))
+                            .and_then(|depth| depth.parse::<usize>().ok());
+                        if let Some(depth) = depth {
+                            self.max_child_requested.fetch_max(depth, Ordering::SeqCst);
+                            return Ok(json!({
+                                "nodes": [
+                                    root_with(&["nested-frame"]),
+                                    iframe_node("nested-frame", 100 + depth as i64)
+                                ]
+                            }));
+                        }
+                        Ok(json!({
+                            "nodes": [
+                                root_with(&["nested-frame"]),
+                                iframe_node("nested-frame", 100)
+                            ]
+                        }))
+                    }
+                    "Runtime.evaluate" => Ok(json!({ "result": { "value": [] } })),
+                    "Page.createIsolatedWorld" => Ok(json!({"executionContextId": 7})),
+                    "Runtime.releaseObjectGroup" => Ok(json!({})),
+                    "DOM.describeNode" => {
+                        let frame_id = params
+                            .get("backendNodeId")
+                            .and_then(Value::as_i64)
+                            .map(|backend_id| format!("child-{}", backend_id - 99));
+                        Ok(json!({
+                            "node": {
+                                "contentDocument": {
+                                    "frameId": frame_id
+                                }
+                            }
+                        }))
+                    }
+                    _ => Ok(json!({})),
+                }
+            })
+        }
+
+        fn send_raw_json<'a>(
+            &'a self,
+            _method: &'a str,
+            _params_json: &'a str,
+            _session: Option<&'a crate::SessionId>,
+        ) -> BoxFuture<'a, Result<String, CdpError>> {
+            Box::pin(async { Ok("{}".to_string()) })
+        }
+
+        fn events(&self) -> broadcast::Receiver<CdpEvent> {
+            let (_tx, rx) = broadcast::channel(1);
+            rx
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn connection_epoch(&self) -> u64 {
+            1
+        }
+    }
+
     async fn observer_harness(
         state: HarnessState,
     ) -> Result<(Arc<HarnessConnection>, Arc<super::Observer>), CoreError> {
@@ -905,6 +1221,28 @@ mod tests {
         Ok((connection, observer))
     }
 
+    async fn sibling_observer(
+        connection: Arc<SiblingConnection>,
+    ) -> Result<Arc<super::Observer>, CoreError> {
+        let session = BrowserSession::new(connection, BrowserSessionHooks::default());
+        let pages = session.pages.list().await?;
+        let Some(page) = pages.first() else {
+            return Err(CoreError::Message("missing test page".to_string()));
+        };
+        Ok(session.observe(page.page_id.clone()).await)
+    }
+
+    async fn depth_observer(
+        connection: Arc<DepthConnection>,
+    ) -> Result<Arc<super::Observer>, CoreError> {
+        let session = BrowserSession::new(connection, BrowserSessionHooks::default());
+        let pages = session.pages.list().await?;
+        let Some(page) = pages.first() else {
+            return Err(CoreError::Message("missing test page".to_string()));
+        };
+        Ok(session.observe(page.page_id.clone()).await)
+    }
+
     fn tab_value(url: &str) -> Value {
         json!({
             "tabId": 101,
@@ -918,6 +1256,39 @@ mod tests {
             "isHidden": false,
             "windowId": 1
         })
+    }
+
+    fn depth_frame_tree() -> Value {
+        let mut child = None;
+        for depth in (1..=7).rev() {
+            let mut node = json!({
+                "frame": {
+                    "id": format!("child-{depth}"),
+                    "parentId": if depth == 1 {
+                        "main".to_string()
+                    } else {
+                        format!("child-{}", depth - 1)
+                    },
+                    "loaderId": format!("loader-{depth}"),
+                    "url": format!("https://example.com/{depth}")
+                }
+            });
+            if let Some(nested) = child {
+                node["childFrames"] = json!([nested]);
+            }
+            child = Some(node);
+        }
+        let mut root = json!({
+            "frame": {
+                "id": "main",
+                "loaderId": "main-loader",
+                "url": "https://example.com/"
+            }
+        });
+        if let Some(child) = child {
+            root["childFrames"] = json!([child]);
+        }
+        root
     }
 
     fn frame_tree_value(state: &HarnessState) -> Value {
@@ -948,6 +1319,15 @@ mod tests {
             node_id: "1".to_string(),
             role: Some(AxValue::role("RootWebArea")),
             child_ids: Some(children.iter().map(|child| (*child).to_string()).collect()),
+            ..AxNode::default()
+        }
+    }
+
+    fn iframe_node(node_id: &str, backend_id: i64) -> AxNode {
+        AxNode {
+            node_id: node_id.to_string(),
+            role: Some(AxValue::role("Iframe")),
+            backend_dom_node_id: Some(backend_id),
             ..AxNode::default()
         }
     }
@@ -1110,6 +1490,152 @@ mod tests {
             ]
             .join("\n")
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observer_acquires_siblings_out_of_order_but_assembles_reverse_stitch_order()
+    -> Result<(), CoreError> {
+        let connection = Arc::new(SiblingConnection::new(false));
+        let observer = sibling_observer(connection.clone()).await?;
+        let task_observer = observer.clone();
+        let task = tokio::spawn(async move { task_observer.snapshot().await });
+
+        let overlap = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            connection.wait_for_both_children(),
+        )
+        .await;
+        if overlap.is_err() {
+            connection.gates[0].add_permits(1);
+            connection.gates[1].add_permits(1);
+            let _result = task
+                .await
+                .map_err(|error| CoreError::Message(error.to_string()))?;
+            return Err(CoreError::Message(
+                "sibling acquisition did not overlap".to_string(),
+            ));
+        }
+        connection.gates[1].add_permits(1);
+        connection.wait_for_completions(1).await;
+        connection.gates[0].add_permits(1);
+        let first = task
+            .await
+            .map_err(|error| CoreError::Message(error.to_string()))??;
+
+        assert_eq!(
+            first.text,
+            [
+                "- iframe",
+                "  - button \"A\" [ref=e2]",
+                "- iframe",
+                "  - button \"B\" [ref=e1]"
+            ]
+            .join("\n")
+        );
+        connection.gates[0].add_permits(1);
+        connection.gates[1].add_permits(1);
+        let second = observer.snapshot().await?;
+        assert_eq!(second.text, first.text);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observer_failed_child_does_not_consume_later_sibling_refs() -> Result<(), CoreError> {
+        let connection = Arc::new(SiblingConnection::new(true));
+        let observer = sibling_observer(connection.clone()).await?;
+        let task = tokio::spawn(async move { observer.snapshot().await });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            connection.wait_for_both_children(),
+        )
+        .await
+        .map_err(|error| CoreError::Message(error.to_string()))?;
+        connection.gates[1].add_permits(1);
+        connection.gates[0].add_permits(1);
+        let snapshot = task
+            .await
+            .map_err(|error| CoreError::Message(error.to_string()))??;
+
+        assert_eq!(
+            snapshot.text,
+            ["- iframe", "  - button \"A\" [ref=e1]", "- iframe"].join("\n")
+        );
+        assert_eq!(
+            snapshot
+                .refs
+                .get(&crate::Ref("e1".to_string()))
+                .map(|entry| entry.backend_node_id),
+            Some(101)
+        );
+        assert!(snapshot.refs.get(&crate::Ref("e2".to_string())).is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observer_navigation_during_sibling_acquisition_retries_capture()
+    -> Result<(), CoreError> {
+        let connection = Arc::new(SiblingConnection::new(false));
+        let observer = sibling_observer(connection.clone()).await?;
+        let task = tokio::spawn(async move { observer.snapshot().await });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            connection.wait_for_both_children(),
+        )
+        .await
+        .map_err(|error| CoreError::Message(error.to_string()))?;
+        if let Ok(mut loader) = connection.main_loader.lock() {
+            *loader = "main-loader-2".to_string();
+        }
+        connection.gates[0].add_permits(2);
+        connection.gates[1].add_permits(2);
+        let snapshot = task
+            .await
+            .map_err(|error| CoreError::Message(error.to_string()))??;
+
+        assert_eq!(connection.root_ax_reads.load(Ordering::SeqCst), 2);
+        assert!(snapshot.text.contains("button \"A\" [ref=e2]"));
+        assert!(snapshot.text.contains("button \"B\" [ref=e1]"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observer_skips_a_nested_frame_cycle() -> Result<(), CoreError> {
+        let connection = Arc::new(SiblingConnection::new(false));
+        connection.cycle_first_child.store(true, Ordering::SeqCst);
+        let observer = sibling_observer(connection.clone()).await?;
+        connection.gates[0].add_permits(1);
+        connection.gates[1].add_permits(1);
+
+        let snapshot = observer.snapshot().await?;
+
+        assert_eq!(
+            snapshot.text,
+            [
+                "- iframe",
+                "  - iframe",
+                "- iframe",
+                "  - button \"B\" [ref=e1]"
+            ]
+            .join("\n")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observer_nested_frames_stop_at_five_levels() -> Result<(), CoreError> {
+        let connection = Arc::new(DepthConnection {
+            max_child_requested: AtomicUsize::new(0),
+        });
+        let observer = depth_observer(connection.clone()).await?;
+
+        let snapshot = observer.snapshot().await?;
+
+        assert_eq!(connection.max_child_requested.load(Ordering::SeqCst), 5);
+        assert_eq!(snapshot.text.lines().count(), 6);
+        assert_eq!(snapshot.text.lines().last(), Some("          - iframe"));
         Ok(())
     }
 

--- a/packages/browseros-agent/crates/browseros-core/src/observer.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer.rs
@@ -14,9 +14,11 @@ use serde_json::{Value, json};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 
+mod acquisition;
+use acquisition::{SnapshotBudget, find_cursor_hits};
+
 const MAX_FRAME_DEPTH: usize = 5;
 const MAX_STABLE_CAPTURE_ATTEMPTS: usize = 3;
-const CURSOR_SCAN_JS: &str = include_str!("assets/cursor-augment.js");
 
 #[derive(Debug, Clone)]
 pub struct SnapshotResult {
@@ -51,6 +53,13 @@ struct CaptureResult {
     refs: RefMap,
     url: String,
     scope: Option<RefScope>,
+}
+
+#[derive(Clone)]
+struct CaptureContext {
+    root_session: ProtocolSession,
+    frame_documents: HashMap<Option<FrameId>, DocumentId>,
+    budget: SnapshotBudget,
 }
 
 #[derive(Debug, Default)]
@@ -143,18 +152,17 @@ impl Observer {
 
     async fn capture(&self) -> Result<CaptureResult, CoreError> {
         let page_session = self.pages.get_session(self.page_id.clone()).await?;
+        let budget = SnapshotBudget::new();
         for _attempt in 0..MAX_STABLE_CAPTURE_ATTEMPTS {
             let before = self.read_main_frame_state(&page_session.session).await;
             let refs = self.refs_for_capture(&before).await;
+            let context = CaptureContext {
+                root_session: page_session.session.clone(),
+                frame_documents: before.frame_documents.clone(),
+                budget: budget.clone(),
+            };
             let (text, refs) = self
-                .capture_frame(
-                    None,
-                    refs,
-                    0,
-                    Vec::new(),
-                    page_session.session.clone(),
-                    before.frame_documents.clone(),
-                )
+                .capture_frame(None, refs, 0, Vec::new(), context)
                 .await?;
             let after = self.read_main_frame_state(&page_session.session).await;
             if !known_main_frame_changed(&before, &after) {
@@ -175,8 +183,7 @@ impl Observer {
         mut refs: RefMap,
         base_depth: usize,
         mut visited: Vec<FrameId>,
-        root_session: ProtocolSession,
-        frame_documents: HashMap<Option<FrameId>, DocumentId>,
+        context: CaptureContext,
     ) -> BoxFuture<'_, Result<(String, RefMap), CoreError>> {
         Box::pin(async move {
             if let Some(frame_id) = &frame_id {
@@ -191,9 +198,19 @@ impl Observer {
                 .resolve_frame_target(self.page_id.clone(), frame_id.clone())
                 .await?;
             let nodes = fetch_ax_tree(&target.session, target.ax_params.clone()).await?;
-            let cursor_hits = find_cursor_hits(&target.session).await.unwrap_or_default();
+            let cursor_hits = find_cursor_hits(
+                &target.session,
+                target.runtime_frame_id.as_ref(),
+                &context.budget,
+            )
+            .await
+            .unwrap_or_default();
             let document_id = self
-                .stable_document_id_for_frame(&root_session, frame_id.clone(), &frame_documents)
+                .stable_document_id_for_frame(
+                    &context.root_session,
+                    frame_id.clone(),
+                    &context.frame_documents,
+                )
                 .await;
             let mut render_opts = RenderOptions {
                 refs: &mut refs,
@@ -228,8 +245,7 @@ impl Observer {
                         refs.clone(),
                         stitch.depth + 1,
                         visited.clone(),
-                        root_session.clone(),
-                        frame_documents.clone(),
+                        context.clone(),
                     )
                     .await;
                 let child_text = match child_result {
@@ -373,24 +389,6 @@ struct DescribedNode {
     content_document: Option<Box<DescribedNode>>,
 }
 
-#[derive(Debug, Deserialize)]
-struct RuntimeEvalResult {
-    result: RemoteValue,
-}
-
-#[derive(Debug, Deserialize)]
-struct RemoteValue {
-    value: Option<Value>,
-    #[serde(rename = "objectId")]
-    object_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct CursorHit {
-    marker: String,
-    reasons: Vec<String>,
-}
-
 pub async fn resolve_ref_entry(
     session: &ProtocolSession,
     entry: &mut RefEntry,
@@ -512,60 +510,6 @@ async fn fetch_ax_tree(
     Ok(result.nodes)
 }
 
-async fn find_cursor_hits(
-    session: &ProtocolSession,
-) -> Result<HashMap<i64, Vec<String>>, CoreError> {
-    let mut hits = HashMap::new();
-    let result: RuntimeEvalResult = session
-        .send(
-            "Runtime.evaluate",
-            json!({ "expression": CURSOR_SCAN_JS, "returnByValue": true }),
-        )
-        .await?;
-    let found = result
-        .result
-        .value
-        .and_then(|value| serde_json::from_value::<Vec<CursorHit>>(value).ok())
-        .unwrap_or_default();
-    if found.is_empty() {
-        return Ok(hits);
-    }
-
-    for hit in found {
-        let query = format!("document.querySelector('[data-__bcid=\"{}\"]')", hit.marker);
-        let result = session
-            .send::<_, RuntimeEvalResult>(
-                "Runtime.evaluate",
-                json!({ "expression": query, "returnByValue": false }),
-            )
-            .await;
-        let Ok(result) = result else {
-            continue;
-        };
-        let Some(object_id) = result.result.object_id else {
-            continue;
-        };
-        let described = session
-            .send::<_, DescribeNodeResult>("DOM.describeNode", json!({ "objectId": object_id }))
-            .await;
-        if let Ok(described) = described
-            && let Some(backend_node_id) = described.node.backend_node_id
-        {
-            hits.insert(backend_node_id, hit.reasons);
-        }
-    }
-    let _ = session
-        .send::<_, Value>(
-            "Runtime.evaluate",
-            json!({
-                "expression": "document.querySelectorAll('[data-__bcid]').forEach(function(e){e.removeAttribute('data-__bcid')})",
-                "returnByValue": true
-            }),
-        )
-        .await;
-    Ok(hits)
-}
-
 async fn resolve_child_frame_id(
     session: &ProtocolSession,
     backend_node_id: i64,
@@ -676,7 +620,7 @@ fn name_of(node: &AxNode) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{RemoteValue, resolve_ref_entry};
+    use super::resolve_ref_entry;
     use crate::{
         BrowserSession, BrowserSessionHooks, CoreError, ProtocolSession,
         connection::CdpConnection,
@@ -776,17 +720,6 @@ mod tests {
                 .then(|| children.iter().map(|child| (*child).to_string()).collect()),
             ..AxNode::default()
         }
-    }
-
-    #[test]
-    fn runtime_remote_value_deserializes_object_id() -> Result<(), serde_json::Error> {
-        let value: RemoteValue = serde_json::from_value(json!({
-            "type": "object",
-            "objectId": "-6404171882913021072.1.1"
-        }))?;
-
-        assert_eq!(value.object_id.as_deref(), Some("-6404171882913021072.1.1"));
-        Ok(())
     }
 
     #[tokio::test]

--- a/packages/browseros-agent/crates/browseros-core/src/observer.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer.rs
@@ -248,7 +248,7 @@ impl Observer {
                 visited.push(frame_id.clone());
             }
 
-            let acquired = self.acquire_frame(frame_id, &context).await?;
+            let acquired = self.acquire_frame(frame_id, None, &context).await?;
             self.assemble_acquired_frame(acquired, refs, base_depth, visited, context)
                 .await
         })
@@ -300,7 +300,13 @@ impl Observer {
                     .collect::<Vec<_>>()
             };
             let children = self
-                .acquire_child_frames(&target, &rendered.iframes, &visited, &context)
+                .acquire_child_frames(
+                    &target,
+                    frame_id.as_ref(),
+                    &rendered.iframes,
+                    &visited,
+                    &context,
+                )
                 .await;
             // `acquire_child_frames` restores original stitch order after unordered completion.
             // Reverse it here because refs and line insertion have historically followed reverse

--- a/packages/browseros-agent/crates/browseros-core/src/observer.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer.rs
@@ -15,7 +15,7 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 
 mod acquisition;
-use acquisition::{SnapshotBudget, find_cursor_hits};
+use acquisition::{AcquiredFrame, SnapshotBudget};
 
 const MAX_FRAME_DEPTH: usize = 5;
 const MAX_STABLE_CAPTURE_ATTEMPTS: usize = 3;
@@ -193,25 +193,12 @@ impl Observer {
                 visited.push(frame_id.clone());
             }
 
-            let target = self
-                .frames
-                .resolve_frame_target(self.page_id.clone(), frame_id.clone())
-                .await?;
-            let nodes = fetch_ax_tree(&target.session, target.ax_params.clone()).await?;
-            let cursor_hits = find_cursor_hits(
-                &target.session,
-                target.runtime_frame_id.as_ref(),
-                &context.budget,
-            )
-            .await
-            .unwrap_or_default();
-            let document_id = self
-                .stable_document_id_for_frame(
-                    &context.root_session,
-                    frame_id.clone(),
-                    &context.frame_documents,
-                )
-                .await;
+            let AcquiredFrame {
+                target,
+                nodes,
+                cursor_hits,
+                document_id,
+            } = self.acquire_frame(frame_id.clone(), &context).await?;
             let mut render_opts = RenderOptions {
                 refs: &mut refs,
                 frame_id: frame_id.clone(),
@@ -312,29 +299,6 @@ impl Observer {
             .flatten()
             .map(|info| info.url)
             .unwrap_or_else(|| "unknown".to_string())
-    }
-
-    async fn stable_document_id_for_frame(
-        &self,
-        root_session: &ProtocolSession,
-        frame_id: Option<FrameId>,
-        frame_documents: &HashMap<Option<FrameId>, DocumentId>,
-    ) -> Option<DocumentId> {
-        let before = frame_documents.get(&frame_id).cloned();
-        if frame_id.is_none() || before.is_none() {
-            return before;
-        }
-        let latest = self.read_frame_documents(root_session).await.ok();
-        let after = latest.and_then(|latest| latest.get(&frame_id).cloned());
-        if after == before { before } else { None }
-    }
-
-    async fn read_frame_documents(
-        &self,
-        session: &ProtocolSession,
-    ) -> Result<HashMap<Option<FrameId>, DocumentId>, CoreError> {
-        let result: GetFrameTreeResult = session.send("Page.getFrameTree", json!({})).await?;
-        Ok(collect_frame_documents(&result.frame_tree))
     }
 }
 
@@ -829,7 +793,9 @@ mod tests {
         child_nodes: Vec<AxNode>,
         fail_ax_tree: bool,
         frame_tree_reads: usize,
+        ax_tree_reads: usize,
         change_child_loader_on_second_read: bool,
+        main_loader_changes_remaining: usize,
     }
 
     struct HarnessConnection {
@@ -870,9 +836,16 @@ mod tests {
                         if state.change_child_loader_on_second_read && state.frame_tree_reads == 2 {
                             state.child_loader_id = Some("child-loader-2".to_string());
                         }
+                        if state.frame_tree_reads % 2 == 0
+                            && state.main_loader_changes_remaining > 0
+                        {
+                            state.loader_id = format!("loader-{}", state.frame_tree_reads);
+                            state.main_loader_changes_remaining -= 1;
+                        }
                         Ok(json!({ "frameTree": frame_tree_value(&state) }))
                     }
                     "Accessibility.getFullAXTree" => {
+                        state.ax_tree_reads += 1;
                         if state.fail_ax_tree {
                             return Err(CdpError::Protocol {
                                 code: -32000,
@@ -988,7 +961,9 @@ mod tests {
             child_nodes: Vec::new(),
             fail_ax_tree: false,
             frame_tree_reads: 0,
+            ax_tree_reads: 0,
             change_child_loader_on_second_read: false,
+            main_loader_changes_remaining: 0,
         }
     }
 
@@ -1054,6 +1029,55 @@ mod tests {
                 .map(|entry| entry.backend_node_id),
             Some(1)
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observer_retries_once_when_main_document_changes() -> Result<(), CoreError> {
+        let mut state = harness_state(vec![root_with(&["2"]), ax_button("2", "A", 1)]);
+        state.main_loader_changes_remaining = 1;
+        let (connection, observer) = observer_harness(state).await?;
+
+        let snapshot = observer.snapshot().await?;
+
+        assert_eq!(snapshot.text, "- button \"A\" [ref=e1]");
+        let (frame_tree_reads, ax_tree_reads) = connection
+            .state
+            .lock()
+            .map(|state| (state.frame_tree_reads, state.ax_tree_reads))
+            .unwrap_or_default();
+        assert_eq!(frame_tree_reads, 4);
+        assert_eq!(ax_tree_reads, 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observer_document_change_exhaustion_keeps_committed_refs() -> Result<(), CoreError> {
+        let state = harness_state(vec![root_with(&["2"]), ax_button("2", "A", 1)]);
+        let (connection, observer) = observer_harness(state).await?;
+        let _snapshot = observer.snapshot().await?;
+        if let Ok(mut state) = connection.state.lock() {
+            state.nodes = vec![root_with(&["3"]), ax_button("3", "B", 2)];
+            state.frame_tree_reads = 0;
+            state.ax_tree_reads = 0;
+            state.main_loader_changes_remaining = 3;
+        }
+
+        let result = observer.snapshot().await;
+
+        assert!(matches!(result, Err(CoreError::DocumentChanged)));
+        let refs = observer.last_refs().await;
+        assert_eq!(
+            refs.get(&crate::Ref("e1".to_string()))
+                .map(|entry| entry.backend_node_id),
+            Some(1)
+        );
+        let ax_tree_reads = connection
+            .state
+            .lock()
+            .map(|state| state.ax_tree_reads)
+            .unwrap_or_default();
+        assert_eq!(ax_tree_reads, 3);
         Ok(())
     }
 

--- a/packages/browseros-agent/crates/browseros-core/src/observer.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer.rs
@@ -11,11 +11,11 @@ use crate::{
 use futures_util::future::BoxFuture;
 use serde::Deserialize;
 use serde_json::{Value, json};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 use tokio::sync::Mutex;
 
 mod acquisition;
-use acquisition::{AcquiredFrame, SnapshotBudget};
+use acquisition::{AcquiredFrame, CaptureTrace, SnapshotBudget, SnapshotStage, trace_stage};
 
 const MAX_FRAME_DEPTH: usize = 5;
 const MAX_STABLE_CAPTURE_ATTEMPTS: usize = 3;
@@ -60,6 +60,7 @@ struct CaptureContext {
     root_session: ProtocolSession,
     frame_documents: HashMap<Option<FrameId>, DocumentId>,
     budget: SnapshotBudget,
+    trace: CaptureTrace,
 }
 
 #[derive(Debug, Default)]
@@ -151,21 +152,60 @@ impl Observer {
     }
 
     async fn capture(&self) -> Result<CaptureResult, CoreError> {
-        let page_session = self.pages.get_session(self.page_id.clone()).await?;
+        let capture_started = Instant::now();
+        let initial_trace = CaptureTrace::new(self.page_id.clone(), 1);
+        let page_session = match self.pages.get_session(self.page_id.clone()).await {
+            Ok(page_session) => page_session,
+            Err(error) => {
+                trace_stage(
+                    &initial_trace,
+                    None,
+                    SnapshotStage::Capture,
+                    capture_started,
+                    "failure",
+                );
+                return Err(error);
+            }
+        };
         let budget = SnapshotBudget::new();
-        for _attempt in 0..MAX_STABLE_CAPTURE_ATTEMPTS {
-            let before = self.read_main_frame_state(&page_session.session).await;
+        for attempt in 1..=MAX_STABLE_CAPTURE_ATTEMPTS {
+            let attempt_started = Instant::now();
+            let trace = CaptureTrace::new(self.page_id.clone(), attempt);
+            let before = self
+                .read_main_frame_state(&page_session.session, &budget)
+                .await;
             let refs = self.refs_for_capture(&before).await;
             let context = CaptureContext {
                 root_session: page_session.session.clone(),
                 frame_documents: before.frame_documents.clone(),
                 budget: budget.clone(),
+                trace: trace.clone(),
             };
-            let (text, refs) = self
-                .capture_frame(None, refs, 0, Vec::new(), context)
-                .await?;
-            let after = self.read_main_frame_state(&page_session.session).await;
+            let frame_result = self.capture_frame(None, refs, 0, Vec::new(), context).await;
+            let (text, refs) = match frame_result {
+                Ok(result) => result,
+                Err(error) => {
+                    trace_stage(
+                        &trace,
+                        None,
+                        SnapshotStage::Capture,
+                        capture_started,
+                        "failure",
+                    );
+                    return Err(error);
+                }
+            };
+            let after = self
+                .read_main_frame_state(&page_session.session, &budget)
+                .await;
             if !known_main_frame_changed(&before, &after) {
+                trace_stage(
+                    &trace,
+                    None,
+                    SnapshotStage::Capture,
+                    capture_started,
+                    "success",
+                );
                 return Ok(CaptureResult {
                     text,
                     refs,
@@ -173,7 +213,22 @@ impl Observer {
                     scope: ref_scope_from(&after),
                 });
             }
+            trace_stage(
+                &trace,
+                None,
+                SnapshotStage::Retry,
+                attempt_started,
+                "document_changed",
+            );
         }
+        let trace = CaptureTrace::new(self.page_id.clone(), MAX_STABLE_CAPTURE_ATTEMPTS);
+        trace_stage(
+            &trace,
+            None,
+            SnapshotStage::Capture,
+            capture_started,
+            "document_changed",
+        );
         Err(CoreError::DocumentChanged)
     }
 
@@ -208,6 +263,8 @@ impl Observer {
         context: CaptureContext,
     ) -> BoxFuture<'_, Result<(String, RefMap), CoreError>> {
         Box::pin(async move {
+            let assembly_started = Instant::now();
+            let assembly_frame_id = acquired.frame_id.clone();
             let AcquiredFrame {
                 frame_id,
                 target,
@@ -225,6 +282,13 @@ impl Observer {
             let rendered = render_snapshot(&nodes, &mut render_opts);
             let mut text = rendered.text;
             if rendered.iframes.is_empty() || base_depth >= MAX_FRAME_DEPTH {
+                trace_stage(
+                    &context.trace,
+                    assembly_frame_id.as_ref(),
+                    SnapshotStage::Assembly,
+                    assembly_started,
+                    "success",
+                );
                 return Ok((text, refs));
             }
 
@@ -274,6 +338,13 @@ impl Observer {
                 }
             }
             text = lines.join("\n");
+            trace_stage(
+                &context.trace,
+                assembly_frame_id.as_ref(),
+                SnapshotStage::Assembly,
+                assembly_started,
+                "success",
+            );
             Ok((text, refs))
         })
     }
@@ -297,9 +368,13 @@ impl Observer {
         }
     }
 
-    async fn read_main_frame_state(&self, session: &ProtocolSession) -> MainFrameState {
-        let result = session
-            .send::<_, GetFrameTreeResult>("Page.getFrameTree", json!({}))
+    async fn read_main_frame_state(
+        &self,
+        session: &ProtocolSession,
+        budget: &SnapshotBudget,
+    ) -> MainFrameState {
+        let result = budget
+            .send::<GetFrameTreeResult>(session, "Page.getFrameTree", json!({}))
             .await;
         if let Ok(result) = result {
             return MainFrameState {

--- a/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
@@ -1,0 +1,929 @@
+//! Unordered Chrome acquisition for accessibility snapshots.
+//!
+//! Cursor candidates and their backend-node lookups may complete in any order, but this module
+//! restores scan order before exposing results to rendering. `SnapshotBudget` is shared by every
+//! acquisition stage in one capture so concurrency is bounded without scheduling CDP work onto a
+//! separate runtime or throttling unrelated browser commands.
+
+use super::DescribeNodeResult;
+use crate::{CoreError, FrameId, ProtocolSession};
+use futures_util::{StreamExt, stream::FuturesUnordered};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use serde_json::json;
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+use tokio::sync::Semaphore;
+
+const MAX_IN_FLIGHT_REQUESTS: usize = 8;
+const CURSOR_SCAN_JS: &str = include_str!("../assets/cursor-augment.js");
+const CURSOR_WORLD_NAME: &str = "browseros-snapshot-cursor";
+static NEXT_CURSOR_NAMESPACE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone)]
+pub(super) struct SnapshotBudget {
+    permits: Arc<Semaphore>,
+}
+
+impl SnapshotBudget {
+    pub(super) fn new() -> Self {
+        Self {
+            permits: Arc::new(Semaphore::new(MAX_IN_FLIGHT_REQUESTS)),
+        }
+    }
+
+    pub(super) async fn send<R>(
+        &self,
+        session: &ProtocolSession,
+        method: &str,
+        params: Value,
+    ) -> Result<R, CoreError>
+    where
+        R: DeserializeOwned,
+    {
+        // A permit represents one pending CDP response, not a worker thread. Releasing it here
+        // prevents dependent operations from holding capacity while they prepare their next call.
+        let permit = self
+            .permits
+            .acquire()
+            .await
+            .map_err(|error| CoreError::Message(error.to_string()))?;
+        let result = session.send(method, params).await;
+        drop(permit);
+        result
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RuntimeEvalResult {
+    result: RemoteObject,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteObject {
+    value: Option<Value>,
+    #[serde(rename = "objectId")]
+    object_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetPropertiesResult {
+    result: Vec<PropertyDescriptor>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PropertyDescriptor {
+    name: String,
+    value: Option<RemoteObject>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateIsolatedWorldResult {
+    execution_context_id: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct CursorHit {
+    reasons: Vec<String>,
+}
+
+struct CursorCleanup {
+    session: ProtocolSession,
+    budget: SnapshotBudget,
+    marker_attribute: String,
+    object_group: String,
+    context_id: Option<i64>,
+    armed: bool,
+}
+
+impl CursorCleanup {
+    async fn finish(&mut self) {
+        cleanup_cursor(
+            &self.session,
+            &self.budget,
+            &self.marker_attribute,
+            &self.object_group,
+            self.context_id,
+        )
+        .await;
+        self.armed = false;
+    }
+}
+
+impl Drop for CursorCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let session = self.session.clone();
+        let budget = self.budget.clone();
+        let marker_attribute = self.marker_attribute.clone();
+        let object_group = self.object_group.clone();
+        let context_id = self.context_id;
+
+        // Cancellation skips the async epilogue, so detach one idempotent cleanup
+        // task for the capture namespace. Candidate requests are never spawned.
+        drop(handle.spawn(async move {
+            cleanup_cursor(
+                &session,
+                &budget,
+                &marker_attribute,
+                &object_group,
+                context_id,
+            )
+            .await;
+        }));
+    }
+}
+
+pub(super) async fn find_cursor_hits(
+    session: &ProtocolSession,
+    frame_id: Option<&FrameId>,
+    budget: &SnapshotBudget,
+) -> Result<HashMap<i64, Vec<String>>, CoreError> {
+    let namespace = NEXT_CURSOR_NAMESPACE.fetch_add(1, Ordering::Relaxed);
+    // Overlapping captures share a document, so both marker cleanup and object release need a
+    // capture-owned namespace. One capture must never remove another capture's temporary handles.
+    let marker_attribute = format!("data-__bcid-{namespace}");
+    let object_group = format!("browseros-snapshot-cursor-{namespace}");
+    let context_id = execution_context(session, frame_id, budget).await?;
+    let mut cleanup = CursorCleanup {
+        session: session.clone(),
+        budget: budget.clone(),
+        marker_attribute: marker_attribute.clone(),
+        object_group: object_group.clone(),
+        context_id,
+        armed: true,
+    };
+
+    let result = acquire_cursor_hits(
+        session,
+        budget,
+        &marker_attribute,
+        &object_group,
+        context_id,
+    )
+    .await;
+    cleanup.finish().await;
+    result
+}
+
+async fn execution_context(
+    session: &ProtocolSession,
+    frame_id: Option<&FrameId>,
+    budget: &SnapshotBudget,
+) -> Result<Option<i64>, CoreError> {
+    let Some(frame_id) = frame_id else {
+        return Ok(None);
+    };
+    let result: CreateIsolatedWorldResult = budget
+        .send(
+            session,
+            "Page.createIsolatedWorld",
+            json!({
+                "frameId": frame_id.0,
+                "worldName": CURSOR_WORLD_NAME
+            }),
+        )
+        .await?;
+    Ok(Some(result.execution_context_id))
+}
+
+async fn acquire_cursor_hits(
+    session: &ProtocolSession,
+    budget: &SnapshotBudget,
+    marker_attribute: &str,
+    object_group: &str,
+    context_id: Option<i64>,
+) -> Result<HashMap<i64, Vec<String>>, CoreError> {
+    let marker_literal = serde_json::to_string(marker_attribute)
+        .map_err(|error| CoreError::Message(error.to_string()))?;
+    let scan_expression = CURSOR_SCAN_JS.replace("__BROWSEROS_CURSOR_MARKER__", &marker_literal);
+    let scan: RuntimeEvalResult = budget
+        .send(
+            session,
+            "Runtime.evaluate",
+            evaluate_params(scan_expression, true, None, context_id),
+        )
+        .await?;
+    let candidates = scan
+        .result
+        .value
+        .and_then(|value| serde_json::from_value::<Vec<CursorHit>>(value).ok())
+        .unwrap_or_default();
+    if candidates.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Marker values are original scan indexes. Preserve them as sparse array positions so a node
+    // that disappears between the scan and this collection leaves a hole instead of shifting the
+    // reasons associated with every later candidate.
+    let collection_expression = format!(
+        "(function(a){{var out=[];document.querySelectorAll('['+a+']').forEach(function(e){{out[Number(e.getAttribute(a))]=e;}});return out;}})({marker_literal})"
+    );
+    let collection: RuntimeEvalResult = budget
+        .send(
+            session,
+            "Runtime.evaluate",
+            evaluate_params(collection_expression, false, Some(object_group), context_id),
+        )
+        .await?;
+    let Some(collection_id) = collection.result.object_id else {
+        return Ok(HashMap::new());
+    };
+    let properties: GetPropertiesResult = budget
+        .send(
+            session,
+            "Runtime.getProperties",
+            json!({
+                "objectId": collection_id,
+                "ownProperties": true
+            }),
+        )
+        .await?;
+    let mut handles = properties
+        .result
+        .into_iter()
+        .filter_map(|property| {
+            let index = property.name.parse::<usize>().ok()?;
+            let object_id = property.value?.object_id?;
+            (index < candidates.len()).then_some((index, object_id))
+        })
+        .collect::<Vec<_>>();
+    handles.sort_by_key(|(index, _object_id)| *index);
+
+    // Chrome may answer these in any order. Store each result in its scan-index slot and pair
+    // reasons only after the whole batch completes; renderer input is therefore deterministic.
+    let mut pending = FuturesUnordered::new();
+    for (index, object_id) in handles {
+        let session = session.clone();
+        let budget = budget.clone();
+        pending.push(async move {
+            let described = budget
+                .send::<DescribeNodeResult>(
+                    &session,
+                    "DOM.describeNode",
+                    json!({ "objectId": object_id }),
+                )
+                .await;
+            (index, described)
+        });
+    }
+
+    let mut ordered = vec![None; candidates.len()];
+    while let Some((index, described)) = pending.next().await {
+        if let Ok(described) = described
+            && let Some(backend_node_id) = described.node.backend_node_id
+        {
+            ordered[index] = Some(backend_node_id);
+        }
+    }
+
+    let mut hits = HashMap::new();
+    for (candidate, backend_node_id) in candidates.into_iter().zip(ordered) {
+        if let Some(backend_node_id) = backend_node_id {
+            hits.insert(backend_node_id, candidate.reasons);
+        }
+    }
+    Ok(hits)
+}
+
+fn evaluate_params(
+    expression: String,
+    return_by_value: bool,
+    object_group: Option<&str>,
+    context_id: Option<i64>,
+) -> Value {
+    let mut params = json!({
+        "expression": expression,
+        "returnByValue": return_by_value
+    });
+    if let Some(object_group) = object_group {
+        params["objectGroup"] = Value::String(object_group.to_string());
+    }
+    if let Some(context_id) = context_id {
+        params["contextId"] = Value::Number(context_id.into());
+    }
+    params
+}
+
+async fn cleanup_cursor(
+    session: &ProtocolSession,
+    budget: &SnapshotBudget,
+    marker_attribute: &str,
+    object_group: &str,
+    context_id: Option<i64>,
+) {
+    if let Ok(marker_literal) = serde_json::to_string(marker_attribute) {
+        let expression = format!(
+            "(function(a){{document.querySelectorAll('['+a+']').forEach(function(e){{e.removeAttribute(a);}});}})({marker_literal})"
+        );
+        let _ = budget
+            .send::<Value>(
+                session,
+                "Runtime.evaluate",
+                evaluate_params(expression, true, None, context_id),
+            )
+            .await;
+    }
+    let _ = budget
+        .send::<Value>(
+            session,
+            "Runtime.releaseObjectGroup",
+            json!({ "objectGroup": object_group }),
+        )
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SnapshotBudget, find_cursor_hits};
+    use crate::{CoreError, ProtocolSession, SessionId, connection::CdpConnection};
+    use browseros_cdp::{CdpError, CdpEvent};
+    use futures_util::future::BoxFuture;
+    use serde_json::{Value, json};
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use tokio::sync::{Notify, Semaphore, broadcast};
+
+    #[derive(Debug, Clone)]
+    struct Call {
+        method: String,
+        params: Value,
+        session: Option<SessionId>,
+    }
+
+    struct CursorConnection {
+        calls: Mutex<Vec<Call>>,
+        omitted_candidate: Option<usize>,
+        failed_candidate: Option<usize>,
+    }
+
+    impl Default for CursorConnection {
+        fn default() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                omitted_candidate: None,
+                failed_candidate: None,
+            }
+        }
+    }
+
+    impl CursorConnection {
+        fn calls(&self) -> Vec<Call> {
+            self.calls
+                .lock()
+                .map(|calls| calls.clone())
+                .unwrap_or_default()
+        }
+    }
+
+    impl CdpConnection for CursorConnection {
+        fn send<'a>(
+            &'a self,
+            method: &'a str,
+            params: Value,
+            session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<Value, CdpError>> {
+            Box::pin(async move {
+                if let Ok(mut calls) = self.calls.lock() {
+                    calls.push(Call {
+                        method: method.to_string(),
+                        params: params.clone(),
+                        session: session.cloned(),
+                    });
+                }
+                match method {
+                    "Runtime.evaluate"
+                        if params
+                            .get("expression")
+                            .and_then(Value::as_str)
+                            .is_some_and(|expression| expression.contains("interactiveTags")) =>
+                    {
+                        Ok(json!({
+                            "result": {
+                                "type": "object",
+                                "value": [
+                                    {"marker": "0", "reasons": ["cursor:pointer"]},
+                                    {"marker": "1", "reasons": ["onclick"]},
+                                    {"marker": "2", "reasons": ["contenteditable"]}
+                                ]
+                            }
+                        }))
+                    }
+                    "Runtime.evaluate"
+                        if params.get("returnByValue") == Some(&Value::Bool(false)) =>
+                    {
+                        Ok(json!({
+                            "result": {
+                                "type": "object",
+                                "objectId": "candidate-array"
+                            }
+                        }))
+                    }
+                    "Runtime.evaluate" => Ok(json!({
+                        "result": {"type": "undefined"}
+                    })),
+                    "Runtime.getProperties" => {
+                        let mut properties = vec![
+                            json!({
+                                "name": "2",
+                                "value": {"type": "object", "objectId": "candidate-2"}
+                            }),
+                            json!({
+                                "name": "0",
+                                "value": {"type": "object", "objectId": "candidate-0"}
+                            }),
+                            json!({
+                                "name": "1",
+                                "value": {"type": "object", "objectId": "candidate-1"}
+                            }),
+                            json!({
+                                "name": "length",
+                                "value": {"type": "number", "value": 3}
+                            }),
+                        ];
+                        if let Some(index) = self.omitted_candidate {
+                            let name = index.to_string();
+                            properties.retain(|property| property["name"] != name);
+                        }
+                        Ok(json!({ "result": properties }))
+                    }
+                    "DOM.describeNode" => {
+                        let index = params
+                            .get("objectId")
+                            .and_then(Value::as_str)
+                            .and_then(|object_id| object_id.rsplit('-').next())
+                            .and_then(|index| index.parse::<usize>().ok());
+                        if index == self.failed_candidate {
+                            return Err(CdpError::Protocol {
+                                code: -32000,
+                                message: "candidate vanished".to_string(),
+                            });
+                        }
+                        Ok(json!({
+                            "node": {
+                                "backendNodeId": index.map(|index| index as i64 + 100)
+                            }
+                        }))
+                    }
+                    "Page.createIsolatedWorld" => Ok(json!({"executionContextId": 7})),
+                    "Runtime.releaseObjectGroup" => Ok(json!({})),
+                    _ => Ok(json!({})),
+                }
+            })
+        }
+
+        fn send_raw_json<'a>(
+            &'a self,
+            _method: &'a str,
+            _params_json: &'a str,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<String, CdpError>> {
+            Box::pin(async { Ok("{}".to_string()) })
+        }
+
+        fn events(&self) -> broadcast::Receiver<CdpEvent> {
+            let (_tx, rx) = broadcast::channel(1);
+            rx
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn connection_epoch(&self) -> u64 {
+            1
+        }
+    }
+
+    struct GatedCursorConnection {
+        candidate_count: usize,
+        gates: Vec<Arc<Semaphore>>,
+        active: AtomicUsize,
+        max_active: AtomicUsize,
+        entered: Notify,
+        completions: Mutex<Vec<usize>>,
+        completed: Notify,
+        cleanup_evaluations: AtomicUsize,
+        released_groups: AtomicUsize,
+        cleaned: Notify,
+    }
+
+    impl GatedCursorConnection {
+        fn new(candidate_count: usize) -> Self {
+            Self {
+                candidate_count,
+                gates: (0..candidate_count)
+                    .map(|_index| Arc::new(Semaphore::new(0)))
+                    .collect(),
+                active: AtomicUsize::new(0),
+                max_active: AtomicUsize::new(0),
+                entered: Notify::new(),
+                completions: Mutex::new(Vec::new()),
+                completed: Notify::new(),
+                cleanup_evaluations: AtomicUsize::new(0),
+                released_groups: AtomicUsize::new(0),
+                cleaned: Notify::new(),
+            }
+        }
+
+        async fn wait_for_entries(&self, target: usize) {
+            loop {
+                let notified = self.entered.notified();
+                if self.max_active.load(Ordering::SeqCst) >= target {
+                    return;
+                }
+                notified.await;
+            }
+        }
+
+        async fn wait_for_completions(&self, target: usize) {
+            loop {
+                let notified = self.completed.notified();
+                if self
+                    .completions
+                    .lock()
+                    .map(|completions| completions.len())
+                    .unwrap_or_default()
+                    >= target
+                {
+                    return;
+                }
+                notified.await;
+            }
+        }
+
+        async fn wait_for_cleanup(&self) {
+            loop {
+                let notified = self.cleaned.notified();
+                if self.released_groups.load(Ordering::SeqCst) > 0 {
+                    return;
+                }
+                notified.await;
+            }
+        }
+
+        fn completion_order(&self) -> Vec<usize> {
+            self.completions
+                .lock()
+                .map(|completions| completions.clone())
+                .unwrap_or_default()
+        }
+    }
+
+    impl CdpConnection for GatedCursorConnection {
+        fn send<'a>(
+            &'a self,
+            method: &'a str,
+            params: Value,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<Value, CdpError>> {
+            Box::pin(async move {
+                match method {
+                    "Runtime.evaluate"
+                        if params
+                            .get("expression")
+                            .and_then(Value::as_str)
+                            .is_some_and(|expression| expression.contains("interactiveTags")) =>
+                    {
+                        let candidates = (0..self.candidate_count)
+                            .map(|index| {
+                                json!({
+                                    "marker": index.to_string(),
+                                    "reasons": [format!("reason-{index}")]
+                                })
+                            })
+                            .collect::<Vec<_>>();
+                        Ok(json!({
+                            "result": {
+                                "type": "object",
+                                "value": candidates
+                            }
+                        }))
+                    }
+                    "Runtime.evaluate"
+                        if params.get("returnByValue") == Some(&Value::Bool(false)) =>
+                    {
+                        Ok(json!({
+                            "result": {
+                                "type": "object",
+                                "objectId": "candidate-array"
+                            }
+                        }))
+                    }
+                    "Runtime.evaluate" => {
+                        if params
+                            .get("expression")
+                            .and_then(Value::as_str)
+                            .is_some_and(|expression| expression.contains("removeAttribute(a)"))
+                        {
+                            self.cleanup_evaluations.fetch_add(1, Ordering::SeqCst);
+                        }
+                        Ok(json!({"result": {"type": "undefined"}}))
+                    }
+                    "Runtime.getProperties" => {
+                        let properties = (0..self.candidate_count)
+                            .map(|index| {
+                                json!({
+                                    "name": index.to_string(),
+                                    "value": {
+                                        "type": "object",
+                                        "objectId": format!("candidate-{index}")
+                                    }
+                                })
+                            })
+                            .collect::<Vec<_>>();
+                        Ok(json!({ "result": properties }))
+                    }
+                    "DOM.describeNode" => {
+                        let Some(index) = params
+                            .get("objectId")
+                            .and_then(Value::as_str)
+                            .and_then(|object_id| object_id.rsplit('-').next())
+                            .and_then(|index| index.parse::<usize>().ok())
+                        else {
+                            return Err(CdpError::Protocol {
+                                code: -1,
+                                message: "missing candidate index".to_string(),
+                            });
+                        };
+                        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+                        self.max_active.fetch_max(active, Ordering::SeqCst);
+                        self.entered.notify_waiters();
+                        let permit =
+                            self.gates[index]
+                                .clone()
+                                .acquire_owned()
+                                .await
+                                .map_err(|error| CdpError::Protocol {
+                                    code: -1,
+                                    message: error.to_string(),
+                                })?;
+                        permit.forget();
+                        self.active.fetch_sub(1, Ordering::SeqCst);
+                        if let Ok(mut completions) = self.completions.lock() {
+                            completions.push(index);
+                        }
+                        self.completed.notify_waiters();
+                        Ok(json!({"node": {"backendNodeId": index as i64 + 100}}))
+                    }
+                    "Runtime.releaseObjectGroup" => {
+                        self.released_groups.fetch_add(1, Ordering::SeqCst);
+                        self.cleaned.notify_waiters();
+                        Ok(json!({}))
+                    }
+                    _ => Ok(json!({})),
+                }
+            })
+        }
+
+        fn send_raw_json<'a>(
+            &'a self,
+            _method: &'a str,
+            _params_json: &'a str,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<String, CdpError>> {
+            Box::pin(async { Ok("{}".to_string()) })
+        }
+
+        fn events(&self) -> broadcast::Receiver<CdpEvent> {
+            let (_tx, rx) = broadcast::channel(1);
+            rx
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn connection_epoch(&self) -> u64 {
+            1
+        }
+    }
+
+    #[tokio::test]
+    async fn cursor_scan_batches_handles_and_restores_candidate_pairing() -> Result<(), CoreError> {
+        let connection = Arc::new(CursorConnection::default());
+        let session = ProtocolSession::for_session(
+            connection.clone(),
+            SessionId::from("page-session".to_string()),
+        );
+
+        let hits = find_cursor_hits(&session, None, &SnapshotBudget::new()).await?;
+
+        assert_eq!(hits.get(&100), Some(&vec!["cursor:pointer".to_string()]));
+        assert_eq!(hits.get(&101), Some(&vec!["onclick".to_string()]));
+        assert_eq!(hits.get(&102), Some(&vec!["contenteditable".to_string()]));
+
+        let calls = connection.calls();
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.method == "Runtime.getProperties")
+                .count(),
+            1
+        );
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.method == "DOM.describeNode")
+                .count(),
+            3
+        );
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.method == "Runtime.releaseObjectGroup")
+                .count(),
+            1
+        );
+        assert!(calls.iter().all(
+            |call| call.session.as_ref().map(|session| session.0.as_str()) == Some("page-session")
+        ));
+        assert!(calls.iter().all(|call| {
+            call.params
+                .get("expression")
+                .and_then(Value::as_str)
+                .is_none_or(|expression| !expression.contains("document.querySelector('"))
+        }));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cursor_resolution_omits_vanished_candidates_and_cleans_its_namespace()
+    -> Result<(), CoreError> {
+        let connection = Arc::new(CursorConnection {
+            calls: Mutex::new(Vec::new()),
+            omitted_candidate: Some(1),
+            failed_candidate: Some(2),
+        });
+        let session = ProtocolSession::root(connection.clone());
+
+        let hits = find_cursor_hits(&session, None, &SnapshotBudget::new()).await?;
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits.get(&100), Some(&vec!["cursor:pointer".to_string()]));
+        let calls = connection.calls();
+        let cleanup = calls.iter().find(|call| {
+            call.method == "Runtime.evaluate"
+                && call
+                    .params
+                    .get("expression")
+                    .and_then(Value::as_str)
+                    .is_some_and(|expression| expression.contains("removeAttribute(a)"))
+        });
+        let released = calls
+            .iter()
+            .find(|call| call.method == "Runtime.releaseObjectGroup");
+        assert!(cleanup.is_some());
+        assert!(released.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cursor_scans_use_unique_markers() -> Result<(), CoreError> {
+        let connection = Arc::new(CursorConnection::default());
+        let session = ProtocolSession::root(connection.clone());
+        let budget = SnapshotBudget::new();
+
+        let _first = find_cursor_hits(&session, None, &budget).await?;
+        let _second = find_cursor_hits(&session, None, &budget).await?;
+
+        let scan_expressions = connection
+            .calls()
+            .into_iter()
+            .filter(|call| call.method == "Runtime.evaluate")
+            .filter_map(|call| {
+                call.params
+                    .get("expression")
+                    .and_then(Value::as_str)
+                    .filter(|expression| expression.contains("interactiveTags"))
+                    .map(ToString::to_string)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(scan_expressions.len(), 2);
+        assert_ne!(scan_expressions[0], scan_expressions[1]);
+        assert!(
+            scan_expressions
+                .iter()
+                .all(|expression| expression.contains("data-__bcid-"))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn child_cursor_scan_uses_frame_context_in_target_session() -> Result<(), CoreError> {
+        let connection = Arc::new(CursorConnection::default());
+        let session = ProtocolSession::for_session(
+            connection.clone(),
+            SessionId::from("oopif-session".to_string()),
+        );
+
+        let _hits = find_cursor_hits(
+            &session,
+            Some(&crate::FrameId("child-frame".to_string())),
+            &SnapshotBudget::new(),
+        )
+        .await?;
+
+        let calls = connection.calls();
+        let create_world = calls
+            .iter()
+            .find(|call| call.method == "Page.createIsolatedWorld");
+        assert_eq!(
+            create_world.and_then(|call| call.params.get("frameId")),
+            Some(&json!("child-frame"))
+        );
+        assert!(calls.iter().all(|call| {
+            call.session
+                .as_ref()
+                .is_some_and(|session| session.0 == "oopif-session")
+        }));
+        assert!(calls.iter().all(|call| {
+            call.method != "Runtime.evaluate" || call.params.get("contextId") == Some(&json!(7))
+        }));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cursor_describe_requests_never_exceed_capture_budget() -> Result<(), CoreError> {
+        let connection = Arc::new(GatedCursorConnection::new(12));
+        let session = ProtocolSession::root(connection.clone());
+        let task =
+            tokio::spawn(
+                async move { find_cursor_hits(&session, None, &SnapshotBudget::new()).await },
+            );
+
+        connection.wait_for_entries(8).await;
+        assert_eq!(connection.max_active.load(Ordering::SeqCst), 8);
+        assert_eq!(connection.active.load(Ordering::SeqCst), 8);
+        for gate in &connection.gates {
+            gate.add_permits(1);
+        }
+
+        let hits = task
+            .await
+            .map_err(|error| CoreError::Message(error.to_string()))??;
+        assert_eq!(hits.len(), 12);
+        assert_eq!(connection.max_active.load(Ordering::SeqCst), 8);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn out_of_order_cursor_describes_keep_candidate_reasons_aligned() -> Result<(), CoreError>
+    {
+        let connection = Arc::new(GatedCursorConnection::new(3));
+        let session = ProtocolSession::root(connection.clone());
+        let task =
+            tokio::spawn(
+                async move { find_cursor_hits(&session, None, &SnapshotBudget::new()).await },
+            );
+
+        connection.wait_for_entries(3).await;
+        connection.gates[2].add_permits(1);
+        connection.wait_for_completions(1).await;
+        connection.gates[0].add_permits(1);
+        connection.wait_for_completions(2).await;
+        connection.gates[1].add_permits(1);
+
+        let hits = task
+            .await
+            .map_err(|error| CoreError::Message(error.to_string()))??;
+        assert_eq!(connection.completion_order(), vec![2, 0, 1]);
+        assert_eq!(hits.get(&100), Some(&vec!["reason-0".to_string()]));
+        assert_eq!(hits.get(&101), Some(&vec!["reason-1".to_string()]));
+        assert_eq!(hits.get(&102), Some(&vec!["reason-2".to_string()]));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancelling_cursor_resolution_still_cleans_marker_and_object_group()
+    -> Result<(), CoreError> {
+        let connection = Arc::new(GatedCursorConnection::new(1));
+        let session = ProtocolSession::root(connection.clone());
+        let task =
+            tokio::spawn(
+                async move { find_cursor_hits(&session, None, &SnapshotBudget::new()).await },
+            );
+
+        connection.wait_for_entries(1).await;
+        task.abort();
+        assert!(task.await.is_err());
+        connection.wait_for_cleanup().await;
+        assert_eq!(connection.cleanup_evaluations.load(Ordering::SeqCst), 1);
+        assert_eq!(connection.released_groups.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+}

--- a/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
@@ -10,7 +10,7 @@ use super::{
     collect_frame_documents,
 };
 use crate::{
-    CoreError, FrameId, ProtocolSession,
+    CoreError, FrameId, PageId, ProtocolSession,
     frames::FrameTarget,
     snapshot::{AxNode, DocumentId, IframeStitch},
 };
@@ -25,6 +25,7 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
+    time::Instant,
 };
 use tokio::sync::Semaphore;
 
@@ -32,6 +33,76 @@ const MAX_IN_FLIGHT_REQUESTS: usize = 8;
 const CURSOR_SCAN_JS: &str = include_str!("../assets/cursor-augment.js");
 const CURSOR_WORLD_NAME: &str = "browseros-snapshot-cursor";
 static NEXT_CURSOR_NAMESPACE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy)]
+pub(super) enum SnapshotStage {
+    Capture,
+    Ax,
+    CursorScan,
+    CursorDescribe,
+    DocumentValidation,
+    SiblingAcquisition,
+    Assembly,
+    Retry,
+}
+
+impl SnapshotStage {
+    #[cfg(test)]
+    const ALL: &[Self] = &[
+        Self::Capture,
+        Self::Ax,
+        Self::CursorScan,
+        Self::CursorDescribe,
+        Self::DocumentValidation,
+        Self::SiblingAcquisition,
+        Self::Assembly,
+        Self::Retry,
+    ];
+
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Capture => "capture",
+            Self::Ax => "ax",
+            Self::CursorScan => "cursor_scan",
+            Self::CursorDescribe => "cursor_describe",
+            Self::DocumentValidation => "document_validation",
+            Self::SiblingAcquisition => "sibling_acquisition",
+            Self::Assembly => "assembly",
+            Self::Retry => "retry",
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct CaptureTrace {
+    page_id: PageId,
+    attempt: usize,
+}
+
+impl CaptureTrace {
+    pub(super) fn new(page_id: PageId, attempt: usize) -> Self {
+        Self { page_id, attempt }
+    }
+}
+
+pub(super) fn trace_stage(
+    trace: &CaptureTrace,
+    frame_id: Option<&FrameId>,
+    stage: SnapshotStage,
+    started: Instant,
+    outcome: &'static str,
+) {
+    tracing::debug!(
+        target: "browseros.snapshot",
+        snapshot_stage = stage.as_str(),
+        page_id = %trace.page_id,
+        frame_id = frame_id.map(|frame_id| frame_id.0.as_str()).unwrap_or("main"),
+        attempt = trace.attempt,
+        duration_ms = started.elapsed().as_secs_f64() * 1000.0,
+        outcome,
+        "snapshot stage complete"
+    );
+}
 
 #[derive(Clone)]
 pub(super) struct SnapshotBudget {
@@ -99,6 +170,7 @@ impl Observer {
             &context.root_session,
             &context.frame_documents,
             &context.budget,
+            Some(&context.trace),
         )
         .await
     }
@@ -110,6 +182,7 @@ impl Observer {
         visited: &[FrameId],
         context: &CaptureContext,
     ) -> Vec<AcquiredChild> {
+        let started = Instant::now();
         let mut pending = FuturesUnordered::new();
         for (stitch_index, stitch) in stitches.iter().cloned().enumerate() {
             let parent_session = parent.session.clone();
@@ -143,6 +216,20 @@ impl Observer {
         // Acquisition completion order is intentionally unordered. Re-establish the renderer's
         // stitch order here so assembly can reverse it exactly as the serialized implementation did.
         acquired.sort_by_key(|child| child.stitch_index);
+        let outcome = if acquired.len() == stitches.len()
+            && acquired.iter().all(|child| child.result.is_ok())
+        {
+            "success"
+        } else {
+            "partial"
+        };
+        trace_stage(
+            &context.trace,
+            parent.runtime_frame_id.as_ref(),
+            SnapshotStage::SiblingAcquisition,
+            started,
+            outcome,
+        );
         acquired
     }
 }
@@ -153,15 +240,37 @@ async fn acquire_frame_data(
     root_session: &ProtocolSession,
     frame_documents: &HashMap<Option<FrameId>, DocumentId>,
     budget: &SnapshotBudget,
+    trace: Option<&CaptureTrace>,
 ) -> Result<AcquiredFrame, CoreError> {
     let acquired_frame_id = frame_id.clone();
-    let ax_tree = budget.send::<AxTreeResult>(
+    let ax_tree = async {
+        let started = Instant::now();
+        let result = budget
+            .send::<AxTreeResult>(
+                &target.session,
+                "Accessibility.getFullAXTree",
+                target.ax_params.clone(),
+            )
+            .await;
+        if let Some(trace) = trace {
+            trace_stage(
+                trace,
+                acquired_frame_id.as_ref(),
+                SnapshotStage::Ax,
+                started,
+                if result.is_ok() { "success" } else { "failure" },
+            );
+        }
+        result
+    };
+    let cursor_hits = find_cursor_hits_with_trace(
         &target.session,
-        "Accessibility.getFullAXTree",
-        target.ax_params.clone(),
+        target.runtime_frame_id.as_ref(),
+        budget,
+        trace,
     );
-    let cursor_hits = find_cursor_hits(&target.session, target.runtime_frame_id.as_ref(), budget);
-    let document_id = stable_document_id_for_frame(root_session, frame_id, frame_documents, budget);
+    let document_id =
+        stable_document_id_for_frame(root_session, frame_id, frame_documents, budget, trace);
     // These stages are independent after target resolution. AX failure remains fatal, while
     // cursor and document identity retain their existing best-effort fallback semantics.
     let (nodes, cursor_hits, document_id) = tokio::join!(ax_tree, cursor_hits, document_id);
@@ -201,18 +310,47 @@ async fn stable_document_id_for_frame(
     frame_id: Option<FrameId>,
     frame_documents: &HashMap<Option<FrameId>, DocumentId>,
     budget: &SnapshotBudget,
+    trace: Option<&CaptureTrace>,
 ) -> Option<DocumentId> {
+    let started = Instant::now();
     let before = frame_documents.get(&frame_id).cloned();
     if frame_id.is_none() || before.is_none() {
+        if let Some(trace) = trace {
+            trace_stage(
+                trace,
+                frame_id.as_ref(),
+                SnapshotStage::DocumentValidation,
+                started,
+                "cached",
+            );
+        }
         return before;
     }
-    let latest = budget
+    let latest_result = budget
         .send::<GetFrameTreeResult>(root_session, "Page.getFrameTree", json!({}))
-        .await
+        .await;
+    let latest = latest_result
+        .as_ref()
         .ok()
         .map(|result| collect_frame_documents(&result.frame_tree));
     let after = latest.and_then(|latest| latest.get(&frame_id).cloned());
-    if after == before { before } else { None }
+    let stable = after == before;
+    if let Some(trace) = trace {
+        trace_stage(
+            trace,
+            frame_id.as_ref(),
+            SnapshotStage::DocumentValidation,
+            started,
+            if latest_result.is_err() {
+                "failure"
+            } else if stable {
+                "success"
+            } else {
+                "changed"
+            },
+        );
+    }
+    if stable { before } else { None }
 }
 
 #[derive(Debug, Deserialize)]
@@ -301,17 +439,42 @@ impl Drop for CursorCleanup {
     }
 }
 
-pub(super) async fn find_cursor_hits(
+#[cfg(test)]
+async fn find_cursor_hits(
     session: &ProtocolSession,
     frame_id: Option<&FrameId>,
     budget: &SnapshotBudget,
+) -> Result<HashMap<i64, Vec<String>>, CoreError> {
+    find_cursor_hits_with_trace(session, frame_id, budget, None).await
+}
+
+async fn find_cursor_hits_with_trace(
+    session: &ProtocolSession,
+    frame_id: Option<&FrameId>,
+    budget: &SnapshotBudget,
+    trace: Option<&CaptureTrace>,
 ) -> Result<HashMap<i64, Vec<String>>, CoreError> {
     let namespace = NEXT_CURSOR_NAMESPACE.fetch_add(1, Ordering::Relaxed);
     // Overlapping captures share a document, so both marker cleanup and object release need a
     // capture-owned namespace. One capture must never remove another capture's temporary handles.
     let marker_attribute = format!("data-__bcid-{namespace}");
     let object_group = format!("browseros-snapshot-cursor-{namespace}");
-    let context_id = execution_context(session, frame_id, budget).await?;
+    let setup_started = Instant::now();
+    let context_id = match execution_context(session, frame_id, budget).await {
+        Ok(context_id) => context_id,
+        Err(error) => {
+            if let Some(trace) = trace {
+                trace_stage(
+                    trace,
+                    frame_id,
+                    SnapshotStage::CursorScan,
+                    setup_started,
+                    "failure",
+                );
+            }
+            return Err(error);
+        }
+    };
     let mut cleanup = CursorCleanup {
         session: session.clone(),
         budget: budget.clone(),
@@ -327,6 +490,8 @@ pub(super) async fn find_cursor_hits(
         &marker_attribute,
         &object_group,
         context_id,
+        frame_id,
+        trace,
     )
     .await;
     cleanup.finish().await;
@@ -360,65 +525,111 @@ async fn acquire_cursor_hits(
     marker_attribute: &str,
     object_group: &str,
     context_id: Option<i64>,
+    frame_id: Option<&FrameId>,
+    trace: Option<&CaptureTrace>,
 ) -> Result<HashMap<i64, Vec<String>>, CoreError> {
-    let marker_literal = serde_json::to_string(marker_attribute)
-        .map_err(|error| CoreError::Message(error.to_string()))?;
-    let scan_expression = CURSOR_SCAN_JS.replace("__BROWSEROS_CURSOR_MARKER__", &marker_literal);
-    let scan: RuntimeEvalResult = budget
-        .send(
-            session,
-            "Runtime.evaluate",
-            evaluate_params(scan_expression, true, None, context_id),
-        )
-        .await?;
-    let candidates = scan
-        .result
-        .value
-        .and_then(|value| serde_json::from_value::<Vec<CursorHit>>(value).ok())
-        .unwrap_or_default();
+    let scan_started = Instant::now();
+    let scan_result = async {
+        let marker_literal = serde_json::to_string(marker_attribute)
+            .map_err(|error| CoreError::Message(error.to_string()))?;
+        let scan_expression =
+            CURSOR_SCAN_JS.replace("__BROWSEROS_CURSOR_MARKER__", &marker_literal);
+        let scan: RuntimeEvalResult = budget
+            .send(
+                session,
+                "Runtime.evaluate",
+                evaluate_params(scan_expression, true, None, context_id),
+            )
+            .await?;
+        let candidates = scan
+            .result
+            .value
+            .and_then(|value| serde_json::from_value::<Vec<CursorHit>>(value).ok())
+            .unwrap_or_default();
+        if candidates.is_empty() {
+            return Ok((candidates, Vec::new()));
+        }
+
+        // Marker values are original scan indexes. Preserve them as sparse array positions so a
+        // node that disappears before collection leaves a hole instead of shifting later reasons.
+        let collection_expression = format!(
+            "(function(a){{var out=[];document.querySelectorAll('['+a+']').forEach(function(e){{out[Number(e.getAttribute(a))]=e;}});return out;}})({marker_literal})"
+        );
+        let collection: RuntimeEvalResult = budget
+            .send(
+                session,
+                "Runtime.evaluate",
+                evaluate_params(collection_expression, false, Some(object_group), context_id),
+            )
+            .await?;
+        let Some(collection_id) = collection.result.object_id else {
+            return Ok((candidates, Vec::new()));
+        };
+        let properties: GetPropertiesResult = budget
+            .send(
+                session,
+                "Runtime.getProperties",
+                json!({
+                    "objectId": collection_id,
+                    "ownProperties": true
+                }),
+            )
+            .await?;
+        let mut handles = properties
+            .result
+            .into_iter()
+            .filter_map(|property| {
+                let index = property.name.parse::<usize>().ok()?;
+                let object_id = property.value?.object_id?;
+                (index < candidates.len()).then_some((index, object_id))
+            })
+            .collect::<Vec<_>>();
+        handles.sort_by_key(|(index, _object_id)| *index);
+        Ok::<_, CoreError>((candidates, handles))
+    }
+    .await;
+    let (candidates, handles) = match scan_result {
+        Ok(result) => {
+            if let Some(trace) = trace {
+                trace_stage(
+                    trace,
+                    frame_id,
+                    SnapshotStage::CursorScan,
+                    scan_started,
+                    "success",
+                );
+            }
+            result
+        }
+        Err(error) => {
+            if let Some(trace) = trace {
+                trace_stage(
+                    trace,
+                    frame_id,
+                    SnapshotStage::CursorScan,
+                    scan_started,
+                    "failure",
+                );
+            }
+            return Err(error);
+        }
+    };
     if candidates.is_empty() {
+        if let Some(trace) = trace {
+            trace_stage(
+                trace,
+                frame_id,
+                SnapshotStage::CursorDescribe,
+                Instant::now(),
+                "skipped",
+            );
+        }
         return Ok(HashMap::new());
     }
 
-    // Marker values are original scan indexes. Preserve them as sparse array positions so a node
-    // that disappears between the scan and this collection leaves a hole instead of shifting the
-    // reasons associated with every later candidate.
-    let collection_expression = format!(
-        "(function(a){{var out=[];document.querySelectorAll('['+a+']').forEach(function(e){{out[Number(e.getAttribute(a))]=e;}});return out;}})({marker_literal})"
-    );
-    let collection: RuntimeEvalResult = budget
-        .send(
-            session,
-            "Runtime.evaluate",
-            evaluate_params(collection_expression, false, Some(object_group), context_id),
-        )
-        .await?;
-    let Some(collection_id) = collection.result.object_id else {
-        return Ok(HashMap::new());
-    };
-    let properties: GetPropertiesResult = budget
-        .send(
-            session,
-            "Runtime.getProperties",
-            json!({
-                "objectId": collection_id,
-                "ownProperties": true
-            }),
-        )
-        .await?;
-    let mut handles = properties
-        .result
-        .into_iter()
-        .filter_map(|property| {
-            let index = property.name.parse::<usize>().ok()?;
-            let object_id = property.value?.object_id?;
-            (index < candidates.len()).then_some((index, object_id))
-        })
-        .collect::<Vec<_>>();
-    handles.sort_by_key(|(index, _object_id)| *index);
-
     // Chrome may answer these in any order. Store each result in its scan-index slot and pair
     // reasons only after the whole batch completes; renderer input is therefore deterministic.
+    let describe_started = Instant::now();
     let mut pending = FuturesUnordered::new();
     for (index, object_id) in handles {
         let session = session.clone();
@@ -449,6 +660,15 @@ async fn acquire_cursor_hits(
         if let Some(backend_node_id) = backend_node_id {
             hits.insert(backend_node_id, candidate.reasons);
         }
+    }
+    if let Some(trace) = trace {
+        trace_stage(
+            trace,
+            frame_id,
+            SnapshotStage::CursorDescribe,
+            describe_started,
+            "success",
+        );
     }
     Ok(hits)
 }
@@ -502,7 +722,7 @@ async fn cleanup_cursor(
 
 #[cfg(test)]
 mod tests {
-    use super::{SnapshotBudget, find_cursor_hits};
+    use super::{SnapshotBudget, SnapshotStage, find_cursor_hits};
     use crate::{
         CoreError, FrameId, ProtocolSession, SessionId, connection::CdpConnection,
         frames::FrameTarget,
@@ -530,6 +750,35 @@ mod tests {
         fail_ax_tree: bool,
         fail_cursor_scan: bool,
         child_loader_id: &'static str,
+    }
+
+    #[test]
+    fn snapshot_trace_stages_are_distinct_and_complete() {
+        let stages = SnapshotStage::ALL
+            .iter()
+            .map(|stage| stage.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            stages,
+            vec![
+                "capture",
+                "ax",
+                "cursor_scan",
+                "cursor_describe",
+                "document_validation",
+                "sibling_acquisition",
+                "assembly",
+                "retry",
+            ]
+        );
+        assert_eq!(
+            stages
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            stages.len()
+        );
     }
 
     impl Default for CursorConnection {
@@ -726,6 +975,7 @@ mod tests {
             &session,
             &frame_documents,
             &SnapshotBudget::new(),
+            None,
         )
         .await?;
 
@@ -1299,6 +1549,7 @@ mod tests {
                 &session,
                 &frame_documents,
                 &SnapshotBudget::new(),
+                None,
             )
             .await
         });
@@ -1350,6 +1601,7 @@ mod tests {
             &ax_session,
             &frame_documents,
             &SnapshotBudget::new(),
+            None,
         )
         .await;
         assert!(result.is_err());
@@ -1371,6 +1623,7 @@ mod tests {
             &optional_session,
             &frame_documents,
             &SnapshotBudget::new(),
+            None,
         )
         .await?;
         assert!(acquired.cursor_hits.is_empty());

--- a/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
@@ -152,11 +152,12 @@ impl Observer {
         &self,
         frame_id: Option<FrameId>,
         runtime_document_id: Option<i64>,
+        same_process_parent: Option<&ProtocolSession>,
         context: &CaptureContext,
     ) -> Result<AcquiredFrame, CoreError> {
         let target = self
             .frames
-            .resolve_frame_target(self.page_id.clone(), frame_id.clone())
+            .resolve_frame_target(self.page_id.clone(), frame_id.clone(), same_process_parent)
             .await?;
         let runtime_document_id = if target.cursor_uses_session_default {
             None
@@ -200,6 +201,7 @@ impl Observer {
                     .acquire_frame(
                         Some(child_frame.frame_id),
                         child_frame.runtime_document_id,
+                        Some(&parent_session),
                         &context,
                     )
                     .await;
@@ -282,16 +284,30 @@ async fn acquire_frame_data(
         budget,
         trace,
     );
+    let document_started = Instant::now();
     let document_id =
-        stable_document_id_for_frame(root_session, frame_id, frame_documents, budget, trace);
+        eager_document_id_for_frame(root_session, frame_id.clone(), frame_documents, budget);
     // These stages are independent after target resolution. AX failure remains fatal, while
     // cursor and document identity retain their existing best-effort fallback semantics.
     let (nodes, cursor_hits, document_id) = tokio::join!(ax_tree, cursor_hits, document_id);
+    let nodes = nodes?.nodes;
+    let (document_id, document_outcome) =
+        revalidate_document_after_acquisition(root_session, frame_id.as_ref(), document_id, budget)
+            .await;
+    if let Some(trace) = trace {
+        trace_stage(
+            trace,
+            frame_id.as_ref(),
+            SnapshotStage::DocumentValidation,
+            document_started,
+            document_outcome,
+        );
+    }
 
     Ok(AcquiredFrame {
         frame_id: acquired_frame_id,
         target,
-        nodes: nodes?.nodes,
+        nodes,
         cursor_hits: cursor_hits.unwrap_or_default(),
         document_id,
     })
@@ -329,25 +345,14 @@ async fn resolve_child_frame(
     })
 }
 
-async fn stable_document_id_for_frame(
+async fn eager_document_id_for_frame(
     root_session: &ProtocolSession,
     frame_id: Option<FrameId>,
     frame_documents: &HashMap<Option<FrameId>, DocumentId>,
     budget: &SnapshotBudget,
-    trace: Option<&CaptureTrace>,
 ) -> Option<DocumentId> {
-    let started = Instant::now();
     let before = frame_documents.get(&frame_id).cloned();
     if frame_id.is_none() || before.is_none() {
-        if let Some(trace) = trace {
-            trace_stage(
-                trace,
-                frame_id.as_ref(),
-                SnapshotStage::DocumentValidation,
-                started,
-                "cached",
-            );
-        }
         return before;
     }
     let latest_result = budget
@@ -358,23 +363,36 @@ async fn stable_document_id_for_frame(
         .ok()
         .map(|result| collect_frame_documents(&result.frame_tree));
     let after = latest.and_then(|latest| latest.get(&frame_id).cloned());
-    let stable = after == before;
-    if let Some(trace) = trace {
-        trace_stage(
-            trace,
-            frame_id.as_ref(),
-            SnapshotStage::DocumentValidation,
-            started,
-            if latest_result.is_err() {
-                "failure"
-            } else if stable {
-                "success"
-            } else {
-                "changed"
-            },
-        );
+    (after == before).then_some(before).flatten()
+}
+
+async fn revalidate_document_after_acquisition(
+    root_session: &ProtocolSession,
+    frame_id: Option<&FrameId>,
+    candidate: Option<DocumentId>,
+    budget: &SnapshotBudget,
+) -> (Option<DocumentId>, &'static str) {
+    let Some(frame_id) = frame_id else {
+        return (candidate, "cached");
+    };
+    let Some(candidate) = candidate else {
+        return (None, "fallback");
+    };
+    let latest_result = budget
+        .send::<GetFrameTreeResult>(root_session, "Page.getFrameTree", json!({}))
+        .await;
+    let latest = latest_result
+        .as_ref()
+        .ok()
+        .map(|result| collect_frame_documents(&result.frame_tree));
+    let after = latest.and_then(|latest| latest.get(&Some(frame_id.clone())).cloned());
+    if latest_result.is_err() {
+        (None, "failure")
+    } else if after.as_ref() == Some(&candidate) {
+        (Some(candidate), "success")
+    } else {
+        (None, "changed")
     }
-    if stable { before } else { None }
 }
 
 #[derive(Debug, Deserialize)]
@@ -884,7 +902,7 @@ mod tests {
     use serde_json::{Value, json};
     use std::sync::{
         Arc, Mutex,
-        atomic::{AtomicU8, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
     };
     use tokio::sync::{Notify, Semaphore, broadcast};
 
@@ -1219,6 +1237,10 @@ mod tests {
         ax_gate: Arc<Semaphore>,
         cursor_gate: Arc<Semaphore>,
         document_gate: Arc<Semaphore>,
+        document_reads: AtomicUsize,
+        document_responses: AtomicUsize,
+        document_responded: Notify,
+        loader_changed: AtomicBool,
     }
 
     impl StageOverlapConnection {
@@ -1229,6 +1251,10 @@ mod tests {
                 ax_gate: Arc::new(Semaphore::new(0)),
                 cursor_gate: Arc::new(Semaphore::new(0)),
                 document_gate: Arc::new(Semaphore::new(0)),
+                document_reads: AtomicUsize::new(0),
+                document_responses: AtomicUsize::new(0),
+                document_responded: Notify::new(),
+                loader_changed: AtomicBool::new(false),
             }
         }
 
@@ -1250,6 +1276,16 @@ mod tests {
             loop {
                 let notified = self.started_changed.notified();
                 if self.started.load(Ordering::SeqCst) == 0b111 {
+                    return;
+                }
+                notified.await;
+            }
+        }
+
+        async fn wait_for_document_response(&self, target: usize) {
+            loop {
+                let notified = self.document_responded.notified();
+                if self.document_responses.load(Ordering::SeqCst) >= target {
                     return;
                 }
                 notified.await;
@@ -1305,8 +1341,18 @@ mod tests {
                         }))
                     }
                     "Page.getFrameTree" => {
-                        self.mark_and_wait(0b100, self.document_gate.clone())
-                            .await?;
+                        let read_index = self.document_reads.fetch_add(1, Ordering::SeqCst);
+                        if read_index == 0 {
+                            self.mark_and_wait(0b100, self.document_gate.clone())
+                                .await?;
+                        }
+                        let child_loader_id = if self.loader_changed.load(Ordering::SeqCst) {
+                            "changed-loader"
+                        } else {
+                            "child-loader"
+                        };
+                        self.document_responses.fetch_add(1, Ordering::SeqCst);
+                        self.document_responded.notify_waiters();
                         Ok(json!({
                             "frameTree": {
                                 "frame": {
@@ -1317,7 +1363,7 @@ mod tests {
                                 "childFrames": [{
                                     "frame": {
                                         "id": "child-frame",
-                                        "loaderId": "child-loader",
+                                        "loaderId": child_loader_id,
                                         "url": "https://example.com/frame"
                                     }
                                 }]
@@ -1983,6 +2029,48 @@ mod tests {
             acquired.document_id.as_deref(),
             Some("child-frame:child-loader")
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn child_navigation_after_eager_validation_uses_fallback_refs() -> Result<(), CoreError> {
+        let connection = Arc::new(StageOverlapConnection::new());
+        let session = ProtocolSession::root(connection.clone());
+        let frame_id = FrameId("child-frame".to_string());
+        let target = FrameTarget {
+            session: session.clone(),
+            ax_params: json!({"frameId": frame_id.0}),
+            cursor_uses_session_default: false,
+        };
+        let frame_documents = std::collections::HashMap::from([(
+            Some(frame_id.clone()),
+            "child-frame:child-loader".to_string(),
+        )]);
+        let task = tokio::spawn(async move {
+            super::acquire_frame_data(
+                target,
+                Some(frame_id),
+                Some(901),
+                &session,
+                &frame_documents,
+                &SnapshotBudget::new(),
+                None,
+            )
+            .await
+        });
+
+        connection.wait_for_all_stages().await;
+        connection.document_gate.add_permits(1);
+        connection.wait_for_document_response(1).await;
+        connection.loader_changed.store(true, Ordering::SeqCst);
+        connection.ax_gate.add_permits(1);
+        connection.cursor_gate.add_permits(1);
+
+        let acquired = task
+            .await
+            .map_err(|error| CoreError::Message(error.to_string()))??;
+        assert!(acquired.document_id.is_none());
+        assert_eq!(connection.document_reads.load(Ordering::SeqCst), 2);
         Ok(())
     }
 

--- a/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     CoreError, FrameId, ProtocolSession,
     frames::FrameTarget,
-    snapshot::{AxNode, DocumentId},
+    snapshot::{AxNode, DocumentId, IframeStitch},
 };
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use serde::Deserialize;
@@ -70,10 +70,17 @@ impl SnapshotBudget {
 /// Immutable Chrome inputs for one frame. Rendering receives this only after acquisition
 /// completes, so no concurrent future can observe or mutate the capture's `RefMap`.
 pub(super) struct AcquiredFrame {
+    pub(super) frame_id: Option<FrameId>,
     pub(super) target: FrameTarget,
     pub(super) nodes: Vec<AxNode>,
     pub(super) cursor_hits: HashMap<i64, Vec<String>>,
     pub(super) document_id: Option<DocumentId>,
+}
+
+pub(super) struct AcquiredChild {
+    pub(super) stitch: IframeStitch,
+    pub(super) result: Result<AcquiredFrame, CoreError>,
+    stitch_index: usize,
 }
 
 impl Observer {
@@ -95,6 +102,49 @@ impl Observer {
         )
         .await
     }
+
+    pub(super) async fn acquire_child_frames(
+        &self,
+        parent: &FrameTarget,
+        stitches: &[IframeStitch],
+        visited: &[FrameId],
+        context: &CaptureContext,
+    ) -> Vec<AcquiredChild> {
+        let mut pending = FuturesUnordered::new();
+        for (stitch_index, stitch) in stitches.iter().cloned().enumerate() {
+            let parent_session = parent.session.clone();
+            let visited = visited.to_vec();
+            let context = context.clone();
+            pending.push(async move {
+                let child_frame_id = resolve_child_frame_id(
+                    &parent_session,
+                    stitch.backend_node_id,
+                    &context.budget,
+                )
+                .await?;
+                if visited.contains(&child_frame_id) {
+                    return None;
+                }
+                let result = self.acquire_frame(Some(child_frame_id), &context).await;
+                Some(AcquiredChild {
+                    stitch,
+                    result,
+                    stitch_index,
+                })
+            });
+        }
+
+        let mut acquired = Vec::with_capacity(stitches.len());
+        while let Some(child) = pending.next().await {
+            if let Some(child) = child {
+                acquired.push(child);
+            }
+        }
+        // Acquisition completion order is intentionally unordered. Re-establish the renderer's
+        // stitch order here so assembly can reverse it exactly as the serialized implementation did.
+        acquired.sort_by_key(|child| child.stitch_index);
+        acquired
+    }
 }
 
 async fn acquire_frame_data(
@@ -104,6 +154,7 @@ async fn acquire_frame_data(
     frame_documents: &HashMap<Option<FrameId>, DocumentId>,
     budget: &SnapshotBudget,
 ) -> Result<AcquiredFrame, CoreError> {
+    let acquired_frame_id = frame_id.clone();
     let ax_tree = budget.send::<AxTreeResult>(
         &target.session,
         "Accessibility.getFullAXTree",
@@ -116,11 +167,33 @@ async fn acquire_frame_data(
     let (nodes, cursor_hits, document_id) = tokio::join!(ax_tree, cursor_hits, document_id);
 
     Ok(AcquiredFrame {
+        frame_id: acquired_frame_id,
         target,
         nodes: nodes?.nodes,
         cursor_hits: cursor_hits.unwrap_or_default(),
         document_id,
     })
+}
+
+async fn resolve_child_frame_id(
+    session: &ProtocolSession,
+    backend_node_id: i64,
+    budget: &SnapshotBudget,
+) -> Option<FrameId> {
+    let described = budget
+        .send::<DescribeNodeResult>(
+            session,
+            "DOM.describeNode",
+            json!({ "backendNodeId": backend_node_id, "depth": 1 }),
+        )
+        .await
+        .ok()?;
+    described
+        .node
+        .content_document
+        .and_then(|node| node.frame_id)
+        .or(described.node.frame_id)
+        .map(FrameId)
 }
 
 async fn stable_document_id_for_frame(

--- a/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
@@ -384,6 +384,7 @@ struct CreateIsolatedWorldResult {
 
 #[derive(Debug, Deserialize)]
 struct CursorHit {
+    marker: String,
     reasons: Vec<String>,
 }
 
@@ -550,8 +551,11 @@ async fn acquire_cursor_hits(
             return Ok((candidates, Vec::new()));
         }
 
-        // Marker values are original scan indexes. Preserve them as sparse array positions so a
-        // node that disappears before collection leaves a hole instead of shifting later reasons.
+        // Markers are indexes in the full DOM scan, while `candidates` is compacted to matching
+        // elements. Preserve the sparse markers in the remote array, then translate property names
+        // back through each candidate's marker; otherwise skipped DOM nodes would mis-pair handles
+        // and reasons. A node that disappears before collection leaves a hole instead of shifting
+        // later candidates.
         let collection_expression = format!(
             "(function(a){{var out=[];document.querySelectorAll('['+a+']').forEach(function(e){{out[Number(e.getAttribute(a))]=e;}});return out;}})({marker_literal})"
         );
@@ -575,13 +579,18 @@ async fn acquire_cursor_hits(
                 }),
             )
             .await?;
+        let candidate_indexes = candidates
+            .iter()
+            .enumerate()
+            .map(|(index, candidate)| (candidate.marker.as_str(), index))
+            .collect::<HashMap<_, _>>();
         let mut handles = properties
             .result
             .into_iter()
             .filter_map(|property| {
-                let index = property.name.parse::<usize>().ok()?;
+                let index = *candidate_indexes.get(property.name.as_str())?;
                 let object_id = property.value?.object_id?;
-                (index < candidates.len()).then_some((index, object_id))
+                Some((index, object_id))
             })
             .collect::<Vec<_>>();
         handles.sort_by_key(|(index, _object_id)| *index);
@@ -745,6 +754,7 @@ mod tests {
 
     struct CursorConnection {
         calls: Mutex<Vec<Call>>,
+        candidate_markers: [usize; 3],
         omitted_candidate: Option<usize>,
         failed_candidate: Option<usize>,
         fail_ax_tree: bool,
@@ -785,6 +795,7 @@ mod tests {
         fn default() -> Self {
             Self {
                 calls: Mutex::new(Vec::new()),
+                candidate_markers: [0, 1, 2],
                 omitted_candidate: None,
                 failed_candidate: None,
                 fail_ax_tree: false,
@@ -835,9 +846,9 @@ mod tests {
                             "result": {
                                 "type": "object",
                                 "value": [
-                                    {"marker": "0", "reasons": ["cursor:pointer"]},
-                                    {"marker": "1", "reasons": ["onclick"]},
-                                    {"marker": "2", "reasons": ["contenteditable"]}
+                                    {"marker": self.candidate_markers[0].to_string(), "reasons": ["cursor:pointer"]},
+                                    {"marker": self.candidate_markers[1].to_string(), "reasons": ["onclick"]},
+                                    {"marker": self.candidate_markers[2].to_string(), "reasons": ["contenteditable"]}
                                 ]
                             }
                         }))
@@ -858,15 +869,15 @@ mod tests {
                     "Runtime.getProperties" => {
                         let mut properties = vec![
                             json!({
-                                "name": "2",
+                                "name": self.candidate_markers[2].to_string(),
                                 "value": {"type": "object", "objectId": "candidate-2"}
                             }),
                             json!({
-                                "name": "0",
+                                "name": self.candidate_markers[0].to_string(),
                                 "value": {"type": "object", "objectId": "candidate-0"}
                             }),
                             json!({
-                                "name": "1",
+                                "name": self.candidate_markers[1].to_string(),
                                 "value": {"type": "object", "objectId": "candidate-1"}
                             }),
                             json!({
@@ -875,7 +886,7 @@ mod tests {
                             }),
                         ];
                         if let Some(index) = self.omitted_candidate {
-                            let name = index.to_string();
+                            let name = self.candidate_markers[index].to_string();
                             properties.retain(|property| property["name"] != name);
                         }
                         Ok(json!({ "result": properties }))
@@ -1359,6 +1370,22 @@ mod tests {
                 .and_then(Value::as_str)
                 .is_none_or(|expression| !expression.contains("document.querySelector('"))
         }));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sparse_cursor_markers_restore_compact_candidate_order() -> Result<(), CoreError> {
+        let connection = Arc::new(CursorConnection {
+            candidate_markers: [12, 37, 90],
+            ..CursorConnection::default()
+        });
+        let session = ProtocolSession::root(connection);
+
+        let hits = find_cursor_hits(&session, None, &SnapshotBudget::new()).await?;
+
+        assert_eq!(hits.get(&100), Some(&vec!["cursor:pointer".to_string()]));
+        assert_eq!(hits.get(&101), Some(&vec!["onclick".to_string()]));
+        assert_eq!(hits.get(&102), Some(&vec!["contenteditable".to_string()]));
         Ok(())
     }
 

--- a/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
@@ -14,6 +14,7 @@ use crate::{
     frames::FrameTarget,
     snapshot::{AxNode, DocumentId, IframeStitch},
 };
+use browseros_cdp::runtime::GetPropertiesResult;
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
@@ -191,11 +192,14 @@ impl Observer {
             let visited = visited.to_vec();
             let context = context.clone();
             pending.push(async move {
-                let child_frame =
+                let Some(child_frame) =
                     resolve_child_frame(&parent_session, stitch.backend_node_id, &context.budget)
-                        .await?;
+                        .await
+                else {
+                    return (None, false);
+                };
                 if visited.contains(&child_frame.frame_id) {
-                    return None;
+                    return (None, true);
                 }
                 let result = self
                     .acquire_frame(
@@ -205,16 +209,21 @@ impl Observer {
                         &context,
                     )
                     .await;
-                Some(AcquiredChild {
-                    stitch,
-                    result,
-                    stitch_index,
-                })
+                (
+                    Some(AcquiredChild {
+                        stitch,
+                        result,
+                        stitch_index,
+                    }),
+                    false,
+                )
             });
         }
 
         let mut acquired = Vec::with_capacity(stitches.len());
-        while let Some(child) = pending.next().await {
+        let mut cycle_skips = 0;
+        while let Some((child, skipped_cycle)) = pending.next().await {
+            cycle_skips += usize::from(skipped_cycle);
             if let Some(child) = child {
                 acquired.push(child);
             }
@@ -222,7 +231,8 @@ impl Observer {
         // Acquisition completion order is intentionally unordered. Re-establish the renderer's
         // stitch order here so assembly can reverse it exactly as the serialized implementation did.
         acquired.sort_by_key(|child| child.stitch_index);
-        let outcome = if acquired.len() == stitches.len()
+        let expected_children = stitches.len().saturating_sub(cycle_skips);
+        let outcome = if acquired.len() == expected_children
             && acquired.iter().all(|child| child.result.is_ok())
         {
             "success"
@@ -405,17 +415,6 @@ struct RemoteObject {
     value: Option<Value>,
     #[serde(rename = "objectId")]
     object_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GetPropertiesResult {
-    result: Vec<PropertyDescriptor>,
-}
-
-#[derive(Debug, Deserialize)]
-struct PropertyDescriptor {
-    name: String,
-    value: Option<RemoteObject>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
@@ -19,20 +19,13 @@ use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use serde_json::json;
-use std::{
-    collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::Instant,
-};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 use tokio::sync::Semaphore;
+use uuid::Uuid;
 
 const MAX_IN_FLIGHT_REQUESTS: usize = 8;
+const MAX_MARKER_COLLISION_RETRIES: usize = 3;
 const CURSOR_SCAN_JS: &str = include_str!("../assets/cursor-augment.js");
-const CURSOR_WORLD_NAME: &str = "browseros-snapshot-cursor";
-static NEXT_CURSOR_NAMESPACE: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy)]
 pub(super) enum SnapshotStage {
@@ -158,15 +151,22 @@ impl Observer {
     pub(super) async fn acquire_frame(
         &self,
         frame_id: Option<FrameId>,
+        runtime_document_id: Option<i64>,
         context: &CaptureContext,
     ) -> Result<AcquiredFrame, CoreError> {
         let target = self
             .frames
             .resolve_frame_target(self.page_id.clone(), frame_id.clone())
             .await?;
+        let runtime_document_id = if target.cursor_uses_session_default {
+            None
+        } else {
+            runtime_document_id
+        };
         acquire_frame_data(
             target,
             frame_id,
+            runtime_document_id,
             &context.root_session,
             &context.frame_documents,
             &context.budget,
@@ -178,6 +178,7 @@ impl Observer {
     pub(super) async fn acquire_child_frames(
         &self,
         parent: &FrameTarget,
+        parent_frame_id: Option<&FrameId>,
         stitches: &[IframeStitch],
         visited: &[FrameId],
         context: &CaptureContext,
@@ -189,16 +190,19 @@ impl Observer {
             let visited = visited.to_vec();
             let context = context.clone();
             pending.push(async move {
-                let child_frame_id = resolve_child_frame_id(
-                    &parent_session,
-                    stitch.backend_node_id,
-                    &context.budget,
-                )
-                .await?;
-                if visited.contains(&child_frame_id) {
+                let child_frame =
+                    resolve_child_frame(&parent_session, stitch.backend_node_id, &context.budget)
+                        .await?;
+                if visited.contains(&child_frame.frame_id) {
                     return None;
                 }
-                let result = self.acquire_frame(Some(child_frame_id), &context).await;
+                let result = self
+                    .acquire_frame(
+                        Some(child_frame.frame_id),
+                        child_frame.runtime_document_id,
+                        &context,
+                    )
+                    .await;
                 Some(AcquiredChild {
                     stitch,
                     result,
@@ -225,7 +229,7 @@ impl Observer {
         };
         trace_stage(
             &context.trace,
-            parent.runtime_frame_id.as_ref(),
+            parent_frame_id,
             SnapshotStage::SiblingAcquisition,
             started,
             outcome,
@@ -237,12 +241,20 @@ impl Observer {
 async fn acquire_frame_data(
     target: FrameTarget,
     frame_id: Option<FrameId>,
+    runtime_document_id: Option<i64>,
     root_session: &ProtocolSession,
     frame_documents: &HashMap<Option<FrameId>, DocumentId>,
     budget: &SnapshotBudget,
     trace: Option<&CaptureTrace>,
 ) -> Result<AcquiredFrame, CoreError> {
     let acquired_frame_id = frame_id.clone();
+    let cursor_document = if target.cursor_uses_session_default {
+        CursorDocument::SessionDefault
+    } else if let Some(backend_node_id) = runtime_document_id {
+        CursorDocument::BackendNode(backend_node_id)
+    } else {
+        CursorDocument::Unavailable
+    };
     let ax_tree = async {
         let started = Instant::now();
         let result = budget
@@ -265,7 +277,8 @@ async fn acquire_frame_data(
     };
     let cursor_hits = find_cursor_hits_with_trace(
         &target.session,
-        target.runtime_frame_id.as_ref(),
+        cursor_document,
+        acquired_frame_id.as_ref(),
         budget,
         trace,
     );
@@ -284,11 +297,16 @@ async fn acquire_frame_data(
     })
 }
 
-async fn resolve_child_frame_id(
+struct ResolvedChildFrame {
+    frame_id: FrameId,
+    runtime_document_id: Option<i64>,
+}
+
+async fn resolve_child_frame(
     session: &ProtocolSession,
     backend_node_id: i64,
     budget: &SnapshotBudget,
-) -> Option<FrameId> {
+) -> Option<ResolvedChildFrame> {
     let described = budget
         .send::<DescribeNodeResult>(
             session,
@@ -297,12 +315,18 @@ async fn resolve_child_frame_id(
         )
         .await
         .ok()?;
-    described
-        .node
-        .content_document
+    let content_document = described.node.content_document;
+    let runtime_document_id = content_document
+        .as_ref()
+        .and_then(|node| node.backend_node_id);
+    let frame_id = content_document
         .and_then(|node| node.frame_id)
         .or(described.node.frame_id)
-        .map(FrameId)
+        .map(FrameId)?;
+    Some(ResolvedChildFrame {
+        frame_id,
+        runtime_document_id,
+    })
 }
 
 async fn stable_document_id_for_frame(
@@ -377,9 +401,21 @@ struct PropertyDescriptor {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct CreateIsolatedWorldResult {
-    execution_context_id: i64,
+struct ResolveNodeResult {
+    object: RemoteObject,
+}
+
+#[derive(Clone, Copy)]
+enum CursorDocument {
+    SessionDefault,
+    BackendNode(i64),
+    Unavailable,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CursorScanResult {
+    collision: bool,
+    candidates: Vec<CursorHit>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -391,22 +427,39 @@ struct CursorHit {
 struct CursorCleanup {
     session: ProtocolSession,
     budget: SnapshotBudget,
-    marker_attribute: String,
+    marker_attribute: Option<String>,
+    marker_token: Option<String>,
     object_group: String,
-    context_id: Option<i64>,
+    document_object_id: Option<String>,
     armed: bool,
 }
 
 impl CursorCleanup {
+    fn arm_marker(&mut self, marker_attribute: String, marker_token: String) {
+        self.marker_attribute = Some(marker_attribute);
+        self.marker_token = Some(marker_token);
+    }
+
+    async fn clear_marker(&mut self) {
+        if let (Some(marker_attribute), Some(marker_token)) =
+            (&self.marker_attribute, &self.marker_token)
+        {
+            cleanup_cursor_marker(
+                &self.session,
+                &self.budget,
+                marker_attribute,
+                marker_token,
+                self.document_object_id.as_deref(),
+            )
+            .await;
+            self.marker_attribute = None;
+            self.marker_token = None;
+        }
+    }
+
     async fn finish(&mut self) {
-        cleanup_cursor(
-            &self.session,
-            &self.budget,
-            &self.marker_attribute,
-            &self.object_group,
-            self.context_id,
-        )
-        .await;
+        self.clear_marker().await;
+        release_cursor_objects(&self.session, &self.budget, &self.object_group).await;
         self.armed = false;
     }
 }
@@ -422,20 +475,25 @@ impl Drop for CursorCleanup {
         let session = self.session.clone();
         let budget = self.budget.clone();
         let marker_attribute = self.marker_attribute.clone();
+        let marker_token = self.marker_token.clone();
         let object_group = self.object_group.clone();
-        let context_id = self.context_id;
+        let document_object_id = self.document_object_id.clone();
 
-        // Cancellation skips the async epilogue, so detach one idempotent cleanup
-        // task for the capture namespace. Candidate requests are never spawned.
+        // Cancellation skips the async epilogue, so detach one idempotent cleanup task for the
+        // capture token. Cleanup matches both attribute and token, preserving page-owned values
+        // even if a generated attribute name collides.
         drop(handle.spawn(async move {
-            cleanup_cursor(
-                &session,
-                &budget,
-                &marker_attribute,
-                &object_group,
-                context_id,
-            )
-            .await;
+            if let (Some(marker_attribute), Some(marker_token)) = (marker_attribute, marker_token) {
+                cleanup_cursor_marker(
+                    &session,
+                    &budget,
+                    &marker_attribute,
+                    &marker_token,
+                    document_object_id.as_deref(),
+                )
+                .await;
+            }
+            release_cursor_objects(&session, &budget, &object_group).await;
         }));
     }
 }
@@ -443,112 +501,156 @@ impl Drop for CursorCleanup {
 #[cfg(test)]
 async fn find_cursor_hits(
     session: &ProtocolSession,
-    frame_id: Option<&FrameId>,
+    runtime_document_id: Option<i64>,
     budget: &SnapshotBudget,
 ) -> Result<HashMap<i64, Vec<String>>, CoreError> {
-    find_cursor_hits_with_trace(session, frame_id, budget, None).await
+    let document =
+        runtime_document_id.map_or(CursorDocument::SessionDefault, CursorDocument::BackendNode);
+    find_cursor_hits_with_trace(session, document, None, budget, None).await
 }
 
 async fn find_cursor_hits_with_trace(
     session: &ProtocolSession,
+    document: CursorDocument,
     frame_id: Option<&FrameId>,
     budget: &SnapshotBudget,
     trace: Option<&CaptureTrace>,
 ) -> Result<HashMap<i64, Vec<String>>, CoreError> {
-    let namespace = NEXT_CURSOR_NAMESPACE.fetch_add(1, Ordering::Relaxed);
-    // Overlapping captures share a document, so both marker cleanup and object release need a
-    // capture-owned namespace. One capture must never remove another capture's temporary handles.
-    let marker_attribute = format!("data-__bcid-{namespace}");
-    let object_group = format!("browseros-snapshot-cursor-{namespace}");
     let setup_started = Instant::now();
-    let context_id = match execution_context(session, frame_id, budget).await {
-        Ok(context_id) => context_id,
-        Err(error) => {
-            if let Some(trace) = trace {
-                trace_stage(
-                    trace,
-                    frame_id,
-                    SnapshotStage::CursorScan,
-                    setup_started,
-                    "failure",
-                );
-            }
-            return Err(error);
-        }
-    };
+    let capture_id = Uuid::new_v4().simple().to_string();
+    let object_group = format!("browseros-snapshot-cursor-{capture_id}");
+    // Arm object-group release before resolving a document wrapper: cancellation can arrive after
+    // Chrome creates that remote object but before its response reaches this future.
     let mut cleanup = CursorCleanup {
         session: session.clone(),
         budget: budget.clone(),
-        marker_attribute: marker_attribute.clone(),
+        marker_attribute: None,
+        marker_token: None,
         object_group: object_group.clone(),
-        context_id,
+        document_object_id: None,
         armed: true,
     };
-
-    let result = acquire_cursor_hits(
-        session,
-        budget,
-        &marker_attribute,
-        &object_group,
-        context_id,
-        frame_id,
-        trace,
-    )
-    .await;
+    let document_object_id =
+        match resolve_cursor_document(session, budget, document, &object_group).await {
+            Ok(document_object_id) => document_object_id,
+            Err(error) => {
+                if let Some(trace) = trace {
+                    trace_stage(
+                        trace,
+                        frame_id,
+                        SnapshotStage::CursorScan,
+                        setup_started,
+                        "failure",
+                    );
+                }
+                return Err(error);
+            }
+        };
+    cleanup.document_object_id = document_object_id;
+    for _attempt in 0..MAX_MARKER_COLLISION_RETRIES {
+        // The random attribute isolates overlapping captures; the separate token lets cancellation
+        // cleanup prove ownership before removing anything from the inspected document.
+        let marker_token = Uuid::new_v4().simple().to_string();
+        let marker_attribute = format!("data-__bcid-{marker_token}");
+        cleanup.arm_marker(marker_attribute.clone(), marker_token.clone());
+        let acquisition = CursorAcquisitionContext {
+            marker_attribute: &marker_attribute,
+            marker_token: &marker_token,
+            object_group: &object_group,
+            document_object_id: cleanup.document_object_id.as_deref(),
+            frame_id,
+            trace,
+        };
+        let result = acquire_cursor_hits(session, budget, &acquisition).await;
+        cleanup.clear_marker().await;
+        match result? {
+            CursorAcquisition::Complete(hits) => {
+                cleanup.finish().await;
+                return Ok(hits);
+            }
+            CursorAcquisition::MarkerCollision => continue,
+        }
+    }
     cleanup.finish().await;
-    result
+    Err(CoreError::Message(
+        "Could not reserve a cursor marker namespace".to_string(),
+    ))
 }
 
-async fn execution_context(
+async fn resolve_cursor_document(
     session: &ProtocolSession,
-    frame_id: Option<&FrameId>,
     budget: &SnapshotBudget,
-) -> Result<Option<i64>, CoreError> {
-    let Some(frame_id) = frame_id else {
-        return Ok(None);
-    };
-    let result: CreateIsolatedWorldResult = budget
-        .send(
-            session,
-            "Page.createIsolatedWorld",
-            json!({
-                "frameId": frame_id.0,
-                "worldName": CURSOR_WORLD_NAME
-            }),
-        )
-        .await?;
-    Ok(Some(result.execution_context_id))
+    document: CursorDocument,
+    object_group: &str,
+) -> Result<Option<String>, CoreError> {
+    match document {
+        CursorDocument::SessionDefault => Ok(None),
+        CursorDocument::Unavailable => Err(CoreError::Message(
+            "Child frame document was unavailable for cursor acquisition".to_string(),
+        )),
+        CursorDocument::BackendNode(backend_node_id) => {
+            // Resolving the child Document without an execution-context override returns its
+            // default-world wrapper. Calling the scan on that object keeps page-assigned
+            // `onclick` properties visible while still targeting the exact same-process frame.
+            let resolved: ResolveNodeResult = budget
+                .send(
+                    session,
+                    "DOM.resolveNode",
+                    json!({
+                        "backendNodeId": backend_node_id,
+                        "objectGroup": object_group
+                    }),
+                )
+                .await?;
+            resolved.object.object_id.map(Some).ok_or_else(|| {
+                CoreError::Message("Resolved frame document had no remote object".to_string())
+            })
+        }
+    }
+}
+
+enum CursorAcquisition {
+    Complete(HashMap<i64, Vec<String>>),
+    MarkerCollision,
+}
+
+struct CursorAcquisitionContext<'a> {
+    marker_attribute: &'a str,
+    marker_token: &'a str,
+    object_group: &'a str,
+    document_object_id: Option<&'a str>,
+    frame_id: Option<&'a FrameId>,
+    trace: Option<&'a CaptureTrace>,
 }
 
 async fn acquire_cursor_hits(
     session: &ProtocolSession,
     budget: &SnapshotBudget,
-    marker_attribute: &str,
-    object_group: &str,
-    context_id: Option<i64>,
-    frame_id: Option<&FrameId>,
-    trace: Option<&CaptureTrace>,
-) -> Result<HashMap<i64, Vec<String>>, CoreError> {
+    context: &CursorAcquisitionContext<'_>,
+) -> Result<CursorAcquisition, CoreError> {
     let scan_started = Instant::now();
     let scan_result = async {
-        let marker_literal = serde_json::to_string(marker_attribute)
-            .map_err(|error| CoreError::Message(error.to_string()))?;
-        let scan_expression =
-            CURSOR_SCAN_JS.replace("__BROWSEROS_CURSOR_MARKER__", &marker_literal);
-        let scan: RuntimeEvalResult = budget
-            .send(
-                session,
-                "Runtime.evaluate",
-                evaluate_params(scan_expression, true, None, context_id),
-            )
-            .await?;
-        let candidates = scan
+        let scan = call_document_function(
+            session,
+            budget,
+            context.document_object_id,
+            CURSOR_SCAN_JS,
+            &[context.marker_attribute, context.marker_token],
+            true,
+            None,
+        )
+        .await?;
+        let scan = scan
             .result
             .value
-            .and_then(|value| serde_json::from_value::<Vec<CursorHit>>(value).ok())
+            .and_then(|value| serde_json::from_value::<CursorScanResult>(value).ok())
             .unwrap_or_default();
+        if scan.collision {
+            return Ok(CursorScanBatch::MarkerCollision);
+        }
+        let candidates = scan.candidates;
         if candidates.is_empty() {
-            return Ok((candidates, Vec::new()));
+            return Ok(CursorScanBatch::Candidates(candidates, Vec::new()));
         }
 
         // Markers are indexes in the full DOM scan, while `candidates` is compacted to matching
@@ -556,18 +658,18 @@ async fn acquire_cursor_hits(
         // back through each candidate's marker; otherwise skipped DOM nodes would mis-pair handles
         // and reasons. A node that disappears before collection leaves a hole instead of shifting
         // later candidates.
-        let collection_expression = format!(
-            "(function(a){{var out=[];document.querySelectorAll('['+a+']').forEach(function(e){{out[Number(e.getAttribute(a))]=e;}});return out;}})({marker_literal})"
-        );
-        let collection: RuntimeEvalResult = budget
-            .send(
-                session,
-                "Runtime.evaluate",
-                evaluate_params(collection_expression, false, Some(object_group), context_id),
-            )
-            .await?;
+        let collection = call_document_function(
+            session,
+            budget,
+            context.document_object_id,
+            "function(a,t){var out=[],p=t+':';this.querySelectorAll('['+a+']').forEach(function(e){var v=e.getAttribute(a);if(v&&v.indexOf(p)===0)out[Number(v.slice(p.length))]=e;});return out;}",
+            &[context.marker_attribute, context.marker_token],
+            false,
+            Some(context.object_group),
+        )
+        .await?;
         let Some(collection_id) = collection.result.object_id else {
-            return Ok((candidates, Vec::new()));
+            return Ok(CursorScanBatch::Candidates(candidates, Vec::new()));
         };
         let properties: GetPropertiesResult = budget
             .send(
@@ -594,27 +696,39 @@ async fn acquire_cursor_hits(
             })
             .collect::<Vec<_>>();
         handles.sort_by_key(|(index, _object_id)| *index);
-        Ok::<_, CoreError>((candidates, handles))
+        Ok::<_, CoreError>(CursorScanBatch::Candidates(candidates, handles))
     }
     .await;
     let (candidates, handles) = match scan_result {
-        Ok(result) => {
-            if let Some(trace) = trace {
+        Ok(CursorScanBatch::Candidates(candidates, handles)) => {
+            if let Some(trace) = context.trace {
                 trace_stage(
                     trace,
-                    frame_id,
+                    context.frame_id,
                     SnapshotStage::CursorScan,
                     scan_started,
                     "success",
                 );
             }
-            result
+            (candidates, handles)
         }
-        Err(error) => {
-            if let Some(trace) = trace {
+        Ok(CursorScanBatch::MarkerCollision) => {
+            if let Some(trace) = context.trace {
                 trace_stage(
                     trace,
-                    frame_id,
+                    context.frame_id,
+                    SnapshotStage::CursorScan,
+                    scan_started,
+                    "marker_collision",
+                );
+            }
+            return Ok(CursorAcquisition::MarkerCollision);
+        }
+        Err(error) => {
+            if let Some(trace) = context.trace {
+                trace_stage(
+                    trace,
+                    context.frame_id,
                     SnapshotStage::CursorScan,
                     scan_started,
                     "failure",
@@ -624,16 +738,16 @@ async fn acquire_cursor_hits(
         }
     };
     if candidates.is_empty() {
-        if let Some(trace) = trace {
+        if let Some(trace) = context.trace {
             trace_stage(
                 trace,
-                frame_id,
+                context.frame_id,
                 SnapshotStage::CursorDescribe,
                 Instant::now(),
                 "skipped",
             );
         }
-        return Ok(HashMap::new());
+        return Ok(CursorAcquisition::Complete(HashMap::new()));
     }
 
     // Chrome may answer these in any order. Store each result in its scan-index slot and pair
@@ -670,56 +784,85 @@ async fn acquire_cursor_hits(
             hits.insert(backend_node_id, candidate.reasons);
         }
     }
-    if let Some(trace) = trace {
+    if let Some(trace) = context.trace {
         trace_stage(
             trace,
-            frame_id,
+            context.frame_id,
             SnapshotStage::CursorDescribe,
             describe_started,
             "success",
         );
     }
-    Ok(hits)
+    Ok(CursorAcquisition::Complete(hits))
 }
 
-fn evaluate_params(
-    expression: String,
+enum CursorScanBatch {
+    Candidates(Vec<CursorHit>, Vec<(usize, String)>),
+    MarkerCollision,
+}
+
+async fn call_document_function(
+    session: &ProtocolSession,
+    budget: &SnapshotBudget,
+    document_object_id: Option<&str>,
+    function_declaration: &str,
+    arguments: &[&str],
     return_by_value: bool,
     object_group: Option<&str>,
-    context_id: Option<i64>,
-) -> Value {
-    let mut params = json!({
-        "expression": expression,
-        "returnByValue": return_by_value
-    });
+) -> Result<RuntimeEvalResult, CoreError> {
+    let mut params = if let Some(object_id) = document_object_id {
+        json!({
+            "functionDeclaration": function_declaration,
+            "objectId": object_id,
+            "arguments": arguments
+                .iter()
+                .map(|value| json!({ "value": value }))
+                .collect::<Vec<_>>(),
+            "returnByValue": return_by_value
+        })
+    } else {
+        let arguments = serde_json::to_string(arguments)
+            .map_err(|error| CoreError::Message(error.to_string()))?;
+        json!({
+            "expression": format!("({function_declaration}).apply(document,{arguments})"),
+            "returnByValue": return_by_value
+        })
+    };
     if let Some(object_group) = object_group {
         params["objectGroup"] = Value::String(object_group.to_string());
     }
-    if let Some(context_id) = context_id {
-        params["contextId"] = Value::Number(context_id.into());
-    }
-    params
+    let method = if document_object_id.is_some() {
+        "Runtime.callFunctionOn"
+    } else {
+        "Runtime.evaluate"
+    };
+    budget.send(session, method, params).await
 }
 
-async fn cleanup_cursor(
+async fn cleanup_cursor_marker(
     session: &ProtocolSession,
     budget: &SnapshotBudget,
     marker_attribute: &str,
-    object_group: &str,
-    context_id: Option<i64>,
+    marker_token: &str,
+    document_object_id: Option<&str>,
 ) {
-    if let Ok(marker_literal) = serde_json::to_string(marker_attribute) {
-        let expression = format!(
-            "(function(a){{document.querySelectorAll('['+a+']').forEach(function(e){{e.removeAttribute(a);}});}})({marker_literal})"
-        );
-        let _ = budget
-            .send::<Value>(
-                session,
-                "Runtime.evaluate",
-                evaluate_params(expression, true, None, context_id),
-            )
-            .await;
-    }
+    let _ = call_document_function(
+        session,
+        budget,
+        document_object_id,
+        "function(a,t){var p=t+':';this.querySelectorAll('['+a+']').forEach(function(e){var v=e.getAttribute(a);if(v&&v.indexOf(p)===0)e.removeAttribute(a);});}",
+        &[marker_attribute, marker_token],
+        true,
+        None,
+    )
+    .await;
+}
+
+async fn release_cursor_objects(
+    session: &ProtocolSession,
+    budget: &SnapshotBudget,
+    object_group: &str,
+) {
     let _ = budget
         .send::<Value>(
             session,
@@ -755,6 +898,7 @@ mod tests {
     struct CursorConnection {
         calls: Mutex<Vec<Call>>,
         candidate_markers: [usize; 3],
+        marker_collisions_remaining: AtomicUsize,
         omitted_candidate: Option<usize>,
         failed_candidate: Option<usize>,
         fail_ax_tree: bool,
@@ -796,6 +940,7 @@ mod tests {
             Self {
                 calls: Mutex::new(Vec::new()),
                 candidate_markers: [0, 1, 2],
+                marker_collisions_remaining: AtomicUsize::new(0),
                 omitted_candidate: None,
                 failed_candidate: None,
                 fail_ax_tree: false,
@@ -811,6 +956,14 @@ mod tests {
                 .lock()
                 .map(|calls| calls.clone())
                 .unwrap_or_default()
+        }
+
+        fn take_marker_collision(&self) -> bool {
+            self.marker_collisions_remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
         }
     }
 
@@ -842,14 +995,25 @@ mod tests {
                                 message: "cursor scan failed".to_string(),
                             });
                         }
+                        if self.take_marker_collision() {
+                            return Ok(json!({
+                                "result": {
+                                    "type": "object",
+                                    "value": {"collision": true, "candidates": []}
+                                }
+                            }));
+                        }
                         Ok(json!({
                             "result": {
                                 "type": "object",
-                                "value": [
-                                    {"marker": self.candidate_markers[0].to_string(), "reasons": ["cursor:pointer"]},
-                                    {"marker": self.candidate_markers[1].to_string(), "reasons": ["onclick"]},
-                                    {"marker": self.candidate_markers[2].to_string(), "reasons": ["contenteditable"]}
-                                ]
+                                "value": {
+                                    "collision": false,
+                                    "candidates": [
+                                        {"marker": self.candidate_markers[0].to_string(), "reasons": ["cursor:pointer"]},
+                                        {"marker": self.candidate_markers[1].to_string(), "reasons": ["onclick"]},
+                                        {"marker": self.candidate_markers[2].to_string(), "reasons": ["contenteditable"]}
+                                    ]
+                                }
                             }
                         }))
                     }
@@ -863,6 +1027,56 @@ mod tests {
                             }
                         }))
                     }
+                    "Runtime.callFunctionOn"
+                        if params
+                            .get("functionDeclaration")
+                            .and_then(Value::as_str)
+                            .is_some_and(|expression| expression.contains("interactiveTags")) =>
+                    {
+                        if self.fail_cursor_scan {
+                            return Err(CdpError::Protocol {
+                                code: -32000,
+                                message: "cursor scan failed".to_string(),
+                            });
+                        }
+                        if self.take_marker_collision() {
+                            return Ok(json!({
+                                "result": {
+                                    "type": "object",
+                                    "value": {"collision": true, "candidates": []}
+                                }
+                            }));
+                        }
+                        Ok(json!({
+                            "result": {
+                                "type": "object",
+                                "value": {
+                                    "collision": false,
+                                    "candidates": [
+                                        {"marker": self.candidate_markers[0].to_string(), "reasons": ["cursor:pointer"]},
+                                        {"marker": self.candidate_markers[1].to_string(), "reasons": ["onclick"]},
+                                        {"marker": self.candidate_markers[2].to_string(), "reasons": ["contenteditable"]}
+                                    ]
+                                }
+                            }
+                        }))
+                    }
+                    "Runtime.callFunctionOn"
+                        if params.get("returnByValue") == Some(&Value::Bool(false)) =>
+                    {
+                        Ok(json!({
+                            "result": {
+                                "type": "object",
+                                "objectId": "candidate-array"
+                            }
+                        }))
+                    }
+                    "Runtime.callFunctionOn" => Ok(json!({
+                        "result": {"type": "undefined"}
+                    })),
+                    "DOM.resolveNode" => Ok(json!({
+                        "object": {"type": "object", "objectId": "document-object"}
+                    })),
                     "Runtime.evaluate" => Ok(json!({
                         "result": {"type": "undefined"}
                     })),
@@ -934,7 +1148,6 @@ mod tests {
                             }]
                         }
                     })),
-                    "Page.createIsolatedWorld" => Ok(json!({"executionContextId": 7})),
                     "Runtime.releaseObjectGroup" => Ok(json!({})),
                     _ => Ok(json!({})),
                 }
@@ -973,7 +1186,7 @@ mod tests {
         let target = FrameTarget {
             session: session.clone(),
             ax_params: json!({"frameId": frame_id.0}),
-            runtime_frame_id: Some(frame_id.clone()),
+            cursor_uses_session_default: false,
         };
         let frame_documents = std::collections::HashMap::from([(
             Some(frame_id.clone()),
@@ -983,6 +1196,7 @@ mod tests {
         let acquired = super::acquire_frame_data(
             target,
             Some(frame_id),
+            Some(901),
             &session,
             &frame_documents,
             &SnapshotBudget::new(),
@@ -1066,7 +1280,27 @@ mod tests {
                         Ok(json!({
                             "result": {
                                 "type": "object",
-                                "value": []
+                                "value": {
+                                    "collision": false,
+                                    "candidates": []
+                                }
+                            }
+                        }))
+                    }
+                    "Runtime.callFunctionOn"
+                        if params
+                            .get("functionDeclaration")
+                            .and_then(Value::as_str)
+                            .is_some_and(|expression| expression.contains("interactiveTags")) =>
+                    {
+                        self.mark_and_wait(0b010, self.cursor_gate.clone()).await?;
+                        Ok(json!({
+                            "result": {
+                                "type": "object",
+                                "value": {
+                                    "collision": false,
+                                    "candidates": []
+                                }
                             }
                         }))
                     }
@@ -1090,7 +1324,10 @@ mod tests {
                             }
                         }))
                     }
-                    "Page.createIsolatedWorld" => Ok(json!({"executionContextId": 7})),
+                    "DOM.resolveNode" => Ok(json!({
+                        "object": {"type": "object", "objectId": "document-object"}
+                    })),
+                    "Runtime.callFunctionOn" => Ok(json!({"result": {"type": "undefined"}})),
                     "Runtime.evaluate" => Ok(json!({"result": {"type": "undefined"}})),
                     "Runtime.releaseObjectGroup" => Ok(json!({})),
                     _ => Ok(json!({})),
@@ -1132,6 +1369,9 @@ mod tests {
         cleanup_evaluations: AtomicUsize,
         released_groups: AtomicUsize,
         cleaned: Notify,
+        document_resolve_gate: Arc<Semaphore>,
+        document_resolve_calls: AtomicUsize,
+        document_resolve_started: Notify,
     }
 
     impl GatedCursorConnection {
@@ -1149,6 +1389,9 @@ mod tests {
                 cleanup_evaluations: AtomicUsize::new(0),
                 released_groups: AtomicUsize::new(0),
                 cleaned: Notify::new(),
+                document_resolve_gate: Arc::new(Semaphore::new(0)),
+                document_resolve_calls: AtomicUsize::new(0),
+                document_resolve_started: Notify::new(),
             }
         }
 
@@ -1182,6 +1425,16 @@ mod tests {
             loop {
                 let notified = self.cleaned.notified();
                 if self.released_groups.load(Ordering::SeqCst) > 0 {
+                    return;
+                }
+                notified.await;
+            }
+        }
+
+        async fn wait_for_document_resolve(&self) {
+            loop {
+                let notified = self.document_resolve_started.notified();
+                if self.document_resolve_calls.load(Ordering::SeqCst) > 0 {
                     return;
                 }
                 notified.await;
@@ -1222,7 +1475,10 @@ mod tests {
                         Ok(json!({
                             "result": {
                                 "type": "object",
-                                "value": candidates
+                                "value": {
+                                    "collision": false,
+                                    "candidates": candidates
+                                }
                             }
                         }))
                     }
@@ -1291,6 +1547,23 @@ mod tests {
                         }
                         self.completed.notify_waiters();
                         Ok(json!({"node": {"backendNodeId": index as i64 + 100}}))
+                    }
+                    "DOM.resolveNode" => {
+                        self.document_resolve_calls.fetch_add(1, Ordering::SeqCst);
+                        self.document_resolve_started.notify_waiters();
+                        let permit = self
+                            .document_resolve_gate
+                            .clone()
+                            .acquire_owned()
+                            .await
+                            .map_err(|error| CdpError::Protocol {
+                                code: -1,
+                                message: error.to_string(),
+                            })?;
+                        permit.forget();
+                        Ok(json!({
+                            "object": {"type": "object", "objectId": "document-object"}
+                        }))
                     }
                     "Runtime.releaseObjectGroup" => {
                         self.released_groups.fetch_add(1, Ordering::SeqCst);
@@ -1364,12 +1637,13 @@ mod tests {
         assert!(calls.iter().all(
             |call| call.session.as_ref().map(|session| session.0.as_str()) == Some("page-session")
         ));
-        assert!(calls.iter().all(|call| {
-            call.params
-                .get("expression")
-                .and_then(Value::as_str)
-                .is_none_or(|expression| !expression.contains("document.querySelector('"))
-        }));
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.method == "Runtime.evaluate")
+                .count(),
+            3
+        );
         Ok(())
     }
 
@@ -1452,36 +1726,126 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn child_cursor_scan_uses_frame_context_in_target_session() -> Result<(), CoreError> {
+    async fn colliding_page_marker_is_preserved_and_retried() -> Result<(), CoreError> {
+        let connection = Arc::new(CursorConnection {
+            marker_collisions_remaining: AtomicUsize::new(1),
+            ..CursorConnection::default()
+        });
+        let session = ProtocolSession::root(connection.clone());
+
+        let hits = find_cursor_hits(&session, None, &SnapshotBudget::new()).await?;
+
+        assert_eq!(hits.len(), 3);
+        let calls = connection.calls();
+        let scans = calls
+            .iter()
+            .filter(|call| {
+                call.method == "Runtime.evaluate"
+                    && call
+                        .params
+                        .get("expression")
+                        .and_then(Value::as_str)
+                        .is_some_and(|expression| expression.contains("interactiveTags"))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(scans.len(), 2);
+        assert_ne!(scans[0].params["expression"], scans[1].params["expression"]);
+        let cleanups = calls
+            .iter()
+            .filter_map(|call| {
+                call.params
+                    .get("expression")
+                    .and_then(Value::as_str)
+                    .filter(|expression| expression.contains("removeAttribute(a)"))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(cleanups.len(), 2);
+        assert!(
+            cleanups
+                .iter()
+                .all(|expression| expression.contains("v.indexOf(p)===0"))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn child_cursor_scan_uses_main_world_document_in_target_session() -> Result<(), CoreError>
+    {
+        let connection = Arc::new(CursorConnection::default());
+        let session = ProtocolSession::for_session(
+            connection.clone(),
+            SessionId::from("page-session".to_string()),
+        );
+
+        let _hits = find_cursor_hits(&session, Some(901), &SnapshotBudget::new()).await?;
+
+        let calls = connection.calls();
+        let resolved_document = calls.iter().find(|call| call.method == "DOM.resolveNode");
+        assert_eq!(
+            resolved_document.and_then(|call| call.params.get("backendNodeId")),
+            Some(&json!(901))
+        );
+        assert!(calls.iter().all(|call| {
+            call.session
+                .as_ref()
+                .is_some_and(|session| session.0 == "page-session")
+        }));
+        let scan = calls.iter().find(|call| {
+            call.method == "Runtime.callFunctionOn"
+                && call
+                    .params
+                    .get("functionDeclaration")
+                    .and_then(Value::as_str)
+                    .is_some_and(|function| function.contains("interactiveTags"))
+        });
+        assert_eq!(
+            scan.and_then(|call| call.params.get("objectId")),
+            Some(&json!("document-object"))
+        );
+        assert!(
+            scan.and_then(|call| call.params.get("functionDeclaration"))
+                .and_then(Value::as_str)
+                .is_some_and(|function| function.contains("el.onclick!==null"))
+        );
+        assert!(
+            calls
+                .iter()
+                .all(|call| call.method != "Page.createIsolatedWorld")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn oopif_cursor_scan_uses_target_session_default_main_world() -> Result<(), CoreError> {
         let connection = Arc::new(CursorConnection::default());
         let session = ProtocolSession::for_session(
             connection.clone(),
             SessionId::from("oopif-session".to_string()),
         );
 
-        let _hits = find_cursor_hits(
-            &session,
-            Some(&crate::FrameId("child-frame".to_string())),
-            &SnapshotBudget::new(),
-        )
-        .await?;
+        let _hits = find_cursor_hits(&session, None, &SnapshotBudget::new()).await?;
 
         let calls = connection.calls();
-        let create_world = calls
-            .iter()
-            .find(|call| call.method == "Page.createIsolatedWorld");
+        let scan = calls.iter().find(|call| {
+            call.method == "Runtime.evaluate"
+                && call
+                    .params
+                    .get("expression")
+                    .and_then(Value::as_str)
+                    .is_some_and(|expression| expression.contains("interactiveTags"))
+        });
+        assert!(scan.is_some());
         assert_eq!(
-            create_world.and_then(|call| call.params.get("frameId")),
-            Some(&json!("child-frame"))
+            scan.and_then(|call| call.session.as_ref())
+                .map(|session| session.0.as_str()),
+            Some("oopif-session")
         );
-        assert!(calls.iter().all(|call| {
-            call.session
-                .as_ref()
-                .is_some_and(|session| session.0 == "oopif-session")
-        }));
-        assert!(calls.iter().all(|call| {
-            call.method != "Runtime.evaluate" || call.params.get("contextId") == Some(&json!(7))
-        }));
+        assert!(calls.iter().all(|call| call.method != "DOM.resolveNode"));
+        assert!(
+            calls
+                .iter()
+                .all(|call| call.params.get("contextId").is_none())
+        );
         Ok(())
     }
 
@@ -1556,6 +1920,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancelling_document_resolution_still_releases_its_object_group()
+    -> Result<(), CoreError> {
+        let connection = Arc::new(GatedCursorConnection::new(1));
+        let session = ProtocolSession::root(connection.clone());
+        let task = tokio::spawn(async move {
+            find_cursor_hits(&session, Some(901), &SnapshotBudget::new()).await
+        });
+
+        connection.wait_for_document_resolve().await;
+        task.abort();
+        assert!(task.await.is_err());
+        connection.wait_for_cleanup().await;
+        assert_eq!(connection.cleanup_evaluations.load(Ordering::SeqCst), 0);
+        assert_eq!(connection.released_groups.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn frame_ax_cursor_and_document_acquisition_overlap() -> Result<(), CoreError> {
         let connection = Arc::new(StageOverlapConnection::new());
         let session = ProtocolSession::root(connection.clone());
@@ -1563,7 +1945,7 @@ mod tests {
         let target = FrameTarget {
             session: session.clone(),
             ax_params: json!({"frameId": frame_id.0}),
-            runtime_frame_id: Some(frame_id.clone()),
+            cursor_uses_session_default: false,
         };
         let frame_documents = std::collections::HashMap::from([(
             Some(frame_id.clone()),
@@ -1573,6 +1955,7 @@ mod tests {
             super::acquire_frame_data(
                 target,
                 Some(frame_id),
+                Some(901),
                 &session,
                 &frame_documents,
                 &SnapshotBudget::new(),
@@ -1620,11 +2003,12 @@ mod tests {
         let ax_target = FrameTarget {
             session: ax_session.clone(),
             ax_params: json!({"frameId": frame_id.0}),
-            runtime_frame_id: Some(frame_id.clone()),
+            cursor_uses_session_default: false,
         };
         let result = super::acquire_frame_data(
             ax_target,
             Some(frame_id.clone()),
+            Some(901),
             &ax_session,
             &frame_documents,
             &SnapshotBudget::new(),
@@ -1642,11 +2026,12 @@ mod tests {
         let optional_target = FrameTarget {
             session: optional_session.clone(),
             ax_params: json!({"frameId": frame_id.0}),
-            runtime_frame_id: Some(frame_id.clone()),
+            cursor_uses_session_default: false,
         };
         let acquired = super::acquire_frame_data(
             optional_target,
             Some(frame_id),
+            Some(901),
             &optional_session,
             &frame_documents,
             &SnapshotBudget::new(),

--- a/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer/acquisition.rs
@@ -5,8 +5,15 @@
 //! acquisition stage in one capture so concurrency is bounded without scheduling CDP work onto a
 //! separate runtime or throttling unrelated browser commands.
 
-use super::DescribeNodeResult;
-use crate::{CoreError, FrameId, ProtocolSession};
+use super::{
+    AxTreeResult, CaptureContext, DescribeNodeResult, GetFrameTreeResult, Observer,
+    collect_frame_documents,
+};
+use crate::{
+    CoreError, FrameId, ProtocolSession,
+    frames::FrameTarget,
+    snapshot::{AxNode, DocumentId},
+};
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
@@ -58,6 +65,81 @@ impl SnapshotBudget {
         drop(permit);
         result
     }
+}
+
+/// Immutable Chrome inputs for one frame. Rendering receives this only after acquisition
+/// completes, so no concurrent future can observe or mutate the capture's `RefMap`.
+pub(super) struct AcquiredFrame {
+    pub(super) target: FrameTarget,
+    pub(super) nodes: Vec<AxNode>,
+    pub(super) cursor_hits: HashMap<i64, Vec<String>>,
+    pub(super) document_id: Option<DocumentId>,
+}
+
+impl Observer {
+    pub(super) async fn acquire_frame(
+        &self,
+        frame_id: Option<FrameId>,
+        context: &CaptureContext,
+    ) -> Result<AcquiredFrame, CoreError> {
+        let target = self
+            .frames
+            .resolve_frame_target(self.page_id.clone(), frame_id.clone())
+            .await?;
+        acquire_frame_data(
+            target,
+            frame_id,
+            &context.root_session,
+            &context.frame_documents,
+            &context.budget,
+        )
+        .await
+    }
+}
+
+async fn acquire_frame_data(
+    target: FrameTarget,
+    frame_id: Option<FrameId>,
+    root_session: &ProtocolSession,
+    frame_documents: &HashMap<Option<FrameId>, DocumentId>,
+    budget: &SnapshotBudget,
+) -> Result<AcquiredFrame, CoreError> {
+    let ax_tree = budget.send::<AxTreeResult>(
+        &target.session,
+        "Accessibility.getFullAXTree",
+        target.ax_params.clone(),
+    );
+    let cursor_hits = find_cursor_hits(&target.session, target.runtime_frame_id.as_ref(), budget);
+    let document_id = stable_document_id_for_frame(root_session, frame_id, frame_documents, budget);
+    // These stages are independent after target resolution. AX failure remains fatal, while
+    // cursor and document identity retain their existing best-effort fallback semantics.
+    let (nodes, cursor_hits, document_id) = tokio::join!(ax_tree, cursor_hits, document_id);
+
+    Ok(AcquiredFrame {
+        target,
+        nodes: nodes?.nodes,
+        cursor_hits: cursor_hits.unwrap_or_default(),
+        document_id,
+    })
+}
+
+async fn stable_document_id_for_frame(
+    root_session: &ProtocolSession,
+    frame_id: Option<FrameId>,
+    frame_documents: &HashMap<Option<FrameId>, DocumentId>,
+    budget: &SnapshotBudget,
+) -> Option<DocumentId> {
+    let before = frame_documents.get(&frame_id).cloned();
+    if frame_id.is_none() || before.is_none() {
+        return before;
+    }
+    let latest = budget
+        .send::<GetFrameTreeResult>(root_session, "Page.getFrameTree", json!({}))
+        .await
+        .ok()
+        .map(|result| collect_frame_documents(&result.frame_tree));
+    let after = latest.and_then(|latest| latest.get(&frame_id).cloned());
+    if after == before { before } else { None }
 }
 
 #[derive(Debug, Deserialize)]
@@ -348,13 +430,16 @@ async fn cleanup_cursor(
 #[cfg(test)]
 mod tests {
     use super::{SnapshotBudget, find_cursor_hits};
-    use crate::{CoreError, ProtocolSession, SessionId, connection::CdpConnection};
+    use crate::{
+        CoreError, FrameId, ProtocolSession, SessionId, connection::CdpConnection,
+        frames::FrameTarget,
+    };
     use browseros_cdp::{CdpError, CdpEvent};
     use futures_util::future::BoxFuture;
     use serde_json::{Value, json};
     use std::sync::{
         Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU8, AtomicUsize, Ordering},
     };
     use tokio::sync::{Notify, Semaphore, broadcast};
 
@@ -369,6 +454,9 @@ mod tests {
         calls: Mutex<Vec<Call>>,
         omitted_candidate: Option<usize>,
         failed_candidate: Option<usize>,
+        fail_ax_tree: bool,
+        fail_cursor_scan: bool,
+        child_loader_id: &'static str,
     }
 
     impl Default for CursorConnection {
@@ -377,6 +465,9 @@ mod tests {
                 calls: Mutex::new(Vec::new()),
                 omitted_candidate: None,
                 failed_candidate: None,
+                fail_ax_tree: false,
+                fail_cursor_scan: false,
+                child_loader_id: "child-loader",
             }
         }
     }
@@ -412,6 +503,12 @@ mod tests {
                             .and_then(Value::as_str)
                             .is_some_and(|expression| expression.contains("interactiveTags")) =>
                     {
+                        if self.fail_cursor_scan {
+                            return Err(CdpError::Protocol {
+                                code: -32000,
+                                message: "cursor scan failed".to_string(),
+                            });
+                        }
                         Ok(json!({
                             "result": {
                                 "type": "object",
@@ -479,7 +576,188 @@ mod tests {
                             }
                         }))
                     }
+                    "Accessibility.getFullAXTree" => {
+                        if self.fail_ax_tree {
+                            return Err(CdpError::Protocol {
+                                code: -32000,
+                                message: "AX tree failed".to_string(),
+                            });
+                        }
+                        Ok(json!({"nodes": []}))
+                    }
+                    "Page.getFrameTree" => Ok(json!({
+                        "frameTree": {
+                            "frame": {
+                                "id": "main",
+                                "loaderId": "main-loader",
+                                "url": "https://example.com/"
+                            },
+                            "childFrames": [{
+                                "frame": {
+                                    "id": "child-frame",
+                                    "loaderId": self.child_loader_id,
+                                    "url": "https://example.com/frame"
+                                }
+                            }]
+                        }
+                    })),
                     "Page.createIsolatedWorld" => Ok(json!({"executionContextId": 7})),
+                    "Runtime.releaseObjectGroup" => Ok(json!({})),
+                    _ => Ok(json!({})),
+                }
+            })
+        }
+
+        fn send_raw_json<'a>(
+            &'a self,
+            _method: &'a str,
+            _params_json: &'a str,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<String, CdpError>> {
+            Box::pin(async { Ok("{}".to_string()) })
+        }
+
+        fn events(&self) -> broadcast::Receiver<CdpEvent> {
+            let (_tx, rx) = broadcast::channel(1);
+            rx
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn connection_epoch(&self) -> u64 {
+            1
+        }
+    }
+
+    #[tokio::test]
+    async fn acquired_frame_contains_only_raw_inputs() -> Result<(), CoreError> {
+        let connection = Arc::new(CursorConnection::default());
+        let session =
+            ProtocolSession::for_session(connection, SessionId::from("page-session".to_string()));
+        let frame_id = FrameId("child-frame".to_string());
+        let target = FrameTarget {
+            session: session.clone(),
+            ax_params: json!({"frameId": frame_id.0}),
+            runtime_frame_id: Some(frame_id.clone()),
+        };
+        let frame_documents = std::collections::HashMap::from([(
+            Some(frame_id.clone()),
+            "child-frame:child-loader".to_string(),
+        )]);
+
+        let acquired = super::acquire_frame_data(
+            target,
+            Some(frame_id),
+            &session,
+            &frame_documents,
+            &SnapshotBudget::new(),
+        )
+        .await?;
+
+        assert!(acquired.nodes.is_empty());
+        assert_eq!(acquired.cursor_hits.len(), 3);
+        assert_eq!(
+            acquired.document_id.as_deref(),
+            Some("child-frame:child-loader")
+        );
+        Ok(())
+    }
+
+    struct StageOverlapConnection {
+        started: AtomicU8,
+        started_changed: Notify,
+        ax_gate: Arc<Semaphore>,
+        cursor_gate: Arc<Semaphore>,
+        document_gate: Arc<Semaphore>,
+    }
+
+    impl StageOverlapConnection {
+        fn new() -> Self {
+            Self {
+                started: AtomicU8::new(0),
+                started_changed: Notify::new(),
+                ax_gate: Arc::new(Semaphore::new(0)),
+                cursor_gate: Arc::new(Semaphore::new(0)),
+                document_gate: Arc::new(Semaphore::new(0)),
+            }
+        }
+
+        async fn mark_and_wait(&self, bit: u8, gate: Arc<Semaphore>) -> Result<(), CdpError> {
+            self.started.fetch_or(bit, Ordering::SeqCst);
+            self.started_changed.notify_waiters();
+            let permit = gate
+                .acquire_owned()
+                .await
+                .map_err(|error| CdpError::Protocol {
+                    code: -1,
+                    message: error.to_string(),
+                })?;
+            permit.forget();
+            Ok(())
+        }
+
+        async fn wait_for_all_stages(&self) {
+            loop {
+                let notified = self.started_changed.notified();
+                if self.started.load(Ordering::SeqCst) == 0b111 {
+                    return;
+                }
+                notified.await;
+            }
+        }
+    }
+
+    impl CdpConnection for StageOverlapConnection {
+        fn send<'a>(
+            &'a self,
+            method: &'a str,
+            params: Value,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<Value, CdpError>> {
+            Box::pin(async move {
+                match method {
+                    "Accessibility.getFullAXTree" => {
+                        self.mark_and_wait(0b001, self.ax_gate.clone()).await?;
+                        Ok(json!({"nodes": []}))
+                    }
+                    "Runtime.evaluate"
+                        if params
+                            .get("expression")
+                            .and_then(Value::as_str)
+                            .is_some_and(|expression| expression.contains("interactiveTags")) =>
+                    {
+                        self.mark_and_wait(0b010, self.cursor_gate.clone()).await?;
+                        Ok(json!({
+                            "result": {
+                                "type": "object",
+                                "value": []
+                            }
+                        }))
+                    }
+                    "Page.getFrameTree" => {
+                        self.mark_and_wait(0b100, self.document_gate.clone())
+                            .await?;
+                        Ok(json!({
+                            "frameTree": {
+                                "frame": {
+                                    "id": "main",
+                                    "loaderId": "main-loader",
+                                    "url": "https://example.com/"
+                                },
+                                "childFrames": [{
+                                    "frame": {
+                                        "id": "child-frame",
+                                        "loaderId": "child-loader",
+                                        "url": "https://example.com/frame"
+                                    }
+                                }]
+                            }
+                        }))
+                    }
+                    "Page.createIsolatedWorld" => Ok(json!({"executionContextId": 7})),
+                    "Runtime.evaluate" => Ok(json!({"result": {"type": "undefined"}})),
                     "Runtime.releaseObjectGroup" => Ok(json!({})),
                     _ => Ok(json!({})),
                 }
@@ -765,9 +1043,9 @@ mod tests {
     async fn cursor_resolution_omits_vanished_candidates_and_cleans_its_namespace()
     -> Result<(), CoreError> {
         let connection = Arc::new(CursorConnection {
-            calls: Mutex::new(Vec::new()),
             omitted_candidate: Some(1),
             failed_candidate: Some(2),
+            ..CursorConnection::default()
         });
         let session = ProtocolSession::root(connection.clone());
 
@@ -924,6 +1202,106 @@ mod tests {
         connection.wait_for_cleanup().await;
         assert_eq!(connection.cleanup_evaluations.load(Ordering::SeqCst), 1);
         assert_eq!(connection.released_groups.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn frame_ax_cursor_and_document_acquisition_overlap() -> Result<(), CoreError> {
+        let connection = Arc::new(StageOverlapConnection::new());
+        let session = ProtocolSession::root(connection.clone());
+        let frame_id = FrameId("child-frame".to_string());
+        let target = FrameTarget {
+            session: session.clone(),
+            ax_params: json!({"frameId": frame_id.0}),
+            runtime_frame_id: Some(frame_id.clone()),
+        };
+        let frame_documents = std::collections::HashMap::from([(
+            Some(frame_id.clone()),
+            "child-frame:child-loader".to_string(),
+        )]);
+        let task = tokio::spawn(async move {
+            super::acquire_frame_data(
+                target,
+                Some(frame_id),
+                &session,
+                &frame_documents,
+                &SnapshotBudget::new(),
+            )
+            .await
+        });
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            connection.wait_for_all_stages(),
+        )
+        .await
+        .map_err(|error| CoreError::Message(error.to_string()))?;
+        connection.ax_gate.add_permits(1);
+        connection.cursor_gate.add_permits(1);
+        connection.document_gate.add_permits(1);
+
+        let acquired = task
+            .await
+            .map_err(|error| CoreError::Message(error.to_string()))??;
+        assert!(acquired.nodes.is_empty());
+        assert!(acquired.cursor_hits.is_empty());
+        assert_eq!(
+            acquired.document_id.as_deref(),
+            Some("child-frame:child-loader")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn frame_acquisition_preserves_required_and_best_effort_failures() -> Result<(), CoreError>
+    {
+        let frame_id = FrameId("child-frame".to_string());
+        let frame_documents = std::collections::HashMap::from([(
+            Some(frame_id.clone()),
+            "child-frame:child-loader".to_string(),
+        )]);
+
+        let ax_failure = Arc::new(CursorConnection {
+            fail_ax_tree: true,
+            ..CursorConnection::default()
+        });
+        let ax_session = ProtocolSession::root(ax_failure);
+        let ax_target = FrameTarget {
+            session: ax_session.clone(),
+            ax_params: json!({"frameId": frame_id.0}),
+            runtime_frame_id: Some(frame_id.clone()),
+        };
+        let result = super::acquire_frame_data(
+            ax_target,
+            Some(frame_id.clone()),
+            &ax_session,
+            &frame_documents,
+            &SnapshotBudget::new(),
+        )
+        .await;
+        assert!(result.is_err());
+
+        let optional_failures = Arc::new(CursorConnection {
+            fail_cursor_scan: true,
+            child_loader_id: "changed-loader",
+            ..CursorConnection::default()
+        });
+        let optional_session = ProtocolSession::root(optional_failures);
+        let optional_target = FrameTarget {
+            session: optional_session.clone(),
+            ax_params: json!({"frameId": frame_id.0}),
+            runtime_frame_id: Some(frame_id.clone()),
+        };
+        let acquired = super::acquire_frame_data(
+            optional_target,
+            Some(frame_id),
+            &optional_session,
+            &frame_documents,
+            &SnapshotBudget::new(),
+        )
+        .await?;
+        assert!(acquired.cursor_hits.is_empty());
+        assert!(acquired.document_id.is_none());
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- overlap AX, cursor, validation, and sibling-frame snapshot acquisition under one capture-local eight-request CDP budget
- batch cursor handle collection and main-world resolution while preserving page attributes and cancellation cleanup
- retain deterministic reverse iframe assembly/ref allocation, retries, rollback, and tabs.new behavior, with stage timing

## Design decisions
- reuse the existing Tokio runtime; each permit covers one pending CDP request only, with no custom pool or global CDP scheduler
- keep acquisition immutable/concurrent and rendering/ref mutation sequential in the historical reverse stitch order
- use target-session default worlds for root/OOPIF frames and resolved Document wrappers for same-process frames; inherit nested target sessions and post-validate child loaders

## Test plan
- `cd packages/browseros-agent && cargo fmt --all --check`
- `cd packages/browseros-agent && cargo clippy --workspace --all-targets -- -D warnings`
- `cd packages/browseros-agent && cargo test --workspace`
- live Chrome exact cursor-asset check for page-assigned `onclick` in same-process iframe and OOPIF