### PR TITLE
fix(ci): recover Windows depot_tools cache safely

### DIFF
--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -153,7 +153,7 @@ jobs:
 
           {
             echo "version=$version"
-            echo "cache_key=chromium-src-${{ inputs.platform }}-${{ inputs.arch }}-v1-$version"
+            echo "cache_key=chromium-src-${{ inputs.platform }}-${{ inputs.arch }}-v2-$version"
           } >> "$GITHUB_OUTPUT"
           {
             echo "CHROMIUM_ROOT=$parent/chromium"
@@ -168,7 +168,7 @@ jobs:
           path: ${{ env.CHROMIUM_ROOT }}
           key: ${{ steps.pin.outputs.cache_key }}
           restore-keys: |
-            chromium-src-${{ inputs.platform }}-${{ inputs.arch }}-v1-
+            chromium-src-${{ inputs.platform }}-${{ inputs.arch }}-v2-
 
       - name: Restore chromium checkout (R2)
         if: runner.os == 'Windows'
@@ -188,7 +188,8 @@ jobs:
         run: |
           set -euo pipefail
           uv run --project packages/browseros browseros source ensure \
-            --root "$CHROMIUM_ROOT" --step checkout
+            --root "$CHROMIUM_ROOT" --step checkout \
+            --repair-cached-depot-tools
 
       - name: Reset chromium tree (clean module)
         working-directory: packages/browseros
@@ -204,7 +205,8 @@ jobs:
         run: |
           set -euo pipefail
           uv run --project packages/browseros browseros source ensure \
-            --root "$CHROMIUM_ROOT" --step sync
+            --root "$CHROMIUM_ROOT" --step sync \
+            --repair-cached-depot-tools
 
       # Save immediately after sync: the tree is pristine (no BrowserOS or
       # BrowserClaw patches, no out/ dir), which keeps the cache deterministic

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -386,7 +386,8 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                 check=True,
                 env=legacy_env,
             )
-            self.assertIn(b"\r\n", (depot_tools / tracked.name).read_bytes())
+            cached_bytes = (depot_tools / tracked.name).read_bytes()
+            self.assertIn(b"\r\n", cached_bytes)
 
             tracked.write_bytes(b"first line\nupstream second line\n")
             subprocess.run(
@@ -439,6 +440,10 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                 }
             )
 
+            # R2 extraction restores working bytes independently of Git's
+            # index stat cache. Rewriting the legacy bytes models that cache
+            # boundary and forces native Git to inspect their line endings.
+            (depot_tools / tracked.name).write_bytes(cached_bytes)
             dirty = subprocess.run(
                 [
                     "git",

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -289,6 +289,8 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
             native_env.update(
                 {
                     "GIT_CONFIG_GLOBAL": config_path,
+                    "GITHUB_ENV": str(github_env),
+                    "GITHUB_PATH": str(temp_root / "github path"),
                     "HOME": str(missing_home),
                 }
             )

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -6,8 +6,11 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import yaml
+
+from bos_build.steps.source import provision
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -94,6 +97,41 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
         ):
             with self.subTest(phase=phase):
                 self.assertLess(bootstrap_index, indexes[phase])
+
+    def test_source_ensure_explicitly_repairs_disposable_depot_tools_cache(self):
+        steps = self.build_steps()
+
+        for phase in (
+            "Ensure chromium checkout at pinned tag",
+            "Sync chromium dependencies (gclient)",
+        ):
+            with self.subTest(phase=phase):
+                step = next(step for step in steps if step.get("name") == phase)
+                self.assertIn("--repair-cached-depot-tools", step["run"])
+
+    def test_checkout_cache_uses_v2_without_v1_fallback(self):
+        steps = self.build_steps()
+        pin_step = next(
+            step
+            for step in steps
+            if step.get("name") == "Resolve chromium pin and paths"
+        )
+        warp_restore = next(
+            step
+            for step in steps
+            if step.get("name") == "Restore chromium checkout (WarpCache)"
+        )
+
+        self.assertIn(
+            "chromium-src-${{ inputs.platform }}-${{ inputs.arch }}-v2-$version",
+            pin_step["run"],
+        )
+        self.assertIn(
+            "chromium-src-${{ inputs.platform }}-${{ inputs.arch }}-v2-",
+            warp_restore["with"]["restore-keys"],
+        )
+        self.assertNotIn("-v1-", pin_step["run"])
+        self.assertNotIn("-v1-", warp_restore["with"]["restore-keys"])
 
     def test_git_bootstrap_uses_isolated_global_config_and_exact_values(self):
         script = self.git_bootstrap_step()["run"]
@@ -280,6 +318,191 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
                     )
                     self.assertEqual(result.stdout.splitlines(), [value])
 
