### PR TITLE
fix(ci): scope WarpBuild release watchdogs

### DIFF
--- a/.github/workflows/bos-build-tests.yml
+++ b/.github/workflows/bos-build-tests.yml
@@ -12,6 +12,8 @@ on:
       - "packages/browseros/uv.lock"
       - "tools/release_secrets/**"
       - ".github/workflows/bos-build-tests.yml"
+      - ".github/workflows/release-linux.yml"
+      - ".github/workflows/release-windows.yml"
 
 jobs:
   tests:

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -77,13 +77,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONCURRENCY_GROUP: release-linux
+          RUNNER_LABEL: warp-custom-browseros-ubuntu-2204-x64-32x
+          JOB_FILTER: >-
+            [.jobs[]
+            | select(any(.labels[]?; . == $runner_label))
+            | {name, status}]
         run: |
           set -euo pipefail
           deadline=$(( $(date +%s) + 20 * 60 ))
           failures=0
           while :; do
-            if jobs="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100" \
-              --jq '[.jobs[] | select(.name != "queue-watchdog") | select(.status != "completed") | {name, status}]')"; then
+            if response="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100")" \
+              && jobs="$(jq -c --arg runner_label "$RUNNER_LABEL" "$JOB_FILTER" <<<"$response")"; then
               failures=0
             else
               failures=$(( failures + 1 ))
@@ -104,7 +109,7 @@ jobs:
             if [ "$(date +%s)" -ge "$deadline" ]; then
               doc="packages/browseros/bos_build/docs/warpbuild-ci.md"
               if [ "$total" -eq 0 ]; then
-                echo "::error::queue-watchdog matched no build jobs - were the matrix job names changed? Fix the filter; not cancelling."
+                echo "::error::queue-watchdog matched no build jobs - did the lane's runner label change? Fix the filter; not cancelling."
                 exit 1
               fi
               stuck="$(jq -r '[.[] | select(.status == "queued") | .name] | join(", ")' <<<"$jobs")"

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -115,13 +115,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONCURRENCY_GROUP: release-windows
+          RUNNER_LABEL: warp-custom-browseros-windows-2025-x64-32x
+          JOB_FILTER: >-
+            [.jobs[]
+            | select(any(.labels[]?; . == $runner_label))
+            | {name, status}]
         run: |
           set -euo pipefail
           deadline=$(( $(date +%s) + 20 * 60 ))
           failures=0
           while :; do
-            if jobs="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100" \
-              --jq '[.jobs[] | select(.name != "queue-watchdog") | select(.status != "completed") | {name, status}]')"; then
+            if response="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100")" \
+              && jobs="$(jq -c --arg runner_label "$RUNNER_LABEL" "$JOB_FILTER" <<<"$response")"; then
               failures=0
             else
               failures=$(( failures + 1 ))
@@ -142,7 +147,7 @@ jobs:
             if [ "$(date +%s)" -ge "$deadline" ]; then
               doc="packages/browseros/bos_build/docs/warpbuild-ci.md"
               if [ "$total" -eq 0 ]; then
-                echo "::error::queue-watchdog matched no build jobs - were the matrix job names changed? Fix the filter; not cancelling."
+                echo "::error::queue-watchdog matched no build jobs - did the lane's runner label change? Fix the filter; not cancelling."
                 exit 1
               fi
               stuck="$(jq -r '[.[] | select(.status == "queued") | .name] | join(", ")' <<<"$jobs")"

--- a/packages/browseros/bos_build/ci_watchdog_test.py
+++ b/packages/browseros/bos_build/ci_watchdog_test.py
@@ -136,5 +136,44 @@ class WatchdogFilterTest(unittest.TestCase):
                 self.assertNotIn("--jq", run)
 
 
