### PR TITLE
feat(app): permanent BrowserClaw banner on MCP settings

### DIFF
--- a/packages/browseros-agent/apps/app/lib/constants/analyticsEvents.ts
+++ b/packages/browseros-agent/apps/app/lib/constants/analyticsEvents.ts
@@ -65,16 +65,16 @@ export const MCP_PROMO_BANNER_CLICKED_EVENT =
   'settings.mcp_promo_banner.clicked'
 
 /** @public */
+export const BROWSERCLAW_MCP_BANNER_CLICKED_EVENT =
+  'settings.browserclaw_mcp_banner.clicked'
+
+/** @public */
 export const BROWSERCLAW_PROMO_BANNER_CLICKED_EVENT =
   'ui.browserclaw_promo_banner.clicked'
 
 /** @public */
 export const BROWSERCLAW_PROMO_BANNER_DISMISSED_EVENT =
   'ui.browserclaw_promo_banner.dismissed'
-
-/** @public */
-export const BROWSERCLAW_MCP_BANNER_CLICKED_EVENT =
-  'settings.browserclaw_mcp_banner.clicked'
 
 /** @public */
 export const MCP_EXTERNAL_ACCESS_ENABLED_EVENT =

--- a/packages/browseros-agent/apps/app/lib/constants/analyticsEvents.ts
+++ b/packages/browseros-agent/apps/app/lib/constants/analyticsEvents.ts
@@ -73,6 +73,10 @@ export const BROWSERCLAW_PROMO_BANNER_DISMISSED_EVENT =
   'ui.browserclaw_promo_banner.dismissed'
 
 /** @public */
+export const BROWSERCLAW_MCP_BANNER_CLICKED_EVENT =
+  'settings.browserclaw_mcp_banner.clicked'
+
+/** @public */
 export const MCP_EXTERNAL_ACCESS_ENABLED_EVENT =
   'settings.mcp_external_access.enabled'
 

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/BrowserClawMcpBanner.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/BrowserClawMcpBanner.test.tsx
@@ -1,0 +1,99 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { type ComponentProps, createElement, type FC } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+type MockButtonProps = Omit<ComponentProps<'button'>, 'onClick'> & {
+  variant?: string
+  size?: string
+  onClick?: () => void
+}
+
+const trackedEvents: string[] = []
+const createdTabs: unknown[] = []
+let renderedCtaClick: (() => void) | undefined
+
+mock.module('@/assets/browserclaw_logo.png', () => ({
+  default: 'logo.png',
+}))
+
+mock.module('@/lib/metrics/track', () => ({
+  track: (event: string) => {
+    trackedEvents.push(event)
+  },
+}))
+
+mock.module('@/lib/constants/analyticsEvents', () => ({
+  BROWSERCLAW_MCP_BANNER_CLICKED_EVENT:
+    'settings.browserclaw_mcp_banner.clicked',
+}))
+
+mock.module('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: MockButtonProps) => {
+    renderedCtaClick = props.onClick
+    return createElement('button', { type: 'button', ...props }, children)
+  },
+}))
+
+let BrowserClawMcpBanner: FC
+
+beforeAll(async () => {
+  BrowserClawMcpBanner = (await import('./BrowserClawMcpBanner'))
+    .BrowserClawMcpBanner
+})
+
+beforeEach(() => {
+  trackedEvents.length = 0
+  createdTabs.length = 0
+  renderedCtaClick = undefined
+  globalThis.chrome = {
+    tabs: {
+      create: async (options: unknown) => {
+        createdTabs.push(options)
+      },
+    },
+  } as unknown as typeof chrome
+})
+
+function render(): string {
+  return renderToStaticMarkup(createElement(BrowserClawMcpBanner))
+}
+
+describe('BrowserClawMcpBanner', () => {
+  it('renders the MCP-specific BrowserClaw pitch', () => {
+    const html = render()
+
+    expect(html).toContain('For better MCP support, use BrowserClaw')
+    expect(html).toContain(
+      'A browser built for AI agents — a bigger MCP toolset, your real logins, and session replay',
+    )
+    expect(html).toContain('browserclaw.ai')
+  })
+
+  it('does not repeat the copy of the banners that link here', () => {
+    const html = render()
+
+    expect(html).not.toContain('Connect your favorite coding tools')
+    expect(html).not.toContain('A new product from the BrowserOS team')
+  })
+
+  it('is permanent: renders only the CTA, with no dismiss control', () => {
+    const html = render()
+
+    expect(html.match(/<button/g) ?? []).toHaveLength(1)
+    expect(html).not.toContain('Dismiss')
+  })
+
+  it('opens browserclaw.ai and tracks the click', () => {
+    render()
+
+    renderedCtaClick?.()
+
+    expect(trackedEvents).toEqual(['settings.browserclaw_mcp_banner.clicked'])
+    expect(createdTabs).toEqual([{ url: 'https://browserclaw.ai' }])
+  })
+})

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/BrowserClawMcpBanner.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/BrowserClawMcpBanner.test.tsx
@@ -99,14 +99,20 @@ describe('BrowserClawMcpBanner', () => {
     expect(html).not.toContain('Dismiss')
   })
 