+    @unittest.skipUnless(os.name == "nt", "requires Git for Windows")
+    def test_cached_crlf_depot_tools_repairs_before_native_batch_self_update(self):
+        script = self.git_bootstrap_step()["run"]
+
+        with tempfile.TemporaryDirectory(
+            prefix="browseros depot tools cache ",
+        ) as tmp:
+            temp_root = Path(tmp)
+            legacy_config = temp_root / "legacy-global.gitconfig"
+            legacy_env = os.environ.copy()
+            legacy_env["GIT_CONFIG_GLOBAL"] = str(legacy_config)
+            subprocess.run(
+                ["git", "config", "--global", "core.autocrlf", "true"],
+                check=True,
+                env=legacy_env,
+            )
+
+            seed = temp_root / "seed"
+            seed.mkdir()
+            subprocess.run(
+                ["git", "init", "--initial-branch=main"],
+                check=True,
+                cwd=seed,
+                env=legacy_env,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "BrowserOS test"],
+                check=True,
+                cwd=seed,
+                env=legacy_env,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "ci@example.invalid"],
+                check=True,
+                cwd=seed,
+                env=legacy_env,
+            )
+            tracked = seed / "gclient.py"
+            tracked.write_bytes(b"first line\nsecond line\n")
+            subprocess.run(
+                ["git", "add", tracked.name],
+                check=True,
+                cwd=seed,
+                env=legacy_env,
+            )
+            subprocess.run(
+                ["git", "commit", "-m", "initial"],
+                check=True,
+                cwd=seed,
+                env=legacy_env,
+            )
+
+            origin = temp_root / "origin.git"
+            subprocess.run(
+                ["git", "clone", "--bare", str(seed), str(origin)],
+                check=True,
+                env=legacy_env,
+            )
+            root = temp_root / "chromium"
+            root.mkdir()
+            depot_tools = root / "depot_tools"
+            subprocess.run(
+                ["git", "clone", str(origin), str(depot_tools)],
+                check=True,
+                env=legacy_env,
+            )
+            self.assertIn(b"\r\n", (depot_tools / tracked.name).read_bytes())
+
+            tracked.write_bytes(b"first line\nupstream second line\n")
+            subprocess.run(
+                ["git", "add", tracked.name],
+                check=True,
+                cwd=seed,
+                env=legacy_env,
+            )
+            subprocess.run(
+                ["git", "commit", "-m", "upstream update"],
+                check=True,
+                cwd=seed,
+                env=legacy_env,
+            )
+            subprocess.run(
+                ["git", "push", str(origin), "main"],
+                check=True,
+                cwd=seed,
+                env=legacy_env,
+            )
+
+            runner_temp = temp_root / "runner temp"
+            runner_temp.mkdir()
+            github_env = temp_root / "github env"
+            missing_home = temp_root / "missing home"
+            bash_env = os.environ.copy()
+            bash_env.pop("GIT_CONFIG_GLOBAL", None)
+            bash_env.update(
+                {
+                    "GITHUB_ENV": str(github_env),
+                    "HOME": str(missing_home),
+                    "RUNNER_OS": "Windows",
+                    "RUNNER_TEMP": str(runner_temp),
+                }
+            )
+            subprocess.run(
+                [git_bash_path(), "-c", script],
+                check=True,
+                env=bash_env,
+            )
+            _, config_path = github_env.read_text(encoding="utf-8").strip().split(
+                "=",
+                maxsplit=1,
+            )
+            native_env = os.environ.copy()
+            native_env.update(
+                {
+                    "GIT_CONFIG_GLOBAL": config_path,
+                    "HOME": str(missing_home),
+                }
+            )
+
+            dirty = subprocess.run(
+                [
+                    "git",
+                    "status",
+                    "--porcelain=v1",
+                    "--untracked-files=no",
+                ],
+                capture_output=True,
+                check=True,
+                cwd=depot_tools,
+                env=native_env,
+                text=True,
+            )
+            self.assertIn(tracked.name, dirty.stdout)
+            subprocess.run(
+                ["git", "fetch", "origin"],
+                check=True,
+                cwd=depot_tools,
+                env=native_env,
+            )
+            blocked = subprocess.run(
+                ["git", "merge", "--ff-only", "origin/main"],
+                capture_output=True,
+                cwd=depot_tools,
+                env=native_env,
+                text=True,
+            )
+            self.assertNotEqual(blocked.returncode, 0)
+            self.assertIn(
+                "local changes",
+                (blocked.stdout + blocked.stderr).lower(),
+            )
+
+            with mock.patch.dict(os.environ, native_env, clear=True):
+                provision.ensure_depot_tools(
+                    root,
+                    repair_cached_depot_tools=True,
+                )
+
+            git_wrapper = depot_tools / "git-wrapper.bat"
+            git_wrapper.write_bytes(b"@echo off\r\ngit %*\r\n")
+            command = subprocess.list2cmdline(
+                [git_wrapper.name, "merge", "--ff-only", "origin/main"]
+            )
+            subprocess.run(
+                ["cmd.exe", "/d", "/c", command],
+                check=True,
+                cwd=depot_tools,
+                env=native_env,
+            )
+            git_wrapper.unlink()
+
+            clean = subprocess.run(
+                ["git", "status", "--porcelain=v1"],
+                capture_output=True,
+                check=True,
+                cwd=depot_tools,
+                env=native_env,
+                text=True,
+            )
+            self.assertEqual(clean.stdout, "")
+            self.assertIn(
+                b"upstream second line\n",
+                (depot_tools / tracked.name).read_bytes(),
+            )
+
     def test_reusable_workflow_changes_trigger_build_system_tests(self):
         test_workflow = self.load_workflow("bos-build-tests.yml")
         # PyYAML's YAML 1.1 resolver treats the GitHub Actions `on` key as a
