### PR TITLE
fix(ci): bootstrap Windows Git for Chromium

### DIFF
--- a/.github/workflows/bos-build-tests.yml
+++ b/.github/workflows/bos-build-tests.yml
@@ -12,6 +12,7 @@ on:
       - "packages/browseros/uv.lock"
       - "tools/release_secrets/**"
       - ".github/workflows/bos-build-tests.yml"
+      - ".github/workflows/build-browseros.yml"
       - ".github/workflows/release-linux.yml"
       - ".github/workflows/release-windows.yml"
 

--- a/.github/workflows/bos-build-tests.yml
+++ b/.github/workflows/bos-build-tests.yml
@@ -53,3 +53,20 @@ jobs:
       - name: Run vendor_uploads tests
         working-directory: packages/browseros/tools/vendor_uploads
         run: uv run python -m unittest discover -s vendor_uploads -t . -p "*_test.py"
+
+  windows-git-bootstrap:
+    name: Windows Git bootstrap / Git Bash + native Git
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.3.2
+
+      - name: Verify Windows Git bootstrap
+        shell: bash
+        working-directory: packages/browseros
+        run: uv run python -m unittest bos_build.ci_workflow_test -v

--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -100,6 +100,27 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Configure Git for depot_tools
+        if: runner.os == 'Windows'
+        run: |
+          set -euo pipefail
+
+          git_config="$RUNNER_TEMP/browseros-global.gitconfig"
+          export GIT_CONFIG_GLOBAL="$git_config"
+          printf 'GIT_CONFIG_GLOBAL=%s\n' "$git_config" >> "$GITHUB_ENV"
+
+          git config --global --replace-all core.autocrlf false
+          git config --global --replace-all core.filemode false
+          git config --global --replace-all core.fscache true
+          git config --global --replace-all core.preloadindex true
+          git config --global --replace-all depot-tools.allowGlobalGitConfig true
+
+          test "$(git config --global --get core.autocrlf)" = false
+          test "$(git config --global --get core.filemode)" = false
+          test "$(git config --global --get core.fscache)" = true
+          test "$(git config --global --get core.preloadindex)" = true
+          test "$(git config --global --get depot-tools.allowGlobalGitConfig)" = true
+
       # v8.x.y releases exist but astral-sh publishes no floating `v8`
       # major tag - `@v8` is unresolvable and kills the job in Set up job.
       - uses: astral-sh/setup-uv@v8.3.2

