### PR TITLE
ci: report real test counts for suites that emit no JUnit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
             junit_path: test-results/build.xml
             needs_browser: false
           - suite: claw-server-rust
-            command: cargo test --workspace --locked
+            command: bun run ./scripts/run-cargo-test.ts test --workspace --locked
             junit_path: test-results/claw-server-rust.xml
             needs_browser: false
             needs_rust: true
@@ -311,12 +311,22 @@ jobs:
               header = f"## :x: Tests failed — {total_failed}/{total_tests} failed"
 
           lines = [marker, header, ""]
+          gate_suites = []
           if suites:
               lines.append("| Suite | Passed | Failed | Skipped |")
               lines.append("|-------|--------|--------|---------|")
               for s in suites:
-                  icon = ":white_check_mark:" if s["failed"] == 0 and s["total"] > 0 else ":warning:" if s["total"] == 0 else ":x:"
-                  lines.append(f"| {icon} `{s['name']}` | {s['passed']}/{s['total']} | {s['failed']} | {s['skipped']} |")
+                  if s["failed"] > 0:
+                      icon, passed_cell = ":x:", f"{s['passed']}/{s['total']}"
+                  elif s["total"] == 0:
+                      # Ran clean but emitted no JUnit counts (a lint/format gate).
+                      icon, passed_cell = ":white_check_mark:", "passed"
+                      gate_suites.append(s["name"])
+                  else:
+                      icon, passed_cell = ":white_check_mark:", f"{s['passed']}/{s['total']}"
+                  lines.append(f"| {icon} `{s['name']}` | {passed_cell} | {s['failed']} | {s['skipped']} |")
+              if gate_suites:
+                  lines += ["", "> `passed` = ran successfully but emits no JUnit counts (a lint/format gate)."]
 
           if failed_cases:
               lines += ["", "<details open>", "<summary><b>Failed tests</b></summary>", ""]

--- a/packages/browseros-agent/apps/claw-onboard/package.json
+++ b/packages/browseros-agent/apps/claw-onboard/package.json
@@ -9,7 +9,7 @@
     "build": "tsc --noEmit && vite build",
     "build:chromium": "tsc --noEmit && vite build --mode chromium && bun scripts/verify-chromium-build.ts",
     "preview": "vite preview",
-    "test": "bun test",
+    "test": "bun run ../../scripts/run-bun-test.ts ./apps/claw-onboard",
     "typecheck": "tsc --noEmit",
     "lint": "bunx biome check",
     "lint:fix": "bunx biome check --write --unsafe"

