### PR TITLE
feat: play replay tabs as sequential chapters

### DIFF
--- a/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.test.ts
@@ -23,8 +23,12 @@ mock.module('./client', () => ({
     }),
 }))
 
-const { fetchReplayEvents, fetchReplayMetadata, replayEventsRevision } =
-  await import('./replay.hooks')
+const {
+  fetchReplayEvents,
+  fetchReplayMetadata,
+  replayEventsRevision,
+  useReplayEvents,
+} = await import('./replay.hooks')
 
 afterAll(() => mock.restore())
 
@@ -34,6 +38,21 @@ beforeEach(() => {
 })
 
 describe('replay queries', () => {
+  it('isolates event snapshots by metadata revision', () => {
+    expect(
+      Array.from(
+        useReplayEvents.getKey({
+          sessionId: 'session-1',
+          revision: 'revision-2',
+        }),
+      ),
+    ).toEqual([
+      'replay',
+      'events',
+      { sessionId: 'session-1', revision: 'revision-2' },
+    ])
+  })
+
   it('changes the event revision when late recording metadata advances', () => {
     const metadata = {
       hasData: true,

--- a/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
@@ -92,6 +92,8 @@ export const useReplayMetadata = createQuery<
 
 export interface UseReplayEventsVariables {
   sessionId: string
+  /** Metadata revision used only to isolate client-side query snapshots. */
+  revision?: string
 }
 
 /** Changes only when replay metadata says the downloadable event set changed. */

--- a/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.test.tsx
@@ -17,12 +17,27 @@ let container: HTMLElement
 function TransportHarness() {
   const playback = usePlayback(10)
   return (
-    <PlaybackTransport
-      playback={playback}
-      totalSeconds={10}
-      frames={[]}
-      onSeek={playback.seek}
-    />
+    <>
+      <PlaybackTransport
+        playback={playback}
+        totalSeconds={10}
+        frames={[]}
+        onSeek={playback.seek}
+      />
+      <button type="button" data-command-pause onClick={playback.pause}>
+        Explicit pause
+      </button>
+      <button type="button" data-command-play onClick={playback.play}>
+        Explicit play
+      </button>
+      <button
+        type="button"
+        data-command-finish
+        onClick={() => playback.syncFromPlayer(10)}
+      >
+        Finish
+      </button>
+    </>
   )
 }
 
@@ -93,5 +108,41 @@ describe('PlaybackTransport', () => {
     })
     expect(speedButton('1×')?.getAttribute('aria-pressed')).toBe('false')
     expect(speedButton('4×')?.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('supports explicit pause, resume, and restart without changing speed', async () => {
+    await act(async () => root.render(<TransportHarness />))
+
+    const click = async (selector: string) => {
+      await act(async () => {
+        container
+          .querySelector(selector)
+          ?.dispatchEvent(new window.Event('click', { bubbles: true }))
+      })
+    }
+    const toggle = () =>
+      container.querySelector('button[aria-label]')?.getAttribute('aria-label')
+
+    const fourTimes = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === '4×',
+    )
+    await act(async () => {
+      fourTimes?.dispatchEvent(new window.Event('click', { bubbles: true }))
+    })
+    expect(toggle()).toBe('Pause')
+
+    await click('[data-command-pause]')
+    expect(toggle()).toBe('Play')
+
+    await click('[data-command-play]')
+    expect(toggle()).toBe('Pause')
+
+    await click('[data-command-finish]')
+    expect(toggle()).toBe('Restart playback')
+
+    await click('[data-command-play]')
+    expect(toggle()).toBe('Pause')
+    expect(container.textContent).toContain('0:00 / 0:10')
+    expect(fourTimes?.getAttribute('aria-pressed')).toBe('true')
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -87,9 +87,11 @@ mock.module('./PlaybackTransport', () => ({
   PlaybackTransport: ({
     playback,
     totalSeconds,
+    onSeek,
   }: {
     playback: Playback
     totalSeconds: number
+    onSeek: (seconds: number) => void
   }) => {
     const finished = playback.time >= totalSeconds
     return (
@@ -122,6 +124,13 @@ mock.module('./PlaybackTransport', () => ({
             {speed}×
           </button>
         ))}
+        <button
+          type="button"
+          data-playback-seek-middle
+          onClick={() => onSeek(totalSeconds / 2)}
+        >
+          Seek middle
+        </button>
       </div>
     )
   },
@@ -150,7 +159,13 @@ mock.module('./EventTimeline', () => ({
   ),
 }))
 
-const TargetSelectContext = createContext<(targetId: string) => void>(() => {})
+const TargetSelectContext = createContext<{
+  selectedTarget: string
+  selectTarget: (targetId: string) => void
+}>({
+  selectedTarget: '',
+  selectTarget: () => {},
+})
 
 mock.module('@/components/ui/tabs', () => ({
   Tabs: ({
@@ -162,7 +177,9 @@ mock.module('@/components/ui/tabs', () => ({
     onValueChange: (targetId: string) => void
     children: ReactNode
   }) => (
-    <TargetSelectContext.Provider value={onValueChange}>
+    <TargetSelectContext.Provider
+      value={{ selectedTarget: value, selectTarget: onValueChange }}
+    >
       <div data-selected-target={value}>{children}</div>
     </TargetSelectContext.Provider>
   ),
@@ -170,16 +187,21 @@ mock.module('@/components/ui/tabs', () => ({
   TabsTrigger: ({
     value,
     children,
+    onClick,
   }: {
     value: string
     children: ReactNode
+    onClick?: () => void
   }) => {
-    const selectTarget = useContext(TargetSelectContext)
+    const { selectedTarget, selectTarget } = useContext(TargetSelectContext)
     return (
       <button
         type="button"
         data-target-chip={value}
-        onClick={() => selectTarget(value)}
+        onClick={() => {
+          onClick?.()
+          if (value !== selectedTarget) selectTarget(value)
+        }}
       >
         {children}
       </button>
@@ -306,6 +328,7 @@ function replayData(
     frames: replayFrames,
     complete: true,
     tabs,
+    eventsLoaded: true,
     eventsForTab: eventCatalog.eventsForTab,
   }
 }
@@ -940,6 +963,93 @@ describe('Replay', () => {
     ).toBe('true')
   })
 
+  it('waits for event loading before completing an all-no-visual replay', async () => {
+    const noVisualReplay = replayData(
+      [noVisualEvent(1, 1_000), noVisualEvent(2, 2_000)],
+      [1, 2],
+      [chapterFrame(1, 1), chapterFrame(2, 2)],
+    )
+    noVisualReplay.eventsLoaded = false
+    replayResult = { ...replayResult, replay: noVisualReplay }
+    await renderReplay()
+
+    expect(container.textContent).toContain('Tab 1 of 2')
+    expect(container.textContent).not.toContain('No visual recordings')
+    expect(transitionTimers.size).toBe(0)
+
+    noVisualReplay.eventsLoaded = true
+    replayResult = { ...replayResult, replay: { ...noVisualReplay } }
+    await renderReplay()
+
+    expect(container.textContent).toContain(
+      'No visual recordings → Replay complete',
+    )
+    expect(container.textContent).toContain(
+      'Skipped Tabs 1–2 — no visual recordings',
+    )
+    expect([...transitionTimers.values()][0]?.delay).toBe(1_000)
+
+    await fireNextTransition()
+    expect(container.textContent).toContain('Replay complete')
+    expect(container.querySelector('[data-playback-toggle]')).toBeNull()
+  })
+
+  it('resets selection, transport, and stale transitions when the session changes', async () => {
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        [...visualEvents(1, 1_000), ...visualEvents(2, 10_000)],
+        [1, 2],
+        [chapterFrame(1, 2), chapterFrame(2, 11)],
+      ),
+    }
+    await renderReplay()
+    await completeCurrentChapter(4_000)
+    const staleTransition = [...transitionTimers.values()][0]?.callback
+
+    const nextSession = replayData(
+      [...visualEvents(2, 1_000), ...visualEvents(3, 10_000)],
+      [2, 3],
+      [chapterFrame(2, 2), chapterFrame(3, 11)],
+    )
+    nextSession.sessionId = 'session-2'
+    replayResult = {
+      ...replayResult,
+      sessionId: 'session-2',
+      replay: nextSession,
+    }
+    await renderReplay()
+
+    expect(transitionTimers.size).toBe(0)
+    expect(container.textContent).not.toContain('Tab 1 complete')
+    expect(container.textContent).not.toContain('Replay complete')
+    expect(container.textContent).toContain('Tab 1 of 2')
+    expect(
+      container
+        .querySelector('[data-selected-target]')
+        ?.getAttribute('data-selected-target'),
+    ).toBe('2')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+
+    await act(async () => {
+      if (typeof staleTransition === 'function') staleTransition()
+    })
+    expect(
+      container
+        .querySelector('[data-selected-target]')
+        ?.getAttribute('data-selected-target'),
+    ).toBe('2')
+  })
+
   it('cancels a pending transition and invalidates its callback on manual selection', async () => {
     const chapterEvents = [
       ...visualEvents(1, 1_000),
@@ -992,6 +1102,45 @@ describe('Replay', () => {
         .querySelector('[data-playback-playing]')
         ?.getAttribute('data-playback-playing'),
     ).toBe('false')
+  })
+
+  it('lets the active destination chip cancel its transition and continue forward', async () => {
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        [
+          ...visualEvents(1, 1_000),
+          ...visualEvents(2, 10_000),
+          ...visualEvents(3, 20_000),
+        ],
+        [1, 2, 3],
+        [chapterFrame(1, 2), chapterFrame(2, 11), chapterFrame(3, 21)],
+      ),
+    }
+    await renderReplay()
+    await completeCurrentChapter(4_000)
+
+    expect(container.textContent).toContain('Tab 1 complete')
+    await click('[data-target-chip="2"]')
+
+    expect(transitionTimers.size).toBe(0)
+    expect(container.textContent).not.toContain('Tab 1 complete')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('false')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
+
+    await click('[data-playback-toggle]')
+    await completeCurrentChapter(4_000)
+    expect(container.textContent).toContain(
+      'Tab 2 complete → Opening Tab 3 · tab-3.example',
+    )
   })
 
   it('keeps a manually selected no-visual chapter paused and tab-local', async () => {
@@ -1089,6 +1238,42 @@ describe('Replay', () => {
     await completeCurrentChapter(4_000)
     expect(container.textContent).toContain('Replay complete')
     expect(transitionTimers.size).toBe(0)
+  })
+
+  it('resumes from a manual seek after sequence completion', async () => {
+    replayResult = {
+      ...replayResult,
+      replay: replayData(visualEvents(1, 1_000), [1], [chapterFrame(1, 2)]),
+    }
+    await renderReplay()
+    await completeCurrentChapter(4_000)
+    expect(container.textContent).toContain('Replay complete')
+
+    await click('[data-playback-seek-middle]')
+
+    expect(container.textContent).not.toContain('Replay complete')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('2')
+    expect(
+      container
+        .querySelector('[data-playback-toggle]')
+        ?.getAttribute('aria-label'),
+    ).toBe('Play')
+
+    await click('[data-playback-toggle]')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('2')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
   })
 
   it('clears the transition timer when the replay unmounts', async () => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -370,6 +370,30 @@ function visualEvents(
   ]
 }
 
+function staticVisualEvents(tabId: number, atMs: number): ReplayEvent[] {
+  const documentId = `document-${tabId}`
+  return [
+    {
+      sessionId: 'session-1',
+      documentId,
+      targetId: `target-${tabId}`,
+      tabId,
+      ts: atMs,
+      type: 4,
+      data: { width: 1280, height: 720 },
+    },
+    {
+      sessionId: 'session-1',
+      documentId,
+      targetId: `target-${tabId}`,
+      tabId,
+      ts: atMs,
+      type: 2,
+      data: {},
+    },
+  ]
+}
+
 function noVisualEvent(tabId: number, atMs: number): ReplayEvent {
   return {
     sessionId: 'session-1',
@@ -992,6 +1016,140 @@ describe('Replay', () => {
     await fireNextTransition()
     expect(container.textContent).toContain('Replay complete')
     expect(container.querySelector('[data-playback-toggle]')).toBeNull()
+  })
+
+  it('autoplays when the first playable snapshot arrives after metadata', async () => {
+    const loadingReplay = replayData(
+      [],
+      [1],
+      [chapterFrame(1, 1, 'first.example')],
+    )
+    loadingReplay.eventsLoaded = false
+    replayResult = { ...replayResult, replay: loadingReplay }
+    await renderReplay()
+
+    expect(container.textContent).toContain('No visual recording for this tab')
+
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        visualEvents(1, 1_000),
+        [1],
+        [chapterFrame(1, 1, 'first.example')],
+      ),
+    }
+    await renderReplay()
+
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
+  })
+
+  it('preserves a manual chapter choice while visual events are loading', async () => {
+    const loadingReplay = replayData(
+      [],
+      [1, 2],
+      [chapterFrame(1, 1), chapterFrame(2, 2)],
+    )
+    loadingReplay.eventsLoaded = false
+    replayResult = { ...replayResult, replay: loadingReplay }
+    await renderReplay()
+    await click('[data-target-chip="2"]')
+
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        [...visualEvents(1, 1_000), ...visualEvents(2, 10_000)],
+        [1, 2],
+        [chapterFrame(1, 1), chapterFrame(2, 11)],
+      ),
+    }
+    await renderReplay()
+
+    expect(
+      container
+        .querySelector('[data-selected-target]')
+        ?.getAttribute('data-selected-target'),
+    ).toBe('2')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('false')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
+  })
+
+  it('cancels an empty-replay transition when a playable snapshot arrives', async () => {
+    const emptyReplay = replayData(
+      [noVisualEvent(1, 1_000)],
+      [1],
+      [chapterFrame(1, 1, 'first.example')],
+    )
+    replayResult = { ...replayResult, replay: emptyReplay }
+    await renderReplay()
+
+    const staleTransition = [...transitionTimers.values()][0]?.callback
+    expect(container.textContent).toContain(
+      'No visual recordings → Replay complete',
+    )
+
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        visualEvents(1, 1_000),
+        [1],
+        [chapterFrame(1, 1, 'first.example')],
+      ),
+    }
+    await renderReplay()
+
+    expect(transitionTimers.size).toBe(0)
+    expect(container.textContent).not.toContain('No visual recordings')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+
+    await act(async () => {
+      if (typeof staleTransition === 'function') staleTransition()
+    })
+    expect(container.textContent).not.toContain('Replay complete')
+  })
+
+  it('plays a static visual snapshot before advancing', async () => {
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        [...staticVisualEvents(1, 1_000), ...visualEvents(2, 10_000)],
+        [1, 2],
+        [chapterFrame(1, 1), chapterFrame(2, 11)],
+      ),
+    }
+    await renderReplay()
+
+    expect(container.querySelector('[data-player-types]')).not.toBeNull()
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+
+    await completeCurrentChapter(0)
+    expect(container.textContent).toContain(
+      'Tab 1 complete → Opening Tab 2 · tab-2.example',
+    )
   })
 
   it('resets selection, transport, and stale transitions when the session changes', async () => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -808,6 +808,47 @@ describe('Replay', () => {
     expect(maxActivePlayers).toBe(1)
   })
 
+  it('changes the warning, viewport, timeline, and local clock as one chapter', async () => {
+    const chapterEvents = [
+      ...visualEvents(1, 1_000),
+      ...visualEvents(2, 10_000),
+    ]
+    const chapterReplay = replayData(
+      chapterEvents,
+      [1, 2],
+      [chapterFrame(1, 2), chapterFrame(2, 11)],
+    )
+    const secondTab = chapterReplay.tabs[1]
+    if (!secondTab) throw new Error('tab 2 metadata missing')
+    secondTab.complete = false
+    const secondSegment = secondTab.segments[0]
+    if (!secondSegment) throw new Error('tab 2 segment missing')
+    secondSegment.hasGap = true
+    replayResult = { ...replayResult, replay: chapterReplay }
+    await renderReplay()
+
+    expect(container.textContent).not.toContain('Recording incomplete')
+    await completeCurrentChapter(4_000)
+
+    expect(container.textContent).toContain('Tab 2 of 2')
+    expect(container.textContent).toContain(
+      'Recording incomplete — this replay contains a known gap',
+    )
+    expect(
+      container
+        .querySelector('[data-player-documents]')
+        ?.getAttribute('data-player-documents'),
+    ).toBe('document-2,document-2,document-2')
+    expect(container.querySelector('[data-event-timeline]')?.textContent).toBe(
+      'Action on Tab 2',
+    )
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
+  })
+
   it('summarizes consecutive middle and trailing no-visual chapters', async () => {
     const chapterEvents = [
       ...visualEvents(1, 1_000),

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -296,7 +296,7 @@ function replayData(
   replayEvents: readonly ReplayEvent[],
   tabOrder?: number[],
   replayFrames: ReplayFrame[] = frames,
-) {
+): replayDataModule.ReplayData {
   const eventCatalog = buildReplayEventCatalog(replayEvents)
   const tabs = (tabOrder ?? eventCatalog.tabIds).map((tabId) => ({
     tabId,
@@ -1110,9 +1110,9 @@ describe('Replay', () => {
     replayResult = {
       ...replayResult,
       replay: replayData(
-        [noVisualEvent(1, 1_000)],
-        [1],
-        [chapterFrame(1, 1, 'first.example')],
+        [noVisualEvent(1, 1_000), noVisualEvent(2, 2_000)],
+        [1, 2],
+        [chapterFrame(1, 1), chapterFrame(2, 2, 'second.example')],
       ),
     }
     await renderReplay()
@@ -1122,14 +1122,29 @@ describe('Replay', () => {
     replayResult = {
       ...replayResult,
       replay: replayData(
-        visualEvents(1, 1_000),
-        [1],
-        [chapterFrame(1, 1, 'first.example')],
+        [noVisualEvent(1, 1_000), ...visualEvents(2, 2_000)],
+        [1, 2],
+        [chapterFrame(1, 1), chapterFrame(2, 2, 'second.example')],
       ),
     }
     await renderReplay()
 
     expect(container.textContent).not.toContain('Replay complete')
+    expect(container.textContent).toContain(
+      'Starting replay → Opening Tab 2 · second.example',
+    )
+    expect(
+      container
+        .querySelector('[data-selected-target]')
+        ?.getAttribute('data-selected-target'),
+    ).toBe('2')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('false')
+
+    await fireNextTransition()
     expect(
       container
         .querySelector('[data-playback-playing]')
@@ -1182,6 +1197,63 @@ describe('Replay', () => {
         .querySelector('[data-playback-playing]')
         ?.getAttribute('data-playback-playing'),
     ).toBe('true')
+  })
+
+  it("resumes when the completed chapter's recording grows", async () => {
+    replayResult = {
+      ...replayResult,
+      replay: replayData(visualEvents(1, 1_000), [1], [chapterFrame(1, 2)]),
+    }
+    await renderReplay()
+    await completeCurrentChapter(4_000)
+    expect(container.textContent).toContain('Replay complete')
+
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        visualEvents(1, 1_000, 6_000),
+        [1],
+        [chapterFrame(1, 2)],
+      ),
+    }
+    await renderReplay()
+
+    expect(container.textContent).not.toContain('Replay complete')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('4')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+
+    await completeCurrentChapter(6_000)
+    expect(container.textContent).toContain('Replay complete')
+  })
+
+  it('waits for the current event revision before finalizing the sequence', async () => {
+    const refreshingReplay = replayData(
+      visualEvents(1, 1_000),
+      [1],
+      [chapterFrame(1, 2)],
+    )
+    refreshingReplay.eventsLoaded = false
+    replayResult = { ...replayResult, replay: refreshingReplay }
+    await renderReplay()
+    await completeCurrentChapter(4_000)
+
+    expect(container.textContent).not.toContain('Replay complete')
+
+    replayResult = {
+      ...replayResult,
+      replay: { ...refreshingReplay, eventsLoaded: true },
+    }
+    await renderReplay()
+
+    expect(container.textContent).toContain('Replay complete')
   })
 
   it('plays a static visual snapshot before advancing', async () => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -1,13 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { parseHTML } from 'linkedom'
-import { act, createContext, type ReactNode, useContext } from 'react'
+import {
+  act,
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+} from 'react'
 import type { Root } from 'react-dom/client'
 import { MemoryRouter } from 'react-router'
 import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
 import * as replayDataModule from './replay.data'
 import { buildReplayEventCatalog } from './replay-events'
+import type { Playback } from './use-playback'
 
 let replayResult: replayDataModule.UseReplayDataResult
+let playerTimeMs = 0
+let activePlayers = 0
+let maxActivePlayers = 0
+const playerCalls: Array<{
+  kind: 'seek' | 'play' | 'pause' | 'speed'
+  tabId: number
+  value?: number
+}> = []
 
 mock.module('./replay.data', () => ({
   ...replayDataModule,
@@ -15,25 +30,101 @@ mock.module('./replay.data', () => ({
 }))
 
 mock.module('./ReplayViewport', () => ({
-  ReplayViewport: ({ events }: { events: readonly ReplayEvent[] }) => (
-    <div
-      data-player-documents={events.map((event) => event.documentId).join(',')}
-      data-player-types={events.map((event) => event.type).join(',')}
-    />
-  ),
+  ReplayViewport: ({
+    events,
+    onPlayerReady,
+  }: {
+    events: readonly ReplayEvent[]
+    onPlayerReady: (
+      handle: {
+        seek: (ms: number) => void
+        play: (ms: number) => void
+        pause: () => void
+        setSpeed: (speed: number) => void
+        getCurrentTime: () => number
+      } | null,
+    ) => void
+  }) => {
+    const tabId = events[0]?.tabId ?? -1
+    // biome-ignore lint/correctness/useExhaustiveDependencies: event-array replacement remounts the real ReplayViewport player.
+    useEffect(() => {
+      activePlayers += 1
+      maxActivePlayers = Math.max(maxActivePlayers, activePlayers)
+      onPlayerReady({
+        seek: (ms) => {
+          playerTimeMs = ms
+          playerCalls.push({ kind: 'seek', tabId, value: ms })
+        },
+        play: (ms) => {
+          playerTimeMs = ms
+          playerCalls.push({ kind: 'play', tabId, value: ms })
+        },
+        pause: () => {
+          playerCalls.push({ kind: 'pause', tabId })
+        },
+        setSpeed: (speed) => {
+          playerCalls.push({ kind: 'speed', tabId, value: speed })
+        },
+        getCurrentTime: () => playerTimeMs,
+      })
+      return () => {
+        activePlayers -= 1
+        onPlayerReady(null)
+      }
+    }, [events, onPlayerReady, tabId])
+    return (
+      <div
+        data-player-documents={events
+          .map((event) => event.documentId)
+          .join(',')}
+        data-player-types={events.map((event) => event.type).join(',')}
+      />
+    )
+  },
 }))
 
 mock.module('./PlaybackTransport', () => ({
   PlaybackTransport: ({
     playback,
+    totalSeconds,
   }: {
-    playback: { time: number; isPlaying: boolean }
-  }) => (
-    <div
-      data-playback-time={playback.time}
-      data-playback-playing={playback.isPlaying}
-    />
-  ),
+    playback: Playback
+    totalSeconds: number
+  }) => {
+    const finished = playback.time >= totalSeconds
+    return (
+      <div
+        data-playback-time={playback.time}
+        data-playback-playing={playback.isPlaying}
+        data-playback-speed={playback.speed}
+      >
+        <button
+          type="button"
+          data-playback-toggle
+          aria-label={
+            finished
+              ? 'Restart playback'
+              : playback.isPlaying
+                ? 'Pause'
+                : 'Play'
+          }
+          onClick={playback.togglePlay}
+        >
+          Toggle
+        </button>
+        {[1, 2, 4].map((speed) => (
+          <button
+            type="button"
+            key={speed}
+            data-playback-speed-option={speed}
+            onClick={() => playback.setSpeed(speed)}
+          >
+            {speed}×
+          </button>
+        ))}
+      </div>
+    )
+  },
 }))
 
 mock.module('./EventTimeline', () => ({
@@ -44,7 +135,7 @@ mock.module('./EventTimeline', () => ({
     frames: readonly ReplayFrame[]
     onSelectFrame: (frame: ReplayFrame) => void
   }) => (
-    <div>
+    <div data-event-timeline>
       {frames.map((frame) => (
         <button
           type="button"
@@ -163,6 +254,7 @@ const frames: ReplayFrame[] = [
     tabId: 1,
     targetId: 'target-a',
     dispatchId: 1,
+    url: 'https://first.example/products',
   },
   {
     t: 12,
@@ -173,10 +265,15 @@ const frames: ReplayFrame[] = [
     tabId: 2,
     targetId: 'target-b',
     dispatchId: 2,
+    url: 'https://second.example/checkout',
   },
 ]
 
-function replayData(replayEvents: readonly ReplayEvent[], tabOrder?: number[]) {
+function replayData(
+  replayEvents: readonly ReplayEvent[],
+  tabOrder?: number[],
+  replayFrames: ReplayFrame[] = frames,
+) {
   const eventCatalog = buildReplayEventCatalog(replayEvents)
   const tabs = (tabOrder ?? eventCatalog.tabIds).map((tabId) => ({
     tabId,
@@ -206,10 +303,77 @@ function replayData(replayEvents: readonly ReplayEvent[], tabOrder?: number[]) {
     tokens: '-',
     steps: '2',
     totalSeconds: 15,
-    frames,
+    frames: replayFrames,
     complete: true,
     tabs,
     eventsForTab: eventCatalog.eventsForTab,
+  }
+}
+
+function visualEvents(
+  tabId: number,
+  startMs: number,
+  durationMs = 4_000,
+): ReplayEvent[] {
+  const documentId = `document-${tabId}`
+  return [
+    {
+      sessionId: 'session-1',
+      documentId,
+      targetId: `target-${tabId}`,
+      tabId,
+      ts: startMs,
+      type: 4,
+      data: { width: 1280, height: 720 },
+    },
+    {
+      sessionId: 'session-1',
+      documentId,
+      targetId: `target-${tabId}`,
+      tabId,
+      ts: startMs + 1,
+      type: 2,
+      data: {},
+    },
+    {
+      sessionId: 'session-1',
+      documentId,
+      targetId: `target-${tabId}`,
+      tabId,
+      ts: startMs + durationMs,
+      type: 3,
+      data: {},
+    },
+  ]
+}
+
+function noVisualEvent(tabId: number, atMs: number): ReplayEvent {
+  return {
+    sessionId: 'session-1',
+    documentId: `document-${tabId}`,
+    targetId: `target-${tabId}`,
+    tabId,
+    ts: atMs,
+    type: 3,
+    data: {},
+  }
+}
+
+function chapterFrame(
+  tabId: number,
+  atSeconds: number,
+  domain = `tab-${tabId}.example`,
+): ReplayFrame {
+  return {
+    t: atSeconds,
+    kind: 'action',
+    verb: 'read',
+    node: `Tab ${tabId}`,
+    caption: `Action on Tab ${tabId}`,
+    tabId,
+    targetId: `target-${tabId}`,
+    dispatchId: tabId,
+    url: `https://${domain}/path`,
   }
 }
 
@@ -221,8 +385,25 @@ const globalDescriptors = new Map(
 
 let root: Root
 let container: HTMLElement
+let nextAnimationFrameId = 1
+let nextTimerId = 1
+const animationFrames = new Map<number, FrameRequestCallback>()
+const transitionTimers = new Map<
+  number,
+  { callback: TimerHandler; delay: number | undefined }
+>()
+const clearedTimerIds: number[] = []
 
 beforeEach(async () => {
+  playerTimeMs = 0
+  activePlayers = 0
+  maxActivePlayers = 0
+  playerCalls.length = 0
+  nextAnimationFrameId = 1
+  nextTimerId = 1
+  animationFrames.clear()
+  transitionTimers.clear()
+  clearedTimerIds.length = 0
   const dom = parseHTML(
     '<!doctype html><html><body><div id="root"></div></body></html>',
   )
@@ -242,8 +423,23 @@ beforeEach(async () => {
     })
   }
   Object.assign(dom.window, {
-    requestAnimationFrame: () => 1,
-    cancelAnimationFrame: () => undefined,
+    requestAnimationFrame: (callback: FrameRequestCallback) => {
+      const id = nextAnimationFrameId++
+      animationFrames.set(id, callback)
+      return id
+    },
+    cancelAnimationFrame: (id: number) => {
+      animationFrames.delete(id)
+    },
+    setTimeout: (callback: TimerHandler, delay?: number) => {
+      const id = nextTimerId++
+      transitionTimers.set(id, { callback, delay })
+      return id
+    },
+    clearTimeout: (id: number) => {
+      clearedTimerIds.push(id)
+      transitionTimers.delete(id)
+    },
   })
   Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
     configurable: true,
@@ -271,8 +467,46 @@ afterEach(async () => {
   Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
 })
 
+async function renderReplay() {
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={['/audit/session-1/replay']}>
+        <Replay />
+      </MemoryRouter>,
+    )
+  })
+}
+
+async function completeCurrentChapter(totalMs: number) {
+  playerTimeMs = totalMs
+  const callbacks = [...animationFrames.values()]
+  animationFrames.clear()
+  await act(async () => {
+    for (const callback of callbacks) callback(performance.now())
+  })
+}
+
+async function fireNextTransition() {
+  const entry = transitionTimers.entries().next().value as
+    | [number, { callback: TimerHandler; delay: number | undefined }]
+    | undefined
+  if (!entry) throw new Error('transition timer missing')
+  transitionTimers.delete(entry[0])
+  await act(async () => {
+    if (typeof entry[1].callback === 'function') entry[1].callback()
+  })
+}
+
+async function click(selector: string) {
+  const target = container.querySelector(selector)
+  if (!target) throw new Error(`missing target: ${selector}`)
+  await act(async () => {
+    target.dispatchEvent(new window.Event('click', { bubbles: true }))
+  })
+}
+
 describe('Replay', () => {
-  it('discovers logical tabs and switches tab on frame click', async () => {
+  it('discovers logical tabs and keeps frame selection tab-local', async () => {
     await act(async () => {
       root.render(
         <MemoryRouter initialEntries={['/audit/session-1/replay']}>
@@ -314,11 +548,8 @@ describe('Replay', () => {
         ?.getAttribute('data-playback-playing'),
     ).toBe('true')
 
-    const targetBFrame = container.querySelector('[data-frame-tab="2"]')
-    if (!targetBFrame) throw new Error('tab 2 frame missing')
-    await act(async () => {
-      targetBFrame.dispatchEvent(new window.Event('click', { bubbles: true }))
-    })
+    expect(container.querySelector('[data-frame-tab="2"]')).toBeNull()
+    await click('[data-target-chip="2"]')
 
     expect(
       container
@@ -330,6 +561,17 @@ describe('Replay', () => {
         .querySelector('[data-player-documents]')
         ?.getAttribute('data-player-documents'),
     ).toBe('document-b,document-b,document-b')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
+
+    const targetBFrame = container.querySelector('[data-frame-tab="2"]')
+    if (!targetBFrame) throw new Error('tab 2 frame missing')
+    await act(async () => {
+      targetBFrame.dispatchEvent(new window.Event('click', { bubbles: true }))
+    })
     expect(
       container
         .querySelector('[data-playback-time]')
@@ -497,6 +739,338 @@ describe('Replay', () => {
     })
 
     expect(container.textContent).not.toContain('Recording incomplete')
+  })
+
+  it('plays each chapter fully, waits one wall-clock second, and preserves speed', async () => {
+    const chapterEvents = [
+      ...visualEvents(1, 1_000),
+      ...visualEvents(2, 10_000, 5_000),
+    ]
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        chapterEvents,
+        [1, 2],
+        [
+          chapterFrame(1, 2, 'first.example'),
+          chapterFrame(2, 12, 'second.example'),
+        ],
+      ),
+    }
+    await renderReplay()
+
+    expect(container.textContent).toContain('Tab 1 of 2')
+    expect(container.querySelector('[data-event-timeline]')?.textContent).toBe(
+      'Action on Tab 1',
+    )
+    await click('[data-playback-speed-option="4"]')
+    await completeCurrentChapter(4_000)
+
+    expect(container.textContent).toContain(
+      'Tab 1 complete → Opening Tab 2 · second.example',
+    )
+    expect(
+      container
+        .querySelector('[data-selected-target]')
+        ?.getAttribute('data-selected-target'),
+    ).toBe('2')
+    expect(container.textContent).toContain('Tab 2 of 2')
+    expect(container.querySelector('[data-event-timeline]')?.textContent).toBe(
+      'Action on Tab 2',
+    )
+    expect([...transitionTimers.values()].map(({ delay }) => delay)).toEqual([
+      1_000,
+    ])
+    expect(
+      playerCalls.some(
+        (call) => call.kind === 'play' && call.tabId === 2 && call.value === 0,
+      ),
+    ).toBe(false)
+
+    await fireNextTransition()
+
+    expect(container.textContent).not.toContain('Tab 1 complete')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+    expect(
+      container
+        .querySelector('[data-playback-speed]')
+        ?.getAttribute('data-playback-speed'),
+    ).toBe('4')
+    expect(
+      playerCalls.some(
+        (call) => call.kind === 'play' && call.tabId === 2 && call.value === 0,
+      ),
+    ).toBe(true)
+    expect(maxActivePlayers).toBe(1)
+  })
+
+  it('summarizes consecutive middle and trailing no-visual chapters', async () => {
+    const chapterEvents = [
+      ...visualEvents(1, 1_000),
+      noVisualEvent(2, 6_000),
+      noVisualEvent(3, 7_000),
+      ...visualEvents(4, 10_000),
+      noVisualEvent(5, 16_000),
+      noVisualEvent(6, 17_000),
+    ]
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        chapterEvents,
+        [1, 2, 3, 4, 5, 6],
+        [
+          chapterFrame(1, 2),
+          chapterFrame(2, 6),
+          chapterFrame(3, 7),
+          chapterFrame(4, 11, 'fourth.example'),
+          chapterFrame(5, 16),
+          chapterFrame(6, 17),
+        ],
+      ),
+    }
+    await renderReplay()
+
+    await completeCurrentChapter(4_000)
+    expect(container.textContent).toContain(
+      'Tab 1 complete → Opening Tab 4 · fourth.example',
+    )
+    expect(container.textContent).toContain(
+      'Skipped Tabs 2–3 — no visual recordings',
+    )
+    expect(container.textContent).toContain('Tab 4 of 6')
+
+    await fireNextTransition()
+    await completeCurrentChapter(4_000)
+    expect(container.textContent).toContain('Tab 4 complete → Replay complete')
+    expect(container.textContent).toContain(
+      'Skipped Tabs 5–6 — no visual recordings',
+    )
+    expect(container.textContent).not.toContain(
+      'Replay completeReplay complete',
+    )
+
+    await fireNextTransition()
+    expect(container.textContent).toContain('Replay complete')
+    expect(transitionTimers.size).toBe(0)
+  })
+
+  it('explains leading skipped chapters before autoplaying the first playable tab', async () => {
+    const chapterEvents = [
+      noVisualEvent(1, 1_000),
+      noVisualEvent(2, 2_000),
+      ...visualEvents(3, 3_000),
+    ]
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        chapterEvents,
+        [1, 2, 3],
+        [
+          chapterFrame(1, 1),
+          chapterFrame(2, 2),
+          chapterFrame(3, 3, 'playable.example'),
+        ],
+      ),
+    }
+    await renderReplay()
+
+    expect(container.textContent).toContain(
+      'Starting replay → Opening Tab 3 · playable.example',
+    )
+    expect(container.textContent).toContain(
+      'Skipped Tabs 1–2 — no visual recordings',
+    )
+    expect(container.textContent).toContain('Tab 3 of 3')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('false')
+
+    await fireNextTransition()
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+  })
+
+  it('cancels a pending transition and invalidates its callback on manual selection', async () => {
+    const chapterEvents = [
+      ...visualEvents(1, 1_000),
+      ...visualEvents(2, 10_000),
+      ...visualEvents(3, 20_000),
+    ]
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        chapterEvents,
+        [1, 2, 3],
+        [chapterFrame(1, 2), chapterFrame(2, 11), chapterFrame(3, 21)],
+      ),
+    }
+    await renderReplay()
+    await completeCurrentChapter(4_000)
+
+    const pending = [...transitionTimers.values()][0]?.callback
+    await click('[data-target-chip="3"]')
+
+    expect(transitionTimers.size).toBe(0)
+    expect(clearedTimerIds).toHaveLength(1)
+    expect(container.textContent).not.toContain('Tab 1 complete')
+    expect(
+      container
+        .querySelector('[data-selected-target]')
+        ?.getAttribute('data-selected-target'),
+    ).toBe('3')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('false')
+
+    await act(async () => {
+      if (typeof pending === 'function') pending()
+    })
+    expect(
+      container
+        .querySelector('[data-selected-target]')
+        ?.getAttribute('data-selected-target'),
+    ).toBe('3')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('false')
+  })
+
+  it('keeps a manually selected no-visual chapter paused and tab-local', async () => {
+    const chapterEvents = [
+      ...visualEvents(1, 1_000),
+      noVisualEvent(2, 7_000),
+      ...visualEvents(3, 10_000),
+    ]
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        chapterEvents,
+        [1, 2, 3],
+        [chapterFrame(1, 2), chapterFrame(2, 7), chapterFrame(3, 11)],
+      ),
+    }
+    await renderReplay()
+    await click('[data-target-chip="2"]')
+
+    expect(container.textContent).toContain('No visual recording for this tab')
+    expect(container.textContent).toContain('Tab 2 of 3')
+    expect(container.querySelector('[data-event-timeline]')?.textContent).toBe(
+      'Action on Tab 2',
+    )
+    expect(container.querySelector('[data-playback-toggle]')).toBeNull()
+    expect(transitionTimers.size).toBe(0)
+  })
+
+  it('restarts a completed sequence from the first playable tab', async () => {
+    const chapterEvents = [
+      ...visualEvents(1, 1_000),
+      ...visualEvents(2, 10_000),
+    ]
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        chapterEvents,
+        [1, 2],
+        [chapterFrame(1, 2), chapterFrame(2, 11)],
+      ),
+    }
+    await renderReplay()
+    await click('[data-playback-speed-option="4"]')
+    await completeCurrentChapter(4_000)
+    await fireNextTransition()
+    await completeCurrentChapter(4_000)
+
+    expect(container.textContent).toContain('Replay complete')
+    expect(
+      container
+        .querySelector('[data-playback-toggle]')
+        ?.getAttribute('aria-label'),
+    ).toBe('Restart playback')
+
+    await click('[data-playback-toggle]')
+
+    expect(
+      container
+        .querySelector('[data-selected-target]')
+        ?.getAttribute('data-selected-target'),
+    ).toBe('1')
+    expect(container.textContent).toContain('Tab 1 of 2')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+    expect(
+      container
+        .querySelector('[data-playback-speed]')
+        ?.getAttribute('data-playback-speed'),
+    ).toBe('4')
+  })
+
+  it('keeps a single playable tab unchanged apart from chapter progress', async () => {
+    replayResult = {
+      ...replayResult,
+      replay: replayData(visualEvents(1, 1_000), [1], [chapterFrame(1, 2)]),
+    }
+    await renderReplay()
+
+    expect(container.textContent).toContain('Tab 1 of 1')
+    expect(container.querySelector('[data-selected-target]')).toBeNull()
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+
+    await completeCurrentChapter(4_000)
+    expect(container.textContent).toContain('Replay complete')
+    expect(transitionTimers.size).toBe(0)
+  })
+
+  it('clears the transition timer when the replay unmounts', async () => {
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        [...visualEvents(1, 1_000), ...visualEvents(2, 10_000)],
+        [1, 2],
+        [chapterFrame(1, 2), chapterFrame(2, 11)],
+      ),
+    }
+    await renderReplay()
+    await completeCurrentChapter(4_000)
+    const pending = [...transitionTimers.values()][0]?.callback
+
+    await act(async () => root.render(<div data-unmounted />))
+
+    expect(transitionTimers.size).toBe(0)
+    expect(clearedTimerIds).toHaveLength(1)
+    await act(async () => {
+      if (typeof pending === 'function') pending()
+    })
+    expect(container.querySelector('[data-unmounted]')).not.toBeNull()
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -4,6 +4,7 @@ import {
   act,
   createContext,
   type ReactNode,
+  StrictMode,
   useContext,
   useEffect,
 } from 'react'
@@ -517,9 +518,11 @@ afterEach(async () => {
 async function renderReplay() {
   await act(async () => {
     root.render(
-      <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-        <Replay />
-      </MemoryRouter>,
+      <StrictMode>
+        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
+          <Replay />
+        </MemoryRouter>
+      </StrictMode>,
     )
   })
 }
@@ -554,13 +557,7 @@ async function click(selector: string) {
 
 describe('Replay', () => {
   it('discovers logical tabs and keeps frame selection tab-local', async () => {
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
+    await renderReplay()
 
     expect(
       [...container.querySelectorAll('[data-target-chip]')].map(
@@ -571,13 +568,7 @@ describe('Replay', () => {
     expect(container.querySelector('[data-player-targets]')).toBeNull()
 
     replayResult = { ...replayResult, replay: replayData(events) }
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
+    await renderReplay()
 
     expect(
       container
@@ -629,13 +620,7 @@ describe('Replay', () => {
       ...replayResult,
       replay: replayData(events, [1]),
     }
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
+    await renderReplay()
 
     expect(
       container
@@ -663,13 +648,7 @@ describe('Replay', () => {
       replay: replayData(navigationEvents),
     }
 
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
+    await renderReplay()
 
     expect(container.textContent).not.toContain('Navigation 1')
     expect(container.textContent).not.toContain('Navigation 2')
@@ -718,13 +697,7 @@ describe('Replay', () => {
       replay: replayData(incompleteEvents),
     }
 
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
+    await renderReplay()
 
     expect(
       container
@@ -750,13 +723,7 @@ describe('Replay', () => {
     }
     replayResult = { ...replayResult, replay: partialReplay }
 
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
+    await renderReplay()
 
     expect(container.textContent).toContain(
       'Recording incomplete — playback starts at 0:01',
@@ -777,13 +744,7 @@ describe('Replay', () => {
     }
     replayResult = { ...replayResult, replay: partialReplay }
 
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={['/audit/session-1/replay']}>
-          <Replay />
-        </MemoryRouter>,
-      )
-    })
+    await renderReplay()
 
     expect(container.textContent).not.toContain('Recording incomplete')
   })
@@ -1018,6 +979,23 @@ describe('Replay', () => {
     expect(container.querySelector('[data-playback-toggle]')).toBeNull()
   })
 
+  it('does not complete an all-no-visual replay while the session is live', async () => {
+    const liveReplay = replayData(
+      [noVisualEvent(1, 1_000)],
+      [1],
+      [chapterFrame(1, 1)],
+    )
+    liveReplay.status = 'running'
+    replayResult = { ...replayResult, replay: liveReplay }
+    await renderReplay()
+
+    expect(container.textContent).not.toContain(
+      'No visual recordings → Replay complete',
+    )
+    expect(container.textContent).not.toContain('Replay complete')
+    expect(transitionTimers.size).toBe(0)
+  })
+
   it('autoplays when the first playable snapshot arrives after metadata', async () => {
     const loadingReplay = replayData(
       [],
@@ -1126,6 +1104,84 @@ describe('Replay', () => {
       if (typeof staleTransition === 'function') staleTransition()
     })
     expect(container.textContent).not.toContain('Replay complete')
+  })
+
+  it('starts a playable snapshot that arrives after empty-replay completion', async () => {
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        [noVisualEvent(1, 1_000)],
+        [1],
+        [chapterFrame(1, 1, 'first.example')],
+      ),
+    }
+    await renderReplay()
+    await fireNextTransition()
+    expect(container.textContent).toContain('Replay complete')
+
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        visualEvents(1, 1_000),
+        [1],
+        [chapterFrame(1, 1, 'first.example')],
+      ),
+    }
+    await renderReplay()
+
+    expect(container.textContent).not.toContain('Replay complete')
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
+    expect(
+      container
+        .querySelector('[data-playback-time]')
+        ?.getAttribute('data-playback-time'),
+    ).toBe('0')
+  })
+
+  it('continues into a later chapter that becomes playable after completion', async () => {
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        [...visualEvents(1, 1_000), noVisualEvent(2, 7_000)],
+        [1, 2],
+        [chapterFrame(1, 2), chapterFrame(2, 7, 'second.example')],
+      ),
+    }
+    await renderReplay()
+    await completeCurrentChapter(4_000)
+    await fireNextTransition()
+    expect(container.textContent).toContain('Replay complete')
+
+    replayResult = {
+      ...replayResult,
+      replay: replayData(
+        [...visualEvents(1, 1_000), ...visualEvents(2, 10_000)],
+        [1, 2],
+        [chapterFrame(1, 2), chapterFrame(2, 11, 'second.example')],
+      ),
+    }
+    await renderReplay()
+
+    expect(container.textContent).not.toContain('Replay complete')
+    expect(container.textContent).toContain(
+      'Tab 1 complete → Opening Tab 2 · second.example',
+    )
+    expect(
+      container
+        .querySelector('[data-selected-target]')
+        ?.getAttribute('data-selected-target'),
+    ).toBe('2')
+
+    await fireNextTransition()
+    expect(
+      container
+        .querySelector('[data-playback-playing]')
+        ?.getAttribute('data-playback-playing'),
+    ).toBe('true')
   })
 
   it('plays a static visual snapshot before advancing', async () => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -28,7 +28,7 @@ const CHAPTER_TRANSITION_MS = 1_000
 const STATIC_CHAPTER_SECONDS = 0.001
 
 interface ChapterTransition {
-  kind: 'chapter' | 'empty'
+  kind: 'advance' | 'complete' | 'empty'
   title: string
   skipped: string | null
 }
@@ -51,6 +51,7 @@ export function Replay() {
   const activeSessionRef = useRef<string | null>(null)
   const autoStartedSessionRef = useRef<string | null>(null)
   const operatorControlledSessionRef = useRef<string | null>(null)
+  const emptySequenceSessionRef = useRef<string | null>(null)
 
   const tabViewInput = useMemo(
     () =>
@@ -123,6 +124,12 @@ export function Replay() {
   useEffect(
     () => () => {
       invalidateTransition()
+      activeSessionRef.current = null
+      autoStartedSessionRef.current = null
+      operatorControlledSessionRef.current = null
+      emptySequenceSessionRef.current = null
+      pendingTabSeekRef.current = null
+      pendingTabPlaybackRef.current = 'pause'
     },
     [invalidateTransition],
   )
@@ -210,6 +217,7 @@ export function Replay() {
         return
       }
       autoStartedSessionRef.current = currentReplay.sessionId
+      emptySequenceSessionRef.current = currentReplay.sessionId
       scheduleTransition(
         {
           kind: 'empty',
@@ -247,7 +255,7 @@ export function Replay() {
       )
       scheduleTransition(
         {
-          kind: 'chapter',
+          kind: 'advance',
           title: `Starting replay → Opening ${chapterName(currentReplay, firstPlayableIndex)}`,
           skipped: skippedChapterSummary(
             Array.from({ length: firstPlayableIndex }, (_, index) => index),
@@ -269,6 +277,7 @@ export function Replay() {
       activeSessionRef.current = replay.sessionId
       autoStartedSessionRef.current = null
       operatorControlledSessionRef.current = null
+      emptySequenceSessionRef.current = null
       cancelTransition()
       setSequenceComplete(false)
     }
@@ -291,12 +300,13 @@ export function Replay() {
       : replay.tabs.find((tab) => tab.tabId === selectedTabId)
     const firstPlayableIndex = playableChapterIndices[0]
     const invalidEmptyTransition =
-      transition?.kind === 'empty' &&
+      emptySequenceSessionRef.current === replay.sessionId &&
       (firstPlayableIndex !== undefined ||
         !replay.eventsLoaded ||
-        replay.complete !== true)
+        replay.status === 'running')
     if (invalidEmptyTransition) {
       cancelTransition()
+      emptySequenceSessionRef.current = null
       autoStartedSessionRef.current = null
       setSequenceComplete(false)
     }
@@ -325,7 +335,6 @@ export function Replay() {
     resetTab,
     selectedTabId,
     startInitialChapter,
-    transition,
   ])
 
   const selectTab = useCallback(
@@ -376,7 +385,7 @@ export function Replay() {
       resetTab(nextTab.tabId, false)
       scheduleTransition(
         {
-          kind: 'chapter',
+          kind: 'advance',
           title: `Tab ${selectedTabIndex + 1} complete → Opening ${chapterName(replay, nextPlayableIndex)}`,
           skipped: skippedChapterSummary(skippedIndices),
         },
@@ -399,7 +408,7 @@ export function Replay() {
     if (trailingSkippedIndices.length > 0) {
       scheduleTransition(
         {
-          kind: 'chapter',
+          kind: 'complete',
           title: `Tab ${selectedTabIndex + 1} complete → Replay complete`,
           skipped: skippedChapterSummary(trailingSkippedIndices),
         },
@@ -414,6 +423,27 @@ export function Replay() {
     resetTab,
     scheduleTransition,
     selectedTabIndex,
+  ])
+
+  useEffect(() => {
+    if (!replay || selectedTabIndex < 0) return
+    const hasNewLaterChapter = playableChapterIndices.some(
+      (index) => index > selectedTabIndex,
+    )
+    const sequenceWasFinished =
+      sequenceComplete || transition?.kind === 'complete'
+    if (!hasNewLaterChapter || !sequenceWasFinished) return
+    cancelTransition()
+    setSequenceComplete(false)
+    advanceChapter()
+  }, [
+    advanceChapter,
+    cancelTransition,
+    playableChapterIndices,
+    replay,
+    selectedTabIndex,
+    sequenceComplete,
+    transition,
   ])
 
   useEffect(() => {
@@ -714,7 +744,7 @@ function shouldCompleteNoVisualReplay(
   autoStartedSessionId: string | null,
 ): boolean {
   return (
-    replay.complete === true &&
+    replay.status !== 'running' &&
     replay.eventsLoaded &&
     autoStartedSessionId !== replay.sessionId
   )

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -33,13 +33,23 @@ interface ChapterTransition {
   skipped: string | null
 }
 
+type SequenceCompletion = 'chapter' | 'empty' | null
+
+interface ReachedChapterEnd {
+  sessionId: string
+  tabId: number
+  seconds: number
+}
+
 /** Renders the audit replay page and syncs rrweb playback to the transport UI. */
 export function Replay() {
   const { replay, isLoading, navigate } = useReplayData()
   const location = useLocation()
   const [selectedTabId, setSelectedTabId] = useState<number | null>(null)
   const [transition, setTransition] = useState<ChapterTransition | null>(null)
-  const [sequenceComplete, setSequenceComplete] = useState(false)
+  const [sequenceCompletion, setSequenceCompletion] =
+    useState<SequenceCompletion>(null)
+  const sequenceComplete = sequenceCompletion !== null
   const playerHandleRef = useRef<ReplayPlayerHandle | null>(null)
   const playbackTimeRef = useRef(0)
   const playbackSpeedRef = useRef(1)
@@ -52,6 +62,7 @@ export function Replay() {
   const autoStartedSessionRef = useRef<string | null>(null)
   const operatorControlledSessionRef = useRef<string | null>(null)
   const emptySequenceSessionRef = useRef<string | null>(null)
+  const reachedChapterEndRef = useRef<ReachedChapterEnd | null>(null)
 
   const tabViewInput = useMemo(
     () =>
@@ -128,6 +139,7 @@ export function Replay() {
       autoStartedSessionRef.current = null
       operatorControlledSessionRef.current = null
       emptySequenceSessionRef.current = null
+      reachedChapterEndRef.current = null
       pendingTabSeekRef.current = null
       pendingTabPlaybackRef.current = 'pause'
     },
@@ -182,6 +194,7 @@ export function Replay() {
 
   const resetTab = useCallback(
     (tabId: number, autoplay: boolean) => {
+      reachedChapterEndRef.current = null
       playback.pause()
       playbackTimeRef.current = 0
       playbackIsPlayingRef.current = false
@@ -226,7 +239,7 @@ export function Replay() {
             currentReplay.tabs.map((_, index) => index),
           ),
         },
-        () => setSequenceComplete(true),
+        () => setSequenceCompletion('empty'),
       )
     },
     [resetTab, scheduleTransition],
@@ -278,8 +291,9 @@ export function Replay() {
       autoStartedSessionRef.current = null
       operatorControlledSessionRef.current = null
       emptySequenceSessionRef.current = null
+      reachedChapterEndRef.current = null
       cancelTransition()
-      setSequenceComplete(false)
+      setSequenceCompletion(null)
     }
 
     const firstTab = replay.tabs[0]
@@ -308,7 +322,7 @@ export function Replay() {
       cancelTransition()
       emptySequenceSessionRef.current = null
       autoStartedSessionRef.current = null
-      setSequenceComplete(false)
+      setSequenceCompletion(null)
     }
     if (firstPlayableIndex === undefined) {
       initializeEmptyReplay(replay, firstTab.tabId, selectedTab !== undefined)
@@ -343,7 +357,7 @@ export function Replay() {
       if (!replay || !Number.isSafeInteger(tabId)) return
       operatorControlledSessionRef.current = replay.sessionId
       cancelTransition()
-      setSequenceComplete(false)
+      setSequenceCompletion(null)
       resetTab(tabId, false)
     },
     [cancelTransition, replay, resetTab],
@@ -353,7 +367,8 @@ export function Replay() {
     (frame: ReplayFrame) => {
       if (transition) return
       if (replay) operatorControlledSessionRef.current = replay.sessionId
-      setSequenceComplete(false)
+      reachedChapterEndRef.current = null
+      setSequenceCompletion(null)
       seekTo(frame.t)
     },
     [replay, seekTo, transition],
@@ -379,7 +394,7 @@ export function Replay() {
         { length: nextPlayableIndex - selectedTabIndex - 1 },
         (_, offset) => selectedTabIndex + offset + 1,
       )
-      setSequenceComplete(false)
+      setSequenceCompletion(null)
       const nextTab = replay.tabs[nextPlayableIndex]
       if (!nextTab) return
       resetTab(nextTab.tabId, false)
@@ -402,8 +417,19 @@ export function Replay() {
       { length: replay.tabs.length - selectedTabIndex - 1 },
       (_, offset) => selectedTabIndex + offset + 1,
     )
+    const selectedTab = replay.tabs[selectedTabIndex]
+    if (!selectedTab) return
+    reachedChapterEndRef.current = {
+      sessionId: replay.sessionId,
+      tabId: selectedTab.tabId,
+      seconds: playbackTotalSeconds,
+    }
+    if (!replay.eventsLoaded || replay.status === 'running') {
+      setSequenceCompletion(null)
+      return
+    }
     const finishSequence = () => {
-      setSequenceComplete(true)
+      setSequenceCompletion('chapter')
     }
     if (trailingSkippedIndices.length > 0) {
       scheduleTransition(
@@ -419,6 +445,7 @@ export function Replay() {
     }
   }, [
     playableChapterIndices,
+    playbackTotalSeconds,
     replay,
     resetTab,
     scheduleTransition,
@@ -427,22 +454,58 @@ export function Replay() {
 
   useEffect(() => {
     if (!replay || selectedTabIndex < 0) return
+    const reachedEnd = reachedChapterEndRef.current
+    const selectedTabId = replay.tabs[selectedTabIndex]?.tabId
+    if (
+      !reachedEnd ||
+      reachedEnd.sessionId !== replay.sessionId ||
+      reachedEnd.tabId !== selectedTabId
+    ) {
+      return
+    }
+
+    if (playbackTotalSeconds > reachedEnd.seconds) {
+      reachedChapterEndRef.current = null
+      cancelTransition()
+      setSequenceCompletion(null)
+      playbackTimeRef.current = reachedEnd.seconds
+      playbackIsPlayingRef.current = true
+      playbackPlayRef.current()
+      return
+    }
+
     const hasNewLaterChapter = playableChapterIndices.some(
       (index) => index > selectedTabIndex,
     )
     const sequenceWasFinished =
-      sequenceComplete || transition?.kind === 'complete'
-    if (!hasNewLaterChapter || !sequenceWasFinished) return
-    cancelTransition()
-    setSequenceComplete(false)
-    advanceChapter()
+      sequenceCompletion === 'chapter' ||
+      transition?.kind === 'complete' ||
+      (sequenceCompletion === null && transition === null)
+    if (hasNewLaterChapter && sequenceWasFinished) {
+      reachedChapterEndRef.current = null
+      cancelTransition()
+      setSequenceCompletion(null)
+      advanceChapter()
+      return
+    }
+
+    if (
+      sequenceCompletion === null &&
+      transition === null &&
+      replay.eventsLoaded &&
+      replay.status !== 'running'
+    ) {
+      reachedChapterEndRef.current = null
+      advanceChapter()
+    }
   }, [
     advanceChapter,
     cancelTransition,
     playableChapterIndices,
+    playbackTotalSeconds,
     replay,
     selectedTabIndex,
-    sequenceComplete,
+    sequenceCompletion,
     transition,
   ])
 
@@ -477,6 +540,7 @@ export function Replay() {
   const toggleSequencePlayback = useCallback(() => {
     if (transition) return
     if (!sequenceComplete) {
+      reachedChapterEndRef.current = null
       playback.togglePlay()
       return
     }
@@ -484,7 +548,7 @@ export function Replay() {
     const firstPlayableIndex = playableChapterIndices[0]
     if (!replay || firstPlayableIndex === undefined) return
     cancelTransition()
-    setSequenceComplete(false)
+    setSequenceCompletion(null)
     const firstPlayableTab = replay.tabs[firstPlayableIndex]
     if (firstPlayableTab) resetTab(firstPlayableTab.tabId, true)
   }, [
@@ -505,7 +569,8 @@ export function Replay() {
     (seconds: number) => {
       if (transition) return
       if (replay) operatorControlledSessionRef.current = replay.sessionId
-      setSequenceComplete(false)
+      reachedChapterEndRef.current = null
+      setSequenceCompletion(null)
       seekTo(seconds)
     },
     [replay, seekTo, transition],

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -14,38 +14,39 @@ import type { ReplayFrame } from '@/modules/api/replay.hooks'
 import { EventTimeline } from './EventTimeline'
 import { PlaybackTransport } from './PlaybackTransport'
 import { type ReplayPlayerHandle, ReplayViewport } from './ReplayViewport'
-import { buildTabView, EMPTY_TAB_VIEW, useReplayData } from './replay.data'
+import {
+  buildTabView,
+  EMPTY_TAB_VIEW,
+  type ReplayData,
+  type TabView,
+  useReplayData,
+} from './replay.data'
 import { frameIndexAt } from './replay.helpers'
-import { tabSeekForFrame } from './tab-view'
 import { usePlayback } from './use-playback'
+
+const CHAPTER_TRANSITION_MS = 1_000
+
+interface ChapterTransition {
+  title: string
+  skipped: string | null
+}
 
 /** Renders the audit replay page and syncs rrweb playback to the transport UI. */
 export function Replay() {
   const { replay, isLoading, navigate } = useReplayData()
   const location = useLocation()
   const [selectedTabId, setSelectedTabId] = useState<number | null>(null)
+  const [transition, setTransition] = useState<ChapterTransition | null>(null)
+  const [sequenceComplete, setSequenceComplete] = useState(false)
   const playerHandleRef = useRef<ReplayPlayerHandle | null>(null)
   const playbackTimeRef = useRef(0)
   const playbackSpeedRef = useRef(1)
   const playbackIsPlayingRef = useRef(true)
   const pendingTabSeekRef = useRef<number | null>(null)
-
-  useEffect(() => {
-    if (!replay) return
-    const firstTab = replay.tabs[0]
-    if (!firstTab) {
-      if (selectedTabId !== null) {
-        pendingTabSeekRef.current = 0
-        setSelectedTabId(null)
-      }
-      return
-    }
-    const selectedTab = replay.tabs.find((tab) => tab.tabId === selectedTabId)
-    if (!selectedTab) {
-      if (selectedTabId !== null) pendingTabSeekRef.current = 0
-      setSelectedTabId(firstTab.tabId)
-    }
-  }, [replay, selectedTabId])
+  const pendingTabPlaybackRef = useRef<'pause' | 'play'>('pause')
+  const transitionTimerRef = useRef<number | null>(null)
+  const transitionTokenRef = useRef(0)
+  const autoStartedSessionRef = useRef<string | null>(null)
 
   const tabViewInput = useMemo(
     () =>
@@ -59,16 +60,70 @@ export function Replay() {
         : null,
     [replay],
   )
-  const perTabView = useMemo(
+  const chapterViews = useMemo(
     () =>
-      tabViewInput ? buildTabView(tabViewInput, selectedTabId) : EMPTY_TAB_VIEW,
-    [selectedTabId, tabViewInput],
+      replay && tabViewInput
+        ? replay.tabs.map(({ tabId }) => buildTabView(tabViewInput, tabId))
+        : [],
+    [replay, tabViewInput],
+  )
+  const selectedTabIndex =
+    replay?.tabs.findIndex(({ tabId }) => tabId === selectedTabId) ?? -1
+  const perTabView =
+    selectedTabIndex >= 0
+      ? (chapterViews[selectedTabIndex] ?? EMPTY_TAB_VIEW)
+      : EMPTY_TAB_VIEW
+  const playableChapterIndices = useMemo(
+    () =>
+      chapterViews.flatMap((view, index) =>
+        isPlayableChapter(view) ? [index] : [],
+      ),
+    [chapterViews],
   )
 
-  const playbackTotalSeconds = perTabView.hasFullSnapshot
+  const playbackTotalSeconds = isPlayableChapter(perTabView)
     ? perTabView.totalSeconds
     : 0
   const playback = usePlayback(playbackTotalSeconds)
+  const playbackPlayRef = useRef(playback.play)
+
+  useEffect(() => {
+    playbackPlayRef.current = playback.play
+  }, [playback.play])
+
+  const invalidateTransition = useCallback(() => {
+    transitionTokenRef.current += 1
+    const timer = transitionTimerRef.current
+    transitionTimerRef.current = null
+    if (timer !== null) window.clearTimeout(timer)
+  }, [])
+
+  const cancelTransition = useCallback(() => {
+    invalidateTransition()
+    setTransition(null)
+  }, [invalidateTransition])
+
+  const scheduleTransition = useCallback(
+    (next: ChapterTransition, onFinished: () => void) => {
+      invalidateTransition()
+      const token = transitionTokenRef.current
+      setTransition(next)
+      transitionTimerRef.current = window.setTimeout(() => {
+        if (transitionTokenRef.current !== token) return
+        transitionTimerRef.current = null
+        setTransition(null)
+        onFinished()
+      }, CHAPTER_TRANSITION_MS)
+    },
+    [invalidateTransition],
+  )
+
+  useEffect(
+    () => () => {
+      invalidateTransition()
+    },
+    [invalidateTransition],
+  )
 
   useEffect(() => {
     playbackTimeRef.current = playback.time
@@ -92,25 +147,6 @@ export function Replay() {
     }
   }, [playback.isPlaying])
 
-  useEffect(() => {
-    if (!playback.isPlaying || playbackTotalSeconds === 0) return
-    let rafId = 0
-    let active = true
-    const sync = () => {
-      if (!active) return
-      const handle = playerHandleRef.current
-      const keepGoing = handle
-        ? playback.syncFromPlayer(handle.getCurrentTime() / 1000)
-        : true
-      if (keepGoing) rafId = window.requestAnimationFrame(sync)
-    }
-    rafId = window.requestAnimationFrame(sync)
-    return () => {
-      active = false
-      window.cancelAnimationFrame(rafId)
-    }
-  }, [playback.isPlaying, playback.syncFromPlayer, playbackTotalSeconds])
-
   const seekTo = useCallback(
     (seconds: number) => {
       const next = playback.seek(seconds)
@@ -125,33 +161,104 @@ export function Replay() {
   useEffect(() => {
     const pendingSeconds = pendingTabSeekRef.current
     if (pendingSeconds === null) return
+    const pendingPlayback = pendingTabPlaybackRef.current
     pendingTabSeekRef.current = null
     seekTo(pendingSeconds)
+    if (pendingPlayback === 'play') {
+      playbackTimeRef.current = pendingSeconds
+      playbackIsPlayingRef.current = true
+      playback.play()
+    }
   }, [seekTo, selectedTabId])
+
+  useEffect(() => {
+    if (!replay) return
+    const firstTab = replay.tabs[0]
+    if (!firstTab) {
+      if (selectedTabId !== null) {
+        cancelTransition()
+        pendingTabSeekRef.current = 0
+        setSelectedTabId(null)
+      }
+      return
+    }
+
+    const selectedTab = replay.tabs.find((tab) => tab.tabId === selectedTabId)
+    const firstPlayableIndex = playableChapterIndices[0]
+    if (firstPlayableIndex === undefined) {
+      if (!selectedTab) setSelectedTabId(firstTab.tabId)
+      return
+    }
+
+    if (autoStartedSessionRef.current !== replay.sessionId) {
+      autoStartedSessionRef.current = replay.sessionId
+      if (firstPlayableIndex > 0) {
+        playback.pause()
+        playbackIsPlayingRef.current = false
+        playerHandleRef.current?.pause()
+        pendingTabSeekRef.current = 0
+        pendingTabPlaybackRef.current = 'pause'
+        setSelectedTabId(
+          replay.tabs[firstPlayableIndex]?.tabId ?? firstTab.tabId,
+        )
+        scheduleTransition(
+          {
+            title: `Starting replay → Opening ${chapterName(replay, firstPlayableIndex)}`,
+            skipped: skippedChapterSummary(
+              Array.from({ length: firstPlayableIndex }, (_, index) => index),
+            ),
+          },
+          () => {
+            playbackIsPlayingRef.current = true
+            playbackPlayRef.current()
+          },
+        )
+        return
+      }
+    }
+
+    if (!selectedTab) {
+      if (selectedTabId !== null) {
+        pendingTabSeekRef.current = 0
+        pendingTabPlaybackRef.current = 'pause'
+      }
+      setSelectedTabId(firstTab.tabId)
+    }
+  }, [
+    cancelTransition,
+    playableChapterIndices,
+    playback.pause,
+    replay,
+    scheduleTransition,
+    selectedTabId,
+  ])
 
   const selectTab = useCallback(
     (value: string) => {
       const tabId = Number(value)
       if (!replay || !Number.isSafeInteger(tabId)) return
-      if (tabId === selectedTabId) return
+      cancelTransition()
+      setSequenceComplete(false)
+      playback.pause()
+      playbackIsPlayingRef.current = false
+      playerHandleRef.current?.pause()
+      if (tabId === selectedTabId) {
+        seekTo(0)
+        return
+      }
       pendingTabSeekRef.current = 0
+      pendingTabPlaybackRef.current = 'pause'
       setSelectedTabId(tabId)
     },
-    [replay, selectedTabId],
+    [cancelTransition, playback.pause, replay, seekTo, selectedTabId],
   )
 
   const selectFrame = useCallback(
     (frame: ReplayFrame) => {
-      if (!tabViewInput) return
-      const tabSeek = tabSeekForFrame(tabViewInput, selectedTabId, frame)
-      if (tabSeek.tabId !== null && tabSeek.tabId !== selectedTabId) {
-        pendingTabSeekRef.current = tabSeek.seconds
-        setSelectedTabId(tabSeek.tabId)
-        return
-      }
-      seekTo(tabSeek.seconds)
+      if (transition) return
+      seekTo(frame.t)
     },
-    [seekTo, selectedTabId, tabViewInput],
+    [seekTo, transition],
   )
 
   const onPlayerReady = useCallback((handle: ReplayPlayerHandle | null) => {
@@ -162,6 +269,138 @@ export function Replay() {
     handle.seek(ms)
     if (playbackIsPlayingRef.current) handle.play(ms)
   }, [])
+
+  const advanceChapter = useCallback(() => {
+    if (!replay || selectedTabIndex < 0) return
+    playback.pause()
+    playbackIsPlayingRef.current = false
+    playerHandleRef.current?.pause()
+
+    const nextPlayableIndex = playableChapterIndices.find(
+      (index) => index > selectedTabIndex,
+    )
+    if (nextPlayableIndex !== undefined) {
+      const skippedIndices = Array.from(
+        { length: nextPlayableIndex - selectedTabIndex - 1 },
+        (_, offset) => selectedTabIndex + offset + 1,
+      )
+      setSequenceComplete(false)
+      pendingTabSeekRef.current = 0
+      pendingTabPlaybackRef.current = 'pause'
+      setSelectedTabId(replay.tabs[nextPlayableIndex]?.tabId ?? null)
+      scheduleTransition(
+        {
+          title: `Tab ${selectedTabIndex + 1} complete → Opening ${chapterName(replay, nextPlayableIndex)}`,
+          skipped: skippedChapterSummary(skippedIndices),
+        },
+        () => {
+          playbackTimeRef.current = 0
+          playbackIsPlayingRef.current = true
+          playbackPlayRef.current()
+        },
+      )
+      return
+    }
+
+    const trailingSkippedIndices = Array.from(
+      { length: replay.tabs.length - selectedTabIndex - 1 },
+      (_, offset) => selectedTabIndex + offset + 1,
+    )
+    const finishSequence = () => {
+      setSequenceComplete(true)
+    }
+    if (trailingSkippedIndices.length > 0) {
+      scheduleTransition(
+        {
+          title: `Tab ${selectedTabIndex + 1} complete → Replay complete`,
+          skipped: skippedChapterSummary(trailingSkippedIndices),
+        },
+        finishSequence,
+      )
+    } else {
+      finishSequence()
+    }
+  }, [
+    playableChapterIndices,
+    playback.pause,
+    replay,
+    scheduleTransition,
+    selectedTabIndex,
+  ])
+
+  useEffect(() => {
+    if (!playback.isPlaying || playbackTotalSeconds === 0) return
+    let rafId = 0
+    let active = true
+    const sync = () => {
+      if (!active) return
+      const handle = playerHandleRef.current
+      const keepGoing = handle
+        ? playback.syncFromPlayer(handle.getCurrentTime() / 1000)
+        : true
+      if (keepGoing) {
+        rafId = window.requestAnimationFrame(sync)
+      } else {
+        advanceChapter()
+      }
+    }
+    rafId = window.requestAnimationFrame(sync)
+    return () => {
+      active = false
+      window.cancelAnimationFrame(rafId)
+    }
+  }, [
+    advanceChapter,
+    playback.isPlaying,
+    playback.syncFromPlayer,
+    playbackTotalSeconds,
+  ])
+
+  const toggleSequencePlayback = useCallback(() => {
+    if (transition) return
+    if (!sequenceComplete) {
+      playback.togglePlay()
+      return
+    }
+
+    const firstPlayableIndex = playableChapterIndices[0]
+    if (!replay || firstPlayableIndex === undefined) return
+    cancelTransition()
+    setSequenceComplete(false)
+    playback.pause()
+    playbackIsPlayingRef.current = false
+    playerHandleRef.current?.pause()
+    const firstPlayableTabId = replay.tabs[firstPlayableIndex]?.tabId ?? null
+    if (firstPlayableTabId === selectedTabId) {
+      seekTo(0)
+      playbackIsPlayingRef.current = true
+      playback.play()
+      return
+    }
+    pendingTabSeekRef.current = 0
+    pendingTabPlaybackRef.current = 'play'
+    setSelectedTabId(firstPlayableTabId)
+  }, [
+    cancelTransition,
+    playableChapterIndices,
+    playback,
+    replay,
+    seekTo,
+    selectedTabId,
+    sequenceComplete,
+    transition,
+  ])
+
+  const transportPlayback = useMemo(
+    () => ({ ...playback, togglePlay: toggleSequencePlayback }),
+    [playback, toggleSequencePlayback],
+  )
+  const seekFromTransport = useCallback(
+    (seconds: number) => {
+      if (!transition) seekTo(seconds)
+    },
+    [seekTo, transition],
+  )
 
   if (isLoading || !replay) {
     return (
@@ -192,12 +431,6 @@ export function Replay() {
     cameFromInAppFlow ? navigate(-1) : navigate(`/audit/${replay.sessionId}`)
   const currentTabFrameIndex = frameIndexAt(perTabView.frames, playback.time)
   const currentTabFrame = perTabView.frames[currentTabFrameIndex]
-  const currentTimelineFrameIndex =
-    currentTabFrame?.dispatchId !== undefined
-      ? replay.frames.findIndex(
-          (frame) => frame.dispatchId === currentTabFrame.dispatchId,
-        )
-      : -1
   const stats: { label: string; value: string }[] = [
     { label: 'Duration', value: replay.duration },
     { label: 'Steps', value: replay.steps },
@@ -245,16 +478,37 @@ export function Replay() {
 
       <div className="flex min-h-0 flex-1">
         <div className="flex min-w-0 flex-1 flex-col gap-3 p-4">
-          {replay.tabs.length > 1 && selectedTabId !== null && (
-            <Tabs value={selectedTabId.toString()} onValueChange={selectTab}>
-              <TabsList variant="line">
-                {replay.tabs.map(({ tabId }, idx) => (
-                  <TabsTrigger key={tabId} value={tabId.toString()}>
-                    Tab {idx + 1}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
-            </Tabs>
+          {selectedTabIndex >= 0 && (
+            <div className="flex min-h-9 items-center gap-3">
+              {replay.tabs.length > 1 && selectedTabId !== null && (
+                <Tabs
+                  value={selectedTabId.toString()}
+                  onValueChange={selectTab}
+                >
+                  <TabsList variant="line">
+                    {replay.tabs.map(({ tabId }, idx) => (
+                      <TabsTrigger key={tabId} value={tabId.toString()}>
+                        Tab {idx + 1}
+                      </TabsTrigger>
+                    ))}
+                  </TabsList>
+                </Tabs>
+              )}
+              <span
+                data-chapter-progress
+                className="ml-auto shrink-0 font-semibold text-ink-3 text-xs"
+              >
+                Tab {selectedTabIndex + 1} of {replay.tabs.length}
+              </span>
+              {sequenceComplete && (
+                <span
+                  role="status"
+                  className="shrink-0 rounded-full bg-accent-tint px-2.5 py-1 font-semibold text-accent-ink text-xs"
+                >
+                  Replay complete
+                </span>
+              )}
+            </div>
           )}
           {perTabView.incompleteUntilMs !== null && (
             <div
@@ -274,30 +528,50 @@ export function Replay() {
                 Recording incomplete — this replay contains a known gap
               </div>
             )}
-          {perTabView.hasFullSnapshot ? (
-            <>
-              <ReplayViewport
-                site={replay.site}
-                frame={currentTabFrame}
-                events={perTabView.events}
-                onPlayerReady={onPlayerReady}
-              />
+          <div className="relative flex min-h-0 flex-1 flex-col gap-3">
+            <div className="flex min-h-0 flex-1">
+              {isPlayableChapter(perTabView) ? (
+                <ReplayViewport
+                  site={replay.site}
+                  frame={currentTabFrame}
+                  events={perTabView.events}
+                  onPlayerReady={onPlayerReady}
+                />
+              ) : (
+                <div className="flex flex-1 items-center justify-center rounded-2xl border border-border-2 bg-card text-ink-3 text-sm shadow-sm">
+                  No visual recording for this tab
+                </div>
+              )}
+            </div>
+            {isPlayableChapter(perTabView) && (
               <PlaybackTransport
-                playback={playback}
+                playback={transportPlayback}
                 totalSeconds={perTabView.totalSeconds}
                 frames={perTabView.frames}
-                onSeek={seekTo}
+                onSeek={seekFromTransport}
               />
-            </>
-          ) : (
-            <div className="flex flex-1 items-center justify-center rounded-2xl border border-border-2 bg-card text-ink-3 text-sm shadow-sm">
-              No visual recording for this tab
-            </div>
-          )}
+            )}
+            {transition && (
+              <div
+                role="status"
+                data-chapter-transition
+                className="absolute inset-0 z-20 flex flex-col items-center justify-center rounded-2xl bg-ink-deep/95 px-8 text-center shadow-sm"
+              >
+                <div className="font-semibold text-base text-white">
+                  {transition.title}
+                </div>
+                {transition.skipped && (
+                  <div className="mt-2 text-sm text-white/70">
+                    {transition.skipped}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
         </div>
         <EventTimeline
-          frames={replay.frames}
-          currentFrameIndex={currentTimelineFrameIndex}
+          frames={perTabView.frames}
+          currentFrameIndex={currentTabFrameIndex}
           onSelectFrame={selectFrame}
         />
       </div>
@@ -310,4 +584,35 @@ function formatIncompleteOffset(milliseconds: number): string {
   const minutes = Math.floor(totalSeconds / 60)
   const seconds = totalSeconds % 60
   return `${minutes}:${String(seconds).padStart(2, '0')}`
+}
+
+function isPlayableChapter(view: TabView): boolean {
+  return (
+    view.hasFullSnapshot && view.events.length >= 2 && view.totalSeconds > 0
+  )
+}
+
+function chapterName(replay: ReplayData, chapterIndex: number): string {
+  const tabId = replay.tabs[chapterIndex]?.tabId
+  const tabUrl = replay.frames.find((frame) => frame.tabId === tabId)?.url
+  return `Tab ${chapterIndex + 1} · ${displayHost(tabUrl ?? replay.site)}`
+}
+
+function displayHost(value: string): string {
+  try {
+    const url = value.includes('://')
+      ? new URL(value)
+      : new URL(`https://${value}`)
+    return url.hostname || value
+  } catch {
+    return value
+  }
+}
+
+function skippedChapterSummary(indices: readonly number[]): string | null {
+  if (indices.length === 0) return null
+  if (indices.length === 1) {
+    return `Skipped Tab ${(indices[0] ?? 0) + 1} — no visual recording`
+  }
+  return `Skipped Tabs ${(indices[0] ?? 0) + 1}–${(indices.at(-1) ?? 0) + 1} — no visual recordings`
 }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -46,6 +46,7 @@ export function Replay() {
   const pendingTabPlaybackRef = useRef<'pause' | 'play'>('pause')
   const transitionTimerRef = useRef<number | null>(null)
   const transitionTokenRef = useRef(0)
+  const activeSessionRef = useRef<string | null>(null)
   const autoStartedSessionRef = useRef<string | null>(null)
 
   const tabViewInput = useMemo(
@@ -171,35 +172,77 @@ export function Replay() {
     }
   }, [seekTo, selectedTabId])
 
+  const resetTab = useCallback(
+    (tabId: number, autoplay: boolean) => {
+      playback.pause()
+      playbackTimeRef.current = 0
+      playbackIsPlayingRef.current = false
+      playerHandleRef.current?.pause()
+      if (tabId === selectedTabId) {
+        seekTo(0)
+        if (autoplay) {
+          playbackIsPlayingRef.current = true
+          playbackPlayRef.current()
+        }
+        return
+      }
+      pendingTabSeekRef.current = 0
+      pendingTabPlaybackRef.current = autoplay ? 'play' : 'pause'
+      setSelectedTabId(tabId)
+    },
+    [playback.pause, seekTo, selectedTabId],
+  )
+
   useEffect(() => {
     if (!replay) return
+    const sessionChanged = activeSessionRef.current !== replay.sessionId
+    if (sessionChanged) {
+      activeSessionRef.current = replay.sessionId
+      autoStartedSessionRef.current = null
+      cancelTransition()
+      setSequenceComplete(false)
+    }
+
     const firstTab = replay.tabs[0]
     if (!firstTab) {
       if (selectedTabId !== null) {
-        cancelTransition()
+        playback.pause()
+        playbackTimeRef.current = 0
+        playbackIsPlayingRef.current = false
+        playerHandleRef.current?.pause()
         pendingTabSeekRef.current = 0
         setSelectedTabId(null)
       }
       return
     }
 
-    const selectedTab = replay.tabs.find((tab) => tab.tabId === selectedTabId)
+    const selectedTab = sessionChanged
+      ? undefined
+      : replay.tabs.find((tab) => tab.tabId === selectedTabId)
     const firstPlayableIndex = playableChapterIndices[0]
     if (firstPlayableIndex === undefined) {
-      if (!selectedTab) setSelectedTabId(firstTab.tabId)
+      if (!selectedTab) resetTab(firstTab.tabId, false)
+      if (shouldCompleteNoVisualReplay(replay, autoStartedSessionRef.current)) {
+        autoStartedSessionRef.current = replay.sessionId
+        scheduleTransition(
+          {
+            title: 'No visual recordings → Replay complete',
+            skipped: skippedChapterSummary(
+              replay.tabs.map((_, index) => index),
+            ),
+          },
+          () => setSequenceComplete(true),
+        )
+      }
       return
     }
 
     if (autoStartedSessionRef.current !== replay.sessionId) {
       autoStartedSessionRef.current = replay.sessionId
       if (firstPlayableIndex > 0) {
-        playback.pause()
-        playbackIsPlayingRef.current = false
-        playerHandleRef.current?.pause()
-        pendingTabSeekRef.current = 0
-        pendingTabPlaybackRef.current = 'pause'
-        setSelectedTabId(
+        resetTab(
           replay.tabs[firstPlayableIndex]?.tabId ?? firstTab.tabId,
+          false,
         )
         scheduleTransition(
           {
@@ -215,20 +258,19 @@ export function Replay() {
         )
         return
       }
+      if (!selectedTab) {
+        resetTab(firstTab.tabId, true)
+        return
+      }
     }
 
-    if (!selectedTab) {
-      if (selectedTabId !== null) {
-        pendingTabSeekRef.current = 0
-        pendingTabPlaybackRef.current = 'pause'
-      }
-      setSelectedTabId(firstTab.tabId)
-    }
+    if (!selectedTab) resetTab(firstTab.tabId, false)
   }, [
     cancelTransition,
     playableChapterIndices,
     playback.pause,
     replay,
+    resetTab,
     scheduleTransition,
     selectedTabId,
   ])
@@ -239,23 +281,15 @@ export function Replay() {
       if (!replay || !Number.isSafeInteger(tabId)) return
       cancelTransition()
       setSequenceComplete(false)
-      playback.pause()
-      playbackIsPlayingRef.current = false
-      playerHandleRef.current?.pause()
-      if (tabId === selectedTabId) {
-        seekTo(0)
-        return
-      }
-      pendingTabSeekRef.current = 0
-      pendingTabPlaybackRef.current = 'pause'
-      setSelectedTabId(tabId)
+      resetTab(tabId, false)
     },
-    [cancelTransition, playback.pause, replay, seekTo, selectedTabId],
+    [cancelTransition, replay, resetTab],
   )
 
   const selectFrame = useCallback(
     (frame: ReplayFrame) => {
       if (transition) return
+      setSequenceComplete(false)
       seekTo(frame.t)
     },
     [seekTo, transition],
@@ -272,9 +306,6 @@ export function Replay() {
 
   const advanceChapter = useCallback(() => {
     if (!replay || selectedTabIndex < 0) return
-    playback.pause()
-    playbackIsPlayingRef.current = false
-    playerHandleRef.current?.pause()
 
     const nextPlayableIndex = playableChapterIndices.find(
       (index) => index > selectedTabIndex,
@@ -285,9 +316,9 @@ export function Replay() {
         (_, offset) => selectedTabIndex + offset + 1,
       )
       setSequenceComplete(false)
-      pendingTabSeekRef.current = 0
-      pendingTabPlaybackRef.current = 'pause'
-      setSelectedTabId(replay.tabs[nextPlayableIndex]?.tabId ?? null)
+      const nextTab = replay.tabs[nextPlayableIndex]
+      if (!nextTab) return
+      resetTab(nextTab.tabId, false)
       scheduleTransition(
         {
           title: `Tab ${selectedTabIndex + 1} complete → Opening ${chapterName(replay, nextPlayableIndex)}`,
@@ -322,8 +353,8 @@ export function Replay() {
     }
   }, [
     playableChapterIndices,
-    playback.pause,
     replay,
+    resetTab,
     scheduleTransition,
     selectedTabIndex,
   ])
@@ -367,26 +398,14 @@ export function Replay() {
     if (!replay || firstPlayableIndex === undefined) return
     cancelTransition()
     setSequenceComplete(false)
-    playback.pause()
-    playbackIsPlayingRef.current = false
-    playerHandleRef.current?.pause()
-    const firstPlayableTabId = replay.tabs[firstPlayableIndex]?.tabId ?? null
-    if (firstPlayableTabId === selectedTabId) {
-      seekTo(0)
-      playbackIsPlayingRef.current = true
-      playback.play()
-      return
-    }
-    pendingTabSeekRef.current = 0
-    pendingTabPlaybackRef.current = 'play'
-    setSelectedTabId(firstPlayableTabId)
+    const firstPlayableTab = replay.tabs[firstPlayableIndex]
+    if (firstPlayableTab) resetTab(firstPlayableTab.tabId, true)
   }, [
     cancelTransition,
     playableChapterIndices,
     playback,
     replay,
-    seekTo,
-    selectedTabId,
+    resetTab,
     sequenceComplete,
     transition,
   ])
@@ -397,7 +416,9 @@ export function Replay() {
   )
   const seekFromTransport = useCallback(
     (seconds: number) => {
-      if (!transition) seekTo(seconds)
+      if (transition) return
+      setSequenceComplete(false)
+      seekTo(seconds)
     },
     [seekTo, transition],
   )
@@ -487,7 +508,15 @@ export function Replay() {
                 >
                   <TabsList variant="line">
                     {replay.tabs.map(({ tabId }, idx) => (
-                      <TabsTrigger key={tabId} value={tabId.toString()}>
+                      <TabsTrigger
+                        key={tabId}
+                        value={tabId.toString()}
+                        onClick={
+                          tabId === selectedTabId
+                            ? () => selectTab(tabId.toString())
+                            : undefined
+                        }
+                      >
                         Tab {idx + 1}
                       </TabsTrigger>
                     ))}
@@ -594,7 +623,9 @@ function isPlayableChapter(view: TabView): boolean {
 
 function chapterName(replay: ReplayData, chapterIndex: number): string {
   const tabId = replay.tabs[chapterIndex]?.tabId
-  const tabUrl = replay.frames.find((frame) => frame.tabId === tabId)?.url
+  const tabUrl = replay.frames.find(
+    (frame) => frame.tabId === tabId && frame.url,
+  )?.url
   return `Tab ${chapterIndex + 1} · ${displayHost(tabUrl ?? replay.site)}`
 }
 
@@ -615,4 +646,15 @@ function skippedChapterSummary(indices: readonly number[]): string | null {
     return `Skipped Tab ${(indices[0] ?? 0) + 1} — no visual recording`
   }
   return `Skipped Tabs ${(indices[0] ?? 0) + 1}–${(indices.at(-1) ?? 0) + 1} — no visual recordings`
+}
+
+function shouldCompleteNoVisualReplay(
+  replay: ReplayData,
+  autoStartedSessionId: string | null,
+): boolean {
+  return (
+    replay.complete === true &&
+    replay.eventsLoaded &&
+    autoStartedSessionId !== replay.sessionId
+  )
 }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -25,8 +25,10 @@ import { frameIndexAt } from './replay.helpers'
 import { usePlayback } from './use-playback'
 
 const CHAPTER_TRANSITION_MS = 1_000
+const STATIC_CHAPTER_SECONDS = 0.001
 
 interface ChapterTransition {
+  kind: 'chapter' | 'empty'
   title: string
   skipped: string | null
 }
@@ -48,6 +50,7 @@ export function Replay() {
   const transitionTokenRef = useRef(0)
   const activeSessionRef = useRef<string | null>(null)
   const autoStartedSessionRef = useRef<string | null>(null)
+  const operatorControlledSessionRef = useRef<string | null>(null)
 
   const tabViewInput = useMemo(
     () =>
@@ -82,9 +85,7 @@ export function Replay() {
     [chapterViews],
   )
 
-  const playbackTotalSeconds = isPlayableChapter(perTabView)
-    ? perTabView.totalSeconds
-    : 0
+  const playbackTotalSeconds = chapterPlaybackSeconds(perTabView)
   const playback = usePlayback(playbackTotalSeconds)
   const playbackPlayRef = useRef(playback.play)
 
@@ -193,12 +194,81 @@ export function Replay() {
     [playback.pause, seekTo, selectedTabId],
   )
 
+  const initializeEmptyReplay = useCallback(
+    (
+      currentReplay: ReplayData,
+      firstTabId: number,
+      hasSelectedTab: boolean,
+    ) => {
+      if (!hasSelectedTab) resetTab(firstTabId, false)
+      if (
+        !shouldCompleteNoVisualReplay(
+          currentReplay,
+          autoStartedSessionRef.current,
+        )
+      ) {
+        return
+      }
+      autoStartedSessionRef.current = currentReplay.sessionId
+      scheduleTransition(
+        {
+          kind: 'empty',
+          title: 'No visual recordings → Replay complete',
+          skipped: skippedChapterSummary(
+            currentReplay.tabs.map((_, index) => index),
+          ),
+        },
+        () => setSequenceComplete(true),
+      )
+    },
+    [resetTab, scheduleTransition],
+  )
+
+  const startInitialChapter = useCallback(
+    (
+      currentReplay: ReplayData,
+      firstTabId: number,
+      firstPlayableIndex: number,
+      hasSelectedTab: boolean,
+    ) => {
+      autoStartedSessionRef.current = currentReplay.sessionId
+      if (operatorControlledSessionRef.current === currentReplay.sessionId) {
+        if (!hasSelectedTab) resetTab(firstTabId, false)
+        return
+      }
+      if (firstPlayableIndex === 0) {
+        resetTab(firstTabId, true)
+        return
+      }
+
+      resetTab(
+        currentReplay.tabs[firstPlayableIndex]?.tabId ?? firstTabId,
+        false,
+      )
+      scheduleTransition(
+        {
+          kind: 'chapter',
+          title: `Starting replay → Opening ${chapterName(currentReplay, firstPlayableIndex)}`,
+          skipped: skippedChapterSummary(
+            Array.from({ length: firstPlayableIndex }, (_, index) => index),
+          ),
+        },
+        () => {
+          playbackIsPlayingRef.current = true
+          playbackPlayRef.current()
+        },
+      )
+    },
+    [resetTab, scheduleTransition],
+  )
+
   useEffect(() => {
     if (!replay) return
     const sessionChanged = activeSessionRef.current !== replay.sessionId
     if (sessionChanged) {
       activeSessionRef.current = replay.sessionId
       autoStartedSessionRef.current = null
+      operatorControlledSessionRef.current = null
       cancelTransition()
       setSequenceComplete(false)
     }
@@ -220,65 +290,49 @@ export function Replay() {
       ? undefined
       : replay.tabs.find((tab) => tab.tabId === selectedTabId)
     const firstPlayableIndex = playableChapterIndices[0]
+    const invalidEmptyTransition =
+      transition?.kind === 'empty' &&
+      (firstPlayableIndex !== undefined ||
+        !replay.eventsLoaded ||
+        replay.complete !== true)
+    if (invalidEmptyTransition) {
+      cancelTransition()
+      autoStartedSessionRef.current = null
+      setSequenceComplete(false)
+    }
     if (firstPlayableIndex === undefined) {
-      if (!selectedTab) resetTab(firstTab.tabId, false)
-      if (shouldCompleteNoVisualReplay(replay, autoStartedSessionRef.current)) {
-        autoStartedSessionRef.current = replay.sessionId
-        scheduleTransition(
-          {
-            title: 'No visual recordings → Replay complete',
-            skipped: skippedChapterSummary(
-              replay.tabs.map((_, index) => index),
-            ),
-          },
-          () => setSequenceComplete(true),
-        )
-      }
+      initializeEmptyReplay(replay, firstTab.tabId, selectedTab !== undefined)
       return
     }
 
     if (autoStartedSessionRef.current !== replay.sessionId) {
-      autoStartedSessionRef.current = replay.sessionId
-      if (firstPlayableIndex > 0) {
-        resetTab(
-          replay.tabs[firstPlayableIndex]?.tabId ?? firstTab.tabId,
-          false,
-        )
-        scheduleTransition(
-          {
-            title: `Starting replay → Opening ${chapterName(replay, firstPlayableIndex)}`,
-            skipped: skippedChapterSummary(
-              Array.from({ length: firstPlayableIndex }, (_, index) => index),
-            ),
-          },
-          () => {
-            playbackIsPlayingRef.current = true
-            playbackPlayRef.current()
-          },
-        )
-        return
-      }
-      if (!selectedTab) {
-        resetTab(firstTab.tabId, true)
-        return
-      }
+      startInitialChapter(
+        replay,
+        firstTab.tabId,
+        firstPlayableIndex,
+        selectedTab !== undefined,
+      )
+      return
     }
 
     if (!selectedTab) resetTab(firstTab.tabId, false)
   }, [
     cancelTransition,
+    initializeEmptyReplay,
     playableChapterIndices,
     playback.pause,
     replay,
     resetTab,
-    scheduleTransition,
     selectedTabId,
+    startInitialChapter,
+    transition,
   ])
 
   const selectTab = useCallback(
     (value: string) => {
       const tabId = Number(value)
       if (!replay || !Number.isSafeInteger(tabId)) return
+      operatorControlledSessionRef.current = replay.sessionId
       cancelTransition()
       setSequenceComplete(false)
       resetTab(tabId, false)
@@ -289,10 +343,11 @@ export function Replay() {
   const selectFrame = useCallback(
     (frame: ReplayFrame) => {
       if (transition) return
+      if (replay) operatorControlledSessionRef.current = replay.sessionId
       setSequenceComplete(false)
       seekTo(frame.t)
     },
-    [seekTo, transition],
+    [replay, seekTo, transition],
   )
 
   const onPlayerReady = useCallback((handle: ReplayPlayerHandle | null) => {
@@ -321,6 +376,7 @@ export function Replay() {
       resetTab(nextTab.tabId, false)
       scheduleTransition(
         {
+          kind: 'chapter',
           title: `Tab ${selectedTabIndex + 1} complete → Opening ${chapterName(replay, nextPlayableIndex)}`,
           skipped: skippedChapterSummary(skippedIndices),
         },
@@ -343,6 +399,7 @@ export function Replay() {
     if (trailingSkippedIndices.length > 0) {
       scheduleTransition(
         {
+          kind: 'chapter',
           title: `Tab ${selectedTabIndex + 1} complete → Replay complete`,
           skipped: skippedChapterSummary(trailingSkippedIndices),
         },
@@ -417,10 +474,11 @@ export function Replay() {
   const seekFromTransport = useCallback(
     (seconds: number) => {
       if (transition) return
+      if (replay) operatorControlledSessionRef.current = replay.sessionId
       setSequenceComplete(false)
       seekTo(seconds)
     },
-    [seekTo, transition],
+    [replay, seekTo, transition],
   )
 
   if (isLoading || !replay) {
@@ -575,7 +633,7 @@ export function Replay() {
             {isPlayableChapter(perTabView) && (
               <PlaybackTransport
                 playback={transportPlayback}
-                totalSeconds={perTabView.totalSeconds}
+                totalSeconds={playbackTotalSeconds}
                 frames={perTabView.frames}
                 onSeek={seekFromTransport}
               />
@@ -616,9 +674,12 @@ function formatIncompleteOffset(milliseconds: number): string {
 }
 
 function isPlayableChapter(view: TabView): boolean {
-  return (
-    view.hasFullSnapshot && view.events.length >= 2 && view.totalSeconds > 0
-  )
+  return view.hasFullSnapshot && view.events.length >= 2
+}
+
+function chapterPlaybackSeconds(view: TabView): number {
+  if (!isPlayableChapter(view)) return 0
+  return Math.max(view.totalSeconds, STATIC_CHAPTER_SECONDS)
 }
 
 function chapterName(replay: ReplayData, chapterIndex: number): string {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -105,15 +105,15 @@ export function useReplayData(): UseReplayDataResult {
     variables: { sessionId },
     enabled: sessionId.length > 0,
   })
-  const eventsQuery = useReplayEvents({
-    variables: { sessionId },
-    enabled: false,
-  })
   const metadataRevision = replayEventsRevision(metadataQuery.data)
   const sessionRevision =
     metadataRevision === null ? null : `${sessionId}:${metadataRevision}`
+  const eventsQuery = useReplayEvents({
+    variables: { sessionId, revision: sessionRevision ?? '' },
+    enabled: false,
+  })
   const requestedRevision = useRef<string | null>(null)
-  const refreshChainRef = useRef<Promise<void>>(Promise.resolve())
+  const requestGenerationRef = useRef(0)
   const retryTimerRef = useRef<number | null>(null)
   const mountedRef = useRef(false)
   const [refreshAttempt, setRefreshAttempt] = useState(0)
@@ -145,38 +145,39 @@ export function useReplayData(): UseReplayDataResult {
       retryTimerRef.current = null
     }
     requestedRevision.current = sessionRevision
+    const requestGeneration = ++requestGenerationRef.current
     // Metadata owns event downloads so each accepted payload can be attributed
     // to the exact revision that requested it, even when revisions race.
-    refreshChainRef.current = refreshChainRef.current
-      .then(async () => {
-        if (requestedRevision.current !== sessionRevision) return
-        try {
-          const result = await eventsQuery.refetch()
-          if (
-            result.isSuccess &&
-            result.data &&
-            requestedRevision.current === sessionRevision
-          ) {
-            setResolvedEventSnapshot({
-              sessionId,
-              revision: sessionRevision,
-              events: result.data.events,
-            })
-            return
-          }
-        } catch {}
+    void (async () => {
+      try {
+        const result = await eventsQuery.refetch()
         if (
+          result.isSuccess &&
+          result.data &&
           mountedRef.current &&
+          requestGenerationRef.current === requestGeneration &&
           requestedRevision.current === sessionRevision
         ) {
-          requestedRevision.current = null
-          retryTimerRef.current = window.setTimeout(() => {
-            retryTimerRef.current = null
-            setRefreshAttempt((attempt) => attempt + 1)
-          }, EVENT_SNAPSHOT_RETRY_MS)
+          setResolvedEventSnapshot({
+            sessionId,
+            revision: sessionRevision,
+            events: result.data.events,
+          })
+          return
         }
-      })
-      .catch(() => undefined)
+      } catch {}
+      if (
+        mountedRef.current &&
+        requestGenerationRef.current === requestGeneration &&
+        requestedRevision.current === sessionRevision
+      ) {
+        requestedRevision.current = null
+        retryTimerRef.current = window.setTimeout(() => {
+          retryTimerRef.current = null
+          setRefreshAttempt((attempt) => attempt + 1)
+        }, EVENT_SNAPSHOT_RETRY_MS)
+      }
+    })()
   }, [eventsQuery.refetch, refreshAttempt, sessionId, sessionRevision])
   const hasCurrentSessionSnapshot =
     resolvedEventSnapshot?.sessionId === sessionId

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -5,7 +5,7 @@
  */
 
 import type { RecordingMetadata } from '@browseros/claw-api'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import type { RunStatus } from '@/lib/status'
 import {
@@ -69,7 +69,7 @@ export interface ReplayData {
   frames: ReplayFrame[]
   complete: boolean | null
   tabs: ReplayTabData[]
-  /** True once the downloadable event snapshot has resolved, including 404-empty. */
+  /** True once events for the current metadata revision resolve, including 404-empty. */
   eventsLoaded: boolean
   eventsForTab: (tabId: number) => readonly ReplayEvent[]
 }
@@ -108,15 +108,31 @@ export function useReplayData(): UseReplayDataResult {
     enabled: sessionId.length > 0,
   })
   const metadataRevision = replayEventsRevision(metadataQuery.data)
+  const sessionRevision =
+    metadataRevision === null ? null : `${sessionId}:${metadataRevision}`
   const requestedRevision = useRef<string | null>(null)
+  const [resolvedEventsRevision, setResolvedEventsRevision] = useState<
+    string | null
+  >(null)
   useEffect(() => {
-    if (metadataRevision === null) return
-    const sessionRevision = `${sessionId}:${metadataRevision}`
-    if (requestedRevision.current === sessionRevision) return
+    if (
+      sessionRevision === null ||
+      requestedRevision.current === sessionRevision
+    ) {
+      return
+    }
     requestedRevision.current = sessionRevision
-    void eventsQuery.refetch()
-  }, [eventsQuery.refetch, metadataRevision, sessionId])
-  const events = eventsQuery.data?.events ?? EMPTY_REPLAY_EVENTS
+    void eventsQuery.refetch().then((result) => {
+      if (result.isSuccess && requestedRevision.current === sessionRevision) {
+        setResolvedEventsRevision(sessionRevision)
+      }
+    })
+  }, [eventsQuery.refetch, sessionRevision])
+  const eventsLoaded =
+    sessionRevision !== null && resolvedEventsRevision === sessionRevision
+  const events = eventsLoaded
+    ? (eventsQuery.data?.events ?? EMPTY_REPLAY_EVENTS)
+    : EMPTY_REPLAY_EVENTS
   const eventCatalog = useMemo(() => buildReplayEventCatalog(events), [events])
   const replay = useMemo<ReplayData | null>(() => {
     if (!taskQuery.data) return null
@@ -124,9 +140,9 @@ export function useReplayData(): UseReplayDataResult {
       taskQuery.data,
       eventCatalog,
       metadataQuery.data,
-      eventsQuery.data !== undefined,
+      eventsLoaded,
     )
-  }, [taskQuery.data, eventCatalog, eventsQuery.data, metadataQuery.data])
+  }, [taskQuery.data, eventCatalog, eventsLoaded, metadataQuery.data])
 
   return {
     replay,

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -69,6 +69,8 @@ export interface ReplayData {
   frames: ReplayFrame[]
   complete: boolean | null
   tabs: ReplayTabData[]
+  /** True once the downloadable event snapshot has resolved, including 404-empty. */
+  eventsLoaded: boolean
   eventsForTab: (tabId: number) => readonly ReplayEvent[]
 }
 
@@ -118,8 +120,13 @@ export function useReplayData(): UseReplayDataResult {
   const eventCatalog = useMemo(() => buildReplayEventCatalog(events), [events])
   const replay = useMemo<ReplayData | null>(() => {
     if (!taskQuery.data) return null
-    return buildReplayData(taskQuery.data, eventCatalog, metadataQuery.data)
-  }, [taskQuery.data, eventCatalog, metadataQuery.data])
+    return buildReplayData(
+      taskQuery.data,
+      eventCatalog,
+      metadataQuery.data,
+      eventsQuery.data !== undefined,
+    )
+  }, [taskQuery.data, eventCatalog, eventsQuery.data, metadataQuery.data])
 
   return {
     replay,
@@ -134,6 +141,7 @@ function buildReplayData(
   detail: TaskDetail,
   eventCatalog: ReplayEventCatalog,
   metadata: RecordingMetadata | undefined,
+  eventsLoaded: boolean,
 ): ReplayData {
   const { session: task, dispatches } = detail
   const sessionStartMs = task.startedAt
@@ -172,6 +180,7 @@ function buildReplayData(
     frames,
     complete: metadata?.complete ?? null,
     tabs,
+    eventsLoaded,
     eventsForTab: eventCatalog.eventsForTab,
   }
 }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -105,15 +105,18 @@ export function useReplayData(): UseReplayDataResult {
   })
   const eventsQuery = useReplayEvents({
     variables: { sessionId },
-    enabled: sessionId.length > 0,
+    enabled: false,
   })
   const metadataRevision = replayEventsRevision(metadataQuery.data)
   const sessionRevision =
     metadataRevision === null ? null : `${sessionId}:${metadataRevision}`
   const requestedRevision = useRef<string | null>(null)
-  const [resolvedEventsRevision, setResolvedEventsRevision] = useState<
-    string | null
-  >(null)
+  const refreshChainRef = useRef<Promise<void>>(Promise.resolve())
+  const [resolvedEventSnapshot, setResolvedEventSnapshot] = useState<{
+    sessionId: string
+    revision: string
+    events: readonly ReplayEvent[]
+  } | null>(null)
   useEffect(() => {
     if (
       sessionRevision === null ||
@@ -122,16 +125,34 @@ export function useReplayData(): UseReplayDataResult {
       return
     }
     requestedRevision.current = sessionRevision
-    void eventsQuery.refetch().then((result) => {
-      if (result.isSuccess && requestedRevision.current === sessionRevision) {
-        setResolvedEventsRevision(sessionRevision)
-      }
-    })
-  }, [eventsQuery.refetch, sessionRevision])
+    // Metadata owns event downloads so each accepted payload can be attributed
+    // to the exact revision that requested it, even when revisions race.
+    refreshChainRef.current = refreshChainRef.current
+      .then(async () => {
+        if (requestedRevision.current !== sessionRevision) return
+        const result = await eventsQuery.refetch()
+        if (
+          result.isSuccess &&
+          result.data &&
+          requestedRevision.current === sessionRevision
+        ) {
+          setResolvedEventSnapshot({
+            sessionId,
+            revision: sessionRevision,
+            events: result.data.events,
+          })
+        }
+      })
+      .catch(() => undefined)
+  }, [eventsQuery.refetch, sessionId, sessionRevision])
+  const hasCurrentSessionSnapshot =
+    resolvedEventSnapshot?.sessionId === sessionId
   const eventsLoaded =
-    sessionRevision !== null && resolvedEventsRevision === sessionRevision
-  const events = eventsLoaded
-    ? (eventsQuery.data?.events ?? EMPTY_REPLAY_EVENTS)
+    sessionRevision !== null &&
+    hasCurrentSessionSnapshot &&
+    resolvedEventSnapshot?.revision === sessionRevision
+  const events = hasCurrentSessionSnapshot
+    ? resolvedEventSnapshot.events
     : EMPTY_REPLAY_EVENTS
   const eventCatalog = useMemo(() => buildReplayEventCatalog(events), [events])
   const replay = useMemo<ReplayData | null>(() => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -30,6 +30,8 @@ import {
   type ReplayEventCatalog,
 } from './replay-events'
 
+const EVENT_SNAPSHOT_RETRY_MS = 10_000
+
 export interface ReplaySegmentData {
   documentId: string
   targetId?: string | null
@@ -112,11 +114,25 @@ export function useReplayData(): UseReplayDataResult {
     metadataRevision === null ? null : `${sessionId}:${metadataRevision}`
   const requestedRevision = useRef<string | null>(null)
   const refreshChainRef = useRef<Promise<void>>(Promise.resolve())
+  const retryTimerRef = useRef<number | null>(null)
+  const mountedRef = useRef(false)
+  const [refreshAttempt, setRefreshAttempt] = useState(0)
   const [resolvedEventSnapshot, setResolvedEventSnapshot] = useState<{
     sessionId: string
     revision: string
     events: readonly ReplayEvent[]
   } | null>(null)
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      if (retryTimerRef.current !== null) {
+        window.clearTimeout(retryTimerRef.current)
+        retryTimerRef.current = null
+      }
+    }
+  }, [])
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshAttempt re-arms the same revision after query retries are exhausted.
   useEffect(() => {
     if (
       sessionRevision === null ||
@@ -124,27 +140,44 @@ export function useReplayData(): UseReplayDataResult {
     ) {
       return
     }
+    if (retryTimerRef.current !== null) {
+      window.clearTimeout(retryTimerRef.current)
+      retryTimerRef.current = null
+    }
     requestedRevision.current = sessionRevision
     // Metadata owns event downloads so each accepted payload can be attributed
     // to the exact revision that requested it, even when revisions race.
     refreshChainRef.current = refreshChainRef.current
       .then(async () => {
         if (requestedRevision.current !== sessionRevision) return
-        const result = await eventsQuery.refetch()
+        try {
+          const result = await eventsQuery.refetch()
+          if (
+            result.isSuccess &&
+            result.data &&
+            requestedRevision.current === sessionRevision
+          ) {
+            setResolvedEventSnapshot({
+              sessionId,
+              revision: sessionRevision,
+              events: result.data.events,
+            })
+            return
+          }
+        } catch {}
         if (
-          result.isSuccess &&
-          result.data &&
+          mountedRef.current &&
           requestedRevision.current === sessionRevision
         ) {
-          setResolvedEventSnapshot({
-            sessionId,
-            revision: sessionRevision,
-            events: result.data.events,
-          })
+          requestedRevision.current = null
+          retryTimerRef.current = window.setTimeout(() => {
+            retryTimerRef.current = null
+            setRefreshAttempt((attempt) => attempt + 1)
+          }, EVENT_SNAPSHOT_RETRY_MS)
         }
       })
       .catch(() => undefined)
-  }, [eventsQuery.refetch, sessionId, sessionRevision])
+  }, [eventsQuery.refetch, refreshAttempt, sessionId, sessionRevision])
   const hasCurrentSessionSnapshot =
     resolvedEventSnapshot?.sessionId === sessionId
   const eventsLoaded =

--- a/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
@@ -9,6 +9,10 @@ export interface Playback {
   /** Multiplier applied by rrweb's internal timer. */
   speed: number
   setSpeed: (next: number) => void
+  /** Starts playback, restarting from zero after local completion. */
+  play: () => void
+  /** Pauses playback without moving the local playhead. */
+  pause: () => void
   /** Toggles play/pause. Restarts from 0 if the session already finished. */
   togglePlay: () => void
   /** Jumps the playhead to `seconds` and pauses. */
@@ -36,6 +40,15 @@ export function usePlayback(totalSeconds: number): Playback {
 
   const setPlaybackSpeed = useCallback((next: number) => {
     if (PLAYBACK_SPEEDS.includes(next)) setSpeed(next)
+  }, [])
+
+  const play = useCallback(() => {
+    setTime((prev) => (prev >= totalSeconds ? 0 : prev))
+    setIsPlaying(totalSeconds > 0)
+  }, [totalSeconds])
+
+  const pause = useCallback(() => {
+    setIsPlaying(false)
   }, [])
 
   const togglePlay = useCallback(() => {
@@ -77,6 +90,8 @@ export function usePlayback(totalSeconds: number): Playback {
     isPlaying,
     speed,
     setSpeed: setPlaybackSpeed,
+    play,
+    pause,
     togglePlay,
     seek,
     syncFromPlayer,

--- a/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { DEFAULT_PLAYBACK_SPEED, PLAYBACK_SPEEDS } from './replay.helpers'
 
 export interface Playback {
-  /** Seconds elapsed in the session. */
+  /** Seconds elapsed in the selected tab's local recording. */
   time: number
   /** True while rrweb's internal timer should be running. */
   isPlaying: boolean
@@ -13,7 +13,7 @@ export interface Playback {
   play: () => void
   /** Pauses playback without moving the local playhead. */
   pause: () => void
-  /** Toggles play/pause. Restarts from 0 if the session already finished. */
+  /** Toggles play/pause. Restarts from 0 if the chapter already finished. */
   togglePlay: () => void
   /** Jumps the playhead to `seconds` and pauses. */
   seek: (seconds: number) => number


### PR DESCRIPTION
## Summary

- Treat recorded Chrome tabs as first-activity-ordered replay chapters, playing each visual recording fully before a fixed one-second explanatory handoff.
- Keep the selected tab, event timeline, warnings, scrubber, rrweb viewport, and 1x/2x/4x speed on one tab-local transport with one live Replayer.
- Skip missing visual chapters with stable full-list numbering, support manual reset/cancellation and sequence restart, and safely absorb late recording revisions without stale timers or false completion.

This is built from the clean `main` replay. It does not reuse the camera, global-clock, or double-buffer orchestration from #2019.

## Test plan

- `bun run scripts/run-bun-test.ts apps/claw-app/screens/replay/Replay.test.tsx apps/claw-app/screens/replay/ReplayViewport.test.tsx apps/claw-app/screens/replay/PlaybackTransport.test.tsx apps/claw-app/screens/replay/tab-view.test.ts apps/claw-app/screens/replay/replay-events.test.ts apps/claw-app/screens/replay/replay.data.test.ts`
- `bun run --filter @browseros/claw-app typecheck`
- `bun run check`
- `bun run test`

All Replay component regressions run under React Strict Mode.
