### PR TITLE
fix(claw): exclude red from automatic tab-group colors

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/services/browser/tab_groups.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/browser/tab_groups.rs
@@ -1,9 +1,8 @@
 pub use crate::services::sessions::TabGroupColor;
 
-const TAB_GROUP_COLORS: [TabGroupColor; 9] = [
+const TAB_GROUP_COLORS: [TabGroupColor; 8] = [
     TabGroupColor::Grey,
     TabGroupColor::Blue,
-    TabGroupColor::Red,
     TabGroupColor::Yellow,
     TabGroupColor::Green,
     TabGroupColor::Pink,
@@ -65,17 +64,34 @@ fn fnv1a(input: &str) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{TabGroupColor, color_for_slug};
+    use super::{TAB_GROUP_COLORS, TabGroupColor, color_for_slug};
+
+    #[test]
+    fn automatic_palette_excludes_red_and_keeps_order() {
+        assert_eq!(
+            TAB_GROUP_COLORS,
+            [
+                TabGroupColor::Grey,
+                TabGroupColor::Blue,
+                TabGroupColor::Yellow,
+                TabGroupColor::Green,
+                TabGroupColor::Pink,
+                TabGroupColor::Purple,
+                TabGroupColor::Cyan,
+                TabGroupColor::Orange,
+            ]
+        );
+    }
 
     #[test]
     fn color_for_slug_matches_tab_group_palette() {
-        assert_eq!(color_for_slug("codex"), TabGroupColor::Purple);
-        assert_eq!(color_for_slug("finance-ops"), TabGroupColor::Grey);
+        assert_eq!(color_for_slug("codex"), TabGroupColor::Pink);
+        assert_eq!(color_for_slug("support"), TabGroupColor::Grey);
     }
 
     #[test]
     fn hex_for_slug_matches_ts_tab_group_hex() {
-        assert_eq!(super::hex_for_slug("codex"), "#7A5AF8");
-        assert_eq!(super::hex_for_slug("finance-ops"), "#6B7280");
+        assert_eq!(super::hex_for_slug("codex"), "#DB2777");
+        assert_eq!(super::hex_for_slug("support"), "#6B7280");
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/canonical_routes.rs
@@ -1299,7 +1299,7 @@ async fn live_projection_hides_handshakes_and_keeps_dispatch_backed_zero_tab_ses
     assert_eq!(second["profileId"], primary["profileId"]);
     assert_ne!(second["sessionId"], primary["sessionId"]);
     assert_eq!(primary["harness"], "Codex");
-    assert_eq!(primary["color"], "#7A5AF8");
+    assert_eq!(primary["color"], "#DB2777");
     assert_eq!(primary["live"]["state"], "active");
     assert_eq!(primary["live"]["browserTabs"][0]["browserTabId"], 101);
     assert_eq!(primary["live"]["browserTabs"][0]["toolCount"], 1);


### PR DESCRIPTION
## Summary
- Remove red from BrowserClaw's deterministic automatic tab-group palette.
- Preserve red in the shared color enum and explicit MCP/CDP tab-group updates.
- Lock the eight-color automatic palette order with a focused regression test.

## Design
Automatic assignment continues hashing each agent slug into a stable ordered palette; only the red entry is removed. Explicitly requested red groups remain supported because the session color representation, MCP enum, and CDP definitions are unchanged.

## Test plan
- [x] `cargo test -p claw-server-rust services::browser::tab_groups::tests`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p claw-server-rust --all-targets -- -D warnings`