### PR TITLE
test(claw): cover snapshot concurrency contracts

### DIFF
--- a/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-cursor-concurrency.html
+++ b/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-cursor-concurrency.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Snapshot cursor concurrency fixture</title>
+    <style>
+      .cursor-candidate,
+      #pointer-only,
+      #vanishing-candidate {
+        cursor: pointer;
+      }
+      #editable-target {
+        border: 1px dashed #666;
+        min-height: 24px;
+        width: 320px;
+      }
+      #zero-sized-excluded {
+        display: inline-block;
+        width: 0;
+        height: 0;
+        overflow: visible;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Snapshot cursor concurrency fixture</h1>
+    <div
+      id="generated-batch"
+      data-first-label="Cursor candidate 00"
+      data-middle-label="Cursor candidate 32"
+      data-last-label="Cursor candidate 63"
+    ></div>
+
+    <div id="pointer-only">Pointer-only target</div>
+    <div id="assigned-onclick">Assigned onclick target</div>
+    <div id="editable-target" contenteditable="true">
+      Editable target ready
+    </div>
+    <span id="tabindex-target" tabindex="0">Tabindex target</span>
+    <span id="zero-sized-excluded">Zero-sized excluded target</span>
+    <div id="vanishing-candidate">Vanishing cursor target</div>
+    <div id="page-owned-marker" data-__bcid-page-owned="fixture-owned">
+      Page-owned marker sentinel
+    </div>
+    <output id="cursor-action-result">Cursor action untouched</output>
+
+    <script>
+      const internalMarkerPrefix = 'data-__bcid-'
+      const pageOwnedMarker = 'data-__bcid-page-owned'
+      const seenMarkerNamespaces = new Set()
+      let maxActiveMarkerNamespaces = 0
+
+      function activeMarkerNamespaces() {
+        const active = new Set()
+        for (const element of document.querySelectorAll('*')) {
+          for (const name of element.getAttributeNames()) {
+            if (
+              name.startsWith(internalMarkerPrefix) &&
+              name !== pageOwnedMarker
+            ) {
+              active.add(name)
+            }
+          }
+        }
+        return active
+      }
+
+      function sampleMarkers() {
+        const active = activeMarkerNamespaces()
+        for (const name of active) seenMarkerNamespaces.add(name)
+        maxActiveMarkerNamespaces = Math.max(
+          maxActiveMarkerNamespaces,
+          active.size,
+        )
+        return active
+      }
+
+      const markerObserver = new MutationObserver((records) => {
+        for (const record of records) {
+          if (
+            record.type === 'attributes' &&
+            record.target.id === 'vanishing-candidate' &&
+            record.attributeName?.startsWith(internalMarkerPrefix)
+          ) {
+            record.target.remove()
+          }
+        }
+        sampleMarkers()
+      })
+      markerObserver.observe(document.documentElement, {
+        attributes: true,
+        subtree: true,
+      })
+
+      const generatedBatch = document.getElementById('generated-batch')
+      for (let index = 0; index < 64; index += 1) {
+        const candidate = document.createElement('div')
+        candidate.className = 'cursor-candidate'
+        candidate.textContent = `Cursor candidate ${String(index).padStart(2, '0')}`
+        generatedBatch.append(candidate)
+      }
+
+      document.getElementById('pointer-only').addEventListener('click', () => {
+        document.getElementById('cursor-action-result').textContent =
+          'Pointer-only target clicked'
+      })
+      document.getElementById('assigned-onclick').onclick = () => {
+        document.getElementById('cursor-action-result').textContent =
+          'Assigned onclick target clicked'
+      }
+
+      window.snapshotCursorFixture = {
+        ready: true,
+        resetProbe() {
+          seenMarkerNamespaces.clear()
+          maxActiveMarkerNamespaces = 0
+          sampleMarkers()
+        },
+        state() {
+          const active = sampleMarkers()
+          const sentinel = document.getElementById('page-owned-marker')
+          return {
+            candidateCount:
+              document.querySelectorAll('.cursor-candidate').length,
+            activeMarkerNamespaces: active.size,
+            distinctMarkerNamespaces: seenMarkerNamespaces.size,
+            maxActiveMarkerNamespaces,
+            sentinelPresent:
+              sentinel?.getAttribute(pageOwnedMarker) === 'fixture-owned',
+            vanishingCandidatePresent: Boolean(
+              document.getElementById('vanishing-candidate'),
+            ),
+          }
+        },
+      }
+    </script>
+  </body>
+</html>

--- a/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-cursor-concurrency.html
+++ b/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-cursor-concurrency.html
@@ -32,14 +32,46 @@
       data-last-label="Cursor candidate 63"
     ></div>
 
-    <div id="pointer-only">Pointer-only target</div>
-    <div id="assigned-onclick">Assigned onclick target</div>
-    <div id="editable-target" contenteditable="true">
+    <div id="pointer-only" role="group" aria-label="Pointer-only target">
+      Pointer-only target
+    </div>
+    <div
+      id="assigned-onclick"
+      role="group"
+      aria-label="Assigned onclick target"
+    >
+      Assigned onclick target
+    </div>
+    <div
+      id="editable-target"
+      contenteditable="true"
+      role="group"
+      aria-label="Editable target ready"
+    >
       Editable target ready
     </div>