+  // Stands alone rather than riding inside the click test below: this is the one
+  // assertion that ties the suite to the value analytics actually ships, so it
+  // should not disappear along with a behavior test someone reworks later.
+  it('pins the shipped event value', () => {
+    expect(BROWSERCLAW_MCP_BANNER_CLICKED_EVENT).toBe(
+      'settings.browserclaw_mcp_banner.clicked',
+    )
+  })
+
   it('opens browserclaw.ai and tracks the click', async () => {
     render()
 
     await renderedCtaClick?.()
 
-    expect(BROWSERCLAW_MCP_BANNER_CLICKED_EVENT).toBe(
-      'settings.browserclaw_mcp_banner.clicked',
-    )
     expect(trackedEvents).toEqual([BROWSERCLAW_MCP_BANNER_CLICKED_EVENT])
     expect(createdTabs).toEqual([{ url: 'https://browserclaw.ai' }])
     expect(capturedErrors).toEqual([])
@@ -118,6 +124,8 @@ describe('BrowserClawMcpBanner', () => {
 
     await renderedCtaClick?.()
 
-    expect(capturedErrors).toEqual([tabsCreateError])
+    expect(capturedErrors).toHaveLength(1)
+    expect(capturedErrors[0]).toBe(tabsCreateError)
+    expect(createdTabs).toEqual([])
   })
 })

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/BrowserClawMcpBanner.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/BrowserClawMcpBanner.test.tsx
@@ -1,16 +1,24 @@
 import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { type ComponentProps, createElement, type FC } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+// Imported relatively on purpose: `@/…` does not resolve under `bun test`, so the
+// component's copy of this module has to be mocked. Pulling the real value in
+// through a path the mock does not intercept keeps the assertion honest — mocking
+// the constant *and* asserting a literal would pass even if the shipped event
+// value were wrong.
+import { BROWSERCLAW_MCP_BANNER_CLICKED_EVENT } from '../../lib/constants/analyticsEvents'
 
 type MockButtonProps = Omit<ComponentProps<'button'>, 'onClick'> & {
   variant?: string
   size?: string
-  onClick?: () => void
+  onClick?: () => void | Promise<void>
 }
 
 const trackedEvents: string[] = []
 const createdTabs: unknown[] = []
