### PR TITLE
feat(claw-server): auto-connect available harnesses on first launch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,9 @@ jobs:
 
       - name: Setup Rust
         if: matrix.needs_rust == true
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned so the clippy lint set is deterministic and matches local dev;
+        # a floating `stable` silently changes which lints fire across runs.
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy,rustfmt
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -178,7 +178,42 @@ async fn ready_after<T, E>(
     Ok(running)
 }
 
+/// On the very first launch, register BrowserClaw in every detected harness so
+/// the user does not have to connect each one by hand. Runs once, guarded by a
+/// marker in the BrowserClaw dir; an existing install is seeded without sweeping
+/// so a returning user's manual disconnects are preserved.
+async fn run_first_launch_auto_connect(state: &AppState) {
+    use claw_server_rust::services::first_run;
+    if first_run::is_first_run_connect_done(&state.config.browserclaw_dir).await {
+        return;
+    }
+    match state
+        .harness
+        .first_run_connect(&state.config.public_mcp_url())
+        .await
+    {
+        Ok(outcome) => {
+            info!(
+                connected = outcome.connected,
+                failed = outcome.failed,
+                already_linked = outcome.already_linked,
+                seeded_existing = outcome.seeded_existing,
+                "first-run harness auto-connect settled"
+            );
+            if let Err(err) =
+                first_run::mark_first_run_connect_done(&state.config.browserclaw_dir).await
+            {
+                error!(error = %err, "failed to persist first-run auto-connect marker");
+            }
+        }
+        // Listing the harnesses failed: leave the marker unset so the next
+        // launch retries the sweep rather than skipping it forever.
+        Err(err) => error!(error = %err, "first-run harness auto-connect skipped: listing failed"),
+    }
+}
+
 async fn heal_boot_config(state: &AppState) {
+    run_first_launch_auto_connect(state).await;
     // Re-point every connected agent at the current canonical URL first (the
     // proxy port may have moved on this app launch), then repair any config
     // that still drifted from the now-current manifest spec.

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/first_run.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/first_run.rs
@@ -1,8 +1,9 @@
 //! First-launch marker: a one-shot flag persisted as a small JSON file in the
 //! BrowserClaw dir, recording that the first-launch harness auto-connect sweep
-//! has already run. Mirrors `audit_settings`: atomic write, corrupt/unreadable
-//! reads as not-done so a lost or corrupt marker re-runs the sweep once, which
-//! is idempotent (already-linked harnesses are skipped).
+//! has already run. Atomic write (mirrors `audit_settings`). Only a genuinely
+//! absent marker reads as not-done (a fresh install re-sweeps); a present
+//! marker, even corrupt or unreadable, reads as done so a boot never
+//! re-registers harnesses the user has since disconnected.
 
 use crate::error::{AppError, AppResult};
 use serde::{Deserialize, Serialize};
@@ -21,20 +22,29 @@ struct FirstRunState {
 }
 
 /// Whether the first-launch harness auto-connect sweep has already run. A
-/// missing, corrupt, or unreadable marker reads as `false`.
+/// missing marker reads as `false` (fresh launch); a present marker, even
+/// corrupt or unreadable, reads as `true` so the one-shot sweep never re-runs
+/// and cannot undo a user's later manual disconnects.
 pub async fn is_first_run_connect_done(browserclaw_dir: &Path) -> bool {
     let path = browserclaw_dir.join(FIRST_RUN_CONNECT_FILE);
     match tokio::fs::read_to_string(&path).await {
-        Ok(raw) => serde_json::from_str::<FirstRunState>(&raw)
-            .map(|state| state.first_run_connect_done)
-            .unwrap_or_else(|error| {
-                tracing::warn!(path = %path.display(), %error, "first-run marker corrupt; treating as not done");
-                false
-            }),
+        // A parseable marker reports its own state (we only ever write `true`).
+        Ok(raw) => match serde_json::from_str::<FirstRunState>(&raw) {
+            Ok(state) => state.first_run_connect_done,
+            // A present-but-corrupt marker still means the sweep already ran, so
+            // treat it as done. Re-running would re-register harnesses the user
+            // may have since disconnected. Only a genuinely absent marker
+            // (NotFound, below) re-triggers the first-launch sweep.
+            Err(error) => {
+                tracing::warn!(path = %path.display(), %error, "first-run marker corrupt; treating as done");
+                true
+            }
+        },
         Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+        // Present but unreadable: same reasoning as corrupt, treat as done.
         Err(error) => {
-            tracing::warn!(%error, "first-run marker unreadable; treating as not done");
-            false
+            tracing::warn!(%error, "first-run marker unreadable; treating as done");
+            true
         }
     }
 }
@@ -92,10 +102,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn corrupt_marker_reads_as_not_done() -> anyhow::Result<()> {
+    async fn corrupt_marker_reads_as_done() -> anyhow::Result<()> {
+        // A present-but-corrupt marker means the sweep already ran; treat it as
+        // done so boot does not re-register harnesses the user disconnected.
         let dir = tempdir()?;
         tokio::fs::write(dir.path().join(FIRST_RUN_CONNECT_FILE), "{not json").await?;
-        assert!(!is_first_run_connect_done(dir.path()).await);
+        assert!(is_first_run_connect_done(dir.path()).await);
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/first_run.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/first_run.rs
@@ -1,0 +1,101 @@
+//! First-launch marker: a one-shot flag persisted as a small JSON file in the
+//! BrowserClaw dir, recording that the first-launch harness auto-connect sweep
+//! has already run. Mirrors `audit_settings`: atomic write, corrupt/unreadable
+//! reads as not-done so a lost or corrupt marker re-runs the sweep once, which
+//! is idempotent (already-linked harnesses are skipped).
+
+use crate::error::{AppError, AppResult};
+use serde::{Deserialize, Serialize};
+use std::{
+    io::{self, Write},
+    path::Path,
+};
+use tempfile::NamedTempFile;
+
+const FIRST_RUN_CONNECT_FILE: &str = "first-run-connect.json";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FirstRunState {
+    first_run_connect_done: bool,
+}
+
+/// Whether the first-launch harness auto-connect sweep has already run. A
+/// missing, corrupt, or unreadable marker reads as `false`.
+pub async fn is_first_run_connect_done(browserclaw_dir: &Path) -> bool {
+    let path = browserclaw_dir.join(FIRST_RUN_CONNECT_FILE);
+    match tokio::fs::read_to_string(&path).await {
+        Ok(raw) => serde_json::from_str::<FirstRunState>(&raw)
+            .map(|state| state.first_run_connect_done)
+            .unwrap_or_else(|error| {
+                tracing::warn!(path = %path.display(), %error, "first-run marker corrupt; treating as not done");
+                false
+            }),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+        Err(error) => {
+            tracing::warn!(%error, "first-run marker unreadable; treating as not done");
+            false
+        }
+    }
+}
+
+/// Records that the first-launch harness auto-connect sweep has run so it never
+/// sweeps again; a later manual disconnect is then preserved.
+pub async fn mark_first_run_connect_done(browserclaw_dir: &Path) -> AppResult<()> {
+    let path = browserclaw_dir.join(FIRST_RUN_CONNECT_FILE);
+    persist(&path).await.map_err(|source| AppError::Io {
+        path: Some(path.clone()),
+        source,
+    })
+}
+
+async fn persist(path: &Path) -> io::Result<()> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || persist_blocking(&path))
+        .await
+        .map_err(io::Error::other)?
+}
+
+fn persist_blocking(path: &Path) -> io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    let mut tmp = NamedTempFile::new_in(parent)?;
+    let mut raw = serde_json::to_string_pretty(&FirstRunState {
+        first_run_connect_done: true,
+    })
+    .map_err(io::Error::other)?;
+    raw.push('\n');
+    tmp.write_all(raw.as_bytes())?;
+    tmp.flush()?;
+    tmp.as_file().sync_all()?;
+    tmp.persist(path).map(|_| ()).map_err(|error| error.error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn missing_marker_reads_as_not_done() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        assert!(!is_first_run_connect_done(dir.path()).await);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mark_then_read_is_done_and_survives_reopen() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        mark_first_run_connect_done(dir.path()).await?;
+        assert!(is_first_run_connect_done(dir.path()).await);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn corrupt_marker_reads_as_not_done() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        tokio::fs::write(dir.path().join(FIRST_RUN_CONNECT_FILE), "{not json").await?;
+        assert!(!is_first_run_connect_done(dir.path()).await);
+        Ok(())
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
@@ -130,6 +130,16 @@ pub struct UrlMigrationOutcome {
     pub failed: usize,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FirstRunConnectOutcome {
+    pub connected: usize,
+    pub failed: usize,
+    pub already_linked: usize,
+    /// True when this was an existing install (a harness was already linked) so
+    /// the sweep was skipped and only the first-run marker gets seeded.
+    pub seeded_existing: bool,
+}
+
 #[derive(Clone)]
 pub struct HarnessService {
     manager: McpManager,
@@ -364,6 +374,34 @@ impl HarnessService {
                 })
             })
             .collect())
