### PR TITLE
fix(app): don't save assistant history in incognito mode (#1189)

### DIFF
--- a/packages/browseros-agent/apps/app/lib/browseros/incognito.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/incognito.ts
@@ -1,0 +1,10 @@
+/**
+ * Whether the current extension page runs in an incognito context. Assistant
+ * history is never persisted there (#1189). `chrome.extension.inIncognitoContext`
+ * is synchronous and reads true for an extension page (side panel, newtab)
+ * opened in an incognito window, so the gate can be applied without racing an
+ * async lookup.
+ */
+export function isIncognitoContext(): boolean {
+  return chrome.extension?.inIncognitoContext ?? false
+}

--- a/packages/browseros-agent/apps/app/lib/browseros/incognito.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/incognito.ts
@@ -1,10 +1,19 @@
 /**
- * Whether the current extension page runs in an incognito context. Assistant
- * history is never persisted there (#1189). `chrome.extension.inIncognitoContext`
- * is synchronous and reads true for an extension page (side panel, newtab)
- * opened in an incognito window, so the gate can be applied without racing an
- * async lookup.
+ * Whether the assistant is running in an incognito window. Assistant history is
+ * never persisted when true (#1189).
+ *
+ * Resolved from the hosting window rather than `chrome.extension.inIncognitoContext`:
+ * in the default "spanning" incognito mode the side panel runs in the shared
+ * (non-incognito) context, so `inIncognitoContext` reads false even when the
+ * panel is shown in an incognito window. The window's own `incognito` flag is
+ * authoritative. `chrome.windows` needs no permission and `tabs` is already
+ * granted, so no manifest change is required.
  */