--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -105,7 +105,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          git_config="$RUNNER_TEMP/browseros-global.gitconfig"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            git_config_dir="$(cd "$RUNNER_TEMP" && pwd -W)"
+          else
+            git_config_dir="$(cd "$RUNNER_TEMP" && pwd)"
+          fi
+          git_config="$git_config_dir/browseros-global.gitconfig"
           export GIT_CONFIG_GLOBAL="$git_config"
           printf 'GIT_CONFIG_GLOBAL=%s\n' "$git_config" >> "$GITHUB_ENV"
 

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Regression tests for the reusable Chromium build workflow."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+GIT_BOOTSTRAP_STEP = "Configure Git for depot_tools"
+EXPECTED_GIT_CONFIG = {
+    "core.autocrlf": "false",
+    "core.filemode": "false",
+    "core.fscache": "true",
+    "core.preloadindex": "true",
+    "depot-tools.allowGlobalGitConfig": "true",
+}
+
+
+class ChromiumBuildWorkflowTest(unittest.TestCase):
+    def load_workflow(self, workflow_name: str) -> dict[str, object]:
+        workflow_path = WORKFLOW_DIR / workflow_name
+        return yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+
+    def build_steps(self) -> list[dict[str, object]]:
+        workflow = self.load_workflow("build-browseros.yml")
+        return workflow["jobs"]["build"]["steps"]
+
+    def git_bootstrap_step(self) -> dict[str, object]:
+        return next(
+            step
+            for step in self.build_steps()
+            if step.get("name") == GIT_BOOTSTRAP_STEP
+        )
+
+    def test_git_bootstrap_is_windows_only_and_immediately_after_checkout(self):
+        steps = self.build_steps()
+        checkout_index = next(
+            index
+            for index, step in enumerate(steps)
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        )
+        bootstrap_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == GIT_BOOTSTRAP_STEP
+        )
+
+        self.assertEqual(bootstrap_index, checkout_index + 1)
+        self.assertEqual(
+            steps[bootstrap_index]["if"],
+            "runner.os == 'Windows'",
+        )
+
+    def test_git_bootstrap_precedes_every_chromium_lifecycle_phase(self):
+        steps = self.build_steps()
+        indexes = {
+            step.get("name"): index
+            for index, step in enumerate(steps)
+            if "name" in step
+        }
+        bootstrap_index = indexes[GIT_BOOTSTRAP_STEP]
+
+        for phase in (
+            "Resolve chromium pin and paths",
+            "Restore chromium checkout (WarpCache)",
+            "Restore chromium checkout (R2)",
+            "Ensure chromium checkout at pinned tag",
+            "Reset chromium tree (clean module)",
+            "Sync chromium dependencies (gclient)",
+        ):
+            with self.subTest(phase=phase):
+                self.assertLess(bootstrap_index, indexes[phase])
+
+    def test_git_bootstrap_uses_isolated_global_config_and_exact_values(self):
+        script = self.git_bootstrap_step()["run"]
+
+        self.assertIn("set -euo pipefail", script)
+        self.assertIn(
+            'git_config="$RUNNER_TEMP/browseros-global.gitconfig"',
+            script,
+        )
+        self.assertIn('export GIT_CONFIG_GLOBAL="$git_config"', script)
+        self.assertIn(
+            "printf 'GIT_CONFIG_GLOBAL=%s\\n' \"$git_config\" >> \"$GITHUB_ENV\"",
+            script,
+        )
+        self.assertNotIn("GIT_CONFIG_NOSYSTEM", script)
+
+        for key, value in EXPECTED_GIT_CONFIG.items():
+            with self.subTest(key=key):
+                self.assertIn(
+                    f"git config --global --replace-all {key} {value}",
+                    script,
+                )
+                self.assertIn(
+                    f'test "$(git config --global --get {key})" = {value}',
+                    script,
+                )
+
+    def test_literal_git_bootstrap_is_home_independent_and_idempotent(self):
+        script = self.git_bootstrap_step()["run"]
+
+        with tempfile.TemporaryDirectory(prefix="browseros git bootstrap ") as tmp:
+            temp_root = Path(tmp)
+            runner_temp = temp_root / "runner temp"
+            runner_temp.mkdir()
+            missing_home = temp_root / "missing home"
+            github_env = temp_root / "github env"
+            config_path = runner_temp / "browseros-global.gitconfig"
+
+            for key in EXPECTED_GIT_CONFIG:
+                subprocess.run(
+                    [
+                        "git",
+                        "config",
+                        "--file",
+                        str(config_path),
+                        "--add",
+                        key,
+                        "stale",
+                    ],
+                    check=True,
+                )
+                subprocess.run(
+                    [
+                        "git",
+                        "config",
+                        "--file",
+                        str(config_path),
+                        "--add",
+                        key,
+                        "duplicate",
+                    ],
+                    check=True,
+                )
+
+            env = os.environ.copy()
+            env.pop("GIT_CONFIG_GLOBAL", None)
+            env.update(
+                {
+                    "GITHUB_ENV": str(github_env),
+                    "HOME": str(missing_home),
+                    "RUNNER_TEMP": str(runner_temp),
+                }
+            )
+
+            for _ in range(2):
+                subprocess.run(
+                    ["bash", "-c", script],
+                    check=True,
+                    env=env,
+                )
+
+            self.assertFalse(missing_home.exists())
+            self.assertEqual(
+                github_env.read_text(encoding="utf-8").splitlines(),
+                [f"GIT_CONFIG_GLOBAL={config_path}"] * 2,
+            )
+            for key, value in EXPECTED_GIT_CONFIG.items():
+                with self.subTest(key=key):
+                    result = subprocess.run(
+                        [
+                            "git",
+                            "config",
+                            "--file",
+                            str(config_path),
+                            "--get-all",
+                            key,
+                        ],
+                        capture_output=True,
+                        check=True,
+                        text=True,
+                    )
+                    self.assertEqual(result.stdout.splitlines(), [value])
+
+    def test_reusable_workflow_changes_trigger_build_system_tests(self):
+        test_workflow = self.load_workflow("bos-build-tests.yml")
+        # PyYAML's YAML 1.1 resolver treats the GitHub Actions `on` key as a
+        # boolean, so accept either representation here.
+        triggers = test_workflow.get("on", test_workflow.get(True))
+        pull_request_paths = triggers["pull_request"]["paths"]
+
+        self.assertIn(
+            ".github/workflows/build-browseros.yml",
+            pull_request_paths,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -114,6 +114,23 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
             github_env = temp_root / "github env"
             config_path = runner_temp / "browseros-global.gitconfig"
 
+            env = os.environ.copy()
+            env.pop("GIT_CONFIG_GLOBAL", None)
+            env.update(
+                {
+                    "GITHUB_ENV": str(github_env),
+                    "HOME": str(missing_home),
+                    "RUNNER_TEMP": str(runner_temp),
+                }
+            )
+
+            subprocess.run(
+                ["bash", "-c", script],
+                check=True,
+                env=env,
+            )
+            self.assertTrue(config_path.is_file())
+
             for key in EXPECTED_GIT_CONFIG:
                 subprocess.run(
                     [
@@ -140,22 +157,11 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                     check=True,
                 )
 
-            env = os.environ.copy()
-            env.pop("GIT_CONFIG_GLOBAL", None)
-            env.update(
-                {
-                    "GITHUB_ENV": str(github_env),
-                    "HOME": str(missing_home),
-                    "RUNNER_TEMP": str(runner_temp),
-                }
+            subprocess.run(
+                ["bash", "-c", script],
+                check=True,
+                env=env,
             )
-
-            for _ in range(2):
-                subprocess.run(
-                    ["bash", "-c", script],
-                    check=True,
-                    env=env,
-                )
 
             self.assertFalse(missing_home.exists())
             self.assertEqual(
@@ -179,6 +185,67 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                     )
                     self.assertEqual(result.stdout.splitlines(), [value])
 
+    @unittest.skipUnless(os.name == "nt", "requires Git for Windows")
+    def test_native_git_wrapper_reads_config_propagated_by_git_bash(self):
+        script = self.git_bootstrap_step()["run"]
+
+        with tempfile.TemporaryDirectory(prefix="browseros native git ") as tmp:
+            temp_root = Path(tmp)
+            runner_temp = temp_root / "runner temp"
+            runner_temp.mkdir()
+            missing_home = temp_root / "missing home"
+            github_env = temp_root / "github env"
+
+            bash_env = os.environ.copy()
+            bash_env.pop("GIT_CONFIG_GLOBAL", None)
+            bash_env.update(
+                {
+                    "GITHUB_ENV": str(github_env),
+                    "HOME": str(missing_home),
+                    "RUNNER_TEMP": str(runner_temp),
+                }
+            )
+            subprocess.run(
+                ["bash", "-c", script],
+                check=True,
+                env=bash_env,
+            )
+
+            assignment = github_env.read_text(encoding="utf-8").strip()
+            name, config_path = assignment.split("=", maxsplit=1)
+            self.assertEqual(name, "GIT_CONFIG_GLOBAL")
+
+            git_wrapper = temp_root / "git-wrapper.bat"
+            git_wrapper.write_bytes(b"@echo off\r\ngit %*\r\n")
+            native_env = os.environ.copy()
+            native_env.update(
+                {
+                    "GIT_CONFIG_GLOBAL": config_path,
+                    "HOME": str(missing_home),
+                }
+            )
+
+            for key, value in EXPECTED_GIT_CONFIG.items():
+                with self.subTest(key=key):
+                    command = subprocess.list2cmdline(
+                        [
+                            "call",
+                            str(git_wrapper),
+                            "config",
+                            "--global",
+                            "--get-all",
+                            key,
+                        ]
+                    )
+                    result = subprocess.run(
+                        ["cmd.exe", "/d", "/c", command],
+                        capture_output=True,
+                        check=True,
+                        env=native_env,
+                        text=True,
+                    )
+                    self.assertEqual(result.stdout.splitlines(), [value])
+
     def test_reusable_workflow_changes_trigger_build_system_tests(self):
         test_workflow = self.load_workflow("bos-build-tests.yml")
         # PyYAML's YAML 1.1 resolver treats the GitHub Actions `on` key as a
@@ -189,6 +256,26 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
         self.assertIn(
             ".github/workflows/build-browseros.yml",
             pull_request_paths,
+        )
+
+    def test_build_system_tests_cross_git_bash_to_native_git_on_windows(self):
+        test_workflow = self.load_workflow("bos-build-tests.yml")
+        windows_job = test_workflow["jobs"]["windows-git-bootstrap"]
+        verification_step = next(
+            step
+            for step in windows_job["steps"]
+            if step.get("name") == "Verify Windows Git bootstrap"
+        )
+
+        self.assertEqual(windows_job["runs-on"], "windows-latest")
+        self.assertEqual(verification_step["shell"], "bash")
+        self.assertEqual(
+            verification_step["working-directory"],
+            "packages/browseros",
+        )
+        self.assertEqual(
+            verification_step["run"],
+            "uv run python -m unittest bos_build.ci_workflow_test -v",
         )
 
 

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -100,7 +100,11 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
 
         self.assertIn("set -euo pipefail", script)
         self.assertIn(
-            'git_config="$RUNNER_TEMP/browseros-global.gitconfig"',
+            'git_config_dir="$(cd "$RUNNER_TEMP" && pwd -W)"',
+            script,
+        )
+        self.assertIn(
+            'git_config="$git_config_dir/browseros-global.gitconfig"',
             script,
         )
         self.assertIn('export GIT_CONFIG_GLOBAL="$git_config"', script)
@@ -138,6 +142,7 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                 {
                     "GITHUB_ENV": str(github_env),
                     "HOME": str(missing_home),
+                    "RUNNER_OS": "Windows" if os.name == "nt" else "Linux",
                     "RUNNER_TEMP": str(runner_temp),
                 }
             )
@@ -182,10 +187,16 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
             )
 
             self.assertFalse(missing_home.exists())
-            self.assertEqual(
-                github_env.read_text(encoding="utf-8").splitlines(),
-                [f"GIT_CONFIG_GLOBAL={config_path}"] * 2,
-            )
+            assignments = github_env.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(assignments), 2)
+            for assignment in assignments:
+                name, emitted_path = assignment.split("=", maxsplit=1)
+                self.assertEqual(name, "GIT_CONFIG_GLOBAL")
+                self.assertNotIn("\\", emitted_path)
+                self.assertEqual(
+                    Path(emitted_path).resolve(),
+                    config_path.resolve(),
+                )
             for key, value in EXPECTED_GIT_CONFIG.items():
                 with self.subTest(key=key):
                     result = subprocess.run(
@@ -220,6 +231,7 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                 {
                     "GITHUB_ENV": str(github_env),
                     "HOME": str(missing_home),
+                    "RUNNER_OS": "Windows",
                     "RUNNER_TEMP": str(runner_temp),
                 }
             )