+class WarpBuildRunbookTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        runbook_path = (
+            REPO_ROOT
+            / "packages"
+            / "browseros"
+            / "bos_build"
+            / "docs"
+            / "warpbuild-ci.md"
+        )
+        cls.runbook = runbook_path.read_text(encoding="utf-8")
+
+    def test_windows_runner_table_uses_live_sku(self):
+        self.assertIn(
+            "| Windows x64 | "
+            "`warp-custom-browseros-windows-2025-x64-32x` | "
+            "Windows Server 2025 | `Standard_D32ls_v5` | P30, 1024 GB |",
+            self.runbook,
+        )
+        self.assertNotIn(
+            "Windows Server 2025 | `Standard_D32als_v7` |",
+            self.runbook,
+        )
+
+    def test_windows_image_generation_constraint_is_documented(self):
+        self.assertIn(
+            "WarpBuild's Windows Server 2025 image is Hypervisor Generation 1",
+            self.runbook,
+        )
+        self.assertIn("Dlsv5 supports both Generation 1 and 2", self.runbook)
+        self.assertIn("Dalsv7 is Generation 2-only", self.runbook)
+
+    def test_troubleshooting_calls_out_stack_launch_errors(self):
+        self.assertIn("BYOC stack's launch errors", self.runbook)
+        self.assertIn("LaunchInstances", self.runbook)
+        self.assertIn("image/VM-size generation mismatch", self.runbook)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/browseros/bos_build/ci_watchdog_test.py
+++ b/packages/browseros/bos_build/ci_watchdog_test.py
@@ -57,9 +57,12 @@ class WatchdogFilterTest(unittest.TestCase):
         ]
     }
 
-    def load_watchdog_step(self, workflow_name: str) -> dict[str, object]:
+    def load_workflow(self, workflow_name: str) -> dict[str, object]:
         workflow_path = REPO_ROOT / ".github" / "workflows" / workflow_name