-    <span id="tabindex-target" tabindex="0">Tabindex target</span>
-    <span id="zero-sized-excluded">Zero-sized excluded target</span>
-    <div id="vanishing-candidate">Vanishing cursor target</div>
+    <span
+      id="tabindex-target"
+      tabindex="0"
+      role="group"
+      aria-label="Tabindex target"
+    >
+      Tabindex target
+    </span>
+    <span
+      id="zero-sized-excluded"
+      role="group"
+      aria-label="Zero-sized excluded target"
+    >
+      Zero-sized excluded target
+    </span>
+    <div
+      id="vanishing-candidate"
+      role="group"
+      aria-label="Vanishing cursor target"
+    >
+      Vanishing cursor target
+    </div>
     <div id="page-owned-marker" data-__bcid-page-owned="fixture-owned">
       Page-owned marker sentinel
     </div>
@@ -98,6 +130,8 @@
         const candidate = document.createElement('div')
         candidate.className = 'cursor-candidate'
         candidate.textContent = `Cursor candidate ${String(index).padStart(2, '0')}`
+        candidate.setAttribute('role', 'group')
+        candidate.setAttribute('aria-label', candidate.textContent)
         generatedBatch.append(candidate)
       }
 

--- a/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-cursor-concurrency.html
+++ b/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-cursor-concurrency.html
@@ -65,13 +65,6 @@
     >
       Zero-sized excluded target
     </span>
-    <div
-      id="vanishing-candidate"
-      role="group"
-      aria-label="Vanishing cursor target"
-    >
-      Vanishing cursor target
-    </div>
     <div id="page-owned-marker" data-__bcid-page-owned="fixture-owned">
       Page-owned marker sentinel
     </div>
@@ -146,6 +139,15 @@
 
       window.snapshotCursorFixture = {
         ready: true,
+        armVanishingCandidate() {
+          if (document.getElementById('vanishing-candidate')) return
+          const candidate = document.createElement('div')
+          candidate.id = 'vanishing-candidate'
+          candidate.setAttribute('role', 'group')
+          candidate.setAttribute('aria-label', 'Vanishing cursor target')
+          candidate.textContent = 'Vanishing cursor target'
+          generatedBatch.children[16].before(candidate)
+        },
         resetProbe() {
           seenMarkerNamespaces.clear()
           maxActiveMarkerNamespaces = 0

--- a/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-a.html
+++ b/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-a.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Snapshot frame A</title>
+    <style>
+      #frame-a-cursor {
+        cursor: pointer;
+      }
+    </style>
+    <script>
+      window.addEventListener('message', (event) => {
+        if (
+          event.data?.fixture === 'snapshot-frame-tree' &&
+          event.data.ready === 'grandchild'
+        ) {
+          parent.postMessage(event.data, '*')
+        }
+      })
+    </script>
+  </head>
+  <body>
+    <button id="frame-a-action" type="button">Frame A action ready</button>
+    <div id="frame-a-cursor">Frame A cursor ready</div>
+    <iframe
+      id="frame-grandchild"
+      title="Snapshot frame grandchild"
+      src="/snapshot-frame-grandchild.html"
+      width="400"
+      height="200"
+    ></iframe>
+    <script>
+      document
+        .getElementById('frame-a-action')
+        .addEventListener('click', () => {
+          document.getElementById('frame-a-action').textContent =
+            'Frame A action clicked'
+        })
+      parent.postMessage(
+        { fixture: 'snapshot-frame-tree', ready: 'frame-a' },
+        '*',
+      )
+    </script>
+  </body>
+</html>

--- a/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-a.html
+++ b/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-a.html
@@ -21,7 +21,13 @@
   </head>
   <body>
     <button id="frame-a-action" type="button">Frame A action ready</button>
-    <div id="frame-a-cursor">Frame A cursor ready</div>
+    <div
+      id="frame-a-cursor"
+      role="group"
+      aria-label="Frame A cursor ready"
+    >
+      Frame A cursor ready
+    </div>
     <iframe
       id="frame-grandchild"
       title="Snapshot frame grandchild"

--- a/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-b.html
+++ b/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-b.html
@@ -11,7 +11,13 @@
   </head>
   <body>
     <button id="frame-b-action" type="button">Frame B action ready</button>
-    <div id="frame-b-cursor">Frame B cursor ready</div>
+    <div
+      id="frame-b-cursor"
+      role="group"
+      aria-label="Frame B cursor ready"
+    >
+      Frame B cursor ready
+    </div>
     <script>
       document
         .getElementById('frame-b-action')

--- a/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-b.html
+++ b/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-b.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Snapshot frame B</title>
+    <style>
+      #frame-b-cursor {
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <button id="frame-b-action" type="button">Frame B action ready</button>
+    <div id="frame-b-cursor">Frame B cursor ready</div>
+    <script>
+      document
+        .getElementById('frame-b-action')
+        .addEventListener('click', () => {
+          document.getElementById('frame-b-action').textContent =
+            'Frame B action clicked'
+        })
+      parent.postMessage(
+        { fixture: 'snapshot-frame-tree', ready: 'frame-b' },
+        '*',
+      )
+    </script>
+  </body>
+</html>

--- a/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-grandchild.html
+++ b/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-grandchild.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Snapshot frame grandchild</title>
+  </head>
+  <body>
+    <button id="grandchild-action" type="button">
+      Grandchild action ready
+    </button>
+    <script>
+      document
+        .getElementById('grandchild-action')
+        .addEventListener('click', () => {
+          document.getElementById('grandchild-action').textContent =
+            'Grandchild action clicked'
+        })
+      parent.postMessage(
+        { fixture: 'snapshot-frame-tree', ready: 'grandchild' },
+        '*',
+      )
+    </script>
+  </body>
+</html>

--- a/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-tree.html
+++ b/packages/browseros-agent/contracts/claw-mcp/fixtures/pages/snapshot-frame-tree.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Snapshot frame tree fixture</title>
+    <script>
+      const readyFrames = new Set(['parent'])
+      window.addEventListener('message', (event) => {
+        if (event.data?.fixture === 'snapshot-frame-tree') {
+          readyFrames.add(event.data.ready)
+        }
+      })
+      window.snapshotFrameFixture = {
+        state() {
+          const frames = [...readyFrames]
+          return {
+            frames,
+            ready: ['parent', 'frame-a', 'frame-b', 'grandchild'].every(
+              (name) => readyFrames.has(name),
+            ),
+          }
+        },
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Snapshot frame tree fixture</h1>
+    <button id="parent-action" type="button">Parent action ready</button>
+    <iframe
+      id="frame-a"
+      title="Snapshot frame A"
+      src="/snapshot-frame-a.html"
+      width="600"
+      height="400"
+    ></iframe>
+    <iframe
+      id="frame-b"
+      title="Snapshot frame B"
+      width="600"
+      height="300"
+    ></iframe>
+    <script>
+      document.getElementById('parent-action').addEventListener('click', () => {
+        document.getElementById('parent-action').textContent =
+          'Parent action clicked'
+      })
+      const childOrigin = new URLSearchParams(location.search).get('childOrigin')
+      document.getElementById('frame-b').src =
+        `${childOrigin ?? location.origin}/snapshot-frame-b.html`
+    </script>
+  </body>
+</html>

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
@@ -441,4 +441,99 @@ export const snapshotConcurrencyCases: ContractCase[] = [
       }
     },
   },