@@ -258,9 +270,13 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                     result = subprocess.run(
                         ["cmd.exe", "/d", "/c", command],
                         capture_output=True,
-                        check=True,
                         env=native_env,
                         text=True,
+                    )
+                    self.assertEqual(
+                        result.returncode,
+                        0,
+                        msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
                     )
                     self.assertEqual(result.stdout.splitlines(), [value])
 

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -259,8 +259,7 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                 with self.subTest(key=key):
                     command = subprocess.list2cmdline(
                         [
-                            "call",
-                            str(git_wrapper),
+                            git_wrapper.name,
                             "config",
                             "--global",
                             "--get-all",
@@ -270,6 +269,7 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                     result = subprocess.run(
                         ["cmd.exe", "/d", "/c", command],
                         capture_output=True,
+                        cwd=temp_root,
                         env=native_env,
                         text=True,
                     )

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -192,5 +192,53 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
         )
 
 
+class ChromiumGitRunbookTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        runbook_path = (
+            REPO_ROOT
+            / "packages"
+            / "browseros"
+            / "bos_build"
+            / "docs"
+            / "warpbuild-ci.md"
+        )
+        cls.runbook = runbook_path.read_text(encoding="utf-8")
+
+    def test_release_flow_puts_windows_git_bootstrap_before_source_ensure(self):
+        release_flow = self.runbook.split(
+            "## Release lane flow",
+            maxsplit=1,
+        )[1].split("## Caching strategy", maxsplit=1)[0]
+
+        bootstrap_index = release_flow.index("`GIT_CONFIG_GLOBAL`")
+        source_ensure_index = release_flow.index(
+            "`browseros source ensure --step checkout`"
+        )
+        self.assertLess(bootstrap_index, source_ensure_index)
+        self.assertIn(
+            "`$RUNNER_TEMP/browseros-global.gitconfig`",
+            release_flow,
+        )
+
+    def test_missing_global_config_failure_has_deterministic_recovery(self):
+        heading = "## Troubleshooting: depot_tools cannot read global Git config"
+        self.assertIn(heading, self.runbook)
+        troubleshooting = self.runbook.split(heading, maxsplit=1)[1].split(
+            "\n## ",
+            maxsplit=1,
+        )[0]
+
+        self.assertIn(
+            "C:/Users/runneradmin/.gitconfig",
+            troubleshooting,
+        )
+        self.assertIn("gclient exit `9009`", troubleshooting)
+        self.assertIn("PATH Git", troubleshooting)
+        self.assertIn("depot_tools `git.bat`", troubleshooting)
+        self.assertIn("`GIT_CONFIG_GLOBAL`", troubleshooting)
+        self.assertIn("do not modify the runner image", troubleshooting)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -22,6 +22,24 @@ EXPECTED_GIT_CONFIG = {
 }
 
 
+def git_bash_path() -> str:
+    """Return Git for Windows' Bash instead of the unrelated WSL stub."""
+    if os.name != "nt":
+        return "bash"
+
+    result = subprocess.run(
+        ["git", "--exec-path"],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    git_install_root = Path(result.stdout.strip()).parents[2]
+    git_bash = git_install_root / "bin" / "bash.exe"
+    if not git_bash.is_file():
+        raise AssertionError(f"Git Bash not found at {git_bash}")
+    return str(git_bash)
+
+
 class ChromiumBuildWorkflowTest(unittest.TestCase):
     def load_workflow(self, workflow_name: str) -> dict[str, object]:
         workflow_path = WORKFLOW_DIR / workflow_name
@@ -125,7 +143,7 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
             )
 
             subprocess.run(
-                ["bash", "-c", script],
+                [git_bash_path(), "-c", script],
                 check=True,
                 env=env,
             )
@@ -158,7 +176,7 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                 )
 
             subprocess.run(
-                ["bash", "-c", script],
+                [git_bash_path(), "-c", script],
                 check=True,
                 env=env,
             )
