### PR TITLE
feat: add bpatch ls command

### DIFF
--- a/packages/browseros/tools/bpatch/README.md
+++ b/packages/browseros/tools/bpatch/README.md
@@ -31,6 +31,17 @@ ch2 = "/Users/shadowfax/ch2-src"
 
 Without a checkout selector, `bpatch` discovers the checkout from the current directory as before.
 
+List the machine-level paths from anywhere:
+
+```console
+$ bpatch ls
+config     /Users/shadowfax/.config/bpatch/config.toml
+store      /Users/shadowfax/code/browseros-project/packages/browseros/chromium_patches
+checkouts
+  ch1              /Users/shadowfax/ch1-src
+  ch2              /Users/shadowfax/ch2-src
+```
+
 Requirements: Git 2.40 or newer; base-bump conflict sessions use `git merge-tree --write-tree --merge-base`.
 
 Install from this directory:
@@ -101,10 +112,13 @@ Global flags:
 | `bpatch alias add <NAME> <PATH>` | global flags | `0`, `1` | Add or update a checkout alias in `~/.config/bpatch/config.toml`. |
 | `bpatch alias list` | global flags | `0`, `1` | List checkout aliases. |
 | `bpatch alias remove <NAME>` | global flags | `0`, `1` | Remove a checkout alias. |
+| `bpatch ls` | `--store`, `--json` | `0`, `1` | List the configured patch store and registered checkout aliases without discovering a checkout. |
 | `bpatch abort` | global flags | `0`, `1` | Remove a pending conflict session. |
 | `bpatch continue` | `--materialize`, global flags | `0`, `2`, `1` | Materialize conflict markers or finish a conflict session after resolution. |
 
 `extract` also has a hidden `--accept-suggestions` flag used by integration tests and scripted TTY bypasses; normal non-interactive routing should use `--feature <FEATURE>` or accept the `needs-feature` JSON result.
+
+`ls` is machine-level and does not accept `-C/--checkout`. It reads the configured store and aliases from `~/.config/bpatch/config.toml`; `--store <STORE>` only overrides the displayed store path for that invocation.
 
 `status`, `diff`, `apply`, `abort`, and `continue` also accept an optional positional checkout selector, for example `bpatch apply ch1`. Use `-C/--checkout` for verbs with their own positional arguments, such as `extract`.
 
@@ -247,6 +261,7 @@ reader.
 | feature inventory | `bpatch feature list` |
 | feature creation/top-up | `bpatch feature add <name> <path> [--desc ...]` or `bpatch feature add <name> --from-dirty` |
 | checkout aliases | `bpatch alias add <name> <path>`, then `bpatch apply <name>` or `bpatch -C <name> ...` |
+| machine path listing | `bpatch ls` |
 | conflict abort | `bpatch abort` |
 | conflict continue | `bpatch continue` or `bpatch continue --materialize` |
 | base repin/rebase-store flow | `bpatch extract --repin` |

--- a/packages/browseros/tools/bpatch/src/cli/ls.rs
+++ b/packages/browseros/tools/bpatch/src/cli/ls.rs
@@ -1,0 +1,68 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::Serialize;
+
+/// Machine-level bpatch configuration listing.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct LsReport {
+    pub result: LsResult,
+    pub store: Option<PathBuf>,
+    pub checkouts: BTreeMap<String, PathBuf>,
+    pub config: PathBuf,
+    pub exit: i32,
+}
+
+/// Listing result discriminator.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LsResult {
+    Listed,
+}
+
+impl LsReport {
+    /// Returns the process exit code represented by the report.
+    pub fn exit_code(&self) -> i32 {
+        self.exit
+    }
+}
+
+/// Lists configured patch store and checkout aliases without requiring a checkout.
+pub fn run(store_override: Option<&Path>, config_path: &Path) -> Result<LsReport> {
+    let config = super::load_config(config_path)?.unwrap_or_default();
+    let store = store_override
+        .map(PathBuf::from)
+        .or_else(|| config.store.clone());
+    Ok(LsReport {
+        result: LsResult::Listed,
+        store,
+        checkouts: config.checkouts,
+        config: config_path.to_path_buf(),
+        exit: 0,
+    })
+}
+
+/// Renders listing output for human terminals.
+pub fn render_human(report: &LsReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("config     {}\n", report.config.display()));
+    match &report.store {
+        Some(store) => out.push_str(&format!("store      {}\n", store.display())),
+        None => out.push_str("store      not configured\n"),
+    }
+    if report.checkouts.is_empty() {
+        out.push_str("checkouts  none\n");
+    } else {
+        out.push_str("checkouts\n");
+        for (alias, path) in &report.checkouts {
+            out.push_str(&format!("  {:<16} {}\n", alias, path.display()));
+        }
+    }
+    out
+}
+
+/// Renders listing output as one JSON object.
+pub fn render_json(report: &LsReport) -> Result<String> {
+    Ok(serde_json::to_string(report)?)
+}