-export function isIncognitoContext(): boolean {
-  return chrome.extension?.inIncognitoContext ?? false
+export async function isIncognitoWindow(): Promise<boolean> {
+  try {
+    const window = await chrome.windows.getCurrent()
+    return window.incognito ?? false
+  } catch {
+    return false
+  }
 }

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session-persistence.test.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session-persistence.test.ts
@@ -3,7 +3,23 @@ import type { ChatStatus, UIMessage } from 'ai'
 import {
   didStreamingTurnFinish,
   getPersistableMessages,
+  shouldPersistHistory,
 } from './chat-session-persistence'
+
+describe('shouldPersistHistory', () => {
+  it('persists a normal, non-temporary chat', () => {
+    expect(shouldPersistHistory(false)).toBe(true)
+  })
+
+  it('never persists in an incognito context', () => {
+    expect(shouldPersistHistory(true)).toBe(false)
+    expect(shouldPersistHistory(true, false)).toBe(false)
+  })
+
+  it('does not persist a temporary chat even in a normal context', () => {
+    expect(shouldPersistHistory(false, true)).toBe(false)
+  })
+})
 
 describe('chat session persistence transitions', () => {
   it('saves exactly once when streaming ends in an error with partial content', () => {

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session-persistence.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session-persistence.ts
@@ -15,3 +15,15 @@ export function getPersistableMessages(messages: UIMessage[]) {
     messages.filter((message) => message.parts?.length > 0),
   )
 }
+
+/**
+ * Whether a chat's history may be written to durable storage or the cloud.
+ * False in incognito so nothing is saved (#1189); the `isTemporaryChat` seam
+ * lets a future "temporary chat" toggle opt out the same way.
+ */
+export function shouldPersistHistory(
+  isIncognito: boolean,
+  isTemporaryChat = false,
+): boolean {
+  return !isIncognito && !isTemporaryChat
+}

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router'
 import useDeepCompareEffect from 'use-deep-compare-effect'
 import type { Provider } from '@/components/chat/chatComponentTypes'
+import { isIncognitoContext } from '@/lib/browseros/incognito'
 import {
   getWindowConversation,
   setWindowConversation,
@@ -41,6 +42,7 @@ import { GetConversationWithMessagesDocument } from './chat-session-document'
 import {
   didStreamingTurnFinish,
   getPersistableMessages,
+  shouldPersistHistory,
 } from './chat-session-persistence'
 import {
   prepareSidepanelSendMessagesRequest,
@@ -176,6 +178,11 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   } = useChatRefs()
   const invalidateCredits = useInvalidateCredits()
 
+  // Incognito chats are never written to history or the cloud (#1189). Resolved
+  // once per session; the context is fixed for the life of the page.
+  const [isIncognito] = useState(isIncognitoContext)
+  const persistHistory = shouldPersistHistory(isIncognito)
+
   const {
     baseUrl: agentServerUrl,
     isLoading: isLoadingAgentUrl,
@@ -226,7 +233,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     startTask: startExecutionTask,
     syncFromMessages: syncExecutionHistory,
     finishTask: finishExecutionTask,
-  } = useExecutionHistoryTracker()
+  } = useExecutionHistoryTracker({ enabled: persistHistory })
 
   const onClickLike = (messageId: string) => {
     const { responseText, queryText } = getResponseAndQueryFromMessageId(
@@ -579,10 +586,14 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     const messagesToSave = getPersistableMessages(messages)
     if (messagesToSave.length === 0) return
 
-    if (isLoggedIn) {
-      saveRemoteConversation(conversationIdRef.current, messagesToSave)
-    } else {
-      saveLocalConversation(conversationIdRef.current, messagesToSave)
+    // Skip all history writes in incognito so the chat never becomes durable
+    // (neither local nor cloud) and can't surface in a normal window (#1189).
+    if (persistHistory) {
+      if (isLoggedIn) {
+        saveRemoteConversation(conversationIdRef.current, messagesToSave)
+      } else {
+        saveLocalConversation(conversationIdRef.current, messagesToSave)
+      }
     }
 
     invalidateCredits()
@@ -770,6 +781,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     isLoading: isLoadingProviders || isLoadingAgentUrl,
     canSend,
     isSyncing: !isIntegrationsSynced,
+    isIncognito,
     isRestoringConversation,
     agentUrlError,
     chatError,

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router'
 import useDeepCompareEffect from 'use-deep-compare-effect'
 import type { Provider } from '@/components/chat/chatComponentTypes'
-import { isIncognitoContext } from '@/lib/browseros/incognito'
+import { isIncognitoWindow } from '@/lib/browseros/incognito'
 import {
   getWindowConversation,
   setWindowConversation,
@@ -179,8 +179,19 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   const invalidateCredits = useInvalidateCredits()
 
   // Incognito chats are never written to history or the cloud (#1189). Resolved
-  // once per session; the context is fixed for the life of the page.
-  const [isIncognito] = useState(isIncognitoContext)
+  // from the hosting window on mount (chrome.extension.inIncognitoContext is
+  // false for a side panel in spanning mode). This settles long before any turn
+  // ends, so the turn-end save always sees the correct value.
+  const [isIncognito, setIsIncognito] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    isIncognitoWindow().then((incognito) => {
+      if (!cancelled) setIsIncognito(incognito)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
   const persistHistory = shouldPersistHistory(isIncognito)
 
   const {

--- a/packages/browseros-agent/apps/app/modules/chat/execution-history-tracker.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/execution-history-tracker.hooks.ts
@@ -63,7 +63,10 @@ function getFinishedStatus(
 
 const WRITE_THROTTLE_MS = 400
 
-export function useExecutionHistoryTracker() {
+export function useExecutionHistoryTracker(options?: { enabled?: boolean }) {
+  // When disabled (incognito), the active task is still tracked in memory so the
+  // live in-session view works, but nothing is written to storage (#1189).
+  const enabled = options?.enabled ?? true
   const activeTaskRef = useRef<ExecutionTaskRecord | null>(null)
   const lastSavedKeyRef = useRef('')
   const pendingWritesRef = useRef<Map<string, ExecutionTaskRecord>>(new Map())
@@ -132,11 +135,12 @@ export function useExecutionHistoryTracker() {
   const persistTask = useCallback(
     (task: ExecutionTaskRecord, options?: { immediate?: boolean }) => {
       activeTaskRef.current = task
+      if (!enabled) return
       const immediate = options?.immediate ?? task.status !== 'running'
       if (!immediate && taskChangeKey(task) === lastSavedKeyRef.current) return
       scheduleWrite(task, immediate)
     },
-    [scheduleWrite],
+    [scheduleWrite, enabled],
   )
 
   const startTask = useCallback(

--- a/packages/browseros-agent/apps/app/screens/sidepanel/index/Chat.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/index/Chat.tsx
@@ -27,6 +27,7 @@ import { ChatEmptyState } from './ChatEmptyState'
 import { ChatError } from './ChatError'
 import { ChatFooter } from './ChatFooter'
 import { ChatMessages } from './ChatMessages'
+import { IncognitoNotice } from './IncognitoNotice'
 
 /**
  * @public
@@ -49,6 +50,7 @@ export const Chat = () => {
     disliked,
     onClickDislike,
     isRestoringConversation,
+    isIncognito,
     retryLastTurn,
   } = useChatSessionContext()
 
@@ -248,6 +250,8 @@ export const Chat = () => {
         )}
         {chatErrorProps && <ChatError {...chatErrorProps} />}
       </main>
+
+      {isIncognito && <IncognitoNotice />}
 
       <ChatFooter
         mode={mode}

--- a/packages/browseros-agent/apps/app/screens/sidepanel/index/IncognitoNotice.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/index/IncognitoNotice.tsx
@@ -1,0 +1,14 @@
+import { VenetianMask } from 'lucide-react'
+
+/**
+ * Shown while the assistant runs in an incognito window so the user knows the
+ * chat is not saved to history (#1189).
+ */
+export const IncognitoNotice = () => {
+  return (
+    <div className="mx-4 mb-2 flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2 text-muted-foreground text-xs">
+      <VenetianMask className="h-4 w-4 shrink-0" />
+      <span>Incognito mode: this chat is not saved to history.</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Problem

Closes #1189. `chrome.storage.local` is a single store shared between an extension's normal and incognito contexts (it isn't partitioned by incognito), and there was no incognito check anywhere. So an assistant chat started in an incognito window was persisted to the same store (and to the cloud when signed in) and showed up in normal-window history after the incognito window closed.

## Fix

Gate every durable history write on a `shouldPersistHistory(isIncognito)` check, resolved once per session via `chrome.extension.inIncognitoContext` (synchronous, and true for an extension page opened in an incognito window, so the gate can't race an async lookup). When incognito:

- the turn-end conversation save is skipped (both the local `conversations` store and the cloud upload);
- execution-history writes are skipped. The active task is still tracked in memory so the live in-session view keeps working; it just never becomes durable.

Nothing else changes. A normal-window chat saves exactly as before.

## UI

While the assistant runs in an incognito window, the chat shows a small notice pinned above the input: "Incognito mode: this chat is not saved to history."

## Scope and follow-up

The `shouldPersistHistory(isIncognito, isTemporaryChat)` helper leaves a seam for a future user-facing "temporary chat" toggle (never-saved chats in a normal window), which the maintainer noted fits alongside this. That toggle is not built here.

## Testing

Unit tests cover `shouldPersistHistory`. Type check, lint, and the extension build all pass. Runtime QA needs the extension allowed in incognito: open the assistant in an incognito window, run a chat, close it, and confirm nothing appears in normal-window history or the cloud, and that the notice shows; then confirm a normal-window chat still saves as before.