@@ -206,7 +224,7 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                 }
             )
             subprocess.run(
-                ["bash", "-c", script],
+                [git_bash_path(), "-c", script],
                 check=True,
                 env=bash_env,
             )

--- a/packages/browseros/bos_build/docs/warpbuild-ci.md
+++ b/packages/browseros/bos_build/docs/warpbuild-ci.md
@@ -126,24 +126,31 @@ used for unsigned verification with `sign=false`. Both lanes pass
 
 The reusable workflow performs the per-platform recipe:
 
-1. `actions/checkout` + `astral-sh/setup-uv`.
-2. Restore the pinned chromium checkout from cache (see below).
-3. `browseros source ensure --step checkout` — ensures depot_tools and
+1. `actions/checkout`.
+2. On Windows, select
+   `$RUNNER_TEMP/browseros-global.gitconfig` through `GIT_CONFIG_GLOBAL`,
+   write depot_tools' required Git settings with PATH Git, and export the
+   selection to every later step. This is deliberately after repository
+   checkout but before any Chromium/depot_tools operation. Linux and macOS
+   skip the step.
+3. `astral-sh/setup-uv`, resolve the Chromium pin and paths, then restore the
+   pinned chromium checkout from cache (see below).
+4. `browseros source ensure --step checkout` — ensures depot_tools and
    `src` at the tag from `packages/browseros/CHROMIUM_VERSION`. No-op when
    the cache is warm and the pin unchanged.