@@ -334,7 +557,7 @@ class ChromiumGitRunbookTest(unittest.TestCase):
 
         bootstrap_index = release_flow.index("`GIT_CONFIG_GLOBAL`")
         source_ensure_index = release_flow.index(
-            "`browseros source ensure --step checkout`"
+            "`browseros source ensure --step checkout --repair-cached-depot-tools`"
         )
         self.assertLess(bootstrap_index, source_ensure_index)
         self.assertIn(
@@ -359,6 +582,21 @@ class ChromiumGitRunbookTest(unittest.TestCase):
         self.assertIn("depot_tools `git.bat`", troubleshooting)
         self.assertIn("`GIT_CONFIG_GLOBAL`", troubleshooting)
         self.assertIn("do not modify the runner image", troubleshooting)
+
+    def test_dirty_depot_tools_cache_failure_has_fail_closed_recovery(self):
+        heading = "## Troubleshooting: cached depot_tools appears all-dirty"
+        self.assertIn(heading, self.runbook)
+        troubleshooting = self.runbook.split(heading, maxsplit=1)[1].split(
+            "\n## ",
+            maxsplit=1,
+        )[0]
+
+        self.assertIn("Your local changes", troubleshooting)
+        self.assertIn("Failed to update depot_tools", troubleshooting)
+        self.assertIn("line-ending-only", troubleshooting)
+        self.assertIn("substantive tracked changes", troubleshooting)
+        self.assertIn("`--repair-cached-depot-tools`", troubleshooting)
+        self.assertIn("`v2`", troubleshooting)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -289,8 +289,6 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
             native_env.update(
                 {
                     "GIT_CONFIG_GLOBAL": config_path,
-                    "GITHUB_ENV": str(github_env),
-                    "GITHUB_PATH": str(temp_root / "github path"),
                     "HOME": str(missing_home),
                 }
             )
@@ -436,6 +434,8 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
             native_env.update(
                 {
                     "GIT_CONFIG_GLOBAL": config_path,
+                    "GITHUB_ENV": str(github_env),
+                    "GITHUB_PATH": str(temp_root / "github path"),
                     "HOME": str(missing_home),
                 }
             )

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -602,6 +602,8 @@ class ChromiumGitRunbookTest(unittest.TestCase):
         self.assertIn("Failed to update depot_tools", troubleshooting)
         self.assertIn("line-ending-only", troubleshooting)
         self.assertIn("substantive tracked changes", troubleshooting)
+        self.assertIn("non-default", troubleshooting)
+        self.assertIn("index flags", troubleshooting)
         self.assertIn("`--repair-cached-depot-tools`", troubleshooting)
         self.assertIn("`v2`", troubleshooting)
 

--- a/packages/browseros/bos_build/cli/source.py
+++ b/packages/browseros/bos_build/cli/source.py
@@ -59,6 +59,14 @@ def ensure_cmd(
         "--version-file",
         help="CHROMIUM_VERSION pin file (default: package root)",
     ),
+    repair_cached_depot_tools: bool = typer.Option(
+        False,
+        "--repair-cached-depot-tools",
+        help=(
+            "Repair line-ending-only tracked changes in an existing depot_tools "
+            "checkout; intended for disposable CI caches"
+        ),
+    ),
 ):
     """Idempotently provision depot_tools + chromium src at the pinned tag."""
     if step not in ("checkout", "sync", "all"):
