### PR TITLE
fix(claw-app): make the session-history poll opt-in (stops audit request flood)

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
@@ -30,6 +30,7 @@ const HOME_TASK_LIMIT = 12
 export function RecentActivity() {
   const query = useSessions({
     variables: { limit: HOME_TASK_LIMIT },
+    // Homepage feed: poll so new sessions surface without a manual refresh.
     refetchInterval: 3000,
   })
   const tasks = (query.data?.pages ?? [])

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
@@ -30,10 +30,6 @@ const HOME_TASK_LIMIT = 12
 export function RecentActivity() {
   const query = useSessions({
     variables: { limit: HOME_TASK_LIMIT },
-    // Homepage feed opts in to a light poll so new sessions surface without a
-    // manual refresh. This consumer never paginates (single page), so a tick
-    // is one request, not the all-pages refetch that makes polling unsafe as a
-    // shared-factory default.
     refetchInterval: 3000,
   })
   const tasks = (query.data?.pages ?? [])

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
@@ -28,7 +28,14 @@ const HOME_TASK_LIMIT = 12
  * At mobile: everything single-column.
  */
 export function RecentActivity() {
-  const query = useSessions({ variables: { limit: HOME_TASK_LIMIT } })
+  const query = useSessions({
+    variables: { limit: HOME_TASK_LIMIT },
+    // Homepage feed opts in to a light poll so new sessions surface without a
+    // manual refresh. This consumer never paginates (single page), so a tick
+    // is one request, not the all-pages refetch that makes polling unsafe as a
+    // shared-factory default.
+    refetchInterval: 3000,
+  })
   const tasks = (query.data?.pages ?? [])
     .flatMap((p) => p.items)
     .slice(0, HOME_TASK_LIMIT)

--- a/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
@@ -69,9 +69,6 @@ export const useSessions = createInfiniteQuery<
     }),
   initialPageParam: undefined,
   getNextPageParam: (last) => last.nextCursor,
-  // No `refetchInterval` default: on an infinite query an interval refetches
-  // every loaded page each tick, so a shared-factory poll would make paginated
-  // views (e.g. audit) request forever. Polling is opt-in per consumer.
   // Keep the prior pages visible while a new filter set loads so the
   // adjacent filter controls remain mounted and retain keyboard focus.
   placeholderData: (previous) => previous,

--- a/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
@@ -69,13 +69,11 @@ export const useSessions = createInfiniteQuery<
     }),
   initialPageParam: undefined,
   getNextPageParam: (last) => last.nextCursor,
-  // No `refetchInterval` default on purpose. This is an infinite query, so an
-  // interval refetches *every loaded page* on each tick; baking a poll into
-  // the shared factory turns any paginated consumer (e.g. the audit view) into
-  // an unbounded, never-stopping request stream. Polling is opt-in per
-  // consumer instead (see RecentActivity and the cockpit onboarding probe).
-  // Keep prior pages visible while a new filter set loads so the adjacent
-  // filter controls stay mounted and retain keyboard focus.
+  // No `refetchInterval` default: on an infinite query an interval refetches
+  // every loaded page each tick, so a shared-factory poll would make paginated
+  // views (e.g. audit) request forever. Polling is opt-in per consumer.
+  // Keep the prior pages visible while a new filter set loads so the
+  // adjacent filter controls remain mounted and retain keyboard focus.
   placeholderData: (previous) => previous,
 })
 

--- a/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
@@ -69,9 +69,13 @@ export const useSessions = createInfiniteQuery<
     }),
   initialPageParam: undefined,
   getNextPageParam: (last) => last.nextCursor,