-4. `uv run browseros build --modules clean ...` — the standard clean module
+5. `uv run browseros build --modules clean ...` — the standard clean module
    resets the tree (it also deletes hook-managed toolchains like
    `third_party/llvm-build`, which the next step restores).
-5. `browseros source ensure --step sync` — `gclient sync -D
+6. `browseros source ensure --step sync` — `gclient sync -D
    --no-history --shallow`, exactly what the git_setup module runs.
-6. Save the cache (only when the restore missed, i.e. first run per pin).
-7. `uv run browseros build --profile release-ci --product <product>
+7. Save the cache (only when the restore missed, i.e. first run per pin).
+8. `uv run browseros build --profile release-ci --product <product>
    --arch <arch> --chromium-src .../src`, with signing and R2 upload flags
    resolved from workflow inputs.
-8. Upload release build artifacts to the Actions run with 14-day retention.
+9. Upload release build artifacts to the Actions run with 14-day retention.
 
 The `release-ci` profile is the release preset minus `clean`/`git_setup`
-(steps 4-5 replace them). Why not run `git_setup` as-is: it does
+(steps 5-6 replace them). Why not run `git_setup` as-is: it does
 `git fetch --tags`, which on the shallow CI clone would pull objects for all
 ~70k chromium tags; the script instead fetches exactly the pinned tag at depth
 2. On Windows the `mini_installer` module builds the installer that the signing
