### PR TITLE
feat: follow replay activity across browser tabs

### DIFF
--- a/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
@@ -25,8 +25,18 @@ export type ReplayVerb =
 export type ReplayKind = 'action' | 'block' | 'done'
 
 export interface ReplayFrame {
-  /** Seconds into the session. */
+  /**
+   * Dispatch completion in seconds from session start. The timeline and audit
+   * highlight use completion because that is the timestamp persisted with the
+   * finished dispatch.
+   */
   t: number
+  /**
+   * Approximate dispatch start in session seconds, derived from completion
+   * minus duration. The automatic camera uses this separate clock so it can
+   * show a tab while work is happening without rewriting the audit timestamp.
+   */
+  cameraT: number
   kind: ReplayKind
   verb: ReplayVerb
   /** Short node label, e.g. the page title or a focused element. */

--- a/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.test.tsx
@@ -45,6 +45,10 @@ beforeEach(async () => {
       value,
     })
   }
+  Object.assign(dom.window, {
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame: () => undefined,
+  })
   Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
     configurable: true,
     writable: true,

--- a/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.test.tsx
@@ -22,6 +22,7 @@ function TransportHarness() {
       totalSeconds={10}
       frames={[]}
       onSeek={playback.seek}
+      transportLabel="Session playback"
     />
   )
 }