--- a/packages/browseros-agent/contracts/claw-mcp/tests/run.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/run.ts
@@ -22,8 +22,20 @@ if (!process.env.BROWSEROS_BINARY) {
 
 buildRustServer()
 
+// Emit JUnit so the PR test summary reports real counts instead of 0/0. The
+// workflow passes an absolute BROWSEROS_JUNIT_PATH, so cwd does not matter.
+const junitPath = process.env.BROWSEROS_JUNIT_PATH?.trim()
+const junitArgs = junitPath
+  ? ['--reporter=junit', `--reporter-outfile=${junitPath}`]
+  : []
+
 const result = Bun.spawnSync({
-  cmd: ['bun', 'test', resolve(import.meta.dir, 'rust-conformance.test.ts')],
+  cmd: [
+    'bun',
+    'test',
+    resolve(import.meta.dir, 'rust-conformance.test.ts'),
+    ...junitArgs,
+  ],
   env: {
     ...process.env,
     ...(smoke ? { CLAW_MCP_SMOKE: '1' } : {}),

--- a/packages/browseros-agent/scripts/run-cargo-test.helpers.ts
+++ b/packages/browseros-agent/scripts/run-cargo-test.helpers.ts
@@ -28,6 +28,23 @@ export function parseCargoTestCounts(output: string): CargoTestCounts {
   return { passed, failed, ignored, total: passed + failed + ignored }
 }
 
+/**
+ * Reconciles parsed counts with cargo's exit code so the JUnit never reports a
+ * failed run as passing. A non-zero exit means the suite failed even when
+ * libtest printed no failing test (a compile or setup error, possibly in a later
+ * crate after earlier tests passed), so force at least one failure. Otherwise the
+ * summary, which treats zero tests and zero failures as a passing gate, would
+ * render a red job as green.
+ */
+export function reconcileCargoCounts(
+  counts: CargoTestCounts,
+  exitCode: number,
+): CargoTestCounts {
+  if (exitCode === 0) return counts
+  const failed = Math.max(counts.failed, 1)
+  return { ...counts, failed, total: Math.max(counts.total, failed) }
+}
+
 /** Builds a JUnit document the PR test summary can parse from cargo counts. */
 export function buildCargoJunitXml(
   suite: string,

--- a/packages/browseros-agent/scripts/run-cargo-test.helpers.ts
+++ b/packages/browseros-agent/scripts/run-cargo-test.helpers.ts
@@ -1,0 +1,45 @@
+export interface CargoTestCounts {
+  passed: number
+  failed: number
+  ignored: number
+  total: number
+}
+
+/**
+ * Sums libtest's per-binary summary lines from `cargo test` output, e.g.
+ * `test result: ok. 12 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out`.
+ * One appears per test binary and one per doctest run, so summing them gives the
+ * whole-workspace totals. cargo emits no JUnit natively; this lets the workflow
+ * report real counts while still running doctests (which cargo-nextest skips).
+ */
+export function parseCargoTestCounts(output: string): CargoTestCounts {
+  let passed = 0
+  let failed = 0
+  let ignored = 0
+
+  const re =
+    /test result:\s+\w+\.\s+(\d+)\s+passed;\s+(\d+)\s+failed;\s+(\d+)\s+ignored/g
+  for (const match of output.matchAll(re)) {
+    passed += Number(match[1])
+    failed += Number(match[2])
+    ignored += Number(match[3])
+  }
+
+  return { passed, failed, ignored, total: passed + failed + ignored }
+}
+
+/** Builds a JUnit document the PR test summary can parse from cargo counts. */
+export function buildCargoJunitXml(
+  suite: string,
+  counts: CargoTestCounts,
+): string {
+  const { total, failed, ignored } = counts
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<testsuites tests="${total}" failures="${failed}">`,
+    `  <testsuite name="${suite}" tests="${total}" failures="${failed}" errors="0" skipped="${ignored}">`,
+    '  </testsuite>',
+    '</testsuites>',
+    '',
+  ].join('\n')
+}

--- a/packages/browseros-agent/scripts/run-cargo-test.test.ts
+++ b/packages/browseros-agent/scripts/run-cargo-test.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   buildCargoJunitXml,
   parseCargoTestCounts,
+  reconcileCargoCounts,
 } from './run-cargo-test.helpers'
 
 describe('parseCargoTestCounts', () => {
@@ -33,6 +34,37 @@ describe('parseCargoTestCounts', () => {
       ignored: 0,
       total: 0,
     })
+  })
+})
+
+describe('reconcileCargoCounts', () => {
+  const counts = (p: number, f: number, i: number) => ({
+    passed: p,
+    failed: f,
+    ignored: i,
+    total: p + f + i,
+  })
+
+  it('leaves counts untouched when cargo exited zero', () => {
+    expect(reconcileCargoCounts(counts(84, 0, 0), 0)).toEqual(counts(84, 0, 0))
+  })
+
+  it('forces a failure when cargo fails before any test result (compile error)', () => {
+    const result = reconcileCargoCounts(counts(0, 0, 0), 101)
+    expect(result.failed).toBe(1)
+    expect(result.total).toBe(1)
+  })
+
+  it('forces a failure when a later crate fails after earlier tests passed', () => {
+    const result = reconcileCargoCounts(counts(84, 0, 0), 101)
+    expect(result.failed).toBe(1)
+    expect(result.total).toBe(84)
+  })
+
+  it('keeps the real failure count when tests actually failed', () => {
+    expect(reconcileCargoCounts(counts(97, 3, 0), 101)).toEqual(
+      counts(97, 3, 0),
+    )
   })
 })
 

--- a/packages/browseros-agent/scripts/run-cargo-test.test.ts
+++ b/packages/browseros-agent/scripts/run-cargo-test.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  buildCargoJunitXml,
+  parseCargoTestCounts,
+} from './run-cargo-test.helpers'
+
+describe('parseCargoTestCounts', () => {
+  it('sums passed/failed/ignored across every test binary and doctest', () => {
+    const output = [
+      '   Compiling browseros-core v0.1.0',
+      'running 3 tests',
+      'test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s',
+      '',
+      'running 5 tests',
+      'test result: FAILED. 4 passed; 1 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.20s',
+      '',
+      '   Doc-tests browseros-core',
+      'test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s',
+    ].join('\n')
+
+    expect(parseCargoTestCounts(output)).toEqual({
+      passed: 13,
+      failed: 1,
+      ignored: 2,
+      total: 16,
+    })
+  })
+
+  it('returns zeroes when there are no result lines', () => {
+    expect(parseCargoTestCounts('error: could not compile')).toEqual({
+      passed: 0,
+      failed: 0,
+      ignored: 0,
+      total: 0,
+    })
+  })
+})
+
+describe('buildCargoJunitXml', () => {
+  it('emits counts the summary parser reads off the testsuite element', () => {
+    const xml = buildCargoJunitXml('claw-server-rust', {
+      passed: 13,
+      failed: 1,
+      ignored: 2,
+      total: 16,
+    })
+    expect(xml).toContain(
+      '<testsuite name="claw-server-rust" tests="16" failures="1" errors="0" skipped="2">',
+    )
+    expect(xml).toContain('<testsuites tests="16" failures="1">')
+  })
+})

--- a/packages/browseros-agent/scripts/run-cargo-test.ts
+++ b/packages/browseros-agent/scripts/run-cargo-test.ts
@@ -16,6 +16,7 @@ import { basename, dirname, resolve } from 'node:path'
 import {
   buildCargoJunitXml,
   parseCargoTestCounts,
+  reconcileCargoCounts,
 } from './run-cargo-test.helpers'
 
 const args = process.argv.slice(2)
@@ -42,12 +43,10 @@ const exitCode: number = await new Promise((res) => {
 
 if (junitPath) {
   const suite = basename(junitPath).replace(/\.xml$/, '') || 'cargo'
+  const counts = reconcileCargoCounts(parseCargoTestCounts(combined), exitCode)
   const outputPath = resolve(junitPath)
   mkdirSync(dirname(outputPath), { recursive: true })
-  writeFileSync(
-    outputPath,
-    buildCargoJunitXml(suite, parseCargoTestCounts(combined)),
-  )
+  writeFileSync(outputPath, buildCargoJunitXml(suite, counts))
 }
 
 process.exit(exitCode)

--- a/packages/browseros-agent/scripts/run-cargo-test.ts
+++ b/packages/browseros-agent/scripts/run-cargo-test.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+/**
+ * Runs `cargo` (typically `test --workspace --locked`), streams its output live,
+ * and parses libtest's "test result:" summary lines into an aggregate JUnit at
+ * BROWSEROS_JUNIT_PATH so the PR test summary reports real counts instead of
+ * 0/0. cargo test emits no JUnit natively; parsing its output keeps doctests
+ * running (unlike cargo-nextest). The process exits with cargo's exit code, so
+ * this never changes whether the job passes: a parser miss only affects counts.
+ *
+ *   bun run ./scripts/run-cargo-test.ts test --workspace --locked
+ */
+
+import { spawn } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { basename, dirname, resolve } from 'node:path'
+import {
+  buildCargoJunitXml,
+  parseCargoTestCounts,
+} from './run-cargo-test.helpers'
+
+const args = process.argv.slice(2)
+const junitPath = process.env.BROWSEROS_JUNIT_PATH?.trim()
+
+const child = spawn('cargo', args, { stdio: ['inherit', 'pipe', 'pipe'] })
+
+let combined = ''
+child.stdout.on('data', (chunk) => {
+  const text = chunk.toString()
+  combined += text
+  process.stdout.write(text)
+})
+child.stderr.on('data', (chunk) => {
+  const text = chunk.toString()
+  combined += text
+  process.stderr.write(text)
+})
+
+const exitCode: number = await new Promise((res) => {
+  child.on('error', () => res(1))
+  child.on('close', (code) => res(code ?? 1))
+})
+
+if (junitPath) {
+  const suite = basename(junitPath).replace(/\.xml$/, '') || 'cargo'
+  const outputPath = resolve(junitPath)
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(
+    outputPath,
+    buildCargoJunitXml(suite, parseCargoTestCounts(combined)),
+  )
+}
+
+process.exit(exitCode)


### PR DESCRIPTION
## Problem

The PR test-summary comment shows `⚠️ 0/0` for four suites — `claw-onboard`, `claw-mcp`, `claw-server-rust`, `claw-server-rust-quality` — instead of real pass/fail counts. All four jobs run and pass; they just write no JUnit XML at the path the summary reads, so `test.yml` substitutes an empty `tests="0" failures="0"` placeholder and the summary marks anything with `total == 0` as a warning.

## Fix

- **claw-onboard** routes its `test` script through the shared `run-bun-test.ts` wrapper (same as `apps/app` and `claw-app`), so its tests emit JUnit. Locally this reports ~74 tests instead of 0.
- **claw-mcp** passes the JUnit reporter to the inner `bun test` when a junit path is set, so the Rust conformance suite reports counts. The skip path (no `BROWSEROS_BINARY`) is unchanged.
- **claw-server-rust** runs cargo through a small `run-cargo-test.ts` wrapper that parses libtest's `test result:` lines into an aggregate JUnit. This keeps `cargo test` (so doctests still run, which `cargo-nextest` would skip) and exits with cargo's own exit code, so it cannot change whether the job passes — a parser miss only affects the cosmetic count.
- **claw-server-rust-quality** is a `fmt`/`clippy` gate with no tests to count. The summary now renders a passing suite that emits no JUnit as `passed` (with a short footnote) rather than a misleading `0/0` warning.

## Verification

- `run-cargo-test.ts` parsing is unit-tested (multi-binary, doctest, and failure cases); ran the wrapper on `browseros-core` locally and it produced a well-formed JUnit with real counts (`tests="84"`) while preserving the exit code.
- Ran the claw-onboard wrapper locally and confirmed it emits JUnit (74 tests).
- Verified the summary rendering against sample inputs: counted suites show `N/N`, the lint gate shows `passed`, a failing suite still shows `❌ P/T`.
- Type-check and lint pass on the new scripts.

No change to how any suite runs beyond emitting JUnit; job pass/fail is unaffected.