@@ -78,7 +86,13 @@ def ensure_cmd(
     log_info(f"Chromium root: {root.resolve()}")
 
     try:
-        ensure(root.resolve(), version, strategy=strategy, step_name=step)
+        ensure(
+            root.resolve(),
+            version,
+            strategy=strategy,
+            step_name=step,
+            repair_cached_depot_tools=repair_cached_depot_tools,
+        )
     except Exception as e:
         log_error(f"Provisioning failed: {e}")
         raise typer.Exit(1)

--- a/packages/browseros/bos_build/docs/warpbuild-ci.md
+++ b/packages/browseros/bos_build/docs/warpbuild-ci.md
@@ -135,14 +135,18 @@ The reusable workflow performs the per-platform recipe:
    skip the step.
 3. `astral-sh/setup-uv`, resolve the Chromium pin and paths, then restore the
    pinned chromium checkout from cache (see below).
-4. `browseros source ensure --step checkout` — ensures depot_tools and
-   `src` at the tag from `packages/browseros/CHROMIUM_VERSION`. No-op when
-   the cache is warm and the pin unchanged.
+4. `browseros source ensure --step checkout --repair-cached-depot-tools` —
+   validates depot_tools, normalizes only line-ending-only tracked changes in
+   the explicitly disposable checkout, and ensures `src` at the tag from
+   `packages/browseros/CHROMIUM_VERSION`. No-op when the cache is warm, clean,
+   and the pin is unchanged. Substantive tracked depot_tools changes fail
+   closed rather than being reset.
 5. `uv run browseros build --modules clean ...` — the standard clean module
    resets the tree (it also deletes hook-managed toolchains like
    `third_party/llvm-build`, which the next step restores).
-6. `browseros source ensure --step sync` — `gclient sync -D
-   --no-history --shallow`, exactly what the git_setup module runs.
+6. `browseros source ensure --step sync --repair-cached-depot-tools` —
+   revalidates depot_tools, then runs `gclient sync -D --no-history
+   --shallow`, exactly what the git_setup module runs.
 7. Save the cache (only when the restore missed, i.e. first run per pin).
 8. `uv run browseros build --profile release-ci --product <product>
    --arch <arch> --chromium-src .../src`, with signing and R2 upload flags
@@ -158,11 +162,17 @@ step signs when `sign=true`.
 
 ## Caching strategy
 
-Cache key: `chromium-src-<platform>-<arch>-v1-<CHROMIUM_VERSION>`. Contents:
+Cache key: `chromium-src-<platform>-<arch>-v2-<CHROMIUM_VERSION>`. Contents:
 the whole gclient root (depot_tools, `.gclient`, post-sync `src`) captured
 immediately after `gclient sync`, before patches and before any `out/` dir
 exists — pristine and deterministic. The pin changes rarely, so steady state
 is one cold sync per chromium bump per platform.
+
+Generation `v2` was introduced after the Windows Git bootstrap standardized
+`core.autocrlf=false`. It deliberately has no `v1` fallback: those immutable
+archives may contain a depot_tools worktree checked out under the previous
+line-ending policy. The first `v2` run per platform is therefore cold and
+publishes a cache under the current policy.
 
 - **Linux / macOS — WarpCache** (`WarpBuilds/cache@v1`): drop-in for
   `actions/cache` with no size cap (entries expire 7 days after last use).
@@ -223,7 +233,7 @@ gh workflow run release-linux.yml -f products=all -f upload_to_r2=true
 
 The first run per platform is the cache warm-up; expect cold timings. If a
 pin bump lands, the next run is cold again for that version. To force a fresh
-checkout, bump the `v1` in the cache key (workflow) — for Windows also delete
+checkout, bump the `v2` in the cache key (workflow) — for Windows also delete
 the old object under `ci-cache/chromium/` in R2.
 
 ## Troubleshooting: depot_tools cannot read global Git config
@@ -249,6 +259,36 @@ the temporary file. Fix the workflow contract; do not modify the runner image
 or create `C:/Users/runneradmin/.gitconfig` manually. WarpBuild runners are
 ephemeral, and account-level repair would disappear with the VM while
 reintroducing HOME-resolution ambiguity.
+
+## Troubleshooting: cached depot_tools appears all-dirty
+
+The Windows cache-policy migration failure occurs after R2 restore and the
+Chromium clean step. `gclient.bat` starts, prints `Updating depot_tools...`,
+then Git reports `Your local changes to the following files would be
+overwritten by checkout` for most depot_tools files, followed by `Aborting`
+and `Failed to update depot_tools`. This is distinct from the missing-global-
+config signature above and from Azure runner provisioning.
+
+An archive written under `core.autocrlf=true` can restore CRLF working-tree
+bytes whose index contains LF. Once the job selects `core.autocrlf=false`,
+Git correctly sees those tracked files as modified. Chromium's later clean
+module resets `src`, but depot_tools self-update happens before anything else
+resets the depot_tools worktree.
+
+The reusable workflow passes `--repair-cached-depot-tools` only on its
+disposable source-provisioning calls. The provisioner validates the repository
+and classifies its tracked diff. It resets and verifies the checkout only when
+every change is line-ending-only. If it finds substantive tracked changes, it
+fails with `substantive tracked changes` and preserves the files; this prevents
+cache corruption from being silently masked. The flag defaults off for local
+CLI use, so developer-owned depot_tools edits are never reset implicitly.
+Untracked files are preserved.
+
+Cache generation `v2` has no `v1` fallback, so normal recovery is a cold sync
+followed by a new archive under the current Git policy. If this signature
+appears on a `v2` hit, inspect the source-ensure log for either the normalization
+message or the fail-closed error. Do not delete files in a persistent checkout
+and do not broaden the repair to unconditional `git reset --hard`.
 
 ## Troubleshooting: jobs stuck in `queued`
 

--- a/packages/browseros/bos_build/docs/warpbuild-ci.md
+++ b/packages/browseros/bos_build/docs/warpbuild-ci.md
@@ -280,9 +280,11 @@ disposable source-provisioning calls. The provisioner validates the repository
 and classifies its tracked diff. It resets and verifies the checkout only when
 every change is line-ending-only. If it finds substantive tracked changes, it
 fails with `substantive tracked changes` and preserves the files; this prevents
-cache corruption from being silently masked. The flag defaults off for local
-CLI use, so developer-owned depot_tools edits are never reset implicitly.
-Untracked files are preserved.
+cache corruption from being silently masked. It likewise rejects non-default
+index flags such as assume-unchanged or skip-worktree, because those flags can
+hide real content from status and diff. The flag defaults off for local CLI
+use, so developer-owned depot_tools edits are never reset implicitly. Untracked
+files are preserved.
 
 Cache generation `v2` has no `v1` fallback, so normal recovery is a cold sync
 followed by a new archive under the current Git policy. If this signature

--- a/packages/browseros/bos_build/steps/source/provision.py
+++ b/packages/browseros/bos_build/steps/source/provision.py
@@ -67,7 +67,80 @@ def append_github_file(env_var: str, line: str) -> None:
         f.write(line + "\n")
 
 
-def ensure_depot_tools(root: Path) -> Path:
+def _repair_cached_depot_tools(depot_tools: Path) -> None:
+    """Normalize only line-ending drift in an explicitly disposable checkout."""
+    worktree = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=depot_tools,
+        capture_output=True,
+        text=True,
+    )
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=depot_tools,
+        capture_output=True,
+        text=True,
+    )
+    if (
+        worktree.returncode != 0
+        or worktree.stdout.strip() != "true"
+        or head.returncode != 0
+    ):
+        raise RuntimeError(
+            f"cached depot_tools is not a valid Git worktree: {depot_tools}"
+        )
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=no"],
+        cwd=depot_tools,
+        capture_output=True,
+        text=True,
+    )
+    if status.returncode != 0:
+        raise RuntimeError(
+            "could not inspect cached depot_tools tracked files: "
+            f"{status.stderr.strip()}"
+        )
+    if not status.stdout:
+        return
+
+    for diff_args in (
+        ["diff", "--quiet", "--ignore-space-at-eol", "--"],
+        ["diff", "--cached", "--quiet", "--ignore-space-at-eol", "--"],
+    ):
+        diff = subprocess.run(["git", *diff_args], cwd=depot_tools)
+        if diff.returncode == 1:
+            raise RuntimeError(
+                "cached depot_tools has substantive tracked changes; "
+                "refusing line-ending repair"
+            )
+        if diff.returncode != 0:
+            raise RuntimeError(
+                "could not classify cached depot_tools changes "
+                f"(git {' '.join(diff_args)} exited {diff.returncode})"
+            )
+
+    log_info("[source] Normalizing cached depot_tools line endings...")
+    run(["git", "reset", "--hard", "HEAD"], cwd=depot_tools)
+
+    verified = subprocess.run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=no"],
+        cwd=depot_tools,
+        capture_output=True,
+        text=True,
+    )
+    if verified.returncode != 0 or verified.stdout:
+        raise RuntimeError(
+            "cached depot_tools line-ending repair did not produce "
+            "a clean tracked worktree"
+        )
+
+
+def ensure_depot_tools(
+    root: Path,
+    *,
+    repair_cached_depot_tools: bool = False,
+) -> Path:
     depot_tools = root / "depot_tools"
     if not (depot_tools / ".git").exists():
         log_info("[source] Cloning depot_tools...")