--- a/packages/browseros/tools/bpatch/src/cli/mod.rs
+++ b/packages/browseros/tools/bpatch/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod diff;
 pub mod extract;
 pub mod feature;
 pub mod init;
+pub mod ls;
 pub mod render;
 pub mod status;
 
@@ -42,6 +43,7 @@ use crate::store::{self, Store};
   Or run bpatch init from inside chromium_patches.
   Pass --store /abs/path/to/chromium_patches on store-reading commands.
   Run bpatch from inside a Chromium checkout.
+  Run bpatch ls from any directory to show configured machine paths.
 
 GLOBAL FLAGS:
   --store <STORE>  Overrides the config file for store-reading commands.
@@ -51,6 +53,7 @@ GLOBAL FLAGS:
 EXAMPLES:
   Setup:
     bpatch init /abs/path/to/chromium_patches
+    bpatch ls
 
   Daily loop:
     bpatch status
@@ -158,6 +161,15 @@ pub enum Command {
 "#
     )]
     Alias(alias::AliasArgs),
+    /// List configured patch store and checkout aliases.
+    #[command(
+        long_about = "List the configured chromium_patches store and registered Chromium checkout aliases without requiring checkout discovery.",
+        after_long_help = r#"EXAMPLE:
+  bpatch ls
+  bpatch --store /abs/path/to/chromium_patches ls --json
+"#
+    )]
+    Ls,
     /// Write the patch store path to the user config.
     #[command(
         long_about = "Canonicalize a chromium_patches store directory, validate that it contains bpatch metadata, and write it to ~/.config/bpatch/config.toml while preserving other config keys and comments.",
@@ -305,7 +317,7 @@ impl Command {
             Self::Apply(args) => args.checkout.as_deref(),
             Self::Annotate(args) => args.checkout.as_deref(),
             Self::Continue(args) => args.checkout.as_deref(),
-            Self::Extract(_) | Self::Feature(_) | Self::Alias(_) | Self::Init(_) => None,
+            Self::Extract(_) | Self::Feature(_) | Self::Alias(_) | Self::Ls | Self::Init(_) => None,
         }
     }
 }
@@ -344,6 +356,21 @@ fn run_inner(cli: &Cli) -> Result<i32> {
             );
         }
         return alias::run(args, cli.json);
