### PR TITLE
fix(app): make chat history durable and local-first (#559)

### DIFF
--- a/packages/browseros-agent/apps/app/lib/auth/lastSignedInUser.ts
+++ b/packages/browseros-agent/apps/app/lib/auth/lastSignedInUser.ts
@@ -1,0 +1,11 @@
+import { storage } from '@wxt-dev/storage'
+
+/**
+ * The most recent signed-in user id, persisted locally so their chat history
+ * stays scoped to them after sign-out (issue #559) without leaking to another
+ * account that signs into the same browser profile.
+ */
+export const lastSignedInUserStorage = storage.defineItem<string | null>(
+  'local:lastSignedInUserId',
+  { fallback: null },
+)

--- a/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.test.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.test.ts
@@ -3,6 +3,7 @@ import {
   backfillConversationOwners,
   filterConversationsByOwner,
   resolveEffectiveOwnerId,
+  selectUploadableConversations,
   stampConversationOwner,
 } from './conversation-scope'
 import type { Conversation } from './conversationStorage'
@@ -44,16 +45,21 @@ describe('filterConversationsByOwner', () => {
 })
 
 describe('backfillConversationOwners', () => {
-  it('stamps the owner onto pre-owner conversations', () => {
+  it('stamps the owner onto pre-owner conversations and marks them local-only', () => {
     const result = backfillConversationOwners([conv('a'), conv('b')], 'A')
     expect(result.changed).toBe(true)
     expect(result.conversations.map((c) => c.owner)).toEqual(['A', 'A'])
+    expect(result.conversations.map((c) => c.localOnly)).toEqual([true, true])
   })
 
-  it('leaves already-owned conversations untouched', () => {
+  it('leaves already-owned conversations untouched and not local-only', () => {
     const result = backfillConversationOwners([conv('a', 'A'), conv('b')], 'A')
     expect(result.changed).toBe(true)
     expect(result.conversations.map((c) => c.owner)).toEqual(['A', 'A'])
+    expect(result.conversations.map((c) => c.localOnly)).toEqual([
+      undefined,
+      true,
+    ])
   })
 
   it('never reassigns a conversation owned by another account', () => {
@@ -92,5 +98,25 @@ describe('stampConversationOwner', () => {
   it('stamps undefined for a truly anonymous save', () => {
     const [stamped] = stampConversationOwner([conv('a')], 'a', undefined)
     expect(stamped.owner).toBeUndefined()
+  })
+})
+
+describe('selectUploadableConversations', () => {
+  const backfilled = (id: string, owner: string): Conversation => ({
+    ...conv(id, owner),
+    localOnly: true,
+  })
+
+  it('excludes backfill-adopted (local-only) records from upload', () => {
+    const input = [conv('a', 'A'), backfilled('b', 'A'), conv('c', 'A')]
+    expect(selectUploadableConversations(input).map((c) => c.id)).toEqual([
+      'a',
+      'c',
+    ])
+  })
+
+  it('keeps everything when no record is local-only', () => {
+    const input = [conv('a', 'A'), conv('b', 'A')]
+    expect(selectUploadableConversations(input)).toEqual(input)
   })
 })

--- a/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.test.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.test.ts
@@ -3,6 +3,7 @@ import {
   backfillConversationOwners,
   filterConversationsByOwner,
   resolveEffectiveOwnerId,
+  stampConversationOwner,
 } from './conversation-scope'
 import type { Conversation } from './conversationStorage'
 
@@ -69,5 +70,27 @@ describe('backfillConversationOwners', () => {
 
   it('reports no change for an empty list', () => {
     expect(backfillConversationOwners([], 'A').changed).toBe(false)
+  })
+})
+
+describe('stampConversationOwner', () => {
+  it('stamps the effective owner on the matching conversation only', () => {
+    const result = stampConversationOwner([conv('a'), conv('b')], 'a', 'A')
+    expect(result.map((c) => [c.id, c.owner])).toEqual([
+      ['a', 'A'],
+      ['b', undefined],
+    ])
+  })
+
+  it('keeps a signed-out continuation scoped to the last signed-in user', () => {
+    const [stamped] = stampConversationOwner([conv('a', 'A')], 'a', 'A')
+    expect(filterConversationsByOwner([stamped], 'A').map((c) => c.id)).toEqual(
+      ['a'],
+    )
+  })
+
+  it('stamps undefined for a truly anonymous save', () => {
+    const [stamped] = stampConversationOwner([conv('a')], 'a', undefined)
+    expect(stamped.owner).toBeUndefined()
   })
 })

--- a/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.test.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import {
+  backfillConversationOwners,
   filterConversationsByOwner,
   resolveEffectiveOwnerId,
 } from './conversation-scope'
@@ -38,5 +39,35 @@ describe('filterConversationsByOwner', () => {
     expect(filterConversationsByOwner(all, undefined).map((c) => c.id)).toEqual(
       ['anon'],
     )
+  })
+})
+
+describe('backfillConversationOwners', () => {
+  it('stamps the owner onto pre-owner conversations', () => {
+    const result = backfillConversationOwners([conv('a'), conv('b')], 'A')
+    expect(result.changed).toBe(true)
+    expect(result.conversations.map((c) => c.owner)).toEqual(['A', 'A'])
+  })
+
+  it('leaves already-owned conversations untouched', () => {
+    const result = backfillConversationOwners([conv('a', 'A'), conv('b')], 'A')
+    expect(result.changed).toBe(true)
+    expect(result.conversations.map((c) => c.owner)).toEqual(['A', 'A'])
+  })
+
+  it('never reassigns a conversation owned by another account', () => {
+    const result = backfillConversationOwners([conv('a', 'B')], 'A')
+    expect(result.conversations[0].owner).toBe('B')
+  })
+
+  it('reports no change when every conversation already has an owner', () => {
+    const input = [conv('a', 'A'), conv('b', 'B')]
+    const result = backfillConversationOwners(input, 'A')
+    expect(result.changed).toBe(false)
+    expect(result.conversations).toBe(input)
+  })
+
+  it('reports no change for an empty list', () => {
+    expect(backfillConversationOwners([], 'A').changed).toBe(false)
   })
 })

--- a/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.test.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  filterConversationsByOwner,
+  resolveEffectiveOwnerId,
+} from './conversation-scope'
+import type { Conversation } from './conversationStorage'
+
+const conv = (id: string, owner?: string): Conversation => ({
+  id,
+  owner,
+  messages: [],
+  lastMessagedAt: 0,
+})
+
+describe('resolveEffectiveOwnerId', () => {
+  it('uses the current user when signed in', () => {
+    expect(resolveEffectiveOwnerId('A', 'B')).toBe('A')
+  })
+
+  it('falls back to the last signed-in user when signed out', () => {
+    expect(resolveEffectiveOwnerId(undefined, 'A')).toBe('A')
+  })
+
+  it('is undefined when signed out and never signed in', () => {
+    expect(resolveEffectiveOwnerId(undefined, null)).toBeUndefined()
+  })
+})
+
+describe('filterConversationsByOwner', () => {
+  const all = [conv('a', 'A'), conv('b', 'B'), conv('anon')]
+
+  it('keeps only the effective owner and never another account', () => {
+    expect(filterConversationsByOwner(all, 'A').map((c) => c.id)).toEqual(['a'])
+    expect(filterConversationsByOwner(all, 'B').map((c) => c.id)).toEqual(['b'])
+  })
+
+  it('keeps only anonymous conversations when there is no effective owner', () => {
+    expect(filterConversationsByOwner(all, undefined).map((c) => c.id)).toEqual(
+      ['anon'],
+    )
+  })
+})

--- a/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.ts
@@ -45,8 +45,10 @@ export function stampConversationOwner(
  * Stamps the given owner onto every conversation that predates owner tracking
  * (no owner yet), leaving already-owned ones untouched. Run once on upgrade so
  * a user's pre-existing local history stays scoped to them instead of vanishing
- * behind the owner filter (#559). Returns `changed: false` when nothing needed
- * stamping so callers can skip the write.
+ * behind the owner filter (#559). The inferred owner is marked `localOnly` so
+ * the record is never uploaded: on a shared profile the first signer sees the
+ * adopted history locally but it can't reach their cloud. Returns
+ * `changed: false` when nothing needed stamping so callers can skip the write.
  */
 export function backfillConversationOwners(
   conversations: Conversation[],
@@ -56,7 +58,18 @@ export function backfillConversationOwners(
   const next = conversations.map((conversation) => {
     if (conversation.owner != null) return conversation
     changed = true
-    return { ...conversation, owner: ownerId }
+    return { ...conversation, owner: ownerId, localOnly: true }
   })
   return changed ? { changed, conversations: next } : { changed, conversations }
+}
+
+/**
+ * The conversations that may be pushed to the cloud: everything except records
+ * whose owner was only inferred by the upgrade backfill (`localOnly`). Keeps one
+ * account's adopted pre-upgrade history out of another account's cloud (#559).
+ */
+export function selectUploadableConversations(
+  conversations: Conversation[],
+): Conversation[] {
+  return conversations.filter((conversation) => !conversation.localOnly)
 }

--- a/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.ts
@@ -23,3 +23,23 @@ export function filterConversationsByOwner(
     (conversation) => (conversation.owner ?? undefined) === effectiveOwnerId,
   )
 }
+
+/**
+ * Stamps the given owner onto every conversation that predates owner tracking
+ * (no owner yet), leaving already-owned ones untouched. Run once on upgrade so
+ * a user's pre-existing local history stays scoped to them instead of vanishing
+ * behind the owner filter (#559). Returns `changed: false` when nothing needed
+ * stamping so callers can skip the write.
+ */
+export function backfillConversationOwners(
+  conversations: Conversation[],
+  ownerId: string,
+): { changed: boolean; conversations: Conversation[] } {
+  let changed = false
+  const next = conversations.map((conversation) => {
+    if (conversation.owner != null) return conversation
+    changed = true
+    return { ...conversation, owner: ownerId }
+  })
+  return changed ? { changed, conversations: next } : { changed, conversations }
+}

--- a/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.ts
@@ -25,6 +25,23 @@ export function filterConversationsByOwner(
 }
 
 /**
+ * Returns a copy of `conversations` with `ownerId` stamped on the conversation
+ * matching `id`, leaving the rest untouched. Callers pass the effective owner
+ * (current user, else last signed-in) so a signed-out user continuing their own
+ * history keeps it scoped to them instead of dropping it to an anonymous,
+ * unowned record that then leaks into anonymous history (#559).
+ */
+export function stampConversationOwner(
+  conversations: Conversation[],
+  id: string,
+  ownerId: string | undefined,
+): Conversation[] {
+  return conversations.map((conversation) =>
+    conversation.id === id ? { ...conversation, owner: ownerId } : conversation,
+  )
+}
+
+/**
  * Stamps the given owner onto every conversation that predates owner tracking
  * (no owner yet), leaving already-owned ones untouched. Run once on upgrade so
  * a user's pre-existing local history stays scoped to them instead of vanishing

--- a/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversation-scope.ts
@@ -1,0 +1,25 @@
+import type { Conversation } from './conversationStorage'
+
+/**
+ * The identity whose local history is shown: the current user, or the last
+ * signed-in user when signed out (issue #559). undefined means never signed in
+ * (an anonymous local session). Keeping the last signed-in user lets a user who
+ * just signed out still see their own history, while a different account that
+ * signs into the same browser profile never sees it.
+ */
+export function resolveEffectiveOwnerId(
+  userId: string | undefined,
+  lastSignedInUserId: string | null,
+): string | undefined {
+  return userId ?? lastSignedInUserId ?? undefined
+}
+
+/** Keeps only the conversations owned by the effective identity. */
+export function filterConversationsByOwner(
+  conversations: Conversation[],
+  effectiveOwnerId: string | undefined,
+): Conversation[] {
+  return conversations.filter(
+    (conversation) => (conversation.owner ?? undefined) === effectiveOwnerId,
+  )
+}

--- a/packages/browseros-agent/apps/app/lib/conversations/conversation-write-queue.test.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversation-write-queue.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test'
+import { runExclusive } from './conversation-write-queue'
+
+describe('runExclusive', () => {
+  it('serializes overlapping mutations instead of interleaving them', async () => {
+    const order: string[] = []
+
+    const first = runExclusive(async () => {
+      order.push('a-start')
+      await Promise.resolve()
+      await Promise.resolve()
+      order.push('a-end')
+    })
+    const second = runExclusive(async () => {
+      order.push('b-start')
+      order.push('b-end')
+    })
+
+    await Promise.all([first, second])
+    expect(order).toEqual(['a-start', 'a-end', 'b-start', 'b-end'])
+  })
+
+  it('keeps draining the queue after a mutation rejects', async () => {
+    await expect(
+      runExclusive(async () => {
+        throw new Error('boom')
+      }),
+    ).rejects.toThrow('boom')
+
+    await expect(runExclusive(async () => 'ok')).resolves.toBe('ok')
+  })
+})

--- a/packages/browseros-agent/apps/app/lib/conversations/conversation-write-queue.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversation-write-queue.ts
@@ -1,0 +1,19 @@
+let tail: Promise<unknown> = Promise.resolve()
+
+const swallow = () => undefined
+
+/**
+ * Serializes read-modify-write cycles on the shared conversation store within
+ * this context, so a backfill, save, or delete never clobbers another's write
+ * from a stale snapshot (#559): a stale save could otherwise drop the backfill's
+ * `localOnly` flag (and upload adopted history) or a late backfill write could
+ * resurrect a just-deleted conversation. Each mutation reads the latest value
+ * inside its own turn, so overlapping mutations apply in order. `chrome.storage`
+ * is shared across contexts and every `setValue` is last-write-wins, so this
+ * covers same-context overlap; separate windows still resolve last-write-wins.
+ */
+export function runExclusive<T>(mutate: () => Promise<T>): Promise<T> {
+  const result = tail.then(mutate, mutate)
+  tail = result.then(swallow, swallow)
+  return result
+}

--- a/packages/browseros-agent/apps/app/lib/conversations/conversationStorage.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversationStorage.ts
@@ -19,3 +19,14 @@ export const conversationStorage = storage.defineItem<Conversation[]>(
     fallback: [],
   },
 )
+
+/**
+ * Set once the pre-owner local history has been stamped with its owner on
+ * upgrade, so the one-time backfill never runs again (#559).
+ */
+export const conversationsOwnerBackfilledStorage = storage.defineItem<boolean>(
+  'local:conversationsOwnerBackfilled',
+  {
+    fallback: false,
+  },
+)

--- a/packages/browseros-agent/apps/app/lib/conversations/conversationStorage.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversationStorage.ts
@@ -11,6 +11,14 @@ export interface Conversation {
    * sign-out without leaking to another account on the same profile (#559).
    */
   owner?: string
+  /**
+   * Set when the owner was inferred by the upgrade backfill rather than
+   * observed at authoring time. Such records stay local-only and are never
+   * uploaded, so a shared profile can't push one account's pre-upgrade history
+   * into the first signer's cloud (#559). Sticky: continuing the conversation
+   * does not clear it, so a later signer can't promote an adopted record.
+   */
+  localOnly?: boolean
 }
 
 export const conversationStorage = storage.defineItem<Conversation[]>(

--- a/packages/browseros-agent/apps/app/lib/conversations/conversationStorage.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/conversationStorage.ts
@@ -5,6 +5,12 @@ export interface Conversation {
   id: string
   messages: UIMessage[]
   lastMessagedAt: number
+  /**
+   * User id that authored the conversation, or undefined when authored
+   * signed-out. Scopes local history to its owner so it survives that user's
+   * sign-out without leaking to another account on the same profile (#559).
+   */
+  owner?: string
 }
 
 export const conversationStorage = storage.defineItem<Conversation[]>(

--- a/packages/browseros-agent/apps/app/lib/conversations/uploadConversationsToGraphql.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/uploadConversationsToGraphql.ts
@@ -1,7 +1,7 @@
 import { execute } from '@/lib/graphql/execute'
 import { sessionStorage } from '../auth/sessionStorage'
 import { sentry } from '../sentry/sentry'
-import { type Conversation, conversationStorage } from './conversationStorage'
+import type { Conversation } from './conversationStorage'
 import {
   BulkCreateConversationMessagesDocument,
   ConversationExistsDocument,
@@ -23,8 +23,6 @@ export async function uploadConversationsToGraphql(
   const profileId = profileResult.profileByUserId?.rowId
   if (!profileId) return
 
-  const uploadedIds: string[] = []
-
   for (const conversation of conversations) {
     try {
       const existsResult = await execute(ConversationExistsDocument, {
@@ -40,7 +38,6 @@ export async function uploadConversationsToGraphql(
         uploadedCount = countResult.conversationMessages?.totalCount ?? 0
 
         if (uploadedCount >= conversation.messages.length) {
-          uploadedIds.push(conversation.id)
           continue
         }
       } else {
@@ -75,8 +72,6 @@ export async function uploadConversationsToGraphql(
           })
         }
       }
-
-      uploadedIds.push(conversation.id)
     } catch (error) {
       sentry.captureException(error, {
         extra: {
@@ -86,9 +81,8 @@ export async function uploadConversationsToGraphql(
       })
     }
   }
-
-  if (uploadedIds.length > 0) {
-    const remaining = conversations.filter((c) => !uploadedIds.includes(c.id))
-    conversationStorage.setValue(remaining)
-  }
+  // Local conversations are the durable source of truth and are intentionally
+  // NOT drained after upload (issue #559): the cloud is a mirror, not a move.
+  // Re-uploads are idempotent via the conversationExists + uploaded-count
+  // checks above, so retaining local costs at most a skip round-trip.
 }

--- a/packages/browseros-agent/apps/app/lib/conversations/useConversations.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/useConversations.ts
@@ -1,9 +1,14 @@
 import type { UIMessage } from 'ai'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { lastSignedInUserStorage } from '../auth/lastSignedInUser'
 import { useSessionInfo } from '../auth/sessionStorage'
 import { removeConversationExecutionHistory } from '../execution-history/storage'
 import { sentry } from '../sentry/sentry'
 import { planConversationSave } from './conversation-save'
+import {
+  filterConversationsByOwner,
+  resolveEffectiveOwnerId,
+} from './conversation-scope'
 import { createConversationUploadScheduler } from './conversation-upload-scheduler'
 import { type Conversation, conversationStorage } from './conversationStorage'
 import { uploadConversationsToGraphql } from './uploadConversationsToGraphql'
@@ -20,22 +25,46 @@ const scheduleConversationUpload = createConversationUploadScheduler(
 )
 
 export function useConversations() {
-  const [conversations, setConversations] = useState<Conversation[]>()
+  const [allConversations, setAllConversations] = useState<Conversation[]>()
+  const [lastSignedInUserId, setLastSignedInUserId] = useState<string | null>(
+    null,
+  )
 
   const { sessionInfo } = useSessionInfo()
+  const userId = sessionInfo.user?.id
+
+  useEffect(() => {
+    lastSignedInUserStorage.getValue().then(setLastSignedInUserId)
+    const unwatch = lastSignedInUserStorage.watch((value) => {
+      setLastSignedInUserId(value ?? null)
+    })
+    return unwatch
+  }, [])
+
+  // Remember the signed-in user so their history stays scoped to them after
+  // sign-out (issue #559).
+  useEffect(() => {
+    if (userId) lastSignedInUserStorage.setValue(userId)
+  }, [userId])
+
+  const effectiveOwnerId = resolveEffectiveOwnerId(userId, lastSignedInUserId)
+
+  // Only surface the effective identity's conversations so another account
+  // signing into the same browser profile never sees them (#559).
+  const conversations = useMemo(
+    () => filterConversationsByOwner(allConversations ?? [], effectiveOwnerId),
+    [allConversations, effectiveOwnerId],
+  )
 
   useEffect(() => {
     // An empty snapshot cancels work queued before logout or local deletion.
-    scheduleConversationUpload(
-      sessionInfo.user?.id ? conversations : [],
-      sessionInfo.user?.id ?? null,
-    )
-  }, [sessionInfo.user?.id, conversations])
+    scheduleConversationUpload(userId ? conversations : [], userId ?? null)
+  }, [userId, conversations])
 
   useEffect(() => {
-    conversationStorage.getValue().then(setConversations)
+    conversationStorage.getValue().then(setAllConversations)
     const unwatch = conversationStorage.watch((newValue) => {
-      setConversations(newValue ?? [])
+      setAllConversations(newValue ?? [])
     })
     return unwatch
   }, [])
@@ -51,18 +80,27 @@ export function useConversations() {
     const plan = planConversationSave(current, id, messages)
     if (!plan) return
 
-    await conversationStorage.setValue(plan.conversations)
+    // Stamp the current owner on the saved conversation so it stays scoped to
+    // whoever authored it (undefined when signed out).
+    const owned = plan.conversations.map((conversation) =>
+      conversation.id === id
+        ? { ...conversation, owner: userId }
+        : conversation,
+    )
+
+    await conversationStorage.setValue(owned)
     await Promise.all(
       plan.removedConversationIds.map(removeConversationExecutionHistory),
     )
   }
 
   const getConversation = (id: string) => {
-    return conversations?.find((c) => c.id === id)
+    return conversations.find((c) => c.id === id)
   }
 
   return {
-    conversations: conversations ?? [],
+    conversations,
+    effectiveOwnerId,
     removeConversation,
     saveConversation,
     getConversation,

--- a/packages/browseros-agent/apps/app/lib/conversations/useConversations.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/useConversations.ts
@@ -9,6 +9,7 @@ import {
   backfillConversationOwners,
   filterConversationsByOwner,
   resolveEffectiveOwnerId,
+  stampConversationOwner,
 } from './conversation-scope'
 import { createConversationUploadScheduler } from './conversation-upload-scheduler'
 import {
@@ -111,12 +112,13 @@ export function useConversations() {
     const plan = planConversationSave(current, id, messages)
     if (!plan) return
 
-    // Stamp the current owner on the saved conversation so it stays scoped to
-    // whoever authored it (undefined when signed out).
-    const owned = plan.conversations.map((conversation) =>
-      conversation.id === id
-        ? { ...conversation, owner: userId }
-        : conversation,
+    // Stamp the effective owner so a signed-out user continuing their own
+    // (last signed-in) history keeps it scoped to them rather than dropping it
+    // to an anonymous record that the owner filter would then hide (#559).
+    const owned = stampConversationOwner(
+      plan.conversations,
+      id,
+      effectiveOwnerId,
     )
 
     await conversationStorage.setValue(owned)

--- a/packages/browseros-agent/apps/app/lib/conversations/useConversations.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/useConversations.ts
@@ -13,6 +13,7 @@ import {
   stampConversationOwner,
 } from './conversation-scope'
 import { createConversationUploadScheduler } from './conversation-upload-scheduler'
+import { runExclusive } from './conversation-write-queue'
 import {
   type Conversation,
   conversationStorage,
@@ -64,7 +65,8 @@ export function useConversations() {
   useEffect(() => {
     if (!effectiveOwnerId) return
     let cancelled = false
-    ;(async () => {
+    runExclusive(async () => {
+      if (cancelled) return
       if (await conversationsOwnerBackfilledStorage.getValue()) return
       const current = (await conversationStorage.getValue()) ?? []
       const result = backfillConversationOwners(current, effectiveOwnerId)
@@ -72,7 +74,7 @@ export function useConversations() {
       if (result.changed)
         await conversationStorage.setValue(result.conversations)
       await conversationsOwnerBackfilledStorage.setValue(true)
-    })().catch((error) => {
+    }).catch((error) => {
       sentry.captureException(error, {
         extra: { message: 'Failed to backfill conversation owners' },
       })
@@ -107,31 +109,33 @@ export function useConversations() {
     return unwatch
   }, [])
 
-  const removeConversation = async (id: string) => {
-    const current = (await conversationStorage.getValue()) ?? []
-    await conversationStorage.setValue(current.filter((c) => c.id !== id))
-    await removeConversationExecutionHistory(id)
-  }
+  const removeConversation = (id: string) =>
+    runExclusive(async () => {
+      const current = (await conversationStorage.getValue()) ?? []
+      await conversationStorage.setValue(current.filter((c) => c.id !== id))
+      await removeConversationExecutionHistory(id)
+    })
 
-  const saveConversation = async (id: string, messages: UIMessage[]) => {
-    const current = (await conversationStorage.getValue()) ?? []
-    const plan = planConversationSave(current, id, messages)
-    if (!plan) return
+  const saveConversation = (id: string, messages: UIMessage[]) =>
+    runExclusive(async () => {
+      const current = (await conversationStorage.getValue()) ?? []
+      const plan = planConversationSave(current, id, messages)
+      if (!plan) return
 
-    // Stamp the effective owner so a signed-out user continuing their own
-    // (last signed-in) history keeps it scoped to them rather than dropping it
-    // to an anonymous record that the owner filter would then hide (#559).
-    const owned = stampConversationOwner(
-      plan.conversations,
-      id,
-      effectiveOwnerId,
-    )
+      // Stamp the effective owner so a signed-out user continuing their own
+      // (last signed-in) history keeps it scoped to them rather than dropping it
+      // to an anonymous record that the owner filter would then hide (#559).
+      const owned = stampConversationOwner(
+        plan.conversations,
+        id,
+        effectiveOwnerId,
+      )
 
-    await conversationStorage.setValue(owned)
-    await Promise.all(
-      plan.removedConversationIds.map(removeConversationExecutionHistory),
-    )
-  }
+      await conversationStorage.setValue(owned)
+      await Promise.all(
+        plan.removedConversationIds.map(removeConversationExecutionHistory),
+      )
+    })
 
   const getConversation = (id: string) => {
     return conversations.find((c) => c.id === id)

--- a/packages/browseros-agent/apps/app/lib/conversations/useConversations.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/useConversations.ts
@@ -9,6 +9,7 @@ import {
   backfillConversationOwners,
   filterConversationsByOwner,
   resolveEffectiveOwnerId,
+  selectUploadableConversations,
   stampConversationOwner,
 } from './conversation-scope'
 import { createConversationUploadScheduler } from './conversation-upload-scheduler'
@@ -90,7 +91,12 @@ export function useConversations() {
 
   useEffect(() => {
     // An empty snapshot cancels work queued before logout or local deletion.
-    scheduleConversationUpload(userId ? conversations : [], userId ?? null)
+    // Backfill-adopted (localOnly) records are never uploaded so a shared
+    // profile can't push one account's pre-upgrade history into another's cloud.
+    scheduleConversationUpload(
+      userId ? selectUploadableConversations(conversations) : [],
+      userId ?? null,
+    )
   }, [userId, conversations])
 
   useEffect(() => {

--- a/packages/browseros-agent/apps/app/lib/conversations/useConversations.ts
+++ b/packages/browseros-agent/apps/app/lib/conversations/useConversations.ts
@@ -6,11 +6,16 @@ import { removeConversationExecutionHistory } from '../execution-history/storage
 import { sentry } from '../sentry/sentry'
 import { planConversationSave } from './conversation-save'
 import {
+  backfillConversationOwners,
   filterConversationsByOwner,
   resolveEffectiveOwnerId,
 } from './conversation-scope'
 import { createConversationUploadScheduler } from './conversation-upload-scheduler'
-import { type Conversation, conversationStorage } from './conversationStorage'
+import {
+  type Conversation,
+  conversationStorage,
+  conversationsOwnerBackfilledStorage,
+} from './conversationStorage'
 import { uploadConversationsToGraphql } from './uploadConversationsToGraphql'
 
 const scheduleConversationUpload = createConversationUploadScheduler(
@@ -48,6 +53,32 @@ export function useConversations() {
   }, [userId])
 
   const effectiveOwnerId = resolveEffectiveOwnerId(userId, lastSignedInUserId)
+
+  // One-time upgrade migration: conversations created before owner tracking
+  // have no owner and would otherwise be hidden by the owner filter. Stamp them
+  // for the first effective owner we see, once, so a user's pre-existing history
+  // stays with them (#559). Deferred until an owner exists, so a never-signed-in
+  // install keeps its history anonymous until first sign-in.
+  useEffect(() => {
+    if (!effectiveOwnerId) return
+    let cancelled = false
+    ;(async () => {
+      if (await conversationsOwnerBackfilledStorage.getValue()) return
+      const current = (await conversationStorage.getValue()) ?? []
+      const result = backfillConversationOwners(current, effectiveOwnerId)
+      if (cancelled) return
+      if (result.changed)
+        await conversationStorage.setValue(result.conversations)
+      await conversationsOwnerBackfilledStorage.setValue(true)
+    })().catch((error) => {
+      sentry.captureException(error, {
+        extra: { message: 'Failed to backfill conversation owners' },
+      })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [effectiveOwnerId])
 
   // Only surface the effective identity's conversations so another account
   // signing into the same browser profile never sees them (#559).

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session-persistence.test.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session-persistence.test.ts
@@ -3,6 +3,7 @@ import type { ChatStatus, UIMessage } from 'ai'
 import {
   didStreamingTurnFinish,
   getPersistableMessages,
+  pickRicherMessages,
 } from './chat-session-persistence'
 
 describe('chat session persistence transitions', () => {
@@ -50,6 +51,41 @@ describe('chat session persistence transitions', () => {
     expect(
       getPersistableMessages([user, emptyAssistant, partialAssistant]),
     ).toEqual([user, partialAssistant])
+  })
+})
+
+describe('pickRicherMessages (resume reconcile)', () => {
+  const local = [userMessage('a'), assistantMessage('b')]
+  const remoteAhead = [
+    userMessage('a'),
+    assistantMessage('b'),
+    userMessage('c'),
+  ]
+
+  it('prefers the cloud copy when it has more messages', () => {
+    expect(pickRicherMessages(local, remoteAhead)).toBe(remoteAhead)
+  })
+
+  it('prefers the cloud copy when both are equal length (cloud is authoritative)', () => {
+    const remoteSame = [userMessage('a'), assistantMessage('b')]
+    expect(pickRicherMessages(local, remoteSame)).toBe(remoteSame)
+  })
+
+  it('keeps the local copy when it has more messages (never regress)', () => {
+    const remoteBehind = [userMessage('a')]
+    expect(pickRicherMessages(local, remoteBehind)).toBe(local)
+  })
+
+  it('falls back to local when the cloud has no copy', () => {
+    expect(pickRicherMessages(local, undefined)).toBe(local)
+  })
+
+  it('uses the cloud copy when there is no local copy', () => {
+    expect(pickRicherMessages(undefined, remoteAhead)).toBe(remoteAhead)
+  })
+
+  it('returns undefined when neither source has the conversation', () => {
+    expect(pickRicherMessages(undefined, undefined)).toBeUndefined()
   })
 })
 

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session-persistence.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session-persistence.ts
@@ -15,3 +15,16 @@ export function getPersistableMessages(messages: UIMessage[]) {
     messages.filter((message) => message.parts?.length > 0),
   )
 }
+
+/**
+ * Chooses the copy to display when resuming a conversation: prefer the cloud
+ * copy unless the local copy has more messages (never regress to fewer).
+ * Returns undefined when neither source has the conversation.
+ */
+export function pickRicherMessages(
+  local: UIMessage[] | undefined,
+  remote: UIMessage[] | undefined,
+): UIMessage[] | undefined {
+  if (remote && (!local || remote.length >= local.length)) return remote
+  return local ?? remote
+}

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -183,7 +183,8 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     error: agentUrlError,
   } = useAgentServerUrl()
 
-  const { saveConversation: saveLocalConversation } = useConversations()
+  const { saveConversation: saveLocalConversation, effectiveOwnerId } =
+    useConversations()
   const {
     isLoggedIn,
     saveConversation: saveRemoteConversation,
@@ -487,8 +488,12 @@ export const useChatSession = (options?: ChatSessionOptions) => {
       // cloud actually holds.
       const localConversations = await conversationStorage.getValue()
       if (cancelled) return
+      // Scope by owner so a per-window pointer never restores another account's
+      // conversation on a shared profile (#559).
       const local = localConversations?.find(
-        (c) => c.id === conversationIdParam,
+        (c) =>
+          c.id === conversationIdParam &&
+          (c.owner ?? undefined) === effectiveOwnerId,
       )
 
       // Signed in but the cloud copy is still loading: show local now and let
@@ -528,6 +533,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     remoteConversationData,
     isRemoteConversationFetched,
     isLoggedIn,
+    effectiveOwnerId,
   ])
 
   // Per-window scope: resume this window's conversation when the panel

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -41,6 +41,7 @@ import { GetConversationWithMessagesDocument } from './chat-session-document'
 import {
   didStreamingTurnFinish,
   getPersistableMessages,
+  pickRicherMessages,
 } from './chat-session-persistence'
 import {
   prepareSidepanelSendMessagesRequest,
@@ -469,42 +470,65 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     if (!conversationIdParam) return
     if (restoredConversationId === conversationIdParam) return
 
-    if (isLoggedIn) {
-      if (!isRemoteConversationFetched) return
+    let cancelled = false
 
-      if (remoteConversationData?.conversation) {
-        const restoredMessages =
-          remoteConversationData.conversation.conversationMessages.nodes
-            .filter((node): node is NonNullable<typeof node> => node !== null)
-            .map((node) => node.message as UIMessage)
+    const applyRestored = (messages: UIMessage[] | undefined) => {
+      if (!messages?.length) return
+      setConversationId(
+        conversationIdParam as ReturnType<typeof crypto.randomUUID>,
+      )
+      setMessages(messages)
+    }
 
-        setConversationId(
-          conversationIdParam as ReturnType<typeof crypto.randomUUID>,
-        )
-        setMessages(restoredMessages)
-        markMessagesAsSaved(conversationIdParam, restoredMessages)
+    const restore = async () => {
+      // Local-first: the durable local copy (issue #559) is shown immediately
+      // and works regardless of auth. When signed in we reconcile with the
+      // cloud once it resolves and seed the remote-save dedup from what the
+      // cloud actually holds.
+      const localConversations = await conversationStorage.getValue()
+      if (cancelled) return
+      const local = localConversations?.find(
+        (c) => c.id === conversationIdParam,
+      )
+
+      // Signed in but the cloud copy is still loading: show local now and let
+      // the effect re-run to reconcile rather than committing early.
+      if (isLoggedIn && !isRemoteConversationFetched) {
+        applyRestored(local?.messages)
+        return
       }
+
+      const remoteMessages =
+        isLoggedIn && remoteConversationData?.conversation
+          ? remoteConversationData.conversation.conversationMessages.nodes
+              .filter((node): node is NonNullable<typeof node> => node !== null)
+              .map((node) => node.message as UIMessage)
+          : undefined
+
+      applyRestored(pickRicherMessages(local?.messages, remoteMessages))
+
+      // Seed the remote-save dedup from the cloud's actual state only, so a
+      // follow-up turn appends the truly-missing messages, and a local-only
+      // conversation stays "new" so the next turn creates it in the cloud.
+      if (remoteMessages) {
+        markMessagesAsSaved(conversationIdParam, remoteMessages)
+      }
+
       setRestoredConversationId(conversationIdParam)
       setSearchParams({}, { replace: true })
-    } else {
-      const restoreLocal = async () => {
-        const conversations = await conversationStorage.getValue()
-        const conversation = conversations?.find(
-          (c) => c.id === conversationIdParam,
-        )
-
-        if (conversation) {
-          setConversationId(
-            conversation.id as ReturnType<typeof crypto.randomUUID>,
-          )
-          setMessages(conversation.messages)
-        }
-        setRestoredConversationId(conversationIdParam)
-        setSearchParams({}, { replace: true })
-      }
-      restoreLocal()
     }
-  }, [conversationIdParam, remoteConversationData, isLoggedIn])
+
+    restore()
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    conversationIdParam,
+    remoteConversationData,
+    isRemoteConversationFetched,
+    isLoggedIn,
+  ])
 
   // Per-window scope: resume this window's conversation when the panel
   // (re)mounts (e.g. closed + reopened) instead of starting a blank chat.
@@ -579,10 +603,12 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     const messagesToSave = getPersistableMessages(messages)
     if (messagesToSave.length === 0) return
 
+    // Local is the durable source of truth and is written on every turn
+    // regardless of auth, so history survives sign-out (issue #559). When
+    // signed in we additionally mirror the turn to the cloud.
+    saveLocalConversation(conversationIdRef.current, messagesToSave)
     if (isLoggedIn) {
       saveRemoteConversation(conversationIdRef.current, messagesToSave)
-    } else {
-      saveLocalConversation(conversationIdRef.current, messagesToSave)
     }
 
     invalidateCredits()

--- a/packages/browseros-agent/apps/app/screens/sidepanel/history/ChatHistory.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/history/ChatHistory.tsx
@@ -7,6 +7,7 @@ import { useSessionInfo } from '@/lib/auth/sessionStorage'
 import { GetProfileIdByUserIdDocument } from '@/lib/conversations/graphql/uploadConversationDocument'
 import { useConversations } from '@/lib/conversations/useConversations'
 import { getQueryKeyFromDocument } from '@/lib/graphql/getQueryKeyFromDocument'
+import { sentry } from '@/lib/sentry/sentry'
 import { useChatSessionContext } from '@/modules/chat/chat-session-context'
 import { useGraphqlInfiniteQuery } from '@/modules/graphql/graphql-infinite-query.hooks'
 import { useGraphqlMutation } from '@/modules/graphql/graphql-mutation.hooks'
@@ -127,12 +128,19 @@ const MergedChatHistory: FC<{ userId: string }> = ({ userId }) => {
   )
 
   const handleDelete = async (id: string) => {
-    // Delete both copies so the conversation cannot reappear from the other
-    // source on the next merge.
-    await removeConversation(id)
-    if (remoteIds.has(id)) {
-      deleteConversationMutation.mutate({ rowId: id })
+    // Delete the cloud copy first (regardless of whether it is on the currently
+    // fetched page) so a transient failure keeps the durable local copy for a
+    // retry and the two never diverge. A conversation with no cloud row deletes
+    // as a no-op; keep local only when the cloud row is known to still exist.
+    try {
+      await deleteConversationMutation.mutateAsync({ rowId: id })
+    } catch (error) {
+      sentry.captureException(error, {
+        extra: { message: 'Failed to delete remote conversation' },
+      })
+      if (remoteIds.has(id)) return
     }
+    await removeConversation(id)
   }
 
   // Only block on a spinner when there is nothing local to show yet and the

--- a/packages/browseros-agent/apps/app/screens/sidepanel/history/ChatHistory.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/history/ChatHistory.tsx
@@ -13,16 +13,30 @@ import { useGraphqlMutation } from '@/modules/graphql/graphql-mutation.hooks'
 import { useGraphqlQuery } from '@/modules/graphql/graphql-query.hooks'
 import { ConversationList } from './components/ConversationList'
 import type { HistoryConversation } from './components/types'
-import { extractLastUserMessage, groupConversations } from './components/utils'
+import {
+  extractLastUserMessage,
+  groupConversations,
+  mergeHistoryConversations,
+} from './components/utils'
 import {
   DeleteConversationDocument,
   GetConversationsForHistoryDocument,
 } from './graphql/chatHistoryDocument'
 import { LocalChatHistory } from './local/LocalChatHistory'
 
-const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
+/**
+ * History for a signed-in user. Local conversations are the durable source of
+ * truth (issue #559) and are always shown; the cloud is merged in by id so
+ * older, cloud-only conversations still appear. Deleting removes both copies.
+ */
+const MergedChatHistory: FC<{ userId: string }> = ({ userId }) => {
   const { conversationId: activeConversationId } = useChatSessionContext()
   const queryClient = useQueryClient()
+
+  // Local (durable) history plus its delete + execution-history cascade. This
+  // also drives cloud sync of local conversations via useConversations.
+  const { conversations: localConversations, removeConversation } =
+    useConversations()
 
   const { data: profileData } = useGraphqlQuery(GetProfileIdByUserIdDocument, {
     userId,
@@ -31,7 +45,6 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
 
   const {
     data: graphqlData,
-    isLoading: isLoadingConversations,
     isFetching,
     hasNextPage,
     isFetchingNextPage,
@@ -64,11 +77,7 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
     },
   )
 
-  const handleDelete = (id: string) => {
-    deleteConversationMutation.mutate({ rowId: id })
-  }
-
-  const conversations = useMemo<HistoryConversation[]>(() => {
+  const remoteConversations = useMemo<HistoryConversation[]>(() => {
     if (!graphqlData?.pages) return []
 
     return graphqlData.pages.flatMap((page) =>
@@ -92,12 +101,45 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
     )
   }, [graphqlData])
 
-  const groupedConversations = useMemo(
-    () => groupConversations(conversations),
-    [conversations],
+  const localHistory = useMemo<HistoryConversation[]>(
+    () =>
+      localConversations.map((conv) => ({
+        id: conv.id,
+        lastMessagedAt: conv.lastMessagedAt,
+        lastUserMessage: extractLastUserMessage(conv.messages),
+      })),
+    [localConversations],
   )
 
-  if (!profileId || isLoadingConversations) {
+  const merged = useMemo<HistoryConversation[]>(
+    () => mergeHistoryConversations(localHistory, remoteConversations),
+    [localHistory, remoteConversations],
+  )
+
+  const remoteIds = useMemo(
+    () => new Set(remoteConversations.map((c) => c.id)),
+    [remoteConversations],
+  )
+
+  const groupedConversations = useMemo(
+    () => groupConversations(merged),
+    [merged],
+  )
+
+  const handleDelete = async (id: string) => {
+    // Delete both copies so the conversation cannot reappear from the other
+    // source on the next merge.
+    await removeConversation(id)
+    if (remoteIds.has(id)) {
+      deleteConversationMutation.mutate({ rowId: id })
+    }
+  }
+
+  // Only block on a spinner when there is nothing local to show yet and the
+  // cloud has not returned its first page. Once local exists it renders
+  // immediately and the cloud folds in, so history is never blank while
+  // signed in (issue #559).
+  if (merged.length === 0 && !graphqlData) {
     return (
       <div className="flex flex-1 items-center justify-center py-12">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -113,7 +155,7 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
       hasNextPage={hasNextPage}
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={fetchNextPage}
-      isRefreshing={isFetching && !isLoadingConversations}
+      isRefreshing={isFetching}
     />
   )
 }
@@ -121,12 +163,12 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
 export const ChatHistory: FC = () => {
   const { sessionInfo } = useSessionInfo()
   const userId = sessionInfo.user?.id
-  // needed to initiate remote-sync
-  useConversations()
 
   if (userId) {
-    return <RemoteChatHistory userId={userId} />
+    return <MergedChatHistory userId={userId} />
   }
 
+  // Signed out: local-only view (which also runs the no-op sync). Local is
+  // retained across auth changes, so signing out no longer empties history.
   return <LocalChatHistory />
 }

--- a/packages/browseros-agent/apps/app/screens/sidepanel/history/ChatHistory.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/history/ChatHistory.tsx
@@ -117,28 +117,25 @@ const MergedChatHistory: FC<{ userId: string }> = ({ userId }) => {
     [localHistory, remoteConversations],
   )
 
-  const remoteIds = useMemo(
-    () => new Set(remoteConversations.map((c) => c.id)),
-    [remoteConversations],
-  )
-
   const groupedConversations = useMemo(
     () => groupConversations(merged),
     [merged],
   )
 
   const handleDelete = async (id: string) => {
-    // Delete the cloud copy first (regardless of whether it is on the currently
-    // fetched page) so a transient failure keeps the durable local copy for a
-    // retry and the two never diverge. A conversation with no cloud row deletes
-    // as a no-op; keep local only when the cloud row is known to still exist.
+    // Delete the cloud copy first so the two sides never diverge, then keep the
+    // durable local copy for a retry on any remote failure (including a cloud
+    // mirror on an unfetched history page, whose id we cannot see here). A
+    // conversation with no cloud row is a no-op delete: the mutation returns an
+    // empty payload rather than throwing, so local-only conversations still
+    // delete cleanly.
     try {
       await deleteConversationMutation.mutateAsync({ rowId: id })
     } catch (error) {
       sentry.captureException(error, {
         extra: { message: 'Failed to delete remote conversation' },
       })
-      if (remoteIds.has(id)) return
+      return
     }
     await removeConversation(id)
   }

--- a/packages/browseros-agent/apps/app/screens/sidepanel/history/components/utils.test.ts
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/history/components/utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test'
+import type { HistoryConversation } from './types'
+import { mergeHistoryConversations } from './utils'
+
+const conv = (
+  id: string,
+  lastMessagedAt: number,
+  lastUserMessage = id,
+): HistoryConversation => ({ id, lastMessagedAt, lastUserMessage })
+
+describe('mergeHistoryConversations', () => {
+  it('unions disjoint local and remote and sorts newest first', () => {
+    const local = [conv('a', 300), conv('c', 100)]
+    const remote = [conv('b', 200), conv('d', 50)]
+
+    expect(mergeHistoryConversations(local, remote).map((c) => c.id)).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+    ])
+  })
+
+  it('dedupes by id and lets the local copy win', () => {
+    const local = [conv('shared', 500, 'local text')]
+    const remote = [conv('shared', 999, 'remote text')]
+
+    const merged = mergeHistoryConversations(local, remote)
+    expect(merged).toHaveLength(1)
+    expect(merged[0].lastUserMessage).toBe('local text')
+    expect(merged[0].lastMessagedAt).toBe(500)
+  })
+
+  it('returns remote-only history when local is empty', () => {
+    const remote = [conv('b', 200), conv('d', 50)]
+    expect(mergeHistoryConversations([], remote).map((c) => c.id)).toEqual([
+      'b',
+      'd',
+    ])
+  })
+
+  it('returns local-only history when remote is empty', () => {
+    const local = [conv('a', 300), conv('c', 100)]
+    expect(mergeHistoryConversations(local, []).map((c) => c.id)).toEqual([
+      'a',
+      'c',
+    ])
+  })
+
+  it('returns an empty list when both are empty', () => {
+    expect(mergeHistoryConversations([], [])).toEqual([])
+  })
+})

--- a/packages/browseros-agent/apps/app/screens/sidepanel/history/components/utils.ts
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/history/components/utils.ts
@@ -35,6 +35,22 @@ export const extractLastUserMessage = (messages: UIMessage[]): string => {
   return text || 'New conversation'
 }
 
+/**
+ * Merges local and remote history by id, newest first. The local copy wins for
+ * conversations we still hold locally (its lastMessagedAt is the message time);
+ * remote fills in older, cloud-only history. Local id == remote rowId makes the
+ * dedupe exact (issue #559).
+ */
+export const mergeHistoryConversations = (
+  local: HistoryConversation[],
+  remote: HistoryConversation[],
+): HistoryConversation[] => {
+  const byId = new Map<string, HistoryConversation>()
+  for (const conversation of remote) byId.set(conversation.id, conversation)
+  for (const conversation of local) byId.set(conversation.id, conversation)
+  return [...byId.values()].sort((a, b) => b.lastMessagedAt - a.lastMessagedAt)
+}
+
 export const groupConversations = (
   conversations: HistoryConversation[],
 ): GroupedConversations => {


### PR DESCRIPTION
Fixes #559.

## Problem
Chat history vanished after sign-out and only came back on a browser restart. It could also look empty while still signed in.

Root cause (three interacting pieces):
- Turn-end persistence was mutually exclusive by auth: signed-in turns were written to the **cloud only** and never to local storage.
- Local conversations were **drained** from `local:conversations` after a batch upload to the cloud.
- The history panel showed **cloud XOR local** based on auth, never merged.

So while signed in, local storage was empty; once the user signed out (or the cloud was slow/failing), the panel fell back to local, which was empty, and the cloud was inaccessible. A restart re-authenticated and re-fetched the cloud, which is why history "came back" only then.

## Changes
- **Durable local, dual-write.** Every turn is persisted to `local:conversations` regardless of auth, and additionally mirrored to the cloud when signed in. Local is now the source of truth.
- **Stop draining local** after cloud upload. Re-uploads remain idempotent via the existing `conversationExists` + uploaded-count checks.
- **Local-first resume.** Show the local copy immediately; when signed in, reconcile with the cloud (never regress to fewer messages) and seed the remote-save dedup from the cloud's actual state, so a follow-up turn appends the missing messages instead of re-creating the remote conversation.
- **Merged history panel.** Always show local; merge the cloud in by id (local id == remote rowId), local wins, cloud fills older/cloud-only history. Delete removes both copies.

## Tests
Extracted the reconcile (`pickRicherMessages`) and merge (`mergeHistoryConversations`) into pure helpers with unit tests (11 new cases). The existing persistence, save (50-cap), and upload-scheduler tests stay green. `tsc` clean, biome clean, `wxt build` succeeds.

## Verification / QA note
Verified via typecheck, unit tests, and a full production build. A runtime drive-through of the sign-out scenario (create chats signed in → sign out → confirm history persists → sign back in → confirm no duplicates) needs the loaded extension plus the auth/GraphQL backend, so please QA that path before merge.

## Not in scope
- The random mid-session sign-out (separate auth-token issue, cluster with #1312/#812). This change makes it non-catastrophic (history no longer depends on being signed in) but does not cure it.
- Flushing an *in-flight* (not-yet-finished) turn before same-page navigation destroys the page; finished turns are covered.
