### PR TITLE
fix(release): make distribution integrity fail closed

### DIFF
--- a/.github/workflows/bos-build-tests.yml
+++ b/.github/workflows/bos-build-tests.yml
@@ -13,6 +13,8 @@ on:
       - "tools/release_secrets/**"
       - ".github/workflows/bos-build-tests.yml"
       - ".github/workflows/build-browseros.yml"
+      - ".github/workflows/release-browseros.yml"
+      - ".github/workflows/release-browserclaw.yml"
       - ".github/workflows/release-linux.yml"
       - ".github/workflows/release-windows.yml"
 

--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -98,7 +98,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Configure Git for depot_tools
         if: runner.os == 'Windows'

--- a/.github/workflows/release-browserclaw.yml
+++ b/.github/workflows/release-browserclaw.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Resolve release version
         id: version
@@ -226,7 +226,7 @@ jobs:
       contents: write
       pull-requests: write
     with:
-      ref: ${{ github.ref_name }}
+      ref: ${{ github.sha }}
     secrets: inherit
 
   server_browserclaw:
@@ -237,7 +237,7 @@ jobs:
     permissions:
       contents: write
     with:
-      ref: ${{ github.ref_name }}
+      ref: ${{ github.sha }}
       publish_ota: false
     secrets: inherit
 
@@ -306,7 +306,7 @@ jobs:
       bump: none
       commit_version: false
       upload_to_r2: ${{ inputs.upload_to_r2 }}
-      ref: ${{ github.ref_name }}
+      ref: ${{ github.sha }}
     secrets: inherit
 
   release_extensions:
@@ -327,7 +327,7 @@ jobs:
     with:
       version: ${{ needs.preflight.outputs.extensions_version }}
       extension: browserclaw
-      branch: ${{ github.ref_name }}
+      branch: ${{ github.sha }}
     secrets: inherit
 
   stage_updates:
@@ -351,6 +351,7 @@ jobs:
       VERSION: ${{ needs.preflight.outputs.version }}
       EXTENSIONS_VERSION: ${{ needs.preflight.outputs.extensions_version }}
       INPUT_PLATFORMS: ${{ inputs.platforms }}
+      INPUT_MACOS_ARCH: ${{ inputs.macos_arch }}
       INPUT_INCLUDE_SERVERS: ${{ inputs.include_servers }}
       INPUT_UPLOAD_TO_R2: ${{ inputs.upload_to_r2 }}
       INPUT_EXTENSIONS: ${{ inputs.extensions }}
@@ -419,6 +420,10 @@ jobs:
             should_stage=false
             reasons+=("extension result is $EXTENSIONS_RESULT")
           fi
+          if [ "$INPUT_PLATFORMS" = "linux" ] && [ "$INPUT_EXTENSIONS" = "skip" ]; then
+            should_stage=false
+            reasons+=("no update feeds are selected for a Linux-only release with extensions skipped")
+          fi
 
           reason="ready"
           if [ "${#reasons[@]}" -gt 0 ]; then
@@ -443,7 +448,7 @@ jobs:
       - uses: actions/checkout@v7
         if: ${{ steps.stage_gate.outputs.should_stage == 'true' }}
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: astral-sh/setup-uv@v8.3.2
         if: ${{ steps.stage_gate.outputs.should_stage == 'true' }}
@@ -470,12 +475,21 @@ jobs:
           rm -rf "$artifact_root"
           mkdir -p "$artifact_root" "$appcast_dir" "$extensions_dir"
 
-          appcast_targets=(
-            appcast-claw.xml
-            appcast-claw-x86_64.xml
-            appcast-claw-win.xml
-            appcast-claw-win-arm64.xml
-          )
+          appcast_targets=()
+          if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "macos" ]; then
+            case "$INPUT_MACOS_ARCH" in
+              arm64) appcast_targets+=(appcast-claw.xml) ;;
+              x64) appcast_targets+=(appcast-claw-x86_64.xml) ;;
+              universal) appcast_targets+=(appcast-claw.xml appcast-claw-x86_64.xml) ;;
+              *)
+                echo "::error::Unsupported macOS architecture: $INPUT_MACOS_ARCH"
+                exit 1
+                ;;
+            esac
+          fi
+          if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "windows" ]; then
+            appcast_targets+=(appcast-claw-win.xml)
+          fi
           extension_targets=()
           if [ "$INPUT_EXTENSIONS" != "skip" ]; then
             if [ "$INPUT_EXTENSIONS" = "alpha" ]; then
@@ -493,19 +507,32 @@ jobs:
             fi
           fi
 
-          for file in "${appcast_targets[@]}"; do
-            rm -f "$appcast_dir/$file"
-          done
+          if [ "${#appcast_targets[@]}" -gt 0 ]; then
+            for file in "${appcast_targets[@]}"; do
+              rm -f "$appcast_dir/$file"
+            done
+          fi
           for file in update-manifest.xml update-manifest.alpha.xml extensions.json extensions.alpha.json bundled-manifest.xml; do
             rm -f "$extensions_dir/$file"
           done
 
-          set +e
-          uv run browseros release appcast --version "$VERSION" --product "$PRODUCT" > "$appcast_log" 2>&1
-          appcast_rc=$?
-          set -e
+          appcast_rc=0
+          if [ "${#appcast_targets[@]}" -gt 0 ]; then
+            set +e
+            uv run browseros release appcast \
+              --version "$VERSION" \
+              --product "$PRODUCT" \
+              --platforms "$INPUT_PLATFORMS" \
+              --macos-arch "$INPUT_MACOS_ARCH" \
+              --source-sha "$GITHUB_SHA" \
+              --workflow-run-id "$GITHUB_RUN_ID" \
+              --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+              > "$appcast_log" 2>&1
+            appcast_rc=$?
+            set -e
+          fi
           if [ "$appcast_rc" -ne 0 ]; then
-            echo "::warning::Appcast staging failed for $PRODUCT v$VERSION; see step summary."
+            echo "::error::Appcast staging failed for $PRODUCT v$VERSION; see step summary."
           fi
 
           extensions_rc=0
@@ -515,19 +542,40 @@ jobs:
             extensions_rc=$?
             set -e
             if [ "$extensions_rc" -ne 0 ]; then
-              echo "::warning::Extension feed staging failed for $EXTENSION_NAME v$EXTENSIONS_VERSION; see step summary."
+              echo "::error::Extension feed staging failed for $EXTENSION_NAME v$EXTENSIONS_VERSION; see step summary."
             fi
           fi
 
-          if [ "$appcast_rc" -ne 0 ]; then
+          if [ "$appcast_rc" -eq 0 ] && [ "${#appcast_targets[@]}" -gt 0 ]; then
             for file in "${appcast_targets[@]}"; do
-              rm -f "$appcast_dir/$file"
+              if [ ! -f "$appcast_dir/$file" ]; then
+                echo "Missing expected staged appcast: $file" >> "$appcast_log"
+                appcast_rc=1
+              fi
             done
           fi
-          if [ "$extensions_rc" -ne 0 ]; then
+          if [ "$extensions_rc" -eq 0 ] && [ "${#extension_targets[@]}" -gt 0 ]; then
             for file in "${extension_targets[@]}"; do
-              rm -f "$extensions_dir/$file"
+              if [ ! -f "$extensions_dir/$file" ]; then
+                echo "Missing expected staged extension feed: $file" >> "$extensions_log"
+                extensions_rc=1
+              fi
             done
+          fi
+
+          if [ "$appcast_rc" -ne 0 ]; then
+            if [ "${#appcast_targets[@]}" -gt 0 ]; then
+              for file in "${appcast_targets[@]}"; do
+                rm -f "$appcast_dir/$file"
+              done
+            fi
+          fi
+          if [ "$extensions_rc" -ne 0 ]; then
+            if [ "${#extension_targets[@]}" -gt 0 ]; then
+              for file in "${extension_targets[@]}"; do
+                rm -f "$extensions_dir/$file"
+              done
+            fi
           fi
 
           staged_files=()
@@ -542,20 +590,26 @@ jobs:
           }
 
           if [ "$appcast_rc" -eq 0 ]; then
-            for file in "${appcast_targets[@]}"; do
-              copy_if_exists "$appcast_dir/$file" "packages/browseros/$appcast_dir/$file"
-            done
+            if [ "${#appcast_targets[@]}" -gt 0 ]; then
+              for file in "${appcast_targets[@]}"; do
+                copy_if_exists "$appcast_dir/$file" "packages/browseros/$appcast_dir/$file"
+              done
+            fi
           fi
           if [ "$extensions_rc" -eq 0 ]; then
-            for file in "${extension_targets[@]}"; do
-              copy_if_exists "$extensions_dir/$file" "updates/extensions/$file"
-            done
+            if [ "${#extension_targets[@]}" -gt 0 ]; then
+              for file in "${extension_targets[@]}"; do
+                copy_if_exists "$extensions_dir/$file" "updates/extensions/$file"
+              done
+            fi
           fi
 
           {
             echo "has_files=$([ "${#staged_files[@]}" -gt 0 ] && echo true || echo false)"
             echo "files<<EOF"
-            printf '%s\n' "${staged_files[@]}"
+            if [ "${#staged_files[@]}" -gt 0 ]; then
+              printf '%s\n' "${staged_files[@]}"
+            fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -574,7 +628,7 @@ jobs:
             echo "### Staged files"
             echo
             if [ "${#staged_files[@]}" -eq 0 ]; then
-              echo "- No XML/JSON files were staged. Review warnings below before promoting."
+              echo "- No XML/JSON files were staged."
             else
               for file in "${staged_files[@]}"; do
                 echo "- \`$file\`"
@@ -582,7 +636,7 @@ jobs:
             fi
             echo
             if [ "$appcast_rc" -ne 0 ]; then
-              echo "### Appcast staging warning"
+              echo "### Appcast staging error"
               echo
               echo '```text'
               tail -n 120 "$appcast_log"
@@ -590,7 +644,7 @@ jobs:
               echo
             fi
             if [ "$extensions_rc" -ne 0 ]; then
-              echo "### Extension feed staging warning"
+              echo "### Extension feed staging error"
               echo
               echo '```text'
               tail -n 120 "$extensions_log"
@@ -622,6 +676,14 @@ jobs:
               echo "Draft GitHub release: skipped because github_release_draft=false."
             fi
           } >> "$summary"
+
+          if [ "$appcast_rc" -ne 0 ] || [ "$extensions_rc" -ne 0 ]; then
+            exit 1
+          fi
+          if [ "${#staged_files[@]}" -eq 0 ]; then
+            echo "::error::Feed staging was selected but produced no files."
+            exit 1
+          fi
 
       - name: Upload staged update feeds
         if: ${{ steps.stage_feeds.outputs.has_files == 'true' }}
@@ -806,6 +868,10 @@ jobs:
             should_create=false
             reasons+=("extension result is $EXTENSIONS_RESULT")
           fi
+          if [ "$STAGE_UPDATES_RESULT" != "success" ]; then
+            should_create=false
+            reasons+=("staged feed result is $STAGE_UPDATES_RESULT")
+          fi
 
           reason="ready"
           if [ "${#reasons[@]}" -gt 0 ]; then
@@ -830,7 +896,7 @@ jobs:
       - uses: actions/checkout@v7
         if: ${{ steps.release_gate.outputs.should_create == 'true' }}
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: astral-sh/setup-uv@v8.3.2
         if: ${{ steps.release_gate.outputs.should_create == 'true' }}
@@ -855,12 +921,13 @@ jobs:
           }
 
           tag="$(normalize_tag "$VERSION")"
-          if release_json="$(gh release view "$tag" --json isDraft,assets --jq '{isDraft, assets: [.assets[].name]}' 2>/dev/null)"; then
+          if release_json="$(gh release view "$tag" --json isDraft,assets,targetCommitish --jq '{isDraft, targetCommitish, assets: [.assets[].name]}' 2>/dev/null)"; then
             is_draft="$(jq -r '.isDraft' <<< "$release_json")"
             if [ "$is_draft" != "true" ]; then
               echo "::error::GitHub release $tag already exists and is not a draft; refusing to modify live release assets."
               exit 1
             fi
+            gh release edit "$tag" --target "$GITHUB_SHA"
 
             mapfile -t assets < <(
               jq -r --arg prefix "BrowserClaw_v${VERSION}_" \
@@ -875,4 +942,10 @@ jobs:
           uv run browseros release github create \
             --version "$VERSION" \
             --draft \
-            --product "$PRODUCT"
+            --product "$PRODUCT" \
+            --platforms "$INPUT_PLATFORMS" \
+            --macos-arch "$INPUT_MACOS_ARCH" \
+            --source-sha "$GITHUB_SHA" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --target "$GITHUB_SHA"

--- a/.github/workflows/release-browserclaw.yml
+++ b/.github/workflows/release-browserclaw.yml
@@ -946,20 +946,36 @@ jobs:
               echo "::error::GitHub release $tag already exists and is not a draft; refusing to modify live release assets."
               exit 1
             fi
+          elif [ "$release_status" = "404" ]; then
+            release_json=""
+          else
+            echo "::error::Could not inspect release $tag (HTTP ${release_status:-unknown}, gh rc=$release_probe_rc); refusing to assume it is absent."
+            exit 1
+          fi
 
-            set +e
-            tag_probe="$(gh api --include "repos/$GITHUB_REPOSITORY/commits/$tag_uri" 2>&1)"
-            tag_probe_rc=$?
-            set -e
-            tag_status="$(sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' <<< "$tag_probe")"
-            if [ "$tag_status" = "200" ] && [ "$tag_probe_rc" -eq 0 ]; then
-              tag_json="$(awk 'body { print } /^[[:space:]]*$/ { body=1 }' <<< "$tag_probe")"
-              actual_target="$(jq -r '.sha' <<< "$tag_json")"
-              if [ "$actual_target" != "$GITHUB_SHA" ]; then
-                echo "::error::Draft release $tag resolves to $actual_target, not workflow SHA $GITHUB_SHA. Delete/recreate the draft tag or dispatch a new version."
-                exit 1
-              fi
-            elif [ "$tag_status" = "404" ]; then
+          set +e
+          tag_probe="$(gh api --include "repos/$GITHUB_REPOSITORY/commits/$tag_uri" 2>&1)"
+          tag_probe_rc=$?
+          set -e
+          tag_status="$(sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' <<< "$tag_probe")"
+          tag_json="$(awk 'body { print } /^[[:space:]]*$/ { body=1 }' <<< "$tag_probe")"
+          tag_absent=false
+          if [ "$tag_status" = "404" ]; then
+            tag_absent=true
+          elif [ "$tag_status" = "422" ]; then
+            tag_error="$(jq -r '.message // ""' <<< "$tag_json" 2>/dev/null || true)"
+            if [ "$tag_error" = "No commit found for SHA: $tag" ]; then
+              tag_absent=true
+            fi
+          fi
+          if [ "$tag_status" = "200" ] && [ "$tag_probe_rc" -eq 0 ]; then
+            actual_target="$(jq -r '.sha' <<< "$tag_json")"
+            if [ "$actual_target" != "$GITHUB_SHA" ]; then
+              echo "::error::Release tag $tag resolves to $actual_target, not workflow SHA $GITHUB_SHA. Delete/recreate the tag or dispatch a new version."
+              exit 1
+            fi
+          elif [ "$tag_absent" = "true" ]; then
+            if [ -n "$release_json" ]; then
               target_commitish="$(jq -r '.target_commitish // ""' <<< "$release_json")"
               if [ "$target_commitish" != "$GITHUB_SHA" ]; then
                 gh release edit "$tag" --target "$GITHUB_SHA"
@@ -969,14 +985,9 @@ jobs:
                   exit 1
                 fi
               fi
-            else
-              echo "::error::Could not resolve existing draft tag $tag (HTTP ${tag_status:-unknown}, gh rc=$tag_probe_rc)."
-              exit 1
             fi
-          elif [ "$release_status" = "404" ]; then
-            :
           else
-            echo "::error::Could not inspect release $tag (HTTP ${release_status:-unknown}, gh rc=$release_probe_rc); refusing to assume it is absent."
+            echo "::error::Could not resolve release tag $tag (HTTP ${tag_status:-unknown}, gh rc=$tag_probe_rc)."
             exit 1
           fi
 

--- a/.github/workflows/release-browserclaw.yml
+++ b/.github/workflows/release-browserclaw.yml
@@ -387,10 +387,6 @@ jobs:
           should_stage=true
           reasons=()
 
-          if [ "$INPUT_UPLOAD_TO_R2" != "true" ]; then
-            should_stage=false
-            reasons+=("upload_to_r2=false, so there are no browser R2 release objects to render against")
-          fi
           if [ -z "${VERSION:-}" ]; then
             should_stage=false
             reasons+=("release version was not resolved")
@@ -420,9 +416,9 @@ jobs:
             should_stage=false
             reasons+=("extension result is $EXTENSIONS_RESULT")
           fi
-          if [ "$INPUT_PLATFORMS" = "linux" ] && [ "$INPUT_EXTENSIONS" = "skip" ]; then
+          if [ "$INPUT_EXTENSIONS" = "skip" ] && { [ "$INPUT_PLATFORMS" = "linux" ] || [ "$INPUT_UPLOAD_TO_R2" != "true" ]; }; then
             should_stage=false
-            reasons+=("no update feeds are selected for a Linux-only release with extensions skipped")
+            reasons+=("no browser appcast or extension feed is selected")
           fi
 
           reason="ready"
@@ -476,19 +472,21 @@ jobs:
           mkdir -p "$artifact_root" "$appcast_dir" "$extensions_dir"
 
           appcast_targets=()
-          if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "macos" ]; then
-            case "$INPUT_MACOS_ARCH" in
-              arm64) appcast_targets+=(appcast-claw.xml) ;;
-              x64) appcast_targets+=(appcast-claw-x86_64.xml) ;;
-              universal) appcast_targets+=(appcast-claw.xml appcast-claw-x86_64.xml) ;;
-              *)
-                echo "::error::Unsupported macOS architecture: $INPUT_MACOS_ARCH"
-                exit 1
-                ;;
-            esac
-          fi
-          if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "windows" ]; then
-            appcast_targets+=(appcast-claw-win.xml)
+          if [ "$INPUT_UPLOAD_TO_R2" = "true" ]; then
+            if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "macos" ]; then
+              case "$INPUT_MACOS_ARCH" in
+                arm64) appcast_targets+=(appcast-claw.xml) ;;
+                x64) appcast_targets+=(appcast-claw-x86_64.xml) ;;
+                universal) appcast_targets+=(appcast-claw.xml appcast-claw-x86_64.xml) ;;
+                *)
+                  echo "::error::Unsupported macOS architecture: $INPUT_MACOS_ARCH"
+                  exit 1
+                  ;;
+              esac
+            fi
+            if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "windows" ]; then
+              appcast_targets+=(appcast-claw-win.xml)
+            fi
           fi
           extension_targets=()
           if [ "$INPUT_EXTENSIONS" != "skip" ]; then
@@ -604,6 +602,13 @@ jobs:
             fi
           fi
 