-        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        return yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+
+    def load_watchdog_step(self, workflow_name: str) -> dict[str, object]:
+        workflow = self.load_workflow(workflow_name)
         steps = workflow["jobs"]["queue-watchdog"]["steps"]
         return next(
             step
@@ -97,9 +100,14 @@ class WatchdogFilterTest(unittest.TestCase):
 
         for workflow_name, expected_label in self.WORKFLOWS.items():
             with self.subTest(workflow=workflow_name):
+                workflow = self.load_workflow(workflow_name)
                 step = self.load_watchdog_step(workflow_name)
                 env = step["env"]
                 self.assertEqual(env["RUNNER_LABEL"], expected_label)
+                self.assertEqual(
+                    env["RUNNER_LABEL"],
+                    workflow["jobs"]["build"]["with"]["runner"],
+                )
 
                 jobs = self.apply_filter(env["JOB_FILTER"], expected_label)
 

--- a/packages/browseros/bos_build/ci_watchdog_test.py
+++ b/packages/browseros/bos_build/ci_watchdog_test.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Regression tests for the WarpBuild release queue-watchdogs."""
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class WatchdogFilterTest(unittest.TestCase):
+    WORKFLOWS = {
+        "release-linux.yml": "warp-custom-browseros-ubuntu-2204-x64-32x",
+        "release-windows.yml": "warp-custom-browseros-windows-2025-x64-32x",
+    }
+
+    JOBS_RESPONSE = {
+        "jobs": [
+            {
+                "name": "Linux browser builds / build (browserclaw linux-x64)",
+                "status": "queued",
+                "labels": ["warp-custom-browseros-ubuntu-2204-x64-32x"],
+            },
+            {
+                "name": "Linux browser builds / build (browseros linux-x64)",
+                "status": "completed",
+                "labels": ["warp-custom-browseros-ubuntu-2204-x64-32x"],
+            },
+            {
+                "name": "Windows browser builds / build (browserclaw windows-x64)",
+                "status": "in_progress",
+                "labels": ["warp-custom-browseros-windows-2025-x64-32x"],
+            },
+            {
+                "name": "Linux browser builds / queue-watchdog",
+                "status": "in_progress",
+                "labels": ["ubuntu-latest"],
+            },
+            {
+                "name": "Windows browser builds / queue-watchdog",
+                "status": "in_progress",
+                "labels": ["ubuntu-latest"],
+            },
+            {
+                "name": "macOS browser builds / build",
+                "status": "in_progress",
+                "labels": ["self-hosted", "browseros-builder"],
+            },
+            {
+                "name": "Caller bookkeeping",
+                "status": "completed",
+            },
+        ]
+    }
+
+    def load_watchdog_step(self, workflow_name: str) -> dict[str, object]:
+        workflow_path = REPO_ROOT / ".github" / "workflows" / workflow_name
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["queue-watchdog"]["steps"]
+        return next(
+            step
+            for step in steps
+            if step["name"] == "Fail fast when no runner picks up the builds"
+        )
+
+    def apply_filter(self, job_filter: str, runner_label: str) -> list[dict[str, str]]:
+        result = subprocess.run(
+            [
+                "jq",
+                "-c",
+                "--arg",
+                "runner_label",
+                runner_label,
+                job_filter,
+            ],
+            input=json.dumps(self.JOBS_RESPONSE),
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        return json.loads(result.stdout)
+
+    def test_each_filter_selects_only_its_runner_jobs(self):
+        expected_names = {
+            "release-linux.yml": [
+                "Linux browser builds / build (browserclaw linux-x64)",
+                "Linux browser builds / build (browseros linux-x64)",
+            ],
+            "release-windows.yml": [
+                "Windows browser builds / build (browserclaw windows-x64)",
+            ],
+        }
+
+        for workflow_name, expected_label in self.WORKFLOWS.items():
+            with self.subTest(workflow=workflow_name):
+                step = self.load_watchdog_step(workflow_name)
+                env = step["env"]
+                self.assertEqual(env["RUNNER_LABEL"], expected_label)
+
+                jobs = self.apply_filter(env["JOB_FILTER"], expected_label)
+
+                self.assertEqual(
+                    [job["name"] for job in jobs],
+                    expected_names[workflow_name],
+                )
+
+    def test_filter_keeps_completed_matching_jobs(self):
+        step = self.load_watchdog_step("release-linux.yml")
+        env = step["env"]
+
+        jobs = self.apply_filter(env["JOB_FILTER"], env["RUNNER_LABEL"])
+
+        self.assertIn(
+            {
+                "name": "Linux browser builds / build (browseros linux-x64)",
+                "status": "completed",
+            },
+            jobs,
+        )
+
+    def test_api_and_filter_failures_share_the_retry_guard(self):
+        for workflow_name in self.WORKFLOWS:
+            with self.subTest(workflow=workflow_name):
+                run = self.load_watchdog_step(workflow_name)["run"]
+                self.assertIn('if response="$(gh api ', run)
+                self.assertIn(
+                    '&& jobs="$(jq -c --arg runner_label "$RUNNER_LABEL" '
+                    '"$JOB_FILTER" <<<"$response")"; then',
+                    run,
+                )
+                self.assertIn('if [ "$failures" -ge 3 ]; then', run)
+                self.assertNotIn("--jq", run)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/ci_watchdog_test.py
+++ b/packages/browseros/bos_build/ci_watchdog_test.py
@@ -143,6 +143,20 @@ class WatchdogFilterTest(unittest.TestCase):
                 self.assertIn('if [ "$failures" -ge 3 ]; then', run)
                 self.assertNotIn("--jq", run)
 
+    def test_release_workflow_changes_trigger_these_tests(self):
+        test_workflow = self.load_workflow("bos-build-tests.yml")
+        # PyYAML's YAML 1.1 resolver treats the GitHub Actions `on` key as a
+        # boolean, so accept either representation here.
+        triggers = test_workflow.get("on", test_workflow.get(True))
+        pull_request_paths = triggers["pull_request"]["paths"]
+
+        for workflow_name in self.WORKFLOWS:
+            with self.subTest(workflow=workflow_name):
+                self.assertIn(
+                    f".github/workflows/{workflow_name}",
+                    pull_request_paths,
+                )
+
 
 class WarpBuildRunbookTest(unittest.TestCase):
     @classmethod

--- a/packages/browseros/bos_build/docs/warpbuild-ci.md
+++ b/packages/browseros/bos_build/docs/warpbuild-ci.md
@@ -19,7 +19,7 @@ nightly lanes use the repo-scoped Mac Mini runner instead; see
 | Platform | Label | Image | Compute | Disk |
 | --- | --- | --- | --- | --- |
 | Linux x64 | `warp-custom-browseros-ubuntu-2204-x64-32x` | Ubuntu 22.04 | `Standard_D32alds_v7` | P40, 2048 GB |
-| Windows x64 | `warp-custom-browseros-windows-2025-x64-32x` | Windows Server 2025 | `Standard_D32als_v7` | P30, 1024 GB |
+| Windows x64 | `warp-custom-browseros-windows-2025-x64-32x` | Windows Server 2025 | `Standard_D32ls_v5` | P30, 1024 GB |
 | macOS arm64 | `warp-macos-26-arm64-12x` | macOS 26 | M4 Pro, 12 vCPU / 44 GB | 500 GB |
 
 WarpBuild provisions the Linux and Windows runners in the BrowserOS Azure
@@ -29,6 +29,12 @@ They are ephemeral:
 the VM and build disk are created for a job and discarded afterward. Their
 compute SKUs and disk capacities mirror the source Azure build VMs, but they
 do not clone or retain those VMs' persistent disks.
+
+WarpBuild's Windows Server 2025 image is Hypervisor Generation 1, so its VM
+family must accept a Gen1 image. Dlsv5 supports both Generation 1 and 2, making
+`Standard_D32ls_v5` compatible; Dalsv7 is Generation 2-only, so
+`Standard_D32als_v7` fails during Azure VM creation before a runner can
+register with GitHub.
 
 There is no 32-core macOS tier; 12x is WarpBuild's largest Mac. The macOS
 label is kept in the runner catalog for future reusable `build-browseros.yml`
@@ -219,9 +225,12 @@ Causes, in the order to check:
    label with the two exact custom labels above in
    https://app.warpbuild.com/. An unsupported label queues forever;
    WarpBuild reports no error back to GitHub.
-3. **Azure BYOC stack** — confirm the connection and stack are healthy,
-   then check subscription quota and East US capacity for the configured
-   VM SKU.
+3. **Azure BYOC stack** — confirm the connection and stack are healthy, then
+   open the BYOC stack's launch errors and inspect `LaunchInstances`. An Azure
+   400 that reports an image/VM-size generation mismatch means the image and
+   selected VM family support different Hypervisor Generations; choose a
+   Gen1-compatible size for the current Windows image. Also check subscription
+   quota and East US capacity for the configured VM SKU.
 4. **WarpBuild incident** — check their dashboard.
 
 Mechanics worth knowing:
@@ -235,9 +244,11 @@ Mechanics worth knowing:
   loudly without cancelling while any build is in progress. In that mixed
   case, cancel the run manually once the live builds finish — a still-queued
   job otherwise pins the group for up to 24h with no watcher left.
-- Fixing the root cause does not revive already-queued jobs: WarpBuild
-  provisions on the `workflow_job.queued` webhook, which has already
-  fired. Cancel the stuck run and re-dispatch.
+- Do not rely on a configuration fix to repair the current release.
+  Unsupported labels need a new `workflow_job.queued` webhook; Azure launch
+  failures may be retried while a job is queued, but the lane's watchdog may
+  already have failed. After correcting the configuration, cancel the stuck
+  run and re-dispatch according to the release procedure.
 - A job that IS picked up but dies in "Set up job" within seconds with
   `Unable to resolve action <owner>/<name>@vN` has nothing to do with
   WarpBuild: the floating major tag does not exist upstream (e.g.


### PR DESCRIPTION
## Summary

- scope each reusable release queue-watchdog to jobs carrying its exact WarpBuild runner label
- retain completed matching jobs so fast pickup/completion cannot look like a missing matrix
- document the Gen1-compatible Windows Azure SKU and BYOC launch-error troubleshooting

## Design

The existing polling and cancellation state machine stays in each platform workflow. The Actions jobs response is now filtered locally with a lane-specific jq program over job labels, which is stable across direct and nested reusable workflow names. Regression tests load and execute the production-configured filters against a mixed full-release fixture.

## Test plan

- [x] `actionlint .github/workflows/release-linux.yml .github/workflows/release-windows.yml`
- [x] `uv run --project packages/browseros python -m unittest discover -s packages/browseros/bos_build -t packages/browseros -p '*_test.py' -v` (740 tests)
- [x] `uv run --project packages/browseros ruff check packages/browseros/bos_build`
- [x] `python3 -m unittest discover -s tools/release_secrets -t . -p '*_test.py' -v` (9 tests)
- [x] `git diff --check origin/main...HEAD`