+    }
+    if matches!(&cli.command, Command::Ls) {
+        if cli.checkout.is_some() {
+            bail!(
+                "ls does not accept -C/--checkout; it lists machine config and does not target a checkout"
+            );
+        }
+        let config_path = config_path();
+        let report = ls::run(cli.store.as_deref(), &config_path)?;
+        write_output(
+            cli.json,
+            &ls::render_json(&report)?,
+            &ls::render_human(&report),
+        )?;
+        return Ok(report.exit_code());
     }
     if let Command::Init(args) = &cli.command {
         let report = init::run(args, &config_path())?;
@@ -420,6 +447,7 @@ fn run_inner(cli: &Cli) -> Result<i32> {
         Command::Extract(args) => run_extract(cli, args, &checkout, &store_dir),
         Command::Feature(args) => run_feature(cli, args, &state_ctx, &store_dir),
         Command::Alias(_) => unreachable!("alias dispatches before checkout/store discovery"),
+        Command::Ls => unreachable!("ls dispatches before checkout/store discovery"),
         Command::Init(_) => unreachable!("init dispatches before checkout/store discovery"),
         Command::Abort(_) => {
             let report = abort::run(&state_ctx);

--- a/packages/browseros/tools/bpatch/src/cli/mod.rs
+++ b/packages/browseros/tools/bpatch/src/cli/mod.rs
@@ -167,6 +167,9 @@ pub enum Command {
         after_long_help = r#"EXAMPLE:
   bpatch ls
   bpatch --store /abs/path/to/chromium_patches ls --json
+
+NOTE:
+  bpatch ls does not accept -C/--checkout because it lists machine config, not a checkout target.
 "#
     )]
     Ls,

--- a/packages/browseros/tools/bpatch/tests/simulations.rs
+++ b/packages/browseros/tools/bpatch/tests/simulations.rs
@@ -78,6 +78,25 @@ fn top_level_help_teaches_chromium_workflow() -> Result<()> {
 }
 
 #[test]
+fn ls_help_explains_machine_level_scope() -> Result<()> {
+    let output = Command::new(env!("CARGO_BIN_EXE_bpatch"))
+        .args(["ls", "--help"])
+        .output()
+        .context("running bpatch ls --help")?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+
+    assert!(output.status.success(), "{stderr}");
+    assert!(stderr.is_empty());
+    assert!(stdout.contains("List the configured chromium_patches store"));
+    assert!(stdout.contains("bpatch ls"));
+    assert!(stdout.contains("bpatch --store /abs/path/to/chromium_patches ls --json"));
+    assert!(stdout.contains("does not accept -C/--checkout"));
+    assert!(stdout.contains("lists machine config, not a checkout target"));
+    Ok(())
+}
+
+#[test]
 fn sim1_extract_hack_commit_renders_routing_net_fold_and_next_step() -> Result<()> {
     let checkout = FixtureRepo::new()?;
     let base = write_extract_base(&checkout)?;

--- a/packages/browseros/tools/bpatch/tests/simulations.rs
+++ b/packages/browseros/tools/bpatch/tests/simulations.rs
@@ -43,12 +43,14 @@ fn top_level_help_teaches_chromium_workflow() -> Result<()> {
     assert!(stdout.contains("bpatch init /abs/path/to/chromium_patches"));
     assert!(stdout.contains("Or run bpatch init from inside chromium_patches."));
     assert!(stdout.contains("Run bpatch from inside a Chromium checkout."));
+    assert!(stdout.contains("Run bpatch ls from any directory to show configured machine paths."));
     assert!(stdout.contains("GLOBAL FLAGS:"));
     assert!(
         stdout.contains("--store <STORE>  Overrides the config file for store-reading commands.")
     );
     assert!(stdout.contains("--json           Emits a single JSON object"));
     assert!(stdout.contains("EXAMPLES:"));
+    assert!(stdout.contains("bpatch ls"));
     assert!(stdout.contains("bpatch status"));
     assert!(stdout.contains("bpatch diff"));
     assert!(stdout.contains("bpatch apply"));
@@ -1308,6 +1310,162 @@ fn checkout_aliases_and_paths_target_fixture_from_unrelated_cwd() -> Result<()> 
         "{}",
         json["reason"]
     );
+    Ok(())
+}
+
+#[test]
+fn ls_lists_store_and_registered_checkouts_from_unrelated_cwd() -> Result<()> {
+    let scenario = applied_rev1_scenario()?;
+    let second_checkout = FixtureRepo::new()?;
+    write_apply_base(&second_checkout)?;
+    let home = tempfile::tempdir()?;
+    write_bpatch_config(
+        home.path(),
+        Some(&scenario.store_dir),
+        &[
+            ("ch-2", second_checkout.path()),
+            ("ch-1", scenario.checkout.path()),
+        ],
+    )?;
+    let unrelated = tempfile::tempdir()?;
+    let config = home.path().join(".config/bpatch/config.toml");
+
+    let human = run_bpatch_with_home(unrelated.path(), None, strs(&["ls"]), home.path())?;
+    assert_eq!(human.code, 0, "{}", human.stderr);
+    assert!(human.stderr.is_empty());
+    assert!(
+        human
+            .stdout
+            .contains(&format!("config     {}", config.display()))
+    );
+    assert!(
+        human
+            .stdout
+            .contains(&format!("store      {}", scenario.store_dir.display()))
+    );
+    let ch1 = format!("  {:<16} {}", "ch-1", scenario.checkout.path().display());
+    let ch2 = format!("  {:<16} {}", "ch-2", second_checkout.path().display());
+    assert!(human.stdout.contains(&ch1));
+    assert!(human.stdout.contains(&ch2));
+    assert!(
+        human.stdout.find(&ch1).expect("ch-1 listed")
+            < human.stdout.find(&ch2).expect("ch-2 listed"),
+        "{}",
+        human.stdout
+    );
+
+    let json_out =
+        run_bpatch_with_home(unrelated.path(), None, strs(&["ls", "--json"]), home.path())?;
+    assert_eq!(json_out.code, 0, "{}", json_out.stderr);
+    assert!(json_out.stderr.is_empty());
+    assert_eq!(json_out.stdout.lines().count(), 1);
+    let json = parse_json(&json_out.stdout)?;
+    assert_eq!(json["result"], "listed");
+    assert_eq!(json["store"], scenario.store_dir.display().to_string());
+    assert_eq!(json["config"], config.display().to_string());
+    assert_eq!(json["exit"], 0);
+    assert_eq!(
+        json["checkouts"]["ch-1"],
+        scenario.checkout.path().display().to_string()
+    );
+    assert_eq!(
+        json["checkouts"]["ch-2"],
+        second_checkout.path().display().to_string()
+    );
+
+    let store_override = unrelated.path().join("missing-chromium-patches");
+    let override_out = run_bpatch_with_home(
+        unrelated.path(),
+        Some(&store_override),
+        strs(&["ls", "--json"]),
+        home.path(),
+    )?;
+    assert_eq!(override_out.code, 0, "{}", override_out.stderr);
+    let json = parse_json(&override_out.stdout)?;
+    assert_eq!(json["store"], store_override.display().to_string());
+    assert_eq!(
+        json["checkouts"]["ch-1"],
+        scenario.checkout.path().display().to_string()
+    );
+
+    let scoped = run_bpatch_with_home(
+        unrelated.path(),
+        None,
+        strs(&["-C", "ch-1", "ls", "--json"]),
+        home.path(),
+    )?;
+    assert_eq!(scoped.code, 1);
+    let json = parse_json(&scoped.stdout)?;
+    assert_eq!(json["result"], "error");
+    assert!(
+        json["reason"]
+            .as_str()
+            .unwrap()
+            .contains("ls does not accept -C/--checkout")
+    );
+    Ok(())
+}
+
+#[test]
+fn ls_handles_missing_empty_and_malformed_config() -> Result<()> {
+    let unrelated = tempfile::tempdir()?;
+
+    let missing_home = tempfile::tempdir()?;
+    let missing = run_bpatch_with_home(unrelated.path(), None, strs(&["ls"]), missing_home.path())?;
+    assert_eq!(missing.code, 0, "{}", missing.stderr);
+    assert!(missing.stderr.is_empty());
+    assert!(missing.stdout.contains("store      not configured"));
+    assert!(missing.stdout.contains("checkouts  none"));
+
+    let missing_json = run_bpatch_with_home(
+        unrelated.path(),
+        None,
+        strs(&["ls", "--json"]),
+        missing_home.path(),
+    )?;
+    assert_eq!(missing_json.code, 0, "{}", missing_json.stderr);
+    let json = parse_json(&missing_json.stdout)?;
+    assert_eq!(json["result"], "listed");
+    assert!(json["store"].is_null());
+    assert_eq!(json["checkouts"].as_object().unwrap().len(), 0);
+    assert_eq!(json["exit"], 0);
+
+    let empty_home = tempfile::tempdir()?;
+    let empty_config_dir = empty_home.path().join(".config/bpatch");
+    fs::create_dir_all(&empty_config_dir)?;
+    fs::write(
+        empty_config_dir.join("config.toml"),
+        "custom = \"preserve\"\n",
+    )?;
+    let empty = run_bpatch_with_home(unrelated.path(), None, strs(&["ls"]), empty_home.path())?;
+    assert_eq!(empty.code, 0, "{}", empty.stderr);
+    assert!(empty.stdout.contains("store      not configured"));
+    assert!(empty.stdout.contains("checkouts  none"));
+
+    let malformed_home = tempfile::tempdir()?;
+    let malformed_config_dir = malformed_home.path().join(".config/bpatch");
+    fs::create_dir_all(&malformed_config_dir)?;
+    fs::write(malformed_config_dir.join("config.toml"), "store = [")?;
+    let malformed_json = run_bpatch_with_home(
+        unrelated.path(),
+        None,
+        strs(&["ls", "--json"]),
+        malformed_home.path(),
+    )?;
+    assert_eq!(malformed_json.code, 1);
+    let json = parse_json(&malformed_json.stdout)?;
+    assert_eq!(json["result"], "error");
+    let reason = json["reason"].as_str().expect("reason string");
+    assert!(reason.contains("parsing"));
+    assert!(reason.contains("config.toml"));
+    assert!(reason.contains("expected"));
+
+    let malformed_human =
+        run_bpatch_with_home(unrelated.path(), None, strs(&["ls"]), malformed_home.path())?;
+    assert_eq!(malformed_human.code, 1);
+    assert!(malformed_human.stdout.is_empty());
+    assert!(malformed_human.stderr.contains("error: parsing"));
+    assert!(malformed_human.stderr.contains("expected"));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Add top-level `bpatch ls` for machine-level listing of the configured patch store and registered Chromium checkout aliases.
- Dispatch `ls` before checkout/store discovery so it works from any directory, including the BrowserOS repo.
- Document human/JSON output, empty config behavior, `--store` display override, and `-C/--checkout` rejection.

## Design
`bpatch ls` reads `~/.config/bpatch/config.toml` through the existing config model and combines it with the optional global `--store` override in a small serializable report. The command is early-dispatched next to `alias` and `init`, avoiding Chromium checkout preflight and store validation.

## Test plan
- [x] `cargo fmt --all --check && cargo test --locked` from `packages/browseros/tools/bpatch`
- [x] Local adversarial review loop: 1 finding fixed, second pass clean