@@ -77,6 +150,8 @@ def ensure_depot_tools(root: Path) -> Path:
         )
     else:
         log_info("[source] depot_tools already present")
+        if repair_cached_depot_tools:
+            _repair_cached_depot_tools(depot_tools)
 
     append_github_file("GITHUB_PATH", str(depot_tools))
     if sys.platform == "win32":
@@ -156,6 +231,7 @@ def ensure(
     version: str,
     strategy: str = "shallow",
     step_name: str = "all",
+    repair_cached_depot_tools: bool = False,
 ) -> None:
     """Idempotently provision root: depot_tools + .gclient + src @ pin.
 
@@ -163,7 +239,10 @@ def ensure(
     the clean step between checkout and sync.
     """
     root.mkdir(parents=True, exist_ok=True)
-    depot_tools = ensure_depot_tools(root)
+    depot_tools = ensure_depot_tools(
+        root,
+        repair_cached_depot_tools=repair_cached_depot_tools,
+    )
     ensure_gclient_config(root)
 
     if step_name in ("checkout", "all"):

--- a/packages/browseros/bos_build/steps/source/provision.py
+++ b/packages/browseros/bos_build/steps/source/provision.py
@@ -105,8 +105,8 @@ def _repair_cached_depot_tools(depot_tools: Path) -> None:
         return
 
     for diff_args in (
-        ["diff", "--quiet", "--ignore-space-at-eol", "--"],
-        ["diff", "--cached", "--quiet", "--ignore-space-at-eol", "--"],
+        ["diff", "--quiet", "--ignore-cr-at-eol", "--"],
+        ["diff", "--cached", "--quiet", "--ignore-cr-at-eol", "--"],
     ):
         diff = subprocess.run(["git", *diff_args], cwd=depot_tools)
         if diff.returncode == 1:

