### PR TITLE
feat(code-mode): self-healing helpers

### DIFF
--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "futures-util",
  "harness-integrations",
  "posthog-rs",
+ "pulldown-cmark",
  "rand 0.9.4",
  "rmcp",
  "sea-orm",
@@ -2047,6 +2048,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,6 +3547,12 @@ dependencies = [
  "rand 0.9.4",
  "web-time",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/packages/browseros-agent/Cargo.toml
+++ b/packages/browseros-agent/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
 serde-saphyr = { version = "0.0.29", default-features = false, features = ["deserialize"] }
+pulldown-cmark = { version = "0.13", default-features = false }
 sha2 = "0.10"
 jsonc-parser = { version = "0.33", features = ["cst"] }
 toml_edit = "0.22"

--- a/packages/browseros-agent/apps/claw-server-rust/Cargo.toml
+++ b/packages/browseros-agent/apps/claw-server-rust/Cargo.toml
@@ -33,6 +33,7 @@ rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde-saphyr.workspace = true
+pulldown-cmark.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tempfile.workspace = true

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/dispatch.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/dispatch.rs
@@ -1,6 +1,6 @@
 use crate::{
     AppState,
-    api::mcp::{effects, guards, observers},
+    api::mcp::{effects, guards, helper_runtime, observers},
     identity::ClientIdentity,
     ids::{ConvoId, DispatchId, SessionId},
     services::sessions::Session,
@@ -22,7 +22,7 @@ use tracing::warn;
 
 const CANCELLATION_REASON: &str = "Operation cancelled by the User";
 const CLIENT_CANCELLATION_ERROR: &str = "Request cancelled by client";
-const ARBITRARY_SCRIPT_TOOLS: &[&str] = &["run", "evaluate"];
+pub(crate) const ARBITRARY_SCRIPT_TOOLS: &[&str] = &["run", "evaluate"];
 const DISPATCH_ERROR_TEXT_MAX: usize = 200;
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
@@ -199,6 +199,10 @@ const EFFECTS: &[NamedToolEffect] = &[
     NamedToolEffect {
         name: "session-naming",
         run: effects::session_naming::apply,
+    },
+    NamedToolEffect {
+        name: "helper-discovery",
+        run: helper_runtime::discovery,
     },
 ];
 
@@ -1095,6 +1099,7 @@ mod tests {
                 "tab-activity",
                 "tab-groups",
                 "session-naming",
+                "helper-discovery",
             ]
         );
         assert_eq!(

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/dispatch.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/dispatch.rs
@@ -1,6 +1,6 @@
 use crate::{
     AppState,
-    api::mcp::{effects, guards, helper_runtime, observers},
+    api::mcp::{distill, effects, guards, helper_runtime, observers},
     identity::ClientIdentity,
     ids::{ConvoId, DispatchId, SessionId},
     services::sessions::Session,
@@ -206,10 +206,16 @@ const EFFECTS: &[NamedToolEffect] = &[
     },
 ];
 
-const OBSERVERS: &[NamedToolObserver] = &[NamedToolObserver {
-    name: "audit",
-    run: observers::audit::apply,
-}];
+const OBSERVERS: &[NamedToolObserver] = &[
+    NamedToolObserver {
+        name: "audit",
+        run: observers::audit::apply,
+    },
+    NamedToolObserver {
+        name: "distill",
+        run: distill::distill,
+    },
+];
 
 struct ExecutionOutcome {
     result: ToolResult,
@@ -1107,7 +1113,7 @@ mod tests {
                 .iter()
                 .map(|observer| observer.name)
                 .collect::<Vec<_>>(),
-            ["audit"]
+            ["audit", "distill"]
         );
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/dispatch.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/dispatch.rs
@@ -393,8 +393,9 @@ async fn execute_with_cancellation(call: &ToolCall) -> DispatchExecution {
             // session, bypassing the guards and audit effect the pipeline runs
             // per tool. Inject a hook so each primitive is ownership-checked and
             // recorded as a child of this script's dispatch.
+            let is_script = ARBITRARY_SCRIPT_TOOLS.contains(&call.tool().name);
             let inner_call_hook: Option<Arc<dyn browseros_mcp::InnerCallHook>> =
-                if ARBITRARY_SCRIPT_TOOLS.contains(&call.tool().name) && call.identity.is_some() {
+                if is_script && call.identity.is_some() {
                     Some(
                         Arc::new(crate::api::mcp::script_hook::ScriptInnerCallHook::new(
                             call.clone(),
@@ -403,6 +404,19 @@ async fn execute_with_cancellation(call: &ToolCall) -> DispatchExecution {
                 } else {
                     None
                 };
+            // Hot-load the helpers the agent's owned-tab hosts make relevant, so
+            // the script can call them by name. Cheap-gated when no helpers exist.
+            let preloaded_helpers = match &call.identity {
+                Some(identity) if is_script => {
+                    crate::api::mcp::helper_runtime::preload_helpers(
+                        &call.state,
+                        &identity.ownership_key,
+                        browser_session,
+                    )
+                    .await
+                }
+                _ => Vec::new(),
+            };
             let ctx = ToolCtx::new(BrowserToolOptions {
                 session: browser_session.clone(),
                 defaults: BrowserToolDefaults {
@@ -412,6 +426,7 @@ async fn execute_with_cancellation(call: &ToolCall) -> DispatchExecution {
                 cancel: call.cancel.clone(),
                 output_files: call.output_files.clone(),
                 inner_call_hook,
+                preloaded_helpers,
             });
             match execute_tool(call.tool(), call.raw_args.clone(), &ctx).await {
                 Ok(result) => result,

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
@@ -62,11 +62,12 @@ pub fn distill(context: ToolObserverContext<'_>) -> BoxFuture<'_, anyhow::Result
             candidate: true,
             deps,
         };
-        if let Err(error) =
-            helpers::save_helper(&context.call.state.config.browserclaw_dir, &meta, &source)
-        {
+        let dir = &context.call.state.config.browserclaw_dir;
+        if let Err(error) = helpers::save_helper(dir, &meta, &source) {
             warn!(error = %error, "distilled candidate helper save failed");
         }
+        // Bound accumulation: keep only the most recent candidates per host.
+        helpers::prune_candidates(dir, &meta.host, helpers::MAX_CANDIDATES_PER_HOST);
         Ok(())
     })
 }
@@ -84,9 +85,11 @@ pub(crate) fn distill_source(children: &[ToolDispatchRow]) -> Option<(String, u6
     // rather than embedded (no credentials or personal data in a shared helper).
     let mut inputs = 0usize;
     for row in children {
-        // Only replay actions that actually succeeded: a caught-and-recovered
-        // failure must not enter a "successful" helper.
-        if row_failed(row) {
+        // Only distill the agent's own successful actions: skip failures (a
+        // caught-and-recovered step) and primitives replayed from inside a
+        // hot-loaded helper (a reuse), so a working reuse does not re-distill and
+        // a failed reuse distills only the manual repair.
+        if row_failed(row) || row_from_helper(row) {
             continue;
         }
         let args: Vec<Value> = row
@@ -117,10 +120,20 @@ pub(crate) fn distill_source(children: &[ToolDispatchRow]) -> Option<(String, u6
 /// Whether a child's recorded result marked it an error, read from its
 /// `result_meta` summary.
 fn row_failed(row: &ToolDispatchRow) -> bool {
+    result_meta_flag(row, "isError")
+}
+
+/// Whether a child primitive ran inside a hot-loaded helper (a replay), tagged
+/// by the script hook in `result_meta`.
+fn row_from_helper(row: &ToolDispatchRow) -> bool {
+    result_meta_flag(row, "fromHelper")
+}
+
+fn result_meta_flag(row: &ToolDispatchRow, key: &str) -> bool {
     row.result_meta
         .as_deref()
         .and_then(|meta| serde_json::from_str::<Value>(meta).ok())
-        .and_then(|meta| meta.get("isError").and_then(Value::as_bool))
+        .and_then(|meta| meta.get(key).and_then(Value::as_bool))
         .unwrap_or(false)
 }
 
@@ -260,6 +273,49 @@ mod tests {
         assert!(source.contains("inputs.field0"));
         assert!(source.contains("inputs.field1"));
         Ok(())
+    }
+
+    #[test]
+    fn excludes_helper_replays_and_distills_only_the_manual_repair() -> anyhow::Result<()> {
+        let tagged = |tool: &str, args: Value, is_error: bool| {
+            let mut row = child(tool, args);
+            row.result_meta = Some(json!({ "isError": is_error, "fromHelper": true }).to_string());
+            row
+        };
+        let children = [
+            // A stale helper replays two fills, then its click fails:
+            tagged("input.fill", json!([3, "e3", "old"]), false),
+            tagged("input.fill", json!([3, "e5", "old"]), false),
+            tagged("input.click", json!([3, "e6"]), true),
+            // The agent repairs manually (not from a helper):
+            child("input.fill", json!([3, "e3", "repaired"])),
+            child("input.click", json!([3, "e7"])),
+        ];
+        let (source, _) = distill_source(&children)
+            .ok_or_else(|| anyhow::anyhow!("expected a distilled macro"))?;
+        // Only the manual repair distills; the helper's replayed actions are gone.
+        assert!(
+            !source.contains("e5"),
+            "helper-replayed action leaked: {source}"
+        );
+        assert!(source.contains("e7"), "repair action missing: {source}");
+        assert_eq!(source.matches("await browser").count(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn a_fully_replayed_reuse_does_not_distill() {
+        let helper = |tool: &str, args: Value| {
+            let mut row = child(tool, args);
+            row.result_meta = Some(json!({ "isError": false, "fromHelper": true }).to_string());
+            row
+        };
+        // Every action came from a helper: nothing new to learn.
+        let children = [
+            helper("input.fill", json!([3, "e3", "x"])),
+            helper("input.click", json!([3, "e6"])),
+        ];
+        assert!(distill_source(&children).is_none());
     }
 
     #[test]

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
@@ -12,7 +12,7 @@ use crate::{
 use browseros_core::{BrowserSession, PageId};
 use futures_util::future::BoxFuture;
 use serde_json::Value;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use tracing::warn;
 
 /// Observer that distills a successful script run into a candidate helper keyed
@@ -48,23 +48,29 @@ pub fn distill(context: ToolObserverContext<'_>) -> BoxFuture<'_, anyhow::Result
             },
         };
         let steps = source.matches("await browser").count();
-        let inputs = source.matches("inputs.field").count();
-        let deps = if inputs > 0 {
-            format!(
-                "distilled from {steps} recorded step(s); expects {inputs} input value(s) in `inputs`"
-            )
+        let input_count = source.matches("inputs.field").count();
+        // An opened-page macro has the `(browser, inputs)` signature; a search-by-URL
+        // one additionally reads a field into the navigation via encodeURIComponent.
+        let opens_page = source.starts_with("async (browser, inputs");
+        let is_search = opens_page && source.contains("encodeURIComponent(inputs.field");
+        let inputs = build_inputs(&source, input_count);
+        let description = describe(&host, steps, opens_page, is_search);
+        // A search-by-URL flow gets one canonical descriptive name per host; other
+        // flows keep a content hash so identical flows dedupe on re-run.
+        let name = if is_search {
+            format!("search-{host}")
         } else {
-            format!("distilled from {steps} recorded step(s)")
+            format!("candidate-{}", short_hash(&source))
         };
         let meta = HelperMeta {
-            // Same flow hashes to the same name, so re-running overwrites rather
-            // than accumulating a new candidate each time.
-            name: format!("candidate-{}", short_hash(&source)),
+            name,
             host,
             last_verified: now_epoch_ms(),
             agent: identity.agent.slug().to_string(),
             candidate: true,
-            deps,
+            opens_page,
+            inputs,
+            description,
         };
         let dir = &context.call.state.config.browserclaw_dir;
         if let Err(error) = helpers::save_helper(dir, &meta, &source) {
@@ -310,6 +316,34 @@ async fn page_host(session: &BrowserSession, page_id: u64) -> Option<String> {
     helpers::host_bucket(&info.url)
 }
 
+/// Builds the `field<n> -> description` input map from the generated source: a
+/// field read into a URL via `encodeURIComponent` is a search query; the rest are
+/// generic input values. Drives the documented call form.
+fn build_inputs(source: &str, count: usize) -> BTreeMap<String, String> {
+    (0..count)
+        .map(|index| {
+            let field = format!("field{index}");
+            let desc = if source.contains(&format!("encodeURIComponent(inputs.{field})")) {
+                "search query"
+            } else {
+                "input value"
+            };
+            (field, desc.to_string())
+        })
+        .collect()
+}
+
+/// A one-line human summary of the distilled flow for the helper's frontmatter.
+fn describe(host: &str, steps: usize, opens_page: bool, is_search: bool) -> String {
+    if is_search {
+        format!("Opens {host} search for a query and returns the results page")
+    } else if opens_page {
+        format!("Opens a {host} page and returns it")
+    } else {
+        format!("Replays {steps} step(s) on {host}")
+    }
+}
+
 /// A short, deterministic id for a helper source so identical flows dedupe.
 fn short_hash(source: &str) -> String {
     use std::hash::{Hash, Hasher};
@@ -470,6 +504,24 @@ mod tests {
             helper("input.click", json!([3, "e6"])),
         ];
         assert!(distill_source(&children).is_none());
+    }
+
+    #[test]
+    fn build_inputs_labels_search_query_field_and_describes_flow() {
+        let search = "const page = await browser.pages.newPage(\"https://www.amazon.in/s?k=\" + encodeURIComponent(inputs.field0));";
+        let inputs = build_inputs(search, 1);
+        assert_eq!(inputs.get("field0").map(String::as_str), Some("search query"));
+        assert_eq!(
+            describe("amazon.in", 2, true, true),
+            "Opens amazon.in search for a query and returns the results page"
+        );
+        // A form fill (not a URL query) is a generic input value.
+        let fill = "await browser.input(page).fill(\"e5\", inputs.field0);";
+        assert_eq!(
+            build_inputs(fill, 1).get("field0").map(String::as_str),
+            Some("input value")
+        );
+        assert_eq!(describe("example.com", 3, false, false), "Replays 3 step(s) on example.com");
     }
 
     #[test]

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
@@ -1,6 +1,6 @@
 //! Audit distillation: after a successful script run, turn the child primitive
 //! sequence recorded under it into a candidate helper, so a proven flow is saved
-//! for reuse with no agent writing. This is uniquely enabled by the Phase 1
+//! for reuse with no agent writing. This is uniquely enabled by the code-mode
 //! audit hierarchy.
 
 use crate::{
@@ -44,6 +44,14 @@ pub fn distill(context: ToolObserverContext<'_>) -> BoxFuture<'_, anyhow::Result
             return Ok(());
         };
         let steps = source.matches("await browser").count();
+        let inputs = source.matches("inputs.field").count();
+        let deps = if inputs > 0 {
+            format!(
+                "distilled from {steps} recorded step(s); expects {inputs} input value(s) in `inputs`"
+            )
+        } else {
+            format!("distilled from {steps} recorded step(s)")
+        };
         let meta = HelperMeta {
             // Same flow hashes to the same name, so re-running overwrites rather
             // than accumulating a new candidate each time.
@@ -52,7 +60,7 @@ pub fn distill(context: ToolObserverContext<'_>) -> BoxFuture<'_, anyhow::Result
             last_verified: now_epoch_ms(),
             agent: identity.agent.slug().to_string(),
             candidate: true,
-            deps: format!("distilled from {steps} recorded step(s)"),
+            deps,
         };
         if let Err(error) =
             helpers::save_helper(&context.call.state.config.browserclaw_dir, &meta, &source)
@@ -72,7 +80,15 @@ const _: ToolObserver = distill;
 pub(crate) fn distill_source(children: &[ToolDispatchRow]) -> Option<(String, u64)> {
     let mut lines = Vec::new();
     let mut pages = BTreeSet::new();
+    // Running index for value inputs, so typed values are read from `inputs`
+    // rather than embedded (no credentials or personal data in a shared helper).
+    let mut inputs = 0usize;
     for row in children {
+        // Only replay actions that actually succeeded: a caught-and-recovered
+        // failure must not enter a "successful" helper.
+        if row_failed(row) {
+            continue;
+        }
         let args: Vec<Value> = row
             .args_json
             .as_deref()
@@ -81,7 +97,7 @@ pub(crate) fn distill_source(children: &[ToolDispatchRow]) -> Option<(String, u6
         let Some(page) = args.first().and_then(Value::as_u64) else {
             continue;
         };
-        let Some(line) = emit_line(&row.tool_name, &args) else {
+        let Some(line) = emit_line(&row.tool_name, &args, &mut inputs) else {
             continue;
         };
         pages.insert(page);
@@ -91,17 +107,37 @@ pub(crate) fn distill_source(children: &[ToolDispatchRow]) -> Option<(String, u6
         return None;
     }
     let page = *pages.iter().next()?;
-    let source = format!("async (browser, page) => {{\n{}\n}}", lines.join("\n"));
+    let source = format!(
+        "async (browser, page, inputs = {{}}) => {{\n{}\n}}",
+        lines.join("\n")
+    );
     Some((source, page))
 }
 
+/// Whether a child's recorded result marked it an error, read from its
+/// `result_meta` summary.
+fn row_failed(row: &ToolDispatchRow) -> bool {
+    row.result_meta
+        .as_deref()
+        .and_then(|meta| serde_json::from_str::<Value>(meta).ok())
+        .and_then(|meta| meta.get("isError").and_then(Value::as_bool))
+        .unwrap_or(false)
+}
+
 /// Maps one recorded driving primitive to its SDK call line, `page` standing in
-/// for the recorded page id. Returns `None` for anything not worth replaying
+/// for the recorded page id. Typed values (fill/type/selectOption) are read from
+/// `inputs.field<n>` rather than embedded, so a distilled helper never persists a
+/// credential or personal data. Returns `None` for anything not worth replaying
 /// (pure reads, page management, escape hatches).
-fn emit_line(tool: &str, args: &[Value]) -> Option<String> {
+fn emit_line(tool: &str, args: &[Value], inputs: &mut usize) -> Option<String> {
     let arg = |index: usize| {
         args.get(index)
             .map_or_else(|| "undefined".to_string(), Value::to_string)
+    };
+    let mut input = || {
+        let field = format!("inputs.field{inputs}");
+        *inputs += 1;
+        field
     };
     let line = match tool {
         "nav.goto" => format!("  await browser.nav(page).goto({});", arg(1)),
@@ -109,15 +145,15 @@ fn emit_line(tool: &str, args: &[Value]) -> Option<String> {
         "nav.forward" => "  await browser.nav(page).forward();".to_string(),
         "nav.reload" => "  await browser.nav(page).reload();".to_string(),
         "input.click" => format!("  await browser.input(page).click({});", arg(1)),
-        "input.fill" => format!("  await browser.input(page).fill({}, {});", arg(1), arg(2)),
-        "input.type" => format!("  await browser.input(page).type({});", arg(1)),
+        "input.fill" => format!("  await browser.input(page).fill({}, {});", arg(1), input()),
+        "input.type" => format!("  await browser.input(page).type({});", input()),
         "input.press" => format!("  await browser.input(page).press({});", arg(1)),
         "input.hover" => format!("  await browser.input(page).hover({});", arg(1)),
         "input.selectOption" => {
             format!(
                 "  await browser.input(page).selectOption({}, {});",
                 arg(1),
-                arg(2)
+                input()
             )
         }
         "input.scroll" => format!(
@@ -188,13 +224,41 @@ mod tests {
         let (source, page) = distill_source(&children)
             .ok_or_else(|| anyhow::anyhow!("expected a distilled macro"))?;
         assert_eq!(page, 3);
+        // The fill value is parameterized (inputs.field0), never embedded.
         assert_eq!(
             source,
-            "async (browser, page) => {\n  \
+            "async (browser, page, inputs = {}) => {\n  \
              await browser.nav(page).goto(\"https://example.com/login\");\n  \
-             await browser.input(page).fill(\"e5\", \"alice\");\n  \
+             await browser.input(page).fill(\"e5\", inputs.field0);\n  \
              await browser.input(page).click(\"e6\");\n}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn drops_failed_actions_and_never_embeds_typed_values() -> anyhow::Result<()> {
+        let mut failed_click = child("input.click", json!([3, "e9"]));
+        // A caught-and-recovered failure must not enter the helper.
+        failed_click.result_meta = Some(json!({ "isError": true }).to_string());
+        let children = [
+            child("nav.goto", json!([3, "https://example.com/login"])),
+            failed_click,
+            child("input.fill", json!([3, "e5", "s3cr3t-password"])),
+            child("input.type", json!([3, "also-secret"])),
+            child("input.click", json!([3, "e6"])),
+        ];
+        let (source, _) = distill_source(&children)
+            .ok_or_else(|| anyhow::anyhow!("expected a distilled macro"))?;
+        // The failed click is dropped.
+        assert!(!source.contains("e9"), "failed action leaked: {source}");
+        // Typed values are parameterized, never embedded.
+        assert!(
+            !source.contains("s3cr3t-password"),
+            "secret leaked: {source}"
+        );
+        assert!(!source.contains("also-secret"), "secret leaked: {source}");
+        assert!(source.contains("inputs.field0"));
+        assert!(source.contains("inputs.field1"));
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
@@ -13,7 +13,13 @@ use browseros_core::{BrowserSession, PageId};
 use futures_util::future::BoxFuture;
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 use tracing::warn;
+
+/// A distilled flow with fewer than this many actions is not worth a helper; more
+/// than the ceiling signals exploration or a retry loop rather than a crisp macro.
+const MIN_ACTIONS: usize = 2;
+const MAX_ACTIONS: usize = 8;
 
 /// Observer that distills a successful script run into a candidate helper keyed
 /// by the host of the single page the flow drove.
@@ -47,6 +53,11 @@ pub fn distill(context: ToolObserverContext<'_>) -> BoxFuture<'_, anyhow::Result
                 None => return Ok(()),
             },
         };
+        // Quality gate: skip exploration and retry loops so only crisp, proven
+        // flows become helpers.
+        if !is_distillable(&source) {
+            return Ok(());
+        }
         let steps = source.matches("await browser").count();
         let input_count = source.matches("inputs.field").count();
         // An opened-page macro has the `(browser, inputs)` signature; a search-by-URL
@@ -56,28 +67,52 @@ pub fn distill(context: ToolObserverContext<'_>) -> BoxFuture<'_, anyhow::Result
         let inputs = build_inputs(&source, input_count);
         let description = describe(&host, steps, opens_page, is_search);
         // A search-by-URL flow gets one canonical descriptive name per host; other
-        // flows keep a content hash so identical flows dedupe on re-run.
+        // flows dedupe across sessions by normalized shape, so the same flow
+        // re-derived elsewhere supersedes rather than piling up.
         let name = if is_search {
             format!("search-{host}")
         } else {
-            format!("candidate-{}", short_hash(&source))
+            format!("candidate-{}", short_hash(&normalize_shape(&source)))
         };
+        let dir = &context.call.state.config.browserclaw_dir;
+        let session = identity.session.convo_id().as_str().to_string();
+        // Hard per-session cap: a single session contributes at most one candidate
+        // per host, the richest qualifying flow it produced. If it already has an
+        // equal-or-richer candidate here, keep that one.
+        let rank = (u8::from(opens_page), steps);
+        let mine: Vec<HelperMeta> = helpers::list_helper_meta(dir, &host)
+            .into_iter()
+            .filter(|meta| meta.candidate && meta.session == session)
+            .collect();
+        if mine
+            .iter()
+            .any(|meta| candidate_rank(dir, &host, meta) >= rank)
+        {
+            return Ok(());
+        }
         let meta = HelperMeta {
-            name,
-            host,
+            name: name.clone(),
+            host: host.clone(),
             last_verified: now_epoch_ms(),
             agent: identity.agent.slug().to_string(),
             candidate: true,
             opens_page,
             inputs,
             description,
+            session,
         };
-        let dir = &context.call.state.config.browserclaw_dir;
         if let Err(error) = helpers::save_helper(dir, &meta, &source) {
             warn!(error = %error, "distilled candidate helper save failed");
+            return Ok(());
         }
-        // Bound accumulation: keep only the most recent candidates per host.
-        helpers::prune_candidates(dir, &meta.host, helpers::MAX_CANDIDATES_PER_HOST);
+        // Enforce the per-session cap: drop this session's now-superseded candidates.
+        for old in mine {
+            if old.name != name {
+                helpers::remove_helper(dir, &host, &old.name);
+            }
+        }
+        // Bound accumulation across sessions: keep only the most recent candidates.
+        helpers::prune_candidates(dir, &host, helpers::MAX_CANDIDATES_PER_HOST);
         Ok(())
     })
 }
@@ -320,17 +355,87 @@ async fn page_host(session: &BrowserSession, page_id: u64) -> Option<String> {
 /// field read into a URL via `encodeURIComponent` is a search query; the rest are
 /// generic input values. Drives the documented call form.
 fn build_inputs(source: &str, count: usize) -> BTreeMap<String, String> {
+    let mut labeled_search = false;
     (0..count)
         .map(|index| {
             let field = format!("field{index}");
-            let desc = if source.contains(&format!("encodeURIComponent(inputs.{field})")) {
-                "search query"
-            } else {
-                "input value"
-            };
+            // Only the first field read into a URL is the search query; the rest
+            // are generic input values.
+            let is_search = !labeled_search
+                && source.contains(&format!("encodeURIComponent(inputs.{field})"));
+            if is_search {
+                labeled_search = true;
+            }
+            let desc = if is_search { "search query" } else { "input value" };
             (field, desc.to_string())
         })
         .collect()
+}
+
+/// Whether a distilled flow is worth saving as a helper: a sane action count, and
+/// no more than one search navigation (multiple is a re-search loop, not a macro).
+fn is_distillable(source: &str) -> bool {
+    let actions = source.matches("await browser").count();
+    if !(MIN_ACTIONS..=MAX_ACTIONS).contains(&actions) {
+        return false;
+    }
+    source
+        .matches("encodeURIComponent(inputs.field")
+        .count()
+        <= 1
+}
+
+/// The (opensPage, action-count) rank of an existing candidate, read from its
+/// source. A search helper (opensPage) outranks a passed-page one; among the
+/// same kind, more actions wins.
+fn candidate_rank(dir: &Path, host: &str, meta: &HelperMeta) -> (u8, usize) {
+    let actions = helpers::read_helper_source(dir, host, &meta.name)
+        .map(|source| source.matches("await browser").count())
+        .unwrap_or(0);
+    (u8::from(meta.opens_page), actions)
+}
+
+/// A structural skeleton of a distilled source: string literals (refs, URLs,
+/// values) collapsed to a placeholder and input indices normalized, so the same
+/// flow re-derived with different specifics hashes the same and supersedes rather
+/// than accumulating.
+fn normalize_shape(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut chars = source.chars();
+    while let Some(character) = chars.next() {
+        if character == '"' {
+            // Skip the string body; refs, URLs, and values all live in quotes.
+            while let Some(inner) = chars.next() {
+                match inner {
+                    '\\' => {
+                        chars.next();
+                    }
+                    '"' => break,
+                    _ => {}
+                }
+            }
+            out.push_str("\"S\"");
+        } else {
+            out.push(character);
+        }
+    }
+    collapse_input_indices(&out)
+}
+
+/// Replaces `inputs.field<n>` with `inputs.fieldN`, so the number of inputs does
+/// not fork the shape.
+fn collapse_input_indices(source: &str) -> String {
+    let needle = "inputs.field";
+    let mut out = String::with_capacity(source.len());
+    let mut rest = source;
+    while let Some(pos) = rest.find(needle) {
+        out.push_str(&rest[..pos]);
+        out.push_str(needle);
+        out.push('N');
+        rest = rest[pos + needle.len()..].trim_start_matches(|c: char| c.is_ascii_digit());
+    }
+    out.push_str(rest);
+    out
 }
 
 /// A one-line human summary of the distilled flow for the helper's frontmatter.
@@ -522,6 +627,37 @@ mod tests {
             Some("input value")
         );
         assert_eq!(describe("example.com", 3, false, false), "Replays 3 step(s) on example.com");
+    }
+
+    #[test]
+    fn is_distillable_rejects_loops_and_oversized_flows() {
+        let clean = "async (browser, inputs = {}) => {\n  const page = await browser.pages.newPage(\"x\" + encodeURIComponent(inputs.field0));\n  await browser.wait(page, {});\n}";
+        assert!(is_distillable(clean));
+        // A re-search loop (more than one search navigation) is rejected.
+        let loop_src = "await browser a encodeURIComponent(inputs.field0) await browser b encodeURIComponent(inputs.field1)";
+        assert!(!is_distillable(loop_src));
+        // Too many actions signals exploration.
+        assert!(!is_distillable(&"await browser x ".repeat(12)));
+        // Too few is rejected.
+        assert!(!is_distillable("await browser x"));
+    }
+
+    #[test]
+    fn normalize_shape_is_stable_across_refs_and_values() {
+        let a = "async (browser, page, inputs = {}) => {\n  await browser.input(page).fill(\"e5\", inputs.field0);\n  await browser.input(page).click(\"e6\");\n}";
+        let b = "async (browser, page, inputs = {}) => {\n  await browser.input(page).fill(\"e9\", inputs.field0);\n  await browser.input(page).click(\"e42\");\n}";
+        assert_eq!(normalize_shape(a), normalize_shape(b));
+        // A structurally different flow differs.
+        let c = "async (browser, page, inputs = {}) => {\n  await browser.input(page).click(\"e6\");\n}";
+        assert_ne!(normalize_shape(a), normalize_shape(c));
+    }
+
+    #[test]
+    fn build_inputs_labels_only_the_first_search_field() {
+        let two_search = "newPage(\"a\" + encodeURIComponent(inputs.field0)); nav(page).goto(\"b\" + encodeURIComponent(inputs.field1));";
+        let inputs = build_inputs(two_search, 2);
+        assert_eq!(inputs.get("field0").map(String::as_str), Some("search query"));
+        assert_eq!(inputs.get("field1").map(String::as_str), Some("input value"));
     }
 
     #[test]

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
@@ -1,0 +1,216 @@
+//! Audit distillation: after a successful script run, turn the child primitive
+//! sequence recorded under it into a candidate helper, so a proven flow is saved
+//! for reuse with no agent writing. This is uniquely enabled by the Phase 1
+//! audit hierarchy.
+
+use crate::{
+    api::mcp::dispatch::{ARBITRARY_SCRIPT_TOOLS, ToolObserver, ToolObserverContext},
+    clock::now_epoch_ms,
+    db::audit_log::ToolDispatchRow,
+    services::helpers::{self, HelperMeta},
+};
+use browseros_core::{BrowserSession, PageId};
+use futures_util::future::BoxFuture;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use tracing::warn;
+
+/// Observer that distills a successful script run into a candidate helper keyed
+/// by the host of the single page the flow drove.
+pub fn distill(context: ToolObserverContext<'_>) -> BoxFuture<'_, anyhow::Result<()>> {
+    Box::pin(async move {
+        if context.result.is_error
+            || context.cancelled
+            || !ARBITRARY_SCRIPT_TOOLS.contains(&context.call.tool().name)
+        {
+            return Ok(());
+        }
+        let (Some(identity), Some(session)) =
+            (&context.call.identity, &context.call.browser_session)
+        else {
+            return Ok(());
+        };
+        let children = context
+            .call
+            .state
+            .audit_log
+            .dispatches_with_parent(context.call.dispatch_id.as_str())
+            .await
+            .unwrap_or_default();
+        let Some((source, page_id)) = distill_source(&children) else {
+            return Ok(());
+        };
+        let Some(host) = page_host(session, page_id).await else {
+            return Ok(());
+        };
+        let steps = source.matches("await browser").count();
+        let meta = HelperMeta {
+            // Same flow hashes to the same name, so re-running overwrites rather
+            // than accumulating a new candidate each time.
+            name: format!("candidate-{}", short_hash(&source)),
+            host,
+            last_verified: now_epoch_ms(),
+            agent: identity.agent.slug().to_string(),
+            candidate: true,
+            deps: format!("distilled from {steps} recorded step(s)"),
+        };
+        if let Err(error) =
+            helpers::save_helper(&context.call.state.config.browserclaw_dir, &meta, &source)
+        {
+            warn!(error = %error, "distilled candidate helper save failed");
+        }
+        Ok(())
+    })
+}
+
+const _: ToolObserver = distill;
+
+/// Synthesizes a single-page action macro from the recorded child sequence, plus
+/// the page id it drove. `None` unless at least two recognized actions all target
+/// one page (multi-page replays are a follow-up).
+#[must_use]
+pub(crate) fn distill_source(children: &[ToolDispatchRow]) -> Option<(String, u64)> {
+    let mut lines = Vec::new();
+    let mut pages = BTreeSet::new();
+    for row in children {
+        let args: Vec<Value> = row
+            .args_json
+            .as_deref()
+            .and_then(|raw| serde_json::from_str(raw).ok())
+            .unwrap_or_default();
+        let Some(page) = args.first().and_then(Value::as_u64) else {
+            continue;
+        };
+        let Some(line) = emit_line(&row.tool_name, &args) else {
+            continue;
+        };
+        pages.insert(page);
+        lines.push(line);
+    }
+    if lines.len() < 2 || pages.len() != 1 {
+        return None;
+    }
+    let page = *pages.iter().next()?;
+    let source = format!("async (browser, page) => {{\n{}\n}}", lines.join("\n"));
+    Some((source, page))
+}
+
+/// Maps one recorded driving primitive to its SDK call line, `page` standing in
+/// for the recorded page id. Returns `None` for anything not worth replaying
+/// (pure reads, page management, escape hatches).
+fn emit_line(tool: &str, args: &[Value]) -> Option<String> {
+    let arg = |index: usize| {
+        args.get(index)
+            .map_or_else(|| "undefined".to_string(), Value::to_string)
+    };
+    let line = match tool {
+        "nav.goto" => format!("  await browser.nav(page).goto({});", arg(1)),
+        "nav.back" => "  await browser.nav(page).back();".to_string(),
+        "nav.forward" => "  await browser.nav(page).forward();".to_string(),
+        "nav.reload" => "  await browser.nav(page).reload();".to_string(),
+        "input.click" => format!("  await browser.input(page).click({});", arg(1)),
+        "input.fill" => format!("  await browser.input(page).fill({}, {});", arg(1), arg(2)),
+        "input.type" => format!("  await browser.input(page).type({});", arg(1)),
+        "input.press" => format!("  await browser.input(page).press({});", arg(1)),
+        "input.hover" => format!("  await browser.input(page).hover({});", arg(1)),
+        "input.selectOption" => {
+            format!(
+                "  await browser.input(page).selectOption({}, {});",
+                arg(1),
+                arg(2)
+            )
+        }
+        "input.scroll" => format!(
+            "  await browser.input(page).scroll({}, {}, {});",
+            arg(1),
+            arg(2),
+            arg(3)
+        ),
+        "wait" => format!("  await browser.wait(page, {});", arg(1)),
+        _ => return None,
+    };
+    Some(line)
+}
+
+async fn page_host(session: &BrowserSession, page_id: u64) -> Option<String> {
+    let page = u32::try_from(page_id).ok()?;
+    let info = session.pages.get_info(PageId(page)).await?;
+    helpers::host_bucket(&info.url)
+}
+
+/// A short, deterministic id for a helper source so identical flows dedupe.
+fn short_hash(source: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    source.hash(&mut hasher);
+    format!("{:08x}", hasher.finish() & 0xffff_ffff)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn child(tool: &str, args: Value) -> ToolDispatchRow {
+        ToolDispatchRow {
+            id: 0,
+            created_at: 0,
+            agent_id: String::new(),
+            slug: String::new(),
+            agent_label: String::new(),
+            session_id: String::new(),
+            tool_name: tool.to_string(),
+            page_id: None,
+            tab_id: None,
+            target_id: None,
+            url: None,
+            title: None,
+            args_json: Some(args.to_string()),
+            result_meta: None,
+            duration_ms: None,
+            tool_input_token_estimate: 0,
+            tool_output_token_estimate: 0,
+            token_estimator_version: 0,
+            dispatch_id: None,
+            parent_dispatch_id: None,
+            has_screenshot: false,
+        }
+    }
+
+    #[test]
+    fn distills_a_single_page_action_macro() -> anyhow::Result<()> {
+        let children = [
+            child("nav.goto", json!([3, "https://example.com/login"])),
+            child("observe.snapshot", json!([3])), // pure read, skipped
+            child("input.fill", json!([3, "e5", "alice"])),
+            child("input.click", json!([3, "e6"])),
+        ];
+        let (source, page) = distill_source(&children)
+            .ok_or_else(|| anyhow::anyhow!("expected a distilled macro"))?;
+        assert_eq!(page, 3);
+        assert_eq!(
+            source,
+            "async (browser, page) => {\n  \
+             await browser.nav(page).goto(\"https://example.com/login\");\n  \
+             await browser.input(page).fill(\"e5\", \"alice\");\n  \
+             await browser.input(page).click(\"e6\");\n}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn skips_multi_page_or_too_short_flows() {
+        // Spans two pages: no clean single-page macro.
+        let multi = [
+            child("input.click", json!([3, "e1"])),
+            child("input.click", json!([4, "e2"])),
+        ];
+        assert!(distill_source(&multi).is_none());
+        // Only one recognized action.
+        let short = [
+            child("nav.goto", json!([3, "https://example.com"])),
+            child("read", json!([3, {}])),
+        ];
+        assert!(distill_source(&short).is_none());
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/distill.rs
@@ -37,11 +37,15 @@ pub fn distill(context: ToolObserverContext<'_>) -> BoxFuture<'_, anyhow::Result
             .dispatches_with_parent(context.call.dispatch_id.as_str())
             .await
             .unwrap_or_default();
-        let Some((source, page_id)) = distill_source(&children) else {
+        let Some((source, target)) = distill_source(&children) else {
             return Ok(());
         };
-        let Some(host) = page_host(session, page_id).await else {
-            return Ok(());
+        let host = match target {
+            DistillTarget::Host(host) => host,
+            DistillTarget::Page(page_id) => match page_host(session, page_id).await {
+                Some(host) => host,
+                None => return Ok(()),
+            },
         };
         let steps = source.matches("await browser").count();
         let inputs = source.matches("inputs.field").count();
@@ -74,16 +78,30 @@ pub fn distill(context: ToolObserverContext<'_>) -> BoxFuture<'_, anyhow::Result
 
 const _: ToolObserver = distill;
 
+/// How the distilled helper's host is resolved: directly from an opening
+/// navigation URL, or from the page id the flow drove.
+pub(crate) enum DistillTarget {
+    Host(String),
+    Page(u64),
+}
+
 /// Synthesizes a single-page action macro from the recorded child sequence, plus
-/// the page id it drove. `None` unless at least two recognized actions all target
-/// one page (multi-page replays are a follow-up).
+/// how to resolve its host. Handles two shapes: a flow that opens its own page
+/// (`newPage(url)`, common for search-by-URL) becomes
+/// `async (browser, inputs) => { const page = await browser.pages.newPage(...); ...; return page; }`;
+/// a flow that acts on an existing page keeps `async (browser, page, inputs) => { ... }`.
+/// `None` unless at least two recognized actions target one page (multi-page
+/// replays are a follow-up).
 #[must_use]
-pub(crate) fn distill_source(children: &[ToolDispatchRow]) -> Option<(String, u64)> {
+pub(crate) fn distill_source(children: &[ToolDispatchRow]) -> Option<(String, DistillTarget)> {
     let mut lines = Vec::new();
     let mut pages = BTreeSet::new();
-    // Running index for value inputs, so typed values are read from `inputs`
-    // rather than embedded (no credentials or personal data in a shared helper).
+    // Running index for value inputs, so typed values (and URL query terms) are
+    // read from `inputs` rather than embedded (no personal data in a shared helper).
     let mut inputs = 0usize;
+    // The opening navigation, if the flow creates its own page: (url JS expression, host bucket).
+    let mut opened: Option<(String, Option<String>)> = None;
+    let mut new_pages = 0usize;
     for row in children {
         // Only distill the agent's own successful actions: skip failures (a
         // caught-and-recovered step) and primitives replayed from inside a
@@ -97,6 +115,17 @@ pub(crate) fn distill_source(children: &[ToolDispatchRow]) -> Option<(String, u6
             .as_deref()
             .and_then(|raw| serde_json::from_str(raw).ok())
             .unwrap_or_default();
+        if row.tool_name == "pages.newPage" {
+            new_pages += 1;
+            let Some(url) = args.first().and_then(Value::as_str) else {
+                continue;
+            };
+            opened = Some((
+                parameterize_url(url, &mut inputs),
+                helpers::host_bucket(url),
+            ));
+            continue;
+        }
         let Some(page) = args.first().and_then(Value::as_u64) else {
             continue;
         };
@@ -106,15 +135,89 @@ pub(crate) fn distill_source(children: &[ToolDispatchRow]) -> Option<(String, u6
         pages.insert(page);
         lines.push(line);
     }
-    if lines.len() < 2 || pages.len() != 1 {
+    // At most one opened page; page-scoped actions all target a single page.
+    if new_pages > 1 || pages.len() > 1 {
         return None;
     }
-    let page = *pages.iter().next()?;
-    let source = format!(
-        "async (browser, page, inputs = {{}}) => {{\n{}\n}}",
-        lines.join("\n")
-    );
-    Some((source, page))
+    let action_count = lines.len() + usize::from(opened.is_some());
+    if action_count < 2 {
+        return None;
+    }
+    match opened {
+        Some((url_expr, host)) => {
+            let mut body = vec![format!(
+                "  const page = await browser.pages.newPage({url_expr});"
+            )];
+            body.extend(lines);
+            body.push("  return page;".to_string());
+            let source = format!(
+                "async (browser, inputs = {{}}) => {{\n{}\n}}",
+                body.join("\n")
+            );
+            let target = match host {
+                Some(host) => DistillTarget::Host(host),
+                None => DistillTarget::Page(*pages.iter().next()?),
+            };
+            Some((source, target))
+        }
+        None => {
+            let page = *pages.iter().next()?;
+            let source = format!(
+                "async (browser, page, inputs = {{}}) => {{\n{}\n}}",
+                lines.join("\n")
+            );
+            Some((source, DistillTarget::Page(page)))
+        }
+    }
+}
+
+/// Rewrites a URL's search-query values as `encodeURIComponent(inputs.field<n>)`
+/// so a search-by-URL navigation becomes a reusable, parameterized macro without
+/// baking in the specific query. Returns a JS string expression. URLs with no
+/// recognized search parameter are emitted as a literal.
+fn parameterize_url(url: &str, inputs: &mut usize) -> String {
+    let Some((base, query)) = url.split_once('?') else {
+        return json_string(url);
+    };
+    let mut fragments: Vec<String> = Vec::new();
+    let mut literal = format!("{base}?");
+    let mut parameterized = false;
+    for (index, pair) in query.split('&').enumerate() {
+        if index > 0 {
+            literal.push('&');
+        }
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        if is_search_key(key) && !value.is_empty() {
+            parameterized = true;
+            literal.push_str(key);
+            literal.push('=');
+            fragments.push(json_string(&literal));
+            literal.clear();
+            fragments.push(format!("encodeURIComponent(inputs.field{inputs})"));
+            *inputs += 1;
+        } else {
+            literal.push_str(pair);
+        }
+    }
+    if !parameterized {
+        return json_string(url);
+    }
+    if !literal.is_empty() {
+        fragments.push(json_string(&literal));
+    }
+    fragments.join(" + ")
+}
+
+/// Common search-query parameter names across sites (amazon `k`, google `q`, ...).
+fn is_search_key(key: &str) -> bool {
+    matches!(
+        key,
+        "q" | "k" | "query" | "search" | "s" | "term" | "keyword" | "keywords" | "field-keywords"
+    )
+}
+
+fn json_string(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
 }
 
 /// Whether a child's recorded result marked it an error, read from its
@@ -147,26 +250,28 @@ fn emit_line(tool: &str, args: &[Value], inputs: &mut usize) -> Option<String> {
         args.get(index)
             .map_or_else(|| "undefined".to_string(), Value::to_string)
     };
-    let mut input = || {
-        let field = format!("inputs.field{inputs}");
-        *inputs += 1;
-        field
-    };
     let line = match tool {
-        "nav.goto" => format!("  await browser.nav(page).goto({});", arg(1)),
+        "nav.goto" => format!(
+            "  await browser.nav(page).goto({});",
+            url_arg(args, 1, inputs)
+        ),
         "nav.back" => "  await browser.nav(page).back();".to_string(),
         "nav.forward" => "  await browser.nav(page).forward();".to_string(),
         "nav.reload" => "  await browser.nav(page).reload();".to_string(),
         "input.click" => format!("  await browser.input(page).click({});", arg(1)),
-        "input.fill" => format!("  await browser.input(page).fill({}, {});", arg(1), input()),
-        "input.type" => format!("  await browser.input(page).type({});", input()),
+        "input.fill" => format!(
+            "  await browser.input(page).fill({}, {});",
+            arg(1),
+            next_input(inputs)
+        ),
+        "input.type" => format!("  await browser.input(page).type({});", next_input(inputs)),
         "input.press" => format!("  await browser.input(page).press({});", arg(1)),
         "input.hover" => format!("  await browser.input(page).hover({});", arg(1)),
         "input.selectOption" => {
             format!(
                 "  await browser.input(page).selectOption({}, {});",
                 arg(1),
-                input()
+                next_input(inputs)
             )
         }
         "input.scroll" => format!(
@@ -179,6 +284,24 @@ fn emit_line(tool: &str, args: &[Value], inputs: &mut usize) -> Option<String> {
         _ => return None,
     };
     Some(line)
+}
+
+/// The next `inputs.field<n>` placeholder, advancing the counter.
+fn next_input(inputs: &mut usize) -> String {
+    let field = format!("inputs.field{inputs}");
+    *inputs += 1;
+    field
+}
+
+/// A URL argument, parameterized when it is a string with a search query, else
+/// emitted as its JSON literal.
+fn url_arg(args: &[Value], index: usize, inputs: &mut usize) -> String {
+    match args.get(index).and_then(Value::as_str) {
+        Some(url) => parameterize_url(url, inputs),
+        None => args
+            .get(index)
+            .map_or_else(|| "undefined".to_string(), Value::to_string),
+    }
 }
 
 async fn page_host(session: &BrowserSession, page_id: u64) -> Option<String> {
@@ -234,9 +357,9 @@ mod tests {
             child("input.fill", json!([3, "e5", "alice"])),
             child("input.click", json!([3, "e6"])),
         ];
-        let (source, page) = distill_source(&children)
+        let (source, target) = distill_source(&children)
             .ok_or_else(|| anyhow::anyhow!("expected a distilled macro"))?;
-        assert_eq!(page, 3);
+        assert!(matches!(target, DistillTarget::Page(3)));
         // The fill value is parameterized (inputs.field0), never embedded.
         assert_eq!(
             source,
@@ -245,6 +368,37 @@ mod tests {
              await browser.input(page).fill(\"e5\", inputs.field0);\n  \
              await browser.input(page).click(\"e6\");\n}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn distills_a_search_by_url_flow_into_a_parameterized_macro() -> anyhow::Result<()> {
+        // The natural real-agent pattern: search by URL, then read (not type + click).
+        let children = [
+            child(
+                "pages.newPage",
+                json!(["https://www.amazon.in/s?k=wireless+earbuds"]),
+            ),
+            child("wait", json!([10, { "text": "results", "timeout": 20000 }])),
+            child("read", json!([10, {}])), // pure read, skipped
+        ];
+        let (source, target) = distill_source(&children)
+            .ok_or_else(|| anyhow::anyhow!("expected a distilled macro"))?;
+        // Host comes straight from the navigation URL.
+        assert!(matches!(&target, DistillTarget::Host(host) if host == "amazon.in"));
+        // The query term is parameterized (never embedded); the macro opens its own page.
+        assert!(!source.contains("wireless"), "query leaked: {source}");
+        assert!(
+            source.contains("async (browser, inputs = {}) =>"),
+            "shape: {source}"
+        );
+        assert!(
+            source.contains(
+                "const page = await browser.pages.newPage(\"https://www.amazon.in/s?k=\" + encodeURIComponent(inputs.field0));"
+            ),
+            "got: {source}"
+        );
+        assert!(source.contains("return page;"));
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/effects/tab_groups.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/effects/tab_groups.rs
@@ -445,6 +445,7 @@ async fn dispatch_tab_groups(
         cancel: operation_cancel.clone(),
         output_files,
         inner_call_hook: None,
+        preloaded_helpers: Vec::new(),
     });
     let execution = timeout(TAB_GROUP_OPERATION, execute_tool(tab_groups, args, &ctx)).await;
     let result = match execution {

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/guards/page_ownership.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/guards/page_ownership.rs
@@ -2,7 +2,14 @@ use crate::api::mcp::dispatch::{ToolCall, ToolGuard, extract_page_id};
 use browseros_core::PageId;
 use browseros_mcp::ToolResult;
 use futures_util::future::BoxFuture;
+use std::time::Duration;
 use tracing::warn;
+
+/// A page mid-navigation is momentarily unlistable. Only prune its ownership
+/// claim if it stays absent across this settle window, so a navigating or
+/// reloading page the agent owns keeps its claim.
+const PRUNE_ATTEMPTS: usize = 3;
+const PRUNE_SETTLE: Duration = Duration::from_millis(150);
 
 /// Prevents an identified agent from dispatching against another agent's page.
 pub fn guard(call: &ToolCall) -> BoxFuture<'_, Option<ToolResult>> {
@@ -38,20 +45,31 @@ async fn page_missing_after_refresh(call: &ToolCall, page_id: &PageId) -> bool {
     let Some(browser) = &call.browser_session else {
         return false;
     };
-    if browser.pages.get_info(page_id.clone()).await.is_some() {
-        return false;
-    }
-    match browser.pages.list().await {
-        Ok(pages) => !pages.iter().any(|page| page.page_id == *page_id),
-        Err(error) => {
-            warn!(
-                error = %error,
-                page_id = page_id.0,
-                "page ownership stale-prune refresh failed"
-            );
-            false
+    // Poll across a short settle window; the page reappearing on any attempt (a
+    // navigation finishing) means it is not gone and keeps its claim. Only a page
+    // absent the whole window is treated as closed.
+    for attempt in 0..PRUNE_ATTEMPTS {
+        if browser.pages.get_info(page_id.clone()).await.is_some() {
+            return false;
+        }
+        match browser.pages.list().await {
+            Ok(pages) if pages.iter().any(|page| page.page_id == *page_id) => return false,
+            Ok(_) => {}
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    page_id = page_id.0,
+                    "page ownership stale-prune refresh failed"
+                );
+                // A refresh error is inconclusive; do not prune on a flake.
+                return false;
+            }
+        }
+        if attempt + 1 < PRUNE_ATTEMPTS {
+            tokio::time::sleep(PRUNE_SETTLE).await;
         }
     }
+    true
 }
 
 const _: ToolGuard = guard;

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
@@ -18,8 +18,10 @@ use std::collections::BTreeSet;
 
 const MS_PER_DAY: i64 = 86_400_000;
 
-/// Discovery/staleness view of a helper: name, soft age signal, and whether it
-/// is a distilled candidate. `ageDays` is null when never stamped.
+/// Discovery/staleness view of a helper: name, soft age signal, whether it is a
+/// distilled candidate, a description, and the exact copy-paste call form so the
+/// agent can reuse it without guessing the signature. `ageDays` is null when
+/// never stamped.
 #[must_use]
 pub(crate) fn helper_info_json(meta: &HelperMeta, now: i64) -> Value {
     let age_days = (meta.last_verified > 0).then(|| (now - meta.last_verified).max(0) / MS_PER_DAY);
@@ -28,6 +30,10 @@ pub(crate) fn helper_info_json(meta: &HelperMeta, now: i64) -> Value {
         "ageDays": age_days,
         "candidate": meta.candidate,
         "agent": meta.agent,
+        "description": meta.description,
+        "opensPage": meta.opens_page,
+        "inputs": meta.inputs,
+        "call": helpers::call_example(meta),
     })
 }
 
@@ -124,23 +130,24 @@ pub fn discovery(
 
 const _: ToolEffect = discovery;
 
-/// A concise, agent-readable summary of the helpers available on the tabs' hosts.
+/// A concise, agent-readable summary of the helpers available on the tabs' hosts:
+/// per helper a freshness signal, a description, and the exact call form to copy.
 #[must_use]
 fn discovery_note(available: &[Value]) -> String {
     let mut lines = vec![
-        "Reusable helpers for your tabs (call helpers.<name>(browser, page), or read one with browser.readHelper(name, { host })):".to_string(),
+        "Reusable helpers for your tabs. Call the one you need with the form shown, or read its full doc with browser.readHelper(name, { host }):".to_string(),
     ];
     for entry in available {
         let host = entry
             .get("host")
             .and_then(Value::as_str)
             .unwrap_or_default();
-        let names: Vec<String> = entry
-            .get("helpers")
-            .and_then(Value::as_array)
-            .map(|items| items.iter().map(format_helper_ref).collect())
-            .unwrap_or_default();
-        lines.push(format!("- {host}: {}", names.join(", ")));
+        lines.push(format!("- {host}:"));
+        if let Some(items) = entry.get("helpers").and_then(Value::as_array) {
+            for helper in items {
+                lines.push(format_helper_ref(helper));
+            }
+        }
     }
     lines.join("\n")
 }
@@ -153,8 +160,7 @@ fn format_helper_ref(helper: &Value) -> String {
     let age = helper
         .get("ageDays")
         .and_then(Value::as_i64)
-        .map(|days| format!(" {days}d"))
-        .unwrap_or_default();
+        .map_or_else(|| "unstamped".to_string(), |days| format!("{days}d"));
     let candidate = if helper
         .get("candidate")
         .and_then(Value::as_bool)
@@ -164,7 +170,14 @@ fn format_helper_ref(helper: &Value) -> String {
     } else {
         ""
     };
-    format!("{name}{age}{candidate}")
+    let description = helper
+        .get("description")
+        .and_then(Value::as_str)
+        .filter(|desc| !desc.is_empty())
+        .map(|desc| format!(": {desc}"))
+        .unwrap_or_default();
+    let call = helper.get("call").and_then(Value::as_str).unwrap_or_default();
+    format!("  - {name} ({age}{candidate}){description}\n    {call}")
 }
 
 /// Builds the `[{ host, helpers: [...] }]` discovery list for a set of hosts,
@@ -200,7 +213,12 @@ mod tests {
             last_verified,
             agent: "codex".to_string(),
             candidate,
-            deps: String::new(),
+            opens_page: true,
+            inputs: std::collections::BTreeMap::from([(
+                "field0".to_string(),
+                "search query".to_string(),
+            )]),
+            description: format!("Opens {host} search for a query"),
         }
     }
 
@@ -215,17 +233,25 @@ mod tests {
     }
 
     #[test]
-    fn discovery_note_summarizes_available_helpers_as_text() {
-        let available = vec![json!({
-            "host": "example.com",
-            "helpers": [
-                { "name": "greet", "ageDays": 0, "candidate": false },
-                { "name": "candidate-abc", "ageDays": 7, "candidate": true }
-            ]
-        })];
+    fn discovery_note_renders_description_and_correct_call_form() {
+        let now = MS_PER_DAY;
+        let entry = helper_info_json(&meta("search-amazon", "amazon.in", MS_PER_DAY, true), now);
+        let available = vec![json!({ "host": "amazon.in", "helpers": [entry] })];
         let note = discovery_note(&available);
-        assert!(note.contains("helpers.<name>"));
-        assert!(note.contains("example.com: greet 0d, candidate-abc 7d, candidate"));
+        assert!(note.contains("browser.readHelper"));
+        assert!(note.contains("- amazon.in:"));
+        // Freshness, candidate flag, and the description ride the helper line.
+        assert!(
+            note.contains("- search-amazon (0d, candidate): Opens amazon.in search for a query"),
+            "note: {note}"
+        );
+        // The exact, copy-paste call form: bracket access, inputs object, no page.
+        assert!(
+            note.contains("helpers[\"search-amazon\"](browser, { field0: \"<search query>\" })"),
+            "note: {note}"
+        );
+        // The wrong dotted form is gone.
+        assert!(!note.contains("helpers.<name>"));
     }
 
     #[test]

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
@@ -155,12 +155,15 @@ fn format_helper_ref(helper: &Value) -> String {
         .and_then(Value::as_i64)
         .map(|days| format!(" {days}d"))
         .unwrap_or_default();
-    let candidate = helper
+    let candidate = if helper
         .get("candidate")
         .and_then(Value::as_bool)
         .unwrap_or(false)
-        .then_some(", candidate")
-        .unwrap_or_default();
+    {
+        ", candidate"
+    } else {
+        ""
+    };
     format!("{name}{age}{candidate}")
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
@@ -2,10 +2,33 @@
 //! owned tabs make relevant so the runtime can expose them by name, and
 //! surfaces what is available for discovery.
 
-use crate::{AppState, ids::ConvoId, services::helpers};
+use crate::{
+    AppState,
+    api::mcp::dispatch::{ARBITRARY_SCRIPT_TOOLS, ToolEffect, ToolEffectContext},
+    clock::now_epoch_ms,
+    ids::ConvoId,
+    services::helpers::{self, HelperMeta},
+};
 use browseros_core::BrowserSession;
-use browseros_mcp::framework::HelperSource;
+use browseros_mcp::{ToolResult, framework::HelperSource};
+use futures_util::future::BoxFuture;
+use serde_json::{Value, json};
 use std::collections::BTreeSet;
+
+const MS_PER_DAY: i64 = 86_400_000;
+
+/// Discovery/staleness view of a helper: name, soft age signal, and whether it
+/// is a distilled candidate. `ageDays` is null when never stamped.
+#[must_use]
+pub(crate) fn helper_info_json(meta: &HelperMeta, now: i64) -> Value {
+    let age_days = (meta.last_verified > 0).then(|| (now - meta.last_verified).max(0) / MS_PER_DAY);
+    json!({
+        "name": meta.name,
+        "ageDays": age_days,
+        "candidate": meta.candidate,
+        "agent": meta.agent,
+    })
+}
 
 /// Collects the helpers to hot-load for a script run: every saved helper for the
 /// hosts of the agent's currently owned tabs. Cheap-gated so a browser with no
@@ -50,4 +73,113 @@ pub(crate) async fn owned_tab_hosts(
         }
     }
     hosts
+}
+
+/// Effect that appends `helpersAvailable` to a successful script run's result so
+/// the agent notices the helpers its owned-tab hosts offer without having to
+/// ask. Cheap-gated when no helpers exist.
+pub fn discovery(
+    context: ToolEffectContext<'_>,
+) -> BoxFuture<'_, anyhow::Result<Option<ToolResult>>> {
+    Box::pin(async move {
+        if context.result.is_error
+            || context.cancelled
+            || !ARBITRARY_SCRIPT_TOOLS.contains(&context.call.tool().name)
+        {
+            return Ok(None);
+        }
+        let (Some(identity), Some(session)) =
+            (&context.call.identity, &context.call.browser_session)
+        else {
+            return Ok(None);
+        };
+        let dir = &context.call.state.config.browserclaw_dir;
+        if !helpers::has_any_helpers(dir) {
+            return Ok(None);
+        }
+        let hosts = owned_tab_hosts(&context.call.state, &identity.ownership_key, session).await;
+        let available = available_for_hosts(dir, &hosts, now_epoch_ms());
+        if available.is_empty() {
+            return Ok(None);
+        }
+        // Append alongside the run's { ok, value, logs }; leave text content as is.
+        let mut result = context.result.clone();
+        result.structured_content = Some(match result.structured_content.take() {
+            Some(Value::Object(mut map)) => {
+                map.insert("helpersAvailable".to_string(), Value::Array(available));
+                Value::Object(map)
+            }
+            _ => json!({ "helpersAvailable": available }),
+        });
+        Ok(Some(result))
+    })
+}
+
+const _: ToolEffect = discovery;
+
+/// Builds the `[{ host, helpers: [...] }]` discovery list for a set of hosts,
+/// omitting hosts with no helpers.
+#[must_use]
+pub(crate) fn available_for_hosts(
+    browserclaw_dir: &std::path::Path,
+    hosts: &BTreeSet<String>,
+    now: i64,
+) -> Vec<Value> {
+    let mut available = Vec::new();
+    for host in hosts {
+        let list: Vec<Value> = helpers::list_helper_meta(browserclaw_dir, host)
+            .iter()
+            .map(|meta| helper_info_json(meta, now))
+            .collect();
+        if !list.is_empty() {
+            available.push(json!({ "host": host, "helpers": list }));
+        }
+    }
+    available
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn meta(name: &str, host: &str, last_verified: i64, candidate: bool) -> HelperMeta {
+        HelperMeta {
+            name: name.to_string(),
+            host: host.to_string(),
+            last_verified,
+            agent: "codex".to_string(),
+            candidate,
+            deps: String::new(),
+        }
+    }
+
+    #[test]
+    fn helper_info_reports_a_soft_age_and_null_when_unstamped() {
+        let now = 10 * MS_PER_DAY;
+        let fresh = helper_info_json(&meta("a", "h", 8 * MS_PER_DAY, true), now);
+        assert_eq!(fresh["ageDays"], json!(2));
+        assert_eq!(fresh["candidate"], json!(true));
+        let unstamped = helper_info_json(&meta("b", "h", 0, false), now);
+        assert_eq!(unstamped["ageDays"], Value::Null);
+    }
+
+    #[test]
+    fn available_for_hosts_lists_only_hosts_with_helpers() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let now = 5 * MS_PER_DAY;
+        helpers::save_helper(
+            dir.path(),
+            &meta("greet", "example.com", 3 * MS_PER_DAY, true),
+            "async () => 1",
+        )?;
+        let hosts = BTreeSet::from(["example.com".to_string(), "empty.com".to_string()]);
+        let available = available_for_hosts(dir.path(), &hosts, now);
+        assert_eq!(available.len(), 1);
+        assert_eq!(available[0]["host"], json!("example.com"));
+        assert_eq!(available[0]["helpers"][0]["name"], json!("greet"));
+        assert_eq!(available[0]["helpers"][0]["ageDays"], json!(2));
+        assert_eq!(available[0]["helpers"][0]["candidate"], json!(true));
+        Ok(())
+    }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
@@ -219,6 +219,7 @@ mod tests {
                 "search query".to_string(),
             )]),
             description: format!("Opens {host} search for a query"),
+            session: String::new(),
         }
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
@@ -1,0 +1,53 @@
+//! Host side of code-mode helper self-healing: loads the helpers a script's
+//! owned tabs make relevant so the runtime can expose them by name, and
+//! surfaces what is available for discovery.
+
+use crate::{AppState, ids::ConvoId, services::helpers};
+use browseros_core::BrowserSession;
+use browseros_mcp::framework::HelperSource;
+use std::collections::BTreeSet;
+
+/// Collects the helpers to hot-load for a script run: every saved helper for the
+/// hosts of the agent's currently owned tabs. Cheap-gated so a browser with no
+/// helpers pays nothing (no page scan).
+pub(crate) async fn preload_helpers(
+    state: &AppState,
+    caller: &ConvoId,
+    session: &BrowserSession,
+) -> Vec<HelperSource> {
+    let dir = &state.config.browserclaw_dir;
+    if !helpers::has_any_helpers(dir) {
+        return Vec::new();
+    }
+    let mut sources = Vec::new();
+    for host in owned_tab_hosts(state, caller, session).await {
+        for meta in helpers::list_helper_meta(dir, &host) {
+            if let Some(source) = helpers::read_helper_source(dir, &host, &meta.name) {
+                sources.push(HelperSource {
+                    name: meta.name,
+                    source,
+                });
+            }
+        }
+    }
+    sources
+}
+
+/// The distinct host buckets of the tabs this agent owns.
+pub(crate) async fn owned_tab_hosts(
+    state: &AppState,
+    caller: &ConvoId,
+    session: &BrowserSession,
+) -> BTreeSet<String> {
+    let ownership = state.sessions.ownership();
+    let mut hosts = BTreeSet::new();
+    for page in session.pages.list().await.unwrap_or_default() {
+        if ownership.owner_of_page(&page.page_id).await.as_ref() != Some(caller) {
+            continue;
+        }
+        if let Some(host) = helpers::host_bucket(&page.url) {
+            hosts.insert(host);
+        }
+    }
+    hosts
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/helper_runtime.rs
@@ -12,6 +12,7 @@ use crate::{
 use browseros_core::BrowserSession;
 use browseros_mcp::{ToolResult, framework::HelperSource};
 use futures_util::future::BoxFuture;
+use rmcp::model::ContentBlock;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
 
@@ -102,8 +103,14 @@ pub fn discovery(
         if available.is_empty() {
             return Ok(None);
         }
-        // Append alongside the run's { ok, value, logs }; leave text content as is.
         let mut result = context.result.clone();
+        // Deliver discovery through a text block: structured content is not
+        // serialized over the MCP wire (the script tool has no output schema),
+        // so a helpersAvailable structured field alone never reaches the agent.
+        result
+            .content
+            .push(ContentBlock::text(discovery_note(&available)));
+        // Also keep the structured field for any client that does read it.
         result.structured_content = Some(match result.structured_content.take() {
             Some(Value::Object(mut map)) => {
                 map.insert("helpersAvailable".to_string(), Value::Array(available));
@@ -116,6 +123,46 @@ pub fn discovery(
 }
 
 const _: ToolEffect = discovery;
+
+/// A concise, agent-readable summary of the helpers available on the tabs' hosts.
+#[must_use]
+fn discovery_note(available: &[Value]) -> String {
+    let mut lines = vec![
+        "Reusable helpers for your tabs (call helpers.<name>(browser, page), or read one with browser.readHelper(name, { host })):".to_string(),
+    ];
+    for entry in available {
+        let host = entry
+            .get("host")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let names: Vec<String> = entry
+            .get("helpers")
+            .and_then(Value::as_array)
+            .map(|items| items.iter().map(format_helper_ref).collect())
+            .unwrap_or_default();
+        lines.push(format!("- {host}: {}", names.join(", ")));
+    }
+    lines.join("\n")
+}
+
+fn format_helper_ref(helper: &Value) -> String {
+    let name = helper
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let age = helper
+        .get("ageDays")
+        .and_then(Value::as_i64)
+        .map(|days| format!(" {days}d"))
+        .unwrap_or_default();
+    let candidate = helper
+        .get("candidate")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        .then_some(", candidate")
+        .unwrap_or_default();
+    format!("{name}{age}{candidate}")
+}
 
 /// Builds the `[{ host, helpers: [...] }]` discovery list for a set of hosts,
 /// omitting hosts with no helpers.
@@ -162,6 +209,20 @@ mod tests {
         assert_eq!(fresh["candidate"], json!(true));
         let unstamped = helper_info_json(&meta("b", "h", 0, false), now);
         assert_eq!(unstamped["ageDays"], Value::Null);
+    }
+
+    #[test]
+    fn discovery_note_summarizes_available_helpers_as_text() {
+        let available = vec![json!({
+            "host": "example.com",
+            "helpers": [
+                { "name": "greet", "ageDays": 0, "candidate": false },
+                { "name": "candidate-abc", "ageDays": 7, "candidate": true }
+            ]
+        })];
+        let note = discovery_note(&available);
+        assert!(note.contains("helpers.<name>"));
+        assert!(note.contains("example.com: greet 0d, candidate-abc 7d, candidate"));
     }
 
     #[test]

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/mod.rs
@@ -1,6 +1,7 @@
 pub mod dispatch;
 pub mod effects;
 pub mod guards;
+pub mod helper_runtime;
 pub mod naming;
 pub mod observers;
 mod prompt;

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/mod.rs
@@ -1,4 +1,5 @@
 pub mod dispatch;
+pub mod distill;
 pub mod effects;
 pub mod guards;
 pub mod helper_runtime;

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
@@ -62,16 +62,19 @@ subagents when your harness supports them, since each gets isolated tabs here.
 Keep to about 5 concurrent tabs per agent unless the user asks for more.
 
 Reuse what already works. A run's result may include helpersAvailable: saved
-helpers for the hosts your tabs are on, each with an ageDays freshness signal.
-browser.listHelpers({ page }) lists them and browser.readHelper(name, { page })
-shows one; read the relevant helper before inventing an approach, and call a
-hot-loaded one by name as helpers.<name>(browser, page). When a multi-step flow
-works, save it with browser.saveHelper(name, source, { page }) where source is a
-function expression like async (browser, page) => { ... }; a proven run is also
-distilled into a candidate helper for you automatically. Treat a stale helper
-(high ageDays) as a hint, not a guarantee: cross-check it against the live page
-before trusting it, then re-save. Keep personal data out of saved helpers, they
-are shared across your sessions on that host.
+helpers for the hosts your tabs are on, each with an ageDays freshness signal, a
+description, and the exact call form to copy. browser.listHelpers({ page }) lists
+them and browser.readHelper(name, { page }) shows one helper's full doc; read the
+relevant helper before inventing an approach, and call a hot-loaded one with
+bracket access using the call form shown: helpers["name"](browser, inputs) for a
+helper that opens its own page and returns it, or helpers["name"](browser, page,
+inputs) for one that acts on a page you pass. When a multi-step flow works, save
+it with browser.saveHelper(name, source, { page }) where source is a function
+expression like async (browser, page, inputs = {}) => { ... }; a proven run is
+also distilled into a candidate helper for you automatically. Treat a stale
+helper (high ageDays) as a hint, not a guarantee: cross-check it against the live
+page before trusting it, then re-save. Keep personal data out of saved helpers,
+they are shared across your sessions on that host.
 
 browser.windows(opts) opens a separate window when a task needs isolation from
 the user's and other agents' work.

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
@@ -33,7 +33,11 @@ Core loop inside a script: snapshot -> act -> verify.
   carry [ref=eN] handles.
 - act by ref, then read back the result and verify before moving on.
 - Refs go stale when the page changes (navigate, submit, re-render), re-snapshot before reusing them within the script.
+- Keep the pageId newPage returns and reuse it across the whole task; do not
+  reopen the page for each step.
 - Still loading? browser.wait on text/selector you expect, not a bare sleep.
+- Extract with browser.evaluate(pageId, { code }) (an async body, use return) or
+  { func } (a function to invoke), in one pass rather than many refining runs.
 - Compose the whole flow in one script: loop over items, paginate, extract in
   bulk, branch on what you find. That is the point of run.
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
@@ -61,6 +61,18 @@ independent primitives with Promise.all; across a large workload, split it over
 subagents when your harness supports them, since each gets isolated tabs here.
 Keep to about 5 concurrent tabs per agent unless the user asks for more.
 
+Reuse what already works. A run's result may include helpersAvailable: saved
+helpers for the hosts your tabs are on, each with an ageDays freshness signal.
+browser.listHelpers({ page }) lists them and browser.readHelper(name, { page })
+shows one; read the relevant helper before inventing an approach, and call a
+hot-loaded one by name as helpers.<name>(browser, page). When a multi-step flow
+works, save it with browser.saveHelper(name, source, { page }) where source is a
+function expression like async (browser, page) => { ... }; a proven run is also
+distilled into a candidate helper for you automatically. Treat a stale helper
+(high ageDays) as a hint, not a guarantee: cross-check it against the live page
+before trusting it, then re-save. Keep personal data out of saved helpers, they
+are shared across your sessions on that host.
+
 browser.windows(opts) opens a separate window when a task needs isolation from
 the user's and other agents' work.
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
@@ -1,8 +1,10 @@
 use crate::{
     api::mcp::dispatch::{ToolCall, ToolIdentity},
     api::mcp::effects::{ownership_claims, tab_groups, tabs_list_view},
+    clock::now_epoch_ms,
     db::audit_log::{RecordToolDispatchInput, bounded_args_json, result_meta},
     ids::DispatchId,
+    services::helpers,
 };
 use browseros_core::PageId;
 use browseros_mcp::{InnerCallHook, InnerCallRecord};
@@ -185,6 +187,63 @@ impl InnerCallHook for ScriptInnerCallHook {
                 "pageId",
             )
             .await
+        })
+    }
+
+    fn resolve_host<'a>(&'a self, page: u32) -> BoxFuture<'a, Option<String>> {
+        Box::pin(async move {
+            let browser = self.call.browser_session.as_ref()?;
+            let info = browser.pages.get_info(PageId(page)).await?;
+            helpers::host_bucket(&info.url)
+        })
+    }
+
+    fn save_helper<'a>(
+        &'a self,
+        host: &'a str,
+        name: &'a str,
+        source: &'a str,
+    ) -> BoxFuture<'a, Result<(), String>> {
+        Box::pin(async move {
+            let Some(identity) = self.identity() else {
+                return Err("no agent identity for this script".to_string());
+            };
+            let meta = helpers::HelperMeta {
+                name: name.to_string(),
+                host: host.to_string(),
+                last_verified: now_epoch_ms(),
+                agent: identity.agent.slug().to_string(),
+                candidate: false,
+                deps: String::new(),
+            };
+            helpers::save_helper(&self.call.state.config.browserclaw_dir, &meta, source)
+                .map_err(|error| format!("could not save helper: {error}"))
+        })
+    }
+
+    fn list_helpers<'a>(&'a self, host: &'a str) -> BoxFuture<'a, Vec<Value>> {
+        Box::pin(async move {
+            let now = now_epoch_ms();
+            helpers::list_helper_meta(&self.call.state.config.browserclaw_dir, host)
+                .into_iter()
+                .map(|meta| {
+                    // Age is a soft staleness signal; absent when never stamped.
+                    let age_days = (meta.last_verified > 0)
+                        .then(|| (now - meta.last_verified).max(0) / 86_400_000);
+                    json!({
+                        "name": meta.name,
+                        "ageDays": age_days,
+                        "candidate": meta.candidate,
+                        "agent": meta.agent,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn read_helper<'a>(&'a self, host: &'a str, name: &'a str) -> BoxFuture<'a, Option<String>> {
+        Box::pin(async move {
+            helpers::read_helper_source(&self.call.state.config.browserclaw_dir, host, name)
         })
     }
 }
@@ -455,6 +514,31 @@ mod tests {
             Some(call.dispatch_id.as_str())
         );
         assert_eq!(child.page_id, Some(4));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn save_helper_writes_provenance_and_lists_and_reads_back() -> anyhow::Result<()> {
+        let call = tool_call("run", json!({ "code": "return 1" })).await?;
+        let hook = hook_for(&call);
+        hook.save_helper("linkedin.com", "greet", "async (browser, page) => 1")
+            .await
+            .map_err(|error| anyhow::anyhow!(error))?;
+
+        // Lists with provenance: a fresh save reads back candidate=false, ageDays 0.
+        let listed = hook.list_helpers("linkedin.com").await;
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0]["name"], json!("greet"));
+        assert_eq!(listed[0]["candidate"], json!(false));
+        assert_eq!(listed[0]["ageDays"], json!(0));
+
+        // Reads back the source body with the provenance header stripped.
+        assert_eq!(
+            hook.read_helper("linkedin.com", "greet").await.as_deref(),
+            Some("async (browser, page) => 1")
+        );
+        // A distinct host does not collide.
+        assert!(hook.list_helpers("docs.google.com").await.is_empty());
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
@@ -210,13 +210,16 @@ impl InnerCallHook for ScriptInnerCallHook {
             let Some(identity) = self.identity() else {
                 return Err("no agent identity for this script".to_string());
             };
+            let (opens_page, inputs) = helpers::analyze_source(source);
             let meta = helpers::HelperMeta {
                 name: name.to_string(),
                 host: host.to_string(),
                 last_verified: now_epoch_ms(),
                 agent: identity.agent.slug().to_string(),
                 candidate: false,
-                deps: String::new(),
+                opens_page,
+                inputs,
+                description: format!("Saved helper for {host}"),
             };
             helpers::save_helper(&self.call.state.config.browserclaw_dir, &meta, source)
                 .map_err(|error| format!("could not save helper: {error}"))
@@ -235,7 +238,10 @@ impl InnerCallHook for ScriptInnerCallHook {
 
     fn read_helper<'a>(&'a self, host: &'a str, name: &'a str) -> BoxFuture<'a, Option<String>> {
         Box::pin(async move {
-            helpers::read_helper_source(&self.call.state.config.browserclaw_dir, host, name)
+            // The agent-facing read returns the full self-documenting doc
+            // (description, call form, source), not the bare source: hot-load uses
+            // the extracted source; a reader wants the context.
+            helpers::read_helper(&self.call.state.config.browserclaw_dir, host, name)
         })
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
@@ -220,6 +220,7 @@ impl InnerCallHook for ScriptInnerCallHook {
                 opens_page,
                 inputs,
                 description: format!("Saved helper for {host}"),
+                session: String::new(),
             };
             helpers::save_helper(&self.call.state.config.browserclaw_dir, &meta, source)
                 .map_err(|error| format!("could not save helper: {error}"))

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
@@ -66,6 +66,7 @@ impl InnerCallHook for ScriptInnerCallHook {
         let page = record.page;
         let is_error = record.is_error;
         let duration_ms = record.duration_ms;
+        let from_helper = record.from_helper;
         let raw_args = record.args.clone();
         Box::pin(async move {
             let Some(identity) = self.identity() else {
@@ -111,7 +112,7 @@ impl InnerCallHook for ScriptInnerCallHook {
                 url: live.as_ref().map(|page| page.url.clone()),
                 title: live.as_ref().map(|page| page.title.clone()),
                 args_json: bounded_args_json(&raw_args),
-                result_meta: result_meta(is_error, false, &Value::Null, 0),
+                result_meta: child_result_meta(is_error, from_helper),
                 duration_ms,
                 // None: child rows keep their completion time so they sort after
                 // the parent script dispatch, which is stamped with its start.
@@ -237,6 +238,22 @@ impl InnerCallHook for ScriptInnerCallHook {
             helpers::read_helper_source(&self.call.state.config.browserclaw_dir, host, name)
         })
     }
+}
+
+/// Result metadata for a child primitive: the standard summary, plus a
+/// `fromHelper` marker when the primitive ran inside a hot-loaded helper, so the
+/// distiller can skip a successful reuse's replayed actions.
+fn child_result_meta(is_error: bool, from_helper: bool) -> String {
+    let base = result_meta(is_error, false, &Value::Null, 0);
+    if !from_helper {
+        return base;
+    }
+    let mut value: Value =
+        serde_json::from_str(&base).unwrap_or_else(|_| Value::Object(serde_json::Map::new()));
+    if let Some(object) = value.as_object_mut() {
+        object.insert("fromHelper".to_string(), Value::Bool(true));
+    }
+    value.to_string()
 }
 
 #[cfg(test)]
@@ -461,6 +478,7 @@ mod tests {
             method: "input.click",
             page: Some(1),
             args: &json!([1, "e5"]),
+            from_helper: false,
             is_error: false,
             duration_ms: 3,
         })
@@ -485,6 +503,7 @@ mod tests {
             method: "input.click",
             page: Some(4),
             args: &json!([4, "e5"]),
+            from_helper: false,
             is_error: false,
             duration_ms: 12,
         })

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
@@ -225,18 +225,8 @@ impl InnerCallHook for ScriptInnerCallHook {
         Box::pin(async move {
             let now = now_epoch_ms();
             helpers::list_helper_meta(&self.call.state.config.browserclaw_dir, host)
-                .into_iter()
-                .map(|meta| {
-                    // Age is a soft staleness signal; absent when never stamped.
-                    let age_days = (meta.last_verified > 0)
-                        .then(|| (now - meta.last_verified).max(0) / 86_400_000);
-                    json!({
-                        "name": meta.name,
-                        "ageDays": age_days,
-                        "candidate": meta.candidate,
-                        "agent": meta.agent,
-                    })
-                })
+                .iter()
+                .map(|meta| super::helper_runtime::helper_info_json(meta, now))
                 .collect()
         })
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/script_hook.rs
@@ -9,7 +9,7 @@ use crate::{
 use browseros_core::PageId;
 use browseros_mcp::{InnerCallHook, InnerCallRecord};
 use futures_util::future::BoxFuture;
-use serde_json::{Value, json};
+use serde_json::Value;
 use tracing::warn;
 
 /// Host hook a `run`/`execute` script invokes around each browser primitive.
@@ -66,6 +66,7 @@ impl InnerCallHook for ScriptInnerCallHook {
         let page = record.page;
         let is_error = record.is_error;
         let duration_ms = record.duration_ms;
+        let raw_args = record.args.clone();
         Box::pin(async move {
             let Some(identity) = self.identity() else {
                 return;
@@ -109,7 +110,7 @@ impl InnerCallHook for ScriptInnerCallHook {
                     .map(|page| page.target_id.as_str().to_string()),
                 url: live.as_ref().map(|page| page.url.clone()),
                 title: live.as_ref().map(|page| page.title.clone()),
-                args_json: bounded_args_json(&json!({ "page": page })),
+                args_json: bounded_args_json(&raw_args),
                 result_meta: result_meta(is_error, false, &Value::Null, 0),
                 duration_ms,
                 // None: child rows keep their completion time so they sort after
@@ -247,6 +248,7 @@ mod tests {
     use browseros_cdp::{CdpError, CdpEvent, SessionId as CdpSessionId};
     use browseros_core::{BrowserSession, BrowserSessionHooks, CdpConnection};
     use futures_util::future::BoxFuture;
+    use serde_json::json;
     use std::sync::Arc;
     use tokio::sync::broadcast;
 
@@ -458,6 +460,7 @@ mod tests {
         hook.record(InnerCallRecord {
             method: "input.click",
             page: Some(1),
+            args: &json!([1, "e5"]),
             is_error: false,
             duration_ms: 3,
         })
@@ -481,6 +484,7 @@ mod tests {
         hook.record(InnerCallRecord {
             method: "input.click",
             page: Some(4),
+            args: &json!([4, "e5"]),
             is_error: false,
             duration_ms: 12,
         })

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/audit_log.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/audit_log.rs
@@ -347,6 +347,20 @@ impl AuditLog {
         mark_screenshot(self.db.connection(), dispatch_id).await
     }
 
+    /// Reads the child primitives recorded inside a script dispatch, in run
+    /// order, so the self-healing distiller can replay the sequence.
+    pub async fn dispatches_with_parent(
+        &self,
+        parent_dispatch_id: &str,
+    ) -> AppResult<Vec<ToolDispatchRow>> {
+        Ok(ToolDispatches::find()
+            .filter(tool_dispatches::Column::ParentDispatchId.eq(parent_dispatch_id))
+            .order_by_asc(tool_dispatches::Column::CreatedAt)
+            .order_by_asc(tool_dispatches::Column::Id)
+            .all(self.db.connection())
+            .await?)
+    }
+
     /// Records a session start and refreshes its task summary atomically.
     pub async fn record_session_start(
         &self,

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
@@ -131,7 +131,10 @@ pub fn format_helper(meta: &HelperMeta, source: &str) -> String {
 pub fn parse_helper(content: &str) -> (Option<HelperMeta>, String) {
     if let Some(rest) = content.strip_prefix(HEADER_PREFIX) {
         let (line, body) = rest.split_once('\n').unwrap_or((rest, ""));
-        return (serde_json::from_str::<HelperMeta>(line.trim()).ok(), body.to_string());
+        return (
+            serde_json::from_str::<HelperMeta>(line.trim()).ok(),
+            body.to_string(),
+        );
     }
     (None, content.to_string())
 }
@@ -233,10 +236,22 @@ mod tests {
 
     #[test]
     fn host_bucket_strips_scheme_www_path_and_port() {
-        assert_eq!(host_bucket("https://www.linkedin.com/feed").as_deref(), Some("linkedin.com"));
-        assert_eq!(host_bucket("https://docs.google.com/document/1").as_deref(), Some("docs.google.com"));
-        assert_eq!(host_bucket("http://localhost:3000/app").as_deref(), Some("localhost"));
-        assert_eq!(host_bucket("https://user@example.com:8443/x").as_deref(), Some("example.com"));
+        assert_eq!(
+            host_bucket("https://www.linkedin.com/feed").as_deref(),
+            Some("linkedin.com")
+        );
+        assert_eq!(
+            host_bucket("https://docs.google.com/document/1").as_deref(),
+            Some("docs.google.com")
+        );
+        assert_eq!(
+            host_bucket("http://localhost:3000/app").as_deref(),
+            Some("localhost")
+        );
+        assert_eq!(
+            host_bucket("https://user@example.com:8443/x").as_deref(),
+            Some("example.com")
+        );
         assert_eq!(host_bucket("about:blank"), None);
         assert_eq!(host_bucket("chrome://newtab"), None);
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
@@ -45,6 +45,10 @@ pub struct HelperMeta {
     /// One-line human summary of what the helper does.
     #[serde(default)]
     pub description: String,
+    /// The conversation/session id that produced this candidate, so distillation
+    /// can cap a single session to one candidate per host (empty for hand-saved).
+    #[serde(default)]
+    pub session: String,
 }
 
 /// A single safe path segment: non-empty, not a traversal token, limited to an
@@ -221,6 +225,9 @@ fn render_frontmatter(meta: &HelperMeta) -> String {
     out.push_str(&format!("candidate: {}\n", meta.candidate));
     out.push_str(&format!("opensPage: {}\n", meta.opens_page));
     out.push_str(&format!("description: {}\n", yaml_str(&meta.description)));
+    if !meta.session.is_empty() {
+        out.push_str(&format!("session: {}\n", yaml_str(&meta.session)));
+    }
     if meta.inputs.is_empty() {
         out.push_str("inputs: {}\n");
     } else {
@@ -335,16 +342,25 @@ pub fn has_any_helpers(browserclaw_dir: &Path) -> bool {
 }
 
 /// Cap on auto-distilled candidate helpers kept per host, so reuse-driven
-/// candidates do not accumulate unbounded.
-pub const MAX_CANDIDATES_PER_HOST: usize = 10;
+/// candidates do not accumulate unbounded. Small because the per-session cap and
+/// shape deduping already keep candidate churn low.
+pub const MAX_CANDIDATES_PER_HOST: usize = 5;
 
-/// Evicts the oldest candidate helpers for a host beyond `keep`. Only files
-/// whose frontmatter marks them `candidate:true` are eligible; promoted or
-/// hand-saved helpers are never removed.
+/// Deletes a helper file, if present. Used by the distiller to supersede a
+/// session's earlier candidate. No-op for an unsafe host/name or a missing file.
+pub fn remove_helper(browserclaw_dir: &Path, host: &str, name: &str) {
+    if let Some(path) = helper_path(browserclaw_dir, host, name) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+/// Evicts the oldest candidate helpers for a host beyond `keep`. Eligible files
+/// are `candidate:true` passed-page helpers; the canonical `opensPage` search
+/// helper is protected, as are promoted or hand-saved helpers.
 pub fn prune_candidates(browserclaw_dir: &Path, host: &str, keep: usize) {
     let mut candidates: Vec<HelperMeta> = list_helper_meta(browserclaw_dir, host)
         .into_iter()
-        .filter(|meta| meta.candidate)
+        .filter(|meta| meta.candidate && !meta.opens_page)
         .collect();
     if candidates.len() <= keep {
         return;
@@ -376,6 +392,7 @@ pub fn list_helper_meta(browserclaw_dir: &Path, host: &str) -> Vec<HelperMeta> {
                 opens_page: false,
                 inputs: BTreeMap::new(),
                 description: String::new(),
+                session: String::new(),
             }))
         })
         .collect()
@@ -396,6 +413,7 @@ mod tests {
             opens_page: true,
             inputs: BTreeMap::from([("field0".to_string(), "search query".to_string())]),
             description: "Opens amazon.in search for a query".to_string(),
+            session: "convo-1".to_string(),
         }
     }
 
@@ -523,6 +541,37 @@ mod tests {
         assert_eq!(listed[0].agent, "codex");
         assert_eq!(listed[0].inputs.get("field0").map(String::as_str), Some("search query"));
         assert_eq!(listed[0].description, "Opens amazon.in search for a query");
+        assert_eq!(listed[0].session, "convo-1");
+        Ok(())
+    }
+
+    #[test]
+    fn prune_never_evicts_the_opens_page_search_helper() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let root = dir.path();
+        // The canonical opensPage search helper (a candidate) must survive a
+        // burst of passed-page fragments.
+        save_helper(root, &search_meta(), "async (browser, inputs = {}) => { return 1; }")?;
+        let fragment = |name: &str, verified: i64| HelperMeta {
+            name: name.to_string(),
+            host: "amazon.in".to_string(),
+            last_verified: verified,
+            agent: String::new(),
+            candidate: true,
+            opens_page: false,
+            inputs: BTreeMap::new(),
+            description: String::new(),
+            session: String::new(),
+        };
+        for i in 1..=4 {
+            save_helper(root, &fragment(&format!("candidate-{i}"), i), "async () => 1")?;
+        }
+        prune_candidates(root, "amazon.in", 1);
+        let names: Vec<String> = list_helper_meta(root, "amazon.in")
+            .into_iter()
+            .map(|meta| meta.name)
+            .collect();
+        assert!(names.contains(&"search-amazon".to_string()), "search helper evicted: {names:?}");
         Ok(())
     }
 
@@ -546,9 +595,11 @@ mod tests {
             last_verified: verified,
             agent: String::new(),
             candidate,
-            opens_page: true,
+            // Passed-page candidates are the evictable kind.
+            opens_page: false,
             inputs: BTreeMap::new(),
             description: String::new(),
+            session: String::new(),
         };
         // A promoted (candidate:false) helper must survive pruning.
         save_helper(root, &helper("keep-me", 500, false), "async () => 1")?;

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
@@ -171,6 +171,30 @@ pub fn has_any_helpers(browserclaw_dir: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// Cap on auto-distilled candidate helpers kept per host, so reuse-driven
+/// candidates do not accumulate unbounded.
+pub const MAX_CANDIDATES_PER_HOST: usize = 10;
+
+/// Evicts the oldest candidate helpers for a host beyond `keep`. Only files
+/// whose header marks them `candidate:true` are eligible; promoted or hand-saved
+/// helpers are never removed.
+pub fn prune_candidates(browserclaw_dir: &Path, host: &str, keep: usize) {
+    let mut candidates: Vec<HelperMeta> = list_helper_meta(browserclaw_dir, host)
+        .into_iter()
+        .filter(|meta| meta.candidate)
+        .collect();
+    if candidates.len() <= keep {
+        return;
+    }
+    // Newest first by last-verified; evict the tail.
+    candidates.sort_by_key(|meta| std::cmp::Reverse(meta.last_verified));
+    for meta in candidates.into_iter().skip(keep) {
+        if let Some(path) = helper_path(browserclaw_dir, host, &meta.name) {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
 /// Lists helpers for a host with their parsed provenance, sorted by name. A file
 /// missing a header still lists, with default provenance.
 #[must_use]
@@ -307,6 +331,39 @@ mod tests {
         };
         let huge = "a".repeat(MAX_HELPER_BYTES + 1);
         assert!(save_helper(dir.path(), &meta, &huge).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn prune_candidates_caps_candidates_and_keeps_promoted_helpers() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let root = dir.path();
+        let helper = |name: &str, verified: i64, candidate: bool| HelperMeta {
+            name: name.to_string(),
+            host: "h".to_string(),
+            last_verified: verified,
+            agent: String::new(),
+            candidate,
+            deps: String::new(),
+        };
+        // A promoted (candidate:false) helper must survive pruning.
+        save_helper(root, &helper("keep-me", 500, false), "async () => 1")?;
+        for i in 1..=3 {
+            save_helper(
+                root,
+                &helper(&format!("candidate-{i}"), i, true),
+                "async () => 1",
+            )?;
+        }
+        prune_candidates(root, "h", 1); // keep only the newest candidate
+        let names: Vec<String> = list_helper_meta(root, "h")
+            .into_iter()
+            .map(|meta| meta.name)
+            .collect();
+        assert!(names.contains(&"keep-me".to_string()));
+        assert!(names.contains(&"candidate-3".to_string())); // newest
+        assert!(!names.contains(&"candidate-1".to_string()));
+        assert!(!names.contains(&"candidate-2".to_string()));
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
@@ -162,6 +162,15 @@ pub fn read_helper_source(browserclaw_dir: &Path, host: &str, name: &str) -> Opt
     read_helper(browserclaw_dir, host, name).map(|content| parse_helper(&content).1)
 }
 
+/// Cheap check for whether any helper exists at all, so the hot-load path can
+/// skip a page scan when there is nothing to load.
+#[must_use]
+pub fn has_any_helpers(browserclaw_dir: &Path) -> bool {
+    fs::read_dir(browserclaw_dir.join(HELPERS_DIR))
+        .map(|mut entries| entries.any(|entry| entry.is_ok()))
+        .unwrap_or(false)
+}
+
 /// Lists helpers for a host with their parsed provenance, sorted by name. A file
 /// missing a header still lists, with default provenance.
 #[must_use]
@@ -298,6 +307,15 @@ mod tests {
         };
         let huge = "a".repeat(MAX_HELPER_BYTES + 1);
         assert!(save_helper(dir.path(), &meta, &huge).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn has_any_helpers_gates_on_a_populated_helpers_root() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        assert!(!has_any_helpers(dir.path()));
+        write_helper(dir.path(), "example.com", "x", "async () => {}")?;
+        assert!(has_any_helpers(dir.path()));
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
@@ -4,6 +4,7 @@
 //! traversal-safe storage; the saveHelper primitive and the hot-load into the
 //! script runtime that build on it land with the self-healing work.
 
+use serde::{Deserialize, Serialize};
 use std::{
     fs, io,
     path::{Path, PathBuf},
@@ -11,6 +12,27 @@ use std::{
 
 const HELPERS_DIR: &str = "helpers";
 const HELPER_EXTENSION: &str = "js";
+const HEADER_PREFIX: &str = "// browserclaw-helper: ";
+
+/// Upper bound on a helper's source so a script cannot fill the disk.
+pub const MAX_HELPER_BYTES: usize = 64 * 1024;
+
+/// Provenance and freshness a helper file carries in a leading comment line, so
+/// a later reader can judge staleness and origin. A `//` line is inert to
+/// `eval`, so the file still evals as a bare function expression.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HelperMeta {
+    pub name: String,
+    pub host: String,
+    #[serde(rename = "lastVerified")]
+    pub last_verified: i64,
+    #[serde(default)]
+    pub agent: String,
+    #[serde(default)]
+    pub candidate: bool,
+    #[serde(default)]
+    pub deps: String,
+}
 
 /// A single safe path segment: non-empty, not a traversal token, limited to an
 /// unsurprising character set so a host or helper name cannot escape the
@@ -80,6 +102,84 @@ pub fn write_helper(browserclaw_dir: &Path, host: &str, name: &str, code: &str) 
     fs::write(path, code)
 }
 
+/// Derives the helper host bucket from a page URL: the hostname minus a leading
+/// `www.`, or `None` when there is no usable host. Subdomains stay distinct so
+/// subdomain-scoped apps do not collide. No URL crate: bounded to http(s) shapes.
+#[must_use]
+pub fn host_bucket(url: &str) -> Option<String> {
+    let (scheme, after_scheme) = url.split_once("://")?;
+    if !matches!(scheme, "http" | "https") {
+        return None;
+    }
+    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or("");
+    let host_port = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    let host = host_port.split(':').next().unwrap_or("");
+    let bucket = host.strip_prefix("www.").unwrap_or(host);
+    is_safe_segment(bucket).then(|| bucket.to_string())
+}
+
+/// Renders a helper file: the provenance header line, then the source.
+#[must_use]
+pub fn format_helper(meta: &HelperMeta, source: &str) -> String {
+    let header = serde_json::to_string(meta).unwrap_or_else(|_| "{}".to_string());
+    format!("{HEADER_PREFIX}{header}\n{source}")
+}
+
+/// Splits a helper file into its parsed header (if any) and its source body,
+/// with the header line removed so the body evals as a bare function expression.
+#[must_use]
+pub fn parse_helper(content: &str) -> (Option<HelperMeta>, String) {
+    if let Some(rest) = content.strip_prefix(HEADER_PREFIX) {
+        let (line, body) = rest.split_once('\n').unwrap_or((rest, ""));
+        return (serde_json::from_str::<HelperMeta>(line.trim()).ok(), body.to_string());
+    }
+    (None, content.to_string())
+}
+
+/// Writes a helper with its provenance header. Rejects an oversized source.
+pub fn save_helper(browserclaw_dir: &Path, meta: &HelperMeta, source: &str) -> io::Result<()> {
+    if source.len() > MAX_HELPER_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "helper source exceeds the size limit",
+        ));
+    }
+    write_helper(
+        browserclaw_dir,
+        &meta.host,
+        &meta.name,
+        &format_helper(meta, source),
+    )
+}
+
+/// Reads a helper's source body with its provenance header stripped, ready to
+/// eval. `None` for an unsafe host/name or a missing file.
+#[must_use]
+pub fn read_helper_source(browserclaw_dir: &Path, host: &str, name: &str) -> Option<String> {
+    read_helper(browserclaw_dir, host, name).map(|content| parse_helper(&content).1)
+}
+
+/// Lists helpers for a host with their parsed provenance, sorted by name. A file
+/// missing a header still lists, with default provenance.
+#[must_use]
+pub fn list_helper_meta(browserclaw_dir: &Path, host: &str) -> Vec<HelperMeta> {
+    list_helpers(browserclaw_dir, host)
+        .into_iter()
+        .filter_map(|name| {
+            let content = read_helper(browserclaw_dir, host, &name)?;
+            let (meta, _) = parse_helper(&content);
+            Some(meta.unwrap_or_else(|| HelperMeta {
+                name,
+                host: host.to_string(),
+                last_verified: 0,
+                agent: String::new(),
+                candidate: false,
+                deps: String::new(),
+            }))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,6 +228,78 @@ mod tests {
         let root = dir.path();
         assert!(read_helper(root, "linkedin.com", "nope").is_none());
         assert!(list_helpers(root, "linkedin.com").is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn host_bucket_strips_scheme_www_path_and_port() {
+        assert_eq!(host_bucket("https://www.linkedin.com/feed").as_deref(), Some("linkedin.com"));
+        assert_eq!(host_bucket("https://docs.google.com/document/1").as_deref(), Some("docs.google.com"));
+        assert_eq!(host_bucket("http://localhost:3000/app").as_deref(), Some("localhost"));
+        assert_eq!(host_bucket("https://user@example.com:8443/x").as_deref(), Some("example.com"));
+        assert_eq!(host_bucket("about:blank"), None);
+        assert_eq!(host_bucket("chrome://newtab"), None);
+    }
+
+    #[test]
+    fn save_read_and_list_carry_provenance_and_strip_header() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let root = dir.path();
+        let meta = HelperMeta {
+            name: "accept-invites".to_string(),
+            host: "linkedin.com".to_string(),
+            last_verified: 1_784_887_201_128,
+            agent: "codex".to_string(),
+            candidate: true,
+            deps: "linkedin.com invitation list".to_string(),
+        };
+        save_helper(root, &meta, "async (browser, page) => { return 1; }")?;
+
+        // The eval body is the source with the header comment stripped.
+        assert_eq!(
+            read_helper_source(root, "linkedin.com", "accept-invites").as_deref(),
+            Some("async (browser, page) => { return 1; }")
+        );
+        // Provenance round-trips through the header.
+        let listed = list_helper_meta(root, "linkedin.com");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "accept-invites");
+        assert_eq!(listed[0].last_verified, 1_784_887_201_128);
+        assert!(listed[0].candidate);
+        assert_eq!(listed[0].agent, "codex");
+        Ok(())
+    }
+
+    #[test]
+    fn oversized_source_is_rejected() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let meta = HelperMeta {
+            name: "big".to_string(),
+            host: "example.com".to_string(),
+            last_verified: 0,
+            agent: String::new(),
+            candidate: false,
+            deps: String::new(),
+        };
+        let huge = "a".repeat(MAX_HELPER_BYTES + 1);
+        assert!(save_helper(dir.path(), &meta, &huge).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn a_headerless_file_still_lists_with_defaults() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let root = dir.path();
+        write_helper(root, "example.com", "legacy", "async () => {}")?;
+        let listed = list_helper_meta(root, "example.com");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].name, "legacy");
+        assert_eq!(listed[0].last_verified, 0);
+        // A headerless file reads back verbatim.
+        assert_eq!(
+            read_helper_source(root, "example.com", "legacy").as_deref(),
+            Some("async () => {}")
+        );
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/helpers.rs
@@ -1,25 +1,29 @@
-//! Persistence seam for code-mode helpers: reusable `.js` a script saves for a
-//! host and a later script loads by name. Layout is
-//! `<browserclaw_dir>/helpers/<host>/<name>.js`. This module owns only the
-//! traversal-safe storage; the saveHelper primitive and the hot-load into the
-//! script runtime that build on it land with the self-healing work.
+//! Persistence seam for code-mode helpers: a reusable flow a script saves for a
+//! host and a later script loads by name. Each helper is a self-documenting
+//! Markdown file at `<browserclaw_dir>/helpers/<host>/<name>.md`: YAML
+//! frontmatter (provenance, freshness, call shape, inputs), a human-and-agent
+//! readable body, and a fenced `js` block holding the function source. The host
+//! extracts that source for the runtime, so the engine still hot-loads a plain
+//! function expression; all Markdown handling stays here.
 
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::BTreeMap,
     fs, io,
     path::{Path, PathBuf},
 };
 
 const HELPERS_DIR: &str = "helpers";
-const HELPER_EXTENSION: &str = "js";
-const HEADER_PREFIX: &str = "// browserclaw-helper: ";
+const HELPER_EXTENSION: &str = "md";
 
-/// Upper bound on a helper's source so a script cannot fill the disk.
+/// Upper bound on a helper's source so a script cannot fill the disk. Bounds the
+/// JS source itself, not the rendered file, so the limit is stable as the
+/// surrounding Markdown grows.
 pub const MAX_HELPER_BYTES: usize = 64 * 1024;
 
-/// Provenance and freshness a helper file carries in a leading comment line, so
-/// a later reader can judge staleness and origin. A `//` line is inert to
-/// `eval`, so the file still evals as a bare function expression.
+/// Provenance, freshness, and call shape a helper file carries in its
+/// frontmatter, so a later reader (human or agent) can judge staleness and
+/// origin and call it correctly.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HelperMeta {
     pub name: String,
@@ -30,8 +34,17 @@ pub struct HelperMeta {
     pub agent: String,
     #[serde(default)]
     pub candidate: bool,
+    /// Whether the macro opens its own page (`(browser, inputs)`, returns a page)
+    /// versus acting on a page passed to it (`(browser, page, inputs)`).
+    #[serde(rename = "opensPage", default)]
+    pub opens_page: bool,
+    /// Input field name to a short human description, e.g. `field0 -> "search
+    /// query"`. Empty when the helper takes no inputs.
     #[serde(default)]
-    pub deps: String,
+    pub inputs: BTreeMap<String, String>,
+    /// One-line human summary of what the helper does.
+    #[serde(default)]
+    pub description: String,
 }
 
 /// A single safe path segment: non-empty, not a traversal token, limited to an
@@ -59,7 +72,7 @@ fn helper_path(browserclaw_dir: &Path, host: &str, name: &str) -> Option<PathBuf
     helpers_dir(browserclaw_dir, host).map(|dir| dir.join(format!("{name}.{HELPER_EXTENSION}")))
 }
 
-/// Lists helper base names (without the `.js` extension) available for a host,
+/// Lists helper base names (without the `.md` extension) available for a host,
 /// sorted. Missing directory or unsafe host yields an empty list.
 #[must_use]
 pub fn list_helpers(browserclaw_dir: &Path, host: &str) -> Vec<String> {
@@ -84,22 +97,23 @@ pub fn list_helpers(browserclaw_dir: &Path, host: &str) -> Vec<String> {
     names
 }
 
-/// Reads a helper's source, or `None` for an unsafe host/name or a missing file.
+/// Reads a helper's raw Markdown file, or `None` for an unsafe host/name or a
+/// missing file. This is the full self-documenting doc a reader sees.
 #[must_use]
 pub fn read_helper(browserclaw_dir: &Path, host: &str, name: &str) -> Option<String> {
     let path = helper_path(browserclaw_dir, host, name)?;
     fs::read_to_string(path).ok()
 }
 
-/// Writes a helper's source, creating the host directory. Errors on an unsafe
-/// host or name.
-pub fn write_helper(browserclaw_dir: &Path, host: &str, name: &str, code: &str) -> io::Result<()> {
+/// Writes a helper file verbatim, creating the host directory. Errors on an
+/// unsafe host or name.
+pub fn write_helper(browserclaw_dir: &Path, host: &str, name: &str, content: &str) -> io::Result<()> {
     let path = helper_path(browserclaw_dir, host, name)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "unsafe helper host or name"))?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(path, code)
+    fs::write(path, content)
 }
 
 /// Derives the helper host bucket from a page URL: the hostname minus a leading
@@ -118,28 +132,177 @@ pub fn host_bucket(url: &str) -> Option<String> {
     is_safe_segment(bucket).then(|| bucket.to_string())
 }
 
-/// Renders a helper file: the provenance header line, then the source.
+/// The exact call form for a helper, derived from its shape and inputs, so the
+/// discovery note, the file body, and `readHelper` never drift. Bracket access
+/// works for any name; the argument object names each input.
+#[must_use]
+pub fn call_example(meta: &HelperMeta) -> String {
+    let name = &meta.name;
+    let inputs_obj = (!meta.inputs.is_empty()).then(|| {
+        let fields: Vec<String> = meta
+            .inputs
+            .iter()
+            .map(|(field, desc)| format!("{field}: {}", input_placeholder(desc)))
+            .collect();
+        format!("{{ {} }}", fields.join(", "))
+    });
+    match (meta.opens_page, inputs_obj) {
+        (true, Some(obj)) => format!("helpers[\"{name}\"](browser, {obj})"),
+        (true, None) => format!("helpers[\"{name}\"](browser)"),
+        (false, Some(obj)) => format!("helpers[\"{name}\"](browser, page, {obj})"),
+        (false, None) => format!("helpers[\"{name}\"](browser, page)"),
+    }
+}
+
+/// A copy-paste placeholder value for an input, tagged with its description so a
+/// reader knows what to fill in.
+fn input_placeholder(desc: &str) -> String {
+    if desc.is_empty() {
+        "\"...\"".to_string()
+    } else {
+        format!("\"<{desc}>\"")
+    }
+}
+
+/// Infers a hand-saved helper's call shape from its source: whether it opens its
+/// own page (no `page` parameter) and which `inputs.field<n>` it reads. A
+/// best-effort heuristic for the `saveHelper` path; the distiller sets these
+/// directly from what it recorded.
+#[must_use]
+pub fn analyze_source(source: &str) -> (bool, BTreeMap<String, String>) {
+    let params = param_list(source);
+    let opens_page = !params.iter().any(|param| param == "page");
+    let mut inputs = BTreeMap::new();
+    let needle = "inputs.field";
+    let mut from = 0;
+    while let Some(pos) = source[from..].find(needle) {
+        let start = from + pos + needle.len();
+        let digits: String = source[start..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        if !digits.is_empty() {
+            inputs.insert(format!("field{digits}"), "input value".to_string());
+        }
+        from = start;
+    }
+    (opens_page, inputs)
+}
+
+/// The parameter identifiers of the first parenthesized list in a source (the
+/// arrow function's params), stripped of default values.
+fn param_list(source: &str) -> Vec<String> {
+    let Some(open) = source.find('(') else {
+        return Vec::new();
+    };
+    let rest = &source[open + 1..];
+    let Some(close) = rest.find(')') else {
+        return Vec::new();
+    };
+    rest[..close]
+        .split(',')
+        .map(|part| part.split('=').next().unwrap_or("").trim().to_string())
+        .filter(|part| !part.is_empty())
+        .collect()
+}
+
+/// Quotes a string as a JSON scalar, which is a valid YAML double-quoted scalar,
+/// so colons, quotes, and newlines survive without a YAML serializer.
+fn yaml_str(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+}
+
+fn render_frontmatter(meta: &HelperMeta) -> String {
+    let mut out = String::from("---\n");
+    out.push_str(&format!("name: {}\n", yaml_str(&meta.name)));
+    out.push_str(&format!("host: {}\n", yaml_str(&meta.host)));
+    out.push_str(&format!("lastVerified: {}\n", meta.last_verified));
+    out.push_str(&format!("agent: {}\n", yaml_str(&meta.agent)));
+    out.push_str(&format!("candidate: {}\n", meta.candidate));
+    out.push_str(&format!("opensPage: {}\n", meta.opens_page));
+    out.push_str(&format!("description: {}\n", yaml_str(&meta.description)));
+    if meta.inputs.is_empty() {
+        out.push_str("inputs: {}\n");
+    } else {
+        out.push_str("inputs:\n");
+        for (field, desc) in &meta.inputs {
+            out.push_str(&format!("  {}: {}\n", yaml_str(field), yaml_str(desc)));
+        }
+    }
+    out.push_str("---\n");
+    out
+}
+
+fn render_body(meta: &HelperMeta, source: &str) -> String {
+    let mut out = String::new();
+    if !meta.description.is_empty() {
+        out.push_str(&meta.description);
+        out.push_str("\n\n");
+    }
+    out.push_str("Call it:\n\n");
+    out.push_str(&format!("`{}`\n\n", call_example(meta)));
+    out.push_str("```js\n");
+    out.push_str(source.trim_end());
+    out.push_str("\n```\n");
+    out
+}
+
+/// Renders a helper file: YAML frontmatter, a readable body, and the source in a
+/// fenced `js` block.
 #[must_use]
 pub fn format_helper(meta: &HelperMeta, source: &str) -> String {
-    let header = serde_json::to_string(meta).unwrap_or_else(|_| "{}".to_string());
-    format!("{HEADER_PREFIX}{header}\n{source}")
+    format!("{}\n{}", render_frontmatter(meta), render_body(meta, source))
 }
 
-/// Splits a helper file into its parsed header (if any) and its source body,
-/// with the header line removed so the body evals as a bare function expression.
+/// Whether a fence info string names JavaScript (first token `js`/`javascript`).
+fn is_js_lang(lang: &str) -> bool {
+    matches!(lang.split_whitespace().next(), Some("js" | "javascript"))
+}
+
+/// Splits a helper file into its parsed frontmatter (if any) and the source from
+/// its first `js` fenced block, using a CommonMark parser so the extraction is
+/// robust. A file with no frontmatter yields `None`; one with no `js` fence
+/// yields an empty source, so a malformed helper simply does not hot-load.
 #[must_use]
 pub fn parse_helper(content: &str) -> (Option<HelperMeta>, String) {
-    if let Some(rest) = content.strip_prefix(HEADER_PREFIX) {
-        let (line, body) = rest.split_once('\n').unwrap_or((rest, ""));
-        return (
-            serde_json::from_str::<HelperMeta>(line.trim()).ok(),
-            body.to_string(),
-        );
+    use pulldown_cmark::{CodeBlockKind, Event, MetadataBlockKind, Options, Parser, Tag, TagEnd};
+
+    let parser = Parser::new_ext(content, Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
+    let mut frontmatter = String::new();
+    let mut source = String::new();
+    let mut in_meta = false;
+    let mut in_js = false;
+    let mut js_captured = false;
+    for event in parser {
+        match event {
+            Event::Start(Tag::MetadataBlock(MetadataBlockKind::YamlStyle)) => in_meta = true,
+            Event::End(TagEnd::MetadataBlock(_)) => in_meta = false,
+            Event::Start(Tag::CodeBlock(CodeBlockKind::Fenced(lang)))
+                if !js_captured && is_js_lang(&lang) =>
+            {
+                in_js = true;
+            }
+            Event::End(TagEnd::CodeBlock) if in_js => {
+                in_js = false;
+                js_captured = true;
+            }
+            Event::Text(text) => {
+                if in_meta {
+                    frontmatter.push_str(&text);
+                } else if in_js {
+                    source.push_str(&text);
+                }
+            }
+            _ => {}
+        }
     }
-    (None, content.to_string())
+    let meta = (!frontmatter.trim().is_empty())
+        .then(|| serde_saphyr::from_str::<HelperMeta>(&frontmatter).ok())
+        .flatten();
+    (meta, source.trim().to_string())
 }
 
-/// Writes a helper with its provenance header. Rejects an oversized source.
+/// Writes a helper as a Markdown doc. Rejects an oversized source.
 pub fn save_helper(browserclaw_dir: &Path, meta: &HelperMeta, source: &str) -> io::Result<()> {
     if source.len() > MAX_HELPER_BYTES {
         return Err(io::Error::new(
@@ -155,8 +318,8 @@ pub fn save_helper(browserclaw_dir: &Path, meta: &HelperMeta, source: &str) -> i
     )
 }
 
-/// Reads a helper's source body with its provenance header stripped, ready to
-/// eval. `None` for an unsafe host/name or a missing file.
+/// Reads a helper's JS source from its `js` fenced block, ready to eval. `None`
+/// for an unsafe host/name or a missing file; empty when the file has no source.
 #[must_use]
 pub fn read_helper_source(browserclaw_dir: &Path, host: &str, name: &str) -> Option<String> {
     read_helper(browserclaw_dir, host, name).map(|content| parse_helper(&content).1)
@@ -176,8 +339,8 @@ pub fn has_any_helpers(browserclaw_dir: &Path) -> bool {
 pub const MAX_CANDIDATES_PER_HOST: usize = 10;
 
 /// Evicts the oldest candidate helpers for a host beyond `keep`. Only files
-/// whose header marks them `candidate:true` are eligible; promoted or hand-saved
-/// helpers are never removed.
+/// whose frontmatter marks them `candidate:true` are eligible; promoted or
+/// hand-saved helpers are never removed.
 pub fn prune_candidates(browserclaw_dir: &Path, host: &str, keep: usize) {
     let mut candidates: Vec<HelperMeta> = list_helper_meta(browserclaw_dir, host)
         .into_iter()
@@ -195,8 +358,8 @@ pub fn prune_candidates(browserclaw_dir: &Path, host: &str, keep: usize) {
     }
 }
 
-/// Lists helpers for a host with their parsed provenance, sorted by name. A file
-/// missing a header still lists, with default provenance.
+/// Lists helpers for a host with their parsed frontmatter, sorted by name. A file
+/// missing frontmatter still lists, with default provenance.
 #[must_use]
 pub fn list_helper_meta(browserclaw_dir: &Path, host: &str) -> Vec<HelperMeta> {
     list_helpers(browserclaw_dir, host)
@@ -210,7 +373,9 @@ pub fn list_helper_meta(browserclaw_dir: &Path, host: &str) -> Vec<HelperMeta> {
                 last_verified: 0,
                 agent: String::new(),
                 candidate: false,
-                deps: String::new(),
+                opens_page: false,
+                inputs: BTreeMap::new(),
+                description: String::new(),
             }))
         })
         .collect()
@@ -221,21 +386,29 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    fn search_meta() -> HelperMeta {
+        HelperMeta {
+            name: "search-amazon".to_string(),
+            host: "amazon.in".to_string(),
+            last_verified: 1_784_887_201_128,
+            agent: "codex".to_string(),
+            candidate: true,
+            opens_page: true,
+            inputs: BTreeMap::from([("field0".to_string(), "search query".to_string())]),
+            description: "Opens amazon.in search for a query".to_string(),
+        }
+    }
+
     #[test]
     fn write_then_read_round_trips_and_lists() -> anyhow::Result<()> {
         let dir = tempdir()?;
         let root = dir.path();
-        write_helper(
-            root,
-            "linkedin.com",
-            "accept-invites",
-            "export const x = 1;",
-        )?;
-        write_helper(root, "linkedin.com", "messages", "export const y = 2;")?;
+        write_helper(root, "linkedin.com", "accept-invites", "one")?;
+        write_helper(root, "linkedin.com", "messages", "two")?;
 
         assert_eq!(
             read_helper(root, "linkedin.com", "accept-invites").as_deref(),
-            Some("export const x = 1;")
+            Some("one")
         );
         assert_eq!(
             list_helpers(root, "linkedin.com"),
@@ -290,45 +463,74 @@ mod tests {
     }
 
     #[test]
-    fn save_read_and_list_carry_provenance_and_strip_header() -> anyhow::Result<()> {
+    fn call_example_matches_shape_and_inputs() {
+        // Open-page macro with an input: bracket access, inputs object, no page.
+        assert_eq!(
+            call_example(&search_meta()),
+            "helpers[\"search-amazon\"](browser, { field0: \"<search query>\" })"
+        );
+        let mut passed = search_meta();
+        passed.name = "reply".to_string();
+        passed.opens_page = false;
+        passed.inputs = BTreeMap::new();
+        assert_eq!(call_example(&passed), "helpers[\"reply\"](browser, page)");
+        passed.opens_page = true;
+        assert_eq!(call_example(&passed), "helpers[\"reply\"](browser)");
+    }
+
+    #[test]
+    fn analyze_source_infers_shape_and_inputs() {
+        let (opens_page, inputs) =
+            analyze_source("async (browser, inputs = {}) => { return inputs.field0 + inputs.field1; }");
+        assert!(opens_page);
+        assert_eq!(inputs.len(), 2);
+        assert!(inputs.contains_key("field0"));
+        assert!(inputs.contains_key("field1"));
+
+        let (opens_page, inputs) =
+            analyze_source("async (browser, page, inputs = {}) => { await browser.input(page).fill('e', inputs.field0); }");
+        assert!(!opens_page);
+        assert_eq!(inputs.len(), 1);
+
+        let (opens_page, inputs) = analyze_source("async (browser, page) => { return 1; }");
+        assert!(!opens_page);
+        assert!(inputs.is_empty());
+    }
+
+    #[test]
+    fn save_read_and_list_round_trip_frontmatter_and_extract_source() -> anyhow::Result<()> {
         let dir = tempdir()?;
         let root = dir.path();
-        let meta = HelperMeta {
-            name: "accept-invites".to_string(),
-            host: "linkedin.com".to_string(),
-            last_verified: 1_784_887_201_128,
-            agent: "codex".to_string(),
-            candidate: true,
-            deps: "linkedin.com invitation list".to_string(),
-        };
-        save_helper(root, &meta, "async (browser, page) => { return 1; }")?;
+        let source = "async (browser, inputs = {}) => { return inputs.field0; }";
+        save_helper(root, &search_meta(), source)?;
 
-        // The eval body is the source with the header comment stripped.
+        // The eval body is the source lifted out of the js fence.
         assert_eq!(
-            read_helper_source(root, "linkedin.com", "accept-invites").as_deref(),
-            Some("async (browser, page) => { return 1; }")
+            read_helper_source(root, "amazon.in", "search-amazon").as_deref(),
+            Some(source)
         );
-        // Provenance round-trips through the header.
-        let listed = list_helper_meta(root, "linkedin.com");
+        // The raw doc a reader sees carries the description and call form.
+        let doc = read_helper(root, "amazon.in", "search-amazon").unwrap_or_default();
+        assert!(doc.contains("Opens amazon.in search for a query"));
+        assert!(doc.contains("helpers[\"search-amazon\"](browser, { field0: \"<search query>\" })"));
+        // Frontmatter round-trips through the parser.
+        let listed = list_helper_meta(root, "amazon.in");
         assert_eq!(listed.len(), 1);
-        assert_eq!(listed[0].name, "accept-invites");
+        assert_eq!(listed[0].name, "search-amazon");
         assert_eq!(listed[0].last_verified, 1_784_887_201_128);
         assert!(listed[0].candidate);
+        assert!(listed[0].opens_page);
         assert_eq!(listed[0].agent, "codex");
+        assert_eq!(listed[0].inputs.get("field0").map(String::as_str), Some("search query"));
+        assert_eq!(listed[0].description, "Opens amazon.in search for a query");
         Ok(())
     }
 
     #[test]
     fn oversized_source_is_rejected() -> anyhow::Result<()> {
         let dir = tempdir()?;
-        let meta = HelperMeta {
-            name: "big".to_string(),
-            host: "example.com".to_string(),
-            last_verified: 0,
-            agent: String::new(),
-            candidate: false,
-            deps: String::new(),
-        };
+        let mut meta = search_meta();
+        meta.name = "big".to_string();
         let huge = "a".repeat(MAX_HELPER_BYTES + 1);
         assert!(save_helper(dir.path(), &meta, &huge).is_err());
         Ok(())
@@ -344,7 +546,9 @@ mod tests {
             last_verified: verified,
             agent: String::new(),
             candidate,
-            deps: String::new(),
+            opens_page: true,
+            inputs: BTreeMap::new(),
+            description: String::new(),
         };
         // A promoted (candidate:false) helper must survive pruning.
         save_helper(root, &helper("keep-me", 500, false), "async () => 1")?;
@@ -371,21 +575,26 @@ mod tests {
     fn has_any_helpers_gates_on_a_populated_helpers_root() -> anyhow::Result<()> {
         let dir = tempdir()?;
         assert!(!has_any_helpers(dir.path()));
-        write_helper(dir.path(), "example.com", "x", "async () => {}")?;
+        save_helper(dir.path(), &search_meta(), "async () => {}")?;
         assert!(has_any_helpers(dir.path()));
         Ok(())
     }
 
     #[test]
-    fn a_headerless_file_still_lists_with_defaults() -> anyhow::Result<()> {
+    fn a_file_without_frontmatter_lists_with_defaults_and_extracts_source() -> anyhow::Result<()> {
         let dir = tempdir()?;
         let root = dir.path();
-        write_helper(root, "example.com", "legacy", "async () => {}")?;
+        write_helper(
+            root,
+            "example.com",
+            "legacy",
+            "no frontmatter here\n\n```js\nasync () => {}\n```\n",
+        )?;
         let listed = list_helper_meta(root, "example.com");
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].name, "legacy");
         assert_eq!(listed[0].last_verified, 0);
-        // A headerless file reads back verbatim.
+        // The js fence is still extracted even without frontmatter.
         assert_eq!(
             read_helper_source(root, "example.com", "legacy").as_deref(),
             Some("async () => {}")

--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -151,6 +151,9 @@ pub struct InnerCallRecord<'a> {
     /// The primitive's arguments as a JSON array, so the audit shows what ran
     /// and the self-healing distiller can replay the sequence.
     pub args: &'a Value,
+    /// Whether this primitive ran inside a hot-loaded helper call (a replay), so
+    /// the distiller can skip a successful reuse's actions.
+    pub from_helper: bool,
     /// Whether the primitive failed.
     pub is_error: bool,
     /// Wall-clock duration of the primitive in milliseconds.

--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -94,6 +94,37 @@ pub trait InnerCallHook: Send + Sync {
     fn annotate_pages<'a>(&'a self, pages: &'a [Value]) -> BoxFuture<'a, Vec<Value>> {
         Box::pin(async move { pages.to_vec() })
     }
+
+    /// Resolve a page id to its helper host bucket (hostname minus a leading
+    /// `www.`). `browseros-mcp` cannot read a page's URL from ownership state,
+    /// so the host does it. The default has no host.
+    fn resolve_host<'a>(&'a self, _page: u32) -> BoxFuture<'a, Option<String>> {
+        Box::pin(async move { None })
+    }
+
+    /// Persist a reusable helper for a host under `helpers/<host>/<name>.js` with
+    /// a provenance header. `Err(reason)` is surfaced to the script. The default
+    /// reports that persistence is unavailable (no host attached).
+    fn save_helper<'a>(
+        &'a self,
+        _host: &'a str,
+        _name: &'a str,
+        _source: &'a str,
+    ) -> BoxFuture<'a, Result<(), String>> {
+        Box::pin(async move { Err("helpers are not available in this context".to_string()) })
+    }
+
+    /// List a host's saved helpers with provenance for discovery. Each value is
+    /// `{ name, ageDays, candidate, agent }`. The default has none.
+    fn list_helpers<'a>(&'a self, _host: &'a str) -> BoxFuture<'a, Vec<Value>> {
+        Box::pin(async move { Vec::new() })
+    }
+
+    /// Read a helper's source body (provenance header stripped), ready to eval.
+    /// The default has none.
+    fn read_helper<'a>(&'a self, _host: &'a str, _name: &'a str) -> BoxFuture<'a, Option<String>> {
+        Box::pin(async move { None })
+    }
 }
 
 /// A completed inner primitive handed to [`InnerCallHook::record`].

--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -148,6 +148,9 @@ pub struct InnerCallRecord<'a> {
     pub method: &'a str,
     /// Target page id, when the primitive addressed a specific page.
     pub page: Option<u32>,
+    /// The primitive's arguments as a JSON array, so the audit shows what ran
+    /// and the self-healing distiller can replay the sequence.
+    pub args: &'a Value,
     /// Whether the primitive failed.
     pub is_error: bool,
     /// Wall-clock duration of the primitive in milliseconds.

--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -24,6 +24,14 @@ pub struct BrowserToolDefaults {
     pub default_tab_group_id: Option<String>,
 }
 
+/// A saved helper the host hot-loads into a script's runtime so the agent can
+/// call it by name. `source` is a bare function expression (header stripped).
+#[derive(Debug, Clone)]
+pub struct HelperSource {
+    pub name: String,
+    pub source: String,
+}
+
 #[derive(Clone)]
 pub struct BrowserToolOptions {
     pub session: Arc<BrowserSession>,
@@ -33,6 +41,9 @@ pub struct BrowserToolOptions {
     /// Host hook a script tool invokes around each primitive; `None` outside
     /// the host (unit tests, non-host callers), which disables the hook.
     pub inner_call_hook: Option<Arc<dyn InnerCallHook>>,
+    /// Helpers the host loads into the script runtime before the agent's code
+    /// runs, exposed as `helpers.<name>`. Empty outside the host.
+    pub preloaded_helpers: Vec<HelperSource>,
 }
 
 #[derive(Clone)]
@@ -43,6 +54,8 @@ pub struct ToolCtx {
     pub output_files: OutputFileAccess,
     /// See [`BrowserToolOptions::inner_call_hook`].
     pub inner_call_hook: Option<Arc<dyn InnerCallHook>>,
+    /// See [`BrowserToolOptions::preloaded_helpers`].
+    pub preloaded_helpers: Vec<HelperSource>,
 }
 
 impl ToolCtx {
@@ -54,6 +67,7 @@ impl ToolCtx {
             cancel: options.cancel,
             output_files: options.output_files,
             inner_call_hook: options.inner_call_hook,
+            preloaded_helpers: options.preloaded_helpers,
         }
     }
 

--- a/packages/browseros-agent/crates/browseros-mcp/src/service.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/service.rs
@@ -175,6 +175,7 @@ impl BrowserMcpService {
             cancel,
             output_files: self.output_files.clone(),
             inner_call_hook: None,
+            preloaded_helpers: Vec::new(),
         })
     }
 

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -110,6 +110,7 @@ fn fake_ctx() -> ToolCtx {
         cancel: CancellationToken::new(),
         output_files: create_browser_output_file_access(),
         inner_call_hook: None,
+        preloaded_helpers: Vec::new(),
     })
 }
 
@@ -361,6 +362,7 @@ async fn harness_ctx() -> (ToolCtx, Arc<HarnessConnection>, u32) {
             cancel: CancellationToken::new(),
             output_files: create_browser_output_file_access(),
             inner_call_hook: None,
+            preloaded_helpers: Vec::new(),
         }),
         connection,
         page,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/evaluate.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/evaluate.rs
@@ -19,14 +19,20 @@ const MAX_TIMEOUT_MS: u64 = 30_000;
 const DESCRIPTION: &str = "\
 Evaluate JavaScript in a page context through CDP Runtime.evaluate. \
 Use this for page-state reads or small DOM scripts that are awkward with read/grep. \
-Return a value to read it back.";
+Provide `code` (an async body; use `return` to read a value) or `func` (a function \
+expression like `() => {...}` that gets invoked). Return a value to read it back.";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 struct EvaluateArgs {
     /// Page id from `tabs`.
     page: u32,
     /// Async-capable JS body evaluated inside the page. Use `return` to read a value.
-    code: String,
+    #[serde(default)]
+    code: Option<String>,
+    /// A function expression to invoke, e.g. `() => {...}` or `async () => {...}`.
+    /// An alternative to `code` for callers that pass a function.
+    #[serde(default)]
+    func: Option<String>,
     /// Max evaluation time in ms (default 30000).
     timeout: Option<f64>,
 }
@@ -66,6 +72,13 @@ fn handler<'a>(
 ) -> BoxFuture<'a, ToolExecResult<Option<ToolResult>>> {
     Box::pin(async move {
         let args: EvaluateArgs = parse_args(raw)?;
+        let Some(expression) = resolve_expression(args.code.as_deref(), args.func.as_deref())
+        else {
+            return Ok(Some(error_result(
+                "evaluate: provide `code` (an async body) or `func` (a function to invoke)"
+                    .to_string(),
+            )));
+        };
         if let Some(result) = pending_dialog_result(ctx, PageId(args.page)) {
             return Ok(Some(result));
         }
@@ -76,7 +89,7 @@ fn handler<'a>(
             .send(
                 "Runtime.evaluate",
                 json!({
-                    "expression": wrap_as_async_iife(&args.code),
+                    "expression": expression,
                     "returnByValue": true,
                     "awaitPromise": true,
                     "timeout": timeout,
@@ -164,8 +177,23 @@ fn handler<'a>(
     })
 }
 
+/// Builds the JS expression to evaluate from either arg form: `code` is an async
+/// body, `func` is a function expression to invoke. `code` wins if both are given;
+/// `None` when neither is provided.
+fn resolve_expression(code: Option<&str>, func: Option<&str>) -> Option<String> {
+    match (code, func) {
+        (Some(code), _) => Some(wrap_as_async_iife(code)),
+        (None, Some(func)) => Some(wrap_as_invoked_fn(func)),
+        (None, None) => None,
+    }
+}
+
 fn wrap_as_async_iife(code: &str) -> String {
     format!("(async () => {{\n{code}\n}})()")
+}
+
+fn wrap_as_invoked_fn(func: &str) -> String {
+    format!("(async () => {{ return await ({func})(); }})()")
 }
 
 fn safe_stringify(value: &Value) -> String {
@@ -191,4 +219,26 @@ fn safe_prefix(text: &str, max_chars: usize) -> String {
         end = end.saturating_sub(1);
     }
     text[..end].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_expression_handles_code_func_and_neither() {
+        // A body is wrapped in an async IIFE.
+        let code = resolve_expression(Some("return 1;"), None).unwrap_or_default();
+        assert!(code.contains("return 1;"));
+        assert!(code.starts_with("(async () =>"));
+        // A function is invoked, so its return value flows back.
+        let func = resolve_expression(None, Some("() => 2")).unwrap_or_default();
+        assert!(func.contains("await (() => 2)()"));
+        // Code wins if both are provided.
+        let both = resolve_expression(Some("return 3;"), Some("() => 4")).unwrap_or_default();
+        assert!(both.contains("return 3;"));
+        assert!(!both.contains("() => 4"));
+        // Neither is an error at the call site.
+        assert!(resolve_expression(None, None).is_none());
+    }
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -101,7 +101,9 @@ const BOOTSTRAP_JS: &str = r#"
   }
 
   function call(method, args) {
-    return __browserosCall(method, JSON.stringify(args ?? []));
+    // The third flag marks primitives that ran inside a hot-loaded helper, so
+    // distillation can skip a successful reuse's replayed actions.
+    return __browserosCall(method, JSON.stringify(args ?? []), (globalThis.__helperDepth || 0) > 0);
   }
 
   function scoped(prefix, pageId) {
@@ -396,12 +398,14 @@ fn load_preloaded_helpers(ctx: &Ctx<'_>, helpers: &[HelperSource]) {
     // references `helpers.<name>` gets a clean `undefined` instead of a
     // `ReferenceError: helpers is not defined`.
     let _ = ctx
-        .eval::<(), _>("globalThis.helpers = globalThis.helpers || {};")
+        .eval::<(), _>("globalThis.helpers = globalThis.helpers || {}; globalThis.__helperDepth = globalThis.__helperDepth || 0;")
         .catch(ctx);
     for helper in helpers {
         let name = serde_json::to_string(&helper.name).unwrap_or_else(|_| "\"helper\"".to_string());
+        // Wrap so calls made inside the helper run at helperDepth > 0, tagging
+        // their primitives as replayed; the depth is restored even if it throws.
         let snippet = format!(
-            "try {{ helpers[{name}] = (\n{source}\n); }} catch (e) {{ console.log('helper load failed: ' + {name} + ': ' + e); }}",
+            "try {{ const __fn = (\n{source}\n); helpers[{name}] = async (...args) => {{ globalThis.__helperDepth++; try {{ return await __fn(...args); }} finally {{ globalThis.__helperDepth--; }} }}; }} catch (e) {{ console.log('helper load failed: ' + {name} + ': ' + e); }}",
             source = helper.source,
         );
         let _ = ctx.eval::<(), _>(snippet).catch(ctx);
@@ -535,10 +539,10 @@ fn install_globals<'js>(
     };
     let call_bridge = {
         let bridge = bridge.clone();
-        move |ctx: Ctx<'js>, method: String, args_json: String| {
+        move |ctx: Ctx<'js>, method: String, args_json: String, from_helper: bool| {
             let bridge = bridge.clone();
             async move {
-                match bridge.call(&method, &args_json).await {
+                match bridge.call(&method, &args_json, from_helper).await {
                     Ok(BrowserCallValue::Json(value)) => json_to_js(&ctx, value),
                     Ok(BrowserCallValue::Undefined) => Ok(JsValue::new_undefined(ctx.clone())),
                     Err(message) => Err(Exception::throw_message(&ctx, &message)),
@@ -562,7 +566,12 @@ fn install_globals<'js>(
 }
 
 impl BrowserBridge {
-    async fn call(&self, method: &str, args_json: &str) -> Result<BrowserCallValue, String> {
+    async fn call(
+        &self,
+        method: &str,
+        args_json: &str,
+        from_helper: bool,
+    ) -> Result<BrowserCallValue, String> {
         let args = parse_bridge_args(args_json)?;
         let page = target_page(method, &args);
         // Kept for the audit record and the self-healing distiller; dispatch
@@ -584,6 +593,7 @@ impl BrowserBridge {
                 method,
                 page,
                 args: &recorded_args,
+                from_helper,
                 is_error: outcome.is_err(),
                 duration_ms: started.elapsed().as_millis() as i64,
             })
@@ -1451,6 +1461,7 @@ mod tests {
         reject: Option<String>,
         annotated: usize,
         saved: Vec<(String, String, String)>,
+        from_helper: Vec<(String, bool)>,
     }
 
     struct MockHook(Arc<Mutex<HookLog>>);
@@ -1470,11 +1481,14 @@ mod tests {
         }
 
         fn record<'a>(&'a self, record: InnerCallRecord<'a>) -> BoxFuture<'a, ()> {
-            self.0
+            let mut log = self
+                .0
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .recorded
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            log.recorded
                 .push((record.method.to_owned(), record.page, record.is_error));
+            log.from_helper
+                .push((record.method.to_owned(), record.from_helper));
             Box::pin(async move {})
         }
 
@@ -1542,6 +1556,36 @@ mod tests {
         let mut ctx = test_ctx();
         ctx.inner_call_hook = Some(Arc::new(MockHook(log)));
         ctx
+    }
+
+    #[tokio::test]
+    async fn run_tags_primitives_called_inside_a_helper() -> anyhow::Result<()> {
+        let log = Arc::new(Mutex::new(HookLog::default()));
+        let mut ctx = ctx_with_hook(log.clone());
+        ctx.preloaded_helpers = vec![HelperSource {
+            name: "act".to_string(),
+            source: "async (browser) => browser.pages.getInfo(1)".to_string(),
+        }];
+        // One direct primitive, then one via the helper.
+        let result = run_tool_with_ctx(
+            "await browser.pages.getInfo(1); await helpers.act(browser); return 'ok';",
+            None,
+            &ctx,
+        )
+        .await?;
+        assert!(!result.is_error);
+        let log = log
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // The direct call is not from a helper; the one inside act() is.
+        assert_eq!(
+            log.from_helper,
+            vec![
+                ("pages.getInfo".to_string(), false),
+                ("pages.getInfo".to_string(), true),
+            ]
+        );
+        Ok(())
     }
 
     #[tokio::test]

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -154,6 +154,20 @@ const BOOTSTRAP_JS: &str = r#"
     upload: (pageId, opts) => call('tool:upload', [pageId, opts]),
     tabGroups: (opts) => call('tool:tab_groups', [opts]),
     windows: (opts) => call('tool:windows', [opts]),
+    saveHelper: (name, source, opts) => {
+      if (typeof source !== 'string' || !source.trim()) {
+        throw new Error('saveHelper: source must be a non-empty function-expression string');
+      }
+      let fn;
+      try { fn = new Function('return (' + source + '\n);')(); }
+      catch (e) { throw new Error('saveHelper: source must be valid JS (' + e + ')'); }
+      if (typeof fn !== 'function') {
+        throw new Error('saveHelper: source must evaluate to a function, e.g. async (browser, page) => { ... }');
+      }
+      return call('helpers.save', [String(name), source, opts || {}]);
+    },
+    listHelpers: (opts) => call('helpers.list', [opts || {}]),
+    readHelper: (name, opts) => call('helpers.read', [String(name), opts || {}]),
   };
 
   const sink = (level) => (...parts) => {
@@ -742,12 +756,71 @@ impl BrowserBridge {
                 let value = serde_json::from_str(&raw).map_err(|err| err.to_string())?;
                 Ok(BrowserCallValue::Json(value))
             }
+            "helpers.save" => {
+                let name = string_arg(&args, 0, "name")?;
+                let source = string_arg(&args, 1, "source")?;
+                let opts = optional_object_arg(&args, 2)?;
+                let host = self.resolve_helper_host(opts).await?;
+                self.helper_hook()?
+                    .save_helper(&host, &name, &source)
+                    .await?;
+                Ok(BrowserCallValue::Json(
+                    json!({ "saved": name, "host": host }),
+                ))
+            }
+            "helpers.list" => {
+                let opts = optional_object_arg(&args, 0)?;
+                let host = self.resolve_helper_host(opts).await?;
+                let helpers = self.helper_hook()?.list_helpers(&host).await;
+                Ok(BrowserCallValue::Json(
+                    json!({ "host": host, "helpers": helpers }),
+                ))
+            }
+            "helpers.read" => {
+                let name = string_arg(&args, 0, "name")?;
+                let opts = optional_object_arg(&args, 1)?;
+                let host = self.resolve_helper_host(opts).await?;
+                match self.helper_hook()?.read_helper(&host, &name).await {
+                    Some(source) => Ok(BrowserCallValue::Json(Value::String(source))),
+                    None => Ok(BrowserCallValue::Json(Value::Null)),
+                }
+            }
             method if method.starts_with("tool:") => {
                 let tool_name = &method["tool:".len()..];
                 self.run_tool(tool_name, build_tool_args(&args)).await
             }
             _ => Err(format!("Unknown browser method {method}")),
         }
+    }
+
+    /// The injected hook, or an error surfaced to the script when helpers are
+    /// unavailable (no host attached, e.g. a unit-test context).
+    fn helper_hook(&self) -> Result<&Arc<dyn crate::framework::InnerCallHook>, String> {
+        self.ctx
+            .inner_call_hook
+            .as_ref()
+            .ok_or_else(|| "helpers are not available in this context".to_string())
+    }
+
+    /// Resolves the helper host bucket from `{ host }` (explicit) or `{ page }`
+    /// (the page's URL, host-side). One is required.
+    async fn resolve_helper_host(
+        &self,
+        opts: Option<&Map<String, Value>>,
+    ) -> Result<String, String> {
+        if let Some(host) = optional_string_field(opts, "host")? {
+            return Ok(host);
+        }
+        if let Some(page) = optional_i64_field(opts, "page")? {
+            let page = u32::try_from(page).map_err(|_| "page id is out of range".to_string())?;
+            if let Some(host) = self.helper_hook()?.resolve_host(page).await {
+                return Ok(host);
+            }
+            return Err(format!(
+                "no host for page {page}; navigate to a site first or pass an explicit host"
+            ));
+        }
+        Err("helpers need a host: pass { host } or { page }".to_string())
     }
 
     /// Dispatches a tool-backed primitive through the real tool handler so the
@@ -1347,6 +1420,7 @@ mod tests {
         created: Vec<u32>,
         reject: Option<String>,
         annotated: usize,
+        saved: Vec<(String, String, String)>,
     }
 
     struct MockHook(Arc<Mutex<HookLog>>);
@@ -1400,12 +1474,134 @@ mod tests {
                 .collect();
             Box::pin(async move { tagged })
         }
+
+        fn resolve_host<'a>(&'a self, _page: u32) -> BoxFuture<'a, Option<String>> {
+            Box::pin(async move { Some("resolved.example".to_string()) })
+        }
+
+        fn save_helper<'a>(
+            &'a self,
+            host: &'a str,
+            name: &'a str,
+            source: &'a str,
+        ) -> BoxFuture<'a, Result<(), String>> {
+            self.0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .saved
+                .push((host.to_owned(), name.to_owned(), source.to_owned()));
+            Box::pin(async move { Ok(()) })
+        }
+
+        fn list_helpers<'a>(&'a self, _host: &'a str) -> BoxFuture<'a, Vec<Value>> {
+            Box::pin(
+                async move { vec![json!({ "name": "greet", "ageDays": 2, "candidate": false })] },
+            )
+        }
+
+        fn read_helper<'a>(
+            &'a self,
+            _host: &'a str,
+            _name: &'a str,
+        ) -> BoxFuture<'a, Option<String>> {
+            Box::pin(async move { Some("async () => 42".to_string()) })
+        }
     }
 
     fn ctx_with_hook(log: Arc<Mutex<HookLog>>) -> ToolCtx {
         let mut ctx = test_ctx();
         ctx.inner_call_hook = Some(Arc::new(MockHook(log)));
         ctx
+    }
+
+    #[tokio::test]
+    async fn run_save_helper_routes_to_the_hook_with_explicit_host() -> anyhow::Result<()> {
+        let log = Arc::new(Mutex::new(HookLog::default()));
+        let ctx = ctx_with_hook(log.clone());
+        let result = run_tool_with_ctx(
+            "return await browser.saveHelper('greet', 'async (browser, page) => 1', { host: 'linkedin.com' })",
+            None,
+            &ctx,
+        )
+        .await?;
+        assert!(!result.is_error);
+        let log = log
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(
+            log.saved,
+            vec![(
+                "linkedin.com".to_string(),
+                "greet".to_string(),
+                "async (browser, page) => 1".to_string()
+            )]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_save_helper_resolves_the_host_from_a_page() -> anyhow::Result<()> {
+        let log = Arc::new(Mutex::new(HookLog::default()));
+        let ctx = ctx_with_hook(log.clone());
+        let result = run_tool_with_ctx(
+            "return await browser.saveHelper('greet', 'async () => 1', { page: 1 })",
+            None,
+            &ctx,
+        )
+        .await?;
+        assert!(!result.is_error);
+        let log = log
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(log.saved[0].0, "resolved.example");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_save_helper_rejects_a_non_function_source() -> anyhow::Result<()> {
+        let ctx = test_ctx();
+        let result = run_tool_with_ctx(
+            "try { await browser.saveHelper('x', '123', { host: 'h' }); return 'saved'; } catch (e) { return String(e); }",
+            None,
+            &ctx,
+        )
+        .await?;
+        let structured = result
+            .structured_content
+            .ok_or_else(|| anyhow::anyhow!("structured content"))?;
+        let value = structured["value"].as_str().unwrap_or_default();
+        assert!(
+            value.contains("saveHelper"),
+            "expected rejection, got: {value}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_list_and_read_helpers_route_to_the_hook() -> anyhow::Result<()> {
+        let log = Arc::new(Mutex::new(HookLog::default()));
+        let ctx = ctx_with_hook(log);
+        let listed = run_tool_with_ctx(
+            "return (await browser.listHelpers({ host: 'h' })).helpers.map((x) => x.name)",
+            None,
+            &ctx,
+        )
+        .await?;
+        assert_eq!(
+            listed.structured_content,
+            Some(json!({ "ok": true, "value": ["greet"], "logs": [] }))
+        );
+        let read = run_tool_with_ctx(
+            "return await browser.readHelper('greet', { host: 'h' })",
+            None,
+            &ctx,
+        )
+        .await?;
+        assert_eq!(
+            read.structured_content,
+            Some(json!({ "ok": true, "value": "async () => 42", "logs": [] }))
+        );
+        Ok(())
     }
 
     #[tokio::test]

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -52,6 +52,9 @@ Read / wait / capture:
   browser.screenshot(pageId) / evaluate(pageId, { code }) / pdf(pageId)
   browser.download(pageId, opts) / upload(pageId, opts)
   browser.tabGroups(opts) / windows(opts)
+Reusable helpers (self-healing): saved helpers for a host, hot-loaded as helpers.<name>(browser, page).
+  browser.saveHelper(name, source, { page } | { host }) - source is a function expression, e.g. async (browser, page) => { ... }
+  browser.listHelpers({ page } | { host }) -> { host, helpers: [{ name, ageDays, candidate }] }; browser.readHelper(name, { page } | { host }) -> source string
 Raw escape hatch: browser.cdp(method, params?, sessionId?) / browser.cdpJsonForPage(pageId, method, paramsJson).
 
 Do the whole task in as few run calls as possible: loop over all the items in one call rather than one run per item. Parallelize independent work with Promise.all so N pages cost one wait cycle, not N. Keep steps on the same page sequential. Efficient pattern:

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -562,6 +562,9 @@ impl BrowserBridge {
     async fn call(&self, method: &str, args_json: &str) -> Result<BrowserCallValue, String> {
         let args = parse_bridge_args(args_json)?;
         let page = target_page(method, &args);
+        // Kept for the audit record and the self-healing distiller; dispatch
+        // consumes the owned args below.
+        let recorded_args = Value::Array(args.clone());
         if let Some(hook) = &self.ctx.inner_call_hook {
             hook.authorize(page).await?;
         }
@@ -577,6 +580,7 @@ impl BrowserBridge {
             hook.record(InnerCallRecord {
                 method,
                 page,
+                args: &recorded_args,
                 is_error: outcome.is_err(),
                 duration_ms: started.elapsed().as_millis() as i64,
             })

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -1,6 +1,6 @@
 use crate::framework::{
-    InnerCallRecord, ToolCtx, ToolDef, ToolError, ToolExecResult, ToolResult, execute_tool,
-    page_json, parse_args, text_result,
+    HelperSource, InnerCallRecord, ToolCtx, ToolDef, ToolError, ToolExecResult, ToolResult,
+    execute_tool, page_json, parse_args, text_result,
 };
 use browseros_core::{
     PageId, Ref, SessionId, WindowId, input::ScrollDirection, pages::NewPageOptions,
@@ -385,13 +385,34 @@ async fn execute_run(args: RunArgs, ctx: &ToolCtx) -> Result<RunOutcome, RunErro
     }
 }
 
+/// Loads the host-provided helpers into the script context as `helpers.<name>`
+/// after the SDK bootstrap. A broken helper is contained by its try/catch and
+/// reported through the captured console; it never fails the run.
+fn load_preloaded_helpers(ctx: &Ctx<'_>, helpers: &[HelperSource]) {
+    if helpers.is_empty() {
+        return;
+    }
+    let _ = ctx
+        .eval::<(), _>("globalThis.helpers = globalThis.helpers || {};")
+        .catch(ctx);
+    for helper in helpers {
+        let name = serde_json::to_string(&helper.name).unwrap_or_else(|_| "\"helper\"".to_string());
+        let snippet = format!(
+            "try {{ helpers[{name}] = (\n{source}\n); }} catch (e) {{ console.log('helper load failed: ' + {name} + ': ' + e); }}",
+            source = helper.source,
+        );
+        let _ = ctx.eval::<(), _>(snippet).catch(ctx);
+    }
+}
+
 async fn execute_quickjs(
     code: String,
-    tool_ctx: ToolCtx,
+    mut tool_ctx: ToolCtx,
     logs: SharedLogs,
     control: RunControl,
     duration: Duration,
 ) -> Result<RunOutcome, RunError> {
+    let preloaded_helpers = std::mem::take(&mut tool_ctx.preloaded_helpers);
     let runtime = AsyncRuntime::new().map_err(engine_error)?;
     runtime.set_memory_limit(RUN_MEMORY_LIMIT_BYTES).await;
     runtime.set_max_stack_size(RUN_STACK_SIZE_BYTES).await;
@@ -412,6 +433,7 @@ async fn execute_quickjs(
                     js_error_message(&ctx, err)
                 ))
             })?;
+            load_preloaded_helpers(&ctx, &preloaded_helpers);
 
             let make_run: Function<'_> = ctx
                 .globals()
@@ -1390,6 +1412,7 @@ mod tests {
             cancel: CancellationToken::new(),
             output_files: create_browser_output_file_access(),
             inner_call_hook: None,
+            preloaded_helpers: Vec::new(),
         })
     }
 
@@ -1512,6 +1535,35 @@ mod tests {
         let mut ctx = test_ctx();
         ctx.inner_call_hook = Some(Arc::new(MockHook(log)));
         ctx
+    }
+
+    #[tokio::test]
+    async fn run_hot_loads_preloaded_helpers_and_skips_a_broken_one() -> anyhow::Result<()> {
+        let mut ctx = test_ctx();
+        ctx.preloaded_helpers = vec![
+            HelperSource {
+                name: "double".to_string(),
+                source: "async (x) => x * 2".to_string(),
+            },
+            // A syntax-broken helper must be skipped without failing the run.
+            HelperSource {
+                name: "broken".to_string(),
+                source: "async (x) => {".to_string(),
+            },
+        ];
+        let result = run_tool_with_ctx(
+            "const ok = typeof helpers.broken; return { doubled: await helpers.double(21), broken: ok };",
+            None,
+            &ctx,
+        )
+        .await?;
+        assert!(!result.is_error);
+        let structured = result
+            .structured_content
+            .ok_or_else(|| anyhow::anyhow!("structured content"))?;
+        assert_eq!(structured["value"]["doubled"], json!(42));
+        assert_eq!(structured["value"]["broken"], json!("undefined"));
+        Ok(())
     }
 
     #[tokio::test]

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -392,9 +392,9 @@ async fn execute_run(args: RunArgs, ctx: &ToolCtx) -> Result<RunOutcome, RunErro
 /// after the SDK bootstrap. A broken helper is contained by its try/catch and
 /// reported through the captured console; it never fails the run.
 fn load_preloaded_helpers(ctx: &Ctx<'_>, helpers: &[HelperSource]) {
-    if helpers.is_empty() {
-        return;
-    }
+    // Always expose the namespace, even with nothing to load, so a script that
+    // references `helpers.<name>` gets a clean `undefined` instead of a
+    // `ReferenceError: helpers is not defined`.
     let _ = ctx
         .eval::<(), _>("globalThis.helpers = globalThis.helpers || {};")
         .catch(ctx);
@@ -1542,6 +1542,25 @@ mod tests {
         let mut ctx = test_ctx();
         ctx.inner_call_hook = Some(Arc::new(MockHook(log)));
         ctx
+    }
+
+    #[tokio::test]
+    async fn run_exposes_an_empty_helpers_namespace_without_preloads() -> anyhow::Result<()> {
+        // No preloaded_helpers: referencing helpers.<name> must not throw.
+        let ctx = test_ctx();
+        let result = run_tool_with_ctx(
+            "return { kind: typeof helpers, missing: typeof helpers.nope };",
+            None,
+            &ctx,
+        )
+        .await?;
+        assert!(!result.is_error);
+        let structured = result
+            .structured_content
+            .ok_or_else(|| anyhow::anyhow!("structured content"))?;
+        assert_eq!(structured["value"]["kind"], json!("object"));
+        assert_eq!(structured["value"]["missing"], json!("undefined"));
+        Ok(())
     }
 
     #[tokio::test]

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -49,7 +49,7 @@ Read / wait / capture:
   browser.read(pageId)               -> the page as a markdown STRING (large pages are truncated with a note pointing to a saved file)
   browser.grep(pageId, { pattern })  -> matching lines as a STRING
   browser.wait(pageId, { for: "text", value: "..." } | { for: "selector", value: "..." } | { value: ms }) -> resolves when ready (default is a timed pause of `value` ms). There is no `ms` option; a plain pause is { value: 3000 }.
-  browser.screenshot(pageId) / evaluate(pageId, { code }) / pdf(pageId)
+  browser.screenshot(pageId) / evaluate(pageId, { code } | { func }) / pdf(pageId)
   browser.download(pageId, opts) / upload(pageId, opts)
   browser.tabGroups(opts) / windows(opts)
 Reusable helpers (self-healing): saved helpers for a host, hot-loaded as helpers.<name>(browser, page).


### PR DESCRIPTION
## What

Turns the code-mode execute substrate into a self-healing browser: a sequence proven in one script run can be saved as a named helper, hot-loaded into a later run and called by name, discovered per host, and distilled automatically from the audit hierarchy so the agent does not have to write the macro. Staleness is a soft signal. This is what running on an audited server buys over a bare CLI.

## Landed here

**Storage and provenance.** Helpers live at `helpers/<host>/<name>.js` with a leading `// browserclaw-helper: {json}` header carrying name, host, last-verified time, authoring agent, and a candidate flag. The header is inert to `eval`, so a file loads as a bare function expression. Host bucketing is the hostname minus a leading `www.` (http/https only), so subdomain apps stay distinct. A size cap bounds each helper.

**saveHelper.** `browser.saveHelper(name, source, { page } | { host })` compile-checks that the source is a function expression, resolves the host (explicit, or the page's URL), and writes it with provenance. `browser.listHelpers` and `browser.readHelper` round out the in-script surface. All three cross the engine/host boundary through new methods on the injected inner-call hook, the same seam ownership and audit already use.

**Hot-load.** Before a script runs, the host preloads every saved helper for the hosts of the agent's owned tabs and the runtime exposes them as `helpers.<name>(browser, page)`. A syntax-broken helper is skipped without failing the run. Cheap-gated: a browser with no helpers pays nothing (no page scan).

**Discovery and staleness.** A post-run effect appends `helpersAvailable` to a script result, one entry per owned-tab host, each helper tagged with a soft `ageDays` and whether it is a distilled candidate, so the agent notices helpers without asking. The same freshness view backs `listHelpers`. The guide tells the agent to cross-check a stale helper against the live page before trusting it.

**Distillation (the differentiator).** Inner-call records now carry each primitive's arguments, so a script's child audit rows capture what actually ran. After a successful run, a distill observer reads the child sequence by `parentDispatchId` and synthesizes a single-page action macro: `nav`, `input`, and `wait` primitives mapped to their SDK calls, with the recorded page id abstracted to the `page` parameter. It is auto-saved as a candidate helper keyed by the flow's host and deduped by a content hash, so re-running a flow overwrites rather than accumulates.

**Operating guide.** The MCP instructions and the run tool description teach the loop: read the discovered helpers first, call a hot-loaded one by name, save a proven flow, honor the staleness signal, and keep personal data out of shared helpers.

## Tests

`browseros-mcp` 60 lib tests and `claw-server-rust` 266 lib tests pass; `cargo check --workspace` clean; clippy and rustfmt clean on the changed crates. New coverage: provenance round-trip and host bucketing; the saveHelper/listHelpers/readHelper bridge and the host save-list-read path; a hot-loaded helper is callable and a broken one is skipped; the discovery list and the staleness age; the distiller synthesizes a single-page macro and skips multi-page or too-short flows.

## Scope notes and follow-ups

- Distillation handles single-page flows; multi-page replays skip. Distinct flows still accumulate candidates (content-hash dedupe only covers identical flows); a GC and promotion pass is a follow-up.
- Distilled macros replay exact element refs, which go stale; the staleness signal plus the cross-check guidance cover this, and re-distillation refreshes.
- Hot-load and discovery each do one page list per script dispatch, cheap-gated when no helpers exist; a shared cached host set is a refinement.
- saveHelper does not scrub embedded personal data; the guide covers it, a scrub pass is a follow-up.
- No separate `list_helpers` MCP tool: the in-script primitive plus the result metadata cover discovery without touching the collapsed surface.

Targets the code-mode epic branch, not the default branch.
