### PR TITLE
feat(claw-onboard): use the BrowserClaw dog logo in the onboarding rail

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/VisualRail.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/VisualRail.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { VisualRail } from './VisualRail'
+
+describe('VisualRail', () => {
+  it('renders the dog logo from the chromium-allowlisted icon path', () => {
+    const html = renderToStaticMarkup(<VisualRail />)
+
+    // A literal /icon/128.png keeps the chromium build allowlist happy; an
+    // import would emit a new hashed asset and fail verify-chromium-build.ts.
+    expect(html).toContain('src="/icon/128.png"')
+    expect(html).toContain('BrowserClaw')
+  })
+})

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/VisualRail.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/VisualRail.tsx
@@ -19,9 +19,14 @@ export function VisualRail() {
         }}
       />
       <div className="relative flex items-center gap-2.5">
-        <div className="flex size-[38px] items-center justify-center rounded-[11px] bg-accent font-extrabold text-card text-lg">
-          B
-        </div>
+        {/* Must stay a literal public path: importing the asset or inlining it
+            breaks scripts/verify-chromium-build.ts (allowlist, no data: URLs). */}
+        <img
+          alt=""
+          aria-hidden
+          className="size-[38px] rounded-[11px]"
+          src="/icon/128.png"
+        />
         <div className="font-extrabold text-[17px] tracking-tight">
           BrowserClaw
         </div>


### PR DESCRIPTION
## What

Replaces the hardcoded letter-"B" placeholder tile in the onboarding rail's top-left brand lockup (`VisualRail.tsx`) with the real BrowserClaw dog logo. The wordmark text beside it is unchanged.

Owner ask: "takes the browserclaw logo and puts it on the top left of this onboarding page. we should have that dog logo there."

## How

The logo is referenced as a **literal public path** — `<img src="/icon/128.png">` — the same pattern `index.html` already uses for the favicon. This is the only approach compatible with `verify-chromium-build.ts`, which allowlists exactly `app.css`/`app.js`/`index.html` + the five `icon/*.png` files and bans `data:` URLs: a Vite asset import would emit a new hashed file, and base64 inlining would trip the data-URL check. A code comment pins this constraint so it doesn't get "cleaned up" into an import later.

Details:
- Renders at the same 38×38 footprint with the same `rounded-[11px]` corner clip as the old tile; the PNG carries its own blue rounded square, so the old `bg-accent` wrapper is gone (no square-in-square).
- `128.png` source ≈ 3.4× the render size, so it stays crisp on retina.
- `alt="" aria-hidden` — the adjacent "BrowserClaw" wordmark is the accessible name, avoiding a double announcement.
- New `VisualRail.test.tsx` pins the literal `/icon/128.png` path so a future refactor to an asset import fails fast.

## Verification

- `bun run check` and `bun run test` pass from `packages/browseros-agent` (74/74 claw-onboard tests).
- `bun run build:claw-onboard` passes; `bun run --filter @browseros/claw-onboard build:chromium` passes including `verify-chromium-build.ts` — emitted files are exactly the allowlist, and the literal `/icon/128.png` string survives into `app.js`.
- Rendered at `http://localhost:5201` and inspected visually, including at 6× zoom: white dog on blue rounded tile in the top-left, crisp edges, correct 38×38 size and 11px corner rounding, vertically centred against the wordmark, blending cleanly into the rail gradient. Runtime-inspected the element: 38×38 rect, `border-radius: 11px`, `naturalWidth: 128`, image `complete: true`.

Diff: `VisualRail.tsx` + its new test file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)