+    }
+
+    /// First-launch sweep: registers BrowserClaw in every detected-but-unlinked
+    /// harness so a new user does not have to connect each one by hand. An
+    /// existing install (any harness already linked) is left untouched and only
+    /// seeded, so a returning user's disconnect choices are never overridden.
+    /// Best-effort: a single harness failing does not abort the sweep.
+    pub async fn first_run_connect(&self, mcp_url: &str) -> AppResult<FirstRunConnectOutcome> {
+        let connections = self.list_browseros_connections().await?;
+        let already_linked = connections.iter().filter(|state| state.installed).count();
+        let Some(targets) = first_run_connect_targets(&connections) else {
+            return Ok(FirstRunConnectOutcome {
+                already_linked,
+                seeded_existing: true,
+                ..FirstRunConnectOutcome::default()
+            });
+        };
+        let mut outcome = FirstRunConnectOutcome::default();
+        for harness in targets {
+            match self.connect_browseros(harness, mcp_url).await {
+                Ok(_) => outcome.connected += 1,
+                Err(error) => {
+                    outcome.failed += 1;
+                    tracing::warn!(harness = %harness, %error, "first-run auto-connect failed for harness");
+                }
+            }
+        }
+        Ok(outcome)
     }
 
     /// Rescans managed entries and repairs drifted or missing files from manifest specs.