@@ -218,6 +225,30 @@ The first run per platform is the cache warm-up; expect cold timings. If a
 pin bump lands, the next run is cold again for that version. To force a fresh
 checkout, bump the `v1` in the cache key (workflow) — for Windows also delete
 the old object under `ci-cache/chromium/` in R2.
+
+## Troubleshooting: depot_tools cannot read global Git config
+
+The Windows failure signature is
+`fatal: unable to read config file 'C:/Users/runneradmin/.gitconfig'`, followed
+by depot_tools' recommended core settings, a stray `'failed' is not
+recognized` message, and gclient exit `9009`. This occurs after the runner has
+started; it is not an Azure provisioning, cache, or clean failure.
+
+The reusable workflow does not depend on the runner account's HOME, XDG, or
+AppData mapping. Its Windows-only bootstrap selects a disposable file under
+`RUNNER_TEMP` with `GIT_CONFIG_GLOBAL`, writes the four Chromium settings plus
+`depot-tools.allowGlobalGitConfig=true`, and verifies each value before source
+setup. It uses PATH Git intentionally because depot_tools may not exist on a
+cold checkout. Later depot_tools `git.bat` and `gclient.bat` processes inherit
+the same `GIT_CONFIG_GLOBAL`, so warm and cold checkouts share one explicit
+configuration.
+
+If this signature returns, inspect the "Configure Git for depot_tools" step and
+confirm its five read-back checks passed and its `GITHUB_ENV` assignment names
+the temporary file. Fix the workflow contract; do not modify the runner image
+or create `C:/Users/runneradmin/.gitconfig` manually. WarpBuild runners are
+ephemeral, and account-level repair would disappear with the VM while
+reintroducing HOME-resolution ambiguity.
 
 ## Troubleshooting: jobs stuck in `queued`
 


### PR DESCRIPTION
## Summary

- bootstrap depot_tools' required global Git settings in the reusable Windows
  Chromium workflow
- isolate the config under `RUNNER_TEMP` with `GIT_CONFIG_GLOBAL`, avoiding
  HOME/XDG/AppData runner-image assumptions
- propagate the same config to cold PATH Git and later `gclient.bat` /
  depot_tools `git.bat`
- add portable and native-Windows regression coverage plus runbook guidance

## Root cause

WarpBuild Azure run `30413676749` reached the Windows D32as v5 runner, restored
the R2 checkout, and completed clean. `gclient sync` then failed because
depot_tools could not read `C:/Users/runneradmin/.gitconfig`, emitted its four
required core settings, and exited 9009.

## Validation

- `uv run python -m unittest discover -s bos_build -t . -p "*_test.py"` —
  751 passed locally (1 Windows-only test skipped off Windows)
- `python3 -m unittest discover -s tools/release_secrets -t . -p "*_test.py"` —
  9 passed
- `uv run ruff check bos_build`
- `actionlint`
- two context-free review rounds; final round clean

The `windows-latest` PR job executes the literal Git Bash bootstrap and then
queries all five values from a fresh native `cmd.exe` process through a `.bat`
Git wrapper.

## Risk and rollback

The new environment is guarded by `runner.os == 'Windows'` and begins only
after `actions/checkout`. Linux and macOS are unchanged. The selected global
file is job-local and disposable; system Git policy remains enabled.

Rollback is the workflow step plus its tests/docs. No WarpBuild or Azure
configuration is changed by this PR.

## Live validation

After merge, the release operator will pull main and dispatch the exact full
BrowserOS + BrowserClaw release through the WarpBuild Azure connector.
