### PR TITLE
feat(replay): keep session replay always playing, default 4x

### DIFF
--- a/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.test.tsx
@@ -119,7 +119,7 @@ afterEach(async () => {
 })
 
 describe('PlaybackTransport', () => {
-  it('starts at 2x and keeps every speed selectable', async () => {
+  it('starts at 4x and keeps every speed selectable', async () => {
     await act(async () => root.render(<TransportHarness />))
 
     const speedButton = (label: string) =>
@@ -128,8 +128,8 @@ describe('PlaybackTransport', () => {
       )
 
     expect(speedButton('1×')?.getAttribute('aria-pressed')).toBe('false')
-    expect(speedButton('2×')?.getAttribute('aria-pressed')).toBe('true')
-    expect(speedButton('4×')?.getAttribute('aria-pressed')).toBe('false')
+    expect(speedButton('2×')?.getAttribute('aria-pressed')).toBe('false')
+    expect(speedButton('4×')?.getAttribute('aria-pressed')).toBe('true')
 
     await act(async () => {
       speedButton('1×')?.dispatchEvent(
@@ -137,15 +137,15 @@ describe('PlaybackTransport', () => {
       )
     })
     expect(speedButton('1×')?.getAttribute('aria-pressed')).toBe('true')
-    expect(speedButton('2×')?.getAttribute('aria-pressed')).toBe('false')
+    expect(speedButton('4×')?.getAttribute('aria-pressed')).toBe('false')
 
     await act(async () => {
-      speedButton('4×')?.dispatchEvent(
+      speedButton('2×')?.dispatchEvent(
         new window.Event('click', { bubbles: true }),
       )
     })
     expect(speedButton('1×')?.getAttribute('aria-pressed')).toBe('false')
-    expect(speedButton('4×')?.getAttribute('aria-pressed')).toBe('true')
+    expect(speedButton('2×')?.getAttribute('aria-pressed')).toBe('true')
   })
 
   it('supports explicit pause, resume, and restart without changing speed', async () => {
@@ -161,11 +161,12 @@ describe('PlaybackTransport', () => {
     const toggle = () =>
       container.querySelector('button[aria-label]')?.getAttribute('aria-label')
 
-    const fourTimes = [...container.querySelectorAll('button')].find(
-      (button) => button.textContent === '4×',
+    const oneTimes = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === '1×',
     )
+    // A speed change through the real picker never pauses playback.
     await act(async () => {
-      fourTimes?.dispatchEvent(new window.Event('click', { bubbles: true }))
+      oneTimes?.dispatchEvent(new window.Event('click', { bubbles: true }))
     })
     expect(toggle()).toBe('Pause')
 
@@ -181,7 +182,7 @@ describe('PlaybackTransport', () => {
     await click('[data-command-play]')
     expect(toggle()).toBe('Pause')
     expect(container.textContent).toContain('0:00 / 0:10')
-    expect(fourTimes?.getAttribute('aria-pressed')).toBe('true')
+    expect(oneTimes?.getAttribute('aria-pressed')).toBe('true')
   })
 
   it('bookmarks non-action tools at their activity start', async () => {
@@ -200,5 +201,9 @@ describe('PlaybackTransport', () => {
       marks[0]?.dispatchEvent(new window.Event('click', { bubbles: true }))
     })
     expect(container.textContent).toContain('0:04 / 0:10')
+    // The jump seeks without pausing the running playback.
+    expect(
+      container.querySelector('button[aria-label]')?.getAttribute('aria-label'),
+    ).toBe('Pause')
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -443,6 +443,7 @@ describe('Replay auto-follow', () => {
     expect(attr('[data-playback-playing]', 'data-playback-playing')).toBe(
       'true',
     )
+    expect(attr('[data-playback-speed]', 'data-playback-speed')).toBe('4')
     // Activity spans the first checkpoint (1s) to the last rrweb event (14s).
     expect(attr('[data-playback-time]', 'data-playback-total')).toBe('13')
     expect(currentCaption()).toBeUndefined()
@@ -568,7 +569,7 @@ describe('Replay auto-follow', () => {
     }).toEqual(forward)
   })
 
-  it('pauses and seeks to an action start when its timeline row is clicked', async () => {
+  it('keeps playing while seeking to a clicked timeline row', async () => {
     replayResult.replay = replayData(
       [...visualEvents(1, 1_000), ...visualEvents(2, 10_000)],
       [1, 2],
@@ -580,7 +581,7 @@ describe('Replay auto-follow', () => {
     // 12s completion minus a 2s tool, rebased on the 1s activity origin.
     expect(attr('[data-playback-time]', 'data-playback-time')).toBe('9')
     expect(attr('[data-playback-playing]', 'data-playback-playing')).toBe(
-      'false',
+      'true',
     )
     expect(viewport('tab')).toBe('2')
     expect(currentCaption()).toBe('Action on Tab 2')
@@ -594,6 +595,26 @@ describe('Replay manual control', () => {
       [1, 2],
       [toolFrame(1, 3), toolFrame(2, 12)],
     )
+
+  it('keeps playing across scrubs and speed changes', async () => {
+    replayResult.replay = twoTabs()
+    await renderReplay()
+    expect(attr('[data-playback-playing]', 'data-playback-playing')).toBe(
+      'true',
+    )
+
+    await clickAct('[data-playback-seek="9"]')
+    expect(attr('[data-playback-time]', 'data-playback-time')).toBe('9')
+    expect(attr('[data-playback-playing]', 'data-playback-playing')).toBe(
+      'true',
+    )
+
+    await clickAct('[data-playback-speed-option="2"]')
+    expect(attr('[data-playback-speed]', 'data-playback-speed')).toBe('2')
+    expect(attr('[data-playback-playing]', 'data-playback-playing')).toBe(
+      'true',
+    )
+  })
 
   it('pins a clicked tab at the unchanged global time', async () => {
     replayResult.replay = twoTabs()

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.helpers.ts
@@ -67,4 +67,4 @@ export function formatTime(seconds: number): string {
 }
 
 export const PLAYBACK_SPEEDS: readonly number[] = [1, 2, 4]
-export const DEFAULT_PLAYBACK_SPEED = 2
+export const DEFAULT_PLAYBACK_SPEED = 4

--- a/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.test.tsx
@@ -111,13 +111,14 @@ describe('usePlayback', () => {
     expect(latest.time).toBe(6)
   })
 
-  it('defaults to 2x without consulting a player', async () => {
+  it('autoplays at 4x by default without consulting a player', async () => {
     await render(100)
 
-    expect(latest.speed).toBe(2)
+    expect(latest.speed).toBe(4)
+    expect(latest.isPlaying).toBe(true)
     await advanceTo(1_000)
     await advanceTo(2_000)
-    expect(latest.time).toBe(2)
+    expect(latest.time).toBe(4)
   })
 
   it('excludes paused wall time when playback resumes', async () => {
@@ -151,7 +152,7 @@ describe('usePlayback', () => {
     expect(latest.isPlaying).toBe(true)
   })
 
-  it('clamps a seek to the activity window and pauses', async () => {
+  it('clamps a seek to the activity window', async () => {
     await render(10)
 
     let applied = 0
@@ -160,13 +161,76 @@ describe('usePlayback', () => {
     })
     expect(applied).toBe(10)
     expect(latest.time).toBe(10)
-    expect(latest.isPlaying).toBe(false)
 
     await act(async () => {
       applied = latest.seek(-5)
     })
     expect(applied).toBe(0)
     expect(latest.time).toBe(0)
+  })
+
+  it('keeps playing through a scrub', async () => {
+    await render(100)
+    await act(async () => latest.setSpeed(1))
+    await advanceTo(0)
+    await advanceTo(2_000)
+    expect(latest.isPlaying).toBe(true)
+
+    await act(async () => {
+      latest.seek(50)
+    })
+    expect(latest.isPlaying).toBe(true)
+    expect(latest.time).toBe(50)
+
+    // The clock re-anchors at the seek target and keeps running.
+    await advanceTo(3_000)
+    await advanceTo(4_000)
+    expect(latest.time).toBe(51)
+  })
+
+  it('keeps playing through a speed change', async () => {
+    await render(100)
+    await act(async () => latest.setSpeed(1))
+    await advanceTo(0)
+    await advanceTo(2_000)
+    expect(latest.isPlaying).toBe(true)
+
+    await act(async () => latest.setSpeed(2))
+    expect(latest.isPlaying).toBe(true)
+
+    await advanceTo(3_000)
+    await advanceTo(4_000)
+    expect(latest.time).toBe(4)
+    expect(latest.isPlaying).toBe(true)
+  })
+
+  it('keeps a deliberate pause through a scrub', async () => {
+    await render(100)
+    await act(async () => latest.pause())
+
+    await act(async () => {
+      latest.seek(5)
+    })
+
+    expect(latest.time).toBe(5)
+    expect(latest.isPlaying).toBe(false)
+    expect(frames.size).toBe(0)
+  })
+
+  it('completes naturally when a playing scrub lands on the end', async () => {
+    await render(10)
+    await act(async () => latest.setSpeed(1))
+    await advanceTo(0)
+
+    await act(async () => {
+      latest.seek(10)
+    })
+    expect(latest.isPlaying).toBe(true)
+
+    await advanceTo(1_000)
+    await advanceTo(2_000)
+    expect(latest.time).toBe(10)
+    expect(latest.isPlaying).toBe(false)
   })
 
   it('resumes when a live recording grows past where activity ended', async () => {
@@ -214,7 +278,7 @@ describe('usePlayback', () => {
     await render(10)
     await advanceTo(0)
     await advanceTo(1_000)
-    expect(latest.time).toBe(2)
+    expect(latest.time).toBe(4)
   })
 
   it('keeps exactly one animation loop across control changes', async () => {

--- a/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
@@ -12,7 +12,10 @@ export interface Playback {
   /** Pauses playback without moving the playhead. */
   pause: () => void
   togglePlay: () => void
-  /** Jumps the playhead to `seconds` and pauses. Returns the applied value. */
+  /**
+   * Jumps the playhead to `seconds`, preserving the play state — only the
+   * pause button stops playback. Returns the applied value.
+   */
   seek: (seconds: number) => number
 }
 
@@ -116,13 +119,15 @@ export function usePlayback(totalSeconds: number): Playback {
     else play()
   }, [isPlaying, pause, play])
 
+  // Seeks never touch isPlaying: a playing scrub re-anchors on the next frame
+  // and keeps running, while a deliberately paused operator can frame-step
+  // without playback restarting under them.
   const seek = useCallback(
     (seconds: number) => {
       const clamped = Math.max(0, Math.min(totalSeconds, seconds))
       anchorRef.current = null
       completedRef.current = false
       applyTime(clamped)
-      setIsPlaying(false)
       return clamped
     },
     [applyTime, totalSeconds],


### PR DESCRIPTION
Session replay now defaults to **4×** and **only the pause button stops playback**. `seek()` preserves the current play state instead of force-pausing, so scrubbing, bookmark jumps, and timeline-row clicks keep the replay running — while an operator who deliberately paused can still frame-step by scrubbing. Tab-pin pause (`selectTab` → `pause()`) and end-of-session stop/Restart are deliberately unchanged.

## Root-cause findings (each symptom reproduced against current `main` first)

Repro method: dev build of unmodified `main` (733050235) served via `dev:web`, opened against the live local claw-server (`?apiUrl=127.0.0.1:9210`) on a real recorded session (`201f26ae`, news.ycombinator.com, 6:30 of activity), driven through CDP with play-state sampled from the DOM after every interaction.

| Symptom reported | Verdict on main | Evidence |
|---|---|---|
| Opens paused, user must press play | **Already correct — not reproducible.** `isPlaying` inits `true` and `Replay.tsx` runs `seek(0); play()` on session load | On load: toggle showed "Pause" (= playing), clock advancing. The owner was likely on an older build |
| Changing speed pauses | **Already correct — not reproducible.** `setSpeed` never touches `isPlaying`; the rrweb path (`setConfig({speed})` + `replayer.play(ms)` in `ReplayViewport.alignPlayer`) keeps the visual player running too | Clicked 4× while playing: toggle stayed "Pause", activity advanced **12.00s in 3.00s wall = exact 4×**, viewport kept rendering. No change made for this symptom |
| Scrubbing pauses | **Real bug.** `use-playback.ts` `seek()` ended with `setIsPlaying(false)` | Clicking the scrubber on main flipped the transport button Pause → Play |
| Bookmark dot / timeline-step click pauses | **Real bug — same root cause.** Both funnel into the same `seek()` (`onSeek(action.startAt)` / `selectAction`) | Clicking a timeline row on main flipped Pause → Play |

So the fix is exactly two source changes: `DEFAULT_PLAYBACK_SPEED` 2 → 4, and `seek()` no longer force-pausing. No change to `ReplayViewport` (root-causing showed the rrweb wiring already handles playing seeks via its drift correction, and speed changes via `controlChanged`).

## Real-UI verification (dev build with this change, same session)

- **Opens already playing at 4×**: toggle "Pause", 4× pressed, clock advanced 12.00s in 3.00s wall (exact 4×). Screenshot verified — transport shows pause icon, 1:18/6:30, 4× active.
- **Click 2× while playing**: stays playing, 2× pressed, clock continues at 2× rate.
- **Scrub while playing** (real pointer click on the range track — jumped ~2:30 → ~0:40): stays playing, clock keeps advancing from the new position (+6.00s in 3.00s at 2×). Same interaction on main paused.
- **Timeline-row click while playing** (row at 3:45): playhead jumped 89s → 226s, stayed playing. (This session has no non-action frames, so no bookmark dots exist to click in-UI; the bookmark path is the identical `onSeek → seek` code path, covered by the `PlaybackTransport` unit test against the real component.)
- **Scrub while deliberately paused**: playhead moved 246.9s → 94.7s, stayed paused, clock frozen — frame-stepping preserved.
- **Pause/resume buttons**: still work; end-of-session Restart untouched.

One measurement note: right after a speed change the clock can briefly under-advance vs wall time (e.g. 5.1s in 3s at 2×) — that's rrweb re-align jank blocking the main thread while the wall-anchored clock intentionally holds (no frames → no advance), then resumes at the exact rate. Pre-existing, by design of the app-owned clock.

## Tests

- `use-playback.test.tsx`: default is 4× and autoplays; scrub while playing keeps playing and re-anchors the clock at the target; speed change while playing keeps playing; scrub while paused stays paused (and runs no clock); a playing scrub onto the end still completes naturally; seek clamping kept.
- `PlaybackTransport.test.tsx`: starts at 4× with all speeds selectable; a speed change through the real Base-UI picker never pauses; a bookmark-dot jump seeks without pausing.
- `Replay.test.tsx`: autoplay asserts speed 4×; timeline-row click keeps playing (was: pauses); new screen-level test for scrub + speed change keeping `isPlaying`; tab-pin still pauses (unchanged assertions).

`bun run check` → exit 0. `bun run test` (full monorepo suite via per-file runner) → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