+  {
+    name: 'snapshot concurrency: overlapping cursor captures stay isolated',
+    async run(ctx) {
+      const page = await ctx.openPage(
+        ctx.fixture('/snapshot-cursor-concurrency.html'),
+      )
+      await waitForCursorFixture(ctx, page)
+      await requireCleanCursorProbe(ctx, page)
+      await evaluateText(
+        ctx,
+        page,
+        'window.snapshotCursorFixture.resetProbe(); return "reset"',
+      )
+
+      const snapshots = await Promise.all(
+        Array.from({ length: 4 }, async () =>
+          expectOk(
+            await ctx.mcp.callTool('snapshot', { page }),
+            'overlapping cursor snapshot',
+          ),
+        ),
+      )
+      const expectedRefs = selectedRefs(snapshots[0], CURSOR_STABLE_LABELS)
+      for (const [index, snapshot] of snapshots.entries()) {
+        requireSameRefs(
+          selectedRefs(snapshot, CURSOR_STABLE_LABELS),
+          expectedRefs,
+          `overlapping cursor snapshot ${index + 1}`,
+        )
+      }
+
+      const overlapState = await requireCleanCursorProbe(ctx, page)
+      if (overlapState.maxActiveMarkerNamespaces < 2) {
+        throw new Error(
+          `cursor captures were serialized instead of overlapping: ${JSON.stringify(overlapState)}`,
+        )
+      }
+
+      const final = expectOk(
+        await ctx.mcp.callTool('snapshot', { page }),
+        'final cursor snapshot after overlap',
+      )
+      requireSameRefs(
+        selectedRefs(final, CURSOR_STABLE_LABELS),
+        expectedRefs,
+        'final cursor snapshot after overlap',
+      )
+      await requireCleanCursorProbe(ctx, page)
+    },
+  },
+  {
+    name: 'snapshot concurrency: overlapping frame captures keep baseline',
+    async run(ctx) {
+      const page = await ctx.openPage(mixedFrameUrl(ctx))
+      const settled = await waitForFrameSnapshot(ctx, page)
+      const expectedRefs = selectedRefs(settled, FRAME_REF_LABELS)
+
+      const snapshots = await Promise.all(
+        Array.from({ length: 4 }, async () =>
+          expectOk(
+            await ctx.mcp.callTool('snapshot', { page }),
+            'overlapping mixed-frame snapshot',
+          ),
+        ),
+      )
+      for (const [index, snapshot] of snapshots.entries()) {
+        requireLabels(snapshot, FRAME_REF_LABELS)
+        requireSameRefs(
+          selectedRefs(snapshot, FRAME_REF_LABELS),
+          expectedRefs,
+          `overlapping mixed-frame snapshot ${index + 1}`,
+        )
+      }
+
+      const final = await waitForFrameSnapshot(ctx, page)
+      requireSameRefs(
+        selectedRefs(final, FRAME_REF_LABELS),
+        expectedRefs,
+        'final mixed-frame snapshot after overlap',
+      )
+      const diffResult = await ctx.mcp.callTool('diff', { page })
+      const diffText = expectOk(diffResult, 'diff after overlapping snapshots')
+      const structured = diffResult.structuredContent as
+        | { changed?: boolean }
+        | undefined
+      if (
+        structured?.changed !== false &&
+        !/no change|unchanged/i.test(diffText)
+      ) {
+        throw new Error(
+          `overlapping snapshot commits poisoned the diff baseline: ${diffText.slice(0, 400)}`,
+        )
+      }
+    },
+  },
 ]

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
@@ -5,7 +5,7 @@
  */
 
 import type { CaseContext, ContractCase } from './cases'