+          publish_platform_args=()
+          case "$INPUT_PLATFORMS" in
+            all) publish_platform_args=(--platform linux --platform win --platform macos) ;;
+            windows) publish_platform_args=(--platform win) ;;
+            linux|macos) publish_platform_args=(--platform "$INPUT_PLATFORMS") ;;
+          esac
+
           {
             echo "has_files=$([ "${#staged_files[@]}" -gt 0 ] && echo true || echo false)"
             echo "files<<EOF"
@@ -655,11 +660,17 @@ jobs:
             echo
             echo '```bash'
             echo "cd packages/browseros"
-            echo "uv run browseros release publish --version $VERSION --product $PRODUCT"
-            if [ "$appcast_rc" -eq 0 ]; then
-              echo "uv run browseros release appcast --version $VERSION --product $PRODUCT --publish"
+            if [ "$INPUT_UPLOAD_TO_R2" = "true" ]; then
+              echo "uv run browseros release publish --version $VERSION --product $PRODUCT ${publish_platform_args[*]}"
             else
-              echo "# Appcast publish blocked: resolve the staging warning and rerun the preview before publishing."
+              echo "# Browser artifact promotion skipped: upload_to_r2=false."
+            fi
+            if [ "$appcast_rc" -eq 0 ] && [ "${#appcast_targets[@]}" -gt 0 ]; then
+              echo "uv run browseros release appcast --version $VERSION --product $PRODUCT --platforms $INPUT_PLATFORMS --macos-arch $INPUT_MACOS_ARCH --source-sha $GITHUB_SHA --workflow-run-id $GITHUB_RUN_ID --workflow-run-attempt $GITHUB_RUN_ATTEMPT --publish"
+            elif [ "${#appcast_targets[@]}" -gt 0 ]; then
+              echo "# Appcast publish blocked: resolve the staging error and rerun the preview before publishing."
+            else
+              echo "# Browser appcast publish skipped: no macOS or Windows appcast was selected."
             fi
             if [ "$INPUT_EXTENSIONS" != "skip" ]; then
               if [ "$extensions_rc" -eq 0 ]; then
@@ -917,26 +928,56 @@ jobs:
             local version="$1"
             local major minor build _rest
             IFS='.' read -r major minor build _rest <<< "$version"
-            echo "v$major.$minor.$build"
+            echo "browserclaw/v$major.$minor.$build"
           }
 
           tag="$(normalize_tag "$VERSION")"
-          if release_json="$(gh release view "$tag" --json isDraft,assets,targetCommitish --jq '{isDraft, targetCommitish, assets: [.assets[].name]}' 2>/dev/null)"; then
-            is_draft="$(jq -r '.isDraft' <<< "$release_json")"
+          tag_uri="$(jq -rn --arg value "$tag" '$value | @uri')"
+          set +e
+          release_probe="$(gh api --include "repos/$GITHUB_REPOSITORY/releases/tags/$tag_uri" 2>&1)"
+          release_probe_rc=$?
+          set -e
+          release_status="$(sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' <<< "$release_probe")"
+
+          if [ "$release_status" = "200" ] && [ "$release_probe_rc" -eq 0 ]; then
+            release_json="$(awk 'body { print } /^[[:space:]]*$/ { body=1 }' <<< "$release_probe")"
+            is_draft="$(jq -r '.draft' <<< "$release_json")"
             if [ "$is_draft" != "true" ]; then
               echo "::error::GitHub release $tag already exists and is not a draft; refusing to modify live release assets."
               exit 1
             fi
-            gh release edit "$tag" --target "$GITHUB_SHA"
 
-            mapfile -t assets < <(
-              jq -r --arg prefix "BrowserClaw_v${VERSION}_" \
-                '.assets[] | select(startswith($prefix))' <<< "$release_json"
-            )
-            for asset in "${assets[@]}"; do
-              echo "Deleting stale draft asset $asset from $tag"
-              gh release delete-asset "$tag" "$asset" --yes
-            done
+            set +e
+            tag_probe="$(gh api --include "repos/$GITHUB_REPOSITORY/commits/$tag_uri" 2>&1)"
+            tag_probe_rc=$?
+            set -e
+            tag_status="$(sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' <<< "$tag_probe")"
+            if [ "$tag_status" = "200" ] && [ "$tag_probe_rc" -eq 0 ]; then
+              tag_json="$(awk 'body { print } /^[[:space:]]*$/ { body=1 }' <<< "$tag_probe")"
+              actual_target="$(jq -r '.sha' <<< "$tag_json")"
+              if [ "$actual_target" != "$GITHUB_SHA" ]; then
+                echo "::error::Draft release $tag resolves to $actual_target, not workflow SHA $GITHUB_SHA. Delete/recreate the draft tag or dispatch a new version."
+                exit 1
+              fi
+            elif [ "$tag_status" = "404" ]; then
+              target_commitish="$(jq -r '.target_commitish // ""' <<< "$release_json")"
+              if [ "$target_commitish" != "$GITHUB_SHA" ]; then
+                gh release edit "$tag" --target "$GITHUB_SHA"
+                verified_target="$(gh release view "$tag" --json targetCommitish --jq '.targetCommitish')"
+                if [ "$verified_target" != "$GITHUB_SHA" ]; then
+                  echo "::error::Draft release $tag target remained $verified_target instead of $GITHUB_SHA."
+                  exit 1
+                fi
+              fi
+            else
+              echo "::error::Could not resolve existing draft tag $tag (HTTP ${tag_status:-unknown}, gh rc=$tag_probe_rc)."
+              exit 1
+            fi
+          elif [ "$release_status" = "404" ]; then
+            :
+          else
+            echo "::error::Could not inspect release $tag (HTTP ${release_status:-unknown}, gh rc=$release_probe_rc); refusing to assume it is absent."
+            exit 1
           fi
 
           uv run browseros release github create \

--- a/.github/workflows/release-browserclaw.yml
+++ b/.github/workflows/release-browserclaw.yml
@@ -661,7 +661,7 @@ jobs:
             echo '```bash'
             echo "cd packages/browseros"
             if [ "$INPUT_UPLOAD_TO_R2" = "true" ]; then
-              echo "uv run browseros release publish --version $VERSION --product $PRODUCT ${publish_platform_args[*]}"
+              echo "uv run browseros release publish --version $VERSION --product $PRODUCT ${publish_platform_args[*]} --macos-arch $INPUT_MACOS_ARCH --source-sha $GITHUB_SHA --workflow-run-id $GITHUB_RUN_ID --workflow-run-attempt $GITHUB_RUN_ATTEMPT"
             else
               echo "# Browser artifact promotion skipped: upload_to_r2=false."
             fi
@@ -978,12 +978,8 @@ jobs:
             if [ -n "$release_json" ]; then
               target_commitish="$(jq -r '.target_commitish // ""' <<< "$release_json")"
               if [ "$target_commitish" != "$GITHUB_SHA" ]; then
-                gh release edit "$tag" --target "$GITHUB_SHA"
-                verified_target="$(gh release view "$tag" --json targetCommitish --jq '.targetCommitish')"
-                if [ "$verified_target" != "$GITHUB_SHA" ]; then
-                  echo "::error::Draft release $tag target remained $verified_target instead of $GITHUB_SHA."
-                  exit 1
-                fi
+                echo "::error::Untagged draft release $tag targets $target_commitish, not workflow SHA $GITHUB_SHA. Refusing to retarget a draft that may already contain assets; use a new version or recreate the draft."
+                exit 1
               fi
             fi
           else

--- a/.github/workflows/release-browseros.yml
+++ b/.github/workflows/release-browseros.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - name: Resolve release version
         id: version
@@ -228,7 +228,7 @@ jobs:
       contents: write
       pull-requests: write
     with:
-      ref: ${{ github.ref_name }}
+      ref: ${{ github.sha }}
       publish_ota: false
     secrets: inherit
 
@@ -294,7 +294,7 @@ jobs:
       bump: none
       commit_version: false
       upload_to_r2: ${{ inputs.upload_to_r2 }}
-      ref: ${{ github.ref_name }}
+      ref: ${{ github.sha }}
     secrets: inherit
 
   release_extensions:
@@ -315,7 +315,7 @@ jobs:
     with:
       version: ${{ needs.preflight.outputs.extensions_version }}
       extension: agent
-      branch: ${{ github.ref_name }}
+      branch: ${{ github.sha }}
     secrets: inherit
 
   stage_updates:
@@ -338,6 +338,7 @@ jobs:
       VERSION: ${{ needs.preflight.outputs.version }}
       EXTENSIONS_VERSION: ${{ needs.preflight.outputs.extensions_version }}
       INPUT_PLATFORMS: ${{ inputs.platforms }}
+      INPUT_MACOS_ARCH: ${{ inputs.macos_arch }}
       INPUT_INCLUDE_SERVERS: ${{ inputs.include_servers }}
       INPUT_UPLOAD_TO_R2: ${{ inputs.upload_to_r2 }}
       INPUT_EXTENSIONS: ${{ inputs.extensions }}
@@ -399,6 +400,10 @@ jobs:
             should_stage=false
             reasons+=("extension result is $EXTENSIONS_RESULT")
           fi
+          if [ "$INPUT_PLATFORMS" = "linux" ] && [ "$INPUT_EXTENSIONS" = "skip" ]; then
+            should_stage=false
+            reasons+=("no update feeds are selected for a Linux-only release with extensions skipped")
+          fi
 
           reason="ready"
           if [ "${#reasons[@]}" -gt 0 ]; then
@@ -423,7 +428,7 @@ jobs:
       - uses: actions/checkout@v7
         if: ${{ steps.stage_gate.outputs.should_stage == 'true' }}
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: astral-sh/setup-uv@v8.3.2
         if: ${{ steps.stage_gate.outputs.should_stage == 'true' }}
@@ -450,12 +455,21 @@ jobs:
           rm -rf "$artifact_root"
           mkdir -p "$artifact_root" "$appcast_dir" "$extensions_dir"
 
-          appcast_targets=(
-            appcast.xml
-            appcast-x86_64.xml
-            appcast-win.xml
-            appcast-win-arm64.xml
-          )
+          appcast_targets=()
+          if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "macos" ]; then
+            case "$INPUT_MACOS_ARCH" in
+              arm64) appcast_targets+=(appcast.xml) ;;
+              x64) appcast_targets+=(appcast-x86_64.xml) ;;
+              universal) appcast_targets+=(appcast.xml appcast-x86_64.xml) ;;
+              *)
+                echo "::error::Unsupported macOS architecture: $INPUT_MACOS_ARCH"
+                exit 1
+                ;;
+            esac
+          fi
+          if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "windows" ]; then
+            appcast_targets+=(appcast-win.xml)
+          fi
           extension_targets=()
           if [ "$INPUT_EXTENSIONS" != "skip" ]; then
             if [ "$INPUT_EXTENSIONS" = "alpha" ]; then
@@ -473,19 +487,32 @@ jobs:
             fi
           fi
 
-          for file in "${appcast_targets[@]}"; do
-            rm -f "$appcast_dir/$file"
-          done
+          if [ "${#appcast_targets[@]}" -gt 0 ]; then
+            for file in "${appcast_targets[@]}"; do
+              rm -f "$appcast_dir/$file"
+            done
+          fi
           for file in update-manifest.xml update-manifest.alpha.xml extensions.json extensions.alpha.json bundled-manifest.xml; do
             rm -f "$extensions_dir/$file"
           done
 
-          set +e
-          uv run browseros release appcast --version "$VERSION" --product "$PRODUCT" > "$appcast_log" 2>&1
-          appcast_rc=$?
-          set -e
+          appcast_rc=0
+          if [ "${#appcast_targets[@]}" -gt 0 ]; then
+            set +e
+            uv run browseros release appcast \
+              --version "$VERSION" \
+              --product "$PRODUCT" \
+              --platforms "$INPUT_PLATFORMS" \
+              --macos-arch "$INPUT_MACOS_ARCH" \
+              --source-sha "$GITHUB_SHA" \
+              --workflow-run-id "$GITHUB_RUN_ID" \
+              --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+              > "$appcast_log" 2>&1
+            appcast_rc=$?
+            set -e
+          fi
           if [ "$appcast_rc" -ne 0 ]; then
-            echo "::warning::Appcast staging failed for $PRODUCT v$VERSION; see step summary."
+            echo "::error::Appcast staging failed for $PRODUCT v$VERSION; see step summary."
           fi
 
           extensions_rc=0
@@ -495,19 +522,40 @@ jobs:
             extensions_rc=$?
             set -e
             if [ "$extensions_rc" -ne 0 ]; then
-              echo "::warning::Extension feed staging failed for $EXTENSION_NAME v$EXTENSIONS_VERSION; see step summary."
+              echo "::error::Extension feed staging failed for $EXTENSION_NAME v$EXTENSIONS_VERSION; see step summary."
             fi
           fi
 
-          if [ "$appcast_rc" -ne 0 ]; then
+          if [ "$appcast_rc" -eq 0 ] && [ "${#appcast_targets[@]}" -gt 0 ]; then
             for file in "${appcast_targets[@]}"; do
-              rm -f "$appcast_dir/$file"
+              if [ ! -f "$appcast_dir/$file" ]; then
+                echo "Missing expected staged appcast: $file" >> "$appcast_log"
+                appcast_rc=1
+              fi
             done
           fi
-          if [ "$extensions_rc" -ne 0 ]; then
+          if [ "$extensions_rc" -eq 0 ] && [ "${#extension_targets[@]}" -gt 0 ]; then
             for file in "${extension_targets[@]}"; do
-              rm -f "$extensions_dir/$file"
+              if [ ! -f "$extensions_dir/$file" ]; then
+                echo "Missing expected staged extension feed: $file" >> "$extensions_log"
+                extensions_rc=1
+              fi
             done
+          fi
+
+          if [ "$appcast_rc" -ne 0 ]; then
+            if [ "${#appcast_targets[@]}" -gt 0 ]; then
+              for file in "${appcast_targets[@]}"; do
+                rm -f "$appcast_dir/$file"
+              done
+            fi
+          fi
+          if [ "$extensions_rc" -ne 0 ]; then
+            if [ "${#extension_targets[@]}" -gt 0 ]; then
+              for file in "${extension_targets[@]}"; do
+                rm -f "$extensions_dir/$file"
+              done
+            fi
           fi
 
           staged_files=()
@@ -522,20 +570,26 @@ jobs:
           }
 
           if [ "$appcast_rc" -eq 0 ]; then
-            for file in "${appcast_targets[@]}"; do
-              copy_if_exists "$appcast_dir/$file" "packages/browseros/$appcast_dir/$file"
-            done
+            if [ "${#appcast_targets[@]}" -gt 0 ]; then
+              for file in "${appcast_targets[@]}"; do
+                copy_if_exists "$appcast_dir/$file" "packages/browseros/$appcast_dir/$file"
+              done
+            fi
           fi
           if [ "$extensions_rc" -eq 0 ]; then
-            for file in "${extension_targets[@]}"; do
-              copy_if_exists "$extensions_dir/$file" "updates/extensions/$file"
-            done
+            if [ "${#extension_targets[@]}" -gt 0 ]; then
+              for file in "${extension_targets[@]}"; do
+                copy_if_exists "$extensions_dir/$file" "updates/extensions/$file"
+              done
+            fi
           fi
 
           {
             echo "has_files=$([ "${#staged_files[@]}" -gt 0 ] && echo true || echo false)"
             echo "files<<EOF"
-            printf '%s\n' "${staged_files[@]}"
+            if [ "${#staged_files[@]}" -gt 0 ]; then
+              printf '%s\n' "${staged_files[@]}"
+            fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -554,7 +608,7 @@ jobs:
             echo "### Staged files"
             echo
             if [ "${#staged_files[@]}" -eq 0 ]; then
-              echo "- No XML/JSON files were staged. Review warnings below before promoting."
+              echo "- No XML/JSON files were staged."
             else
               for file in "${staged_files[@]}"; do
                 echo "- \`$file\`"
@@ -562,7 +616,7 @@ jobs:
             fi
             echo
             if [ "$appcast_rc" -ne 0 ]; then
-              echo "### Appcast staging warning"
+              echo "### Appcast staging error"
               echo
               echo '```text'
               tail -n 120 "$appcast_log"
@@ -570,7 +624,7 @@ jobs:
               echo
             fi
             if [ "$extensions_rc" -ne 0 ]; then
-              echo "### Extension feed staging warning"
+              echo "### Extension feed staging error"
               echo
               echo '```text'
               tail -n 120 "$extensions_log"
@@ -602,6 +656,14 @@ jobs:
               echo "Draft GitHub release: skipped because github_release_draft=false."
             fi
           } >> "$summary"
+
+          if [ "$appcast_rc" -ne 0 ] || [ "$extensions_rc" -ne 0 ]; then
+            exit 1
+          fi
+          if [ "${#staged_files[@]}" -eq 0 ]; then
+            echo "::error::Feed staging was selected but produced no files."
+            exit 1
+          fi
 
       - name: Upload staged update feeds
         if: ${{ steps.stage_feeds.outputs.has_files == 'true' }}
@@ -777,6 +839,10 @@ jobs:
             should_create=false
             reasons+=("extension result is $EXTENSIONS_RESULT")
           fi
+          if [ "$STAGE_UPDATES_RESULT" != "success" ]; then
+            should_create=false
+            reasons+=("staged feed result is $STAGE_UPDATES_RESULT")
+          fi
 
           reason="ready"
           if [ "${#reasons[@]}" -gt 0 ]; then
@@ -801,7 +867,7 @@ jobs:
       - uses: actions/checkout@v7
         if: ${{ steps.release_gate.outputs.should_create == 'true' }}
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
 
       - uses: astral-sh/setup-uv@v8.3.2
         if: ${{ steps.release_gate.outputs.should_create == 'true' }}
@@ -826,12 +892,13 @@ jobs:
           }
 
           tag="$(normalize_tag "$VERSION")"
-          if release_json="$(gh release view "$tag" --json isDraft,assets --jq '{isDraft, assets: [.assets[].name]}' 2>/dev/null)"; then
+          if release_json="$(gh release view "$tag" --json isDraft,assets,targetCommitish --jq '{isDraft, targetCommitish, assets: [.assets[].name]}' 2>/dev/null)"; then
             is_draft="$(jq -r '.isDraft' <<< "$release_json")"
             if [ "$is_draft" != "true" ]; then
               echo "::error::GitHub release $tag already exists and is not a draft; refusing to modify live release assets."
               exit 1
             fi
+            gh release edit "$tag" --target "$GITHUB_SHA"
 
             mapfile -t assets < <(
               jq -r --arg prefix "BrowserOS_v${VERSION}_" \
@@ -846,4 +913,10 @@ jobs:
           uv run browseros release github create \
             --version "$VERSION" \
             --draft \
-            --product "$PRODUCT"
+            --product "$PRODUCT" \
+            --platforms "$INPUT_PLATFORMS" \
+            --macos-arch "$INPUT_MACOS_ARCH" \
+            --source-sha "$GITHUB_SHA" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --target "$GITHUB_SHA"

--- a/.github/workflows/release-browseros.yml
+++ b/.github/workflows/release-browseros.yml
@@ -373,10 +373,6 @@ jobs:
           should_stage=true
           reasons=()
 
-          if [ "$INPUT_UPLOAD_TO_R2" != "true" ]; then
-            should_stage=false
-            reasons+=("upload_to_r2=false, so there are no browser R2 release objects to render against")
-          fi
           if [ -z "${VERSION:-}" ]; then
             should_stage=false
             reasons+=("release version was not resolved")
@@ -400,9 +396,9 @@ jobs:
             should_stage=false
             reasons+=("extension result is $EXTENSIONS_RESULT")
           fi
-          if [ "$INPUT_PLATFORMS" = "linux" ] && [ "$INPUT_EXTENSIONS" = "skip" ]; then
+          if [ "$INPUT_EXTENSIONS" = "skip" ] && { [ "$INPUT_PLATFORMS" = "linux" ] || [ "$INPUT_UPLOAD_TO_R2" != "true" ]; }; then
             should_stage=false
-            reasons+=("no update feeds are selected for a Linux-only release with extensions skipped")
+            reasons+=("no browser appcast or extension feed is selected")
           fi
 
           reason="ready"
@@ -456,19 +452,21 @@ jobs:
           mkdir -p "$artifact_root" "$appcast_dir" "$extensions_dir"
 
           appcast_targets=()
-          if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "macos" ]; then
-            case "$INPUT_MACOS_ARCH" in
-              arm64) appcast_targets+=(appcast.xml) ;;
-              x64) appcast_targets+=(appcast-x86_64.xml) ;;
-              universal) appcast_targets+=(appcast.xml appcast-x86_64.xml) ;;
-              *)
-                echo "::error::Unsupported macOS architecture: $INPUT_MACOS_ARCH"
-                exit 1
-                ;;
-            esac
-          fi
-          if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "windows" ]; then
-            appcast_targets+=(appcast-win.xml)
+          if [ "$INPUT_UPLOAD_TO_R2" = "true" ]; then
+            if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "macos" ]; then
+              case "$INPUT_MACOS_ARCH" in
+                arm64) appcast_targets+=(appcast.xml) ;;
+                x64) appcast_targets+=(appcast-x86_64.xml) ;;
+                universal) appcast_targets+=(appcast.xml appcast-x86_64.xml) ;;
+                *)
+                  echo "::error::Unsupported macOS architecture: $INPUT_MACOS_ARCH"
+                  exit 1
+                  ;;
+              esac
+            fi
+            if [ "$INPUT_PLATFORMS" = "all" ] || [ "$INPUT_PLATFORMS" = "windows" ]; then
+              appcast_targets+=(appcast-win.xml)
+            fi
           fi
           extension_targets=()
           if [ "$INPUT_EXTENSIONS" != "skip" ]; then
@@ -584,6 +582,13 @@ jobs:
             fi
           fi
 
