### PR TITLE
docs(ci): update WarpBuild Windows capacity guidance

### DIFF
--- a/packages/browseros/bos_build/ci_watchdog_test.py
+++ b/packages/browseros/bos_build/ci_watchdog_test.py
@@ -170,6 +170,18 @@ class WarpBuildRunbookTest(unittest.TestCase):
             / "warpbuild-ci.md"
         )
         cls.runbook = runbook_path.read_text(encoding="utf-8")
+        paragraphs = [
+            " ".join(paragraph.split())
+            for paragraph in cls.runbook.split("\n\n")
+        ]
+        cls.windows_generation_guidance = next(
+            paragraph
+            for paragraph in paragraphs
+            if paragraph.startswith(
+                "WarpBuild's Windows Server 2025 image is "
+                "Hypervisor Generation 1"
+            )
+        )
         troubleshooting = cls.runbook.split(
             "## Troubleshooting: jobs stuck in `queued`",
             maxsplit=1,
@@ -195,20 +207,24 @@ class WarpBuildRunbookTest(unittest.TestCase):
     def test_windows_image_generation_constraint_is_documented(self):
         self.assertIn(
             "WarpBuild's Windows Server 2025 image is Hypervisor Generation 1",
-            self.runbook,
+            self.windows_generation_guidance,
         )
         self.assertRegex(
-            self.runbook,
+            self.windows_generation_guidance,
             r"`Standard_D32as_v5` supports both Generation 1\s+and 2",
         )
-        self.assertIn("Dalsv7 is Generation 2-only", self.runbook)
+        self.assertIn(
+            "Dalsv7 is Generation 2-only",
+            self.windows_generation_guidance,
+        )
 
     def test_windows_capacity_history_is_distinct_from_compatibility(self):
-        self.assertIn(
-            "`Standard_D32ls_v5` is Gen1-compatible",
-            self.runbook,
+        self.assertRegex(
+            self.windows_generation_guidance,
+            r"`Standard_D32ls_v5` is Gen1-compatible [^.]* "
+            r"East US returned HTTP 409 `SkuNotAvailable`; [^.]* "
+            r"regional-capacity failure, not an image-generation mismatch",
         )
-        self.assertIn("East US returned HTTP 409 `SkuNotAvailable`", self.runbook)
 
     def test_troubleshooting_calls_out_stack_launch_errors(self):
         self.assertIn("BYOC stack's launch errors", self.troubleshooting)

--- a/packages/browseros/bos_build/ci_watchdog_test.py
+++ b/packages/browseros/bos_build/ci_watchdog_test.py
@@ -170,6 +170,11 @@ class WarpBuildRunbookTest(unittest.TestCase):
             / "warpbuild-ci.md"
         )
         cls.runbook = runbook_path.read_text(encoding="utf-8")
+        troubleshooting = cls.runbook.split(
+            "## Troubleshooting: jobs stuck in `queued`",
+            maxsplit=1,
+        )[1]
+        cls.troubleshooting = " ".join(troubleshooting.split())
 
     def test_windows_runner_table_uses_live_sku(self):
         self.assertIn(
@@ -206,12 +211,24 @@ class WarpBuildRunbookTest(unittest.TestCase):
         self.assertIn("East US returned HTTP 409 `SkuNotAvailable`", self.runbook)
 
     def test_troubleshooting_calls_out_stack_launch_errors(self):
-        self.assertIn("BYOC stack's launch errors", self.runbook)
-        self.assertIn("LaunchInstances", self.runbook)
-        self.assertIn("image/VM-size generation mismatch", self.runbook)
-        self.assertIn("regional capacity", self.runbook)
-        self.assertIn("regionally available Gen1-compatible size", self.runbook)
-        self.assertIn("`Standard_D32as_v4`", self.runbook)
+        self.assertIn("BYOC stack's launch errors", self.troubleshooting)
+        self.assertIn("LaunchInstances", self.troubleshooting)
+        self.assertRegex(
+            self.troubleshooting,
+            r"An Azure 400 [^.]* image/VM-size generation mismatch [^.]* "
+            r"choose a Gen1-compatible size",
+        )
+        self.assertRegex(
+            self.troubleshooting,
+            r"An Azure 409 `SkuNotAvailable` [^.]*\. "
+            r"Check quota and regional capacity [^.]* "
+            r"choose a regionally available Gen1-compatible size",
+        )
+        self.assertRegex(
+            self.troubleshooting,
+            r"`Standard_D32as_v4` is the verified-family fallback [^.]* "
+            r"confirm its capacity in East US before switching",
+        )
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/ci_watchdog_test.py
+++ b/packages/browseros/bos_build/ci_watchdog_test.py
@@ -175,7 +175,11 @@ class WarpBuildRunbookTest(unittest.TestCase):
         self.assertIn(
             "| Windows x64 | "
             "`warp-custom-browseros-windows-2025-x64-32x` | "
-            "Windows Server 2025 | `Standard_D32ls_v5` | P30, 1024 GB |",
+            "Windows Server 2025 | `Standard_D32as_v5` | P30, 1024 GB |",
+            self.runbook,
+        )
+        self.assertNotIn(
+            "Windows Server 2025 | `Standard_D32ls_v5` |",
             self.runbook,
         )
         self.assertNotIn(
@@ -188,13 +192,26 @@ class WarpBuildRunbookTest(unittest.TestCase):
             "WarpBuild's Windows Server 2025 image is Hypervisor Generation 1",
             self.runbook,
         )
-        self.assertIn("Dlsv5 supports both Generation 1 and 2", self.runbook)
+        self.assertRegex(
+            self.runbook,
+            r"`Standard_D32as_v5` supports both Generation 1\s+and 2",
+        )
         self.assertIn("Dalsv7 is Generation 2-only", self.runbook)
+
+    def test_windows_capacity_history_is_distinct_from_compatibility(self):
+        self.assertIn(
+            "`Standard_D32ls_v5` is Gen1-compatible",
+            self.runbook,
+        )
+        self.assertIn("East US returned HTTP 409 `SkuNotAvailable`", self.runbook)
 
     def test_troubleshooting_calls_out_stack_launch_errors(self):
         self.assertIn("BYOC stack's launch errors", self.runbook)
         self.assertIn("LaunchInstances", self.runbook)
         self.assertIn("image/VM-size generation mismatch", self.runbook)
+        self.assertIn("regional capacity", self.runbook)
+        self.assertIn("regionally available Gen1-compatible size", self.runbook)
+        self.assertIn("`Standard_D32as_v4`", self.runbook)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/docs/warpbuild-ci.md
+++ b/packages/browseros/bos_build/docs/warpbuild-ci.md
@@ -19,7 +19,7 @@ nightly lanes use the repo-scoped Mac Mini runner instead; see
 | Platform | Label | Image | Compute | Disk |
 | --- | --- | --- | --- | --- |
 | Linux x64 | `warp-custom-browseros-ubuntu-2204-x64-32x` | Ubuntu 22.04 | `Standard_D32alds_v7` | P40, 2048 GB |
-| Windows x64 | `warp-custom-browseros-windows-2025-x64-32x` | Windows Server 2025 | `Standard_D32ls_v5` | P30, 1024 GB |
+| Windows x64 | `warp-custom-browseros-windows-2025-x64-32x` | Windows Server 2025 | `Standard_D32as_v5` | P30, 1024 GB |
 | macOS arm64 | `warp-macos-26-arm64-12x` | macOS 26 | M4 Pro, 12 vCPU / 44 GB | 500 GB |
 
 WarpBuild provisions the Linux and Windows runners in the BrowserOS Azure
@@ -31,8 +31,12 @@ compute SKUs and disk capacities mirror the source Azure build VMs, but they
 do not clone or retain those VMs' persistent disks.
 
 WarpBuild's Windows Server 2025 image is Hypervisor Generation 1, so its VM
-family must accept a Gen1 image. Dlsv5 supports both Generation 1 and 2, making
-`Standard_D32ls_v5` compatible; Dalsv7 is Generation 2-only, so
+family must accept a Gen1 image. `Standard_D32as_v5` supports both Generation 1
+and 2, making the current 32-vCPU/128-GiB configuration image-compatible. A
+live smoke run successfully provisioned its VM and registered a GitHub runner.
+`Standard_D32ls_v5` is Gen1-compatible too, but it was rejected for this stack
+after East US returned HTTP 409 `SkuNotAvailable`; that is a regional-capacity
+failure, not an image-generation mismatch. Dalsv7 is Generation 2-only, so
 `Standard_D32als_v7` fails during Azure VM creation before a runner can
 register with GitHub.
 
@@ -98,10 +102,18 @@ leaves `queued`:
    configurations listed above. Also check Azure quota and regional capacity
    for their VM SKUs when provisioning fails.
 
-Smoke test after changing either:
-`gh workflow run release-linux.yml -f products=browseros -f upload_to_r2=false`,
-then watch the build job leave `queued` within ~5 minutes (`gh run watch`).
-Only do this when you intentionally want to spend Azure compute time.
+Smoke test the platform whose runner configuration changed:
+
+```bash
+gh workflow run release-linux.yml -f products=browseros -f upload_to_r2=false
+gh workflow run release-windows.yml \
+  -f products=browserclaw \
+  -f sign=false \
+  -f upload_to_r2=false
+```
+
+Then watch its build job leave `queued` within ~5 minutes (`gh run watch`).
+Only dispatch one when you intentionally want to spend Azure compute time.
 
 ## Release lane flow
 
@@ -229,8 +241,12 @@ Causes, in the order to check:
    open the BYOC stack's launch errors and inspect `LaunchInstances`. An Azure
    400 that reports an image/VM-size generation mismatch means the image and
    selected VM family support different Hypervisor Generations; choose a
-   Gen1-compatible size for the current Windows image. Also check subscription
-   quota and East US capacity for the configured VM SKU.
+   Gen1-compatible size for the current Windows image. An Azure 409
+   `SkuNotAvailable` is different: the requested SKU has no capacity for that
+   subscription, location, or zone. Check quota and regional capacity in the
+   configured region, then choose a regionally available Gen1-compatible size.
+   `Standard_D32as_v4` is the verified-family fallback if D32as v5 is
+   unavailable, but confirm its capacity in East US before switching.
 4. **WarpBuild incident** — check their dashboard.
 
 Mechanics worth knowing:


### PR DESCRIPTION
## Summary

- Record `Standard_D32as_v5` as the live Windows WarpBuild size while keeping
  the runner label, image, and P30 1024-GB disk unchanged.
- Distinguish Gen1 compatibility from East US `SkuNotAvailable` capacity
  failures and document `Standard_D32as_v4` as a capacity-qualified fallback.
- Strengthen runbook regression tests so SKU, status-code, and remediation
  relationships cannot drift independently.

## Design

The existing operations runbook remains the durable mapping from stable
GitHub runner labels to live Azure compute configuration. The update changes
only the Windows compute cell, then gives operators separate decision paths
for image-generation mismatch and regional capacity. Focused paragraph- and
section-scoped assertions pin those relationships without changing workflows
or live infrastructure.

## Test plan

- [x] Focused `WarpBuildRunbookTest` (4 tests)
- [x] Complete `bos_build` unittest suite (742 tests)
- [x] Release-secret unittest suite (9 tests)
- [x] Ruff
- [x] `git diff --check`
- [x] No `.github/workflows` changes
- [x] Three context-free review rounds; final round clean