@@ -81,6 +82,15 @@ describe('PlaybackTransport', () => {
     expect(speedButton('1×')?.getAttribute('aria-pressed')).toBe('false')
     expect(speedButton('2×')?.getAttribute('aria-pressed')).toBe('true')
     expect(speedButton('4×')?.getAttribute('aria-pressed')).toBe('false')
+    expect(
+      container.querySelector('[aria-label="Pause Session playback"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[aria-label="Session playback position"]'),
+    ).not.toBeNull()
+    expect(
+      container.querySelector('[aria-label="Session playback speed"]'),
+    ).not.toBeNull()
 
     await act(async () => {
       speedButton('1×')?.dispatchEvent(

--- a/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.tsx
@@ -13,6 +13,8 @@ interface PlaybackTransportProps {
   totalSeconds: number
   frames: readonly ReplayFrame[]
   onSeek: (seconds: number) => void
+  /** Distinguishes the global session transport from pinned tab inspection. */
+  transportLabel?: string
 }
 
 /**
@@ -25,6 +27,7 @@ export function PlaybackTransport({
   totalSeconds,
   frames,
   onSeek,
+  transportLabel = 'playback',
 }: PlaybackTransportProps) {
   const { time, isPlaying, speed, setSpeed, togglePlay } = playback
   const finished = time >= totalSeconds
@@ -35,14 +38,15 @@ export function PlaybackTransport({
   }
 
   return (
-    <div className="rounded-2xl border border-border-2 bg-card p-3 shadow-sm">
+    <fieldset
+      aria-label={transportLabel}
+      className="m-0 min-w-0 rounded-2xl border border-border-2 bg-card p-3 shadow-sm"
+    >
       <div className="flex items-center gap-3">
         <button
           type="button"
           onClick={togglePlay}
-          aria-label={
-            finished ? 'Restart playback' : isPlaying ? 'Pause' : 'Play'
-          }
+          aria-label={`${finished ? 'Restart' : isPlaying ? 'Pause' : 'Play'} ${transportLabel}`}
           className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-accent text-white shadow"
         >
           {finished ? (
@@ -91,7 +95,7 @@ export function PlaybackTransport({
           />
           <input
             type="range"
-            aria-label="Playback position"
+            aria-label={`${transportLabel} position`}
             aria-valuetext={`${formatTime(time)} of ${formatTime(totalSeconds)}`}
             min={0}
             max={totalSeconds}
@@ -102,6 +106,7 @@ export function PlaybackTransport({
           />
         </div>
         <ToggleGroup
+          aria-label={`${transportLabel} speed`}
           value={[String(speed)]}
           onValueChange={(values) => {
             const next = Number(values[0])
@@ -122,6 +127,6 @@ export function PlaybackTransport({
           ))}
         </ToggleGroup>
       </div>
-    </div>
+    </fieldset>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -6,7 +6,13 @@
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { parseHTML } from 'linkedom'
-import { act, createContext, type ReactNode, useContext } from 'react'
+import {
+  act,
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+} from 'react'
 import type { Root } from 'react-dom/client'
 import { MemoryRouter } from 'react-router'
 import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
@@ -15,6 +21,8 @@ import { buildReplayEventCatalog } from './replay-events'
 import type { Playback } from './use-playback'
 
 let replayResult: replayDataModule.UseReplayDataResult
+let autoCommitPresentedTrack = true
+let commitPresentedTrack: ((tabId: number) => void) | null = null
 
 mock.module('./replay.data', () => ({
   ...replayDataModule,
@@ -28,28 +36,38 @@ mock.module('./ReplayViewport', () => ({
     activeTimeMs,
     frame,
     mode,
+    onPresentedTrackChange,
   }: {
     activeTrack: { tabId: number; events: readonly ReplayEvent[] }
     standbyTrack: { tabId: number } | null
     activeTimeMs: number
     frame: ReplayFrame | undefined
     mode: string
-  }) => (
-    <div
-      data-active-tab={activeTrack.tabId}
-      data-standby-tab={standbyTrack?.tabId}
-      data-player-documents={activeTrack.events
-        .map((event) => event.documentId)
-        .join(',')}
-      data-player-types={activeTrack.events
-        .map((event) => event.type)
-        .join(',')}
-      data-player-time={activeTimeMs / 1000}
-      data-player-mode={mode}
-      data-player-caption={frame?.caption}
-      data-player-url={frame?.url}
-    />
-  ),
+    onPresentedTrackChange: (tabId: number) => void
+  }) => {
+    useEffect(() => {
+      commitPresentedTrack = onPresentedTrackChange
+      if (autoCommitPresentedTrack) {
+        onPresentedTrackChange(activeTrack.tabId)
+      }
+    }, [activeTrack.tabId, onPresentedTrackChange])
+    return (
+      <div
+        data-active-tab={activeTrack.tabId}
+        data-standby-tab={standbyTrack?.tabId}
+        data-player-documents={activeTrack.events
+          .map((event) => event.documentId)
+          .join(',')}
+        data-player-types={activeTrack.events
+          .map((event) => event.type)
+          .join(',')}
+        data-player-time={activeTimeMs / 1000}
+        data-player-mode={mode}
+        data-player-caption={frame?.caption}
+        data-player-url={frame?.url}
+      />
+    )
+  },
 }))
 
 mock.module('./PlaybackTransport', () => ({
@@ -110,7 +128,10 @@ mock.module('./EventTimeline', () => ({
   ),
 }))
 
-const TabSelectContext = createContext<(tabId: string) => void>(() => {})
+const TabSelectContext = createContext<{
+  selected: string
+  select: (tabId: string) => void
+}>({ selected: '', select: () => {} })
 
 mock.module('@/components/ui/tabs', () => ({
   Tabs: ({
@@ -122,7 +143,9 @@ mock.module('@/components/ui/tabs', () => ({
     onValueChange: (tabId: string) => void
     children: ReactNode
   }) => (
-    <TabSelectContext.Provider value={onValueChange}>
+    <TabSelectContext.Provider
+      value={{ selected: value, select: onValueChange }}
+    >
       <div data-selected-tab={value}>{children}</div>
     </TabSelectContext.Provider>
   ),
@@ -130,18 +153,23 @@ mock.module('@/components/ui/tabs', () => ({
   TabsTrigger: ({
     value,
     children,
+    onClick,
     ...props
   }: {
     value: string
     children: ReactNode
     'aria-label'?: string
+    onClick?: () => void
   }) => {
-    const selectTab = useContext(TabSelectContext)
+    const tabs = useContext(TabSelectContext)
     return (
       <button
         type="button"
         data-tab-chip={value}
-        onClick={() => selectTab(value)}
+        onClick={() => {
+          onClick?.()
+          if (value !== tabs.selected) tabs.select(value)
+        }}
         {...props}
       >
         {children}
@@ -314,6 +342,8 @@ beforeEach(async () => {
   nowMs = 0
   nextAnimationFrameId = 1
   animationFrames = new Map()
+  autoCommitPresentedTrack = true
+  commitPresentedTrack = null
   const requestAnimationFrame = (callback: FrameRequestCallback): number => {
     const id = nextAnimationFrameId
     nextAnimationFrameId += 1
@@ -435,6 +465,35 @@ describe('Replay', () => {
     expect(container.querySelectorAll('[data-frame-tab="3"]')).toHaveLength(1)
   })
 
+  it('keeps the chip, URL, and caption on the committed player until promotion is ready', async () => {
+    autoCommitPresentedTrack = false
+    await renderReplay()
+
+    await advanceClock(10_000)
+    expect(viewport().getAttribute('data-active-tab')).toBe('2')
+    expect(
+      container
+        .querySelector('[data-selected-tab]')
+        ?.getAttribute('data-selected-tab'),
+    ).toBe('1')
+    expect(viewport().getAttribute('data-player-url')).not.toBe(
+      'https://two.example/result',
+    )
+
+    await act(async () => commitPresentedTrack?.(2))
+    expect(
+      container
+        .querySelector('[data-selected-tab]')
+        ?.getAttribute('data-selected-tab'),
+    ).toBe('2')
+    expect(viewport().getAttribute('data-player-caption')).toBe(
+      'Return to tab two',
+    )
+    expect(viewport().getAttribute('data-player-url')).toBe(
+      'https://two.example/result',
+    )
+  })
+
   it('globally seeks, prefers a selected timeline tab, and ignores a selected no-visual tab', async () => {
     await renderReplay()
 
@@ -519,6 +578,18 @@ describe('Replay', () => {
         .querySelector('[data-playback-playing]')
         ?.getAttribute('data-playback-playing'),
     ).toBe('false')
+  })
+
+  it('enters inspection when the already-selected follow chip is clicked', async () => {
+    await renderReplay()
+
+    await click('[data-tab-chip="1"]')
+
+    expect(viewport().getAttribute('data-active-tab')).toBe('1')
+    expect(viewport().getAttribute('data-player-mode')).toBe('inspect')
+    expect(viewport().getAttribute('data-player-time')).toBe('0')
+    expect(container.textContent).toContain('Inspecting Tab 1')
+    expect(container.textContent).toContain('Tab 1 · Pinned')
   })
 
   it('switches before ten real seconds when the active track ends', async () => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -156,6 +156,7 @@ const events: ReplayEvent[] = [
 const frames: ReplayFrame[] = [
   {
     t: 1,
+    cameraT: 1,
     kind: 'action',
     verb: 'read',
     node: 'A',
@@ -166,6 +167,7 @@ const frames: ReplayFrame[] = [
   },
   {
     t: 12,
+    cameraT: 12,
     kind: 'action',
     verb: 'click',
     node: 'B',

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { parseHTML } from 'linkedom'
 import { act, createContext, type ReactNode, useContext } from 'react'
@@ -6,6 +12,7 @@ import { MemoryRouter } from 'react-router'
 import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
 import * as replayDataModule from './replay.data'
 import { buildReplayEventCatalog } from './replay-events'
+import type { Playback } from './use-playback'
 
 let replayResult: replayDataModule.UseReplayDataResult
 
@@ -15,10 +22,32 @@ mock.module('./replay.data', () => ({
 }))
 
 mock.module('./ReplayViewport', () => ({
-  ReplayViewport: ({ events }: { events: readonly ReplayEvent[] }) => (
+  ReplayViewport: ({
+    activeTrack,
+    standbyTrack,
+    activeTimeMs,
+    frame,
+    mode,
+  }: {
+    activeTrack: { tabId: number; events: readonly ReplayEvent[] }
+    standbyTrack: { tabId: number } | null
+    activeTimeMs: number
+    frame: ReplayFrame | undefined
+    mode: string
+  }) => (
     <div
-      data-player-documents={events.map((event) => event.documentId).join(',')}
-      data-player-types={events.map((event) => event.type).join(',')}
+      data-active-tab={activeTrack.tabId}
+      data-standby-tab={standbyTrack?.tabId}
+      data-player-documents={activeTrack.events
+        .map((event) => event.documentId)
+        .join(',')}
+      data-player-types={activeTrack.events
+        .map((event) => event.type)
+        .join(',')}
+      data-player-time={activeTimeMs / 1000}
+      data-player-mode={mode}
+      data-player-caption={frame?.caption}
+      data-player-url={frame?.url}
     />
   ),
 }))
@@ -26,30 +55,52 @@ mock.module('./ReplayViewport', () => ({
 mock.module('./PlaybackTransport', () => ({
   PlaybackTransport: ({
     playback,
+    totalSeconds,
+    onSeek,
+    transportLabel,
   }: {
-    playback: { time: number; isPlaying: boolean }
+    playback: Playback
+    totalSeconds: number
+    onSeek: (seconds: number) => void
+    transportLabel: string
   }) => (
     <div
+      data-transport-label={transportLabel}
       data-playback-time={playback.time}
       data-playback-playing={playback.isPlaying}
-    />
+      data-playback-total={totalSeconds}
+    >
+      <button
+        type="button"
+        aria-label={`Toggle ${transportLabel}`}
+        onClick={playback.togglePlay}
+      >
+        Toggle
+      </button>
+      <button type="button" data-seek-twelve onClick={() => onSeek(12)}>
+        Seek 12
+      </button>
+    </div>
   ),
 }))
 
 mock.module('./EventTimeline', () => ({
   EventTimeline: ({
     frames,
+    currentFrameIndex,
     onSelectFrame,
   }: {
     frames: readonly ReplayFrame[]
+    currentFrameIndex: number
     onSelectFrame: (frame: ReplayFrame) => void
   }) => (
-    <div>
+    <div data-timeline-current={currentFrameIndex}>
       {frames.map((frame) => (
         <button
           type="button"
           key={frame.dispatchId}
           data-frame-tab={frame.tabId}
+          data-frame-id={frame.dispatchId}
           onClick={() => onSelectFrame(frame)}
         >
           {frame.caption}
@@ -59,7 +110,7 @@ mock.module('./EventTimeline', () => ({
   ),
 }))
 
-const TargetSelectContext = createContext<(targetId: string) => void>(() => {})
+const TabSelectContext = createContext<(tabId: string) => void>(() => {})
 
 mock.module('@/components/ui/tabs', () => ({
   Tabs: ({
@@ -68,27 +119,30 @@ mock.module('@/components/ui/tabs', () => ({
     children,
   }: {
     value: string
-    onValueChange: (targetId: string) => void
+    onValueChange: (tabId: string) => void
     children: ReactNode
   }) => (
-    <TargetSelectContext.Provider value={onValueChange}>
-      <div data-selected-target={value}>{children}</div>
-    </TargetSelectContext.Provider>
+    <TabSelectContext.Provider value={onValueChange}>
+      <div data-selected-tab={value}>{children}</div>
+    </TabSelectContext.Provider>
   ),
   TabsList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   TabsTrigger: ({
     value,
     children,
+    ...props
   }: {
     value: string
     children: ReactNode
+    'aria-label'?: string
   }) => {
-    const selectTarget = useContext(TargetSelectContext)
+    const selectTab = useContext(TabSelectContext)
     return (
       <button
         type="button"
-        data-target-chip={value}
-        onClick={() => selectTarget(value)}
+        data-tab-chip={value}
+        onClick={() => selectTab(value)}
+        {...props}
       >
         {children}
       </button>
@@ -96,98 +150,117 @@ mock.module('@/components/ui/tabs', () => ({
   },
 }))
 
-const events: ReplayEvent[] = [
-  {
+function event(
+  ts: number,
+  documentId: string,
+  tabId: number,
+  type: number,
+): ReplayEvent {
+  return {
     sessionId: 'session-1',
-    documentId: 'document-a',
-    targetId: 'target-a',
-    tabId: 1,
-    ts: 1_000,
-    type: 4,
-    data: { width: 1280, height: 720 },
-  },
-  {
-    sessionId: 'session-1',
-    documentId: 'document-a',
-    targetId: 'target-a',
-    tabId: 1,
-    ts: 1_001,
-    type: 2,
-    data: {},
-  },
-  {
-    sessionId: 'session-1',
-    documentId: 'document-a',
-    targetId: 'target-a',
-    tabId: 1,
-    ts: 5_000,
-    type: 3,
-    data: {},
-  },
-  {
-    sessionId: 'session-1',
-    documentId: 'document-b',
-    targetId: 'target-b',
-    tabId: 2,
-    ts: 10_000,
-    type: 4,
-    data: { width: 1280, height: 720 },
-  },
-  {
-    sessionId: 'session-1',
-    documentId: 'document-b',
-    targetId: 'target-b',
-    tabId: 2,
-    ts: 10_001,
-    type: 2,
-    data: {},
-  },
-  {
-    sessionId: 'session-1',
-    documentId: 'document-b',
-    targetId: 'target-b',
-    tabId: 2,
-    ts: 15_000,
-    type: 3,
-    data: {},
-  },
+    documentId,
+    targetId: `target-${tabId}`,
+    tabId,
+    ts,
+    type,
+    data: type === 4 ? { width: 1280, height: 720 } : {},
+  }
+}
+
+const sessionEvents: ReplayEvent[] = [
+  event(0, 'tab-one-a', 1, 4),
+  event(1, 'tab-one-a', 1, 2),
+  event(20_000, 'tab-one-a', 1, 3),
+  event(30_000, 'tab-one-b', 1, 4),
+  event(30_001, 'tab-one-b', 1, 2),
+  event(40_000, 'tab-one-b', 1, 3),
+  event(5_000, 'tab-two', 2, 4),
+  event(5_001, 'tab-two', 2, 2),
+  event(50_000, 'tab-two', 2, 3),
+  event(6_000, 'tab-four', 4, 4),
+  event(6_001, 'tab-four', 4, 2),
+  event(50_000, 'tab-four', 4, 3),
+  event(3_000, 'tab-three-no-visual', 3, 3),
 ]
 
-const frames: ReplayFrame[] = [
+const sessionFrames: ReplayFrame[] = [
   {
-    t: 1,
-    cameraT: 1,
+    t: 2,
+    cameraT: 0,
     kind: 'action',
     verb: 'read',
-    node: 'A',
-    caption: 'Read target A',
+    node: 'Tab one',
+    caption: 'Read tab one',
+    url: 'https://one.example/start',
     tabId: 1,
-    targetId: 'target-a',
     dispatchId: 1,
   },
   {
-    t: 12,
-    cameraT: 12,
+    t: 4,
+    cameraT: 3,
+    kind: 'action',
+    verb: 'read',
+    node: 'No visual',
+    caption: 'Read no-visual tab',
+    tabId: 3,
+    dispatchId: 3,
+  },
+  {
+    t: 8,
+    cameraT: 5,
     kind: 'action',
     verb: 'click',
-    node: 'B',
-    caption: 'Click target B',
+    node: 'Tab two',
+    caption: 'Click tab two',
+    url: 'https://two.example/click',
     tabId: 2,
-    targetId: 'target-b',
     dispatchId: 2,
+  },
+  {
+    t: 9,
+    cameraT: 6,
+    kind: 'action',
+    verb: 'click',
+    node: 'Tab four',
+    caption: 'Click tab four',
+    url: 'https://four.example/click',
+    tabId: 4,
+    dispatchId: 4,
+  },
+  {
+    t: 12,
+    cameraT: 10,
+    kind: 'action',
+    verb: 'read',
+    node: 'Tab two again',
+    caption: 'Return to tab two',
+    url: 'https://two.example/result',
+    tabId: 2,
+    dispatchId: 5,
   },
 ]
 
-function replayData(replayEvents: readonly ReplayEvent[], tabOrder?: number[]) {
+function replayData(
+  replayEvents: readonly ReplayEvent[],
+  options: {
+    frames?: ReplayFrame[]
+    tabOrder?: number[]
+    totalSeconds?: number
+  } = {},
+): replayDataModule.ReplayData {
   const eventCatalog = buildReplayEventCatalog(replayEvents)
-  const tabs = (tabOrder ?? eventCatalog.tabIds).map((tabId) => ({
+  const tabOrder =
+    options.tabOrder ??
+    [1, 2, 4, 3].filter((tabId) => eventCatalog.tabIds.includes(tabId))
+  const tabs = tabOrder.map((tabId) => ({
     tabId,
     complete: true,
     segments: eventCatalog.documentIdsForTab(tabId).map((documentId) => {
       const documentEvents = eventCatalog.eventsForDocument(documentId)
       return {
         documentId,
-        targetId: documentEvents.find((event) => event.targetId)?.targetId,
+        targetId: documentEvents.find((candidate) => candidate.targetId)
+          ?.targetId,
         firstEventAt: documentEvents[0]?.ts ?? 0,
         lastEventAt: documentEvents.at(-1)?.ts ?? 0,
         hasGap: false,
@@ -195,20 +268,21 @@ function replayData(replayEvents: readonly ReplayEvent[], tabOrder?: number[]) {
       }
     }),
   }))
+  const totalSeconds = options.totalSeconds ?? 60
   return {
     sessionId: 'session-1',
     agentLabel: 'Codex',
     taskTitle: 'Replay test',
     harness: 'Codex',
-    status: 'done' as const,
+    status: 'done',
     site: 'example.com',
-    startedAt: 'Jul 18, 2026',
+    startedAt: 'Jul 23, 2026',
     startedAtMs: 0,
-    duration: '0:15',
+    duration: `0:${String(totalSeconds).padStart(2, '0')}`,
     tokens: '-',
-    steps: '2',
-    totalSeconds: 15,
-    frames,
+    steps: String((options.frames ?? sessionFrames).length),
+    totalSeconds,
+    frames: options.frames ?? sessionFrames,
     complete: true,
     tabs,
     eventsForTab: eventCatalog.eventsForTab,
@@ -216,18 +290,40 @@ function replayData(replayEvents: readonly ReplayEvent[], tabOrder?: number[]) {
 }
 
 const globalDescriptors = new Map(
-  ['window', 'document', 'navigator', 'HTMLElement', 'Node', 'Event'].map(
-    (name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)],
-  ),
+  [
+    'window',
+    'document',
+    'navigator',
+    'HTMLElement',
+    'Node',
+    'Event',
+    'performance',
+  ].map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
 )
 
-let root: Root
+let root: Root | null
 let container: HTMLElement
+let nowMs = 0
+let nextAnimationFrameId = 1
+let animationFrames: Map<number, FrameRequestCallback>
 
 beforeEach(async () => {
   const dom = parseHTML(
     '<!doctype html><html><body><div id="root"></div></body></html>',
   )
+  nowMs = 0
+  nextAnimationFrameId = 1
+  animationFrames = new Map()
+  const requestAnimationFrame = (callback: FrameRequestCallback): number => {
+    const id = nextAnimationFrameId
+    nextAnimationFrameId += 1
+    animationFrames.set(id, callback)
+    return id
+  }
+  const cancelAnimationFrame = (id: number): void => {
+    animationFrames.delete(id)
+  }
+  Object.assign(dom.window, { requestAnimationFrame, cancelAnimationFrame })
   const globals = {
     window: dom.window,
     document: dom.document,
@@ -235,6 +331,7 @@ beforeEach(async () => {
     HTMLElement: dom.window.HTMLElement,
     Node: dom.window.Node,
     Event: dom.window.Event,
+    performance: { now: () => nowMs },
   }
   for (const [name, value] of Object.entries(globals)) {
     Object.defineProperty(globalThis, name, {
@@ -243,10 +340,6 @@ beforeEach(async () => {
       value,
     })
   }
-  Object.assign(dom.window, {
-    requestAnimationFrame: () => 1,
-    cancelAnimationFrame: () => undefined,
-  })
   Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
     configurable: true,
     writable: true,
@@ -254,7 +347,7 @@ beforeEach(async () => {
   })
 
   replayResult = {
-    replay: replayData([]),
+    replay: replayData(sessionEvents),
     sessionId: 'session-1',
     isLoading: false,
     navigate: mock(() => undefined) as never,
@@ -265,7 +358,8 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  await act(async () => root.unmount())
+  if (root) await act(async () => root?.unmount())
+  root = null
   for (const [name, descriptor] of globalDescriptors) {
     if (descriptor) Object.defineProperty(globalThis, name, descriptor)
     else Reflect.deleteProperty(globalThis, name)
@@ -273,188 +367,217 @@ afterEach(async () => {
   Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
 })
 
+async function renderReplay(): Promise<void> {
+  await act(async () => {
+    root?.render(
+      <MemoryRouter initialEntries={['/audit/session-1/replay']}>
+        <Replay />
+      </MemoryRouter>,
+    )
+  })
+}
+
+async function advanceClock(toMs: number): Promise<void> {
+  nowMs = toMs
+  const callbacks = [...animationFrames.values()]
+  animationFrames.clear()
+  await act(async () => {
+    for (const callback of callbacks) callback(toMs)
+  })
+}
+
+function viewport(): Element {
+  const element = container.querySelector('[data-active-tab]')
+  if (!element) throw new Error('expected replay viewport')
+  return element
+}
+
+function click(selector: string): Promise<void> {
+  const element = container.querySelector(selector)
+  if (!element) throw new Error(`missing element: ${selector}`)
+  return act(async () => {
+    element.dispatchEvent(new window.Event('click', { bubbles: true }))
+  })
+}
+
 describe('Replay', () => {
-  it('discovers logical tabs and switches tab on frame click', async () => {
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
+  it('follows semantic activity, coalesces parallel work, and never selects a no-visual tab', async () => {
+    await renderReplay()
 
-    expect(
-      [...container.querySelectorAll('[data-target-chip]')].map(
-        (chip) => chip.textContent,
-      ),
-    ).toEqual([])
-    expect(container.textContent).toContain('No visual recording for this tab')
-    expect(container.querySelector('[data-player-targets]')).toBeNull()
-
-    replayResult = { ...replayResult, replay: replayData(events) }
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
-
+    expect(viewport().getAttribute('data-active-tab')).toBe('1')
+    expect(container.textContent).toContain('Following session')
     expect(
       container
-        .querySelector('[data-player-documents]')
-        ?.getAttribute('data-player-documents'),
-    ).toBe('document-a,document-a,document-a')
+        .querySelector('[data-playback-total]')
+        ?.getAttribute('data-playback-total'),
+    ).toBe('60')
+
+    await advanceClock(3_000)
+    expect(viewport().getAttribute('data-active-tab')).toBe('1')
+    expect(viewport().getAttribute('data-standby-tab')).toBe('4')
+
+    await advanceClock(5_000)
+    expect(viewport().getAttribute('data-standby-tab')).toBe('2')
+
+    await advanceClock(10_000)
+    expect(viewport().getAttribute('data-active-tab')).toBe('2')
+    expect(viewport().getAttribute('data-player-caption')).toBe(
+      'Return to tab two',
+    )
+    expect(viewport().getAttribute('data-player-url')).toBe(
+      'https://two.example/result',
+    )
     expect(
-      [...container.querySelectorAll('[data-target-chip]')].map(
-        (chip) => chip.textContent,
-      ),
-    ).toEqual(['Tab 1', 'Tab 2'])
+      container
+        .querySelector('[data-selected-tab]')
+        ?.getAttribute('data-selected-tab'),
+    ).toBe('2')
+    expect(container.querySelectorAll('[data-frame-tab="3"]')).toHaveLength(1)
+  })
+
+  it('globally seeks, prefers a selected timeline tab, and ignores a selected no-visual tab', async () => {
+    await renderReplay()
+
+    await click('[data-seek-twelve]')
+    expect(viewport().getAttribute('data-active-tab')).toBe('2')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('12')
     expect(
       container
         .querySelector('[data-playback-playing]')
         ?.getAttribute('data-playback-playing'),
-    ).toBe('true')
+    ).toBe('false')
 
-    const targetBFrame = container.querySelector('[data-frame-tab="2"]')
-    if (!targetBFrame) throw new Error('tab 2 frame missing')
-    await act(async () => {
-      targetBFrame.dispatchEvent(new window.Event('click', { bubbles: true }))
-    })
-
+    await click('[data-frame-id="4"]')
+    expect(viewport().getAttribute('data-active-tab')).toBe('4')
     expect(
       container
-        .querySelector('[data-selected-target]')
-        ?.getAttribute('data-selected-target'),
-    ).toBe('2')
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('9')
+
+    await click('[data-frame-id="3"]')
+    expect(viewport().getAttribute('data-active-tab')).toBe('1')
     expect(
       container
-        .querySelector('[data-player-documents]')
-        ?.getAttribute('data-player-documents'),
-    ).toBe('document-b,document-b,document-b')
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('4')
+  })
+
+  it('pins a tab at local zero and resumes the exact preserved global moment paused', async () => {
+    await renderReplay()
+    await advanceClock(2_000)
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('4')
+
+    nowMs = 2_250
+    await click('[data-tab-chip="2"]')
+    expect(viewport().getAttribute('data-active-tab')).toBe('2')
+    expect(viewport().getAttribute('data-player-mode')).toBe('inspect')
+    expect(viewport().getAttribute('data-player-time')).toBe('0')
+    expect(viewport().getAttribute('data-standby-tab')).toBe(null)
+    expect(container.textContent).toContain('Inspecting Tab 2')
+    expect(container.textContent).toContain('Tab 2 · Pinned')
+    expect(
+      container
+        .querySelector('[data-transport-label]')
+        ?.getAttribute('data-transport-label'),
+    ).toBe('Tab 2 playback')
+
+    await click('[aria-label="Toggle Tab 2 playback"]')
+    await advanceClock(3_250)
     expect(
       container
         .querySelector('[data-playback-time]')
         ?.getAttribute('data-playback-time'),
     ).toBe('2')
 
-    replayResult = {
-      ...replayResult,
-      replay: replayData(events, [1]),
-    }
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
-
-    expect(
-      container
-        .querySelector('[data-player-documents]')
-        ?.getAttribute('data-player-documents'),
-    ).toBe('document-a,document-a,document-a')
-    expect(
-      container
-        .querySelector('[data-playback-time]')
-        ?.getAttribute('data-playback-time'),
-    ).toBe('0')
-  })
-
-  it('merges navigation lifecycles into one tab-level replay', async () => {
-    const navigationEvents: ReplayEvent[] = [
-      ...events.slice(0, 3),
-      ...events.slice(3).map((candidate) => ({
-        ...candidate,
-        tabId: 1,
-        documentId: 'document-b',
-      })),
-    ]
-    replayResult = {
-      ...replayResult,
-      replay: replayData(navigationEvents),
-    }
-
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
-
-    expect(container.textContent).not.toContain('Navigation 1')
-    expect(container.textContent).not.toContain('Navigation 2')
-    expect(
-      container
-        .querySelector('[data-player-documents]')
-        ?.getAttribute('data-player-documents'),
-    ).toBe('document-a,document-a,document-a,document-b,document-b,document-b')
-    expect(
-      container.querySelector('[data-target-chip="document-b"]'),
-    ).toBeNull()
-  })
-
-  it('slices orphan mutations and explains where visual playback starts', async () => {
-    const incompleteEvents: ReplayEvent[] = [
-      {
-        sessionId: 'session-1',
-        documentId: 'document-a',
-        targetId: 'target-a',
-        tabId: 1,
-        ts: 1_000,
-        type: 3,
-        data: {},
-      },
-      {
-        sessionId: 'session-1',
-        documentId: 'document-a',
-        targetId: 'target-a',
-        tabId: 1,
-        ts: 4_000,
-        type: 2,
-        data: {},
-      },
-      {
-        sessionId: 'session-1',
-        documentId: 'document-a',
-        targetId: 'target-a',
-        tabId: 1,
-        ts: 5_000,
-        type: 3,
-        data: {},
-      },
-    ]
-    replayResult = {
-      ...replayResult,
-      replay: replayData(incompleteEvents),
-    }
-
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
-
-    expect(
-      container
-        .querySelector('[data-player-types]')
-        ?.getAttribute('data-player-types'),
-    ).toBe('2,3')
-    expect(container.textContent).toContain(
-      'Recording incomplete — playback starts at 0:03',
+    const resumeButton = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Resume session',
     )
+    if (!resumeButton) throw new Error('missing Resume session')
+    await act(async () => {
+      resumeButton.dispatchEvent(new window.Event('click', { bubbles: true }))
+    })
+
+    expect(viewport().getAttribute('data-active-tab')).toBe('1')
+    expect(viewport().getAttribute('data-player-mode')).toBe('follow')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('4.5')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('false')
   })
 
-  it("keeps the selected tab's prefix warning when another tab has a gap", async () => {
-    const partialReplay = replayData([
-      { ...events[0], ts: 0, type: 3 },
-      ...events,
-    ])
-    partialReplay.complete = false
+  it('switches before ten real seconds when the active track ends', async () => {
+    const earlyEvents = [
+      event(0, 'short-tab', 1, 4),
+      event(1, 'short-tab', 1, 2),
+      event(6_000, 'short-tab', 1, 3),
+      event(1_000, 'next-tab', 2, 4),
+      event(1_001, 'next-tab', 2, 2),
+      event(20_000, 'next-tab', 2, 3),
+    ]
+    replayResult = {
+      ...replayResult,
+      replay: replayData(earlyEvents, {
+        frames: [
+          {
+            ...sessionFrames[0],
+            t: 1,
+            cameraT: 0,
+            tabId: 1,
+          },
+          {
+            ...sessionFrames[2],
+            t: 2,
+            cameraT: 1,
+            tabId: 2,
+          },
+        ],
+        tabOrder: [1, 2],
+        totalSeconds: 20,
+      }),
+    }
+    await renderReplay()
+
+    await advanceClock(3_000)
+    expect(viewport().getAttribute('data-active-tab')).toBe('2')
+  })
+
+  it('merges same-tab navigation lifecycles into one automatic track', async () => {
+    await renderReplay()
+
+    expect(viewport().getAttribute('data-player-documents')).toBe(
+      'tab-one-a,tab-one-a,tab-one-a,tab-one-b,tab-one-b,tab-one-b',
+    )
+    expect(container.textContent).not.toContain('Navigation 1')
+    expect(container.querySelector('[data-tab-chip="tab-one-b"]')).toBeNull()
+  })
+
+  it("keeps warnings scoped to the camera's active tab", async () => {
+    const incompleteEvents = [
+      event(0, 'incomplete-tab', 1, 3),
+      event(3_000, 'incomplete-tab', 1, 2),
+      event(5_000, 'incomplete-tab', 1, 3),
+      ...sessionEvents.filter(({ tabId }) => tabId === 2),
+    ]
+    const partialReplay = replayData(incompleteEvents, {
+      frames: sessionFrames.filter(({ tabId }) => tabId === 1 || tabId === 2),
+      tabOrder: [1, 2],
+    })
     const secondTab = partialReplay.tabs[1]
     if (secondTab) {
       secondTab.complete = false
@@ -462,43 +585,63 @@ describe('Replay', () => {
       if (firstSegment) firstSegment.hasGap = true
     }
     replayResult = { ...replayResult, replay: partialReplay }
-
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
+    await renderReplay()
 
     expect(container.textContent).toContain(
-      'Recording incomplete — playback starts at 0:01',
+      'Recording incomplete — playback starts at 0:03',
     )
     expect(container.textContent).not.toContain(
       'this replay contains a known gap',
     )
   })
 
-  it("does not leak another tab's gap into the selected tab", async () => {
-    const partialReplay = replayData(events)
-    partialReplay.complete = false
-    const secondTab = partialReplay.tabs[1]
-    if (secondTab) {
-      secondTab.complete = false
-      const firstSegment = secondTab.segments[0]
-      if (firstSegment) firstSegment.hasGap = true
+  it('restarts both the global clock and automatic camera from the beginning', async () => {
+    await renderReplay()
+    await advanceClock(30_000)
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('60')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('false')
+
+    await click('[aria-label="Toggle Session playback"]')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
+    expect(viewport().getAttribute('data-active-tab')).toBe('1')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+  })
+
+  it('keeps a single-tab replay on the global transport without tab controls', async () => {
+    const singleTabEvents = sessionEvents.filter(({ tabId }) => tabId === 1)
+    replayResult = {
+      ...replayResult,
+      replay: replayData(singleTabEvents, {
+        frames: sessionFrames.filter(({ tabId }) => tabId === 1),
+        tabOrder: [1],
+      }),
     }
-    replayResult = { ...replayResult, replay: partialReplay }
+    await renderReplay()
 
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
-
-    expect(container.textContent).not.toContain('Recording incomplete')
+    expect(container.querySelectorAll('[data-tab-chip]')).toHaveLength(0)
+    expect(container.textContent).toContain('Following session')
+    expect(
+      container
+        .querySelector('[data-playback-total]')
+        ?.getAttribute('data-playback-total'),
+    ).toBe('60')
+    expect(viewport().getAttribute('data-active-tab')).toBe('1')
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -27,6 +27,7 @@ import {
 import { frameIndexAt } from './replay.helpers'
 import {
   createSessionCameraState,
+  rebaseSessionCameraState,
   type SessionCameraState,
   sessionCameraReducer,
 } from './session-camera'
@@ -89,34 +90,23 @@ function ReplaySession({ replay, navigate, location }: ReplaySessionProps) {
   const [camera, setCamera] = useState<SessionCameraState>(() =>
     createSessionCameraState(plan),
   )
+  const [presentedTabId, setPresentedTabId] = useState(camera.activeTabId)
   const [syncKey, setSyncKey] = useState(0)
-  const lastSessionIdRef = useRef(replay.sessionId)
+  const lastPlanRef = useRef(plan)
   const lastGlobalPlayedRealMsRef = useRef(globalPlayback.playedRealMs)
 
   /**
-   * Live audit polling may append semantic candidates without changing rrweb
-   * event identity. Keep the current dwell/camera when its track still exists;
-   * only initialize anew for a different session or a newly playable replay.
+   * Live polling rebuilds an immutable plan. Camera cursors cannot be copied as
+   * raw indexes because a newly completed long dispatch can sort before them;
+   * rebasing translates the consumed window and admits newly observed work.
    */
   useEffect(() => {
-    const changedSession = lastSessionIdRef.current !== replay.sessionId
-    lastSessionIdRef.current = replay.sessionId
-    setCamera((current) => {
-      if (changedSession) return createSessionCameraState(plan)
-      const activeTrack =
-        current.activeTabId === null
-          ? undefined
-          : plan.tracksByTab.get(current.activeTabId)
-      if (
-        current.mode === 'inspect'
-          ? activeTrack !== undefined
-          : activeTrack?.hasFullSnapshot
-      ) {
-        return current
-      }
-      return createSessionCameraState(plan)
-    })
-  }, [plan, replay.sessionId])
+    const previousPlan = lastPlanRef.current
+    lastPlanRef.current = plan
+    setCamera((current) =>
+      rebaseSessionCameraState(previousPlan, plan, current),
+    )
+  }, [plan])
 
   /**
    * The clock exposes cumulative real playing time alongside session seconds.
@@ -253,7 +243,14 @@ function ReplaySession({ replay, navigate, location }: ReplaySessionProps) {
     [globalPlayback, toggleGlobalPlayback],
   )
 
-  const activeTrack = trackForCamera(plan, camera)
+  const cameraTrack = trackForCamera(plan, camera)
+  const presentedTrack =
+    presentedTabId === null ? undefined : plan.tracksByTab.get(presentedTabId)
+  useEffect(() => {
+    if (!cameraTrack?.hasFullSnapshot) {
+      setPresentedTabId(camera.activeTabId)
+    }
+  }, [camera.activeTabId, cameraTrack])
   const pendingTrack =
     camera.mode === 'follow' && camera.pendingTabId !== null
       ? plan.tracksByTab.get(camera.pendingTabId)
@@ -261,13 +258,19 @@ function ReplaySession({ replay, navigate, location }: ReplaySessionProps) {
   const activeSeconds =
     camera.mode === 'inspect'
       ? inspectPlayback.time
-      : activeTrack
-        ? projectGlobalTimeToTrack(activeTrack, globalPlayback.time)
+      : cameraTrack
+        ? projectGlobalTimeToTrack(cameraTrack, globalPlayback.time)
+        : 0
+  const presentedSeconds =
+    camera.mode === 'inspect' && presentedTabId === camera.activeTabId
+      ? inspectPlayback.time
+      : presentedTrack
+        ? projectGlobalTimeToTrack(presentedTrack, globalPlayback.time)
         : 0
   const pendingSeconds = pendingTrack
     ? projectGlobalTimeToTrack(pendingTrack, globalPlayback.time)
     : 0
-  const activeFrame = frameAt(activeTrack?.frames ?? [], activeSeconds)
+  const presentedFrame = frameAt(presentedTrack?.frames ?? [], presentedSeconds)
   const timelineSeconds =
     camera.mode === 'inspect'
       ? (camera.resumeGlobalSeconds ?? camera.globalSeconds)
@@ -280,10 +283,10 @@ function ReplaySession({ replay, navigate, location }: ReplaySessionProps) {
     camera.mode === 'inspect' ? inspectPlayback : sessionPlayback
   const transportTotalSeconds =
     camera.mode === 'inspect'
-      ? (activeTrack?.totalSeconds ?? 0)
+      ? (cameraTrack?.totalSeconds ?? 0)
       : plan.totalSeconds
   const transportFrames =
-    camera.mode === 'inspect' ? (activeTrack?.frames ?? []) : replay.frames
+    camera.mode === 'inspect' ? (cameraTrack?.frames ?? []) : replay.frames
   const transportLabel =
     camera.mode === 'inspect'
       ? `${tabLabel(plan, camera.activeTabId)} playback`
@@ -362,76 +365,22 @@ function ReplaySession({ replay, navigate, location }: ReplaySessionProps) {
 
       <div className="flex min-h-0 flex-1">
         <div className="flex min-w-0 flex-1 flex-col gap-3 p-4">
-          <div className="flex min-h-8 items-center justify-between gap-3">
-            {replay.tabs.length > 1 && camera.activeTabId !== null ? (
-              <Tabs
-                value={camera.activeTabId.toString()}
-                onValueChange={selectTab}
-              >
-                <TabsList variant="line">
-                  {replay.tabs.map(({ tabId }, index) => {
-                    const pinned =
-                      camera.mode === 'inspect' && camera.activeTabId === tabId
-                    return (
-                      <TabsTrigger
-                        key={tabId}
-                        value={tabId.toString()}
-                        aria-label={`Inspect Tab ${index + 1}`}
-                      >
-                        Tab {index + 1}
-                        {pinned ? ' · Pinned' : ''}
-                      </TabsTrigger>
-                    )
-                  })}
-                </TabsList>
-              </Tabs>
-            ) : (
-              <span />
-            )}
-            <div className="flex items-center gap-2">
-              <span role="status" className="font-semibold text-ink-3 text-xs">
-                {camera.mode === 'follow'
-                  ? 'Following session'
-                  : `Inspecting ${tabLabel(plan, camera.activeTabId)}`}
-              </span>
-              {camera.mode === 'inspect' && (
-                <button
-                  type="button"
-                  onClick={resumeSession}
-                  className="rounded-lg border border-border-2 bg-card px-2.5 py-1 font-semibold text-accent-ink text-xs hover:bg-accent-tint"
-                >
-                  Resume session
-                </button>
-              )}
-            </div>
-          </div>
+          <ReplayModeBar
+            tabs={replay.tabs}
+            plan={plan}
+            camera={camera}
+            presentedTabId={presentedTabId}
+            onSelectTab={selectTab}
+            onResume={resumeSession}
+          />
+          <RecordingWarning track={presentedTrack} />
 
-          {activeTrack?.incompleteUntilMs !== null &&
-            activeTrack?.incompleteUntilMs !== undefined && (
-              <div
-                role="status"
-                className="rounded-lg border border-amber/30 bg-amber-tint px-3 py-2 font-medium text-ink-2 text-xs"
-              >
-                Recording incomplete — playback starts at{' '}
-                {formatIncompleteOffset(activeTrack.incompleteUntilMs)}
-              </div>
-            )}
-          {activeTrack?.incompleteUntilMs === null &&
-            activeTrack.knownIncomplete && (
-              <div
-                role="status"
-                className="rounded-lg border border-amber/30 bg-amber-tint px-3 py-2 font-medium text-ink-2 text-xs"
-              >
-                Recording incomplete — this replay contains a known gap
-              </div>
-            )}
-
-          {activeTrack?.hasFullSnapshot ? (
+          {cameraTrack?.hasFullSnapshot ? (
             <>
               <ReplayViewport
                 site={replay.site}
-                frame={activeFrame}
-                activeTrack={activeTrack}
+                frame={presentedFrame}
+                activeTrack={cameraTrack}
                 standbyTrack={pendingTrack ?? null}
                 activeTimeMs={activeSeconds * 1000}
                 standbyTimeMs={pendingSeconds * 1000}
@@ -439,6 +388,7 @@ function ReplaySession({ replay, navigate, location }: ReplaySessionProps) {
                 speed={transport.speed}
                 syncKey={syncKey}
                 mode={camera.mode}
+                onPresentedTrackChange={setPresentedTabId}
               />
               <PlaybackTransport
                 playback={transport}
@@ -460,6 +410,95 @@ function ReplaySession({ replay, navigate, location }: ReplaySessionProps) {
           onSelectFrame={selectFrame}
         />
       </div>
+    </div>
+  )
+}
+
+interface ReplayModeBarProps {
+  tabs: ReplayData['tabs']
+  plan: SessionReplayPlan
+  camera: SessionCameraState
+  presentedTabId: number | null
+  onSelectTab: (tabId: string) => void
+  onResume: () => void
+}
+
+function ReplayModeBar({
+  tabs,
+  plan,
+  camera,
+  presentedTabId,
+  onSelectTab,
+  onResume,
+}: ReplayModeBarProps) {
+  return (
+    <div className="flex min-h-8 items-center justify-between gap-3">
+      {tabs.length > 1 && presentedTabId !== null ? (
+        <Tabs
+          value={presentedTabId.toString()}
+          onValueChange={(tabId) => {
+            if (tabId !== presentedTabId.toString()) onSelectTab(tabId)
+          }}
+        >
+          <TabsList variant="line">
+            {tabs.map(({ tabId }, index) => {
+              const pinned =
+                camera.mode === 'inspect' && camera.activeTabId === tabId
+              return (
+                <TabsTrigger
+                  key={tabId}
+                  value={tabId.toString()}
+                  aria-label={`Inspect Tab ${index + 1}`}
+                  // Base UI emits no value change for its selected trigger.
+                  // That click is still an inspection command in follow mode.
+                  onClick={
+                    camera.mode === 'follow' && presentedTabId === tabId
+                      ? () => onSelectTab(tabId.toString())
+                      : undefined
+                  }
+                >
+                  Tab {index + 1}
+                  {pinned ? ' · Pinned' : ''}
+                </TabsTrigger>
+              )
+            })}
+          </TabsList>
+        </Tabs>
+      ) : (
+        <span />
+      )}
+      <div className="flex items-center gap-2">
+        <span role="status" className="font-semibold text-ink-3 text-xs">
+          {camera.mode === 'follow'
+            ? 'Following session'
+            : `Inspecting ${tabLabel(plan, presentedTabId)}`}
+        </span>
+        {camera.mode === 'inspect' && (
+          <button
+            type="button"
+            onClick={onResume}
+            className="rounded-lg border border-border-2 bg-card px-2.5 py-1 font-semibold text-accent-ink text-xs hover:bg-accent-tint"
+          >
+            Resume session
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function RecordingWarning({ track }: { track: TabTrack | undefined }) {
+  if (!track?.knownIncomplete) return null
+  const message =
+    track.incompleteUntilMs === null
+      ? 'Recording incomplete — this replay contains a known gap'
+      : `Recording incomplete — playback starts at ${formatIncompleteOffset(track.incompleteUntilMs)}`
+  return (
+    <div
+      role="status"
+      className="rounded-lg border border-amber/30 bg-amber-tint px-3 py-2 font-medium text-ink-2 text-xs"
+    >
+      {message}
     </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -2,6 +2,11 @@
  * @license
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Session replay orchestration. BrowserClaw owns one global clock and a pure
+ * semantic camera; rrweb players are bounded visual sinks for the selected
+ * per-tab streams. Manual inspection deliberately switches to an independent
+ * local transport without rewriting the preserved session position.
  */
 
 import { ArrowLeft, History } from 'lucide-react'
@@ -13,155 +18,30 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import type { ReplayFrame } from '@/modules/api/replay.hooks'
 import { EventTimeline } from './EventTimeline'
 import { PlaybackTransport } from './PlaybackTransport'
-import { type ReplayPlayerHandle, ReplayViewport } from './ReplayViewport'
-import { buildTabView, EMPTY_TAB_VIEW, useReplayData } from './replay.data'
+import { ReplayViewport } from './ReplayViewport'
+import {
+  type ReplayData,
+  type UseReplayDataResult,
+  useReplayData,
+} from './replay.data'
 import { frameIndexAt } from './replay.helpers'
-import { tabSeekForFrame } from './tab-view'
+import {
+  createSessionCameraState,
+  type SessionCameraState,
+  sessionCameraReducer,
+} from './session-camera'
+import {
+  buildSessionReplayPlan,
+  projectGlobalTimeToTrack,
+  type SessionReplayPlan,
+  type TabTrack,
+} from './session-replay'
 import { usePlayback } from './use-playback'
 
-/** Renders the audit replay page and syncs rrweb playback to the transport UI. */
+/** Loads replay data, then keeps the stateful transport scoped to one session. */
 export function Replay() {
   const { replay, isLoading, navigate } = useReplayData()
   const location = useLocation()
-  const [selectedTabId, setSelectedTabId] = useState<number | null>(null)
-  const playerHandleRef = useRef<ReplayPlayerHandle | null>(null)
-  const playbackTimeRef = useRef(0)
-  const playbackSpeedRef = useRef(1)
-  const playbackIsPlayingRef = useRef(true)
-  const pendingTabSeekRef = useRef<number | null>(null)
-
-  useEffect(() => {
-    if (!replay) return
-    const firstTab = replay.tabs[0]
-    if (!firstTab) {
-      if (selectedTabId !== null) {
-        pendingTabSeekRef.current = 0
-        setSelectedTabId(null)
-      }
-      return
-    }
-    const selectedTab = replay.tabs.find((tab) => tab.tabId === selectedTabId)
-    if (!selectedTab) {
-      if (selectedTabId !== null) pendingTabSeekRef.current = 0
-      setSelectedTabId(firstTab.tabId)
-    }
-  }, [replay, selectedTabId])
-
-  const tabViewInput = useMemo(
-    () =>
-      replay
-        ? {
-            frames: replay.frames,
-            tabs: replay.tabs,
-            eventsForTab: replay.eventsForTab,
-            startedAtMs: replay.startedAtMs,
-          }
-        : null,
-    [replay],
-  )
-  const perTabView = useMemo(
-    () =>
-      tabViewInput ? buildTabView(tabViewInput, selectedTabId) : EMPTY_TAB_VIEW,
-    [selectedTabId, tabViewInput],
-  )
-
-  const playbackTotalSeconds = perTabView.hasFullSnapshot
-    ? perTabView.totalSeconds
-    : 0
-  const playback = usePlayback(playbackTotalSeconds)
-
-  useEffect(() => {
-    playbackTimeRef.current = playback.time
-  }, [playback.time])
-
-  useEffect(() => {
-    playbackSpeedRef.current = playback.speed
-    playerHandleRef.current?.setSpeed(playback.speed)
-  }, [playback.speed])
-
-  useEffect(() => {
-    playbackIsPlayingRef.current = playback.isPlaying
-  }, [playback.isPlaying])
-
-  useEffect(() => {
-    if (!playerHandleRef.current) return
-    if (playback.isPlaying) {
-      playerHandleRef.current.play(playbackTimeRef.current * 1000)
-    } else {
-      playerHandleRef.current.pause()
-    }
-  }, [playback.isPlaying])
-
-  useEffect(() => {
-    if (!playback.isPlaying || playbackTotalSeconds === 0) return
-    let rafId = 0
-    let active = true
-    const sync = () => {
-      if (!active) return
-      const handle = playerHandleRef.current
-      const keepGoing = handle
-        ? playback.syncFromPlayer(handle.getCurrentTime() / 1000)
-        : true
-      if (keepGoing) rafId = window.requestAnimationFrame(sync)
-    }
-    rafId = window.requestAnimationFrame(sync)
-    return () => {
-      active = false
-      window.cancelAnimationFrame(rafId)
-    }
-  }, [playback.isPlaying, playback.syncFromPlayer, playbackTotalSeconds])
-
-  const seekTo = useCallback(
-    (seconds: number) => {
-      const next = playback.seek(seconds)
-      playbackTimeRef.current = next
-      playbackIsPlayingRef.current = false
-      playerHandleRef.current?.seek(next * 1000)
-    },
-    [playback.seek],
-  )
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: tab changes must flush pending seeks even when consecutive tabs have the same duration.
-  useEffect(() => {
-    const pendingSeconds = pendingTabSeekRef.current
-    if (pendingSeconds === null) return
-    pendingTabSeekRef.current = null
-    seekTo(pendingSeconds)
-  }, [seekTo, selectedTabId])
-
-  const selectTab = useCallback(
-    (value: string) => {
-      const tabId = Number(value)
-      if (!replay || !Number.isSafeInteger(tabId)) return
-      if (tabId === selectedTabId) return
-      pendingTabSeekRef.current = 0
-      setSelectedTabId(tabId)
-    },
-    [replay, selectedTabId],
-  )
-
-  const selectFrame = useCallback(
-    (frame: ReplayFrame) => {
-      if (!tabViewInput) return
-      const tabSeek = tabSeekForFrame(tabViewInput, selectedTabId, frame)
-      if (tabSeek.tabId !== null && tabSeek.tabId !== selectedTabId) {
-        pendingTabSeekRef.current = tabSeek.seconds
-        setSelectedTabId(tabSeek.tabId)
-        return
-      }
-      seekTo(tabSeek.seconds)
-    },
-    [seekTo, selectedTabId, tabViewInput],
-  )
-
-  const onPlayerReady = useCallback((handle: ReplayPlayerHandle | null) => {
-    playerHandleRef.current = handle
-    if (!handle) return
-    const ms = playbackTimeRef.current * 1000
-    handle.setSpeed(playbackSpeedRef.current)
-    handle.seek(ms)
-    if (playbackIsPlayingRef.current) handle.play(ms)
-  }, [])
 
   if (isLoading || !replay) {
     return (
@@ -170,6 +50,251 @@ export function Replay() {
       </div>
     )
   }
+
+  return (
+    <ReplaySession
+      key={replay.sessionId}
+      replay={replay}
+      navigate={navigate}
+      location={location}
+    />
+  )
+}
+
+interface ReplaySessionProps {
+  replay: ReplayData
+  navigate: UseReplayDataResult['navigate']
+  location: ReturnType<typeof useLocation>
+}
+
+function ReplaySession({ replay, navigate, location }: ReplaySessionProps) {
+  const plan = useMemo(
+    () =>
+      buildSessionReplayPlan({
+        totalSeconds: replay.totalSeconds,
+        frames: replay.frames,
+        tabs: replay.tabs,
+        eventsForTab: replay.eventsForTab,
+        startedAtMs: replay.startedAtMs,
+      }),
+    [
+      replay.eventsForTab,
+      replay.frames,
+      replay.startedAtMs,
+      replay.tabs,
+      replay.totalSeconds,
+    ],
+  )
+  const globalPlayback = usePlayback(plan.totalSeconds)
+  const [camera, setCamera] = useState<SessionCameraState>(() =>
+    createSessionCameraState(plan),
+  )
+  const [syncKey, setSyncKey] = useState(0)
+  const lastSessionIdRef = useRef(replay.sessionId)
+  const lastGlobalPlayedRealMsRef = useRef(globalPlayback.playedRealMs)
+
+  /**
+   * Live audit polling may append semantic candidates without changing rrweb
+   * event identity. Keep the current dwell/camera when its track still exists;
+   * only initialize anew for a different session or a newly playable replay.
+   */
+  useEffect(() => {
+    const changedSession = lastSessionIdRef.current !== replay.sessionId
+    lastSessionIdRef.current = replay.sessionId
+    setCamera((current) => {
+      if (changedSession) return createSessionCameraState(plan)
+      const activeTrack =
+        current.activeTabId === null
+          ? undefined
+          : plan.tracksByTab.get(current.activeTabId)
+      if (
+        current.mode === 'inspect'
+          ? activeTrack !== undefined
+          : activeTrack?.hasFullSnapshot
+      ) {
+        return current
+      }
+      return createSessionCameraState(plan)
+    })
+  }, [plan, replay.sessionId])
+
+  /**
+   * The clock exposes cumulative real playing time alongside session seconds.
+   * Feeding the delta into the camera avoids a second animation loop and keeps
+   * ten seconds of dwell equal at 1x, 2x, and 4x. A final delta charged while
+   * pausing is applied before the state's visible playing flag is cleared.
+   */
+  useEffect(() => {
+    const realDeltaMs = Math.max(
+      0,
+      globalPlayback.playedRealMs - lastGlobalPlayedRealMsRef.current,
+    )
+    lastGlobalPlayedRealMsRef.current = globalPlayback.playedRealMs
+    setCamera((current) => {
+      if (current.mode !== 'follow') return current
+      const advanced = sessionCameraReducer(plan, current, {
+        type: 'tick',
+        globalSeconds: globalPlayback.time,
+        realDeltaMs,
+        playing: globalPlayback.isPlaying || realDeltaMs > 0,
+      })
+      return advanced.isPlaying === globalPlayback.isPlaying
+        ? advanced
+        : { ...advanced, isPlaying: globalPlayback.isPlaying }
+    })
+  }, [
+    globalPlayback.isPlaying,
+    globalPlayback.playedRealMs,
+    globalPlayback.time,
+    plan,
+  ])
+
+  const inspectedTrack =
+    camera.inspectTabId === null
+      ? undefined
+      : plan.tracksByTab.get(camera.inspectTabId)
+  const inspectPlayback = usePlayback(
+    camera.mode === 'inspect' && inspectedTrack?.hasFullSnapshot
+      ? inspectedTrack.totalSeconds
+      : 0,
+  )
+
+  const requestViewportSync = useCallback(() => {
+    setSyncKey((current) => current + 1)
+  }, [])
+
+  const seekGlobal = useCallback(
+    (seconds: number) => {
+      const applied = globalPlayback.seek(seconds)
+      setCamera((current) =>
+        sessionCameraReducer(plan, current, {
+          type: 'seek',
+          globalSeconds: applied,
+        }),
+      )
+      inspectPlayback.seek(0)
+      requestViewportSync()
+    },
+    [globalPlayback.seek, inspectPlayback.seek, plan, requestViewportSync],
+  )
+
+  const selectFrame = useCallback(
+    (frame: ReplayFrame) => {
+      const applied = globalPlayback.seek(frame.t)
+      setCamera((current) =>
+        sessionCameraReducer(plan, current, {
+          type: 'select-frame',
+          frame: { ...frame, t: applied },
+        }),
+      )
+      inspectPlayback.seek(0)
+      requestViewportSync()
+    },
+    [globalPlayback.seek, inspectPlayback.seek, plan, requestViewportSync],
+  )
+
+  const selectTab = useCallback(
+    (value: string) => {
+      const tabId = Number(value)
+      if (!Number.isSafeInteger(tabId) || !plan.tracksByTab.has(tabId)) return
+      if (camera.mode === 'inspect' && camera.inspectTabId === tabId) return
+      const preservedGlobalSeconds = globalPlayback.pause()
+      inspectPlayback.seek(0)
+      setCamera((current) =>
+        sessionCameraReducer(plan, current, {
+          type: 'inspect',
+          tabId,
+          globalSeconds: current.resumeGlobalSeconds ?? preservedGlobalSeconds,
+        }),
+      )
+      requestViewportSync()
+    },
+    [
+      camera.inspectTabId,
+      camera.mode,
+      globalPlayback.pause,
+      inspectPlayback.seek,
+      plan,
+      requestViewportSync,
+    ],
+  )
+
+  const resumeSession = useCallback(() => {
+    const resumed = sessionCameraReducer(plan, camera, { type: 'resume' })
+    globalPlayback.seek(resumed.globalSeconds)
+    inspectPlayback.seek(0)
+    setCamera(resumed)
+    requestViewportSync()
+  }, [
+    camera,
+    globalPlayback.seek,
+    inspectPlayback.seek,
+    plan,
+    requestViewportSync,
+  ])
+
+  const toggleGlobalPlayback = useCallback(() => {
+    if (plan.totalSeconds > 0 && globalPlayback.time >= plan.totalSeconds) {
+      setCamera((current) =>
+        sessionCameraReducer(plan, current, { type: 'restart' }),
+      )
+      requestViewportSync()
+    }
+    globalPlayback.togglePlay()
+  }, [
+    globalPlayback.time,
+    globalPlayback.togglePlay,
+    plan,
+    requestViewportSync,
+  ])
+
+  const sessionPlayback = useMemo(
+    () => ({ ...globalPlayback, togglePlay: toggleGlobalPlayback }),
+    [globalPlayback, toggleGlobalPlayback],
+  )
+
+  const activeTrack = trackForCamera(plan, camera)
+  const pendingTrack =
+    camera.mode === 'follow' && camera.pendingTabId !== null
+      ? plan.tracksByTab.get(camera.pendingTabId)
+      : undefined
+  const activeSeconds =
+    camera.mode === 'inspect'
+      ? inspectPlayback.time
+      : activeTrack
+        ? projectGlobalTimeToTrack(activeTrack, globalPlayback.time)
+        : 0
+  const pendingSeconds = pendingTrack
+    ? projectGlobalTimeToTrack(pendingTrack, globalPlayback.time)
+    : 0
+  const activeFrame = frameAt(activeTrack?.frames ?? [], activeSeconds)
+  const timelineSeconds =
+    camera.mode === 'inspect'
+      ? (camera.resumeGlobalSeconds ?? camera.globalSeconds)
+      : globalPlayback.time
+  const currentTimelineFrameIndex =
+    replay.frames.length === 0
+      ? -1
+      : frameIndexAt(replay.frames, timelineSeconds)
+  const transport =
+    camera.mode === 'inspect' ? inspectPlayback : sessionPlayback
+  const transportTotalSeconds =
+    camera.mode === 'inspect'
+      ? (activeTrack?.totalSeconds ?? 0)
+      : plan.totalSeconds
+  const transportFrames =
+    camera.mode === 'inspect' ? (activeTrack?.frames ?? []) : replay.frames
+  const transportLabel =
+    camera.mode === 'inspect'
+      ? `${tabLabel(plan, camera.activeTabId)} playback`
+      : 'Session playback'
+  const seekTransport =
+    camera.mode === 'inspect'
+      ? (seconds: number) => {
+          inspectPlayback.seek(seconds)
+          requestViewportSync()
+        }
+      : seekGlobal
 
   // navigate(-1) preserves task detail's original location.state.from
   // (the entry we're moving back to is re-focused, not re-created), so
@@ -190,14 +315,6 @@ export function Replay() {
     typeof (location.state as { from: unknown }).from === 'string'
   const back = () =>
     cameFromInAppFlow ? navigate(-1) : navigate(`/audit/${replay.sessionId}`)
-  const currentTabFrameIndex = frameIndexAt(perTabView.frames, playback.time)
-  const currentTabFrame = perTabView.frames[currentTabFrameIndex]
-  const currentTimelineFrameIndex =
-    currentTabFrame?.dispatchId !== undefined
-      ? replay.frames.findIndex(
-          (frame) => frame.dispatchId === currentTabFrame.dispatchId,
-        )
-      : -1
   const stats: { label: string; value: string }[] = [
     { label: 'Duration', value: replay.duration },
     { label: 'Steps', value: replay.steps },
@@ -245,28 +362,62 @@ export function Replay() {
 
       <div className="flex min-h-0 flex-1">
         <div className="flex min-w-0 flex-1 flex-col gap-3 p-4">
-          {replay.tabs.length > 1 && selectedTabId !== null && (
-            <Tabs value={selectedTabId.toString()} onValueChange={selectTab}>
-              <TabsList variant="line">
-                {replay.tabs.map(({ tabId }, idx) => (
-                  <TabsTrigger key={tabId} value={tabId.toString()}>
-                    Tab {idx + 1}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
-            </Tabs>
-          )}
-          {perTabView.incompleteUntilMs !== null && (
-            <div
-              role="status"
-              className="rounded-lg border border-amber/30 bg-amber-tint px-3 py-2 font-medium text-ink-2 text-xs"
-            >
-              Recording incomplete — playback starts at{' '}
-              {formatIncompleteOffset(perTabView.incompleteUntilMs)}
+          <div className="flex min-h-8 items-center justify-between gap-3">
+            {replay.tabs.length > 1 && camera.activeTabId !== null ? (
+              <Tabs
+                value={camera.activeTabId.toString()}
+                onValueChange={selectTab}
+              >
+                <TabsList variant="line">
+                  {replay.tabs.map(({ tabId }, index) => {
+                    const pinned =
+                      camera.mode === 'inspect' && camera.activeTabId === tabId
+                    return (
+                      <TabsTrigger
+                        key={tabId}
+                        value={tabId.toString()}
+                        aria-label={`Inspect Tab ${index + 1}`}
+                      >
+                        Tab {index + 1}
+                        {pinned ? ' · Pinned' : ''}
+                      </TabsTrigger>
+                    )
+                  })}
+                </TabsList>
+              </Tabs>
+            ) : (
+              <span />
+            )}
+            <div className="flex items-center gap-2">
+              <span role="status" className="font-semibold text-ink-3 text-xs">
+                {camera.mode === 'follow'
+                  ? 'Following session'
+                  : `Inspecting ${tabLabel(plan, camera.activeTabId)}`}
+              </span>
+              {camera.mode === 'inspect' && (
+                <button
+                  type="button"
+                  onClick={resumeSession}
+                  className="rounded-lg border border-border-2 bg-card px-2.5 py-1 font-semibold text-accent-ink text-xs hover:bg-accent-tint"
+                >
+                  Resume session
+                </button>
+              )}
             </div>
-          )}
-          {perTabView.incompleteUntilMs === null &&
-            perTabView.knownIncomplete && (
+          </div>
+
+          {activeTrack?.incompleteUntilMs !== null &&
+            activeTrack?.incompleteUntilMs !== undefined && (
+              <div
+                role="status"
+                className="rounded-lg border border-amber/30 bg-amber-tint px-3 py-2 font-medium text-ink-2 text-xs"
+              >
+                Recording incomplete — playback starts at{' '}
+                {formatIncompleteOffset(activeTrack.incompleteUntilMs)}
+              </div>
+            )}
+          {activeTrack?.incompleteUntilMs === null &&
+            activeTrack.knownIncomplete && (
               <div
                 role="status"
                 className="rounded-lg border border-amber/30 bg-amber-tint px-3 py-2 font-medium text-ink-2 text-xs"
@@ -274,19 +425,27 @@ export function Replay() {
                 Recording incomplete — this replay contains a known gap
               </div>
             )}
-          {perTabView.hasFullSnapshot ? (
+
+          {activeTrack?.hasFullSnapshot ? (
             <>
               <ReplayViewport
                 site={replay.site}
-                frame={currentTabFrame}
-                events={perTabView.events}
-                onPlayerReady={onPlayerReady}
+                frame={activeFrame}
+                activeTrack={activeTrack}
+                standbyTrack={pendingTrack ?? null}
+                activeTimeMs={activeSeconds * 1000}
+                standbyTimeMs={pendingSeconds * 1000}
+                isPlaying={transport.isPlaying}
+                speed={transport.speed}
+                syncKey={syncKey}
+                mode={camera.mode}
               />
               <PlaybackTransport
-                playback={playback}
-                totalSeconds={perTabView.totalSeconds}
-                frames={perTabView.frames}
-                onSeek={seekTo}
+                playback={transport}
+                totalSeconds={transportTotalSeconds}
+                frames={transportFrames}
+                onSeek={seekTransport}
+                transportLabel={transportLabel}
               />
             </>
           ) : (
@@ -303,6 +462,27 @@ export function Replay() {
       </div>
     </div>
   )
+}
+
+function trackForCamera(
+  plan: SessionReplayPlan,
+  camera: SessionCameraState,
+): TabTrack | undefined {
+  return camera.activeTabId === null
+    ? undefined
+    : plan.tracksByTab.get(camera.activeTabId)
+}
+
+function frameAt(
+  frames: readonly ReplayFrame[],
+  seconds: number,
+): ReplayFrame | undefined {
+  return frames.length === 0 ? undefined : frames[frameIndexAt(frames, seconds)]
+}
+
+function tabLabel(plan: SessionReplayPlan, tabId: number | null): string {
+  const index = plan.tracks.findIndex((track) => track.tabId === tabId)
+  return index === -1 ? 'tab' : `Tab ${index + 1}`
 }
 
 function formatIncompleteOffset(milliseconds: number): string {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayPlayer.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayPlayer.test.tsx
@@ -204,18 +204,21 @@ describe('ReplayPlayer', () => {
   })
 
   it('exposes clamped seek, play, pause, speed, and current-time controls', async () => {
-    let handle: ReplayPlayerHandle | null = null
+    const handles: Array<ReplayPlayerHandle | null> = []
     const { ReplayPlayer } = await import('./ReplayPlayer')
     await act(async () => {
       root?.render(
         <ReplayPlayer
           events={events}
           onReady={(nextHandle) => {
-            handle = nextHandle
+            handles.push(nextHandle)
           }}
         />,
       )
     })
+    const handle = handles.find(
+      (candidate): candidate is ReplayPlayerHandle => candidate !== null,
+    )
     if (!handle) throw new Error('expected ReplayPlayer handle')
 
     handle.seek(0)

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayPlayer.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayPlayer.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { parseHTML } from 'linkedom'
+import { act, StrictMode } from 'react'
+import type { Root } from 'react-dom/client'
+import type { ReplayEvent } from '@/modules/api/replay.hooks'
+import type { ReplayPlayerHandle } from './ReplayPlayer'
+
+interface ReplayerConfig {
+  root: HTMLElement
+}
+
+class FakeResizeObserver {
+  disconnected = false
+
+  constructor(_callback: ResizeObserverCallback) {
+    fakeResizeObservers.push(this)
+  }
+
+  observe(_target: Element): void {}
+
+  disconnect(): void {
+    this.disconnected = true
+  }
+}
+
+class FakeReplayer {
+  readonly marker: HTMLElement
+  readonly pauseCalls: number[] = []
+  readonly playCalls: number[] = []
+  readonly speeds: number[] = []
+  destroyed = false
+
+  constructor(_events: unknown[], config: ReplayerConfig) {
+    this.marker = document.createElement('div')
+    this.marker.dataset.fakeReplayer = String(fakeReplayers.length + 1)
+    this.marker.className = 'replayer-wrapper'
+    config.root.append(this.marker)
+    fakeReplayers.push(this)
+  }
+
+  pause(ms?: number): void {
+    if (ms !== undefined) this.pauseCalls.push(ms)
+  }
+
+  play(ms = 0): void {
+    this.playCalls.push(ms)
+  }
+
+  setConfig({ speed }: { speed: number }): void {
+    this.speeds.push(speed)
+  }
+
+  getCurrentTime(): number {
+    return 321
+  }
+
+  destroy(): void {
+    this.destroyed = true
+    this.marker.remove()
+  }
+}
+
+const fakeReplayers: FakeReplayer[] = []
+const fakeResizeObservers: FakeResizeObserver[] = []
+
+mock.module('rrweb', () => ({ Replayer: FakeReplayer }))
+
+const globalDescriptors = new Map(
+  [
+    'window',
+    'document',
+    'navigator',
+    'HTMLElement',
+    'Node',
+    'Event',
+    'ResizeObserver',
+  ].map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
+)
+
+const events: ReplayEvent[] = [
+  {
+    sessionId: 'session-1',
+    documentId: 'document-a',
+    targetId: 'target-a',
+    tabId: 1,
+    ts: 1_000,
+    type: 4,
+    data: { width: 1280, height: 720 },
+  },
+  {
+    sessionId: 'session-1',
+    documentId: 'document-a',
+    targetId: 'target-a',
+    tabId: 1,
+    ts: 1_001,
+    type: 2,
+    data: {},
+  },
+]
+
+let root: Root | null
+let container: HTMLElement
+
+beforeEach(async () => {
+  fakeReplayers.length = 0
+  fakeResizeObservers.length = 0
+  const dom = parseHTML(
+    '<!doctype html><html><body><div id="root"></div></body></html>',
+  )
+  const globals = {
+    window: dom.window,
+    document: dom.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+    ResizeObserver: FakeResizeObserver,
+  }
+  for (const [name, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    })
+  }
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  })
+
+  container = dom.document.getElementById('root') as unknown as HTMLElement
+  const { createRoot } = await import('react-dom/client')
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  for (const [name, descriptor] of globalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor)
+    else Reflect.deleteProperty(globalThis, name)
+  }
+  Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
+})
+
+describe('ReplayPlayer', () => {
+  it('owns one live Replayer across Strict Mode setup, replacement, and unmount', async () => {
+    const readyValues: Array<ReplayPlayerHandle | null> = []
+    const { ReplayPlayer } = await import('./ReplayPlayer')
+
+    await act(async () => {
+      root?.render(
+        <StrictMode>
+          <ReplayPlayer
+            events={events}
+            onReady={(handle) => readyValues.push(handle)}
+          />
+        </StrictMode>,
+      )
+    })
+
+    expect(fakeReplayers).toHaveLength(2)
+    expect(
+      fakeReplayers.filter((replayer) => !replayer.destroyed),
+    ).toHaveLength(1)
+    expect(readyValues.at(-1)).not.toBeNull()
+
+    const firstLiveReplayer = fakeReplayers.find(
+      (replayer) => !replayer.destroyed,
+    )
+    const replacementEvents = events.map((event) => ({
+      ...event,
+      documentId: 'document-b',
+    }))
+    await act(async () => {
+      root?.render(
+        <StrictMode>
+          <ReplayPlayer
+            events={replacementEvents}
+            onReady={(handle) => readyValues.push(handle)}
+          />
+        </StrictMode>,
+      )
+    })
+
+    expect(firstLiveReplayer?.destroyed).toBe(true)
+    expect(
+      fakeReplayers.filter((replayer) => !replayer.destroyed),
+    ).toHaveLength(1)
+
+    await act(async () => root?.unmount())
+    root = null
+    expect(fakeReplayers.every((replayer) => replayer.destroyed)).toBe(true)
+    expect(fakeResizeObservers.every((observer) => observer.disconnected)).toBe(
+      true,
+    )
+    expect(readyValues.at(-1)).toBeNull()
+  })
+
+  it('exposes clamped seek, play, pause, speed, and current-time controls', async () => {
+    let handle: ReplayPlayerHandle | null = null
+    const { ReplayPlayer } = await import('./ReplayPlayer')
+    await act(async () => {
+      root?.render(
+        <ReplayPlayer
+          events={events}
+          onReady={(nextHandle) => {
+            handle = nextHandle
+          }}
+        />,
+      )
+    })
+    if (!handle) throw new Error('expected ReplayPlayer handle')
+
+    handle.seek(0)
+    handle.play(50)
+    handle.pause()
+    handle.setSpeed(4)
+
+    const replayer = fakeReplayers.at(-1)
+    expect(replayer?.pauseCalls).toEqual([1])
+    expect(replayer?.playCalls).toEqual([50])
+    expect(replayer?.speeds).toEqual([4])
+    expect(handle.getCurrentTime()).toBe(321)
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayPlayer.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayPlayer.tsx
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * One rrweb stream and its imperative lifetime. ReplayViewport composes two of
+ * these primitives, but this component knows nothing about active/standby
+ * roles so every constructed Replayer still has one owner and one cleanup.
+ */
+
+import { useEffect, useRef } from 'react'
+import type { ReplayEvent } from '@/modules/api/replay.hooks'
+
+import 'rrweb-player/dist/style.css'
+// We use rrweb's Replayer directly. The rrweb-player wrapper at v2.x
+// publishes a broken bundle: its built JS has no `new Replayer(...)`
+// call AND no import statement for @rrweb/replay, so the wrapper's
+// Player.svelte never instantiates a Replayer (the `replayer` Svelte
+// state stays undefined, the Controller `{#if replayer}` block never
+// renders, the player-frame div stays empty). The rrweb package
+// itself bundles Replayer cleanly; we mount it ourselves and skip
+// the wrapper. rrweb-player's CSS is still imported for the
+// `.replayer-wrapper` styling.
+import { Replayer } from 'rrweb'
+
+export interface ReplayPlayerHandle {
+  seek(ms: number): void
+  play(ms: number): void
+  pause(): void
+  setSpeed(speed: number): void
+  getCurrentTime(): number
+}
+
+export interface ReplayPlayerProps {
+  events: readonly ReplayEvent[]
+  onReady: (handle: ReplayPlayerHandle | null) => void
+}
+
+/**
+ * Fallback DOM viewport for pages that never emitted a meta event.
+ * rrweb ALWAYS emits type 4 as its first event under normal
+ * conditions, so this is defensive.
+ */
+const DEFAULT_RECORDED_SIZE = { width: 1280, height: 720 }
+// rrweb casts events strictly before the target; 0ms can leave the first
+// snapshot blank while paused.
+const MIN_RENDER_SEEK_MS = 1
+
+function readRecordedSize(events: readonly ReplayEvent[]): {
+  width: number
+  height: number
+} {
+  const meta = events.find((event) => event.type === 4)
+  const data = meta?.data as { width?: unknown; height?: unknown } | undefined
+  const width =
+    typeof data?.width === 'number' && data.width > 0
+      ? data.width
+      : DEFAULT_RECORDED_SIZE.width
+  const height =
+    typeof data?.height === 'number' && data.height > 0
+      ? data.height
+      : DEFAULT_RECORDED_SIZE.height
+  return { width, height }
+}
+
+/** Mounts rrweb's imperative Replayer and exposes the narrow playback handle. */
+export function ReplayPlayer({ events, onReady }: ReplayPlayerProps) {
+  const mountRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const mount = mountRef.current
+    if (!mount || events.length < 2) return
+
+    const rrwebEvents = events.map((event) => ({
+      type: event.type,
+      data: event.data,
+      timestamp: event.ts,
+      // biome-ignore lint/suspicious/noExplicitAny: rrweb's event union is wide; we trust the recorder's output shape.
+    })) as any[]
+
+    mount.replaceChildren()
+    let replayer: Replayer
+    try {
+      replayer = new Replayer(rrwebEvents, {
+        root: mount,
+        speed: 1,
+        skipInactive: false,
+        showWarning: false,
+      })
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('[browseros-claw replay] Replayer ctor threw', error)
+      return
+    }
+
+    const { width: recordedWidth, height: recordedHeight } =
+      readRecordedSize(events)
+    const wrapper = mount.querySelector<HTMLElement>('.replayer-wrapper')
+    let observer: ResizeObserver | null = null
+    if (wrapper) {
+      wrapper.style.position = 'absolute'
+      wrapper.style.transformOrigin = 'top left'
+      const applyScale = (): void => {
+        const rect = mount.getBoundingClientRect()
+        if (rect.width === 0 || rect.height === 0) return
+        const scale = Math.min(
+          rect.width / recordedWidth,
+          rect.height / recordedHeight,
+        )
+        const scaledWidth = recordedWidth * scale
+        const scaledHeight = recordedHeight * scale
+        wrapper.style.transform = `scale(${scale})`
+        wrapper.style.left = `${Math.max(0, (rect.width - scaledWidth) / 2)}px`
+        wrapper.style.top = `${Math.max(0, (rect.height - scaledHeight) / 2)}px`
+      }
+      applyScale()
+      observer = new ResizeObserver(applyScale)
+      observer.observe(mount)
+    }
+
+    onReady({
+      seek: (ms) => replayer.pause(Math.max(MIN_RENDER_SEEK_MS, ms)),
+      play: (ms) => replayer.play(ms),
+      pause: () => replayer.pause(),
+      setSpeed: (speed) => replayer.setConfig({ speed }),
+      getCurrentTime: () => replayer.getCurrentTime(),
+    })
+    return () => {
+      onReady(null)
+      observer?.disconnect()
+      try {
+        replayer.destroy()
+      } catch {
+        // ignore; we're tearing down anyway
+      }
+      mount.replaceChildren()
+    }
+  }, [events, onReady])
+
+  return (
+    <div
+      ref={mountRef}
+      className="relative h-full w-full overflow-hidden"
+      data-replay-canvas
+    />
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.test.tsx
@@ -207,6 +207,7 @@ async function renderViewport(
     speed: 2,
     syncKey: 0,
     mode: 'follow',
+    onPresentedTrackChange: () => {},
     ...overrides,
   }
   await act(async () => root?.render(<ReplayViewport {...props} />))
@@ -320,6 +321,52 @@ describe('ReplayViewport', () => {
         .querySelector('[data-replay-slot-active="true"]')
         ?.getAttribute('data-replay-tab-id'),
     ).toBe('3')
+  })
+
+  it('keeps presentation and drift ownership on the old slot until delayed promotion commits', async () => {
+    immediatelyReadyTabs.add(1)
+    const presentedTabs: number[] = []
+    const onPresentedTrackChange = (tabId: number) => {
+      presentedTabs.push(tabId)
+    }
+    await renderViewport({ onPresentedTrackChange })
+    const tabOnePlayer = fakePlayers.find(
+      ({ tabId, destroyed }) => tabId === 1 && !destroyed,
+    )
+    const tabTwoPlayer = fakePlayers.find(
+      ({ tabId, destroyed }) => tabId === 2 && !destroyed,
+    )
+    if (!tabOnePlayer || !tabTwoPlayer) {
+      throw new Error('expected active and delayed standby')
+    }
+    expect(presentedTabs.at(-1)).toBe(1)
+
+    nowMs = 2_000
+    await renderViewport({
+      activeTrack: tabTwo,
+      standbyTrack: null,
+      activeTimeMs: 8_000,
+      onPresentedTrackChange,
+    })
+
+    expect(tabOnePlayer.handle.running).toBe(true)
+    expect(tabOnePlayer.handle.seekCalls).not.toContain(8_000)
+    expect(presentedTabs.at(-1)).toBe(1)
+    expect(
+      container
+        .querySelector('[data-replay-slot-active="true"]')
+        ?.getAttribute('data-replay-tab-id'),
+    ).toBe('1')
+
+    await act(async () => tabTwoPlayer.ready())
+    expect(presentedTabs.at(-1)).toBe(2)
+    expect(tabOnePlayer.handle.running).toBe(false)
+    expect(tabTwoPlayer.handle.seekCalls).toContain(8_000)
+    expect(
+      container
+        .querySelector('[data-replay-slot-active="true"]')
+        ?.getAttribute('data-replay-tab-id'),
+    ).toBe('2')
   })
 
   it('keeps rapid pending churn within two live player instances', async () => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.test.tsx
@@ -1,77 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { parseHTML } from 'linkedom'
-import { act, StrictMode } from 'react'
+import { act, useEffect, useMemo } from 'react'
 import type { Root } from 'react-dom/client'
 import type { ReplayEvent } from '@/modules/api/replay.hooks'
-import type { ReplayPlayerHandle } from './ReplayViewport'
+import type { ReplayPlayerHandle, ReplayPlayerProps } from './ReplayPlayer'
+import type { ReplayViewportTrack } from './ReplayViewport'
 
-interface ReplayerConfig {
-  root: HTMLElement
+interface FakeHandle extends ReplayPlayerHandle {
+  running: boolean
+  currentTime: number
+  destroyed: boolean
+  pauseCalls: number
+  playCalls: number[]
+  seekCalls: number[]
+  speedCalls: number[]
 }
 
-class FakeReplayer {
-  readonly marker: HTMLElement
-  destroyed = false
+interface FakePlayer {
+  tabId: number
+  handle: FakeHandle
+  destroyed: boolean
+  ready: () => void
+}
 
-  constructor(_events: unknown[], config: ReplayerConfig) {
-    this.marker = document.createElement('div')
-    this.marker.dataset.fakeReplayer = String(fakeReplayers.length + 1)
-    config.root.append(this.marker)
-    fakeReplayers.push(this)
-  }
+const fakePlayers: FakePlayer[] = []
+const immediatelyReadyTabs = new Set<number>()
 
-  pause(_ms?: number): void {}
-
-  play(_ms?: number): void {}
-
-  setConfig(_config: { speed: number }): void {}
-
-  getCurrentTime(): number {
-    return 0
-  }
-
-  destroy(): void {
-    this.destroyed = true
-    this.marker.remove()
+function createHandle(): FakeHandle {
+  return {
+    running: false,
+    currentTime: 0,
+    destroyed: false,
+    pauseCalls: 0,
+    playCalls: [],
+    seekCalls: [],
+    speedCalls: [],
+    seek(ms) {
+      this.currentTime = ms
+      this.running = false
+      this.seekCalls.push(ms)
+    },
+    play(ms) {
+      this.currentTime = ms
+      this.running = true
+      this.playCalls.push(ms)
+    },
+    pause() {
+      this.running = false
+      this.pauseCalls += 1
+    },
+    setSpeed(speed) {
+      this.speedCalls.push(speed)
+    },
+    getCurrentTime() {
+      return this.currentTime
+    },
   }
 }
 
-const fakeReplayers: FakeReplayer[] = []
+function FakeReplayPlayer({ events, onReady }: ReplayPlayerProps) {
+  const tabId = events[0]?.tabId ?? -1
+  const player = useMemo<FakePlayer>(() => {
+    const handle = createHandle()
+    const empty = tabId === -1
+    handle.destroyed = empty
+    const instance = {
+      tabId,
+      handle,
+      destroyed: empty,
+      ready: () => onReady(handle),
+    }
+    fakePlayers.push(instance)
+    return instance
+  }, [onReady, tabId])
 
-mock.module('rrweb', () => ({ Replayer: FakeReplayer }))
+  useEffect(() => {
+    if (events.length < 2) return
+    if (immediatelyReadyTabs.has(tabId)) player.ready()
+    return () => {
+      player.destroyed = true
+      player.handle.destroyed = true
+      player.handle.pause()
+      onReady(null)
+    }
+  }, [events.length, onReady, player, tabId])
+
+  return <div data-fake-player={tabId} />
+}
+
+mock.module('./ReplayPlayer', () => ({
+  ReplayPlayer: FakeReplayPlayer,
+}))
+
+mock.module('@/lib/utils', () => ({
+  cn: (...values: Array<string | false | null | undefined>) =>
+    values.filter(Boolean).join(' '),
+}))
 
 const globalDescriptors = new Map(
-  ['window', 'document', 'navigator', 'HTMLElement', 'Node', 'Event'].map(
-    (name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)],
-  ),
+  [
+    'window',
+    'document',
+    'navigator',
+    'HTMLElement',
+    'Node',
+    'Event',
+    'performance',
+  ].map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
 )
-
-const events: ReplayEvent[] = [
-  {
-    sessionId: 'session-1',
-    documentId: 'document-a',
-    targetId: 'target-a',
-    tabId: 1,
-    ts: 1_000,
-    type: 4,
-    data: { width: 1280, height: 720 },
-  },
-  {
-    sessionId: 'session-1',
-    documentId: 'document-a',
-    targetId: 'target-a',
-    tabId: 1,
-    ts: 1_001,
-    type: 2,
-    data: {},
-  },
-]
 
 let root: Root | null
 let container: HTMLElement
+let nowMs = 0
+
+function eventsForTab(tabId: number): ReplayEvent[] {
+  return [
+    {
+      sessionId: 'session-1',
+      documentId: `document-${tabId}`,
+      targetId: `target-${tabId}`,
+      tabId,
+      ts: tabId * 1_000,
+      type: 4,
+      data: { width: 1280, height: 720 },
+    },
+    {
+      sessionId: 'session-1',
+      documentId: `document-${tabId}`,
+      targetId: `target-${tabId}`,
+      tabId,
+      ts: tabId * 1_000 + 1,
+      type: 2,
+      data: {},
+    },
+  ]
+}
+
+function track(tabId: number): ReplayViewportTrack {
+  return { tabId, events: eventsForTab(tabId) }
+}
+
+const tabOne = track(1)
+const tabTwo = track(2)
+const tabThree = track(3)
 
 beforeEach(async () => {
-  fakeReplayers.length = 0
+  fakePlayers.length = 0
+  immediatelyReadyTabs.clear()
+  nowMs = 0
   const dom = parseHTML(
     '<!doctype html><html><body><div id="root"></div></body></html>',
   )
@@ -82,6 +164,7 @@ beforeEach(async () => {
     HTMLElement: dom.window.HTMLElement,
     Node: dom.window.Node,
     Event: dom.window.Event,
+    performance: { now: () => nowMs },
   }
   for (const [name, value] of Object.entries(globals)) {
     Object.defineProperty(globalThis, name, {
@@ -110,66 +193,195 @@ afterEach(async () => {
   Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
 })
 
+async function renderViewport(
+  overrides: Partial<React.ComponentProps<typeof ReplayViewport>> = {},
+): Promise<void> {
+  const props: React.ComponentProps<typeof ReplayViewport> = {
+    site: 'example.com',
+    frame: undefined,
+    activeTrack: tabOne,
+    standbyTrack: tabTwo,
+    activeTimeMs: 1_000,
+    standbyTimeMs: 2_000,
+    isPlaying: true,
+    speed: 2,
+    syncKey: 0,
+    mode: 'follow',
+    ...overrides,
+  }
+  await act(async () => root?.render(<ReplayViewport {...props} />))
+}
+
 describe('ReplayViewport', () => {
-  it('owns one live Replayer across Strict Mode setup, replacement, and unmount', async () => {
-    const readyValues: Array<ReplayPlayerHandle | null> = []
-    const onPlayerReady = (handle: ReplayPlayerHandle | null): void => {
-      readyValues.push(handle)
-    }
-    const { ReplayViewport } = await import('./ReplayViewport')
+  it('prepares one paused standby while only the visible slot runs', async () => {
+    immediatelyReadyTabs.add(1)
+    immediatelyReadyTabs.add(2)
+    await renderViewport()
 
-    await act(async () => {
-      root?.render(
-        <StrictMode>
-          <ReplayViewport
-            site="example.com"
-            frame={undefined}
-            events={events}
-            onPlayerReady={onPlayerReady}
-          />
-        </StrictMode>,
-      )
-    })
+    const livePlayers = fakePlayers.filter(({ destroyed }) => !destroyed)
+    expect(livePlayers).toHaveLength(2)
+    const active = livePlayers.find(({ tabId }) => tabId === 1)
+    const standby = livePlayers.find(({ tabId }) => tabId === 2)
+    expect(active?.handle.playCalls).toContain(1_000)
+    expect(active?.handle.running).toBe(true)
+    expect(standby?.handle.seekCalls).toContain(2_000)
+    expect(standby?.handle.running).toBe(false)
+    expect(livePlayers.filter(({ handle }) => handle.running)).toHaveLength(1)
+  })
 
-    const canvas = container.querySelector('[data-replay-canvas]')
-    expect(canvas?.querySelectorAll('[data-fake-replayer]')).toHaveLength(1)
-    expect(fakeReplayers).toHaveLength(2)
-    expect(
-      fakeReplayers.filter((replayer) => !replayer.destroyed),
-    ).toHaveLength(1)
-    expect(readyValues.at(-1)).not.toBeNull()
-
-    const firstLiveReplayer = fakeReplayers.find(
-      (replayer) => !replayer.destroyed,
+  it('pauses the old active, re-seeks the standby, then promotes without an empty slot', async () => {
+    immediatelyReadyTabs.add(1)
+    immediatelyReadyTabs.add(2)
+    await renderViewport()
+    const tabOnePlayer = fakePlayers.find(
+      ({ tabId, destroyed }) => tabId === 1 && !destroyed,
     )
-    const replacementEvents = events.map((event) => ({
-      ...event,
-      documentId: 'document-b',
-      targetId: 'target-b',
-    }))
-    await act(async () => {
-      root?.render(
-        <StrictMode>
-          <ReplayViewport
-            site="example.com"
-            frame={undefined}
-            events={replacementEvents}
-            onPlayerReady={onPlayerReady}
-          />
-        </StrictMode>,
-      )
+    const tabTwoPlayer = fakePlayers.find(
+      ({ tabId, destroyed }) => tabId === 2 && !destroyed,
+    )
+
+    await renderViewport({
+      activeTrack: tabTwo,
+      standbyTrack: null,
+      activeTimeMs: 5_000,
+      standbyTimeMs: 0,
     })
 
-    expect(firstLiveReplayer?.destroyed).toBe(true)
-    expect(canvas?.querySelectorAll('[data-fake-replayer]')).toHaveLength(1)
+    expect(tabOnePlayer?.handle.running).toBe(false)
+    expect(tabTwoPlayer?.handle.seekCalls).toContain(5_000)
+    expect(tabTwoPlayer?.handle.running).toBe(true)
     expect(
-      fakeReplayers.filter((replayer) => !replayer.destroyed),
-    ).toHaveLength(1)
+      container
+        .querySelector('[data-replay-slot-active="true"]')
+        ?.getAttribute('data-replay-tab-id'),
+    ).toBe('2')
+  })
+
+  it('reuses the paused prior active when the camera returns to that tab', async () => {
+    immediatelyReadyTabs.add(1)
+    immediatelyReadyTabs.add(2)
+    await renderViewport()
+    await renderViewport({
+      activeTrack: tabTwo,
+      standbyTrack: null,
+      activeTimeMs: 5_000,
+    })
+    const playerCountAfterFirstPromotion = fakePlayers.length
+
+    await renderViewport({
+      activeTrack: tabOne,
+      standbyTrack: null,
+      activeTimeMs: 6_000,
+    })
+
+    expect(fakePlayers).toHaveLength(playerCountAfterFirstPromotion)
+    const tabOnePlayer = fakePlayers.find(
+      ({ tabId, destroyed }) => tabId === 1 && !destroyed,
+    )
+    const tabTwoPlayer = fakePlayers.find(
+      ({ tabId, destroyed }) => tabId === 2 && !destroyed,
+    )
+    expect(tabOnePlayer?.handle.running).toBe(true)
+    expect(tabOnePlayer?.handle.seekCalls).toContain(6_000)
+    expect(tabTwoPlayer?.handle.running).toBe(false)
+  })
+
+  it('rejects stale readiness after rapid standby replacement and waits for the current generation', async () => {
+    immediatelyReadyTabs.add(1)
+    await renderViewport()
+    const staleTabTwo = fakePlayers.find(({ tabId }) => tabId === 2)
+    if (!staleTabTwo) throw new Error('expected tab 2 standby')
+
+    await renderViewport({ standbyTrack: tabThree, standbyTimeMs: 3_000 })
+    const tabThreePlayer = fakePlayers.find(
+      ({ tabId, destroyed }) => tabId === 3 && !destroyed,
+    )
+    if (!tabThreePlayer) throw new Error('expected tab 3 standby')
+
+    await renderViewport({
+      activeTrack: tabThree,
+      standbyTrack: null,
+      activeTimeMs: 4_000,
+    })
+    await act(async () => staleTabTwo.ready())
+    expect(staleTabTwo.handle.running).toBe(false)
+    expect(
+      container
+        .querySelector('[data-replay-slot-active="true"]')
+        ?.getAttribute('data-replay-tab-id'),
+    ).toBe('1')
+
+    await act(async () => tabThreePlayer.ready())
+    expect(tabThreePlayer.handle.running).toBe(true)
+    expect(
+      container
+        .querySelector('[data-replay-slot-active="true"]')
+        ?.getAttribute('data-replay-tab-id'),
+    ).toBe('3')
+  })
+
+  it('keeps rapid pending churn within two live player instances', async () => {
+    immediatelyReadyTabs.add(1)
+    for (let tabId = 2; tabId <= 12; tabId += 1) {
+      immediatelyReadyTabs.add(tabId)
+    }
+    await renderViewport()
+
+    for (let tabId = 3; tabId <= 12; tabId += 1) {
+      await renderViewport({
+        standbyTrack: track(tabId),
+        standbyTimeMs: tabId * 1_000,
+      })
+      expect(
+        fakePlayers.filter(({ destroyed }) => !destroyed).length,
+      ).toBeLessThanOrEqual(2)
+      expect(
+        fakePlayers.filter(({ handle }) => handle.running).length,
+      ).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('checks drift on a throttle and corrects only beyond 250 ms', async () => {
+    immediatelyReadyTabs.add(1)
+    await renderViewport({ standbyTrack: null, activeTimeMs: 0 })
+    const active = fakePlayers.find(
+      ({ tabId, destroyed }) => tabId === 1 && !destroyed,
+    )
+    if (!active) throw new Error('expected active player')
+    const initialSeekCount = active.handle.seekCalls.length
+    active.handle.currentTime = 0
+
+    nowMs = 500
+    await renderViewport({ standbyTrack: null, activeTimeMs: 500 })
+    expect(active.handle.seekCalls).toHaveLength(initialSeekCount)
+
+    nowMs = 1_000
+    await renderViewport({ standbyTrack: null, activeTimeMs: 200 })
+    expect(active.handle.seekCalls).toHaveLength(initialSeekCount)
+
+    nowMs = 2_000
+    await renderViewport({ standbyTrack: null, activeTimeMs: 400 })
+    expect(active.handle.seekCalls).toHaveLength(initialSeekCount + 1)
+    expect(active.handle.seekCalls.at(-1)).toBe(400)
+  })
+
+  it('removes the inactive player for inspection and stops everything on cleanup', async () => {
+    immediatelyReadyTabs.add(1)
+    immediatelyReadyTabs.add(2)
+    await renderViewport()
+    await renderViewport({
+      mode: 'inspect',
+      standbyTrack: null,
+      isPlaying: false,
+    })
+
+    expect(fakePlayers.filter(({ destroyed }) => !destroyed)).toHaveLength(1)
 
     await act(async () => root?.unmount())
     root = null
-
-    expect(fakeReplayers.every((replayer) => replayer.destroyed)).toBe(true)
-    expect(readyValues.at(-1)).toBeNull()
+    expect(fakePlayers.every(({ destroyed }) => destroyed)).toBe(true)
+    expect(fakePlayers.every(({ handle }) => !handle.running)).toBe(true)
   })
 })
+
+const { ReplayViewport } = await import('./ReplayViewport')

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.test.tsx
@@ -245,9 +245,11 @@ describe('ReplayViewport', () => {
       standbyTrack: null,
       activeTimeMs: 5_000,
       standbyTimeMs: 0,
+      syncKey: 1,
     })
 
     expect(tabOnePlayer?.handle.running).toBe(false)
+    expect(tabOnePlayer?.handle.seekCalls).not.toContain(5_000)
     expect(tabTwoPlayer?.handle.seekCalls).toContain(5_000)
     expect(tabTwoPlayer?.handle.running).toBe(true)
     expect(

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -225,6 +225,40 @@ export function ReplayViewport({
     if (appliedSyncKeyRef.current === syncKey) return
     appliedSyncKeyRef.current = syncKey
     const current = stageRef.current
+    if (!sameTrack(current.slots[current.activeSlot].track, activeTrack)) {
+      const oldActiveHandle = handleForSlot(
+        current,
+        handlesRef.current,
+        current.activeSlot,
+      )
+      const desiredSlot = slotForTrack(current.slots, activeTrack)
+      const targetHandle = desiredSlot
+        ? handleForSlot(current, handlesRef.current, desiredSlot)
+        : null
+      oldActiveHandle?.pause()
+      targetHandle?.pause()
+      targetHandle?.seek(activeTimeMsRef.current)
+      lastDriftCheckMsRef.current = performance.now()
+      return
+    }
+    if (current.promoteSlot) {
+      const oldActiveHandle = handleForSlot(
+        current,
+        handlesRef.current,
+        current.activeSlot,
+      )
+      const targetHandle = handleForSlot(
+        current,
+        handlesRef.current,
+        current.promoteSlot,
+      )
+      oldActiveHandle?.pause()
+      targetHandle?.pause()
+      targetHandle?.seek(activeTimeMsRef.current)
+      promoteReadySlot(current.promoteSlot)
+      lastDriftCheckMsRef.current = performance.now()
+      return
+    }
     const activeHandle = handleForSlot(
       current,
       handlesRef.current,
@@ -242,7 +276,7 @@ export function ReplayViewport({
       activeHandle.play(activeTimeMsRef.current)
     }
     lastDriftCheckMsRef.current = performance.now()
-  }, [syncKey])
+  }, [activeTrack, promoteReadySlot, syncKey])
 
   useEffect(() => {
     if (!isPlaying) return

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -1,66 +1,466 @@
 /**
  * @license
- * Copyright 2025 BrowserOS
+ * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Bounded rrweb stage for session replay. Two physical slots are permanent:
+ * one visible active player and at most one hidden, paused standby. Role swaps
+ * never create a third player or let a hidden rrweb timer run.
  */
 
 import { Lock } from 'lucide-react'
-import { useEffect, useRef } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 import { cn } from '@/lib/utils'
 import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
+import { ReplayPlayer, type ReplayPlayerHandle } from './ReplayPlayer'
 import { KIND_STYLE, VERB_META } from './replay.helpers'
 
-import 'rrweb-player/dist/style.css'
-// We use rrweb's Replayer directly. The rrweb-player wrapper at v2.x
-// publishes a broken bundle: its built JS has no `new Replayer(...)`
-// call AND no import statement for @rrweb/replay, so the wrapper's
-// Player.svelte never instantiates a Replayer (the `replayer` Svelte
-// state stays undefined, the Controller `{#if replayer}` block never
-// renders, the player-frame div stays empty). The rrweb package
-// itself bundles Replayer cleanly; we mount it ourselves and skip
-// the wrapper. rrweb-player's CSS is still imported for the
-// `.replayer-wrapper` styling.
-import { Replayer } from 'rrweb'
+export type { ReplayPlayerHandle } from './ReplayPlayer'
 
-export interface ReplayPlayerHandle {
-  seek(ms: number): void
-  play(ms: number): void
-  pause(): void
-  setSpeed(speed: number): void
-  getCurrentTime(): number
+export interface ReplayViewportTrack {
+  tabId: number
+  events: readonly ReplayEvent[]
 }
 
 interface ReplayViewportProps {
   site: string
-  /** The frame whose caption is currently displayed in the overlay. */
+  /** The active tab frame whose caption and URL are currently displayed. */
   frame: ReplayFrame | undefined
-  /** Every playable document lifecycle in the selected tab. */
-  events: readonly ReplayEvent[]
-  /** Called when the rrweb Replayer mounts or is destroyed. */
-  onPlayerReady: (handle: ReplayPlayerHandle | null) => void
+  activeTrack: ReplayViewportTrack
+  standbyTrack: ReplayViewportTrack | null
+  /** Current app-clock projection into the active rrweb stream. */
+  activeTimeMs: number
+  /** Projection captured when the pending standby was prepared. */
+  standbyTimeMs: number
+  isPlaying: boolean
+  speed: number
+  /**
+   * Changes only for discontinuities such as seek/resume. Ordinary clock ticks
+   * update `activeTimeMs` without forcing rrweb to seek every animation frame.
+   */
+  syncKey: number
+  mode: 'follow' | 'inspect'
 }
 
-/** Displays the selected tab's rrweb replay inside the audit browser chrome. */
+type SlotId = 'a' | 'b'
+
+interface SlotAssignment {
+  track: ReplayViewportTrack | null
+  generation: number
+}
+
+interface StageState {
+  activeSlot: SlotId
+  /** A ready target is promoted only after the old active has been paused. */
+  promoteSlot: SlotId | null
+  slots: Record<SlotId, SlotAssignment>
+}
+
+interface HandleEntry {
+  generation: number
+  handle: ReplayPlayerHandle | null
+}
+
+const DRIFT_CHECK_INTERVAL_MS = 1_000
+const DRIFT_THRESHOLD_MS = 250
+
+/**
+ * Keeps one browser chrome while independent rrweb players swap underneath.
+ * BrowserClaw's projected time is authoritative; rrweb is positioned on
+ * discontinuities and corrected only for material, throttled drift.
+ */
 export function ReplayViewport({
   site,
   frame,
-  events,
-  onPlayerReady,
+  activeTrack,
+  standbyTrack,
+  activeTimeMs,
+  standbyTimeMs,
+  isPlaying,
+  speed,
+  syncKey,
+  mode,
 }: ReplayViewportProps) {
-  // Prefer the current frame's full URL so the address bar shows
-  // exactly where the agent was at this instant. Falls back to the
-  // task-level site (a hostname) when the frame carries no url
-  // (e.g. `run`, `windows`, `tab_groups` dispatches).
+  const [stage, setStage] = useState<StageState>(() =>
+    initialStage(activeTrack, standbyTrack),
+  )
+  const stageRef = useRef(stage)
+  const handlesRef = useRef<Record<SlotId, HandleEntry | null>>({
+    a: null,
+    b: null,
+  })
+  const activeTimeMsRef = useRef(activeTimeMs)
+  const standbyTimeMsRef = useRef(standbyTimeMs)
+  const isPlayingRef = useRef(isPlaying)
+  const speedRef = useRef(speed)
+  const modeRef = useRef(mode)
+  const lastDriftCheckMsRef = useRef(performance.now())
+  const appliedSyncKeyRef = useRef<number | null>(null)
+  stageRef.current = stage
+  activeTimeMsRef.current = activeTimeMs
+  standbyTimeMsRef.current = standbyTimeMs
+  isPlayingRef.current = isPlaying
+  speedRef.current = speed
+  modeRef.current = mode
+
+  const writeStage = useCallback(
+    (update: (current: StageState) => StageState) => {
+      setStage((current) => {
+        const next = update(current)
+        stageRef.current = next
+        return next
+      })
+    },
+    [],
+  )
+
+  const promoteReadySlot = useCallback(
+    (slot: SlotId) => {
+      const current = stageRef.current
+      if (current.promoteSlot !== slot) return
+      const nextHandle = handleForSlot(current, handlesRef.current, slot)
+      if (!nextHandle) return
+
+      const previousHandle = handleForSlot(
+        current,
+        handlesRef.current,
+        current.activeSlot,
+      )
+      // Promotion order is deliberate: stop the only running rrweb timer,
+      // refresh the hidden player's projection, then expose it. Playback is
+      // started by the post-swap layout effect, never while the slot is hidden.
+      previousHandle?.pause()
+      nextHandle.pause()
+      nextHandle.seek(activeTimeMsRef.current)
+      nextHandle.setSpeed(speedRef.current)
+      writeStage((latest) => {
+        if (latest.promoteSlot !== slot) return latest
+        const oldActiveSlot = latest.activeSlot
+        const next: StageState = {
+          ...latest,
+          activeSlot: slot,
+          promoteSlot: null,
+        }
+        if (modeRef.current === 'inspect') {
+          next.slots = assignTrack(next.slots, oldActiveSlot, null)
+        }
+        return next
+      })
+    },
+    [writeStage],
+  )
+
+  const onSlotReady = useCallback(
+    (slot: SlotId, generation: number, handle: ReplayPlayerHandle | null) => {
+      const current = stageRef.current
+      if (current.slots[slot].generation !== generation) return
+      handlesRef.current[slot] = { generation, handle }
+      if (!handle) return
+
+      handle.setSpeed(speedRef.current)
+      if (slot === current.activeSlot && current.promoteSlot !== slot) {
+        handle.seek(activeTimeMsRef.current)
+        if (isPlayingRef.current) handle.play(activeTimeMsRef.current)
+        else handle.pause()
+      } else {
+        // Standby readiness is never permission to run. It is prepared at the
+        // best projection known now and re-seeked immediately before promotion.
+        handle.pause()
+        handle.seek(
+          current.promoteSlot === slot
+            ? activeTimeMsRef.current
+            : standbyTimeMsRef.current,
+        )
+      }
+      promoteReadySlot(slot)
+    },
+    [promoteReadySlot],
+  )
+
+  useLayoutEffect(() => {
+    writeStage((current) =>
+      reconcileStage(current, activeTrack, standbyTrack, mode),
+    )
+  }, [activeTrack, mode, standbyTrack, writeStage])
+
+  useLayoutEffect(() => {
+    if (stage.promoteSlot) promoteReadySlot(stage.promoteSlot)
+  }, [promoteReadySlot, stage.promoteSlot])
+
+  const activeSlot = stage.activeSlot
+  const inactiveSlot = otherSlot(activeSlot)
+  const activeGeneration = stage.slots[activeSlot].generation
+  const inactiveGeneration = stage.slots[inactiveSlot].generation
+  useLayoutEffect(() => {
+    const activeEntry = handlesRef.current[activeSlot]
+    const inactiveEntry = handlesRef.current[inactiveSlot]
+    const activeHandle =
+      activeEntry?.generation === activeGeneration ? activeEntry.handle : null
+    const inactiveHandle =
+      inactiveEntry?.generation === inactiveGeneration
+        ? inactiveEntry.handle
+        : null
+    inactiveHandle?.pause()
+    if (!activeHandle) return
+    activeHandle.setSpeed(speed)
+    if (isPlaying) activeHandle.play(activeTimeMsRef.current)
+    else activeHandle.pause()
+    lastDriftCheckMsRef.current = performance.now()
+  }, [
+    activeGeneration,
+    activeSlot,
+    inactiveGeneration,
+    inactiveSlot,
+    isPlaying,
+    speed,
+  ])
+
+  useLayoutEffect(() => {
+    if (appliedSyncKeyRef.current === syncKey) return
+    appliedSyncKeyRef.current = syncKey
+    const current = stageRef.current
+    const activeHandle = handleForSlot(
+      current,
+      handlesRef.current,
+      current.activeSlot,
+    )
+    const inactiveHandle = handleForSlot(
+      current,
+      handlesRef.current,
+      otherSlot(current.activeSlot),
+    )
+    activeHandle?.seek(activeTimeMsRef.current)
+    inactiveHandle?.pause()
+    inactiveHandle?.seek(standbyTimeMsRef.current)
+    if (activeHandle && isPlayingRef.current) {
+      activeHandle.play(activeTimeMsRef.current)
+    }
+    lastDriftCheckMsRef.current = performance.now()
+  }, [syncKey])
+
+  useEffect(() => {
+    if (!isPlaying) return
+    const nowMs = performance.now()
+    if (nowMs - lastDriftCheckMsRef.current < DRIFT_CHECK_INTERVAL_MS) return
+    lastDriftCheckMsRef.current = nowMs
+    const current = stageRef.current
+    const handle = handleForSlot(
+      current,
+      handlesRef.current,
+      current.activeSlot,
+    )
+    if (
+      !handle ||
+      Math.abs(handle.getCurrentTime() - activeTimeMs) <= DRIFT_THRESHOLD_MS
+    ) {
+      return
+    }
+    handle.seek(activeTimeMs)
+    handle.play(activeTimeMs)
+  }, [activeTimeMs, isPlaying])
+
+  useEffect(
+    () => () => {
+      for (const entry of Object.values(handlesRef.current)) {
+        entry?.handle?.pause()
+      }
+      handlesRef.current = { a: null, b: null }
+    },
+    [],
+  )
+
   const addressBar = frame?.url ?? site
   return (
     <div className="relative flex flex-1 flex-col overflow-hidden rounded-2xl border border-border-2 bg-card shadow-sm">
       <Chrome url={addressBar} />
       <div className="relative flex flex-1 items-stretch justify-center overflow-hidden bg-bg-sunken">
-        <PlayerCanvas events={events} onReady={onPlayerReady} />
+        {(['a', 'b'] as const).map((slot) => {
+          const assignment = stage.slots[slot]
+          const active = slot === stage.activeSlot
+          return (
+            <div
+              key={slot}
+              aria-hidden={!active}
+              data-replay-slot={slot}
+              data-replay-slot-active={active}
+              data-replay-tab-id={assignment.track?.tabId}
+              className={cn(
+                'absolute inset-0',
+                active
+                  ? 'visible z-0 opacity-100'
+                  : 'pointer-events-none invisible -z-10 opacity-0',
+              )}
+            >
+              <PlayerSlot
+                slot={slot}
+                assignment={assignment}
+                onReady={onSlotReady}
+              />
+            </div>
+          )
+        })}
         {frame && <Caption frame={frame} />}
       </div>
     </div>
   )
+}
+
+function PlayerSlot({
+  slot,
+  assignment,
+  onReady,
+}: {
+  slot: SlotId
+  assignment: SlotAssignment
+  onReady: (
+    slot: SlotId,
+    generation: number,
+    handle: ReplayPlayerHandle | null,
+  ) => void
+}) {
+  const { generation, track } = assignment
+  const reportReady = useCallback(
+    (handle: ReplayPlayerHandle | null) => onReady(slot, generation, handle),
+    [generation, onReady, slot],
+  )
+  return <ReplayPlayer events={track?.events ?? []} onReady={reportReady} />
+}
+
+function initialStage(
+  activeTrack: ReplayViewportTrack,
+  standbyTrack: ReplayViewportTrack | null,
+): StageState {
+  return {
+    activeSlot: 'a',
+    promoteSlot: null,
+    slots: {
+      a: { track: activeTrack, generation: 1 },
+      b: { track: standbyTrack, generation: standbyTrack ? 1 : 0 },
+    },
+  }
+}
+
+/**
+ * Reconciliation changes only slot assignments and desired roles. Imperative
+ * promotion waits for readiness, which keeps the prior active slot visible if
+ * a new standby is still constructing or reports readiness out of order.
+ */
+function reconcileStage(
+  current: StageState,
+  activeTrack: ReplayViewportTrack,
+  standbyTrack: ReplayViewportTrack | null,
+  mode: ReplayViewportProps['mode'],
+): StageState {
+  let next = current
+  const matchingActiveSlot = slotForTrack(current.slots, activeTrack)
+  if (matchingActiveSlot === current.activeSlot) {
+    if (current.promoteSlot !== null) {
+      next = { ...next, promoteSlot: null }
+    }
+  } else if (matchingActiveSlot) {
+    next = { ...next, promoteSlot: matchingActiveSlot }
+  } else if (!current.slots[current.activeSlot].track) {
+    next = {
+      ...next,
+      slots: assignTrack(next.slots, current.activeSlot, activeTrack),
+    }
+  } else {
+    const targetSlot = otherSlot(current.activeSlot)
+    next = {
+      ...next,
+      promoteSlot: targetSlot,
+      slots: assignTrack(next.slots, targetSlot, activeTrack),
+    }
+  }
+
+  const inactiveSlot = otherSlot(next.activeSlot)
+  if (mode === 'inspect') {
+    if (next.promoteSlot === null) {
+      next = {
+        ...next,
+        slots: assignTrack(next.slots, inactiveSlot, null),
+      }
+    }
+    return sameStage(current, next) ? current : next
+  }
+
+  if (
+    standbyTrack &&
+    !sameTrack(standbyTrack, activeTrack) &&
+    next.promoteSlot === null
+  ) {
+    next = {
+      ...next,
+      slots: assignTrack(next.slots, inactiveSlot, standbyTrack),
+    }
+  }
+  return sameStage(current, next) ? current : next
+}
+
+function assignTrack(
+  slots: StageState['slots'],
+  slot: SlotId,
+  track: ReplayViewportTrack | null,
+): StageState['slots'] {
+  if (sameTrack(slots[slot].track, track)) return slots
+  return {
+    ...slots,
+    [slot]: {
+      track,
+      generation: slots[slot].generation + 1,
+    },
+  }
+}
+
+function slotForTrack(
+  slots: StageState['slots'],
+  track: ReplayViewportTrack,
+): SlotId | null {
+  if (sameTrack(slots.a.track, track)) return 'a'
+  if (sameTrack(slots.b.track, track)) return 'b'
+  return null
+}
+
+function sameTrack(
+  left: ReplayViewportTrack | null,
+  right: ReplayViewportTrack | null,
+): boolean {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      left.tabId === right.tabId &&
+      left.events === right.events)
+  )
+}
+
+function sameStage(left: StageState, right: StageState): boolean {
+  return (
+    left.activeSlot === right.activeSlot &&
+    left.promoteSlot === right.promoteSlot &&
+    left.slots === right.slots
+  )
+}
+
+function otherSlot(slot: SlotId): SlotId {
+  return slot === 'a' ? 'b' : 'a'
+}
+
+function handleForSlot(
+  stage: StageState,
+  handles: Record<SlotId, HandleEntry | null>,
+  slot: SlotId,
+): ReplayPlayerHandle | null {
+  const entry = handles[slot]
+  return entry?.generation === stage.slots[slot].generation
+    ? entry.handle
+    : null
 }
 
 function Chrome({ url }: { url: string }) {
@@ -76,117 +476,6 @@ function Chrome({ url }: { url: string }) {
         <span className="truncate">{url}</span>
       </div>
     </div>
-  )
-}
-
-interface PlayerCanvasProps {
-  events: readonly ReplayEvent[]
-  onReady: (handle: ReplayPlayerHandle | null) => void
-}
-
-/**
- * Fallback DOM viewport for pages that never emitted a meta event.
- * rrweb ALWAYS emits type 4 as its first event under normal
- * conditions, so this is defensive.
- */
-const DEFAULT_RECORDED_SIZE = { width: 1280, height: 720 }
-// rrweb casts events strictly before the target; 0ms can leave the first
-// snapshot blank while paused.
-const MIN_RENDER_SEEK_MS = 1
-
-function readRecordedSize(events: readonly ReplayEvent[]): {
-  width: number
-  height: number
-} {
-  const meta = events.find((e) => e.type === 4)
-  const data = meta?.data as { width?: unknown; height?: unknown } | undefined
-  const width =
-    typeof data?.width === 'number' && data.width > 0
-      ? data.width
-      : DEFAULT_RECORDED_SIZE.width
-  const height =
-    typeof data?.height === 'number' && data.height > 0
-      ? data.height
-      : DEFAULT_RECORDED_SIZE.height
-  return { width, height }
-}
-
-/** Mounts rrweb's imperative Replayer and exposes the narrow playback handle. */
-function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
-  const mountRef = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    const mount = mountRef.current
-    if (!mount) return
-    if (events.length < 2) return
-
-    const rrwebEvents = events.map((e) => ({
-      type: e.type,
-      data: e.data,
-      timestamp: e.ts,
-      // biome-ignore lint/suspicious/noExplicitAny: rrweb's event union is wide; we trust the recorder's output shape.
-    })) as any[]
-
-    mount.replaceChildren()
-    let replayer: Replayer
-    try {
-      replayer = new Replayer(rrwebEvents, {
-        root: mount,
-        speed: 1,
-        skipInactive: false,
-        showWarning: false,
-      })
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn('[browseros-claw replay] Replayer ctor threw', err)
-      return
-    }
-
-    const { width: recordedW, height: recordedH } = readRecordedSize(events)
-    const wrapper = mount.querySelector<HTMLElement>('.replayer-wrapper')
-    let observer: ResizeObserver | null = null
-    if (wrapper) {
-      wrapper.style.position = 'absolute'
-      wrapper.style.transformOrigin = 'top left'
-      const applyScale = (): void => {
-        const rect = mount.getBoundingClientRect()
-        if (rect.width === 0 || rect.height === 0) return
-        const scale = Math.min(rect.width / recordedW, rect.height / recordedH)
-        const scaledW = recordedW * scale
-        const scaledH = recordedH * scale
-        wrapper.style.transform = `scale(${scale})`
-        wrapper.style.left = `${Math.max(0, (rect.width - scaledW) / 2)}px`
-        wrapper.style.top = `${Math.max(0, (rect.height - scaledH) / 2)}px`
-      }
-      applyScale()
-      observer = new ResizeObserver(applyScale)
-      observer.observe(mount)
-    }
-
-    onReady({
-      seek: (ms) => replayer.pause(Math.max(MIN_RENDER_SEEK_MS, ms)),
-      play: (ms) => replayer.play(ms),
-      pause: () => replayer.pause(),
-      setSpeed: (speed) => replayer.setConfig({ speed }),
-      getCurrentTime: () => replayer.getCurrentTime(),
-    })
-    return () => {
-      onReady(null)
-      observer?.disconnect()
-      try {
-        replayer.destroy()
-      } catch {
-        // ignore; we're tearing down anyway
-      }
-      mount.replaceChildren()
-    }
-  }, [events, onReady])
-
-  return (
-    <div
-      ref={mountRef}
-      className="relative flex-1 overflow-hidden"
-      data-replay-canvas
-    />
   )
 }
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -46,6 +46,12 @@ interface ReplayViewportProps {
    */
   syncKey: number
   mode: 'follow' | 'inspect'
+  /**
+   * Reports the track whose ready player actually owns the visible slot.
+   * Replay keeps the selected chip, warning, URL, and caption on this committed
+   * presentation until a delayed standby promotion is complete.
+   */
+  onPresentedTrackChange: (tabId: number) => void
 }
 
 type SlotId = 'a' | 'b'
@@ -86,6 +92,7 @@ export function ReplayViewport({
   speed,
   syncKey,
   mode,
+  onPresentedTrackChange,
 }: ReplayViewportProps) {
   const [stage, setStage] = useState<StageState>(() =>
     initialStage(activeTrack, standbyTrack),
@@ -100,6 +107,8 @@ export function ReplayViewport({
   const isPlayingRef = useRef(isPlaying)
   const speedRef = useRef(speed)
   const modeRef = useRef(mode)
+  const desiredTrackRef = useRef(activeTrack)
+  const onPresentedTrackChangeRef = useRef(onPresentedTrackChange)
   const lastDriftCheckMsRef = useRef(performance.now())
   const appliedSyncKeyRef = useRef<number | null>(null)
   stageRef.current = stage
@@ -108,6 +117,8 @@ export function ReplayViewport({
   isPlayingRef.current = isPlaying
   speedRef.current = speed
   modeRef.current = mode
+  desiredTrackRef.current = activeTrack
+  onPresentedTrackChangeRef.current = onPresentedTrackChange
 
   const writeStage = useCallback(
     (update: (current: StageState) => StageState) => {
@@ -168,6 +179,10 @@ export function ReplayViewport({
         handle.seek(activeTimeMsRef.current)
         if (isPlayingRef.current) handle.play(activeTimeMsRef.current)
         else handle.pause()
+        const track = current.slots[slot].track
+        if (track && sameTrack(track, desiredTrackRef.current)) {
+          onPresentedTrackChangeRef.current(track.tabId)
+        }
       } else {
         // Standby readiness is never permission to run. It is prepared at the
         // best projection known now and re-seeked immediately before promotion.
@@ -208,9 +223,19 @@ export function ReplayViewport({
         : null
     inactiveHandle?.pause()
     if (!activeHandle) return
+    const committedTrack = stageRef.current.slots[activeSlot].track
+    if (!sameTrack(committedTrack, desiredTrackRef.current)) {
+      // The requested camera has not finished mounting. Freeze the prior
+      // visual rather than applying the new tab's local clock to the old DOM.
+      activeHandle.pause()
+      return
+    }
     activeHandle.setSpeed(speed)
     if (isPlaying) activeHandle.play(activeTimeMsRef.current)
     else activeHandle.pause()
+    if (committedTrack) {
+      onPresentedTrackChangeRef.current(committedTrack.tabId)
+    }
     lastDriftCheckMsRef.current = performance.now()
   }, [
     activeGeneration,
@@ -284,6 +309,7 @@ export function ReplayViewport({
     if (nowMs - lastDriftCheckMsRef.current < DRIFT_CHECK_INTERVAL_MS) return
     lastDriftCheckMsRef.current = nowMs
     const current = stageRef.current
+    if (!sameTrack(current.slots[current.activeSlot].track, activeTrack)) return
     const handle = handleForSlot(
       current,
       handlesRef.current,
@@ -297,7 +323,7 @@ export function ReplayViewport({
     }
     handle.seek(activeTimeMs)
     handle.play(activeTimeMs)
-  }, [activeTimeMs, isPlaying])
+  }, [activeTimeMs, activeTrack, isPlaying])
 
   useEffect(
     () => () => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.test.ts
@@ -1,8 +1,52 @@
 import { describe, expect, it } from 'bun:test'
-import { mapTaskStatus } from './replay.data'
+import type { ToolDispatchRow } from '@/modules/api/audit.hooks'
+import { mapDispatchToFrame, mapTaskStatus } from './replay.data'
+
+function dispatch(createdAt: number, durationMs?: number): ToolDispatchRow {
+  return {
+    dispatchId: 42,
+    createdAt,
+    slug: 'codex',
+    label: 'Codex',
+    sessionId: 'session-1',
+    toolName: 'read',
+    tabId: 7,
+    durationMs,
+  }
+}
 
 describe('mapTaskStatus', () => {
   it('maps cancelled API sessions to the existing stopped run status', () => {
     expect(mapTaskStatus('cancelled')).toBe('stopped')
+  })
+})
+
+describe('mapDispatchToFrame', () => {
+  it('keeps completion time for the timeline and derives camera time from duration', () => {
+    const frame = mapDispatchToFrame(dispatch(15_000, 4_000), 1_000, new Map())
+
+    expect(frame.t).toBe(14)
+    expect(frame.cameraT).toBe(10)
+  })
+
+  it.each([undefined, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    'falls back to completion for unusable duration %p',
+    (durationMs) => {
+      const frame = mapDispatchToFrame(
+        dispatch(15_000, durationMs),
+        1_000,
+        new Map(),
+      )
+
+      expect(frame.t).toBe(14)
+      expect(frame.cameraT).toBe(14)
+    },
+  )
+
+  it('clamps an operation start at the beginning of the session', () => {
+    const frame = mapDispatchToFrame(dispatch(2_000, 5_000), 1_000, new Map())
+
+    expect(frame.t).toBe(1)
+    expect(frame.cameraT).toBe(0)
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.test.ts
@@ -29,9 +29,13 @@ describe('mapDispatchToFrame', () => {
     expect(frame.cameraT).toBe(10)
   })
 
-  it.each([undefined, -1, Number.NaN, Number.POSITIVE_INFINITY])(
-    'falls back to completion for unusable duration %p',
-    (durationMs) => {
+  it('falls back to completion for every unusable duration', () => {
+    for (const durationMs of [
+      undefined,
+      -1,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+    ]) {
       const frame = mapDispatchToFrame(
         dispatch(15_000, durationMs),
         1_000,
@@ -40,8 +44,8 @@ describe('mapDispatchToFrame', () => {
 
       expect(frame.t).toBe(14)
       expect(frame.cameraT).toBe(14)
-    },
-  )
+    }
+  })
 
   it('clamps an operation start at the beginning of the session', () => {
     const frame = mapDispatchToFrame(dispatch(2_000, 5_000), 1_000, new Map())

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -239,12 +239,25 @@ const TOOL_TO_VERB: Record<string, ReplayVerb> = {
   evaluate: 'type',
 }
 
-function mapDispatchToFrame(
+/**
+ * Keeps the audit timeline on persisted completion time while giving the
+ * camera the best start approximation available in the existing contract.
+ * Invalid durations deliberately collapse to completion so old recordings
+ * remain deterministic without a schema migration.
+ */
+export function mapDispatchToFrame(
   row: ToolDispatchRow,
   sessionStartMs: number,
   targetTabs: ReadonlyMap<string, number>,
 ): ReplayFrame {
   const t = Math.max(0, (row.createdAt - sessionStartMs) / 1000)
+  const usableDurationMs =
+    typeof row.durationMs === 'number' &&
+    Number.isFinite(row.durationMs) &&
+    row.durationMs >= 0
+      ? row.durationMs
+      : 0
+  const cameraT = Math.max(0, t - usableDurationMs / 1000)
   const meta = row.resultMeta ? safeParse(row.resultMeta) : null
   const isError = meta?.isError === true
   const cancellationKind = meta?.cancellationKind
@@ -256,6 +269,7 @@ function mapDispatchToFrame(
   const caption = buildCaption(row, verb, isError, cancelled)
   return {
     t,
+    cameraT,
     kind,
     verb,
     node,

--- a/packages/browseros-agent/apps/claw-app/screens/replay/session-camera.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/session-camera.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'bun:test'
 import type { ReplayFrame } from '@/modules/api/replay.hooks'
 import {
   createSessionCameraState,
+  rebaseSessionCameraState,
   sessionCameraReducer,
 } from './session-camera'
 import type {
@@ -308,5 +309,42 @@ describe('sessionCameraReducer', () => {
     })
 
     expect(restarted).toEqual(initial)
+  })
+
+  it('rebases a live candidate inserted before the prior cursor without replaying old work', () => {
+    const replayPlan = plan(
+      [track(1, 0, 100), track(2, 0, 100), track(3, 0, 100)],
+      [candidate(1, 2, 2)],
+    )
+    const promoted = tick(
+      replayPlan,
+      createSessionCameraState(replayPlan),
+      10,
+      10_000,
+    )
+    expect(promoted).toMatchObject({
+      activeTabId: 2,
+      candidateCursor: 1,
+      candidateWindowStartCursor: 1,
+      pendingTabId: null,
+    })
+
+    const refreshedPlan = plan(
+      [...replayPlan.tracks],
+      [candidate(0.5, 3, 3), candidate(1, 2, 2)],
+    )
+    const rebased = rebaseSessionCameraState(
+      replayPlan,
+      refreshedPlan,
+      promoted,
+    )
+    expect(rebased).toMatchObject({
+      activeTabId: 2,
+      candidateCursor: 2,
+      candidateWindowStartCursor: 2,
+      pendingTabId: 3,
+    })
+
+    expect(tick(refreshedPlan, rebased, 11, 10_000).activeTabId).toBe(3)
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/replay/session-camera.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/session-camera.test.ts
@@ -1,0 +1,312 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { ReplayFrame } from '@/modules/api/replay.hooks'
+import {
+  createSessionCameraState,
+  sessionCameraReducer,
+} from './session-camera'
+import type {
+  CameraCandidate,
+  SessionReplayPlan,
+  TabTrack,
+} from './session-replay'
+
+function frame(
+  t: number,
+  tabId: number | null,
+  dispatchId: number,
+): ReplayFrame {
+  return {
+    t,
+    cameraT: t,
+    kind: 'action',
+    verb: 'read',
+    node: `dispatch-${dispatchId}`,
+    caption: `Dispatch ${dispatchId}`,
+    tabId,
+    dispatchId,
+  }
+}
+
+function track(
+  tabId: number,
+  globalStartSeconds: number,
+  globalEndSeconds: number,
+  hasFullSnapshot = true,
+): TabTrack {
+  return {
+    tabId,
+    frames: [],
+    events: [],
+    globalStartSeconds,
+    globalEndSeconds,
+    totalSeconds: globalEndSeconds - globalStartSeconds,
+    hasFullSnapshot,
+    knownIncomplete: false,
+    incompleteUntilMs: null,
+  }
+}
+
+function candidate(
+  cameraT: number,
+  tabId: number,
+  dispatchId: number,
+): CameraCandidate {
+  const candidateFrame = frame(cameraT, tabId, dispatchId)
+  return {
+    frame: candidateFrame,
+    tabId,
+    cameraT,
+    completionT: cameraT,
+    dispatchId,
+    sourceIndex: dispatchId,
+  }
+}
+
+function plan(
+  tracks: TabTrack[],
+  cameraCandidates: CameraCandidate[] = [],
+): SessionReplayPlan {
+  return {
+    totalSeconds: Math.max(
+      ...tracks.map(({ globalEndSeconds }) => globalEndSeconds),
+      0,
+    ),
+    frames: cameraCandidates.map(({ frame: candidateFrame }) => candidateFrame),
+    tracks,
+    tracksByTab: new Map(tracks.map((tabTrack) => [tabTrack.tabId, tabTrack])),
+    cameraCandidates,
+    firstPlayableTabId:
+      tracks.find(({ hasFullSnapshot }) => hasFullSnapshot)?.tabId ?? null,
+  }
+}
+
+function tick(
+  replayPlan: SessionReplayPlan,
+  state: ReturnType<typeof createSessionCameraState>,
+  globalSeconds: number,
+  realDeltaMs: number,
+  playing = true,
+) {
+  return sessionCameraReducer(replayPlan, state, {
+    type: 'tick',
+    globalSeconds,
+    realDeltaMs,
+    playing,
+  })
+}
+
+describe('sessionCameraReducer', () => {
+  it('starts follow mode on the first camera-eligible track', () => {
+    const replayPlan = plan([
+      track(1, 0, 10, false),
+      track(2, 1, 20),
+      track(3, 2, 20),
+    ])
+
+    expect(createSessionCameraState(replayPlan)).toMatchObject({
+      mode: 'follow',
+      activeTabId: 2,
+      pendingTabId: null,
+      globalSeconds: 0,
+      dwellMs: 0,
+      isPlaying: true,
+    })
+  })
+
+  it.each([
+    { speed: 1, globalSeconds: 10 },
+    { speed: 2, globalSeconds: 20 },
+    { speed: 4, globalSeconds: 40 },
+  ])('promotes after ten real seconds at $speed x', ({ globalSeconds }) => {
+    const replayPlan = plan(
+      [track(1, 0, 100), track(2, 1, 100)],
+      [candidate(1, 2, 2)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+
+    const promoted = tick(replayPlan, initial, globalSeconds, 10_000)
+
+    expect(promoted.activeTabId).toBe(2)
+    expect(promoted.dwellMs).toBe(0)
+  })
+
+  it('does not charge paused wall time to the dwell window', () => {
+    const replayPlan = plan(
+      [track(1, 0, 100), track(2, 1, 100)],
+      [candidate(1, 2, 2)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+
+    const paused = tick(replayPlan, initial, 1, 50_000, false)
+    const resumed = tick(replayPlan, paused, 2, 9_999, true)
+
+    expect(paused.dwellMs).toBe(0)
+    expect(resumed.activeTabId).toBe(1)
+    expect(resumed.pendingTabId).toBe(2)
+  })
+
+  it('coalesces parallel candidates and displays only the most recent tab', () => {
+    const replayPlan = plan(
+      [track(1, 0, 100), track(2, 1, 100), track(3, 2, 100)],
+      [candidate(1, 2, 2), candidate(2, 3, 3)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+
+    const dwelling = tick(replayPlan, initial, 3, 5_000)
+    const promoted = tick(replayPlan, dwelling, 4, 5_000)
+
+    expect(dwelling.activeTabId).toBe(1)
+    expect(dwelling.pendingTabId).toBe(3)
+    expect(promoted.activeTabId).toBe(3)
+  })
+
+  it('promotes early when the active track has no playable time left', () => {
+    const replayPlan = plan(
+      [track(1, 0, 6), track(2, 1, 100)],
+      [candidate(1, 2, 2)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+
+    const promoted = tick(replayPlan, initial, 6, 1_000)
+
+    expect(promoted.activeTabId).toBe(2)
+  })
+
+  it('re-resolves an expired newest candidate to the latest playable candidate in the dwell window', () => {
+    const replayPlan = plan(
+      [track(1, 0, 100), track(2, 1, 20), track(3, 2, 8)],
+      [candidate(1, 2, 2), candidate(2, 3, 3)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+
+    const newestPending = tick(replayPlan, initial, 6, 5_000)
+    const promoted = tick(replayPlan, newestPending, 10, 5_000)
+
+    expect(newestPending.pendingTabId).toBe(3)
+    expect(promoted.activeTabId).toBe(2)
+  })
+
+  it('ignores candidates with missing tracks or unplayable visuals', () => {
+    const replayPlan = plan(
+      [track(1, 0, 100), track(2, 0, 100, false)],
+      [candidate(1, 99, 99), candidate(2, 2, 2)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+
+    const afterCandidates = tick(replayPlan, initial, 3, 20_000)
+
+    expect(afterCandidates.activeTabId).toBe(1)
+    expect(afterCandidates.pendingTabId).toBeNull()
+  })
+
+  it('holds an exhausted final visual, then immediately promotes the next eligible candidate', () => {
+    const replayPlan = plan(
+      [track(1, 0, 5), track(2, 8, 30)],
+      [candidate(8, 2, 2)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+
+    const held = tick(replayPlan, initial, 6, 1_000)
+    const promoted = tick(replayPlan, held, 8, 500)
+
+    expect(held.activeTabId).toBe(1)
+    expect(promoted.activeTabId).toBe(2)
+  })
+
+  it('seeks backward by resetting the candidate cursor and resolving the latest playable camera', () => {
+    const replayPlan = plan(
+      [track(1, 0, 100), track(2, 10, 30), track(3, 20, 100)],
+      [candidate(10, 2, 2), candidate(20, 3, 3)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+    const late = tick(replayPlan, initial, 25, 10_000)
+
+    const sought = sessionCameraReducer(replayPlan, late, {
+      type: 'seek',
+      globalSeconds: 15,
+    })
+
+    expect(sought).toMatchObject({
+      activeTabId: 2,
+      pendingTabId: null,
+      candidateCursor: 1,
+      candidateWindowStartCursor: 1,
+      dwellMs: 0,
+      isPlaying: false,
+      globalSeconds: 15,
+    })
+  })
+
+  it("prefers a selected timeline frame's playable tab at completion time", () => {
+    const replayPlan = plan(
+      [track(1, 0, 100), track(2, 10, 30), track(3, 10, 30)],
+      [candidate(10, 2, 2), candidate(11, 3, 3)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+
+    const selected = sessionCameraReducer(replayPlan, initial, {
+      type: 'select-frame',
+      frame: frame(12, 2, 20),
+    })
+
+    expect(selected.activeTabId).toBe(2)
+    expect(selected.globalSeconds).toBe(12)
+    expect(selected.isPlaying).toBe(false)
+  })
+
+  it('preserves the global position through inspect mode and resumes follow mode paused', () => {
+    const replayPlan = plan(
+      [track(1, 0, 100), track(2, 10, 100)],
+      [candidate(10, 2, 2)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+    const atTwelve = tick(replayPlan, initial, 12, 4_000)
+
+    const inspecting = sessionCameraReducer(replayPlan, atTwelve, {
+      type: 'inspect',
+      tabId: 1,
+      globalSeconds: 12,
+    })
+    const resumed = sessionCameraReducer(replayPlan, inspecting, {
+      type: 'resume',
+    })
+
+    expect(inspecting).toMatchObject({
+      mode: 'inspect',
+      activeTabId: 1,
+      inspectTabId: 1,
+      inspectSeconds: 0,
+      resumeGlobalSeconds: 12,
+      isPlaying: false,
+      pendingTabId: null,
+    })
+    expect(resumed).toMatchObject({
+      mode: 'follow',
+      activeTabId: 2,
+      globalSeconds: 12,
+      resumeGlobalSeconds: null,
+      isPlaying: false,
+    })
+  })
+
+  it('restarts the clock, cursor, dwell, pending state, and initial camera', () => {
+    const replayPlan = plan(
+      [track(1, 0, 100), track(2, 10, 100)],
+      [candidate(10, 2, 2)],
+    )
+    const initial = createSessionCameraState(replayPlan)
+    const advanced = tick(replayPlan, initial, 20, 10_000)
+
+    const restarted = sessionCameraReducer(replayPlan, advanced, {
+      type: 'restart',
+    })
+
+    expect(restarted).toEqual(initial)
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/replay/session-camera.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/session-camera.ts
@@ -9,7 +9,11 @@
  */
 
 import type { ReplayFrame } from '@/modules/api/replay.hooks'
-import { isTrackPlayableAt, type SessionReplayPlan } from './session-replay'
+import {
+  type CameraCandidate,
+  isTrackPlayableAt,
+  type SessionReplayPlan,
+} from './session-replay'
 
 export const CAMERA_DWELL_MS = 10_000
 const TIME_EPSILON_SECONDS = 0.001
@@ -96,6 +100,91 @@ export function sessionCameraReducer(
   }
 }
 
+/**
+ * Carries camera state across a live replay-plan refresh. Cursors are indexes
+ * into an immutable snapshot, so reusing them against a newly sorted array can
+ * skip a long-running dispatch whose completion arrived late but whose
+ * completion-minus-duration start sorts before the old cursor.
+ *
+ * Existing dwell history is translated through stable candidate identities.
+ * A genuinely new, already-crossed candidate is retained as pending even when
+ * its semantic start belongs before that translated window; subsequent ticks
+ * preserve it until it expires, is superseded, or is promoted.
+ */
+export function rebaseSessionCameraState(
+  previousPlan: SessionReplayPlan,
+  plan: SessionReplayPlan,
+  state: SessionCameraState,
+): SessionCameraState {
+  const activeTrack =
+    state.activeTabId === null
+      ? undefined
+      : plan.tracksByTab.get(state.activeTabId)
+  const activeStillValid =
+    state.mode === 'inspect'
+      ? activeTrack !== undefined
+      : activeTrack?.hasFullSnapshot === true
+  if (!activeStillValid) {
+    const resolved = resolveFollowAt(plan, state.globalSeconds)
+    return { ...resolved, isPlaying: state.isPlaying }
+  }
+
+  const candidateCursor = candidateCursorAt(plan, state.globalSeconds)
+  const candidateWindowStartCursor = Math.min(
+    candidateCursor,
+    translateWindowStart(previousPlan, plan, state.candidateWindowStartCursor),
+  )
+  let pendingTabId = resolvePendingFromWindow(
+    plan,
+    state.activeTabId,
+    candidateWindowStartCursor,
+    candidateCursor,
+    state.globalSeconds,
+  )
+
+  if (
+    pendingTabId === null &&
+    state.pendingTabId !== null &&
+    state.pendingTabId !== state.activeTabId
+  ) {
+    const priorPendingTrack = plan.tracksByTab.get(state.pendingTabId)
+    if (
+      priorPendingTrack &&
+      isTrackPlayableAt(priorPendingTrack, state.globalSeconds)
+    ) {
+      pendingTabId = state.pendingTabId
+    }
+  }
+
+  if (pendingTabId === null) {
+    const previousCandidates = new Set(
+      previousPlan.cameraCandidates.map(candidateIdentity),
+    )
+    for (let index = candidateCursor - 1; index >= 0; index -= 1) {
+      const candidate = plan.cameraCandidates[index]
+      if (
+        !candidate ||
+        previousCandidates.has(candidateIdentity(candidate)) ||
+        candidate.tabId === state.activeTabId
+      ) {
+        continue
+      }
+      const track = plan.tracksByTab.get(candidate.tabId)
+      if (track && isTrackPlayableAt(track, state.globalSeconds)) {
+        pendingTabId = candidate.tabId
+        break
+      }
+    }
+  }
+
+  return {
+    ...state,
+    candidateCursor,
+    candidateWindowStartCursor,
+    pendingTabId,
+  }
+}
+
 function tickCamera(
   plan: SessionReplayPlan,
   state: SessionCameraState,
@@ -122,13 +211,24 @@ function tickCamera(
         state.dwellMs + usableRealDelta(action.realDeltaMs),
       )
     : state.dwellMs
-  const pendingTabId = resolvePendingFromWindow(
+  const windowPendingTabId = resolvePendingFromWindow(
     plan,
     state.activeTabId,
     state.candidateWindowStartCursor,
     candidateCursor,
     globalSeconds,
   )
+  const retainedPendingTrack =
+    state.pendingTabId === null
+      ? undefined
+      : plan.tracksByTab.get(state.pendingTabId)
+  const pendingTabId =
+    windowPendingTabId ??
+    (state.pendingTabId !== state.activeTabId &&
+    retainedPendingTrack &&
+    isTrackPlayableAt(retainedPendingTrack, globalSeconds)
+      ? state.pendingTabId
+      : null)
   const activeTrack =
     state.activeTabId === null
       ? undefined
@@ -296,4 +396,40 @@ function clampGlobal(plan: SessionReplayPlan, seconds: number): number {
 
 function usableRealDelta(milliseconds: number): number {
   return Number.isFinite(milliseconds) && milliseconds > 0 ? milliseconds : 0
+}
+
+function translateWindowStart(
+  previousPlan: SessionReplayPlan,
+  plan: SessionReplayPlan,
+  previousWindowStart: number,
+): number {
+  for (
+    let index = Math.min(
+      previousWindowStart - 1,
+      previousPlan.cameraCandidates.length - 1,
+    );
+    index >= 0;
+    index -= 1
+  ) {
+    const boundary = previousPlan.cameraCandidates[index]
+    if (!boundary) continue
+    const identity = candidateIdentity(boundary)
+    const translatedIndex = plan.cameraCandidates.findIndex(
+      (candidate) => candidateIdentity(candidate) === identity,
+    )
+    if (translatedIndex !== -1) return translatedIndex + 1
+  }
+  return 0
+}
+
+function candidateIdentity(candidate: CameraCandidate): string {
+  return candidate.dispatchId !== null
+    ? `dispatch:${candidate.dispatchId}`
+    : [
+        'legacy',
+        candidate.tabId,
+        candidate.cameraT,
+        candidate.completionT,
+        candidate.sourceIndex,
+      ].join(':')
 }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/session-camera.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/session-camera.ts
@@ -1,0 +1,299 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Pure camera choreography for session replay. This state machine never talks
+ * to React or rrweb: BrowserClaw supplies global session time plus real wall
+ * time, and the reducer decides which independent tab film should be visible.
+ */
+
+import type { ReplayFrame } from '@/modules/api/replay.hooks'
+import { isTrackPlayableAt, type SessionReplayPlan } from './session-replay'
+
+export const CAMERA_DWELL_MS = 10_000
+const TIME_EPSILON_SECONDS = 0.001
+
+export type SessionCameraMode = 'follow' | 'inspect'
+
+export interface SessionCameraState {
+  mode: SessionCameraMode
+  activeTabId: number | null
+  pendingTabId: number | null
+  globalSeconds: number
+  isPlaying: boolean
+  /**
+   * Number of sorted candidates already crossed by the global playhead. This
+   * is a cursor, not an event id: candidates before it need no reconsideration
+   * during ordinary forward playback.
+   */
+  candidateCursor: number
+  /**
+   * Inclusive beginning of the candidates observed during the active tab's
+   * dwell. We retain this bounded logical window so an expired newest pending
+   * tab can fall back to the latest earlier candidate still drawable now.
+   */
+  candidateWindowStartCursor: number
+  /** Real playing time spent viewing the active tab; speed never scales it. */
+  dwellMs: number
+  inspectTabId: number | null
+  inspectSeconds: number
+  /** Exact app-clock position to restore after independent tab inspection. */
+  resumeGlobalSeconds: number | null
+}
+
+export type SessionCameraAction =
+  | {
+      type: 'tick'
+      globalSeconds: number
+      realDeltaMs: number
+      playing: boolean
+    }
+  | { type: 'seek'; globalSeconds: number }
+  | { type: 'select-frame'; frame: ReplayFrame }
+  | { type: 'inspect'; tabId: number; globalSeconds: number }
+  | { type: 'resume' }
+  | { type: 'restart' }
+
+/** Initializes automatic following without consuming a visual-only tab. */
+export function createSessionCameraState(
+  plan: SessionReplayPlan,
+): SessionCameraState {
+  const candidateCursor = candidateCursorAt(plan, 0)
+  return {
+    mode: 'follow',
+    activeTabId: plan.firstPlayableTabId,
+    pendingTabId: null,
+    globalSeconds: 0,
+    isPlaying: true,
+    candidateCursor,
+    candidateWindowStartCursor: candidateCursor,
+    dwellMs: 0,
+    inspectTabId: null,
+    inspectSeconds: 0,
+    resumeGlobalSeconds: null,
+  }
+}
+
+export function sessionCameraReducer(
+  plan: SessionReplayPlan,
+  state: SessionCameraState,
+  action: SessionCameraAction,
+): SessionCameraState {
+  switch (action.type) {
+    case 'tick':
+      return tickCamera(plan, state, action)
+    case 'seek':
+      return resolveFollowAt(plan, action.globalSeconds)
+    case 'select-frame':
+      return resolveFollowAt(plan, action.frame.t, action.frame.tabId)
+    case 'inspect':
+      return enterInspection(plan, state, action.tabId, action.globalSeconds)
+    case 'resume':
+      return resumeFollowing(plan, state)
+    case 'restart':
+      return createSessionCameraState(plan)
+  }
+}
+
+function tickCamera(
+  plan: SessionReplayPlan,
+  state: SessionCameraState,
+  action: Extract<SessionCameraAction, { type: 'tick' }>,
+): SessionCameraState {
+  if (state.mode === 'inspect') {
+    return { ...state, isPlaying: false }
+  }
+
+  const globalSeconds = clampGlobal(plan, action.globalSeconds)
+  if (globalSeconds + TIME_EPSILON_SECONDS < state.globalSeconds) {
+    const resolved = resolveFollowAt(plan, globalSeconds)
+    return { ...resolved, isPlaying: action.playing }
+  }
+
+  const candidateCursor = advanceCandidateCursor(
+    plan,
+    state.candidateCursor,
+    globalSeconds,
+  )
+  const dwellMs = action.playing
+    ? Math.min(
+        CAMERA_DWELL_MS,
+        state.dwellMs + usableRealDelta(action.realDeltaMs),
+      )
+    : state.dwellMs
+  const pendingTabId = resolvePendingFromWindow(
+    plan,
+    state.activeTabId,
+    state.candidateWindowStartCursor,
+    candidateCursor,
+    globalSeconds,
+  )
+  const activeTrack =
+    state.activeTabId === null
+      ? undefined
+      : plan.tracksByTab.get(state.activeTabId)
+  const activeTrackEnded =
+    activeTrack === undefined ||
+    globalSeconds >= activeTrack.globalEndSeconds - TIME_EPSILON_SECONDS
+  const shouldPromote =
+    action.playing &&
+    pendingTabId !== null &&
+    (dwellMs >= CAMERA_DWELL_MS || activeTrackEnded)
+
+  if (shouldPromote) {
+    return {
+      ...state,
+      activeTabId: pendingTabId,
+      pendingTabId: null,
+      globalSeconds,
+      isPlaying: true,
+      candidateCursor,
+      candidateWindowStartCursor: candidateCursor,
+      dwellMs: 0,
+    }
+  }
+
+  return {
+    ...state,
+    pendingTabId,
+    globalSeconds,
+    isPlaying: action.playing,
+    candidateCursor,
+    dwellMs,
+  }
+}
+
+function resolveFollowAt(
+  plan: SessionReplayPlan,
+  requestedSeconds: number,
+  preferredTabId?: number | null,
+): SessionCameraState {
+  const globalSeconds = clampGlobal(plan, requestedSeconds)
+  const candidateCursor = candidateCursorAt(plan, globalSeconds)
+  const preferredTrack =
+    preferredTabId === null || preferredTabId === undefined
+      ? undefined
+      : plan.tracksByTab.get(preferredTabId)
+  let activeTabId =
+    preferredTrack && isTrackPlayableAt(preferredTrack, globalSeconds)
+      ? preferredTrack.tabId
+      : null
+
+  if (activeTabId === null) {
+    for (let index = candidateCursor - 1; index >= 0; index -= 1) {
+      const candidate = plan.cameraCandidates[index]
+      if (!candidate) continue
+      const track = plan.tracksByTab.get(candidate.tabId)
+      if (track && isTrackPlayableAt(track, globalSeconds)) {
+        activeTabId = candidate.tabId
+        break
+      }
+    }
+  }
+  activeTabId ??= plan.firstPlayableTabId
+
+  return {
+    mode: 'follow',
+    activeTabId,
+    pendingTabId: null,
+    globalSeconds,
+    isPlaying: false,
+    candidateCursor,
+    candidateWindowStartCursor: candidateCursor,
+    dwellMs: 0,
+    inspectTabId: null,
+    inspectSeconds: 0,
+    resumeGlobalSeconds: null,
+  }
+}
+
+function enterInspection(
+  plan: SessionReplayPlan,
+  state: SessionCameraState,
+  tabId: number,
+  requestedGlobalSeconds: number,
+): SessionCameraState {
+  const globalSeconds = clampGlobal(plan, requestedGlobalSeconds)
+  return {
+    ...state,
+    mode: 'inspect',
+    activeTabId: tabId,
+    pendingTabId: null,
+    globalSeconds,
+    isPlaying: false,
+    dwellMs: 0,
+    inspectTabId: tabId,
+    inspectSeconds: 0,
+    resumeGlobalSeconds: globalSeconds,
+  }
+}
+
+function resumeFollowing(
+  plan: SessionReplayPlan,
+  state: SessionCameraState,
+): SessionCameraState {
+  const restoredSeconds = state.resumeGlobalSeconds ?? state.globalSeconds
+  // `resolveFollowAt` intentionally returns paused. Resume changes ownership
+  // back to the global transport but never surprises the inspector by moving.
+  return resolveFollowAt(plan, restoredSeconds)
+}
+
+/**
+ * Scans newest-to-oldest only inside the current dwell window. Parallel work
+ * therefore coalesces to one pending camera, while retaining enough history to
+ * recover if that newest tab's short recording ends before promotion.
+ */
+function resolvePendingFromWindow(
+  plan: SessionReplayPlan,
+  activeTabId: number | null,
+  windowStartCursor: number,
+  candidateCursor: number,
+  globalSeconds: number,
+): number | null {
+  for (
+    let index = candidateCursor - 1;
+    index >= windowStartCursor;
+    index -= 1
+  ) {
+    const candidate = plan.cameraCandidates[index]
+    if (!candidate || candidate.tabId === activeTabId) continue
+    const track = plan.tracksByTab.get(candidate.tabId)
+    if (track && isTrackPlayableAt(track, globalSeconds)) {
+      return candidate.tabId
+    }
+  }
+  return null
+}
+
+function candidateCursorAt(
+  plan: SessionReplayPlan,
+  globalSeconds: number,
+): number {
+  return advanceCandidateCursor(plan, 0, globalSeconds)
+}
+
+function advanceCandidateCursor(
+  plan: SessionReplayPlan,
+  initialCursor: number,
+  globalSeconds: number,
+): number {
+  let cursor = initialCursor
+  while (
+    cursor < plan.cameraCandidates.length &&
+    (plan.cameraCandidates[cursor]?.cameraT ?? Number.POSITIVE_INFINITY) <=
+      globalSeconds + TIME_EPSILON_SECONDS
+  ) {
+    cursor += 1
+  }
+  return cursor
+}
+
+function clampGlobal(plan: SessionReplayPlan, seconds: number): number {
+  if (!Number.isFinite(seconds)) return 0
+  return Math.max(0, Math.min(plan.totalSeconds, seconds))
+}
+
+function usableRealDelta(milliseconds: number): number {
+  return Number.isFinite(milliseconds) && milliseconds > 0 ? milliseconds : 0
+}

--- a/packages/browseros-agent/apps/claw-app/screens/replay/session-replay.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/session-replay.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
+import type { ReplayTabData } from './replay.data'
+import { buildReplayEventCatalog } from './replay-events'
+import {
+  buildSessionReplayPlan,
+  projectGlobalTimeToTrack,
+} from './session-replay'
+
+function frame(
+  t: number,
+  cameraT: number,
+  tabId: number | null,
+  dispatchId?: number,
+): ReplayFrame {
+  return {
+    t,
+    cameraT,
+    kind: 'action',
+    verb: 'read',
+    node: `dispatch-${dispatchId ?? 'missing'}`,
+    caption: 'test',
+    tabId,
+    dispatchId,
+  }
+}
+
+function event(
+  ts: number,
+  documentId: string,
+  tabId: number,
+  type = 2,
+): ReplayEvent {
+  return {
+    sessionId: 'session-1',
+    documentId,
+    targetId: `target-${documentId}`,
+    tabId,
+    type,
+    data: {},
+    ts,
+  }
+}
+
+function tab(tabId: number, documentIds: string[]): ReplayTabData {
+  return {
+    tabId,
+    complete: true,
+    segments: documentIds.map((documentId) => ({
+      documentId,
+      targetId: `target-${documentId}`,
+      firstEventAt: 0,
+      lastEventAt: 0,
+      hasGap: false,
+      legacy: false,
+    })),
+  }
+}
+
+describe('buildSessionReplayPlan', () => {
+  it('builds one stitched track per Chrome tab and projects from absolute session time', () => {
+    const events = [
+      event(11_000, 'document-a', 1, 4),
+      event(11_001, 'document-a', 1),
+      event(15_000, 'document-a', 1, 3),
+      event(20_000, 'document-b', 1, 4),
+      event(20_001, 'document-b', 1),
+      event(25_000, 'document-b', 1, 3),
+    ]
+    const catalog = buildReplayEventCatalog(events)
+    const plan = buildSessionReplayPlan({
+      totalSeconds: 30,
+      startedAtMs: 10_000,
+      frames: [frame(2, 1, 1, 1), frame(12, 11, 1, 2)],
+      tabs: [tab(1, ['document-a', 'document-b'])],
+      eventsForTab: catalog.eventsForTab,
+    })
+
+    expect(plan.tracks).toHaveLength(1)
+    const track = plan.tracks[0]
+    if (!track) throw new Error('expected a playable tab track')
+    expect(track.events.map(({ documentId }) => documentId)).toEqual([
+      'document-a',
+      'document-a',
+      'document-a',
+      'document-b',
+      'document-b',
+      'document-b',
+    ])
+    expect(track.globalStartSeconds).toBe(1)
+    expect(track.globalEndSeconds).toBe(15)
+    expect(projectGlobalTimeToTrack(track, 12)).toBe(11)
+  })
+
+  it('keeps no-visual actions in the plan but excludes their tab from camera candidates', () => {
+    const events = [
+      event(11_000, 'playable', 1, 4),
+      event(11_001, 'playable', 1),
+      event(20_000, 'playable', 1, 3),
+      event(12_000, 'mutation-only', 2, 3),
+    ]
+    const catalog = buildReplayEventCatalog(events)
+    const noVisualFrame = frame(3, 2, 2, 22)
+    const plan = buildSessionReplayPlan({
+      totalSeconds: 30,
+      startedAtMs: 10_000,
+      frames: [frame(2, 1, 1, 11), noVisualFrame, frame(4, 3, null, 33)],
+      tabs: [tab(1, ['playable']), tab(2, ['mutation-only'])],
+      eventsForTab: catalog.eventsForTab,
+    })
+
+    expect(plan.frames).toContain(noVisualFrame)
+    expect(plan.tracksByTab.get(2)?.hasFullSnapshot).toBe(false)
+    expect(plan.cameraCandidates.map(({ tabId }) => tabId)).toEqual([1])
+  })
+
+  it('orders overlapping candidates by camera time, completion, dispatch id, then source order', () => {
+    const events = [
+      event(12_000, 'tab-one', 1, 4),
+      event(12_001, 'tab-one', 1),
+      event(30_000, 'tab-one', 1, 3),
+    ]
+    const catalog = buildReplayEventCatalog(events)
+    const plan = buildSessionReplayPlan({
+      totalSeconds: 30,
+      startedAtMs: 10_000,
+      frames: [
+        frame(8, 5, 1, 4),
+        frame(7, 5, 1, 9),
+        frame(7, 5, 1, 3),
+        frame(7, 4, 1, 8),
+        frame(7, 5, 1),
+        frame(7, 5, 1),
+      ],
+      tabs: [tab(1, ['tab-one'])],
+      eventsForTab: catalog.eventsForTab,
+    })
+
+    expect(
+      plan.cameraCandidates.map(
+        ({ cameraT, completionT, dispatchId, sourceIndex }) => ({
+          cameraT,
+          completionT,
+          dispatchId,
+          sourceIndex,
+        }),
+      ),
+    ).toEqual([
+      { cameraT: 4, completionT: 7, dispatchId: 8, sourceIndex: 3 },
+      { cameraT: 5, completionT: 7, dispatchId: 3, sourceIndex: 2 },
+      { cameraT: 5, completionT: 7, dispatchId: 9, sourceIndex: 1 },
+      { cameraT: 5, completionT: 7, dispatchId: null, sourceIndex: 4 },
+      { cameraT: 5, completionT: 7, dispatchId: null, sourceIndex: 5 },
+      { cameraT: 5, completionT: 8, dispatchId: 4, sourceIndex: 0 },
+    ])
+  })
+
+  it('does not schedule a candidate before its tab can render', () => {
+    const events = [
+      event(15_000, 'late-tab', 1, 4),
+      event(15_001, 'late-tab', 1),
+      event(20_000, 'late-tab', 1, 3),
+    ]
+    const catalog = buildReplayEventCatalog(events)
+    const plan = buildSessionReplayPlan({
+      totalSeconds: 20,
+      startedAtMs: 10_000,
+      frames: [frame(8, 1, 1, 1)],
+      tabs: [tab(1, ['late-tab'])],
+      eventsForTab: catalog.eventsForTab,
+    })
+
+    expect(plan.cameraCandidates[0]?.cameraT).toBe(5)
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/replay/session-replay.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/session-replay.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Immutable session-replay model shared by the global clock, camera reducer,
+ * and viewport orchestration. Globally ordered dispatches schedule where the
+ * camera looks; each TabTrack keeps one Chrome tab's rrweb DOM stream isolated.
+ */
+
+import type { ReplayFrame } from '@/modules/api/replay.hooks'
+import {
+  type BuildTabViewInput,
+  buildTabView,
+  projectGlobalTimeToTab,
+  type TabView,
+} from './tab-view'
+
+export interface TabTrack extends TabView {
+  tabId: number
+}
+
+export interface CameraCandidate {
+  /** Frame remains the completion-timestamped action shown in the timeline. */
+  frame: ReplayFrame
+  tabId: number
+  /**
+   * Effective camera time. An operation may start before rrweb can draw its
+   * tab, so eligibility is delayed to the first playable event.
+   */
+  cameraT: number
+  completionT: number
+  dispatchId: number | null
+  /** Final deterministic tie-breaker when persisted identities are absent. */
+  sourceIndex: number
+}
+
+export interface SessionReplayPlan {
+  totalSeconds: number
+  /** All actions remain available even when their tab has no drawable stream. */
+  frames: readonly ReplayFrame[]
+  tracks: readonly TabTrack[]
+  tracksByTab: ReadonlyMap<number, TabTrack>
+  cameraCandidates: readonly CameraCandidate[]
+  firstPlayableTabId: number | null
+}
+
+export interface BuildSessionReplayPlanInput extends BuildTabViewInput {
+  totalSeconds: number
+}
+
+/**
+ * Builds the semantic schedule once per replay snapshot. Candidate sorting is
+ * intentionally independent of input order until every persisted key is
+ * exhausted; source order is only the last fallback for legacy rows.
+ */
+export function buildSessionReplayPlan(
+  input: BuildSessionReplayPlanInput,
+): SessionReplayPlan {
+  const tracks = input.tabs.map(
+    ({ tabId }): TabTrack => ({
+      tabId,
+      ...buildTabView(input, tabId),
+    }),
+  )
+  const tracksByTab = new Map(tracks.map((track) => [track.tabId, track]))
+  const cameraCandidates = input.frames
+    .map((frame, sourceIndex): CameraCandidate | null => {
+      if (frame.tabId === null || frame.tabId === undefined) return null
+      const track = tracksByTab.get(frame.tabId)
+      if (!track?.hasFullSnapshot) return null
+      return {
+        frame,
+        tabId: frame.tabId,
+        cameraT: Math.max(frame.cameraT, track.globalStartSeconds),
+        completionT: frame.t,
+        dispatchId: frame.dispatchId ?? null,
+        sourceIndex,
+      }
+    })
+    .filter((candidate): candidate is CameraCandidate => candidate !== null)
+    .sort(compareCameraCandidates)
+
+  return {
+    totalSeconds: input.totalSeconds,
+    frames: input.frames,
+    tracks,
+    tracksByTab,
+    cameraCandidates,
+    firstPlayableTabId:
+      tracks.find((track) => track.hasFullSnapshot)?.tabId ?? null,
+  }
+}
+
+function compareCameraCandidates(
+  left: CameraCandidate,
+  right: CameraCandidate,
+): number {
+  return (
+    left.cameraT - right.cameraT ||
+    left.completionT - right.completionT ||
+    compareDispatchIds(left.dispatchId, right.dispatchId) ||
+    left.sourceIndex - right.sourceIndex
+  )
+}
+
+function compareDispatchIds(left: number | null, right: number | null): number {
+  if (left === null && right === null) return 0
+  if (left === null) return 1
+  if (right === null) return -1
+  return left - right
+}
+
+/** Converts global session time to the local offset consumed by one rrweb tab. */
+export function projectGlobalTimeToTrack(
+  track: TabTrack,
+  globalSeconds: number,
+): number {
+  return projectGlobalTimeToTab(track, globalSeconds)
+}
+
+/**
+ * Camera eligibility is stricter than local-time projection: projection holds
+ * boundary visuals, while a tab may take over only when the global playhead is
+ * inside its real recorded interval.
+ */
+export function isTrackPlayableAt(
+  track: TabTrack,
+  globalSeconds: number,
+): boolean {
+  return (
+    track.hasFullSnapshot &&
+    globalSeconds >= track.globalStartSeconds &&
+    globalSeconds <= track.globalEndSeconds
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   type BuildTabViewInput,
   buildTabView,
+  projectGlobalTimeToTab,
   tabSeekForFrame,
 } from './tab-view'
 
@@ -25,6 +26,7 @@ function frame(
 ): ReplayFrame {
   return {
     t,
+    cameraT: t,
     kind: 'action',
     verb: 'read',
     node: 'test',
@@ -138,6 +140,32 @@ describe('buildTabView', () => {
     ])
     expect(view.frames.map(({ t }) => t)).toEqual([0, 4])
     expect(view.totalSeconds).toBe(5)
+    expect(view.globalStartSeconds).toBe(1)
+    expect(view.globalEndSeconds).toBe(6)
+  })
+
+  it('projects absolute session time onto the tab clock and clamps both boundaries', () => {
+    const input = makeInput({
+      frames: [frame(12, 1)],
+      tabs: [
+        tab(1, [
+          {
+            documentId: 'document-a',
+            firstEventAt: 1_010_000,
+            lastEventAt: 1_015_000,
+          },
+        ]),
+      ],
+      eventsForTab: () => [
+        event(1_010_000, 'document-a'),
+        event(1_015_000, 'document-a', 1, 3),
+      ],
+    })
+    const view = buildTabView(input, 1)
+
+    expect(projectGlobalTimeToTab(view, 8)).toBe(0)
+    expect(projectGlobalTimeToTab(view, 12)).toBe(2)
+    expect(projectGlobalTimeToTab(view, 20)).toBe(5)
   })
 
   it('keeps a merged tab event array stable across audit polling', () => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
@@ -11,6 +11,12 @@ export interface TabView {
   frames: ReplayFrame[]
   /** Every playable document lifecycle from one Chrome tab. */
   events: readonly ReplayEvent[]
+  /**
+   * Absolute bounds in session seconds for this tab's filtered rrweb stream.
+   * These remain global even though `frames[].t` and `totalSeconds` are local.
+   */
+  globalStartSeconds: number
+  globalEndSeconds: number
   totalSeconds: number
   hasFullSnapshot: boolean
   knownIncomplete: boolean
@@ -21,6 +27,8 @@ export interface TabView {
 export const EMPTY_TAB_VIEW: TabView = {
   frames: [],
   events: [],
+  globalStartSeconds: 0,
+  globalEndSeconds: 0,
   totalSeconds: 0,
   hasFullSnapshot: false,
   knownIncomplete: false,
@@ -91,6 +99,8 @@ export function buildTabView(
       t: Math.max(0, frame.t - originT),
     })),
     events: stream.events,
+    globalStartSeconds: originT,
+    globalEndSeconds: (endMs - input.startedAtMs) / 1000,
     totalSeconds: Math.max(0, (endMs - originMs) / 1000),
     hasFullSnapshot,
     knownIncomplete: hasCatalogedGap || stream.hasOmittedEvents,
@@ -99,6 +109,22 @@ export function buildTabView(
         ? null
         : stream.incompleteUntilMs,
   }
+}
+
+/**
+ * Projects the app-owned session clock into one rrweb stream. Absolute bounds
+ * matter here: subtracting a tab's duration or action time would drift after a
+ * same-tab navigation. Clamping holds the first/last drawable visual outside
+ * the tab's recorded interval instead of asking rrweb to seek out of range.
+ */
+export function projectGlobalTimeToTab(
+  view: Pick<TabView, 'globalStartSeconds' | 'totalSeconds'>,
+  globalSeconds: number,
+): number {
+  return Math.max(
+    0,
+    Math.min(view.totalSeconds, globalSeconds - view.globalStartSeconds),
+  )
 }
 
 export interface TabSeek {
@@ -116,12 +142,9 @@ export function tabSeekForFrame(
   if (tabId === null) return { tabId, seconds: frame.t }
 
   const view = buildTabView(input, tabId)
-  const originMs =
-    view.events[0]?.ts ?? input.eventsForTab(tabId)[0]?.ts ?? input.startedAtMs
-  const timestamp = input.startedAtMs + frame.t * 1000
   return {
     tabId,
-    seconds: Math.max(0, (timestamp - originMs) / 1000),
+    seconds: projectGlobalTimeToTab(view, frame.t),
   }
 }
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.test.tsx
@@ -148,6 +148,21 @@ describe('usePlayback', () => {
     expect(playback.time).toBe(4)
   })
 
+  it('pauses at the exact monotonic instant between animation frames', async () => {
+    await render(100)
+    await advanceAnimationFrame(1_000)
+    nowMs = 1_250
+
+    let pausedAt = 0
+    await act(async () => {
+      pausedAt = playback.pause()
+    })
+
+    expect(pausedAt).toBe(2.5)
+    expect(playback.time).toBe(2.5)
+    expect(playback.isPlaying).toBe(false)
+  })
+
   it('clamps seeks, pauses, and returns the applied destination', async () => {
     await render(10)
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { parseHTML } from 'linkedom'
+import { act } from 'react'
+import type { Root } from 'react-dom/client'
+import { type Playback, usePlayback } from './use-playback'
+
+const globalDescriptors = new Map(
+  [
+    'window',
+    'document',
+    'navigator',
+    'HTMLElement',
+    'Node',
+    'Event',
+    'performance',
+  ].map((name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)]),
+)
+
+let root: Root | null
+let container: HTMLElement
+let playback: Playback
+let nowMs = 0
+let nextAnimationFrameId = 1
+let cancelledAnimationFrames: number[]
+let animationFrames: Map<number, FrameRequestCallback>
+
+function PlaybackHarness({ totalSeconds }: { totalSeconds: number }) {
+  playback = usePlayback(totalSeconds)
+  return <div data-time={playback.time} data-playing={playback.isPlaying} />
+}
+
+async function render(totalSeconds: number): Promise<void> {
+  await act(async () =>
+    root?.render(<PlaybackHarness totalSeconds={totalSeconds} />),
+  )
+}
+
+async function advanceAnimationFrame(toMs: number): Promise<void> {
+  nowMs = toMs
+  const callbacks = [...animationFrames.values()]
+  animationFrames.clear()
+  await act(async () => {
+    for (const callback of callbacks) callback(toMs)
+  })
+}
+
+beforeEach(async () => {
+  const dom = parseHTML(
+    '<!doctype html><html><body><div id="root"></div></body></html>',
+  )
+  nowMs = 0
+  nextAnimationFrameId = 1
+  cancelledAnimationFrames = []
+  animationFrames = new Map()
+  const requestAnimationFrame = (callback: FrameRequestCallback): number => {
+    const id = nextAnimationFrameId++
+    animationFrames.set(id, callback)
+    return id
+  }
+  const cancelAnimationFrame = (id: number): void => {
+    cancelledAnimationFrames.push(id)
+    animationFrames.delete(id)
+  }
+  Object.assign(dom.window, { requestAnimationFrame, cancelAnimationFrame })
+  const globals = {
+    window: dom.window,
+    document: dom.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+    performance: { now: () => nowMs },
+  }
+  for (const [name, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    })
+  }
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  })
+
+  container = dom.document.getElementById('root') as unknown as HTMLElement
+  const { createRoot } = await import('react-dom/client')
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount())
+  root = null
+  for (const [name, descriptor] of globalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor)
+    else Reflect.deleteProperty(globalThis, name)
+  }
+  Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
+})
+
+describe('usePlayback', () => {
+  it('advances from the monotonic app clock at 1x, 2x, and 4x', async () => {
+    await render(100)
+
+    await act(async () => playback.setSpeed(1))
+    await advanceAnimationFrame(1_000)
+    expect(playback.time).toBe(1)
+
+    await act(async () => playback.setSpeed(2))
+    await advanceAnimationFrame(2_000)
+    expect(playback.time).toBe(3)
+
+    await act(async () => playback.setSpeed(4))
+    await advanceAnimationFrame(3_000)
+    expect(playback.time).toBe(7)
+  })
+
+  it('accounts for elapsed time at the old speed before changing speed', async () => {
+    await render(100)
+    await advanceAnimationFrame(1_000)
+    expect(playback.time).toBe(2)
+
+    nowMs = 1_500
+    await act(async () => playback.setSpeed(4))
+    expect(playback.time).toBe(3)
+
+    await advanceAnimationFrame(2_000)
+    expect(playback.time).toBe(5)
+  })
+
+  it('freezes while paused and excludes paused wall time after resume', async () => {
+    await render(100)
+    await advanceAnimationFrame(1_000)
+    expect(playback.time).toBe(2)
+
+    await act(async () => playback.togglePlay())
+    nowMs = 5_000
+    await act(async () => playback.togglePlay())
+    await advanceAnimationFrame(6_000)
+
+    expect(playback.time).toBe(4)
+  })
+
+  it('clamps seeks, pauses, and returns the applied destination', async () => {
+    await render(10)
+
+    let applied = -1
+    await act(async () => {
+      applied = playback.seek(50)
+    })
+    expect(applied).toBe(10)
+    expect(playback.time).toBe(10)
+    expect(playback.isPlaying).toBe(false)
+
+    await act(async () => {
+      applied = playback.seek(-5)
+    })
+    expect(applied).toBe(0)
+    expect(playback.time).toBe(0)
+  })
+
+  it('stops exactly at the end and restarts from zero on the next Play', async () => {
+    await render(10)
+    await advanceAnimationFrame(6_000)
+
+    expect(playback.time).toBe(10)
+    expect(playback.isPlaying).toBe(false)
+
+    await act(async () => playback.togglePlay())
+    expect(playback.time).toBe(0)
+    expect(playback.isPlaying).toBe(true)
+
+    await advanceAnimationFrame(6_500)
+    expect(playback.time).toBe(1)
+  })
+
+  it('clamps a changed duration and never schedules two clock loops', async () => {
+    await render(100)
+    expect(animationFrames.size).toBe(1)
+
+    await advanceAnimationFrame(2_000)
+    expect(playback.time).toBe(4)
+    expect(animationFrames.size).toBe(1)
+
+    await render(3)
+    expect(playback.time).toBe(3)
+    expect(playback.isPlaying).toBe(false)
+    expect(animationFrames.size).toBe(0)
+  })
+
+  it('cancels the only scheduled animation frame on unmount', async () => {
+    await render(100)
+    const scheduledId = [...animationFrames.keys()][0]
+    expect(scheduledId).toBeDefined()
+
+    await act(async () => root?.unmount())
+    root = null
+
+    if (scheduledId === undefined) throw new Error('expected a scheduled frame')
+    expect(cancelledAnimationFrames).toContain(scheduledId)
+    expect(animationFrames.size).toBe(0)
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
@@ -1,76 +1,149 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { DEFAULT_PLAYBACK_SPEED, PLAYBACK_SPEEDS } from './replay.helpers'
 
 export interface Playback {
-  /** Seconds elapsed in the session. */
+  /** Seconds elapsed on this BrowserClaw-owned transport. */
   time: number
-  /** True while rrweb's internal timer should be running. */
+  /** True while the transport clock and visible rrweb sink should run. */
   isPlaying: boolean
-  /** Multiplier applied by rrweb's internal timer. */
+  /** Multiplier applied to wall-clock deltas and the visible rrweb player. */
   speed: number
   setSpeed: (next: number) => void
-  /** Toggles play/pause. Restarts from 0 if the session already finished. */
+  /** Toggles play/pause. Restarts from 0 if the transport already finished. */
   togglePlay: () => void
-  /** Jumps the playhead to `seconds` and pauses. */
+  /** Jumps the playhead to `seconds`, pauses, and returns the clamped value. */
   seek: (seconds: number) => number
-  /** Updates display state from rrweb without seeking the player. */
+  /**
+   * Compatibility predicate for viewport orchestration. rrweb time is ignored:
+   * the renderer is a visual sink and may never write BrowserClaw's clock.
+   */
   syncFromPlayer: (seconds: number) => boolean
 }
 
-const END_EPSILON_SECONDS = 0.01
+function clampTime(seconds: number, totalSeconds: number): number {
+  return Math.max(0, Math.min(totalSeconds, seconds))
+}
 
-/** Owns replay transport state while rrweb owns the playback timer. */
+/**
+ * Owns replay time from one monotonic animation-frame loop. rrweb receives
+ * projected seeks/play commands elsewhere, but its per-tab timer cannot be the
+ * authority for a session clock that continues across player promotion.
+ */
 export function usePlayback(totalSeconds: number): Playback {
   const [time, setTime] = useState(0)
   const [isPlaying, setIsPlaying] = useState(true)
   const [speed, setSpeed] = useState<number>(DEFAULT_PLAYBACK_SPEED)
+  const timeRef = useRef(0)
+  const isPlayingRef = useRef(true)
+  const speedRef = useRef<number>(DEFAULT_PLAYBACK_SPEED)
+  const totalSecondsRef = useRef(totalSeconds)
+  const lastNowMsRef = useRef<number | null>(null)
 
-  const clamp = useCallback(
-    (seconds: number) => Math.max(0, Math.min(totalSeconds, seconds)),
-    [totalSeconds],
+  const writeTime = useCallback((next: number) => {
+    timeRef.current = next
+    setTime(next)
+  }, [])
+
+  const writePlaying = useCallback((next: boolean) => {
+    isPlayingRef.current = next
+    setIsPlaying(next)
+  }, [])
+
+  /**
+   * Accounts for elapsed wall time exactly once before any discontinuity.
+   * Reusing this for frames, pause, and speed changes prevents stale closures
+   * from charging an interval at both its old and new speed.
+   */
+  const advanceTo = useCallback(
+    (nowMs: number): number => {
+      const previousNowMs = lastNowMsRef.current
+      lastNowMsRef.current = nowMs
+      if (!isPlayingRef.current || previousNowMs === null) {
+        return timeRef.current
+      }
+
+      const elapsedMs = Math.max(0, nowMs - previousNowMs)
+      const next = clampTime(
+        timeRef.current + (elapsedMs / 1000) * speedRef.current,
+        totalSecondsRef.current,
+      )
+      if (next !== timeRef.current) writeTime(next)
+      if (totalSecondsRef.current > 0 && next >= totalSecondsRef.current) {
+        writePlaying(false)
+      }
+      return next
+    },
+    [writePlaying, writeTime],
   )
 
   useEffect(() => {
-    setTime((prev) => clamp(prev))
-  }, [clamp])
+    totalSecondsRef.current = totalSeconds
+    const clamped = clampTime(timeRef.current, totalSeconds)
+    if (clamped !== timeRef.current) writeTime(clamped)
+    if (totalSeconds > 0 && clamped >= totalSeconds) writePlaying(false)
+  }, [totalSeconds, writePlaying, writeTime])
 
-  const setPlaybackSpeed = useCallback((next: number) => {
-    if (PLAYBACK_SPEEDS.includes(next)) setSpeed(next)
-  }, [])
+  useEffect(() => {
+    if (!isPlaying || totalSeconds <= 0) {
+      lastNowMsRef.current = null
+      return
+    }
+
+    let active = true
+    let animationFrameId = 0
+    lastNowMsRef.current = performance.now()
+    const tick = (nowMs: number): void => {
+      if (!active) return
+      advanceTo(nowMs)
+      if (isPlayingRef.current) {
+        animationFrameId = window.requestAnimationFrame(tick)
+      }
+    }
+    animationFrameId = window.requestAnimationFrame(tick)
+    return () => {
+      active = false
+      window.cancelAnimationFrame(animationFrameId)
+      lastNowMsRef.current = null
+    }
+  }, [advanceTo, isPlaying, totalSeconds])
+
+  const setPlaybackSpeed = useCallback(
+    (next: number) => {
+      if (!PLAYBACK_SPEEDS.includes(next) || next === speedRef.current) return
+      if (isPlayingRef.current) advanceTo(performance.now())
+      speedRef.current = next
+      setSpeed(next)
+    },
+    [advanceTo],
+  )
 
   const togglePlay = useCallback(() => {
-    setIsPlaying((playing) => {
-      if (playing) return false
-      setTime((prev) => (prev >= totalSeconds ? 0 : prev))
-      return totalSeconds > 0
-    })
-  }, [totalSeconds])
+    if (isPlayingRef.current) {
+      advanceTo(performance.now())
+      writePlaying(false)
+      lastNowMsRef.current = null
+      return
+    }
+
+    if (timeRef.current >= totalSecondsRef.current) writeTime(0)
+    lastNowMsRef.current = performance.now()
+    writePlaying(totalSecondsRef.current > 0)
+  }, [advanceTo, writePlaying, writeTime])
 
   const seek = useCallback(
     (seconds: number) => {
-      const clamped = clamp(seconds)
-      setTime(clamped)
-      setIsPlaying(false)
+      const clamped = clampTime(seconds, totalSecondsRef.current)
+      writeTime(clamped)
+      writePlaying(false)
+      lastNowMsRef.current = null
       return clamped
     },
-    [clamp],
+    [writePlaying, writeTime],
   )
 
-  const syncFromPlayer = useCallback(
-    (seconds: number) => {
-      const clamped = clamp(seconds)
-      const finished =
-        totalSeconds > 0 && clamped >= totalSeconds - END_EPSILON_SECONDS
-      if (finished) {
-        setTime(totalSeconds)
-        setIsPlaying(false)
-        return false
-      }
-      setTime(clamped)
-      return true
-    },
-    [clamp, totalSeconds],
-  )
+  const syncFromPlayer = useCallback((_seconds: number) => {
+    return isPlayingRef.current
+  }, [])
 
   return {
     time,

--- a/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
@@ -8,16 +8,18 @@ export interface Playback {
   isPlaying: boolean
   /** Multiplier applied to wall-clock deltas and the visible rrweb player. */
   speed: number
+  /**
+   * Cumulative wall milliseconds actually played. Camera dwell consumes its
+   * delta so speed changes never distort the human viewing window.
+   */
+  playedRealMs: number
   setSpeed: (next: number) => void
+  /** Freezes at the current monotonic instant and returns that exact position. */
+  pause: () => number
   /** Toggles play/pause. Restarts from 0 if the transport already finished. */
   togglePlay: () => void
   /** Jumps the playhead to `seconds`, pauses, and returns the clamped value. */
   seek: (seconds: number) => number
-  /**
-   * Compatibility predicate for viewport orchestration. rrweb time is ignored:
-   * the renderer is a visual sink and may never write BrowserClaw's clock.
-   */
-  syncFromPlayer: (seconds: number) => boolean
 }
 
 function clampTime(seconds: number, totalSeconds: number): number {
@@ -33,11 +35,13 @@ export function usePlayback(totalSeconds: number): Playback {
   const [time, setTime] = useState(0)
   const [isPlaying, setIsPlaying] = useState(true)
   const [speed, setSpeed] = useState<number>(DEFAULT_PLAYBACK_SPEED)
+  const [playedRealMs, setPlayedRealMs] = useState(0)
   const timeRef = useRef(0)
   const isPlayingRef = useRef(true)
   const speedRef = useRef<number>(DEFAULT_PLAYBACK_SPEED)
   const totalSecondsRef = useRef(totalSeconds)
   const lastNowMsRef = useRef<number | null>(null)
+  const playedRealMsRef = useRef(0)
 
   const writeTime = useCallback((next: number) => {
     timeRef.current = next
@@ -63,6 +67,10 @@ export function usePlayback(totalSeconds: number): Playback {
       }
 
       const elapsedMs = Math.max(0, nowMs - previousNowMs)
+      if (elapsedMs > 0) {
+        playedRealMsRef.current += elapsedMs
+        setPlayedRealMs(playedRealMsRef.current)
+      }
       const next = clampTime(
         timeRef.current + (elapsedMs / 1000) * speedRef.current,
         totalSecondsRef.current,
@@ -117,18 +125,25 @@ export function usePlayback(totalSeconds: number): Playback {
     [advanceTo],
   )
 
+  const pause = useCallback(() => {
+    const pausedAt = isPlayingRef.current
+      ? advanceTo(performance.now())
+      : timeRef.current
+    writePlaying(false)
+    lastNowMsRef.current = null
+    return pausedAt
+  }, [advanceTo, writePlaying])
+
   const togglePlay = useCallback(() => {
     if (isPlayingRef.current) {
-      advanceTo(performance.now())
-      writePlaying(false)
-      lastNowMsRef.current = null
+      pause()
       return
     }
 
     if (timeRef.current >= totalSecondsRef.current) writeTime(0)
     lastNowMsRef.current = performance.now()
     writePlaying(totalSecondsRef.current > 0)
-  }, [advanceTo, writePlaying, writeTime])
+  }, [pause, writePlaying, writeTime])
 
   const seek = useCallback(
     (seconds: number) => {
@@ -141,17 +156,14 @@ export function usePlayback(totalSeconds: number): Playback {
     [writePlaying, writeTime],
   )
 
-  const syncFromPlayer = useCallback((_seconds: number) => {
-    return isPlayingRef.current
-  }, [])
-
   return {
     time,
     isPlaying,
     speed,
+    playedRealMs,
     setSpeed: setPlaybackSpeed,
+    pause,
     togglePlay,
     seek,
-    syncFromPlayer,
   }
 }


### PR DESCRIPTION
## Summary

- Replace rrweb-owned tab-local playback with one BrowserClaw-owned global session clock and a deterministic completion-minus-duration camera schedule.
- Keep unrelated tab DOM streams isolated behind a bounded stage with one active player and at most one paused standby.
- Preserve global position across explicit tab inspection, while keeping no-visual actions in the timeline and existing same-tab stitching and gap warnings intact.

## Design

This implements the approved bounded double-buffered architecture. A pure session plan projects absolute global time into independent tab tracks, and a pure camera reducer coalesces parallel candidates with a 10-second real-time dwell that is independent of playback speed. rrweb is only a visual sink: promotion is generation-guarded and presentation metadata changes only after the target player is ready, with throttled 250 ms drift correction rather than per-frame seeks. The change is frontend-only.

## Test plan

- [x] Run the full `@browseros/claw-app` test suite.
- [x] Run `@browseros/claw-app` typecheck.
- [x] Run targeted Biome checks for the replay screen and replay API model.
- [ ] Open a replay with sequential and overlapping activity across at least two recorded tabs; confirm the camera follows activity without rapid intermediate jumps.
- [ ] Exercise 1x, 2x, and 4x; confirm a long-lived tab remains visible for about 10 wall-clock seconds at each speed, while a short track switches when its visuals end.
- [ ] Scrub globally and select timeline actions; confirm the replay pauses and resolves the expected tab, URL, caption, and warning.
- [ ] Click both the followed tab chip and another tab chip; confirm inspection starts at local zero, then `Resume session` restores the exact global position and remains paused.
- [ ] Confirm same-tab navigation stays one track, no-visual actions remain in the timeline without taking the viewport, completion restarts from zero, and rapid switches never mount more than two players.