--- a/packages/browseros/bos_build/steps/source/provision.py
+++ b/packages/browseros/bos_build/steps/source/provision.py
@@ -90,6 +90,29 @@ def _repair_cached_depot_tools(depot_tools: Path) -> None:
             f"cached depot_tools is not a valid Git worktree: {depot_tools}"
         )
 
+    index_state = subprocess.run(
+        ["git", "ls-files", "-v", "-z"],
+        cwd=depot_tools,
+        capture_output=True,
+        text=True,
+    )
+    if index_state.returncode != 0:
+        raise RuntimeError(
+            "could not inspect cached depot_tools index flags: "
+            f"{index_state.stderr.strip()}"
+        )
+    unsafe_index_entries = [
+        entry
+        for entry in index_state.stdout.split("\0")
+        if entry and not entry.startswith("H ")
+    ]
+    if unsafe_index_entries:
+        markers = sorted({entry[0] for entry in unsafe_index_entries})
+        raise RuntimeError(
+            "cached depot_tools has non-default index flags "
+            f"({', '.join(markers)}); refusing line-ending repair"
+        )
+
     status = subprocess.run(
         ["git", "status", "--porcelain=v1", "--untracked-files=no"],
         cwd=depot_tools,
@@ -105,8 +128,25 @@ def _repair_cached_depot_tools(depot_tools: Path) -> None:
         return
 
     for diff_args in (
-        ["diff", "--quiet", "--ignore-cr-at-eol", "--"],
-        ["diff", "--cached", "--quiet", "--ignore-cr-at-eol", "--"],
+        [
+            "diff",
+            "--quiet",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--ignore-submodules=none",
+            "--ignore-cr-at-eol",
+            "--",
+        ],
+        [
+            "diff",
+            "--cached",
+            "--quiet",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--ignore-submodules=none",
+            "--ignore-cr-at-eol",
+            "--",
+        ],
     ):
         diff = subprocess.run(["git", *diff_args], cwd=depot_tools)
         if diff.returncode == 1:

--- a/packages/browseros/bos_build/steps/source/provision_test.py
+++ b/packages/browseros/bos_build/steps/source/provision_test.py
@@ -125,6 +125,33 @@ class DepotToolsRecoveryTest(unittest.TestCase):
             self.assertEqual(tracked.read_bytes(), changed)
             self.assertTrue(self._tracked_status(depot_tools))
 
+    def test_authorized_repair_rejects_hidden_index_flags(self):
+        for index_flag in ("--assume-unchanged", "--skip-worktree"):
+            with self.subTest(index_flag=index_flag):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    depot_tools, tracked = self._create_depot_tools(root)
+                    self._git(
+                        depot_tools,
+                        "update-index",
+                        index_flag,
+                        tracked.name,
+                    )
+                    changed = b"first line\nhidden substantive change\n"
+                    tracked.write_bytes(changed)
+                    self.assertEqual(self._tracked_status(depot_tools), "")
+
+                    with self.assertRaisesRegex(
+                        RuntimeError,
+                        "non-default index flags",
+                    ):
+                        provision.ensure_depot_tools(
+                            root,
+                            repair_cached_depot_tools=True,
+                        )
+
+                    self.assertEqual(tracked.read_bytes(), changed)
+
     def test_default_preserves_dirty_developer_checkout(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/packages/browseros/bos_build/steps/source/provision_test.py
+++ b/packages/browseros/bos_build/steps/source/provision_test.py
@@ -106,6 +106,25 @@ class DepotToolsRecoveryTest(unittest.TestCase):
             self.assertEqual(tracked.read_bytes(), changed)
             self.assertTrue(self._tracked_status(depot_tools))
 
+    def test_authorized_repair_rejects_trailing_whitespace_change(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            depot_tools, tracked = self._create_depot_tools(root)
+            changed = b"first line \nsecond line\n"
+            tracked.write_bytes(changed)
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "substantive tracked changes",
+            ):
+                provision.ensure_depot_tools(
+                    root,
+                    repair_cached_depot_tools=True,
+                )
+
+            self.assertEqual(tracked.read_bytes(), changed)
+            self.assertTrue(self._tracked_status(depot_tools))
+
     def test_default_preserves_dirty_developer_checkout(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/packages/browseros/bos_build/steps/source/provision_test.py
+++ b/packages/browseros/bos_build/steps/source/provision_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for chromium source provisioning."""
 
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -31,6 +32,102 @@ class GclientConfigTest(unittest.TestCase):
             (root / ".gclient").write_text(spec)
             provision.ensure_gclient_config(root)
             self.assertEqual((root / ".gclient").read_text(), spec)
+
+
+class DepotToolsRecoveryTest(unittest.TestCase):
+    def _git(self, cwd: Path, *args: str, check: bool = True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            check=check,
+            text=True,
+        )
+
+    def _create_depot_tools(self, root: Path) -> tuple[Path, Path]:
+        depot_tools = root / "depot_tools"
+        depot_tools.mkdir()
+        self._git(depot_tools, "init")
+        self._git(depot_tools, "config", "user.name", "BrowserOS test")
+        self._git(depot_tools, "config", "user.email", "ci@example.invalid")
+        tracked = depot_tools / "gclient.py"
+        tracked.write_bytes(b"first line\nsecond line\n")
+        self._git(depot_tools, "add", tracked.name)
+        self._git(depot_tools, "commit", "-m", "initial")
+        return depot_tools, tracked
+
+    def _tracked_status(self, depot_tools: Path) -> str:
+        return self._git(
+            depot_tools,
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=no",
+        ).stdout
+
+    def test_authorized_repair_normalizes_only_crlf_and_preserves_untracked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            depot_tools, tracked = self._create_depot_tools(root)
+            tracked.write_bytes(b"first line\r\nsecond line\r\n")
+            untracked = depot_tools / "local-note.txt"
+            untracked.write_text("preserve me")
+            self.assertTrue(self._tracked_status(depot_tools))
+
+            provision.ensure_depot_tools(root, repair_cached_depot_tools=True)
+
+            self.assertEqual(tracked.read_bytes(), b"first line\nsecond line\n")
+            self.assertEqual(self._tracked_status(depot_tools), "")
+            self.assertEqual(untracked.read_text(), "preserve me")
+
+    def test_authorized_repair_leaves_clean_checkout_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            depot_tools, tracked = self._create_depot_tools(root)
+            before = tracked.stat().st_mtime_ns
+
+            provision.ensure_depot_tools(root, repair_cached_depot_tools=True)
+
+            self.assertEqual(self._tracked_status(depot_tools), "")
+            self.assertEqual(tracked.stat().st_mtime_ns, before)
+
+    def test_authorized_repair_rejects_and_preserves_substantive_change(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            depot_tools, tracked = self._create_depot_tools(root)
+            changed = b"first line\nchanged content\n"
+            tracked.write_bytes(changed)
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "substantive tracked changes",
+            ):
+                provision.ensure_depot_tools(root, repair_cached_depot_tools=True)
+
+            self.assertEqual(tracked.read_bytes(), changed)
+            self.assertTrue(self._tracked_status(depot_tools))
+
+    def test_default_preserves_dirty_developer_checkout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            depot_tools, tracked = self._create_depot_tools(root)
+            changed = b"first line\r\nsecond line\r\n"
+            tracked.write_bytes(changed)
+
+            provision.ensure_depot_tools(root)
+
+            self.assertEqual(tracked.read_bytes(), changed)
+            self.assertTrue(self._tracked_status(depot_tools))
+
+    def test_authorized_repair_rejects_invalid_repository(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "depot_tools" / ".git").mkdir(parents=True)
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "not a valid Git worktree",
+            ):
+                provision.ensure_depot_tools(root, repair_cached_depot_tools=True)
 
 
 class CheckoutCommandsTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- repair restored depot_tools only when every tracked difference is CR-at-EOL-only and the caller explicitly opts into disposable CI recovery
- fail closed on substantive changes, trailing whitespace, invalid repositories, or hidden index flags; preserve untracked files and default developer checkouts
- invalidate the incompatible checkout cache with schema v2 and document the observed Windows failure signature
- add Linux real-Git coverage and a native Windows Git Bash to cmd batch regression that proves the blocked update recovers and ends clean

## Design
The source provisioner owns depot_tools readiness immediately before gclient. The reusable build workflow explicitly enables a default-off repair at checkout and sync. Classification validates the repository and index, compares staged and unstaged data with only CR-at-EOL ignored, resets committed tracked content only after that proof, and verifies cleanliness. The immutable checkout cache moves to v2 with no v1 fallback so the first post-migration run is cold and deterministic.

## Test plan
- [x] 814 bos_build tests pass (2 platform-only skips on macOS)
- [x] 9 release-secret tests pass
- [x] 47 vendor_uploads tests pass
- [x] Ruff, actionlint, CLI smoke, and diff checks pass
- [x] Three adversarial review rounds end clean after fixing the one verified Important finding
- [ ] GitHub Windows Git bootstrap job runs the native Git-for-Windows CRLF recovery regression