-let renderedCtaClick: (() => void) | undefined
+const capturedErrors: unknown[] = []
+let renderedCtaClick: (() => void | Promise<void>) | undefined
+let tabsCreateError: Error | null = null
 
 mock.module('@/assets/browserclaw_logo.png', () => ({
   default: 'logo.png',
@@ -22,9 +30,16 @@ mock.module('@/lib/metrics/track', () => ({
   },
 }))
 
+mock.module('@/lib/sentry/sentry', () => ({
+  sentry: {
+    captureException: (error: unknown) => {
+      capturedErrors.push(error)
+    },
+  },
+}))
+
 mock.module('@/lib/constants/analyticsEvents', () => ({
-  BROWSERCLAW_MCP_BANNER_CLICKED_EVENT:
-    'settings.browserclaw_mcp_banner.clicked',
+  BROWSERCLAW_MCP_BANNER_CLICKED_EVENT,
 }))
 
 mock.module('@/components/ui/button', () => ({
@@ -49,10 +64,13 @@ beforeAll(async () => {
 beforeEach(() => {
   trackedEvents.length = 0
   createdTabs.length = 0
+  capturedErrors.length = 0
   renderedCtaClick = undefined
+  tabsCreateError = null
   globalThis.chrome = {
     tabs: {
       create: async (options: unknown) => {
+        if (tabsCreateError) throw tabsCreateError
         createdTabs.push(options)
       },
     },
@@ -74,13 +92,6 @@ describe('BrowserClawMcpBanner', () => {
     expect(html).toContain('browserclaw.ai')
   })
 
-  it('does not repeat the copy of the banners that link here', () => {
-    const html = render()
-
-    expect(html).not.toContain('Connect your favorite coding tools')
-    expect(html).not.toContain('A new product from the BrowserOS team')
-  })
-
   it('is permanent: renders only the CTA, with no dismiss control', () => {
     const html = render()
 
@@ -88,12 +99,25 @@ describe('BrowserClawMcpBanner', () => {
     expect(html).not.toContain('Dismiss')
   })
 
-  it('opens browserclaw.ai and tracks the click', () => {
+  it('opens browserclaw.ai and tracks the click', async () => {
     render()
 
-    renderedCtaClick?.()
+    await renderedCtaClick?.()
 
-    expect(trackedEvents).toEqual(['settings.browserclaw_mcp_banner.clicked'])
+    expect(BROWSERCLAW_MCP_BANNER_CLICKED_EVENT).toBe(
+      'settings.browserclaw_mcp_banner.clicked',
+    )
+    expect(trackedEvents).toEqual([BROWSERCLAW_MCP_BANNER_CLICKED_EVENT])
     expect(createdTabs).toEqual([{ url: 'https://browserclaw.ai' }])
+    expect(capturedErrors).toEqual([])
+  })
+
+  it('reports to Sentry when the tab cannot be opened', async () => {
+    tabsCreateError = new Error('no window available')
+    render()
+
+    await renderedCtaClick?.()
+
+    expect(capturedErrors).toEqual([tabsCreateError])
   })
 })

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/BrowserClawMcpBanner.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/BrowserClawMcpBanner.tsx
@@ -1,0 +1,54 @@
+import { ArrowRight } from 'lucide-react'
+import type { FC } from 'react'
+import BrowserClawLogo from '@/assets/browserclaw_logo.png'
+import { Button } from '@/components/ui/button'
+import { BROWSERCLAW_MCP_BANNER_CLICKED_EVENT } from '@/lib/constants/analyticsEvents'
+import { track } from '@/lib/metrics/track'
+
+const BROWSERCLAW_URL = 'https://browserclaw.ai'
+
+/**
+ * Permanent BrowserClaw pitch on the MCP settings page — deliberately no dismiss
+ * control and no persisted visibility, so it never reads
+ * `browserClawPromoDismissedStorage` the way `components/promo/BrowserClawPromoBanner`
+ * does. That key is global: honouring it would hide this banner from everyone who
+ * dismissed the new-tab promo, which is the opposite of what it is for.
+ *
+ * Copy stays MCP-specific on purpose. `ai-settings/McpPromoBanner` links straight
+ * to this page, so a user can arrive having just read the generic BrowserClaw
+ * promo; repeating it here would waste the one line this banner gets.
+ */
+export const BrowserClawMcpBanner: FC = () => {
+  const handleClick = () => {
+    track(BROWSERCLAW_MCP_BANNER_CLICKED_EVENT)
+    chrome.tabs.create({ url: BROWSERCLAW_URL })
+  }
+
+  return (
+    <div className="flex items-center gap-4 rounded-xl border border-border bg-card p-4 shadow-sm transition-all hover:shadow-md">
+      <img
+        src={BrowserClawLogo}
+        alt="BrowserClaw"
+        className="h-10 w-10 shrink-0 rounded-lg"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="font-semibold text-sm">
+          For better MCP support, use BrowserClaw
+        </p>
+        <p className="text-muted-foreground text-xs">
+          A browser built for AI agents — a bigger MCP toolset, your real
+          logins, and session replay
+        </p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleClick}
+        className="shrink-0 border-[var(--accent-orange)] bg-[var(--accent-orange)]/10 text-[var(--accent-orange)] hover:bg-[var(--accent-orange)]/20 hover:text-[var(--accent-orange)]"
+      >
+        browserclaw.ai
+        <ArrowRight className="ml-1 h-3 w-3" />
+      </Button>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/BrowserClawMcpBanner.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/BrowserClawMcpBanner.tsx
@@ -4,6 +4,7 @@ import BrowserClawLogo from '@/assets/browserclaw_logo.png'
 import { Button } from '@/components/ui/button'
 import { BROWSERCLAW_MCP_BANNER_CLICKED_EVENT } from '@/lib/constants/analyticsEvents'
 import { track } from '@/lib/metrics/track'
+import { sentry } from '@/lib/sentry/sentry'
 
 const BROWSERCLAW_URL = 'https://browserclaw.ai'
 
@@ -19,9 +20,15 @@ const BROWSERCLAW_URL = 'https://browserclaw.ai'
  * promo; repeating it here would waste the one line this banner gets.
  */
 export const BrowserClawMcpBanner: FC = () => {
-  const handleClick = () => {
+  const handleClick = async () => {
     track(BROWSERCLAW_MCP_BANNER_CLICKED_EVENT)
-    chrome.tabs.create({ url: BROWSERCLAW_URL })
+    try {
+      await chrome.tabs.create({ url: BROWSERCLAW_URL })
+    } catch (error) {
+      sentry.captureException(error, {
+        extra: { message: 'Failed to open BrowserClaw site from MCP settings' },
+      })
+    }
   }
 
   return (

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/MCPSettingsPage.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/MCPSettingsPage.test.tsx
@@ -1,0 +1,66 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import { createElement, type FC } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// The three sibling sections are stubbed so this exercises the page's own
+// composition; BrowserClawMcpBanner is deliberately left real, because the
+// banner being mounted at all is the thing under test.
+mock.module('./MCPServerHeader', () => ({
+  MCPServerHeader: () => createElement('div', null, 'server-header'),
+}))
+
+mock.module('./IntegrationsSection', () => ({
+  IntegrationsSection: () => createElement('div', null, 'integrations'),
+}))
+
+mock.module('./MCPToolsSection', () => ({
+  MCPToolsSection: () => createElement('div', null, 'tools'),
+}))
+
+mock.module('@/assets/browserclaw_logo.png', () => ({
+  default: 'logo.png',
+}))
+
+mock.module('@/components/ui/button', () => ({
+  Button: ({ children }: { children?: unknown }) =>
+    createElement('button', { type: 'button' }, children as never),
+}))
+
+mock.module('@/lib/metrics/track', () => ({
+  track: () => {},
+}))
+
+mock.module('@/lib/sentry/sentry', () => ({
+  sentry: { captureException: () => {} },
+}))
+
+mock.module('@/lib/constants/analyticsEvents', () => ({
+  BROWSERCLAW_MCP_BANNER_CLICKED_EVENT:
+    'settings.browserclaw_mcp_banner.clicked',
+}))
+
+mock.module('@/lib/browseros/helpers', () => ({
+  getMcpServerUrl: async () => 'http://127.0.0.1:9200/mcp',
+}))
+
+mock.module('@/lib/messaging/server/serverMessages', () => ({
+  sendServerMessage: async () => ({ tools: [] }),
+}))
+
+let MCPSettingsPage: FC
+
+beforeAll(async () => {
+  MCPSettingsPage = (await import('./MCPSettingsPage')).MCPSettingsPage
+})
+
+describe('MCPSettingsPage', () => {
+  it('mounts the permanent BrowserClaw banner between the server header and integrations', () => {
+    const html = renderToStaticMarkup(createElement(MCPSettingsPage))
+
+    expect(html).toContain('For better MCP support, use BrowserClaw')
+
+    const bannerIndex = html.indexOf('For better MCP support')
+    expect(bannerIndex).toBeGreaterThan(html.indexOf('server-header'))
+    expect(bannerIndex).toBeLessThan(html.indexOf('integrations'))
+  })
+})

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/MCPSettingsPage.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/MCPSettingsPage.test.tsx
@@ -1,6 +1,10 @@
 import { beforeAll, describe, expect, it, mock } from 'bun:test'
-import { createElement, type FC } from 'react'
+import { createElement, type FC, type ReactNode } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+// Relative on purpose — see the note in BrowserClawMcpBanner.test.tsx. Nothing
+// here asserts on the value, but forwarding the real one keeps every test in this
+// folder honest about where the constant comes from.
+import { BROWSERCLAW_MCP_BANNER_CLICKED_EVENT } from '../../lib/constants/analyticsEvents'
 
 // The three sibling sections are stubbed so this exercises the page's own
 // composition; BrowserClawMcpBanner is deliberately left real, because the
@@ -22,8 +26,8 @@ mock.module('@/assets/browserclaw_logo.png', () => ({
 }))
 
 mock.module('@/components/ui/button', () => ({
-  Button: ({ children }: { children?: unknown }) =>
-    createElement('button', { type: 'button' }, children as never),
+  Button: ({ children }: { children?: ReactNode }) =>
+    createElement('button', { type: 'button' }, children),
 }))
 
 mock.module('@/lib/metrics/track', () => ({
@@ -35,8 +39,7 @@ mock.module('@/lib/sentry/sentry', () => ({
 }))
 
 mock.module('@/lib/constants/analyticsEvents', () => ({
-  BROWSERCLAW_MCP_BANNER_CLICKED_EVENT:
-    'settings.browserclaw_mcp_banner.clicked',
+  BROWSERCLAW_MCP_BANNER_CLICKED_EVENT,
 }))
 
 mock.module('@/lib/browseros/helpers', () => ({
@@ -59,8 +62,15 @@ describe('MCPSettingsPage', () => {
 
     expect(html).toContain('For better MCP support, use BrowserClaw')
 
+    // Pin the stub positions first: a missing stub would return -1 and turn the
+    // ordering bounds below into assertions that are trivially true.
+    const headerIndex = html.indexOf('server-header')
+    const integrationsIndex = html.indexOf('integrations')
+    expect(headerIndex).toBeGreaterThan(-1)
+    expect(integrationsIndex).toBeGreaterThan(-1)
+
     const bannerIndex = html.indexOf('For better MCP support')
-    expect(bannerIndex).toBeGreaterThan(html.indexOf('server-header'))
-    expect(bannerIndex).toBeLessThan(html.indexOf('integrations'))
+    expect(bannerIndex).toBeGreaterThan(headerIndex)
+    expect(bannerIndex).toBeLessThan(integrationsIndex)
   })
 })

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/MCPSettingsPage.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/MCPSettingsPage.tsx
@@ -2,6 +2,7 @@ import { type FC, useCallback, useEffect, useState } from 'react'
 import { getMcpServerUrl } from '@/lib/browseros/helpers'
 import type { McpTool } from '@/lib/mcp/client'
 import { sendServerMessage } from '@/lib/messaging/server/serverMessages'
+import { BrowserClawMcpBanner } from './BrowserClawMcpBanner'
 import { IntegrationsSection } from './IntegrationsSection'
 import { MCPServerHeader } from './MCPServerHeader'
 import { MCPToolsSection } from './MCPToolsSection'
@@ -82,6 +83,8 @@ export const MCPSettingsPage: FC = () => {
         error={urlError}
         onServerRestart={loadServerUrlAndTools}
       />
+
+      <BrowserClawMcpBanner />
 
       <IntegrationsSection serverUrl={serverUrl} />
 


### PR DESCRIPTION
## Summary

- Adds a **permanent** (non-dismissible) BrowserClaw banner to the BrowserOS MCP settings page, telling anyone wiring up the MCP server that BrowserClaw is the stronger MCP surface for their agents, and sending them to `browserclaw.ai`.
- New component rather than a reuse of `components/promo/BrowserClawPromoBanner`: that one gates on `browserClawPromoDismissedStorage`, a single **global** WXT key. Honouring it would hide this banner from everyone who dismissed the unrelated new-tab promo — the opposite of permanent. This one has no dismiss control and no persisted visibility at all.
- Adds `BROWSERCLAW_MCP_BANNER_CLICKED_EVENT` (`settings.browserclaw_mcp_banner.clicked`). No dismiss event, since there is no dismiss.

## Design

`BrowserClawMcpBanner` is a stateless FC colocated in `screens/mcp-settings/`, matching `McpPromoBanner` (also single-consumer, also colocated) rather than the shared `components/promo/` folder. The card shell, typography and outline accent-orange CTA are copied verbatim from the two shipped banners so the three read as one family; the one intentional divergence is the missing dismiss `<button>`. The URL lives as a module-level const, the same way `MCPServerHeader.tsx` in this very folder holds its `DOCS_URL`.

It sits directly **under** `<MCPServerHeader />` rather than above it — `ai-settings/McpPromoBanner`'s "Set up" CTA navigates users to this page to do exactly one thing, and burying the server URL / copy / restart controls under a promo would fight that.

Copy is deliberately MCP-specific, since a user can land here having just read the generic BrowserClaw promo on the AI settings page. Every claim is traceable:

| Line | Source |
|---|---|
| "A browser built for AI agents" | README "The browser for AI agents"; `browserclaw/SKILL.md` "The user's dedicated browser for agents" |
| "a bigger MCP toolset" | `contracts/claw-mcp/README.md` — 17 tools (`tabs`, `tab_groups`, `windows`, `navigate`, `snapshot`, `diff`, `act`, `grep`, `read`, `evaluate`, `run`, `screenshot`, `pdf`, `wait`, `upload`, `download`, `name_session`) |
| "your real logins" | README "using the accounts you're already signed into" |
| "session replay" | README "replay any session like a video" |

## What it looks like

Rendered on the real page (light and dark), directly below the server header:

> **For better MCP support, use BrowserClaw**
> A browser built for AI agents — a bigger MCP toolset, your real logins, and session replay
> `[ browserclaw.ai → ]`

BrowserClaw logo on the left, outline accent-orange CTA on the right, no dismiss X.

## Review fixes (second commit)

An adversarial review of the first commit found two real test gaps. Both were reproduced before being fixed:

- **The analytics assertion was tautological.** The test mocked `@/lib/constants/analyticsEvents` and then asserted against its own literal, so the real constant was never loaded. Setting the shipped value to `'BROKEN.value.here'` left the suite green. It now imports the constant via a relative specifier — which the `@/`-keyed mock doesn't intercept — so the assertion sees the real value. Against the same sabotage it now fails correctly. (The mock can't just be dropped: `@/*` doesn't resolve under `bun test` from `packages/browseros-agent`, which is why every test here mocks its `@/` imports.)
- **Nothing guarded that the page mounts the banner.** Deleting `<BrowserClawMcpBanner />` left all 13 tests passing. Added `MCPSettingsPage.test.tsx`, which asserts the banner renders *between* the server header and integrations, so the placement decision is guarded too, not just presence. Mutation-checked both ways.
- `chrome.tabs.create` is now awaited in a try/catch reporting via `sentry.captureException`, per the app rule on capturing runtime errors; a test forces the rejection path.
- Dropped two "does not repeat sibling copy" assertions — they hardcoded strings from files the test doesn't import, so a reword elsewhere would have silently turned the guard into a no-op. The constraint lives in the component's doc comment instead.

**Knowingly deferred:** the card shell and the 4-clause accent-orange CTA className are now duplicated across three banner files (this one, `McpPromoBanner`, `BrowserClawPromoBanner`). Extracting a shared `PromoBannerCard` would mean editing two already-shipped banners on unrelated screens, which is outside the scope of adding one banner to one page. Worth doing before a fourth copy appears.

## Test plan

- [x] `bun run check` (lint + typecheck + fallow) — green
- [x] `bun run test` — green
- [x] `cd apps/app && bun run typecheck` — green
- [x] `cd apps/app && bun run test` — green
- [x] Unit tests cover: the banner renders its copy; renders exactly one `<button>` and no dismiss control; the CTA tracks the real event constant and calls `chrome.tabs.create({ url: 'https://browserclaw.ai' })`; a failed tab-open reports to Sentry; and `MCPSettingsPage` mounts the banner in the right slot
- [x] Verified live via the CDP inspector on `#/settings/mcp`: banner renders in the right slot, one button, logo present, correct copy, correct in dark theme — and clicking the CTA really opened `browserclaw.ai` (which resolves to the BrowserClaw page)