-import { expectOk, waitUntil } from './helpers'
+import { expectOk, parsePageId, waitUntil } from './helpers'
 
 const CURSOR_STABLE_LABELS = [
   'Cursor candidate 00',
@@ -20,6 +20,24 @@ const CURSOR_REASON_LABELS = [
   'Tabindex target',
 ] as const
 
+const FRAME_REF_LABELS = [
+  'Parent action ready',
+  'Frame A action ready',
+  'Frame A cursor ready',
+  'Grandchild action ready',
+  'Frame B action ready',
+  'Frame B cursor ready',
+] as const
+
+const FRAME_TEXT_ORDER = [
+  'Parent action ready',
+  'Frame A action ready',
+  'Frame A cursor ready',
+  'Grandchild action ready',
+  'Frame B action ready',
+  'Frame B cursor ready',
+] as const
+
 interface CursorProbeState {
   candidateCount: number
   activeMarkerNamespaces: number
@@ -27,6 +45,11 @@ interface CursorProbeState {
   maxActiveMarkerNamespaces: number
   sentinelPresent: boolean
   vanishingCandidatePresent: boolean
+}
+
+interface FrameProbeState {
+  frames: string[]
+  ready: boolean
 }
 
 function snapshotLine(snapshot: string, label: string): string | undefined {
@@ -51,6 +74,27 @@ function selectedRefs(
   return Object.fromEntries(
     labels.map((label) => [label, refFor(snapshot, label)]),
   )
+}
+
+function requireLabels(snapshot: string, labels: readonly string[]): void {
+  const missing = labels.filter((label) => !snapshot.includes(label))
+  if (missing.length > 0) {
+    throw new Error(
+      `snapshot is missing ${missing.join(', ')}:\n${snapshot.slice(0, 1200)}`,
+    )
+  }
+}
+
+function requireSameRefs(
+  actual: Record<string, string>,
+  expected: Record<string, string>,
+  context: string,
+): void {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${context} changed selected refs:\nexpected ${JSON.stringify(expected)}\nactual ${JSON.stringify(actual)}`,
+    )
+  }
 }
 
 async function evaluateText(
@@ -90,6 +134,77 @@ async function cursorProbeState(
     'return JSON.stringify(window.snapshotCursorFixture.state())',
   )
   return parseJsonObject<CursorProbeState>(text, 'cursor fixture state')
+}
+
+function mixedFrameUrl(ctx: CaseContext): string {
+  const url = new URL(ctx.fixture('/snapshot-frame-tree.html'))
+  url.searchParams.set('childOrigin', new URL(ctx.fixture2('/')).origin)
+  return url.toString()
+}
+
+async function frameProbeState(
+  ctx: CaseContext,
+  page: number,
+): Promise<FrameProbeState> {
+  const text = await evaluateText(
+    ctx,
+    page,
+    'return JSON.stringify(window.snapshotFrameFixture.state())',
+  )
+  return parseJsonObject<FrameProbeState>(text, 'frame fixture state')
+}
+
+async function waitForFrameSnapshot(
+  ctx: CaseContext,
+  page: number,
+  labels: readonly string[] = FRAME_REF_LABELS,
+): Promise<string> {
+  let snapshot = ''
+  await waitUntil(
+    async () => {
+      const state = await frameProbeState(ctx, page)
+      if (!state.ready) return false
+      const result = await ctx.mcp.callTool('snapshot', { page })
+      if (result.isError) return false
+      snapshot = expectOk(result, 'settled mixed-frame snapshot')
+      return labels.every((label) => snapshot.includes(label))
+    },
+    `the mixed-frame snapshot to contain ${labels.join(', ')}`,
+    { timeoutMs: 30_000 },
+  )
+  return snapshot
+}
+
+async function waitForSnapshotLabels(
+  ctx: CaseContext,
+  page: number,
+  labels: readonly string[],
+): Promise<string> {
+  let snapshot = ''
+  await waitUntil(
+    async () => {
+      const result = await ctx.mcp.callTool('snapshot', { page })
+      if (result.isError) return false
+      snapshot = expectOk(result, 'snapshot while waiting for labels')
+      return labels.every((label) => snapshot.includes(label))
+    },
+    `the snapshot to contain ${labels.join(', ')}`,
+    { timeoutMs: 30_000 },
+  )
+  return snapshot
+}
+
+function requireFrameTextOrder(snapshot: string): void {
+  let previousIndex = -1
+  for (const label of FRAME_TEXT_ORDER) {
+    const index = snapshot.indexOf(label, previousIndex + 1)
+    if (index === -1) {
+      throw new Error(
+        `mixed-frame text is not in DOM stitch order at "${label}":\n${snapshot.slice(0, 1400)}`,
+      )
+    }
+    previousIndex = index
+  }
 }
 
 async function waitForCursorFixture(
@@ -213,6 +328,117 @@ export const snapshotConcurrencyCases: ContractCase[] = [
         'contenteditable cursor ref to receive text',
       )
       await requireCleanCursorProbe(ctx, page)
+    },
+  },
+  {
+    name: 'snapshot concurrency: mixed frames keep stitch and ref order',
+    async run(ctx) {
+      const page = await ctx.openPage(mixedFrameUrl(ctx))
+      const first = await waitForFrameSnapshot(ctx, page)
+      requireFrameTextOrder(first)
+      const firstRefs = selectedRefs(first, FRAME_REF_LABELS)
+
+      const frameARef = Number(firstRefs['Frame A action ready'].slice(1))
+      const frameBRef = Number(firstRefs['Frame B action ready'].slice(1))
+      if (frameBRef >= frameARef) {
+        throw new Error(
+          `reverse sibling ref allocation changed: frame B=${frameBRef}, frame A=${frameARef}`,
+        )
+      }
+
+      const second = await waitForFrameSnapshot(ctx, page)
+      requireFrameTextOrder(second)
+      requireSameRefs(
+        selectedRefs(second, FRAME_REF_LABELS),
+        firstRefs,
+        'second settled mixed-frame snapshot',
+      )
+    },
+  },
+  {
+    name: 'snapshot concurrency: refs act across every frame session',
+    async run(ctx) {
+      const page = await ctx.openPage(mixedFrameUrl(ctx))
+      const initial = await waitForFrameSnapshot(ctx, page)
+
+      expectOk(
+        await ctx.mcp.callTool('act', {
+          page,
+          kind: 'click',
+          ref: refFor(initial, 'Frame A action ready'),
+        }),
+        'click same-process frame ref',
+      )
+      const afterFrameA = await waitForSnapshotLabels(ctx, page, [
+        'Frame A action clicked',
+        'Frame B action ready',
+        'Grandchild action ready',
+      ])
+      requireLabels(afterFrameA, [
+        'Parent action ready',
+        'Frame B cursor ready',
+      ])
+
+      expectOk(
+        await ctx.mcp.callTool('act', {
+          page,
+          kind: 'click',
+          ref: refFor(initial, 'Frame B action ready'),
+        }),
+        'click cross-origin frame ref',
+      )
+      const afterFrameB = await waitForSnapshotLabels(ctx, page, [
+        'Frame A action clicked',
+        'Frame B action clicked',
+        'Grandchild action ready',
+      ])
+      requireLabels(afterFrameB, [
+        'Parent action ready',
+        'Frame A cursor ready',
+      ])
+
+      expectOk(
+        await ctx.mcp.callTool('act', {
+          page,
+          kind: 'click',
+          ref: refFor(initial, 'Grandchild action ready'),
+        }),
+        'click nested grandchild frame ref',
+      )
+      const final = await waitForSnapshotLabels(ctx, page, [
+        'Frame A action clicked',
+        'Frame B action clicked',
+        'Grandchild action clicked',
+      ])
+      requireLabels(final, [
+        'Parent action ready',
+        'Frame A cursor ready',
+        'Frame B cursor ready',
+      ])
+    },
+  },
+  {
+    name: 'snapshot concurrency: tabs new returns complete frame auto-context',
+    async run(ctx) {
+      let page: number | undefined
+      try {
+        const result = await ctx.mcp.callTool('tabs', {
+          action: 'new',
+          url: mixedFrameUrl(ctx),
+          background: false,
+        })
+        const text = expectOk(result, 'tabs new mixed-frame auto-context')
+        page = parsePageId(result)
+        requireLabels(text, FRAME_REF_LABELS)
+        selectedRefs(text, FRAME_REF_LABELS)
+        requireFrameTextOrder(text)
+      } finally {
+        if (page !== undefined) {
+          await ctx.mcp
+            .callTool('tabs', { action: 'close', page })
+            .catch(() => {})
+        }
+      }
     },
   },
 ]

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
@@ -138,7 +138,12 @@ async function cursorProbeState(
 
 function mixedFrameUrl(ctx: CaseContext): string {
   const url = new URL(ctx.fixture('/snapshot-frame-tree.html'))
-  url.searchParams.set('childOrigin', new URL(ctx.fixture2('/')).origin)
+  const childOrigin = new URL(ctx.fixture2('/'))
+  // Ports separate origins, but Chromium isolates by site. A loopback hostname
+  // boundary makes frame B an OOPIF while preserving the secondary server.
+  childOrigin.hostname =
+    url.hostname === 'localhost' ? '127.0.0.1' : 'localhost'
+  url.searchParams.set('childOrigin', childOrigin.origin)
   return url.toString()
 }
 
@@ -515,12 +520,6 @@ export const snapshotConcurrencyCases: ContractCase[] = [
         )
       }
 
-      const final = await waitForFrameSnapshot(ctx, page)
-      requireSameRefs(
-        selectedRefs(final, FRAME_REF_LABELS),
-        expectedRefs,
-        'final mixed-frame snapshot after overlap',
-      )
       const diffResult = await ctx.mcp.callTool('diff', { page })
       const diffText = expectOk(diffResult, 'diff after overlapping snapshots')
       const structured = diffResult.structuredContent as
@@ -534,6 +533,13 @@ export const snapshotConcurrencyCases: ContractCase[] = [
           `overlapping snapshot commits poisoned the diff baseline: ${diffText.slice(0, 400)}`,
         )
       }
+
+      const final = await waitForFrameSnapshot(ctx, page)
+      requireSameRefs(
+        selectedRefs(final, FRAME_REF_LABELS),
+        expectedRefs,
+        'final mixed-frame snapshot after overlap',
+      )
     },
   },
 ]

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
@@ -1,0 +1,218 @@
+/**
+ * Live-browser contracts for cursor snapshot acquisition and frame stitching.
+ * These cases exercise public MCP tools against fixture state; scheduler
+ * limits and forced completion order remain covered by the Rust unit tests.
+ */
+
+import type { CaseContext, ContractCase } from './cases'
+import { expectOk, waitUntil } from './helpers'
+
+const CURSOR_STABLE_LABELS = [
+  'Cursor candidate 00',
+  'Cursor candidate 32',
+  'Cursor candidate 63',
+] as const
+
+const CURSOR_REASON_LABELS = [
+  'Pointer-only target',
+  'Assigned onclick target',
+  'Editable target ready',
+  'Tabindex target',
+] as const
+
+interface CursorProbeState {
+  candidateCount: number
+  activeMarkerNamespaces: number
+  distinctMarkerNamespaces: number
+  maxActiveMarkerNamespaces: number
+  sentinelPresent: boolean
+  vanishingCandidatePresent: boolean
+}
+
+function snapshotLine(snapshot: string, label: string): string | undefined {
+  return snapshot.split('\n').find((line) => line.includes(label))
+}
+
+function refFor(snapshot: string, label: string): string {
+  const line = snapshotLine(snapshot, label)
+  const ref = line?.match(/\[ref=(e\d+)\]/)?.[1]
+  if (!ref) {
+    throw new Error(
+      `no ref found for "${label}" in:\n${snapshot.slice(0, 800)}`,
+    )
+  }
+  return ref
+}
+
+function selectedRefs(
+  snapshot: string,
+  labels: readonly string[],
+): Record<string, string> {
+  return Object.fromEntries(
+    labels.map((label) => [label, refFor(snapshot, label)]),
+  )
+}
+
+async function evaluateText(
+  ctx: CaseContext,
+  page: number,
+  code: string,
+): Promise<string> {
+  return expectOk(
+    await ctx.mcp.callTool('evaluate', { page, code }),
+    `evaluate ${code}`,
+  )
+}
+
+function parseJsonObject<T>(text: string, context: string): T {
+  const start = text.indexOf('{')
+  const end = text.lastIndexOf('}')
+  if (start === -1 || end < start) {
+    throw new Error(`${context} did not return JSON: ${text.slice(0, 400)}`)
+  }
+  try {
+    return JSON.parse(text.slice(start, end + 1)) as T
+  } catch (error) {
+    throw new Error(
+      `${context} returned invalid JSON: ${text.slice(start, end + 1)}`,
+      { cause: error },
+    )
+  }
+}
+
+async function cursorProbeState(
+  ctx: CaseContext,
+  page: number,
+): Promise<CursorProbeState> {
+  const text = await evaluateText(
+    ctx,
+    page,
+    'return JSON.stringify(window.snapshotCursorFixture.state())',
+  )
+  return parseJsonObject<CursorProbeState>(text, 'cursor fixture state')
+}
+
+async function waitForCursorFixture(
+  ctx: CaseContext,
+  page: number,
+): Promise<void> {
+  await waitUntil(async () => {
+    const state = await cursorProbeState(ctx, page)
+    return state.candidateCount === 64
+  }, 'the cursor concurrency fixture to be ready')
+}
+
+async function requireCleanCursorProbe(
+  ctx: CaseContext,
+  page: number,
+): Promise<CursorProbeState> {
+  let state: CursorProbeState | undefined
+  await waitUntil(async () => {
+    state = await cursorProbeState(ctx, page)
+    return (
+      state.activeMarkerNamespaces === 0 && !state.vanishingCandidatePresent
+    )
+  }, 'cursor markers to be cleaned and the vanishing candidate to disappear')
+  if (!state?.sentinelPresent) {
+    throw new Error(
+      `snapshot cleanup removed the page-owned marker: ${JSON.stringify(state)}`,
+    )
+  }
+  return state
+}
+
+export const snapshotConcurrencyCases: ContractCase[] = [
+  {
+    name: 'snapshot concurrency: real cursor batch keeps refs and exclusions',
+    async run(ctx) {
+      const page = await ctx.openPage(
+        ctx.fixture('/snapshot-cursor-concurrency.html'),
+      )
+      await waitForCursorFixture(ctx, page)
+
+      const snapshot = expectOk(
+        await ctx.mcp.callTool('snapshot', { page }),
+        'cursor concurrency snapshot',
+      )
+      selectedRefs(snapshot, CURSOR_STABLE_LABELS)
+      selectedRefs(snapshot, CURSOR_REASON_LABELS)
+
+      const zeroSizedLine = snapshotLine(snapshot, 'Zero-sized excluded target')
+      if (zeroSizedLine?.includes('[ref=')) {
+        throw new Error(
+          `zero-sized cursor candidate received a ref: ${zeroSizedLine}`,
+        )
+      }
+      const state = await requireCleanCursorProbe(ctx, page)
+      if (state.distinctMarkerNamespaces === 0) {
+        throw new Error(
+          `fixture did not observe a snapshot marker namespace: ${JSON.stringify(state)}`,
+        )
+      }
+    },
+  },
+  {
+    name: 'snapshot concurrency: cursor refs remain actionable',
+    async run(ctx) {
+      const page = await ctx.openPage(
+        ctx.fixture('/snapshot-cursor-concurrency.html'),
+      )
+      await waitForCursorFixture(ctx, page)
+      const snapshot = expectOk(
+        await ctx.mcp.callTool('snapshot', { page }),
+        'cursor action snapshot',
+      )
+
+      expectOk(
+        await ctx.mcp.callTool('act', {
+          page,
+          kind: 'click',
+          ref: refFor(snapshot, 'Pointer-only target'),
+        }),
+        'click pointer-only cursor ref',
+      )
+      await waitUntil(
+        async () =>
+          (
+            await evaluateText(
+              ctx,
+              page,
+              'return document.getElementById("cursor-action-result").textContent',
+            )
+          ).includes('Pointer-only target clicked'),
+        'the pointer-only ref click to update its result',
+      )
+
+      const editableRef = refFor(snapshot, 'Editable target ready')
+      expectOk(
+        await ctx.mcp.callTool('act', {
+          page,
+          kind: 'click',
+          ref: editableRef,
+        }),
+        'focus contenteditable cursor ref',
+      )
+      expectOk(
+        await ctx.mcp.callTool('act', {
+          page,
+          kind: 'type',
+          ref: editableRef,
+          text: 'typed through cursor ref',
+        }),
+        'type through contenteditable cursor ref',
+      )
+      await waitUntil(
+        async () =>
+          (
+            await evaluateText(
+              ctx,
+              page,
+              'return document.getElementById("editable-target").textContent',
+            )
+          ).includes('typed through cursor ref'),
+        'contenteditable cursor ref to receive text',
+      )
+      await requireCleanCursorProbe(ctx, page)
+    },
+  },
+]

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
@@ -222,6 +222,21 @@ async function waitForCursorFixture(
   }, 'the cursor concurrency fixture to be ready')
 }
 
+async function armVanishingCandidate(
+  ctx: CaseContext,
+  page: number,
+): Promise<void> {
+  await evaluateText(
+    ctx,
+    page,
+    'window.snapshotCursorFixture.armVanishingCandidate(); return "armed"',
+  )
+  await waitUntil(async () => {
+    const state = await cursorProbeState(ctx, page)
+    return state.vanishingCandidatePresent
+  }, 'the vanishing cursor candidate to be armed')
+}
+
 async function requireCleanCursorProbe(
   ctx: CaseContext,
   page: number,
@@ -249,6 +264,7 @@ export const snapshotConcurrencyCases: ContractCase[] = [
         ctx.fixture('/snapshot-cursor-concurrency.html'),
       )
       await waitForCursorFixture(ctx, page)
+      await armVanishingCandidate(ctx, page)
 
       const snapshot = expectOk(
         await ctx.mcp.callTool('snapshot', { page }),
@@ -261,6 +277,12 @@ export const snapshotConcurrencyCases: ContractCase[] = [
       if (zeroSizedLine?.includes('[ref=')) {
         throw new Error(
           `zero-sized cursor candidate received a ref: ${zeroSizedLine}`,
+        )
+      }
+      const vanishingLine = snapshotLine(snapshot, 'Vanishing cursor target')
+      if (vanishingLine?.includes('[ref=')) {
+        throw new Error(
+          `vanished cursor candidate received a ref: ${vanishingLine}`,
         )
       }
       const state = await requireCleanCursorProbe(ctx, page)

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases.ts
@@ -43,6 +43,7 @@ import { captureIoCases } from './cases-capture-io'
 import { clawLayerCases } from './cases-claw-layer'
 import { navigateSnapshotCases } from './cases-navigate-snapshot'
 import { readEvalCases } from './cases-read-eval'
+import { snapshotConcurrencyCases } from './cases-snapshot-concurrency'
 import { tabsCases } from './cases-tabs'
 import { transportCases } from './cases-transport'
 
@@ -52,6 +53,7 @@ export const contractCases: ContractCase[] = [
   ...transportCases,
   ...tabsCases,
   ...navigateSnapshotCases,
+  ...snapshotConcurrencyCases,
   ...actCases,
   ...readEvalCases,
   ...captureIoCases,

--- a/packages/browseros-agent/contracts/claw-mcp/tests/fixture-server.test.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/fixture-server.test.ts
@@ -24,6 +24,11 @@ const EXPECTED_PAGES = [
   'media.html',
   'overlay.html',
   'scroll.html',
+  'snapshot-cursor-concurrency.html',
+  'snapshot-frame-a.html',
+  'snapshot-frame-b.html',
+  'snapshot-frame-grandchild.html',
+  'snapshot-frame-tree.html',
   'upload.html',
 ]
 
@@ -90,5 +95,27 @@ describe('fixture server', () => {
     expect(injection).toInclude('[ref=e99]')
     expect(injection).toInclude('[END_UNTRUSTED_PAGE_CONTENT nonce=')
     expect(await read('media.html')).toInclude('block blue')
+
+    const cursorConcurrency = await read('snapshot-cursor-concurrency.html')
+    expect(cursorConcurrency).toInclude('snapshotCursorFixture')
+    expect(cursorConcurrency).toInclude('data-__bcid-page-owned')
+    expect(cursorConcurrency).toInclude('Cursor candidate 63')
+    expect(cursorConcurrency).toInclude('zero-sized-excluded')
+
+    const frameTree = await read('snapshot-frame-tree.html')
+    expect(frameTree).toInclude('snapshotFrameFixture')
+    expect(frameTree).toInclude('childOrigin')
+    expect(frameTree).toInclude('/snapshot-frame-a.html')
+    expect(frameTree).toInclude('/snapshot-frame-b.html')
+
+    const frameA = await read('snapshot-frame-a.html')
+    expect(frameA).toInclude('Frame A action ready')
+    expect(frameA).toInclude('/snapshot-frame-grandchild.html')
+    expect(await read('snapshot-frame-b.html')).toInclude(
+      'Frame B cursor ready',
+    )
+    expect(await read('snapshot-frame-grandchild.html')).toInclude(
+      'Grandchild action ready',
+    )
   })
 })

--- a/packages/browseros-agent/contracts/claw-mcp/tests/fixture-server.test.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/fixture-server.test.ts
@@ -101,6 +101,7 @@ describe('fixture server', () => {
     expect(cursorConcurrency).toInclude('data-__bcid-page-owned')
     expect(cursorConcurrency).toInclude('Cursor candidate 63')
     expect(cursorConcurrency).toInclude('zero-sized-excluded')
+    expect(cursorConcurrency).toInclude('armVanishingCandidate')
 
     const frameTree = await read('snapshot-frame-tree.html')
     expect(frameTree).toInclude('snapshotFrameFixture')


### PR DESCRIPTION
## Summary
- add isolated live-browser fixtures for cursor batching, marker cleanup/overlap, and same-process/OOPIF/nested frame stitching
- assert stable semantic refs, cross-frame actions, complete `tabs new` auto-context, overlapping public captures, and an un-repaired diff baseline
- keep scheduler limits, forced completion order, and cancellation races in the existing deterministic Rust tests; production code is unchanged

## Design
The new contract module drives the production Rust MCP server through public tools against purpose-built fixture pages. Fixture-owned readiness and marker probes make concurrency and cleanup observable without CDP hooks, blind sleeps, latency thresholds, or whole-response comparisons.

## Test plan
- [x] `bun test contracts/claw-mcp/tests/fixture-server.test.ts`
- [x] `env -u BROWSEROS_BINARY bun test contracts/claw-mcp/tests/rust-conformance.test.ts` (parse-only gated check)
- [x] `BROWSEROS_BINARY=/Applications/BrowserOS.app/Contents/MacOS/BrowserOS bun run test:claw-mcp-contract` (`109 pass`, `0 fail`)
- [x] `git diff --check`
- [x] changed-path audit: only `contracts/claw-mcp/fixtures/**` and `contracts/claw-mcp/tests/**`