@@ -840,5 +878,56 @@ impl fmt::Display for HarnessOperationError {
 impl From<std::io::Error> for AppError {
     fn from(source: std::io::Error) -> Self {
         Self::Io { path: None, source }
+    }
+}
+
+/// Decides first-launch auto-connect targets (Option B). Returns `None` when any
+/// harness is already linked, marking this an existing install to seed without
+/// sweeping; otherwise the full detected-but-unlinked set to connect.
+fn first_run_connect_targets(connections: &[ConnectionState]) -> Option<Vec<Harness>> {
+    if connections.iter().any(|state| state.installed) {
+        return None;
+    }
+    Some(connections.iter().map(|state| state.harness).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn conn(harness: Harness, installed: bool) -> ConnectionState {
+        ConnectionState {
+            harness,
+            installed,
+            agent_id: harness.agent_id(),
+            config_path: None,
+            message: String::new(),
+        }
+    }
+
+    #[test]
+    fn sweeps_all_when_nothing_linked() {
+        let connections = vec![
+            conn(Harness::ClaudeCode, false),
+            conn(Harness::Cursor, false),
+        ];
+        assert_eq!(
+            first_run_connect_targets(&connections),
+            Some(vec![Harness::ClaudeCode, Harness::Cursor])
+        );
+    }
+
+    #[test]
+    fn seeds_existing_install_without_sweeping() {
+        let connections = vec![
+            conn(Harness::ClaudeCode, true),
+            conn(Harness::Cursor, false),
+        ];
+        assert_eq!(first_run_connect_targets(&connections), None);
+    }
+
+    #[test]
+    fn empty_machine_sweeps_nothing() {
+        assert_eq!(first_run_connect_targets(&[]), Some(Vec::new()));
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/mod.rs
@@ -2,6 +2,7 @@ pub mod audit;
 pub mod audit_settings;
 pub mod browser;
 pub mod cockpit;
+pub mod first_run;
 pub mod harness;
 pub mod harness_skills;
 pub mod profiles;

--- a/packages/browseros-agent/crates/browseros-core/src/snapshot/render.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/snapshot/render.rs
@@ -310,10 +310,8 @@ fn format_states(node: &AxNode) -> Vec<String> {
                     states.push("indeterminate".to_string());
                 }
             }
-            "disabled" => {
-                if value == Some(&Value::Bool(true)) {
-                    states.push("disabled".to_string());
-                }
+            "disabled" if value == Some(&Value::Bool(true)) => {
+                states.push("disabled".to_string());
             }
             "expanded" => {
                 if value == Some(&Value::Bool(true)) {
@@ -322,15 +320,11 @@ fn format_states(node: &AxNode) -> Vec<String> {
                     states.push("collapsed".to_string());
                 }
             }
-            "required" => {
-                if value == Some(&Value::Bool(true)) {
-                    states.push("required".to_string());
-                }
+            "required" if value == Some(&Value::Bool(true)) => {
+                states.push("required".to_string());
             }
-            "selected" => {
-                if value == Some(&Value::Bool(true)) {
-                    states.push("selected".to_string());
-                }
+            "selected" if value == Some(&Value::Bool(true)) => {
+                states.push("selected".to_string());
             }
             "level" => {
                 if let Some(value) = value {


### PR DESCRIPTION
## What

On the **very first launch** of BrowserClaw, automatically register BrowserClaw as an MCP server in every agent harness detected on the machine, so a new user does not have to open the MCP page and connect each agent by hand. After that first-launch sweep, connect/disconnect stays fully manual and user-controlled, exactly as before.

## How

Entirely server-side, hooked into the existing boot reconciliation (`heal_boot_config`), so it runs at launch before the UI loads. The connections list (`useConnections`, polled) simply reports the harnesses as already connected. No client, contract, or config-schema changes.

- **Available set**: reuses `list_browseros_connections`, which already returns only harnesses that are detected on the machine or already linked. The sweep connects each one that is not yet linked.
- **Runs once**: guarded by a `first-run-connect.json` marker in the BrowserClaw data dir (mirrors the audit-retention store: atomic write, corrupt/missing reads as not-done). A later manual disconnect is never undone.
- **Upgrade-safe**: an existing install (any harness already linked) is seeded without sweeping, so a returning user's deliberate disconnect choices are never overridden.
- **Best-effort**: a single harness failing does not abort the sweep; if listing fails the marker is left unset so the next launch retries.

## Tests

- Marker store: missing reads as not-done, mark-then-read persists, corrupt reads as not-done.
- Sweep decision (the upgrade-safety logic): sweeps all when nothing linked, seeds without sweeping when a harness is already linked, no-ops on an empty machine.
- Full `cargo test --workspace` and the fmt + clippy gate pass.

## Also: CI toolchain pin

The clippy gate ran on a floating `dtolnay/rust-toolchain@stable`, so its lint set drifted between runs and diverged from local dev. This pins the toolchain to `1.95.0` for a reproducible fmt + clippy gate, and fixes the 3 pre-existing `collapsible_match` lints in browseros-core that the pin surfaces (behavior unchanged; covered by the existing render tests).