### PR TITLE
docs(acpx-ai-provider): finish workspace consolidation

### DIFF
--- a/packages/browseros-agent/packages/acpx-ai-provider/PROVENANCE.md
+++ b/packages/browseros-agent/packages/acpx-ai-provider/PROVENANCE.md
@@ -1,6 +1,6 @@
 # Provenance
 
-Inlined snapshot of `acpx-ai-provider` from https://github.com/DaniAkash/acpx (monorepo path `packages/acpx-ai-provider`).
+Inlined snapshot of `acpx-ai-provider` from https://github.com/DaniAkash/agent-toolkit (monorepo path `packages/acpx-ai-provider`). The repository was previously named `DaniAkash/acpx`; historical metadata in the pinned tag may still use that name.
 
 - Upstream commit: `ffb54400bf581e61c4cfcba3dccfcb72bc5cd44d`
 - Upstream tag: `acpx-ai-provider-v0.0.6`

--- a/packages/browseros-agent/packages/acpx-ai-provider/README.md
+++ b/packages/browseros-agent/packages/acpx-ai-provider/README.md
@@ -1,9 +1,14 @@
-# acpx-ai-provider
+# @browseros/acpx-ai-provider
 
 > Vercel AI SDK provider on top of [`acpx/runtime`](https://www.npmjs.com/package/acpx).
 > One install, any ACP agent — Claude Code, Codex, Gemini, Copilot, Cursor, Pi, and more.
 
-[![npm](https://img.shields.io/npm/v/acpx-ai-provider.svg)](https://www.npmjs.com/package/acpx-ai-provider)
+> [!NOTE]
+> This is BrowserOS's in-repo fork of
+> [`acpx-ai-provider`](https://github.com/DaniAkash/agent-toolkit/tree/acpx-ai-provider-v0.0.6/packages/acpx-ai-provider).
+> Internal consumers use the scoped workspace package. See
+> [PROVENANCE.md](./PROVENANCE.md) for the pinned upstream revision and local
+> adaptations.
 
 > [!WARNING]
 > **Alpha software.** Both this package and its underlying runtime
@@ -21,7 +26,7 @@ bridges Vercel AI SDK to the Agent Client Protocol via the bare
 install each agent's CLI and write their own `{ command, args }`
 spawn config.
 
-`acpx-ai-provider` sits one level higher — on top of `acpx/runtime` — so:
+`@browseros/acpx-ai-provider` sits one level higher — on top of `acpx/runtime` — so:
 
 - **Zero extra installs.** `acpx` resolves and `npx`-spawns built-in
   agents (Claude, Codex, Gemini, Copilot, Cursor, Pi, etc.) on first
@@ -33,10 +38,14 @@ spawn config.
 
 ## Install
 
-```bash
-bun add acpx-ai-provider acpx ai
-# or
-npm i acpx-ai-provider acpx ai
+```json
+{
+  "dependencies": {
+    "@browseros/acpx-ai-provider": "workspace:*",
+    "acpx": "^0.12.0",
+    "ai": "6.0.230"
+  }
+}
 ```
 
 `acpx` and `ai` are peer dependencies. Use `ai` ≥ 6, `acpx` ≥ 0.6.
@@ -44,7 +53,7 @@ npm i acpx-ai-provider acpx ai
 ## Quickstart
 
 ```ts
-import { createAcpxProvider } from 'acpx-ai-provider'
+import { createAcpxProvider } from '@browseros/acpx-ai-provider'
 import { generateText } from 'ai'
 
 const provider = createAcpxProvider({
@@ -66,7 +75,7 @@ adapter on first run; subsequent runs are warm.
 ### Streaming
 
 ```ts
-import { createAcpxProvider } from 'acpx-ai-provider'
+import { createAcpxProvider } from '@browseros/acpx-ai-provider'
 import { streamText } from 'ai'
 
 const provider = createAcpxProvider({ agent: 'claude' })
@@ -584,7 +593,7 @@ import {
   AcpxAgentNotFoundError,
   AcpxAuthRequiredError,
   AcpxTurnTimeoutError,
-} from 'acpx-ai-provider'
+} from '@browseros/acpx-ai-provider'
 ```
 
 Catch `AcpxError` for the broad case; the three subclasses cover the
@@ -593,7 +602,10 @@ class with the runtime's `code` preserved.
 
 ## Repository
 
-Source, issues, and roadmap: <https://github.com/DaniAkash/acpx>.
+BrowserOS source and issues live in the
+[BrowserOS repository](https://github.com/browseros-ai/BrowserOS/tree/main/packages/browseros-agent/packages/acpx-ai-provider).
+The pinned upstream source lives in
+[`DaniAkash/agent-toolkit`](https://github.com/DaniAkash/agent-toolkit/tree/acpx-ai-provider-v0.0.6/packages/acpx-ai-provider).
 
 ## License
 

--- a/packages/browseros-agent/packages/acpx-ai-provider/package.json
+++ b/packages/browseros-agent/packages/acpx-ai-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@browseros/acpx-ai-provider",
   "version": "0.0.6",
-  "description": "Vercel AI SDK provider on top of the acpx ACP runtime. Inlined snapshot of acpx-ai-provider from DaniAkash/acpx.",
+  "description": "Vercel AI SDK provider on top of the acpx ACP runtime. Inlined snapshot of acpx-ai-provider from DaniAkash/agent-toolkit.",
   "license": "MIT",
   "author": "Dani Akash",
   "type": "module",


### PR DESCRIPTION
## Summary

- finish the in-repo `acpx-ai-provider` consolidation by documenting the scoped `@browseros/acpx-ai-provider` workspace package everywhere developers copy package names
- correct package metadata and provenance to the current `DaniAkash/agent-toolkit` repository and retain the exact AI SDK v6-compatible tag/commit boundary
- preserve the already-landed source, tests, `workspace:*` server dependency, TypeScript project reference, and local lockfile resolution without runtime changes

## Design

The provider implementation already on `main` was compared with `DaniAkash/agent-toolkit` tag `acpx-ai-provider-v0.0.6` at `ffb54400bf581e61c4cfcba3dccfcb72bc5cd44d`; every source and non-E2E test file matches after BrowserOS's documented extensionless-import rewrite. This change keeps that verified fork intact and closes only the remaining stale unscoped-package and old-repository references.

## Test plan

- [x] source-equivalence check for all vendored source and non-E2E tests
- [x] `bun install --frozen-lockfile` (no changes)
- [x] `bun run --filter @browseros/acpx-ai-provider typecheck`
- [x] `bun run --filter @browseros/acpx-ai-provider test` (210 passed)
- [x] `bun run check`
- [x] `bun run test`
- [x] context-free adversarial review (clean)