+          publish_platform_args=()
+          case "$INPUT_PLATFORMS" in
+            all) publish_platform_args=(--platform linux --platform win --platform macos) ;;
+            windows) publish_platform_args=(--platform win) ;;
+            linux|macos) publish_platform_args=(--platform "$INPUT_PLATFORMS") ;;
+          esac
+
           {
             echo "has_files=$([ "${#staged_files[@]}" -gt 0 ] && echo true || echo false)"
             echo "files<<EOF"
@@ -635,11 +640,17 @@ jobs:
             echo
             echo '```bash'
             echo "cd packages/browseros"
-            echo "uv run browseros release publish --version $VERSION --product $PRODUCT"
-            if [ "$appcast_rc" -eq 0 ]; then
-              echo "uv run browseros release appcast --version $VERSION --product $PRODUCT --publish"
+            if [ "$INPUT_UPLOAD_TO_R2" = "true" ]; then
+              echo "uv run browseros release publish --version $VERSION --product $PRODUCT ${publish_platform_args[*]}"
             else
-              echo "# Appcast publish blocked: resolve the staging warning and rerun the preview before publishing."
+              echo "# Browser artifact promotion skipped: upload_to_r2=false."
+            fi
+            if [ "$appcast_rc" -eq 0 ] && [ "${#appcast_targets[@]}" -gt 0 ]; then
+              echo "uv run browseros release appcast --version $VERSION --product $PRODUCT --platforms $INPUT_PLATFORMS --macos-arch $INPUT_MACOS_ARCH --source-sha $GITHUB_SHA --workflow-run-id $GITHUB_RUN_ID --workflow-run-attempt $GITHUB_RUN_ATTEMPT --publish"
+            elif [ "${#appcast_targets[@]}" -gt 0 ]; then
+              echo "# Appcast publish blocked: resolve the staging error and rerun the preview before publishing."
+            else
+              echo "# Browser appcast publish skipped: no macOS or Windows appcast was selected."
             fi
             if [ "$INPUT_EXTENSIONS" != "skip" ]; then
               if [ "$extensions_rc" -eq 0 ]; then
@@ -892,22 +903,52 @@ jobs:
           }
 
           tag="$(normalize_tag "$VERSION")"
-          if release_json="$(gh release view "$tag" --json isDraft,assets,targetCommitish --jq '{isDraft, targetCommitish, assets: [.assets[].name]}' 2>/dev/null)"; then
-            is_draft="$(jq -r '.isDraft' <<< "$release_json")"
+          tag_uri="$(jq -rn --arg value "$tag" '$value | @uri')"
+          set +e
+          release_probe="$(gh api --include "repos/$GITHUB_REPOSITORY/releases/tags/$tag_uri" 2>&1)"
+          release_probe_rc=$?
+          set -e
+          release_status="$(sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' <<< "$release_probe")"
+
+          if [ "$release_status" = "200" ] && [ "$release_probe_rc" -eq 0 ]; then
+            release_json="$(awk 'body { print } /^[[:space:]]*$/ { body=1 }' <<< "$release_probe")"
+            is_draft="$(jq -r '.draft' <<< "$release_json")"
             if [ "$is_draft" != "true" ]; then
               echo "::error::GitHub release $tag already exists and is not a draft; refusing to modify live release assets."
               exit 1
             fi
-            gh release edit "$tag" --target "$GITHUB_SHA"
 
-            mapfile -t assets < <(
-              jq -r --arg prefix "BrowserOS_v${VERSION}_" \
-                '.assets[] | select(startswith($prefix))' <<< "$release_json"
-            )
-            for asset in "${assets[@]}"; do
-              echo "Deleting stale draft asset $asset from $tag"
-              gh release delete-asset "$tag" "$asset" --yes
-            done
+            set +e
+            tag_probe="$(gh api --include "repos/$GITHUB_REPOSITORY/commits/$tag_uri" 2>&1)"
+            tag_probe_rc=$?
+            set -e
+            tag_status="$(sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' <<< "$tag_probe")"
+            if [ "$tag_status" = "200" ] && [ "$tag_probe_rc" -eq 0 ]; then
+              tag_json="$(awk 'body { print } /^[[:space:]]*$/ { body=1 }' <<< "$tag_probe")"
+              actual_target="$(jq -r '.sha' <<< "$tag_json")"
+              if [ "$actual_target" != "$GITHUB_SHA" ]; then
+                echo "::error::Draft release $tag resolves to $actual_target, not workflow SHA $GITHUB_SHA. Delete/recreate the draft tag or dispatch a new version."
+                exit 1
+              fi
+            elif [ "$tag_status" = "404" ]; then
+              target_commitish="$(jq -r '.target_commitish // ""' <<< "$release_json")"
+              if [ "$target_commitish" != "$GITHUB_SHA" ]; then
+                gh release edit "$tag" --target "$GITHUB_SHA"
+                verified_target="$(gh release view "$tag" --json targetCommitish --jq '.targetCommitish')"
+                if [ "$verified_target" != "$GITHUB_SHA" ]; then
+                  echo "::error::Draft release $tag target remained $verified_target instead of $GITHUB_SHA."
+                  exit 1
+                fi
+              fi
+            else
+              echo "::error::Could not resolve existing draft tag $tag (HTTP ${tag_status:-unknown}, gh rc=$tag_probe_rc)."
+              exit 1
+            fi
+          elif [ "$release_status" = "404" ]; then
+            :
+          else
+            echo "::error::Could not inspect release $tag (HTTP ${release_status:-unknown}, gh rc=$release_probe_rc); refusing to assume it is absent."
+            exit 1
           fi
 
           uv run browseros release github create \

--- a/.github/workflows/release-browseros.yml
+++ b/.github/workflows/release-browseros.yml
@@ -641,7 +641,7 @@ jobs:
             echo '```bash'
             echo "cd packages/browseros"
             if [ "$INPUT_UPLOAD_TO_R2" = "true" ]; then
-              echo "uv run browseros release publish --version $VERSION --product $PRODUCT ${publish_platform_args[*]}"
+              echo "uv run browseros release publish --version $VERSION --product $PRODUCT ${publish_platform_args[*]} --macos-arch $INPUT_MACOS_ARCH --source-sha $GITHUB_SHA --workflow-run-id $GITHUB_RUN_ID --workflow-run-attempt $GITHUB_RUN_ATTEMPT"
             else
               echo "# Browser artifact promotion skipped: upload_to_r2=false."
             fi
@@ -949,12 +949,8 @@ jobs:
             if [ -n "$release_json" ]; then
               target_commitish="$(jq -r '.target_commitish // ""' <<< "$release_json")"
               if [ "$target_commitish" != "$GITHUB_SHA" ]; then
-                gh release edit "$tag" --target "$GITHUB_SHA"
-                verified_target="$(gh release view "$tag" --json targetCommitish --jq '.targetCommitish')"
-                if [ "$verified_target" != "$GITHUB_SHA" ]; then
-                  echo "::error::Draft release $tag target remained $verified_target instead of $GITHUB_SHA."
-                  exit 1
-                fi
+                echo "::error::Untagged draft release $tag targets $target_commitish, not workflow SHA $GITHUB_SHA. Refusing to retarget a draft that may already contain assets; use a new version or recreate the draft."
+                exit 1
               fi
             fi
           else

--- a/.github/workflows/release-browseros.yml
+++ b/.github/workflows/release-browseros.yml
@@ -917,20 +917,36 @@ jobs:
               echo "::error::GitHub release $tag already exists and is not a draft; refusing to modify live release assets."
               exit 1
             fi
+          elif [ "$release_status" = "404" ]; then
+            release_json=""
+          else
+            echo "::error::Could not inspect release $tag (HTTP ${release_status:-unknown}, gh rc=$release_probe_rc); refusing to assume it is absent."
+            exit 1
+          fi
 
-            set +e
-            tag_probe="$(gh api --include "repos/$GITHUB_REPOSITORY/commits/$tag_uri" 2>&1)"
-            tag_probe_rc=$?
-            set -e
-            tag_status="$(sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' <<< "$tag_probe")"
-            if [ "$tag_status" = "200" ] && [ "$tag_probe_rc" -eq 0 ]; then
-              tag_json="$(awk 'body { print } /^[[:space:]]*$/ { body=1 }' <<< "$tag_probe")"
-              actual_target="$(jq -r '.sha' <<< "$tag_json")"
-              if [ "$actual_target" != "$GITHUB_SHA" ]; then
-                echo "::error::Draft release $tag resolves to $actual_target, not workflow SHA $GITHUB_SHA. Delete/recreate the draft tag or dispatch a new version."
-                exit 1
-              fi
-            elif [ "$tag_status" = "404" ]; then
+          set +e
+          tag_probe="$(gh api --include "repos/$GITHUB_REPOSITORY/commits/$tag_uri" 2>&1)"
+          tag_probe_rc=$?
+          set -e
+          tag_status="$(sed -n '1s/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' <<< "$tag_probe")"
+          tag_json="$(awk 'body { print } /^[[:space:]]*$/ { body=1 }' <<< "$tag_probe")"
+          tag_absent=false
+          if [ "$tag_status" = "404" ]; then
+            tag_absent=true
+          elif [ "$tag_status" = "422" ]; then
+            tag_error="$(jq -r '.message // ""' <<< "$tag_json" 2>/dev/null || true)"
+            if [ "$tag_error" = "No commit found for SHA: $tag" ]; then
+              tag_absent=true
+            fi
+          fi
+          if [ "$tag_status" = "200" ] && [ "$tag_probe_rc" -eq 0 ]; then
+            actual_target="$(jq -r '.sha' <<< "$tag_json")"
+            if [ "$actual_target" != "$GITHUB_SHA" ]; then
+              echo "::error::Release tag $tag resolves to $actual_target, not workflow SHA $GITHUB_SHA. Delete/recreate the tag or dispatch a new version."
+              exit 1
+            fi
+          elif [ "$tag_absent" = "true" ]; then
+            if [ -n "$release_json" ]; then
               target_commitish="$(jq -r '.target_commitish // ""' <<< "$release_json")"
               if [ "$target_commitish" != "$GITHUB_SHA" ]; then
                 gh release edit "$tag" --target "$GITHUB_SHA"
@@ -940,14 +956,9 @@ jobs:
                   exit 1
                 fi
               fi
-            else
-              echo "::error::Could not resolve existing draft tag $tag (HTTP ${tag_status:-unknown}, gh rc=$tag_probe_rc)."
-              exit 1
             fi
-          elif [ "$release_status" = "404" ]; then
-            :
           else
-            echo "::error::Could not inspect release $tag (HTTP ${release_status:-unknown}, gh rc=$release_probe_rc); refusing to assume it is absent."
+            echo "::error::Could not resolve release tag $tag (HTTP ${tag_status:-unknown}, gh rc=$tag_probe_rc)."
             exit 1
           fi
 

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -817,6 +817,22 @@ fi
                 0,
                 "not workflow SHA",
             ),
+            (
+                "orphaned-tag-mismatch",
+                self.api_probe(404, '{"message":"Not Found"}'),
+                1,
+                self.api_probe(200, f'{{"sha":"{other_sha}"}}'),
+                0,
+                "not workflow SHA",
+            ),
+            (
+                "unrelated-tag-lookup-error",
+                self.api_probe(404, '{"message":"Not Found"}'),
+                1,
+                self.api_probe(422, '{"message":"Validation Failed"}'),
+                1,
+                "Could not resolve release tag",
+            ),
         )
         for workflow_name, product, _ in self.RELEASE_WORKFLOWS:
             for label, release, release_rc, tag, tag_rc, error in cases:
@@ -837,12 +853,21 @@ fi
     def test_finalize_accepts_verified_absence_or_matching_draft_target(self):
         sha = "a" * 40
         for workflow_name, product, _ in self.RELEASE_WORKFLOWS:
+            expected_tag = (
+                "browserclaw/v0.49.0"
+                if product == "browserclaw"
+                else "v0.49.0"
+            )
+            missing_tag = self.api_probe(
+                422,
+                f'{{"message":"No commit found for SHA: {expected_tag}"}}',
+            )
             cases = (
                 (
                     "absent",
                     self.api_probe(404, '{"message":"Not Found"}'),
                     1,
-                    "",
+                    missing_tag,
                     1,
                 ),
                 (
@@ -862,7 +887,7 @@ fi
                         '{"draft":true,"target_commitish":"old"}',
                     ),
                     0,
-                    self.api_probe(404, '{"message":"Not Found"}'),
+                    missing_tag,
                     1,
                 ),
             )
@@ -886,17 +911,28 @@ fi
                     uv_calls = Path(env["FAKE_UV_CALLS"]).read_text(
                         encoding="utf-8"
                     )
-                    self.assertIn("release github create", uv_calls)
+                    for token in (
+                        "release github create",
+                        "--version 0.49.0",
+                        "--draft",
+                        f"--product {product}",
+                        "--platforms all",
+                        "--macos-arch universal",
+                        f"--source-sha {sha}",
+                        "--workflow-run-id 30418029456",
+                        "--workflow-run-attempt 2",
+                        f"--target {sha}",
+                    ):
+                        self.assertIn(token, uv_calls)
                     gh_calls = (root / "gh-calls").read_text(encoding="utf-8")