-  refetchInterval: 3000,
-  // Keep the prior pages visible while a new filter set loads so the
-  // adjacent filter controls remain mounted and retain keyboard focus.
+  // No `refetchInterval` default on purpose. This is an infinite query, so an
+  // interval refetches *every loaded page* on each tick; baking a poll into
+  // the shared factory turns any paginated consumer (e.g. the audit view) into
+  // an unbounded, never-stopping request stream. Polling is opt-in per
+  // consumer instead (see RecentActivity and the cockpit onboarding probe).
+  // Keep prior pages visible while a new filter set loads so the adjacent
+  // filter controls stay mounted and retain keyboard focus.
   placeholderData: (previous) => previous,
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.data.ts
@@ -70,6 +70,10 @@ export function useAuditScreenData(): AuditScreenData {
   const [params, setParams] = useSearchParams()
   const filters = useMemo(() => paramsToFilters(params), [params])
 
+  // Audit is a historical review, not a live feed, so it does not opt in to
+  // `useSessions` polling (the factory does not poll by default). Freshness
+  // comes from refetch on window focus, on remount, and from the cleanup
+  // mutation's invalidation.
   const query = useSessions({
     variables: {
       slug: filters.agentSlug ?? undefined,
@@ -78,12 +82,6 @@ export function useAuditScreenData(): AuditScreenData {
       search: filters.search || undefined,
       limit: 100,
     },
-    // Audit is a historical review, not a live feed. Opt out of the shared
-    // factory's 3s poll here: on an infinite query it re-requests every loaded
-    // page on each tick, so a paginated audit view fires an unbounded, never-
-    // stopping stream of session requests. Freshness still comes from refetch
-    // on window focus, remount, and the cleanup mutation's invalidation.
-    refetchInterval: false,
   })
 
   const pages = query.data?.pages

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.data.ts
@@ -70,10 +70,6 @@ export function useAuditScreenData(): AuditScreenData {
   const [params, setParams] = useSearchParams()
   const filters = useMemo(() => paramsToFilters(params), [params])
 
-  // Audit is a historical review, not a live feed, so it does not opt in to
-  // `useSessions` polling (the factory does not poll by default). Freshness
-  // comes from refetch on window focus, on remount, and from the cleanup
-  // mutation's invalidation.
   const query = useSessions({
     variables: {
       slug: filters.agentSlug ?? undefined,

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.data.ts
@@ -78,6 +78,12 @@ export function useAuditScreenData(): AuditScreenData {
       search: filters.search || undefined,
       limit: 100,
     },
+    // Audit is a historical review, not a live feed. Opt out of the shared
+    // factory's 3s poll here: on an infinite query it re-requests every loaded
+    // page on each tick, so a paginated audit view fires an unbounded, never-
+    // stopping stream of session requests. Freshness still comes from refetch
+    // on window focus, remount, and the cleanup mutation's invalidation.
+    refetchInterval: false,
   })
 
   const pages = query.data?.pages


### PR DESCRIPTION
## Problem

The `/audit` page fires a never-stopping stream of `GET /api/v1/sessions?limit=100` requests. It keeps requesting long after the list has loaded instead of stopping at the end of the data.

## Root cause

`useSessions` is the only infinite query in the app, and it baked `refetchInterval: 3000` into the shared factory. On an infinite query, each interval tick refetches **every loaded page**, so any paginated consumer inherits an unbounded, continuous request stream. The audit view was the visible victim.

The interval was also a *silent* default: the cockpit onboarding probe's own comment already states "elsewhere in the app react-query's default no-polling behaviour is unchanged" — the author assumed the factory did not poll. The baked-in interval contradicted that intended design and forced polling on every non-opting consumer.

I verified the behaviour is client-side and visibility-gated (zero requests fired while the tab was backgrounded, which rules out a render or query-key loop and pins it on the interval). The server pagination itself terminates correctly.

## Fix: make polling opt-in per consumer

Drop the `refetchInterval` default from the shared factory so an infinite query no longer polls unless a consumer asks for it:

- **RecentActivity** (single-page homepage feed) opts in explicitly with `refetchInterval: 3000`. It never paginates, so a tick is one request, not an all-pages refetch.
- **The cockpit onboarding probe** already opts in with its own conditional interval; unchanged.
- **The audit view** simply does not opt in, which is the correct default for a historical review surface. Freshness still comes from refetch on window focus, on remount, and from the cleanup mutation's invalidation.

This is the whole codebase: `useSessions` is the only `createInfiniteQuery`. The remaining `refetchInterval`s are on regular single-result queries (live sessions, screenshots, storage), where a bounded poll is a legitimate default and is left as-is.

## Validation

- `typecheck` passes.
- `biome check` clean.
- Audit and cockpit test suites pass.