### PR TITLE
feat(claw-app): default audit replay to 2x

### DIFF
--- a/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { parseHTML } from 'linkedom'
+import { act } from 'react'
+import type { Root } from 'react-dom/client'
+import { PlaybackTransport } from './PlaybackTransport'
+import { usePlayback } from './use-playback'
+
+const globalDescriptors = new Map(
+  ['window', 'document', 'navigator', 'HTMLElement', 'Node', 'Event'].map(
+    (name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)],
+  ),
+)
+
+let root: Root
+let container: HTMLElement
+
+function TransportHarness() {
+  const playback = usePlayback(10)
+  return (
+    <PlaybackTransport
+      playback={playback}
+      totalSeconds={10}
+      frames={[]}
+      onSeek={playback.seek}
+    />
+  )
+}
+
+beforeEach(async () => {
+  const dom = parseHTML(
+    '<!doctype html><html><body><div id="root"></div></body></html>',
+  )
+  const globals = {
+    window: dom.window,
+    document: dom.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+  }
+  for (const [name, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    })
+  }
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  })
+
+  container = dom.document.getElementById('root') as unknown as HTMLElement
+  const { createRoot } = await import('react-dom/client')
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  for (const [name, descriptor] of globalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor)
+    else Reflect.deleteProperty(globalThis, name)
+  }
+  Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
+})
+
+describe('PlaybackTransport', () => {
+  it('starts at 2x and keeps every speed selectable', async () => {
+    await act(async () => root.render(<TransportHarness />))
+
+    const speedButton = (label: string) =>
+      [...container.querySelectorAll('button')].find(
+        (button) => button.textContent === label,
+      )
+
+    expect(speedButton('1×')?.getAttribute('aria-pressed')).toBe('false')
+    expect(speedButton('2×')?.getAttribute('aria-pressed')).toBe('true')
+    expect(speedButton('4×')?.getAttribute('aria-pressed')).toBe('false')
+
+    await act(async () => {
+      speedButton('1×')?.dispatchEvent(
+        new window.Event('click', { bubbles: true }),
+      )
+    })
+    expect(speedButton('1×')?.getAttribute('aria-pressed')).toBe('true')
+    expect(speedButton('2×')?.getAttribute('aria-pressed')).toBe('false')
+
+    await act(async () => {
+      speedButton('4×')?.dispatchEvent(
+        new window.Event('click', { bubbles: true }),
+      )
+    })
+    expect(speedButton('1×')?.getAttribute('aria-pressed')).toBe('false')
+    expect(speedButton('4×')?.getAttribute('aria-pressed')).toBe('true')
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.helpers.ts
@@ -83,3 +83,4 @@ export function frameIndexAt(
 }
 
 export const PLAYBACK_SPEEDS: readonly number[] = [1, 2, 4]
+export const DEFAULT_PLAYBACK_SPEED = 2

--- a/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { PLAYBACK_SPEEDS } from './replay.helpers'
+import { DEFAULT_PLAYBACK_SPEED, PLAYBACK_SPEEDS } from './replay.helpers'
 
 export interface Playback {
   /** Seconds elapsed in the session. */
@@ -23,7 +23,7 @@ const END_EPSILON_SECONDS = 0.01
 export function usePlayback(totalSeconds: number): Playback {
   const [time, setTime] = useState(0)
   const [isPlaying, setIsPlaying] = useState(true)
-  const [speed, setSpeed] = useState<number>(PLAYBACK_SPEEDS[0])
+  const [speed, setSpeed] = useState<number>(DEFAULT_PLAYBACK_SPEED)
 
   const clamp = useCallback(
     (seconds: number) => Math.max(0, Math.min(totalSeconds, seconds)),


### PR DESCRIPTION
## Summary
- Start Audit Replay playback at 2× by default.
- Keep the existing 1×, 2×, and 4× speed controls selectable.
- Cover the visible default selection and manual speed changes with a focused transport test.

## Design
The replay transport now names 2× as its default alongside the supported speed list, and `usePlayback` initializes from that default. The existing controlled toggle group and rrweb speed synchronization remain unchanged.

## Test plan
- [x] `bun test apps/claw-app/screens/replay/PlaybackTransport.test.tsx`
- [x] `bun run test` from `apps/claw-app`
- [x] `bun run --filter @browseros/claw-app typecheck`
- [x] Biome check on all touched files

## Baseline notes
- Repository-wide `bun run check` still reports the two existing `noUnsafeOptionalChaining` errors in `apps/server/tests/lib/agents/acpx-runtime.test.ts`; that file is identical to `origin/main`.
- Repository-wide `bun run test` still reports the existing stale `setup-uv@v8.2.0` assertion in `scripts/release/release-claw-server-rust-workflow.test.ts`; that file is identical to `origin/main`.