-                    expected_tag = (
-                        "browserclaw%2Fv0.49.0"
-                        if product == "browserclaw"
-                        else "v0.49.0"
+                    expected_tag_uri = expected_tag.replace("/", "%2F")
+                    self.assertIn(
+                        f"/releases/tags/{expected_tag_uri}",
+                        gh_calls,
                     )
-                    self.assertIn(f"/releases/tags/{expected_tag}", gh_calls)
                     if label == "untagged-draft-retarget":
                         self.assertIn(
-                            f"release edit {expected_tag.replace('%2F', '/')} "
+                            f"release edit {expected_tag} "
                             f"--target {sha}",
                             gh_calls,
                         )

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -434,9 +434,6 @@ if [ "$1" = "api" ] && [[ "$*" == *"/commits/"* ]]; then
   printf '%s\\n' "$FAKE_TAG_PROBE"
   exit "$FAKE_TAG_RC"
 fi
-if [ "$1" = "release" ] && [ "$2" = "view" ]; then
-  printf '%s\\n' "$FAKE_VERIFIED_TARGET"
-fi
 """,
             encoding="utf-8",
         )
@@ -495,7 +492,6 @@ fi
         release_rc: int,
         tag_probe: str = "",
         tag_rc: int = 1,
-        verified_target: str = "",
     ) -> tuple[subprocess.CompletedProcess[str], Path, dict[str, str]]:
         script = self.named_step(
             workflow_name,
@@ -519,7 +515,6 @@ fi
                 "FAKE_RELEASE_RC": str(release_rc),
                 "FAKE_TAG_PROBE": tag_probe,
                 "FAKE_TAG_RC": str(tag_rc),
-                "FAKE_VERIFIED_TARGET": verified_target,
                 "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
             }
         )
@@ -736,6 +731,15 @@ fi
                     encoding="utf-8"
                 )
                 self.assertIn("--platform win", summary)
+                self.assertIn(
+                    "release publish --version 0.49.0 "
+                    f"--product {product} --platform win "
+                    "--macos-arch universal "
+                    f"--source-sha {'a' * 40} "
+                    "--workflow-run-id 30418029456 "
+                    "--workflow-run-attempt 2",
+                    summary,
+                )
                 for token in (
                     "--platforms windows",
                     "--macos-arch universal",
@@ -881,10 +885,10 @@ fi
                     0,
                 ),
                 (
-                    "untagged-draft-retarget",
+                    "matching-untagged-draft",
                     self.api_probe(
                         200,
-                        '{"draft":true,"target_commitish":"old"}',
+                        f'{{"draft":true,"target_commitish":"{sha}"}}',
                     ),
                     0,
                     missing_tag,
@@ -900,7 +904,6 @@ fi
                         release_rc=release_rc,
                         tag_probe=tag,
                         tag_rc=tag_rc,
-                        verified_target=sha,
                     )
 
                     self.assertEqual(
@@ -930,12 +933,40 @@ fi
                         f"/releases/tags/{expected_tag_uri}",
                         gh_calls,
                     )
-                    if label == "untagged-draft-retarget":
-                        self.assertIn(
-                            f"release edit {expected_tag} "
-                            f"--target {sha}",
-                            gh_calls,
-                        )
+                    self.assertNotIn("release edit", gh_calls)
+
+    def test_finalize_never_retargets_an_untagged_draft(self):
+        for workflow_name, product, _ in self.RELEASE_WORKFLOWS:
+            expected_tag = (
+                "browserclaw/v0.49.0"
+                if product == "browserclaw"
+                else "v0.49.0"
+            )
+            missing_tag = self.api_probe(
+                422,
+                f'{{"message":"No commit found for SHA: {expected_tag}"}}',
+            )
+
+            result, root, _ = self.run_finalize_script(
+                workflow_name,
+                product,
+                release_probe=self.api_probe(
+                    200,
+                    '{"draft":true,"target_commitish":"old"}',
+                ),
+                release_rc=0,
+                tag_probe=missing_tag,
+                tag_rc=1,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Refusing to retarget a draft",
+                result.stdout + result.stderr,
+            )
+            self.assertFalse((root / "uv-calls").exists())
+            gh_calls = (root / "gh-calls").read_text(encoding="utf-8")
+            self.assertNotIn("release edit", gh_calls)
 
     def test_release_workflows_pin_source_and_draft_to_workflow_sha(self):
         reusable = (WORKFLOW_DIR / "build-browseros.yml").read_text(

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -313,6 +313,328 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
         )
 
 
+class ReleaseIntegrityWorkflowTest(unittest.TestCase):
+    RELEASE_WORKFLOWS = (
+        ("release-browseros.yml", "browseros", ""),
+        ("release-browserclaw.yml", "browserclaw", "-claw"),
+    )
+
+    def load_workflow(self, workflow_name: str) -> dict[str, object]:
+        path = WORKFLOW_DIR / workflow_name
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    def named_step(
+        self,
+        workflow_name: str,
+        job_name: str,
+        step_name: str,
+    ) -> dict[str, object]:
+        workflow = self.load_workflow(workflow_name)
+        return next(
+            step
+            for step in workflow["jobs"][job_name]["steps"]
+            if step.get("name") == step_name
+        )
+
+    def run_shell(
+        self,
+        script: str,
+        *,
+        env: dict[str, str],
+        cwd: Path,
+    ) -> subprocess.CompletedProcess[str]:
+        resolved_env = os.environ.copy()
+        resolved_env.update(env)
+        return subprocess.run(
+            ["bash", "-c", script],
+            cwd=cwd,
+            env=resolved_env,
+            capture_output=True,
+            text=True,
+        )
+
+    def workflow_env(self, root: Path, product: str) -> dict[str, str]:
+        output = root / "github-output"
+        summary = root / "github-summary"
+        calls = root / "uv-calls"
+        runner_temp = root / "runner-temp"
+        runner_temp.mkdir()
+        return {
+            "EXTENSION_NAME": (
+                "browserclaw" if product == "browserclaw" else "agent"
+            ),
+            "EXTENSIONS_VERSION": "1.2.3",
+            "FAKE_APPCAST_RC": "0",
+            "FAKE_EXTENSIONS_RC": "0",
+            "FAKE_UV_CALLS": str(calls),
+            "GITHUB_OUTPUT": str(output),
+            "GITHUB_RUN_ATTEMPT": "2",
+            "GITHUB_RUN_ID": "30418029456",
+            "GITHUB_SHA": "a" * 40,
+            "GITHUB_STEP_SUMMARY": str(summary),
+            "GITHUB_WORKSPACE": str(root),
+            "INPUT_EXTENSIONS": "skip",
+            "INPUT_GITHUB_RELEASE_DRAFT": "true",
+            "INPUT_MACOS_ARCH": "universal",
+            "INPUT_PLATFORMS": "all",
+            "PRODUCT": product,
+            "PRODUCT_LABEL": (
+                "BrowserClaw" if product == "browserclaw" else "BrowserOS"
+            ),
+            "RUNNER_TEMP": str(runner_temp),
+            "VERSION": "0.49.0",
+        }
+
+    def install_fake_uv(self, root: Path) -> Path:
+        fake_bin = root / "fake-bin"
+        fake_bin.mkdir()
+        uv = fake_bin / "uv"
+        uv.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_UV_CALLS"
+if [[ "$*" == *"release appcast"* ]]; then
+  if [ "$FAKE_APPCAST_RC" -ne 0 ]; then
+    exit "$FAKE_APPCAST_RC"
+  fi
+  for file in $FAKE_APPCAST_FILES; do
+    mkdir -p bos_build/config/appcast
+    printf '<rss/>\\n' > "bos_build/config/appcast/$file"
+  done
+elif [[ "$*" == *"release extensions"* ]]; then
+  if [ "$FAKE_EXTENSIONS_RC" -ne 0 ]; then
+    exit "$FAKE_EXTENSIONS_RC"
+  fi
+  for file in $FAKE_EXTENSION_FILES; do
+    mkdir -p ../../updates/extensions
+    printf '<feed/>\\n' > "../../updates/extensions/$file"
+  done
+fi
+""",
+            encoding="utf-8",
+        )
+        uv.chmod(0o755)
+        return fake_bin
+
+    def run_stage_script(
+        self,
+        workflow_name: str,
+        product: str,
+        appcast_files: list[str],
+        *,
+        appcast_rc: int = 0,
+        extensions: str = "skip",
+        extension_files: list[str] | None = None,
+        extensions_rc: int = 0,
+    ) -> tuple[subprocess.CompletedProcess[str], Path, dict[str, str]]:
+        script = self.named_step(
+            workflow_name,
+            "stage_updates",
+            "Render staged update feeds",
+        )["run"]
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        workdir = root / "packages" / "browseros"
+        workdir.mkdir(parents=True)
+        fake_bin = self.install_fake_uv(root)
+        env = self.workflow_env(root, product)
+        extension_files = extension_files or []
+        env.update(
+            {
+                "FAKE_APPCAST_FILES": " ".join(appcast_files),
+                "FAKE_APPCAST_RC": str(appcast_rc),
+                "FAKE_EXTENSION_FILES": " ".join(extension_files),
+                "FAKE_EXTENSIONS_RC": str(extensions_rc),
+                "INPUT_EXTENSIONS": extensions,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            }
+        )
+        return self.run_shell(script, env=env, cwd=workdir), root, env
+
+    def test_literal_stage_scripts_emit_exact_three_appcasts_for_all_universal(self):
+        for workflow_name, product, infix in self.RELEASE_WORKFLOWS:
+            expected = [
+                f"appcast{infix}.xml",
+                f"appcast{infix}-x86_64.xml",
+                f"appcast{infix}-win.xml",
+            ]
+            with self.subTest(workflow=workflow_name):
+                result, root, env = self.run_stage_script(
+                    workflow_name,
+                    product,
+                    expected,
+                )
+
+                self.assertEqual(
+                    result.returncode,
+                    0,
+                    msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+                )
+                staged = sorted(
+                    path.name
+                    for path in (root / "staged-update-feeds").rglob("*.xml")
+                )
+                self.assertEqual(staged, sorted(expected))
+                self.assertIn(
+                    "has_files=true",
+                    Path(env["GITHUB_OUTPUT"]).read_text(encoding="utf-8"),
+                )
+                call = Path(env["FAKE_UV_CALLS"]).read_text(encoding="utf-8")
+                for token in (
+                    "--platforms all",
+                    "--macos-arch universal",
+                    f"--source-sha {'a' * 40}",
+                    "--workflow-run-id 30418029456",
+                    "--workflow-run-attempt 2",
+                ):
+                    self.assertIn(token, call)
+
+    def test_literal_stage_scripts_fail_on_command_error_or_missing_output(self):
+        for workflow_name, product, infix in self.RELEASE_WORKFLOWS:
+            expected = [
+                f"appcast{infix}.xml",
+                f"appcast{infix}-x86_64.xml",
+                f"appcast{infix}-win.xml",
+            ]
+            for label, files, rc in (
+                ("command", expected, 19),
+                ("missing", expected[:-1], 0),
+            ):
+                with self.subTest(workflow=workflow_name, failure=label):
+                    result, _, _ = self.run_stage_script(
+                        workflow_name,
+                        product,
+                        files,
+                        appcast_rc=rc,
+                    )
+                    self.assertNotEqual(
+                        result.returncode,
+                        0,
+                        msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+                    )
+
+    def test_literal_stage_scripts_fail_on_extension_error_or_missing_output(self):
+        extension_files = [
+            "update-manifest.alpha.xml",
+            "extensions.alpha.json",
+            "bundled-manifest.xml",
+        ]
+        for workflow_name, product, infix in self.RELEASE_WORKFLOWS:
+            appcast_files = [
+                f"appcast{infix}.xml",
+                f"appcast{infix}-x86_64.xml",
+                f"appcast{infix}-win.xml",
+            ]
+            for label, files, rc in (
+                ("command", extension_files, 23),
+                ("missing", extension_files[:-1], 0),
+            ):
+                with self.subTest(workflow=workflow_name, failure=label):
+                    result, _, _ = self.run_stage_script(
+                        workflow_name,
+                        product,
+                        appcast_files,
+                        extensions="alpha",
+                        extension_files=files,
+                        extensions_rc=rc,
+                    )
+                    self.assertNotEqual(
+                        result.returncode,
+                        0,
+                        msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+                    )
+
+    def test_literal_stage_gates_skip_linux_without_feed_surface(self):
+        for workflow_name, product, _ in self.RELEASE_WORKFLOWS:
+            script = self.named_step(
+                workflow_name,
+                "stage_updates",
+                "Evaluate staged feed gate",
+            )["run"]
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                output = root / "output"
+                env = {
+                    **self.workflow_env(root, product),
+                    "GITHUB_OUTPUT": str(output),
+                    "INPUT_PLATFORMS": "linux",
+                    "INPUT_EXTENSIONS": "skip",
+                    "INPUT_INCLUDE_SERVERS": "false",
+                    "INPUT_UPLOAD_TO_R2": "true",
+                    "PREFLIGHT_RESULT": "success",
+                    "ONBOARD_RESULT": "skipped",
+                    "SERVER_RESULT": "skipped",
+                    "LINUX_RESULT": "success",
+                    "WINDOWS_RESULT": "skipped",
+                    "MACOS_RESULT": "skipped",
+                    "EXTENSIONS_RESULT": "skipped",
+                }
+                result = self.run_shell(script, env=env, cwd=root)
+                gate = output.read_text(encoding="utf-8")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("should_stage=false", gate)
+            self.assertIn("no update feeds", gate)
+
+    def test_literal_finalize_gates_require_successful_staging(self):
+        for workflow_name, product, _ in self.RELEASE_WORKFLOWS:
+            script = self.named_step(
+                workflow_name,
+                "finalize",
+                "Evaluate draft release gate",
+            )["run"]
+            for stage_result, expected in (("failure", "false"), ("success", "true")):
+                with self.subTest(
+                    workflow=workflow_name,
+                    stage_result=stage_result,
+                ), tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    output = root / "output"
+                    env = {
+                        **self.workflow_env(root, product),
+                        "GITHUB_OUTPUT": str(output),
+                        "INPUT_PLATFORMS": "linux",
+                        "INPUT_INCLUDE_SERVERS": "false",
+                        "INPUT_UPLOAD_TO_R2": "true",
+                        "PREFLIGHT_RESULT": "success",
+                        "ONBOARD_RESULT": "skipped",
+                        "SERVER_RESULT": "skipped",
+                        "LINUX_RESULT": "success",
+                        "WINDOWS_RESULT": "skipped",
+                        "MACOS_RESULT": "skipped",
+                        "EXTENSIONS_RESULT": "skipped",
+                        "STAGE_UPDATES_RESULT": stage_result,
+                    }
+                    result = self.run_shell(script, env=env, cwd=root)
+
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    gate = output.read_text(encoding="utf-8")
+                    self.assertIn(f"should_create={expected}", gate)
+                    if stage_result == "failure":
+                        self.assertIn("staged feed result is failure", gate)
+
+    def test_release_workflows_pin_source_and_draft_to_workflow_sha(self):
+        reusable = (WORKFLOW_DIR / "build-browseros.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("ref: ${{ inputs.ref || github.sha }}", reusable)
+
+        for workflow_name, _, _ in self.RELEASE_WORKFLOWS:
+            workflow = (WORKFLOW_DIR / workflow_name).read_text(encoding="utf-8")
+            self.assertNotIn("github.ref_name", workflow)
+            self.assertNotIn("ref: ${{ github.ref }}", workflow)
+            self.assertIn('gh release edit "$tag" --target "$GITHUB_SHA"', workflow)
+            self.assertIn('--target "$GITHUB_SHA"', workflow)
+
+    def test_top_level_release_changes_trigger_build_system_tests(self):
+        workflow = self.load_workflow("bos-build-tests.yml")
+        triggers = workflow.get("on", workflow.get(True))
+        paths = triggers["pull_request"]["paths"]
+        self.assertIn(".github/workflows/release-browseros.yml", paths)
+        self.assertIn(".github/workflows/release-browserclaw.yml", paths)
+
+
 class ChromiumGitRunbookTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -370,6 +370,7 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
             "GITHUB_OUTPUT": str(output),
             "GITHUB_RUN_ATTEMPT": "2",
             "GITHUB_RUN_ID": "30418029456",
+            "GITHUB_REPOSITORY": "browseros-ai/BrowserOS",
             "GITHUB_SHA": "a" * 40,
             "GITHUB_STEP_SUMMARY": str(summary),
             "GITHUB_WORKSPACE": str(root),
@@ -377,6 +378,7 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
             "INPUT_GITHUB_RELEASE_DRAFT": "true",
             "INPUT_MACOS_ARCH": "universal",
             "INPUT_PLATFORMS": "all",
+            "INPUT_UPLOAD_TO_R2": "true",
             "PRODUCT": product,
             "PRODUCT_LABEL": (
                 "BrowserClaw" if product == "browserclaw" else "BrowserOS"
@@ -387,7 +389,7 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
 
     def install_fake_uv(self, root: Path) -> Path:
         fake_bin = root / "fake-bin"
-        fake_bin.mkdir()
+        fake_bin.mkdir(exist_ok=True)
         uv = fake_bin / "uv"
         uv.write_text(
             """#!/usr/bin/env bash
@@ -416,6 +418,34 @@ fi
         uv.chmod(0o755)
         return fake_bin
 
+    def install_fake_gh(self, root: Path) -> Path:
+        fake_bin = root / "fake-bin"
+        fake_bin.mkdir(exist_ok=True)
+        gh = fake_bin / "gh"
+        gh.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_GH_CALLS"
+if [ "$1" = "api" ] && [[ "$*" == *"/releases/tags/"* ]]; then
+  printf '%s\\n' "$FAKE_RELEASE_PROBE"
+  exit "$FAKE_RELEASE_RC"
+fi
+if [ "$1" = "api" ] && [[ "$*" == *"/commits/"* ]]; then
+  printf '%s\\n' "$FAKE_TAG_PROBE"
+  exit "$FAKE_TAG_RC"
+fi
+if [ "$1" = "release" ] && [ "$2" = "view" ]; then
+  printf '%s\\n' "$FAKE_VERIFIED_TARGET"
+fi
+""",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+        return fake_bin
+
+    def api_probe(self, status: int, body: str) -> str:
+        return f"HTTP/2.0 {status} Status\nContent-Type: application/json\n\n{body}"
+
     def run_stage_script(
         self,
         workflow_name: str,
@@ -426,6 +456,8 @@ fi
         extensions: str = "skip",
         extension_files: list[str] | None = None,
         extensions_rc: int = 0,
+        platforms: str = "all",
+        upload_to_r2: bool = True,
     ) -> tuple[subprocess.CompletedProcess[str], Path, dict[str, str]]:
         script = self.named_step(
             workflow_name,
@@ -447,6 +479,47 @@ fi
                 "FAKE_EXTENSION_FILES": " ".join(extension_files),
                 "FAKE_EXTENSIONS_RC": str(extensions_rc),
                 "INPUT_EXTENSIONS": extensions,
+                "INPUT_PLATFORMS": platforms,
+                "INPUT_UPLOAD_TO_R2": str(upload_to_r2).lower(),
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            }
+        )
+        return self.run_shell(script, env=env, cwd=workdir), root, env
+
+    def run_finalize_script(
+        self,
+        workflow_name: str,
+        product: str,
+        *,
+        release_probe: str,
+        release_rc: int,
+        tag_probe: str = "",
+        tag_rc: int = 1,
+        verified_target: str = "",
+    ) -> tuple[subprocess.CompletedProcess[str], Path, dict[str, str]]:
+        script = self.named_step(
+            workflow_name,
+            "finalize",
+            "Create or refresh draft GitHub release",
+        )["run"]
+        temp = tempfile.TemporaryDirectory()
+        self.addCleanup(temp.cleanup)
+        root = Path(temp.name)
+        workdir = root / "packages" / "browseros"
+        workdir.mkdir(parents=True)
+        fake_bin = self.install_fake_uv(root)
+        self.install_fake_gh(root)
+        env = self.workflow_env(root, product)
+        env.update(
+            {
+                "FAKE_APPCAST_FILES": "",
+                "FAKE_EXTENSION_FILES": "",
+                "FAKE_GH_CALLS": str(root / "gh-calls"),
+                "FAKE_RELEASE_PROBE": release_probe,
+                "FAKE_RELEASE_RC": str(release_rc),
+                "FAKE_TAG_PROBE": tag_probe,
+                "FAKE_TAG_RC": str(tag_rc),
+                "FAKE_VERIFIED_TARGET": verified_target,
                 "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
             }
         )
@@ -575,7 +648,103 @@ fi
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("should_stage=false", gate)
-            self.assertIn("no update feeds", gate)
+            self.assertIn("no browser appcast or extension feed", gate)
+
+    def test_linux_extension_only_staging_ignores_browser_r2_switch(self):
+        extension_files = [
+            "update-manifest.alpha.xml",
+            "extensions.alpha.json",
+            "bundled-manifest.xml",
+        ]
+        for workflow_name, product, _ in self.RELEASE_WORKFLOWS:
+            gate_script = self.named_step(
+                workflow_name,
+                "stage_updates",
+                "Evaluate staged feed gate",
+            )["run"]
+            with self.subTest(workflow=workflow_name), tempfile.TemporaryDirectory() as tmp:
+                gate_root = Path(tmp)
+                gate_output = gate_root / "output"
+                gate_env = {
+                    **self.workflow_env(gate_root, product),
+                    "GITHUB_OUTPUT": str(gate_output),
+                    "INPUT_PLATFORMS": "linux",
+                    "INPUT_EXTENSIONS": "alpha",
+                    "INPUT_INCLUDE_SERVERS": "false",
+                    "INPUT_UPLOAD_TO_R2": "false",
+                    "PREFLIGHT_RESULT": "success",
+                    "ONBOARD_RESULT": "skipped",
+                    "SERVER_RESULT": "skipped",
+                    "LINUX_RESULT": "success",
+                    "WINDOWS_RESULT": "skipped",
+                    "MACOS_RESULT": "skipped",
+                    "EXTENSIONS_RESULT": "success",
+                }
+                gate_result = self.run_shell(
+                    gate_script,
+                    env=gate_env,
+                    cwd=gate_root,
+                )
+                gate = gate_output.read_text(encoding="utf-8")
+
+            self.assertEqual(gate_result.returncode, 0, gate_result.stderr)
+            self.assertIn("should_stage=true", gate)
+
+            result, root, env = self.run_stage_script(
+                workflow_name,
+                product,
+                [],
+                extensions="alpha",
+                extension_files=extension_files,
+                platforms="linux",
+                upload_to_r2=False,
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            staged = sorted(
+                path.name
+                for path in (root / "staged-update-feeds").rglob("*")
+                if path.is_file()
+            )
+            self.assertEqual(staged, sorted(extension_files))
+            calls = Path(env["FAKE_UV_CALLS"]).read_text(encoding="utf-8")
+            self.assertNotIn("release appcast", calls)
+            self.assertIn("release extensions", calls)
+            summary = Path(env["GITHUB_STEP_SUMMARY"]).read_text(encoding="utf-8")
+            self.assertIn("Browser artifact promotion skipped", summary)
+
+    def test_partial_stage_summary_preserves_promotion_contract(self):
+        for workflow_name, product, infix in self.RELEASE_WORKFLOWS:
+            expected = [f"appcast{infix}-win.xml"]
+            with self.subTest(workflow=workflow_name):
+                result, _, env = self.run_stage_script(
+                    workflow_name,
+                    product,
+                    expected,
+                    platforms="windows",
+                )
+
+                self.assertEqual(
+                    result.returncode,
+                    0,
+                    msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+                )
+                summary = Path(env["GITHUB_STEP_SUMMARY"]).read_text(
+                    encoding="utf-8"
+                )
+                self.assertIn("--platform win", summary)
+                for token in (
+                    "--platforms windows",
+                    "--macos-arch universal",
+                    f"--source-sha {'a' * 40}",
+                    "--workflow-run-id 30418029456",
+                    "--workflow-run-attempt 2",
+                    "--publish",
+                ):
+                    self.assertIn(token, summary)
 
     def test_literal_finalize_gates_require_successful_staging(self):
         for workflow_name, product, _ in self.RELEASE_WORKFLOWS:
@@ -614,6 +783,124 @@ fi
                     if stage_result == "failure":
                         self.assertIn("staged feed result is failure", gate)
 
+    def test_finalize_release_inspection_and_tag_target_fail_closed(self):
+        sha = "a" * 40
+        other_sha = "b" * 40
+        cases = (
+            (
+                "inspection-error",
+                self.api_probe(500, '{"message":"server error"}'),
+                1,
+                "",
+                1,
+                "Could not inspect release",
+            ),
+            (
+                "published",
+                self.api_probe(
+                    200,
+                    f'{{"draft":false,"target_commitish":"{sha}"}}',
+                ),
+                0,
+                "",
+                1,
+                "not a draft",
+            ),
+            (
+                "tag-mismatch",
+                self.api_probe(
+                    200,
+                    f'{{"draft":true,"target_commitish":"{sha}"}}',
+                ),
+                0,
+                self.api_probe(200, f'{{"sha":"{other_sha}"}}'),
+                0,
+                "not workflow SHA",
+            ),
+        )
+        for workflow_name, product, _ in self.RELEASE_WORKFLOWS:
+            for label, release, release_rc, tag, tag_rc, error in cases:
+                with self.subTest(workflow=workflow_name, failure=label):
+                    result, root, _ = self.run_finalize_script(
+                        workflow_name,
+                        product,
+                        release_probe=release,
+                        release_rc=release_rc,
+                        tag_probe=tag,
+                        tag_rc=tag_rc,
+                    )
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(error, result.stdout + result.stderr)
+                    self.assertFalse((root / "uv-calls").exists())
+
+    def test_finalize_accepts_verified_absence_or_matching_draft_target(self):
+        sha = "a" * 40
+        for workflow_name, product, _ in self.RELEASE_WORKFLOWS:
+            cases = (
+                (
+                    "absent",
+                    self.api_probe(404, '{"message":"Not Found"}'),
+                    1,
+                    "",
+                    1,
+                ),
+                (
+                    "matching-draft",
+                    self.api_probe(
+                        200,
+                        f'{{"draft":true,"target_commitish":"{sha}"}}',
+                    ),
+                    0,
+                    self.api_probe(200, f'{{"sha":"{sha}"}}'),
+                    0,
+                ),
+                (
+                    "untagged-draft-retarget",
+                    self.api_probe(
+                        200,
+                        '{"draft":true,"target_commitish":"old"}',
+                    ),
+                    0,
+                    self.api_probe(404, '{"message":"Not Found"}'),
+                    1,
+                ),
+            )
+            for label, release, release_rc, tag, tag_rc in cases:
+                with self.subTest(workflow=workflow_name, state=label):
+                    result, root, env = self.run_finalize_script(
+                        workflow_name,
+                        product,
+                        release_probe=release,
+                        release_rc=release_rc,
+                        tag_probe=tag,
+                        tag_rc=tag_rc,
+                        verified_target=sha,
+                    )
+
+                    self.assertEqual(
+                        result.returncode,
+                        0,
+                        msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+                    )
+                    uv_calls = Path(env["FAKE_UV_CALLS"]).read_text(
+                        encoding="utf-8"
+                    )
+                    self.assertIn("release github create", uv_calls)
+                    gh_calls = (root / "gh-calls").read_text(encoding="utf-8")
+                    expected_tag = (
+                        "browserclaw%2Fv0.49.0"
+                        if product == "browserclaw"
+                        else "v0.49.0"
+                    )
+                    self.assertIn(f"/releases/tags/{expected_tag}", gh_calls)
+                    if label == "untagged-draft-retarget":
+                        self.assertIn(
+                            f"release edit {expected_tag.replace('%2F', '/')} "
+                            f"--target {sha}",
+                            gh_calls,
+                        )
+
     def test_release_workflows_pin_source_and_draft_to_workflow_sha(self):
         reusable = (WORKFLOW_DIR / "build-browseros.yml").read_text(
             encoding="utf-8"
@@ -624,8 +911,14 @@ fi
             workflow = (WORKFLOW_DIR / workflow_name).read_text(encoding="utf-8")
             self.assertNotIn("github.ref_name", workflow)
             self.assertNotIn("ref: ${{ github.ref }}", workflow)
-            self.assertIn('gh release edit "$tag" --target "$GITHUB_SHA"', workflow)
+            self.assertIn('actual_target" != "$GITHUB_SHA"', workflow)
+            self.assertIn('release_status" = "404"', workflow)
             self.assertIn('--target "$GITHUB_SHA"', workflow)
+
+        browserclaw = (WORKFLOW_DIR / "release-browserclaw.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('echo "browserclaw/v$major.$minor.$build"', browserclaw)
 
     def test_top_level_release_changes_trigger_build_system_tests(self):
         workflow = self.load_workflow("bos-build-tests.yml")

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -346,7 +346,7 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
         resolved_env = os.environ.copy()
         resolved_env.update(env)
         return subprocess.run(
-            ["bash", "-c", script],
+            [git_bash_path(), "-c", script],
             cwd=cwd,
             env=resolved_env,
             capture_output=True,

--- a/packages/browseros/bos_build/cli/release.py
+++ b/packages/browseros/bos_build/cli/release.py
@@ -178,11 +178,40 @@ def publish(
         "--platform",
         help="Platform to promote: macos, win, or linux (repeatable; default: all)",
     ),
+    macos_arch: str = typer.Option(
+        "universal",
+        "--macos-arch",
+        help="Expected macOS artifact set: arm64, x64, or universal",
+    ),
+    source_sha: str = typer.Option(
+        "",
+        "--source-sha",
+        help="Require release metadata from this source commit",
+    ),
+    workflow_run_id: str = typer.Option(
+        "",
+        "--workflow-run-id",
+        help="Require release metadata from this Actions run",
+    ),
+    workflow_run_attempt: str = typer.Option(
+        "",
+        "--workflow-run-attempt",
+        help="Require release metadata from this Actions run attempt",
+    ),
 ):
     """Publish versioned artifacts to download/ paths (make live)."""
     release_ctx = create_release_context(version, product=product)
     log_info(f"🚀 Publishing v{version} to download/ paths")
-    execute_module(release_ctx, PublishModule(platforms=platforms))
+    execute_module(
+        release_ctx,
+        PublishModule(
+            platforms=platforms,
+            macos_arch=macos_arch,
+            source_sha=source_sha,
+            workflow_run_id=workflow_run_id,
+            workflow_run_attempt=workflow_run_attempt,
+        ),
+    )
 
 
 @app.command("download")
@@ -289,7 +318,19 @@ def github_create(
 
     if publish_to_download:
         log_info(f"\n🚀 Publishing v{version} to download/ paths")
-        execute_module(ctx, PublishModule())
+        publish_platforms = None
+        if platforms and platforms != "all":
+            publish_platforms = ["win" if platforms == "windows" else platforms]
+        execute_module(
+            ctx,
+            PublishModule(
+                platforms=publish_platforms,
+                macos_arch=macos_arch,
+                source_sha=source_sha,
+                workflow_run_id=workflow_run_id,
+                workflow_run_attempt=workflow_run_attempt,
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/cli/release.py
+++ b/packages/browseros/bos_build/cli/release.py
@@ -2,7 +2,7 @@
 """Release CLI - Modular release automation for BrowserOS"""
 
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import typer
 
@@ -173,11 +173,16 @@ def publish(
         ..., "--version", "-v", help="Version to operate on (e.g., 0.31.0)"
     ),
     product: Optional[str] = typer.Option(None, "--product", help=_PRODUCT_HELP),
+    platforms: Optional[List[str]] = typer.Option(
+        None,
+        "--platform",
+        help="Platform to promote: macos, win, or linux (repeatable; default: all)",
+    ),
 ):
     """Publish versioned artifacts to download/ paths (make live)."""
     release_ctx = create_release_context(version, product=product)
     log_info(f"🚀 Publishing v{version} to download/ paths")
-    execute_module(release_ctx, PublishModule())
+    execute_module(release_ctx, PublishModule(platforms=platforms))
 
 
 @app.command("download")
@@ -227,6 +232,36 @@ def github_create(
         False, "--publish", "-p", help="Also publish to download/ paths after creating release"
     ),
     product: Optional[str] = typer.Option(None, "--product", help=_PRODUCT_HELP),
+    platforms: Optional[str] = typer.Option(
+        None,
+        "--platforms",
+        help="Release platform selection: all, linux, windows, or macos",
+    ),
+    macos_arch: str = typer.Option(
+        "universal",
+        "--macos-arch",
+        help="Expected macOS artifact set: arm64, x64, or universal",
+    ),
+    source_sha: str = typer.Option(
+        "",
+        "--source-sha",
+        help="Require release metadata from this source commit",
+    ),
+    workflow_run_id: str = typer.Option(
+        "",
+        "--workflow-run-id",
+        help="Require release metadata from this Actions run",
+    ),
+    workflow_run_attempt: str = typer.Option(
+        "",
+        "--workflow-run-attempt",
+        help="Require release metadata from this Actions run attempt",
+    ),
+    target: str = typer.Option(
+        "",
+        "--target",
+        help="Commit SHA or branch for the release tag",
+    ),
 ):
     """Create GitHub release from R2 artifacts
 
@@ -243,6 +278,12 @@ def github_create(
         draft=draft,
         skip_upload=skip_upload,
         title=title,
+        platforms=platforms,
+        macos_arch=macos_arch,
+        source_sha=source_sha,
+        workflow_run_id=workflow_run_id,
+        workflow_run_attempt=workflow_run_attempt,
+        target=target,
     )
     execute_module(ctx, module)
 

--- a/packages/browseros/bos_build/cli/release_feeds.py
+++ b/packages/browseros/bos_build/cli/release_feeds.py
@@ -70,6 +70,31 @@ def appcast_command(
     allow_downgrade: bool = typer.Option(
         False, "--allow-downgrade", help="Override the version-downgrade guard"
     ),
+    platforms: str | None = typer.Option(
+        None,
+        "--platforms",
+        help="Release platform selection: all, linux, windows, or macos",
+    ),
+    macos_arch: str = typer.Option(
+        "universal",
+        "--macos-arch",
+        help="Expected macOS artifact set: arm64, x64, or universal",
+    ),
+    source_sha: str = typer.Option(
+        "",
+        "--source-sha",
+        help="Require release metadata from this source commit",
+    ),
+    workflow_run_id: str = typer.Option(
+        "",
+        "--workflow-run-id",
+        help="Require release metadata from this Actions run",
+    ),
+    workflow_run_attempt: str = typer.Option(
+        "",
+        "--workflow-run-attempt",
+        help="Require release metadata from this Actions run attempt",
+    ),
 ):
     """Generate complete browser appcast feeds from R2 release metadata.
 
@@ -85,7 +110,14 @@ def appcast_command(
     _execute(
         ctx,
         AppcastModule(
-            product_id=product, publish=publish, allow_downgrade=allow_downgrade
+            product_id=product,
+            publish=publish,
+            allow_downgrade=allow_downgrade,
+            platforms=platforms,
+            macos_arch=macos_arch,
+            source_sha=source_sha,
+            workflow_run_id=workflow_run_id,
+            workflow_run_attempt=workflow_run_attempt,
         ),
     )
 

--- a/packages/browseros/bos_build/cli/release_test.py
+++ b/packages/browseros/bos_build/cli/release_test.py
@@ -5,6 +5,7 @@ import re
 import os
 import unittest
 from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest import mock
 
 from typer.testing import CliRunner
@@ -283,6 +284,11 @@ class GithubCreateCliIntegrityTest(unittest.TestCase):
                 "download_and_upload_artifacts",
                 return_value=[("BrowserClaw_installer.exe", True)],
             ),
+            mock.patch.object(
+                github_module,
+                "resolve_github_tag_target",
+                return_value=target,
+            ),
         ):
             result = self.invoke_create("--target", target)
 
@@ -291,6 +297,31 @@ class GithubCreateCliIntegrityTest(unittest.TestCase):
         self.assertIn("## BrowserClaw v0.49.0", args[3])
         self.assertEqual(args[0], "browserclaw/v0.49.0")
         self.assertEqual(args[5], target)
+
+    def test_created_release_target_mismatch_blocks_asset_upload(self):
+        target = "a" * 40
+        with (
+            self.patches(),
+            mock.patch.object(
+                github_module,
+                "create_github_release",
+                return_value=(True, "https://github.com/release"),
+            ),
+            mock.patch.object(
+                github_module,
+                "resolve_github_tag_target",
+                return_value="b" * 40,
+            ),
+            mock.patch.object(
+                github_module,
+                "download_and_upload_artifacts",
+            ) as upload,
+        ):
+            result = self.invoke_create("--target", target)
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("not requested target", plain_output(result))
+        upload.assert_not_called()
 
     def test_existing_release_remains_refreshable_when_uploads_succeed(self):
         with (
@@ -391,6 +422,88 @@ class GithubCreateCliIntegrityTest(unittest.TestCase):
             initial_assets,
         )
 
+    def test_skip_upload_preserves_existing_draft_assets(self):
+        with (
+            self.patches(),
+            mock.patch.object(
+                github_module,
+                "create_github_release",
+                return_value=(False, "Release browserclaw/v0.49.0 already exists"),
+            ),
+            mock.patch.object(
+                github_module,
+                "inspect_github_release",
+                return_value={"isDraft": True, "assets": ["keep.exe", "keep.zip"]},
+            ),
+            mock.patch.object(
+                github_module,
+                "delete_github_release_asset",
+            ) as delete,
+            mock.patch.object(github_module, "edit_github_release"),
+            mock.patch.object(
+                github_module,
+                "download_and_upload_artifacts",
+            ) as upload,
+        ):
+            result = self.invoke_create(
+                "--platforms",
+                "windows",
+                "--source-sha",
+                "a" * 40,
+                "--workflow-run-id",
+                "123",
+                "--workflow-run-attempt",
+                "1",
+                "--skip-upload",
+            )
+
+        self.assertEqual(result.exit_code, 0, plain_output(result))
+        delete.assert_not_called()
+        upload.assert_not_called()
+
+    def test_tag_resolver_treats_only_missing_ref_422_as_absent(self):
+        tag = "browserclaw/v0.49.0"
+        missing = SimpleNamespace(
+            returncode=1,
+            stdout=(
+                "HTTP/2.0 422 Unprocessable Entity\n"
+                "Content-Type: application/json\n\n"
+                f'{{"message":"No commit found for SHA: {tag}"}}'
+            ),
+            stderr="gh: no commit",
+        )
+        unrelated = SimpleNamespace(
+            returncode=1,
+            stdout=(
+                "HTTP/2.0 422 Unprocessable Entity\n"
+                "Content-Type: application/json\n\n"
+                '{"message":"Validation Failed"}'
+            ),
+            stderr="gh: validation failed",
+        )
+
+        with mock.patch.object(
+            github_module.subprocess,
+            "run",
+            side_effect=[missing, unrelated],
+        ) as run:
+            self.assertIsNone(
+                github_module.resolve_github_tag_target(
+                    tag,
+                    "browseros-ai/BrowserOS",
+                )
+            )
+            with self.assertRaisesRegex(RuntimeError, "Could not resolve Git tag"):
+                github_module.resolve_github_tag_target(
+                    tag,
+                    "browseros-ai/BrowserOS",
+                )
+
+        self.assertIn(
+            "commits/browserclaw%2Fv0.49.0",
+            run.call_args_list[0].args[0][-1],
+        )
+
 
 class PublishCliIntegrityTest(unittest.TestCase):
     def invoke_publish(self, *extra: str):
@@ -484,7 +597,7 @@ class PublishCliIntegrityTest(unittest.TestCase):
                 publish_module,
                 "copy_to_download_path",
                 return_value=True,
-            ),
+            ) as copy,
         ):
             result = self.invoke_publish(
                 "--platform",
@@ -495,6 +608,7 @@ class PublishCliIntegrityTest(unittest.TestCase):
 
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("requested platform win", plain_output(result))
+        copy.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/cli/release_test.py
+++ b/packages/browseros/bos_build/cli/release_test.py
@@ -2,13 +2,17 @@
 """CLI surface tests for the release subcommands."""
 
 import re
+import os
 import unittest
+from contextlib import contextmanager
 from unittest import mock
 
 from typer.testing import CliRunner
 
 from bos_build.browseros import app
 from bos_build.cli import release as release_cli
+from bos_build.release import github as github_module
+from bos_build.release import publish as publish_module
 
 runner = CliRunner()
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -136,6 +140,230 @@ class CreateReleaseContextTest(unittest.TestCase):
         ctx = release_cli.create_release_context("1.0.0")
 
         self.assertEqual(ctx.product.id, "browseros")
+
+
+def _configured_r2_env():
+    return mock.patch.dict(
+        os.environ,
+        {
+            "R2_ACCOUNT_ID": "account",
+            "R2_ACCESS_KEY_ID": "key",
+            "R2_SECRET_ACCESS_KEY": "secret",
+            "R2_BUCKET": "bucket",
+        },
+        clear=False,
+    )
+
+
+def _github_metadata(product: str = "browserclaw"):
+    prefix = "BrowserClaw" if product == "browserclaw" else "BrowserOS"
+    filename = f"{prefix}_v0.49.0_x64_installer.exe"
+    return {
+        "win": {
+            "product": product,
+            "version": "0.49.0",
+            "platform": "win",
+            "chromium_version": "140.0.0.0",
+            "artifacts": {
+                "x64_installer": {
+                    "filename": filename,
+                    "url": f"https://cdn.browseros.com/{filename}",
+                },
+            },
+        }
+    }
+
+
+class GithubCreateCliIntegrityTest(unittest.TestCase):
+    def invoke_create(self, *extra: str):
+        return invoke(
+            "github",
+            "create",
+            "--version",
+            "0.49.0",
+            "--product",
+            "browserclaw",
+            "--repo",
+            "browseros-ai/BrowserOS",
+            *extra,
+        )
+
+    @contextmanager
+    def patches(self, metadata=None):
+        with (
+            _configured_r2_env(),
+            mock.patch.object(github_module, "BOTO3_AVAILABLE", True),
+            mock.patch.object(github_module, "check_gh_cli", return_value=True),
+            mock.patch.object(
+                github_module,
+                "fetch_all_release_metadata",
+                return_value=_github_metadata() if metadata is None else metadata,
+            ),
+        ):
+            yield
+
+    def test_create_failure_makes_actual_cli_exit_nonzero(self):
+        with (
+            self.patches(),
+            mock.patch.object(
+                github_module,
+                "create_github_release",
+                return_value=(False, "GitHub API unavailable"),
+            ),
+        ):
+            result = self.invoke_create()
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("GitHub API unavailable", plain_output(result))
+
+    def test_missing_metadata_makes_actual_cli_exit_nonzero(self):
+        with self.patches(metadata={}):
+            result = self.invoke_create()
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("No release metadata", plain_output(result))
+
+    def test_failed_asset_transfer_makes_actual_cli_exit_nonzero(self):
+        with (
+            self.patches(),
+            mock.patch.object(
+                github_module,
+                "create_github_release",
+                return_value=(True, "https://github.com/release"),
+            ),
+            mock.patch.object(
+                github_module,
+                "download_and_upload_artifacts",
+                return_value=[("BrowserClaw_installer.exe", False)],
+            ),
+        ):
+            result = self.invoke_create()
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("BrowserClaw_installer.exe", plain_output(result))
+
+    def test_zero_asset_candidates_makes_actual_cli_exit_nonzero(self):
+        with (
+            self.patches(),
+            mock.patch.object(
+                github_module,
+                "create_github_release",
+                return_value=(True, "https://github.com/release"),
+            ),
+            mock.patch.object(
+                github_module,
+                "download_and_upload_artifacts",
+                return_value=[],
+            ),
+        ):
+            result = self.invoke_create()
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("No release artifacts", plain_output(result))
+
+    def test_success_pins_target_and_uses_product_notes(self):
+        target = "a" * 40
+        with (
+            self.patches(),
+            mock.patch.object(
+                github_module,
+                "create_github_release",
+                return_value=(True, "https://github.com/release"),
+            ) as create,
+            mock.patch.object(
+                github_module,
+                "download_and_upload_artifacts",
+                return_value=[("BrowserClaw_installer.exe", True)],
+            ),
+        ):
+            result = self.invoke_create("--target", target)
+
+        self.assertEqual(result.exit_code, 0, plain_output(result))
+        args = create.call_args.args
+        self.assertIn("## BrowserClaw v0.49.0", args[3])
+        self.assertEqual(args[5], target)
+
+    def test_existing_release_remains_refreshable_when_uploads_succeed(self):
+        with (
+            self.patches(),
+            mock.patch.object(
+                github_module,
+                "create_github_release",
+                return_value=(False, "Release v0.49.0 already exists"),
+            ),
+            mock.patch.object(
+                github_module,
+                "download_and_upload_artifacts",
+                return_value=[("BrowserClaw_installer.exe", True)],
+            ),
+        ):
+            result = self.invoke_create()
+
+        self.assertEqual(result.exit_code, 0, plain_output(result))
+
+
+class PublishCliIntegrityTest(unittest.TestCase):
+    def invoke_publish(self, *extra: str):
+        return invoke(
+            "publish",
+            "--version",
+            "0.49.0",
+            "--product",
+            "browserclaw",
+            *extra,
+        )
+
+    @contextmanager
+    def patches(self, metadata):
+        with (
+            _configured_r2_env(),
+            mock.patch.object(publish_module, "BOTO3_AVAILABLE", True),
+            mock.patch.object(
+                publish_module,
+                "fetch_all_release_metadata",
+                return_value=metadata,
+            ),
+        ):
+            yield
+
+    def test_missing_requested_platform_makes_actual_cli_exit_nonzero(self):
+        with (
+            self.patches(_github_metadata()),
+            mock.patch.object(publish_module, "get_r2_client", return_value=object()),
+        ):
+            result = self.invoke_publish()
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("missing release metadata", plain_output(result).lower())
+
+    def test_copy_failure_makes_actual_cli_exit_nonzero(self):
+        with (
+            self.patches(_github_metadata()),
+            mock.patch.object(publish_module, "get_r2_client", return_value=object()),
+            mock.patch.object(
+                publish_module,
+                "copy_to_download_path",
+                return_value=False,
+            ),
+        ):
+            result = self.invoke_publish("--platform", "win")
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Failed to publish", plain_output(result))
+
+    def test_explicit_partial_platform_can_succeed(self):
+        with (
+            self.patches(_github_metadata()),
+            mock.patch.object(publish_module, "get_r2_client", return_value=object()),
+            mock.patch.object(
+                publish_module,
+                "copy_to_download_path",
+                return_value=True,
+            ),
+        ):
+            result = self.invoke_publish("--platform", "win")
+
+        self.assertEqual(result.exit_code, 0, plain_output(result))
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/cli/release_test.py
+++ b/packages/browseros/bos_build/cli/release_test.py
@@ -158,16 +158,24 @@ def _configured_r2_env():
 def _github_metadata(product: str = "browserclaw"):
     prefix = "BrowserClaw" if product == "browserclaw" else "BrowserOS"
     filename = f"{prefix}_v0.49.0_x64_installer.exe"
+    zip_filename = f"{prefix}_v0.49.0_x64_installer.zip"
     return {
         "win": {
             "product": product,
             "version": "0.49.0",
             "platform": "win",
             "chromium_version": "140.0.0.0",
+            "source_sha": "a" * 40,
+            "workflow_run_id": "123",
+            "workflow_run_attempt": "1",
             "artifacts": {
                 "x64_installer": {
                     "filename": filename,
                     "url": f"https://cdn.browseros.com/{filename}",
+                },
+                "x64_zip": {
+                    "filename": zip_filename,
+                    "url": f"https://cdn.browseros.com/{zip_filename}",
                 },
             },
         }
@@ -281,6 +289,7 @@ class GithubCreateCliIntegrityTest(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, plain_output(result))
         args = create.call_args.args
         self.assertIn("## BrowserClaw v0.49.0", args[3])
+        self.assertEqual(args[0], "browserclaw/v0.49.0")
         self.assertEqual(args[5], target)
 
     def test_existing_release_remains_refreshable_when_uploads_succeed(self):
@@ -296,10 +305,91 @@ class GithubCreateCliIntegrityTest(unittest.TestCase):
                 "download_and_upload_artifacts",
                 return_value=[("BrowserClaw_installer.exe", True)],
             ),
+            mock.patch.object(
+                github_module,
+                "inspect_github_release",
+                return_value={"isDraft": True, "assets": []},
+            ),
+            mock.patch.object(github_module, "edit_github_release") as edit,
         ):
             result = self.invoke_create()
 
         self.assertEqual(result.exit_code, 0, plain_output(result))
+        self.assertEqual(edit.call_args.args[0], "browserclaw/v0.49.0")
+
+    def test_existing_published_release_is_never_refreshable(self):
+        with (
+            self.patches(),
+            mock.patch.object(
+                github_module,
+                "create_github_release",
+                return_value=(False, "Release browserclaw/v0.49.0 already exists"),
+            ),
+            mock.patch.object(
+                github_module,
+                "inspect_github_release",
+                return_value={"isDraft": False, "assets": []},
+            ),
+            mock.patch.object(
+                github_module,
+                "download_and_upload_artifacts",
+            ) as upload,
+        ):
+            result = self.invoke_create()
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("not a draft", plain_output(result))
+        upload.assert_not_called()
+
+    def test_contracted_refresh_reconciles_and_verifies_exact_assets(self):
+        metadata = _github_metadata()
+        expected = {
+            artifact["filename"]
+            for artifact in metadata["win"]["artifacts"].values()
+        }
+        initial_assets = ["BrowserOS_v0.49.0_universal.dmg", "stale.bin"]
+        with (
+            self.patches(metadata),
+            mock.patch.object(
+                github_module,
+                "create_github_release",
+                return_value=(False, "Release browserclaw/v0.49.0 already exists"),
+            ),
+            mock.patch.object(
+                github_module,
+                "inspect_github_release",
+                side_effect=[
+                    {"isDraft": True, "assets": initial_assets},
+                    {"isDraft": True, "assets": sorted(expected)},
+                ],
+            ),
+            mock.patch.object(
+                github_module,
+                "delete_github_release_asset",
+            ) as delete,
+            mock.patch.object(github_module, "edit_github_release"),
+            mock.patch.object(
+                github_module,
+                "download_and_upload_artifacts",
+                return_value=[(filename, True) for filename in sorted(expected)],
+            ),
+        ):
+            result = self.invoke_create(
+                "--platforms",
+                "windows",
+                "--source-sha",
+                "a" * 40,
+                "--workflow-run-id",
+                "123",
+                "--workflow-run-attempt",
+                "1",
+            )
+
+        self.assertEqual(result.exit_code, 0, plain_output(result))
+        self.assertEqual(
+            [call.args[2] for call in delete.call_args_list],
+            initial_assets,
+        )
 
 
 class PublishCliIntegrityTest(unittest.TestCase):
@@ -364,6 +454,47 @@ class PublishCliIntegrityTest(unittest.TestCase):
             result = self.invoke_publish("--platform", "win")
 
         self.assertEqual(result.exit_code, 0, plain_output(result))
+
+    def test_mixed_request_fails_when_one_platform_has_no_promotable_assets(self):
+        metadata = {
+            "macos": {
+                "artifacts": {
+                    "universal": {
+                        "filename": "BrowserClaw_v0.49.0_universal.dmg",
+                        "url": (
+                            "https://cdn.browseros.com/releases/browserclaw/"
+                            "0.49.0/macos/BrowserClaw_v0.49.0_universal.dmg"
+                        ),
+                    }
+                }
+            },
+            "win": {
+                "artifacts": {
+                    "unknown": {
+                        "filename": "unknown.bin",
+                        "url": "https://cdn.browseros.com/unknown.bin",
+                    }
+                }
+            },
+        }
+        with (
+            self.patches(metadata),
+            mock.patch.object(publish_module, "get_r2_client", return_value=object()),
+            mock.patch.object(
+                publish_module,
+                "copy_to_download_path",
+                return_value=True,
+            ),
+        ):
+            result = self.invoke_publish(
+                "--platform",
+                "macos",
+                "--platform",
+                "win",
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("requested platform win", plain_output(result))
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/cli/release_test.py
+++ b/packages/browseros/bos_build/cli/release_test.py
@@ -378,7 +378,7 @@ class GithubCreateCliIntegrityTest(unittest.TestCase):
             artifact["filename"]
             for artifact in metadata["win"]["artifacts"].values()
         }
-        initial_assets = ["BrowserOS_v0.49.0_universal.dmg", "stale.bin"]
+        initial_assets = [sorted(expected)[0]]
         with (
             self.patches(metadata),
             mock.patch.object(
@@ -421,6 +421,50 @@ class GithubCreateCliIntegrityTest(unittest.TestCase):
             [call.args[2] for call in delete.call_args_list],
             initial_assets,
         )
+
+    def test_partial_refresh_never_deletes_other_platform_assets(self):
+        existing_assets = [
+            "BrowserClaw_v0.49.0_universal.dmg",
+            "BrowserClaw_v0.49.0_x64_installer.exe",
+        ]
+        with (
+            self.patches(),
+            mock.patch.object(
+                github_module,
+                "create_github_release",
+                return_value=(False, "Release browserclaw/v0.49.0 already exists"),
+            ),
+            mock.patch.object(
+                github_module,
+                "inspect_github_release",
+                return_value={"isDraft": True, "assets": existing_assets},
+            ),
+            mock.patch.object(
+                github_module,
+                "delete_github_release_asset",
+            ) as delete,
+            mock.patch.object(github_module, "edit_github_release") as edit,
+            mock.patch.object(
+                github_module,
+                "download_and_upload_artifacts",
+            ) as upload,
+        ):
+            result = self.invoke_create(
+                "--platforms",
+                "windows",
+                "--source-sha",
+                "a" * 40,
+                "--workflow-run-id",
+                "123",
+                "--workflow-run-attempt",
+                "1",
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Refusing a partial refresh", plain_output(result))
+        delete.assert_not_called()
+        edit.assert_not_called()
+        upload.assert_not_called()
 
     def test_skip_upload_preserves_existing_draft_assets(self):
         with (
@@ -549,7 +593,18 @@ class PublishCliIntegrityTest(unittest.TestCase):
                 return_value=False,
             ),
         ):
-            result = self.invoke_publish("--platform", "win")
+            result = self.invoke_publish(
+                "--platform",
+                "win",
+                "--macos-arch",
+                "universal",
+                "--source-sha",
+                "a" * 40,
+                "--workflow-run-id",
+                "123",
+                "--workflow-run-attempt",
+                "1",
+            )
 
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("Failed to publish", plain_output(result))
@@ -564,9 +619,49 @@ class PublishCliIntegrityTest(unittest.TestCase):
                 return_value=True,
             ),
         ):
-            result = self.invoke_publish("--platform", "win")
+            result = self.invoke_publish(
+                "--platform",
+                "win",
+                "--macos-arch",
+                "universal",
+                "--source-sha",
+                "a" * 40,
+                "--workflow-run-id",
+                "123",
+                "--workflow-run-attempt",
+                "1",
+            )
 
         self.assertEqual(result.exit_code, 0, plain_output(result))
+
+    def test_promotion_provenance_mismatch_blocks_every_copy(self):
+        metadata = _github_metadata()
+        metadata["win"]["source_sha"] = "b" * 40
+        with (
+            self.patches(metadata),
+            mock.patch.object(publish_module, "get_r2_client", return_value=object()),
+            mock.patch.object(
+                publish_module,
+                "copy_to_download_path",
+                return_value=True,
+            ) as copy,
+        ):
+            result = self.invoke_publish(
+                "--platform",
+                "win",
+                "--macos-arch",
+                "universal",
+                "--source-sha",
+                "a" * 40,
+                "--workflow-run-id",
+                "123",
+                "--workflow-run-attempt",
+                "1",
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("source_sha mismatch", plain_output(result))
+        copy.assert_not_called()
 
     def test_mixed_request_fails_when_one_platform_has_no_promotable_assets(self):
         metadata = {

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -225,9 +225,13 @@ uv run browseros release github create --version <version> --draft --product bro
 uv run browseros release github create --version <version> --draft --product browserclaw
 ```
 
-If the target GitHub release already exists and is published, the workflow
-refuses to modify it. If it is still a draft, matching product assets are
-removed first so reruns refresh the draft from current R2 artifacts.
+BrowserOS owns the `vX.Y.Z` release namespace; BrowserClaw owns
+`browserclaw/vX.Y.Z`, so same-version releases cannot share notes or assets.
+If the target release already exists and is published, or its existing Git tag
+does not resolve to the workflow SHA, the workflow refuses to modify it.
+Verified same-target drafts are refreshed by replacing their complete asset
+set, updating title and notes, and checking that the final assets exactly match
+the selected current-run R2 metadata.
 
 ## Staged Update Feed Artifacts
 

--- a/packages/browseros/bos_build/release/appcast.py
+++ b/packages/browseros/bos_build/release/appcast.py
@@ -11,6 +11,7 @@ from ..core.step import Step, ValidationError
 from ..lib.utils import log_error, log_info
 from ..lib.r2 import BOTO3_AVAILABLE
 from .common import fetch_all_release_metadata
+from .common import validate_release_metadata
 from .feeds.publisher import FeedPublisher
 from .feeds.render import render_browser_appcast
 from .feeds.spec import browser_feeds_for_product
@@ -28,12 +29,22 @@ class AppcastModule(Step):
         product_id: str = "browseros",
         publish: bool = False,
         allow_downgrade: bool = False,
+        platforms: str | None = None,
+        macos_arch: str = "universal",
+        source_sha: str = "",
+        workflow_run_id: str = "",
+        workflow_run_attempt: str = "",
         publisher=None,
         fetch_metadata=None,
     ):
         self.product_id = product_id
         self.publish = publish
         self.allow_downgrade = allow_downgrade
+        self.platforms = platforms
+        self.macos_arch = macos_arch
+        self.source_sha = source_sha
+        self.workflow_run_id = workflow_run_id
+        self.workflow_run_attempt = workflow_run_attempt
         self._publisher = publisher
         self._fetch_metadata = fetch_metadata or fetch_all_release_metadata
 
@@ -69,6 +80,17 @@ class AppcastModule(Step):
             raise RuntimeError(
                 f"No release metadata found for version {version} "
                 f"(product {self.product_id})"
+            )
+        if self.platforms is not None:
+            metadata = validate_release_metadata(
+                metadata,
+                version=version,
+                product_id=self.product_id,
+                platforms=self.platforms,
+                macos_arch=self.macos_arch,
+                source_sha=self.source_sha,
+                workflow_run_id=self.workflow_run_id,
+                workflow_run_attempt=self.workflow_run_attempt,
             )
 
         publisher = self._publisher or FeedPublisher(env=ctx.env)

--- a/packages/browseros/bos_build/release/appcast_test.py
+++ b/packages/browseros/bos_build/release/appcast_test.py
@@ -160,6 +160,101 @@ class AppcastModuleTest(unittest.TestCase):
             [c.key for c in self.publisher.calls], ["appcast-claw.xml"]
         )
 
+    def test_all_universal_contract_renders_exactly_three_browserclaw_feeds(self):
+        metadata = {
+            "macos": {
+                **_macos_release("arm64", "x64", "universal"),
+                "product": "browserclaw",
+                "version": "0.47.0.2",
+                "platform": "macos",
+                "source_sha": "a" * 40,
+                "workflow_run_id": "123",
+                "workflow_run_attempt": "1",
+            },
+            "win": {
+                **_win_release("x64_installer"),
+                "product": "browserclaw",
+                "version": "0.47.0.2",
+                "platform": "win",
+                "source_sha": "a" * 40,
+                "workflow_run_id": "123",
+                "workflow_run_attempt": "1",
+                "artifacts": {
+                    **_win_release("x64_installer")["artifacts"],
+                    "x64_zip": _artifact(
+                        "BrowserClaw_v0.47.0.2_x64_installer.zip"
+                    ),
+                },
+            },
+            "linux": {
+                "product": "browserclaw",
+                "version": "0.47.0.2",
+                "platform": "linux",
+                "source_sha": "a" * 40,
+                "workflow_run_id": "123",
+                "workflow_run_attempt": "1",
+                "artifacts": {
+                    "x64_appimage": _artifact(
+                        "BrowserClaw_v0.47.0.2_x64.AppImage"
+                    ),
+                    "x64_deb": _artifact(
+                        "BrowserClaw_v0.47.0.2_amd64.deb"
+                    ),
+                },
+            },
+        }
+        module = self._module(
+            metadata,
+            product_id="browserclaw",
+            platforms="all",
+            macos_arch="universal",
+            source_sha="a" * 40,
+            workflow_run_id="123",
+            workflow_run_attempt="1",
+        )
+
+        module.execute(self._ctx())
+
+        self.assertEqual(
+            [call.key for call in self.publisher.calls],
+            [
+                "appcast-claw.xml",
+                "appcast-claw-x86_64.xml",
+                "appcast-claw-win.xml",
+            ],
+        )
+
+    def test_contract_rejects_stale_release_metadata_before_rendering(self):
+        metadata = {
+            "win": {
+                **_win_release("x64_installer"),
+                "product": "browseros",
+                "version": "0.47.0.2",
+                "platform": "win",
+                "source_sha": "old",
+                "workflow_run_id": "122",
+                "workflow_run_attempt": "1",
+                "artifacts": {
+                    **_win_release("x64_installer")["artifacts"],
+                    "x64_zip": _artifact(
+                        "BrowserOS_v0.47.0.2_x64_installer.zip"
+                    ),
+                },
+            },
+        }
+        module = self._module(
+            metadata,
+            platforms="windows",
+            source_sha="new",
+            workflow_run_id="123",
+            workflow_run_attempt="1",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "source_sha"):
+            module.execute(self._ctx())
+
+        self.assertEqual(self.publisher.calls, [])
+
     def test_validate_refuses_publishing_unpublishable_feed(self):
         # Every real product now has a client, so synthesize an unpublishable
         # feed set to exercise the gate itself.

--- a/packages/browseros/bos_build/release/common.py
+++ b/packages/browseros/bos_build/release/common.py
@@ -13,6 +13,127 @@ from ..lib.r2 import get_release_json, get_r2_client, BOTO3_AVAILABLE
 
 PLATFORMS = ["macos", "win", "linux"]
 PLATFORM_DISPLAY_NAMES = {"macos": "macOS", "win": "Windows", "linux": "Linux"}
+_PLATFORM_ALIASES = {
+    "linux": "linux",
+    "macos": "macos",
+    "win": "win",
+    "windows": "win",
+}
+_PROVENANCE_FIELDS = (
+    "source_sha",
+    "workflow_run_id",
+    "workflow_run_attempt",
+)
+
+
+def selected_release_platforms(platforms: str) -> Tuple[str, ...]:
+    """Map a workflow platform selection to release.json platform keys."""
+    if platforms == "all":
+        return tuple(PLATFORMS)
+    try:
+        return (_PLATFORM_ALIASES[platforms],)
+    except KeyError as exc:
+        valid = ", ".join(("all", *sorted(_PLATFORM_ALIASES)))
+        raise ValueError(
+            f"Unknown release platform selection '{platforms}'. Valid: {valid}"
+        ) from exc
+
+
+def expected_browser_artifact_keys(
+    platforms: str,
+    macos_arch: str,
+) -> Dict[str, set[str]]:
+    """Exact browser artifact keys selected by the top-level release inputs."""
+    expected: Dict[str, set[str]] = {}
+    for platform in selected_release_platforms(platforms):
+        if platform == "linux":
+            expected[platform] = {"x64_appimage", "x64_deb"}
+        elif platform == "win":
+            expected[platform] = {"x64_installer", "x64_zip"}
+        elif macos_arch == "universal":
+            expected[platform] = {"arm64", "x64", "universal"}
+        elif macos_arch in ("arm64", "x64"):
+            expected[platform] = {macos_arch}
+        else:
+            raise ValueError(
+                f"Unknown macOS architecture '{macos_arch}'. "
+                "Valid: arm64, x64, universal"
+            )
+    return expected
+
+
+def validate_release_metadata(
+    metadata: Dict[str, Dict],
+    *,
+    version: str,
+    product_id: str,
+    platforms: str,
+    macos_arch: str,
+    source_sha: str = "",
+    workflow_run_id: str = "",
+    workflow_run_attempt: str = "",
+) -> Dict[str, Dict]:
+    """Select and validate the exact R2 metadata for one release invocation."""
+    expected = expected_browser_artifact_keys(platforms, macos_arch)
+    provenance = {
+        "source_sha": source_sha,
+        "workflow_run_id": workflow_run_id,
+        "workflow_run_attempt": workflow_run_attempt,
+    }
+    selected: Dict[str, Dict] = {}
+
+    for platform, expected_keys in expected.items():
+        release = metadata.get(platform)
+        if release is None:
+            raise RuntimeError(
+                f"Missing {platform} release metadata for {product_id} v{version}"
+            )
+
+        identity = {
+            "product": product_id,
+            "version": version,
+            "platform": platform,
+        }
+        for field, expected_value in identity.items():
+            if str(release.get(field, "")) != expected_value:
+                raise RuntimeError(
+                    f"{platform} release metadata {field} mismatch: "
+                    f"expected {expected_value!r}, got {release.get(field)!r}"
+                )
+
+        for field in _PROVENANCE_FIELDS:
+            expected_value = provenance[field]
+            if expected_value and str(release.get(field, "")) != expected_value:
+                raise RuntimeError(
+                    f"{platform} release metadata {field} mismatch: "
+                    f"expected {expected_value!r}, got {release.get(field)!r}"
+                )
+
+        artifacts = release.get("artifacts")
+        if not isinstance(artifacts, dict):
+            raise RuntimeError(
+                f"{platform} release metadata artifacts is not an object"
+            )
+        actual_keys = set(artifacts)
+        if actual_keys != expected_keys:
+            raise RuntimeError(
+                f"{platform} release metadata artifact keys mismatch: "
+                f"expected {sorted(expected_keys)}, got {sorted(actual_keys)}"
+            )
+        for key, artifact in artifacts.items():
+            if (
+                not isinstance(artifact, dict)
+                or not artifact.get("filename")
+                or not artifact.get("url")
+            ):
+                raise RuntimeError(
+                    f"{platform} release metadata artifact {key!r} "
+                    "must include filename and url"
+                )
+
+        selected[platform] = release
+
+    return selected
 
 
 def get_download_path_mapping(
@@ -203,15 +324,20 @@ def generate_appcast_item(
 </item>"""
 
 
-def generate_release_notes(version: str, metadata: Dict[str, Dict]) -> str:
+def generate_release_notes(
+    version: str,
+    metadata: Dict[str, Dict],
+    product: Optional[ProductDescriptor] = None,
+) -> str:
     """Generate markdown release notes from metadata"""
+    product = product or default_product_descriptor()
     chromium_version = "unknown"
     for platform in PLATFORMS:
         if platform in metadata:
             chromium_version = metadata[platform].get("chromium_version", "unknown")
             break
 
-    notes = f"""## BrowserOS v{version}
+    notes = f"""## {product.display_name} v{version}
 
 Chromium version: {chromium_version}
 

--- a/packages/browseros/bos_build/release/common_test.py
+++ b/packages/browseros/bos_build/release/common_test.py
@@ -10,10 +10,12 @@ from ..core.products import get_product_descriptor
 from ..lib.env import EnvConfig
 from . import common
 from .common import (
+    generate_release_notes,
     generate_appcast_item,
     get_download_path_mapping,
     list_all_versions,
     list_legacy_versions,
+    validate_release_metadata,
 )
 
 ARTIFACT = {
@@ -46,6 +48,120 @@ class GenerateAppcastItemTest(unittest.TestCase):
             item,
         )
         self.assertNotIn("sparkle:os=", item)
+
+
+def _release_metadata(
+    platform: str,
+    artifact_keys: set[str],
+    *,
+    product: str = "browserclaw",
+    version: str = "0.49.0",
+    source_sha: str = "a" * 40,
+    run_id: str = "123",
+    run_attempt: str = "1",
+) -> dict:
+    prefix = "BrowserClaw" if product == "browserclaw" else "BrowserOS"
+    return {
+        "product": product,
+        "version": version,
+        "platform": platform,
+        "source_sha": source_sha,
+        "workflow_run_id": run_id,
+        "workflow_run_attempt": run_attempt,
+        "artifacts": {
+            key: {
+                "filename": f"{prefix}_{key}",
+                "url": f"https://cdn.browseros.com/{prefix}_{key}",
+            }
+            for key in artifact_keys
+        },
+    }
+
+
+class ReleaseContractTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.metadata = {
+            "macos": _release_metadata(
+                "macos",
+                {"arm64", "x64", "universal"},
+            ),
+            "win": _release_metadata(
+                "win",
+                {"x64_installer", "x64_zip"},
+            ),
+            "linux": _release_metadata(
+                "linux",
+                {"x64_appimage", "x64_deb"},
+            ),
+        }
+
+    def test_all_universal_contract_selects_exactly_seven_current_run_assets(self):
+        selected = validate_release_metadata(
+            self.metadata,
+            version="0.49.0",
+            product_id="browserclaw",
+            platforms="all",
+            macos_arch="universal",
+            source_sha="a" * 40,
+            workflow_run_id="123",
+            workflow_run_attempt="1",
+        )
+
+        self.assertEqual(set(selected), {"macos", "win", "linux"})
+        self.assertEqual(
+            sum(len(release["artifacts"]) for release in selected.values()),
+            7,
+        )
+
+    def test_stale_run_provenance_is_rejected(self):
+        with self.assertRaisesRegex(RuntimeError, "workflow_run_id"):
+            validate_release_metadata(
+                self.metadata,
+                version="0.49.0",
+                product_id="browserclaw",
+                platforms="all",
+                macos_arch="universal",
+                source_sha="a" * 40,
+                workflow_run_id="999",
+                workflow_run_attempt="1",
+            )
+
+    def test_missing_or_extra_artifact_keys_are_rejected(self):
+        del self.metadata["win"]["artifacts"]["x64_zip"]
+        self.metadata["win"]["artifacts"]["arm64_zip"] = {
+            "filename": "stale.zip",
+            "url": "https://cdn.browseros.com/stale.zip",
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "artifact keys"):
+            validate_release_metadata(
+                self.metadata,
+                version="0.49.0",
+                product_id="browserclaw",
+                platforms="all",
+                macos_arch="universal",
+            )
+
+    def test_partial_platform_contract_excludes_stale_other_platforms(self):
+        selected = validate_release_metadata(
+            self.metadata,
+            version="0.49.0",
+            product_id="browserclaw",
+            platforms="windows",
+            macos_arch="universal",
+        )
+
+        self.assertEqual(set(selected), {"win"})
+
+    def test_release_notes_use_product_display_name(self):
+        notes = generate_release_notes(
+            "0.49.0",
+            {"win": self.metadata["win"]},
+            get_product_descriptor("browserclaw"),
+        )
+
+        self.assertIn("## BrowserClaw v0.49.0", notes)
+        self.assertNotIn("## BrowserOS v", notes)
 
 
 # Golden copy of the pre-productization DOWNLOAD_PATH_MAPPING constant —

--- a/packages/browseros/bos_build/release/feeds/publisher.py
+++ b/packages/browseros/bos_build/release/feeds/publisher.py
@@ -20,6 +20,7 @@ from ...lib.paths import get_package_root
 from ...lib.r2 import get_r2_client
 from ...lib.utils import log_error, log_info, log_success, log_warning
 from .render import (
+    SPARKLE_NS,
     extract_appcast_item_count,
     extract_appcast_version,
     extract_channel_metadata,
@@ -59,6 +60,50 @@ def _has_single_direct_channel(root: ET.Element) -> bool:
         and channels[0] in list(root)
         and _xml_local_name(channels[0].tag) == "channel"
     )
+
+
+def _strict_appcast_versions(content: str) -> Optional[List[str]]:
+    """Return every direct item's strict Sparkle version, or None if unsafe."""
+    try:
+        root = ET.fromstring(content)
+    except ET.ParseError:
+        return None
+    if root.tag != "rss" or not _has_single_direct_channel(root):
+        return None
+
+    channel = next(
+        element
+        for element in root
+        if _xml_local_name(element.tag) == "channel"
+    )
+    direct_items = [
+        element
+        for element in channel
+        if _xml_local_name(element.tag) == "item"
+    ]
+    all_items = [
+        element
+        for element in root.iter()
+        if _xml_local_name(element.tag) == "item"
+    ]
+    if len(all_items) != len(direct_items) or any(
+        item not in direct_items for item in all_items
+    ):
+        return None
+
+    versions: List[str] = []
+    version_tag = f"{{{SPARKLE_NS}}}version"
+    for item in direct_items:
+        version_elements = [
+            element for element in item if element.tag == version_tag
+        ]
+        if len(version_elements) != 1:
+            return None
+        value = version_elements[0].text
+        if _strict_dotted_version(value) is None:
+            return None
+        versions.append(value.strip())
+    return versions
 
 
 def _is_empty_appcast_shell(content: str) -> bool:
@@ -215,13 +260,13 @@ class FeedPublisher:
         if not self._check_channel_metadata(spec, content):
             return False
 
-        # A single-item appcast must carry its version even on a first
-        # publish to an absent key — the guard below only runs against live.
-        if spec.kind in ("browser", "server") and _strict_dotted_version(
-            extract_appcast_version(content)
-        ) is None:
-            self._log_appcast_version_error(spec, content)
-            return False
+        # Every appcast item must carry exactly one strict version, even on a
+        # first publish to an absent key — the guard below only runs live.
+        if spec.kind in ("browser", "server"):
+            new_versions = _strict_appcast_versions(content)
+            if not new_versions:
+                self._log_appcast_version_error(spec, content)
+                return False
 
         if not self._check_download_urls(spec, content):
             return False
@@ -358,10 +403,14 @@ class FeedPublisher:
     def _guard_appcast_version(
         self, spec: FeedSpec, content: str, live: str, allow_downgrade: bool
     ) -> bool:
-        new_version = extract_appcast_version(content)
-        if _strict_dotted_version(new_version) is None:
+        new_versions = _strict_appcast_versions(content)
+        if not new_versions:
             self._log_appcast_version_error(spec, content)
             return False
+        new_version = max(
+            new_versions,
+            key=lambda value: tuple(int(part) for part in value.split(".")),
+        )
 
         if not self._check_well_formed(spec, live):
             return False
@@ -378,8 +427,8 @@ class FeedPublisher:
         if not self._check_channel_metadata(spec, live):
             return False
 
-        live_version = extract_appcast_version(live)
-        if _strict_dotted_version(live_version) is None:
+        live_versions = _strict_appcast_versions(live)
+        if not live_versions:
             if _is_empty_appcast_shell(live):
                 log_info(
                     f"{spec.key}: live appcast is an empty shell "
@@ -387,6 +436,10 @@ class FeedPublisher:
                 )
                 return True
             return self._refuse_unguardable_live(spec, allow_downgrade)
+        live_version = max(
+            live_versions,
+            key=lambda value: tuple(int(part) for part in value.split(".")),
+        )
 
         return self._refuse_downgrade(
             spec, f"{spec.key}", new_version, live_version, allow_downgrade
@@ -398,14 +451,21 @@ class FeedPublisher:
             return
         version = extract_appcast_version(content)
         if version is not None:
+            if _strict_dotted_version(version) is None:
+                log_error(
+                    f"{spec.key}: new content has invalid sparkle:version "
+                    f"{version!r}; expected numeric dotted components"
+                )
+                return
             log_error(
-                f"{spec.key}: new content has invalid sparkle:version "
-                f"{version!r}; expected numeric dotted components"
+                f"{spec.key}: every direct <item> must contain exactly one "
+                "numeric dotted sparkle:version"
             )
-            return
-        log_error(
-            f"{spec.key}: new content has <item> entries but no sparkle:version"
-        )
+        else:
+            log_error(
+                f"{spec.key}: new content has <item> entries but no "
+                "sparkle:version"
+            )
 
     def _guard_manifest_versions(
         self, spec: FeedSpec, content: str, live: str, allow_downgrade: bool

--- a/packages/browseros/bos_build/release/feeds/publisher.py
+++ b/packages/browseros/bos_build/release/feeds/publisher.py
@@ -33,6 +33,34 @@ BACKUP_PREFIX = "feeds-history"
 _TIMESTAMP_FORMAT = "%Y%m%dT%H%M%SZ"
 
 
+def _xml_local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _strict_dotted_version(value: Optional[str]) -> Optional[tuple[int, ...]]:
+    """Parse only a nonempty sequence of numeric dotted components."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    parts = stripped.split(".")
+    if not stripped or any(not part.isdigit() for part in parts):
+        return None
+    return tuple(int(part) for part in parts)
+
+
+def _has_single_direct_channel(root: ET.Element) -> bool:
+    channels = [
+        element
+        for element in root.iter()
+        if _xml_local_name(element.tag) == "channel"
+    ]
+    return (
+        len(channels) == 1
+        and channels[0] in list(root)
+        and _xml_local_name(channels[0].tag) == "channel"
+    )
+
+
 def _is_empty_appcast_shell(content: str) -> bool:
     """Whether content is an unambiguously unpopulated RSS appcast.
 
@@ -47,14 +75,32 @@ def _is_empty_appcast_shell(content: str) -> bool:
         return False
     if root.tag != "rss":
         return False
-    channel = root.find("channel")
-    if channel is None:
+    if not _has_single_direct_channel(root):
+        return False
+    channel = next(
+        element
+        for element in root
+        if _xml_local_name(element.tag) == "channel"
+    )
+    direct_items = [
+        element
+        for element in channel
+        if _xml_local_name(element.tag) == "item"
+    ]
+    all_items = [
+        element
+        for element in root.iter()
+        if _xml_local_name(element.tag) == "item"
+    ]
+    if len(all_items) != len(direct_items) or any(
+        item not in direct_items for item in all_items
+    ):
         return False
     return all(
         not item.attrib
         and not list(item)
         and not (item.text or "").strip()
-        for item in channel.findall("item")
+        for item in direct_items
     )
 
 
@@ -171,10 +217,9 @@ class FeedPublisher:
 
         # A single-item appcast must carry its version even on a first
         # publish to an absent key — the guard below only runs against live.
-        if (
-            spec.kind in ("browser", "server")
-            and extract_appcast_version(content) is None
-        ):
+        if spec.kind in ("browser", "server") and _strict_dotted_version(
+            extract_appcast_version(content)
+        ) is None:
             self._log_appcast_version_error(spec, content)
             return False
 
@@ -314,15 +359,28 @@ class FeedPublisher:
         self, spec: FeedSpec, content: str, live: str, allow_downgrade: bool
     ) -> bool:
         new_version = extract_appcast_version(content)
-        if new_version is None:
+        if _strict_dotted_version(new_version) is None:
             self._log_appcast_version_error(spec, content)
             return False
 
+        if not self._check_well_formed(spec, live):
+            return False
+        try:
+            live_root = ET.fromstring(live)
+        except ET.ParseError:
+            return False
+        if not _has_single_direct_channel(live_root):
+            log_error(
+                f"{spec.key}: live appcast must contain exactly one direct "
+                "<channel>; refusing to publish."
+            )
+            return False
+        if not self._check_channel_metadata(spec, live):
+            return False
+
         live_version = extract_appcast_version(live)
-        if live_version is None:
+        if _strict_dotted_version(live_version) is None:
             if _is_empty_appcast_shell(live):
-                if not self._check_channel_metadata(spec, live):
-                    return False
                 log_info(
                     f"{spec.key}: live appcast is an empty shell "
                     "(first population)"
@@ -337,6 +395,13 @@ class FeedPublisher:
     def _log_appcast_version_error(self, spec: FeedSpec, content: str) -> None:
         if extract_appcast_item_count(content) == 0:
             log_error(f"{spec.key}: new content has no <item> entries")
+            return
+        version = extract_appcast_version(content)
+        if version is not None:
+            log_error(
+                f"{spec.key}: new content has invalid sparkle:version "
+                f"{version!r}; expected numeric dotted components"
+            )
             return
         log_error(
             f"{spec.key}: new content has <item> entries but no sparkle:version"

--- a/packages/browseros/bos_build/release/feeds/publisher.py
+++ b/packages/browseros/bos_build/release/feeds/publisher.py
@@ -33,6 +33,31 @@ BACKUP_PREFIX = "feeds-history"
 _TIMESTAMP_FORMAT = "%Y%m%dT%H%M%SZ"
 
 
+def _is_empty_appcast_shell(content: str) -> bool:
+    """Whether content is an unambiguously unpopulated RSS appcast.
+
+    BrowserClaw's Windows feeds were provisioned before their first release
+    with one whitespace-only ``<item>``.  Treat that shape, and the equivalent
+    shell with no items, as first publication.  Any item attributes, text, or
+    children make the live document meaningful and therefore unguardable.
+    """
+    try:
+        root = ET.fromstring(content)
+    except ET.ParseError:
+        return False
+    if root.tag != "rss":
+        return False
+    channel = root.find("channel")
+    if channel is None:
+        return False
+    return all(
+        not item.attrib
+        and not list(item)
+        and not (item.text or "").strip()
+        for item in channel.findall("item")
+    )
+
+
 def _default_http_head(url: str) -> int:
     import requests
 
@@ -295,6 +320,14 @@ class FeedPublisher:
 
         live_version = extract_appcast_version(live)
         if live_version is None:
+            if _is_empty_appcast_shell(live):
+                if not self._check_channel_metadata(spec, live):
+                    return False
+                log_info(
+                    f"{spec.key}: live appcast is an empty shell "
+                    "(first population)"
+                )
+                return True
             return self._refuse_unguardable_live(spec, allow_downgrade)
 
         return self._refuse_downgrade(

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -88,6 +88,13 @@ def _empty_mac_appcast():
 """
 
 
+def _empty_item_mac_appcast():
+    return _empty_mac_appcast().replace(
+        "  </channel>",
+        "    <item>\n    </item>\n  </channel>",
+    )
+
+
 class PublisherTestCase(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
@@ -170,6 +177,72 @@ class PublisherTestCase(unittest.TestCase):
         self.assertEqual(
             self.client.calls, [("put", "appcast.xml", "application/xml")]
         )
+
+    def test_empty_live_shell_is_valid_first_population(self):
+        publisher = self._publisher(
+            {"appcast.xml": _empty_mac_appcast().encode()}
+        )
+
+        ok = publisher.publish(feed_by_key("appcast.xml"), _mac_appcast())
+
+        self.assertTrue(ok)
+        self.assertEqual(self.client.calls, [])
+        self.assertEqual(
+            (self.appcast_staging / "appcast.xml").read_text(),
+            _mac_appcast(),
+        )
+
+    def test_empty_live_item_is_backed_up_before_first_population(self):
+        publisher = self._publisher(
+            {"appcast.xml": _empty_item_mac_appcast().encode()}
+        )
+
+        ok = publisher.publish(
+            feed_by_key("appcast.xml"),
+            _mac_appcast(),
+            publish=True,
+        )
+
+        self.assertTrue(ok)
+        self.assertEqual(
+            self.client.calls,
+            [
+                ("copy", "appcast.xml", "feeds-history/appcast.xml.20260701T120000Z"),
+                ("put", "appcast.xml", "application/xml"),
+            ],
+        )
+
+    def test_wrong_channel_empty_live_shell_fails_closed(self):
+        live = _empty_item_mac_appcast().replace(
+            "https://cdn.browseros.com/appcast.xml",
+            "https://cdn.browseros.com/appcast-claw.xml",
+        )
+        publisher = self._publisher({"appcast.xml": live.encode()})
+
+        ok = publisher.publish(
+            feed_by_key("appcast.xml"),
+            _mac_appcast(),
+            publish=True,
+        )
+
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
+
+    def test_populated_versionless_live_appcast_fails_closed(self):
+        live = _mac_appcast().replace(
+            "<sparkle:version>10000.0.47.0.2</sparkle:version>",
+            "",
+        )
+        publisher = self._publisher({"appcast.xml": live.encode()})
+
+        ok = publisher.publish(
+            feed_by_key("appcast.xml"),
+            _mac_appcast("10000.0.48.0.0"),
+            publish=True,
+        )
+
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
 
     def test_downgrade_refused_without_flag(self):
         publisher = self._publisher(

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -244,6 +244,75 @@ class PublisherTestCase(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(self.client.calls, [])
 
+    def test_duplicate_channel_with_populated_item_is_not_an_empty_shell(self):
+        populated_channel = _mac_appcast().split("<channel>", 1)[1].split(
+            "</channel>", 1
+        )[0]
+        live = _empty_mac_appcast().replace(
+            "</rss>",
+            f"  <channel>{populated_channel}</channel>\n</rss>",
+        )
+        publisher = self._publisher({"appcast.xml": live.encode()})
+
+        ok = publisher.publish(
+            feed_by_key("appcast.xml"),
+            _mac_appcast("10000.0.48.0.0"),
+            publish=True,
+        )
+
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
+
+    def test_item_outside_the_single_channel_is_not_an_empty_shell(self):
+        live = _empty_mac_appcast().replace(
+            "</rss>",
+            "<item><title>meaningful old release</title></item>\n</rss>",
+        )
+        publisher = self._publisher({"appcast.xml": live.encode()})
+
+        ok = publisher.publish(
+            feed_by_key("appcast.xml"),
+            _mac_appcast("10000.0.48.0.0"),
+            publish=True,
+        )
+
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
+
+    def test_malformed_live_appcast_version_fails_closed(self):
+        for live_version in ("garbage", "10000.0.beta"):
+            with self.subTest(live_version=live_version):
+                live = _mac_appcast().replace(
+                    "10000.0.47.0.2",
+                    live_version,
+                )
+                publisher = self._publisher({"appcast.xml": live.encode()})
+
+                ok = publisher.publish(
+                    feed_by_key("appcast.xml"),
+                    _mac_appcast("10000.0.48.0.0"),
+                    publish=True,
+                )
+
+                self.assertFalse(ok)
+                self.assertEqual(self.client.calls, [])
+
+    def test_populated_wrong_channel_live_appcast_fails_closed(self):
+        live = _mac_appcast("10000.0.46.0.0").replace(
+            "<title>BrowserOS</title>",
+            "<title>BrowserClaw</title>",
+        )
+        publisher = self._publisher({"appcast.xml": live.encode()})
+
+        ok = publisher.publish(
+            feed_by_key("appcast.xml"),
+            _mac_appcast(),
+            publish=True,
+        )
+
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
+
     def test_downgrade_refused_without_flag(self):
         publisher = self._publisher(
             {"appcast.xml": _mac_appcast("10000.0.48.0.0").encode()}
@@ -490,7 +559,7 @@ class PublisherTestCase(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(self.client.calls, [])
 
-    def test_unparseable_live_replaced_with_flag_after_backup(self):
+    def test_unparseable_live_remains_blocked_with_override(self):
         publisher = self._publisher({"appcast.xml": b"garbage <not xml"})
 
         ok = publisher.publish(
@@ -500,9 +569,8 @@ class PublisherTestCase(unittest.TestCase):
             allow_downgrade=True,
         )
 
-        self.assertTrue(ok)
-        self.assertEqual(self.client.calls[0][0], "copy")
-        self.assertEqual(self.client.calls[1][0], "put")
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
 
     def test_extensions_json_for_wrong_channel_refused(self):
         publisher = self._publisher()

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -297,6 +297,48 @@ class PublisherTestCase(unittest.TestCase):
                 self.assertFalse(ok)
                 self.assertEqual(self.client.calls, [])
 
+    def test_every_populated_live_item_requires_one_strict_version(self):
+        bad_items = (
+            (
+                "malformed",
+                "<item><sparkle:version>garbage</sparkle:version></item>",
+            ),
+            ("versionless", "<item><title>old release</title></item>"),
+        )
+        for label, bad_item in bad_items:
+            with self.subTest(item=label):
+                live = _mac_appcast("10000.0.46.0.0").replace(
+                    "  </channel>",
+                    f"    {bad_item}\n  </channel>",
+                )
+                publisher = self._publisher({"appcast.xml": live.encode()})
+
+                ok = publisher.publish(
+                    feed_by_key("appcast.xml"),
+                    _mac_appcast("10000.0.48.0.0"),
+                    publish=True,
+                )
+
+                self.assertFalse(ok)
+                self.assertEqual(self.client.calls, [])
+
+    def test_every_new_appcast_item_requires_one_strict_version(self):
+        content = _mac_appcast().replace(
+            "  </channel>",
+            "    <item><title>versionless</title></item>\n  </channel>",
+        )
+        publisher = self._publisher()
+
+        ok = publisher.publish(
+            feed_by_key("appcast.xml"),
+            content,
+            publish=True,
+            allow_downgrade=True,
+        )
+
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
+
     def test_populated_wrong_channel_live_appcast_fails_closed(self):
         live = _mac_appcast("10000.0.46.0.0").replace(
             "<title>BrowserOS</title>",

--- a/packages/browseros/bos_build/release/github.py
+++ b/packages/browseros/bos_build/release/github.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """GitHub module - Create GitHub releases from R2 artifacts"""
 
+import json
 import subprocess
 import tempfile
 from pathlib import Path
@@ -23,7 +24,7 @@ from .common import (
 
 
 def create_github_release(
-    version: str,
+    tag: str,
     repo: str,
     title: str,
     notes: str,
@@ -35,7 +36,7 @@ def create_github_release(
         "gh",
         "release",
         "create",
-        f"v{version}",
+        tag,
         "--repo",
         repo,
         "--title",
@@ -52,9 +53,11 @@ def create_github_release(
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
         return True, result.stdout.strip()
     except subprocess.CalledProcessError as e:
-        if "already exists" in e.stderr:
-            return False, f"Release v{version} already exists"
-        return False, e.stderr
+        stderr = e.stderr or str(e)
+        normalized_error = stderr.lower().replace("_", " ")
+        if "already exist" in normalized_error:
+            return False, f"Release {tag} already exists"
+        return False, stderr
 
 
 def download_file(url: str, dest: Path) -> bool:
@@ -70,11 +73,11 @@ def download_file(url: str, dest: Path) -> bool:
         return False
 
 
-def upload_to_github_release(version: str, repo: str, file_path: Path) -> bool:
+def upload_to_github_release(tag: str, repo: str, file_path: Path) -> bool:
     """Upload file to existing GitHub release"""
     try:
         subprocess.run(
-            ["gh", "release", "upload", f"v{version}", str(file_path), "--repo", repo],
+            ["gh", "release", "upload", tag, str(file_path), "--repo", repo],
             check=True,
             capture_output=True,
         )
@@ -91,8 +94,87 @@ def normalize_version(version: str) -> str:
     return version
 
 
+def github_release_tag(version: str, product_id: str) -> str:
+    """Return the product-owned Git tag for a browser release."""
+    normalized = normalize_version(version)
+    if product_id == "browseros":
+        return f"v{normalized}"
+    return f"{product_id}/v{normalized}"
+
+
+def inspect_github_release(tag: str, repo: str) -> Dict:
+    """Read a release or raise; callers must never treat API failure as absence."""
+    result = subprocess.run(
+        [
+            "gh",
+            "release",
+            "view",
+            tag,
+            "--repo",
+            repo,
+            "--json",
+            "isDraft,assets,targetCommitish",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    document = json.loads(result.stdout)
+    document["assets"] = [
+        asset["name"]
+        for asset in document.get("assets", [])
+        if isinstance(asset, dict) and asset.get("name")
+    ]
+    return document
+
+
+def edit_github_release(
+    tag: str,
+    repo: str,
+    title: str,
+    notes: str,
+) -> None:
+    """Refresh release presentation after validating draft ownership."""
+    subprocess.run(
+        [
+            "gh",
+            "release",
+            "edit",
+            tag,
+            "--repo",
+            repo,
+            "--title",
+            title,
+            "--notes",
+            notes,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def delete_github_release_asset(tag: str, repo: str, asset: str) -> None:
+    """Delete one stale asset from a validated draft release."""
+    subprocess.run(
+        [
+            "gh",
+            "release",
+            "delete-asset",
+            tag,
+            asset,
+            "--repo",
+            repo,
+            "--yes",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
 def download_and_upload_artifacts(
-    version: str,
+    tag: str,
     repo: str,
     metadata: Dict[str, Dict],
     platforms: Optional[List[str]] = None,
@@ -122,7 +204,7 @@ def download_and_upload_artifacts(
                     continue
 
                 log_info(f"  Uploading {filename}...")
-                if upload_to_github_release(version, repo, local_path):
+                if upload_to_github_release(tag, repo, local_path):
                     log_success(f"  Uploaded {filename}")
                     results.append((filename, True))
                 else:
@@ -190,6 +272,7 @@ class GithubModule(Step):
     def execute(self, ctx: Context) -> None:
         version = ctx.release_version
         tag_version = normalize_version(version)
+        tag = github_release_tag(tag_version, ctx.product.id)
         repo = ctx.github_repo
 
         metadata = fetch_all_release_metadata(version, ctx.env, ctx.product.id)
@@ -208,7 +291,7 @@ class GithubModule(Step):
             )
 
         log_info(f"\n{'='*60}")
-        log_info(f"Creating GitHub Release: v{tag_version}")
+        log_info(f"Creating GitHub Release: {tag}")
         log_info(f"{'='*60}")
 
         for platform, release in metadata.items():
@@ -219,12 +302,12 @@ class GithubModule(Step):
         log_info(f"  Draft: {self.draft}")
 
         # Create release
-        release_title = self.title or f"v{tag_version}"
+        release_title = self.title or f"{ctx.product.display_name} v{tag_version}"
         notes = generate_release_notes(tag_version, metadata, ctx.product)
 
         log_info("\nCreating GitHub release...")
         success, result = create_github_release(
-            tag_version,
+            tag,
             repo,
             release_title,
             notes,
@@ -237,6 +320,31 @@ class GithubModule(Step):
         else:
             if "already exists" in result:
                 log_warning(result)
+                try:
+                    existing = inspect_github_release(tag, repo)
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Could not inspect existing release {tag}: {exc}"
+                    ) from exc
+                if existing.get("isDraft") is not True:
+                    raise RuntimeError(
+                        f"Release {tag} already exists and is not a draft; "
+                        "refusing to modify live release assets"
+                    )
+                if self.platforms is not None:
+                    for asset in existing.get("assets", []):
+                        try:
+                            delete_github_release_asset(tag, repo, asset)
+                        except Exception as exc:
+                            raise RuntimeError(
+                                f"Failed to delete stale draft asset {asset}: {exc}"
+                            ) from exc
+                try:
+                    edit_github_release(tag, repo, release_title, notes)
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Failed to refresh draft release {tag}: {exc}"
+                    ) from exc
             else:
                 raise RuntimeError(f"Failed to create release: {result}")
 
@@ -244,7 +352,7 @@ class GithubModule(Step):
         if not self.skip_upload:
             log_info("\nUploading artifacts to GitHub release...")
             results = download_and_upload_artifacts(
-                tag_version,
+                tag,
                 repo,
                 metadata,
                 platforms=list(metadata),
@@ -255,6 +363,29 @@ class GithubModule(Step):
             failed = [f for f, ok in results if not ok]
             if failed:
                 raise RuntimeError(f"Failed to upload: {', '.join(failed)}")
+            if self.platforms is not None:
+                expected_assets = {
+                    artifact["filename"]
+                    for release in metadata.values()
+                    for artifact in release["artifacts"].values()
+                }
+                try:
+                    final_release = inspect_github_release(tag, repo)
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Could not verify release assets for {tag}: {exc}"
+                    ) from exc
+                if final_release.get("isDraft") is not True:
+                    raise RuntimeError(
+                        f"Release {tag} is no longer a draft; refusing to "
+                        "accept the asset upload"
+                    )
+                actual_assets = set(final_release.get("assets", []))
+                if actual_assets != expected_assets:
+                    raise RuntimeError(
+                        f"Release {tag} asset set mismatch: expected "
+                        f"{sorted(expected_assets)}, got {sorted(actual_assets)}"
+                    )
 
         # Print appcast snippet
         if "macos" in metadata:
@@ -275,4 +406,4 @@ class GithubModule(Step):
                     print(generate_appcast_item(artifact, tag_version, sparkle_version, build_date))
 
         log_info(f"\n{'='*60}")
-        log_success(f"Release v{tag_version} complete!")
+        log_success(f"Release {tag} complete!")

--- a/packages/browseros/bos_build/release/github.py
+++ b/packages/browseros/bos_build/release/github.py
@@ -2,10 +2,12 @@
 """GitHub module - Create GitHub releases from R2 artifacts"""
 
 import json
+import re
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+from urllib.parse import quote
 
 from ..core.context import Context
 from ..core.step import Step, ValidationError
@@ -126,6 +128,80 @@ def inspect_github_release(tag: str, repo: str) -> Dict:
         if isinstance(asset, dict) and asset.get("name")
     ]
     return document
+
+
+def resolve_github_tag_target(tag: str, repo: str) -> Optional[str]:
+    """Resolve a release tag to its commit, distinguishing 404 from API errors."""
+    tag_uri = quote(tag, safe="")
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "--include",
+            f"repos/{repo}/commits/{tag_uri}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = (result.stdout or "").replace("\r\n", "\n")
+    match = re.match(r"HTTP/\S+\s+(\d{3})", output)
+    status = match.group(1) if match else ""
+    _, separator, body = output.partition("\n\n")
+    document = None
+    if separator:
+        try:
+            document = json.loads(body)
+        except json.JSONDecodeError:
+            document = None
+
+    if status == "404":
+        return None
+    if (
+        status == "422"
+        and isinstance(document, dict)
+        and document.get("message") == f"No commit found for SHA: {tag}"
+    ):
+        return None
+    if status != "200" or result.returncode != 0:
+        detail = (result.stderr or output or "no response").strip()
+        raise RuntimeError(
+            f"Could not resolve Git tag {tag} "
+            f"(HTTP {status or 'unknown'}, gh rc={result.returncode}): {detail}"
+        )
+
+    if not separator:
+        raise RuntimeError(f"GitHub returned no JSON body while resolving tag {tag}")
+    if document is None:
+        raise RuntimeError(f"GitHub returned invalid JSON while resolving tag {tag}")
+    target = document.get("sha") if isinstance(document, dict) else None
+    if not isinstance(target, str) or not target:
+        raise RuntimeError(f"GitHub returned no commit SHA while resolving tag {tag}")
+    return target
+
+
+def verify_github_release_target(
+    tag: str,
+    repo: str,
+    expected_target: str,
+    release: Optional[Dict] = None,
+) -> Dict:
+    """Verify a draft points at the immutable workflow commit before mutation."""
+    if not expected_target:
+        return release or {}
+
+    resolved_target = resolve_github_tag_target(tag, repo)
+    current_release = release
+    if resolved_target is None:
+        current_release = current_release or inspect_github_release(tag, repo)
+        resolved_target = current_release.get("targetCommitish")
+
+    if resolved_target != expected_target:
+        raise RuntimeError(
+            f"Release {tag} resolves to {resolved_target or 'no target'}, "
+            f"not requested target {expected_target}"
+        )
+    return current_release or {}
 
 
 def edit_github_release(
@@ -317,6 +393,12 @@ class GithubModule(Step):
 
         if success:
             log_success(f"Release created: {result}")
+            try:
+                verify_github_release_target(tag, repo, self.target)
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Could not verify release target for {tag}: {exc}"
+                ) from exc
         else:
             if "already exists" in result:
                 log_warning(result)
@@ -331,7 +413,18 @@ class GithubModule(Step):
                         f"Release {tag} already exists and is not a draft; "
                         "refusing to modify live release assets"
                     )
-                if self.platforms is not None:
+                try:
+                    verify_github_release_target(
+                        tag,
+                        repo,
+                        self.target,
+                        release=existing,
+                    )
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Could not verify release target for {tag}: {exc}"
+                    ) from exc
+                if self.platforms is not None and not self.skip_upload:
                     for asset in existing.get("assets", []):
                         try:
                             delete_github_release_asset(tag, repo, asset)
@@ -380,6 +473,17 @@ class GithubModule(Step):
                         f"Release {tag} is no longer a draft; refusing to "
                         "accept the asset upload"
                     )
+                try:
+                    verify_github_release_target(
+                        tag,
+                        repo,
+                        self.target,
+                        release=final_release,
+                    )
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Could not verify final release target for {tag}: {exc}"
+                    ) from exc
                 actual_assets = set(final_release.get("assets", []))
                 if actual_assets != expected_assets:
                     raise RuntimeError(

--- a/packages/browseros/bos_build/release/github.py
+++ b/packages/browseros/bos_build/release/github.py
@@ -354,6 +354,7 @@ class GithubModule(Step):
         metadata = fetch_all_release_metadata(version, ctx.env, ctx.product.id)
         if not metadata:
             raise RuntimeError(f"No release metadata found for version {version}")
+        expected_assets: Optional[set[str]] = None
         if self.platforms is not None:
             metadata = validate_release_metadata(
                 metadata,
@@ -365,6 +366,11 @@ class GithubModule(Step):
                 workflow_run_id=self.workflow_run_id,
                 workflow_run_attempt=self.workflow_run_attempt,
             )
+            expected_assets = {
+                artifact["filename"]
+                for release in metadata.values()
+                for artifact in release["artifacts"].values()
+            }
 
         log_info(f"\n{'='*60}")
         log_info(f"Creating GitHub Release: {tag}")
@@ -424,8 +430,18 @@ class GithubModule(Step):
                     raise RuntimeError(
                         f"Could not verify release target for {tag}: {exc}"
                     ) from exc
-                if self.platforms is not None and not self.skip_upload:
-                    for asset in existing.get("assets", []):
+                if expected_assets is not None and not self.skip_upload:
+                    existing_assets = set(existing.get("assets", []))
+                    unexpected_assets = existing_assets - expected_assets
+                    if self.platforms != "all" and unexpected_assets:
+                        raise RuntimeError(
+                            f"Draft release {tag} contains assets outside the "
+                            f"selected {self.platforms} contract: "
+                            f"{sorted(unexpected_assets)}. Refusing a partial "
+                            "refresh that would delete other platforms; rerun "
+                            "with --platforms all or use a new version."
+                        )
+                    for asset in sorted(existing_assets):
                         try:
                             delete_github_release_asset(tag, repo, asset)
                         except Exception as exc:
@@ -456,12 +472,7 @@ class GithubModule(Step):
             failed = [f for f, ok in results if not ok]
             if failed:
                 raise RuntimeError(f"Failed to upload: {', '.join(failed)}")
-            if self.platforms is not None:
-                expected_assets = {
-                    artifact["filename"]
-                    for release in metadata.values()
-                    for artifact in release["artifacts"].values()
-                }
+            if expected_assets is not None:
                 try:
                     final_release = inspect_github_release(tag, repo)
                 except Exception as exc:

--- a/packages/browseros/bos_build/release/github.py
+++ b/packages/browseros/bos_build/release/github.py
@@ -18,6 +18,7 @@ from .common import (
     generate_release_notes,
     get_repo_from_git,
     check_gh_cli,
+    validate_release_metadata,
 )
 
 
@@ -27,6 +28,7 @@ def create_github_release(
     title: str,
     notes: str,
     draft: bool = True,
+    target: str = "",
 ) -> Tuple[bool, str]:
     """Create GitHub release via gh CLI"""
     cmd = [
@@ -43,6 +45,8 @@ def create_github_release(
     ]
     if draft:
         cmd.append("--draft")
+    if target:
+        cmd.extend(["--target", target])
 
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
@@ -57,7 +61,7 @@ def download_file(url: str, dest: Path) -> bool:
     """Download file from URL using curl"""
     try:
         subprocess.run(
-            ["curl", "-L", "-o", str(dest), url],
+            ["curl", "--fail", "--show-error", "-L", "-o", str(dest), url],
             check=True,
             capture_output=True,
         )
@@ -140,10 +144,22 @@ class GithubModule(Step):
         draft: bool = True,
         skip_upload: bool = False,
         title: Optional[str] = None,
+        platforms: Optional[str] = None,
+        macos_arch: str = "universal",
+        source_sha: str = "",
+        workflow_run_id: str = "",
+        workflow_run_attempt: str = "",
+        target: str = "",
     ):
         self.draft = draft
         self.skip_upload = skip_upload
         self.title = title
+        self.platforms = platforms
+        self.macos_arch = macos_arch
+        self.source_sha = source_sha
+        self.workflow_run_id = workflow_run_id
+        self.workflow_run_attempt = workflow_run_attempt
+        self.target = target
 
     def validate(self, ctx: Context) -> None:
         if not BOTO3_AVAILABLE:
@@ -178,8 +194,18 @@ class GithubModule(Step):
 
         metadata = fetch_all_release_metadata(version, ctx.env, ctx.product.id)
         if not metadata:
-            log_error(f"No release metadata found for version {version}")
-            return
+            raise RuntimeError(f"No release metadata found for version {version}")
+        if self.platforms is not None:
+            metadata = validate_release_metadata(
+                metadata,
+                version=version,
+                product_id=ctx.product.id,
+                platforms=self.platforms,
+                macos_arch=self.macos_arch,
+                source_sha=self.source_sha,
+                workflow_run_id=self.workflow_run_id,
+                workflow_run_attempt=self.workflow_run_attempt,
+            )
 
         log_info(f"\n{'='*60}")
         log_info(f"Creating GitHub Release: v{tag_version}")
@@ -194,10 +220,17 @@ class GithubModule(Step):
 
         # Create release
         release_title = self.title or f"v{tag_version}"
-        notes = generate_release_notes(tag_version, metadata)
+        notes = generate_release_notes(tag_version, metadata, ctx.product)
 
         log_info("\nCreating GitHub release...")
-        success, result = create_github_release(tag_version, repo, release_title, notes, self.draft)
+        success, result = create_github_release(
+            tag_version,
+            repo,
+            release_title,
+            notes,
+            self.draft,
+            self.target,
+        )
 
         if success:
             log_success(f"Release created: {result}")
@@ -205,17 +238,23 @@ class GithubModule(Step):
             if "already exists" in result:
                 log_warning(result)
             else:
-                log_error(f"Failed to create release: {result}")
-                return
+                raise RuntimeError(f"Failed to create release: {result}")
 
         # Upload artifacts
         if not self.skip_upload:
             log_info("\nUploading artifacts to GitHub release...")
-            results = download_and_upload_artifacts(tag_version, repo, metadata)
+            results = download_and_upload_artifacts(
+                tag_version,
+                repo,
+                metadata,
+                platforms=list(metadata),
+            )
 
+            if not results:
+                raise RuntimeError("No release artifacts found to upload")
             failed = [f for f, ok in results if not ok]
             if failed:
-                log_warning(f"Failed to upload: {', '.join(failed)}")
+                raise RuntimeError(f"Failed to upload: {', '.join(failed)}")
 
         # Print appcast snippet
         if "macos" in metadata:

--- a/packages/browseros/bos_build/release/publish.py
+++ b/packages/browseros/bos_build/release/publish.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Publish module - Copy versioned artifacts to download/ paths for fresh installs"""
 
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from ..core.context import Context
 from ..core.step import Step, ValidationError
-from ..lib.utils import log_info, log_error, log_success, log_warning
+from ..lib.utils import log_info, log_error, log_success
 from ..lib.r2 import BOTO3_AVAILABLE, get_r2_client
 from .common import (
     PLATFORMS,
@@ -78,6 +78,26 @@ class PublishModule(Step):
                 f"{', '.join(missing_platforms)}"
             )
 
+        candidates: Dict[str, List[Tuple[str, str, str]]] = {}
+        for platform in self.platforms:
+            release = metadata[platform]
+            artifacts = release.get("artifacts", {})
+            platform_mapping = get_download_path_mapping(ctx.product).get(platform, {})
+            platform_candidates: List[Tuple[str, str, str]] = []
+            for artifact_key, artifact in artifacts.items():
+                if artifact_key not in platform_mapping:
+                    continue
+                dest_path = platform_mapping[artifact_key]
+                source_key = _release_source_key(ctx, platform, version, artifact)
+                platform_candidates.append(
+                    (artifact["filename"], source_key, dest_path)
+                )
+            if not platform_candidates:
+                raise RuntimeError(
+                    f"No promotable artifacts found for requested platform {platform}"
+                )
+            candidates[platform] = platform_candidates
+
         log_info(f"\n{'='*60}")
         log_info(f"Publishing v{version} to download/ paths")
         log_info(f"{'='*60}")
@@ -88,37 +108,15 @@ class PublishModule(Step):
 
         results: List[Tuple[str, str, bool]] = []
 
-        for platform in self.platforms:
-            platform_result_start = len(results)
-            if platform not in metadata:
-                log_warning(f"Skipping {platform}: no release metadata")
-                continue
-
-            release = metadata[platform]
-            artifacts = release.get("artifacts", {})
-            platform_mapping = get_download_path_mapping(ctx.product).get(platform, {})
-
+        for platform, platform_candidates in candidates.items():
             log_info(f"\n{PLATFORM_DISPLAY_NAMES[platform]}:")
-
-            for artifact_key, artifact in artifacts.items():
-                if artifact_key not in platform_mapping:
-                    log_info(f"  Skipping {artifact_key}: no download path mapping")
-                    continue
-
-                dest_path = platform_mapping[artifact_key]
-                source_key = _release_source_key(ctx, platform, version, artifact)
-
-                log_info(f"  Copying {artifact['filename']} → {dest_path}")
+            for filename, source_key, dest_path in platform_candidates:
+                log_info(f"  Copying {filename} → {dest_path}")
                 success = copy_to_download_path(client, env.r2_bucket, source_key, dest_path)
-                results.append((artifact["filename"], dest_path, success))
+                results.append((filename, dest_path, success))
 
                 if success:
                     log_success(f"    ✓ Published to {env.r2_cdn_base_url}/{dest_path}")
-
-            if len(results) == platform_result_start:
-                raise RuntimeError(
-                    f"No promotable artifacts found for requested platform {platform}"
-                )
 
         log_info(f"\n{'='*60}")
         succeeded = sum(1 for _, _, ok in results if ok)

--- a/packages/browseros/bos_build/release/publish.py
+++ b/packages/browseros/bos_build/release/publish.py
@@ -89,6 +89,7 @@ class PublishModule(Step):
         results: List[Tuple[str, str, bool]] = []
 
         for platform in self.platforms:
+            platform_result_start = len(results)
             if platform not in metadata:
                 log_warning(f"Skipping {platform}: no release metadata")
                 continue
@@ -113,6 +114,11 @@ class PublishModule(Step):
 
                 if success:
                     log_success(f"    ✓ Published to {env.r2_cdn_base_url}/{dest_path}")
+
+            if len(results) == platform_result_start:
+                raise RuntimeError(
+                    f"No promotable artifacts found for requested platform {platform}"
+                )
 
         log_info(f"\n{'='*60}")
         succeeded = sum(1 for _, _, ok in results if ok)

--- a/packages/browseros/bos_build/release/publish.py
+++ b/packages/browseros/bos_build/release/publish.py
@@ -12,6 +12,7 @@ from .common import (
     PLATFORM_DISPLAY_NAMES,
     fetch_all_release_metadata,
     get_download_path_mapping,
+    validate_release_metadata,
 )
 
 
@@ -41,8 +42,19 @@ class PublishModule(Step):
     requires = []
     description = "Publish versioned artifacts to latest download URLs"
 
-    def __init__(self, platforms: Optional[List[str]] = None):
+    def __init__(
+        self,
+        platforms: Optional[List[str]] = None,
+        macos_arch: str = "universal",
+        source_sha: str = "",
+        workflow_run_id: str = "",
+        workflow_run_attempt: str = "",
+    ):
         self.platforms = platforms or PLATFORMS
+        self.macos_arch = macos_arch
+        self.source_sha = source_sha
+        self.workflow_run_id = workflow_run_id
+        self.workflow_run_attempt = workflow_run_attempt
 
     def validate(self, ctx: Context) -> None:
         if not BOTO3_AVAILABLE:
@@ -69,6 +81,29 @@ class PublishModule(Step):
         metadata = fetch_all_release_metadata(version, env, ctx.product.id)
         if not metadata:
             raise RuntimeError(f"No release metadata found for version {version}")
+        if any(
+            (
+                self.source_sha,
+                self.workflow_run_id,
+                self.workflow_run_attempt,
+            )
+        ):
+            validated: Dict[str, dict] = {}
+            for platform in self.platforms:
+                selection = "windows" if platform == "win" else platform
+                validated.update(
+                    validate_release_metadata(
+                        metadata,
+                        version=version,
+                        product_id=ctx.product.id,
+                        platforms=selection,
+                        macos_arch=self.macos_arch,
+                        source_sha=self.source_sha,
+                        workflow_run_id=self.workflow_run_id,
+                        workflow_run_attempt=self.workflow_run_attempt,
+                    )
+                )
+            metadata = validated
         missing_platforms = [
             platform for platform in self.platforms if platform not in metadata
         ]

--- a/packages/browseros/bos_build/release/publish.py
+++ b/packages/browseros/bos_build/release/publish.py
@@ -55,6 +55,12 @@ class PublishModule(Step):
 
         if not ctx.release_version:
             raise ValidationError("--version is required")
+        invalid = sorted(set(self.platforms) - set(PLATFORMS))
+        if invalid:
+            raise ValidationError(
+                f"Unknown platform(s): {', '.join(invalid)}. "
+                f"Valid: {', '.join(PLATFORMS)}"
+            )
 
     def execute(self, ctx: Context) -> None:
         version = ctx.release_version
@@ -62,8 +68,15 @@ class PublishModule(Step):
 
         metadata = fetch_all_release_metadata(version, env, ctx.product.id)
         if not metadata:
-            log_error(f"No release metadata found for version {version}")
-            return
+            raise RuntimeError(f"No release metadata found for version {version}")
+        missing_platforms = [
+            platform for platform in self.platforms if platform not in metadata
+        ]
+        if missing_platforms:
+            raise RuntimeError(
+                "Missing release metadata for requested platform(s): "
+                f"{', '.join(missing_platforms)}"
+            )
 
         log_info(f"\n{'='*60}")
         log_info(f"Publishing v{version} to download/ paths")
@@ -71,8 +84,7 @@ class PublishModule(Step):
 
         client = get_r2_client(env)
         if not client:
-            log_error("Failed to create R2 client")
-            return
+            raise RuntimeError("Failed to create R2 client")
 
         results: List[Tuple[str, str, bool]] = []
 
@@ -106,13 +118,16 @@ class PublishModule(Step):
         succeeded = sum(1 for _, _, ok in results if ok)
         failed = sum(1 for _, _, ok in results if not ok)
 
-        if failed == 0:
-            log_success(f"Published {succeeded} artifact(s) to download/ paths")
-        else:
-            log_warning(f"Published {succeeded}/{succeeded + failed} artifact(s)")
+        if not results:
+            raise RuntimeError("No promotable artifacts found in release metadata")
+        if failed:
             for filename, dest, ok in results:
                 if not ok:
                     log_error(f"  Failed: {filename} → {dest}")
+            raise RuntimeError(
+                f"Failed to publish {failed}/{succeeded + failed} artifact(s)"
+            )
+        log_success(f"Published {succeeded} artifact(s) to download/ paths")
 
 
 def _release_source_key(

--- a/packages/browseros/bos_build/release/publish_test.py
+++ b/packages/browseros/bos_build/release/publish_test.py
@@ -111,6 +111,55 @@ class PublishModuleIntegrityTest(unittest.TestCase):
         ):
             module.execute(ctx)
 
+    def test_each_requested_platform_requires_a_promotable_artifact(self):
+        module = PublishModule(platforms=["macos", "win"])
+        ctx = SimpleNamespace(
+            release_version="0.49.0",
+            env=SimpleNamespace(
+                r2_bucket="bucket",
+                r2_cdn_base_url="https://cdn.browseros.com",
+            ),
+            product=get_product_descriptor("browserclaw"),
+        )
+        metadata = {
+            "macos": {
+                "artifacts": {
+                    "universal": {
+                        "filename": "BrowserClaw_v0.49.0_universal.dmg",
+                        "url": (
+                            "https://cdn.browseros.com/releases/browserclaw/"
+                            "0.49.0/macos/BrowserClaw_v0.49.0_universal.dmg"
+                        ),
+                    }
+                }
+            },
+            "win": {
+                "artifacts": {
+                    "unknown": {
+                        "filename": "unknown.bin",
+                        "url": "https://cdn.browseros.com/unknown.bin",
+                    }
+                }
+            },
+        }
+
+        with (
+            mock.patch(
+                "bos_build.release.publish.fetch_all_release_metadata",
+                return_value=metadata,
+            ),
+            mock.patch(
+                "bos_build.release.publish.get_r2_client",
+                return_value=object(),
+            ),
+            mock.patch(
+                "bos_build.release.publish.copy_to_download_path",
+                return_value=True,
+            ),
+            self.assertRaisesRegex(RuntimeError, "requested platform win"),
+        ):
+            module.execute(ctx)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/browseros/bos_build/release/publish_test.py
+++ b/packages/browseros/bos_build/release/publish_test.py
@@ -4,10 +4,11 @@
 import unittest
 from types import SimpleNamespace
 from typing import cast
+from unittest import mock
 
 from ..core.context import Context
 from ..core.products import get_product_descriptor
-from .publish import _release_source_key
+from .publish import PublishModule, _release_source_key
 
 
 class ReleaseSourceKeyTest(unittest.TestCase):
@@ -52,6 +53,63 @@ class ReleaseSourceKeyTest(unittest.TestCase):
                 product=get_product_descriptor(product),
             ),
         )
+
+
+class PublishModuleIntegrityTest(unittest.TestCase):
+    def test_missing_r2_client_raises(self):
+        module = PublishModule(platforms=["win"])
+        ctx = SimpleNamespace(
+            release_version="0.49.0",
+            env=SimpleNamespace(),
+            product=get_product_descriptor("browserclaw"),
+        )
+
+        with (
+            mock.patch(
+                "bos_build.release.publish.fetch_all_release_metadata",
+                return_value={"win": {"artifacts": {}}},
+            ),
+            mock.patch(
+                "bos_build.release.publish.get_r2_client",
+                return_value=None,
+            ),
+            self.assertRaisesRegex(RuntimeError, "R2 client"),
+        ):
+            module.execute(ctx)
+
+    def test_zero_mapped_artifacts_raises(self):
+        module = PublishModule(platforms=["win"])
+        ctx = SimpleNamespace(
+            release_version="0.49.0",
+            env=SimpleNamespace(
+                r2_bucket="bucket",
+                r2_cdn_base_url="https://cdn.browseros.com",
+            ),
+            product=get_product_descriptor("browserclaw"),
+        )
+        metadata = {
+            "win": {
+                "artifacts": {
+                    "unknown": {
+                        "filename": "unknown.bin",
+                        "url": "https://cdn.browseros.com/unknown.bin",
+                    }
+                }
+            }
+        }
+
+        with (
+            mock.patch(
+                "bos_build.release.publish.fetch_all_release_metadata",
+                return_value=metadata,
+            ),
+            mock.patch(
+                "bos_build.release.publish.get_r2_client",
+                return_value=object(),
+            ),
+            self.assertRaisesRegex(RuntimeError, "No promotable artifacts"),
+        ):
+            module.execute(ctx)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/release/publish_test.py
+++ b/packages/browseros/bos_build/release/publish_test.py
@@ -60,14 +60,26 @@ class PublishModuleIntegrityTest(unittest.TestCase):
         module = PublishModule(platforms=["win"])
         ctx = SimpleNamespace(
             release_version="0.49.0",
-            env=SimpleNamespace(),
+            env=SimpleNamespace(
+                r2_cdn_base_url="https://cdn.browseros.com",
+                r2_bucket="bucket",
+            ),
             product=get_product_descriptor("browserclaw"),
         )
 
         with (
             mock.patch(
                 "bos_build.release.publish.fetch_all_release_metadata",
-                return_value={"win": {"artifacts": {}}},
+                return_value={
+                    "win": {
+                        "artifacts": {
+                            "x64_installer": {
+                                "filename": "BrowserClaw_installer.exe",
+                                "url": "https://cdn.browseros.com/installer.exe",
+                            }
+                        }
+                    }
+                },
             ),
             mock.patch(
                 "bos_build.release.publish.get_r2_client",
@@ -155,10 +167,12 @@ class PublishModuleIntegrityTest(unittest.TestCase):
             mock.patch(
                 "bos_build.release.publish.copy_to_download_path",
                 return_value=True,
-            ),
+            ) as copy,
             self.assertRaisesRegex(RuntimeError, "requested platform win"),
         ):
             module.execute(ctx)
+
+        copy.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/steps/storage/upload.py
+++ b/packages/browseros/bos_build/steps/storage/upload.py
@@ -2,6 +2,7 @@
 """Upload module for BrowserOS build artifacts to Cloudflare R2"""
 
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
@@ -102,6 +103,14 @@ def generate_release_json(
         "build_date": datetime.now(timezone.utc).isoformat(),
         "artifacts": {},
     }
+    actions_provenance = {
+        "source_sha": os.environ.get("GITHUB_SHA", ""),
+        "workflow_run_id": os.environ.get("GITHUB_RUN_ID", ""),
+        "workflow_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+    }
+    release_data.update(
+        {key: value for key, value in actions_provenance.items() if value}
+    )
 
     # Sparkle (macOS) and WinSparkle (Windows) both compare against this
     # epoch-prefixed BrowserOS version in the appcast (Context.get_sparkle_version).
@@ -130,6 +139,14 @@ def generate_release_json(
 
 def merge_release_metadata(existing: Optional[Dict], new: Dict) -> Dict:
     if not existing:
+        return new
+
+    provenance_fields = (
+        "source_sha",
+        "workflow_run_id",
+        "workflow_run_attempt",
+    )
+    if any(existing.get(field) != new.get(field) for field in provenance_fields):
         return new
 
     merged = dict(existing)

--- a/packages/browseros/bos_build/steps/storage/upload_test.py
+++ b/packages/browseros/bos_build/steps/storage/upload_test.py
@@ -10,6 +10,7 @@ from unittest import mock
 from bos_build.core.context import ArtifactRegistry
 from bos_build.steps.storage.upload import (
     _get_artifact_key,
+    generate_release_json,
     merge_release_metadata,
     upload_release_artifacts,
 )
@@ -44,6 +45,26 @@ def _upload_ctx(
 
 
 class UploadMetadataTest(unittest.TestCase):
+    def test_release_json_records_actions_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(
+            "os.environ",
+            {
+                "GITHUB_SHA": "a" * 40,
+                "GITHUB_RUN_ID": "30418029456",
+                "GITHUB_RUN_ATTEMPT": "2",
+            },
+            clear=False,
+        ):
+            release = generate_release_json(
+                _upload_ctx(Path(tmp)),
+                [{"filename": "BrowserOS_v1.2.3_x64.AppImage", "size": 12}],
+                "linux",
+            )
+
+        self.assertEqual(release["source_sha"], "a" * 40)
+        self.assertEqual(release["workflow_run_id"], "30418029456")
+        self.assertEqual(release["workflow_run_attempt"], "2")
+
     def test_linux_x64_artifacts_use_x64_keys(self) -> None:
         self.assertEqual(
             _get_artifact_key("BrowserOS_v1.2.3_x64.AppImage", "linux"),
@@ -265,6 +286,43 @@ class UploadMetadataTest(unittest.TestCase):
             merged["artifacts"]["x64_appimage"]["filename"], "new.AppImage"
         )
         self.assertEqual(merged["artifacts"]["x64_appimage"]["size"], 2)
+
+    def test_merge_release_metadata_replaces_an_earlier_run(self) -> None:
+        existing = {
+            "source_sha": "old",
+            "workflow_run_id": "1",
+            "workflow_run_attempt": "1",
+            "artifacts": {"arm64_deb": {"filename": "stale.deb"}},
+        }
+        new = {
+            "source_sha": "new",
+            "workflow_run_id": "2",
+            "workflow_run_attempt": "1",
+            "artifacts": {"x64_deb": {"filename": "current.deb"}},
+        }
+
+        merged = merge_release_metadata(existing, new)
+
+        self.assertEqual(merged, new)
+        self.assertNotIn("arm64_deb", merged["artifacts"])
+
+    def test_merge_release_metadata_replaces_an_earlier_attempt(self) -> None:
+        existing = {
+            "source_sha": "same",
+            "workflow_run_id": "2",
+            "workflow_run_attempt": "1",
+            "artifacts": {"arm64_deb": {"filename": "stale.deb"}},
+        }
+        new = {
+            "source_sha": "same",
+            "workflow_run_id": "2",
+            "workflow_run_attempt": "2",
+            "artifacts": {"x64_deb": {"filename": "current.deb"}},
+        }
+
+        merged = merge_release_metadata(existing, new)
+
+        self.assertEqual(merged, new)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- bind release metadata, draft tags, and artifacts to the immutable workflow SHA/run provenance
- enforce exact product/platform asset and appcast contracts before GitHub or R2 distribution
- make feed initialization, downgrade guards, draft refreshes, and multi-platform promotion fail closed
- harden both top-level release workflows with literal-shell regression coverage

## Key guarantees

- BrowserOS and BrowserClaw use product-owned release tags and exact draft asset sets
- stale or mismatched tags, published releases, malformed live appcasts, partial metadata, and failed API inspection stop distribution
- every requested promotion platform is preflighted before the first R2 copy
- notes-only `--skip-upload` refreshes preserve existing draft assets

## Verification

- 800 `bos_build` tests passed (1 platform-only skip)
- 9 release-secret tests passed
- 47 vendor-upload tests passed
- focused independent rereview: 91 tests passed (1 platform-only skip), 0 Critical/Important findings
- Ruff, actionlint, CLI smoke, and `git diff --check` passed