### PR TITLE
fix(claw): harden BrowserClaw analytics telemetry

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
@@ -84,7 +84,7 @@ export function FilterBar({
           )}
           <ChevronDown className="size-3 text-ink-3" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="min-w-52">
+        <DropdownMenuContent align="start" className="ph-no-capture min-w-52">
           <DropdownMenuItem onClick={() => onAgentChange(null)}>
             <span className="flex-1">All</span>
             {selectedAgentSlug === null && <Check className="size-3.5" />}
@@ -118,7 +118,7 @@ export function FilterBar({
           {selectedStatus ? <StatusPill status={selectedStatus} /> : 'Status'}
           <ChevronDown className="size-3 text-ink-3" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="min-w-44">
+        <DropdownMenuContent align="start" className="ph-no-capture min-w-44">
           <DropdownMenuItem onClick={() => onStatusChange(null)}>
             <span className="flex-1">All</span>
             {selectedStatus === null && <Check className="size-3.5" />}
@@ -154,7 +154,7 @@ export function FilterBar({
           </DropdownMenuTrigger>
           <DropdownMenuContent
             align="start"
-            className="max-h-64 min-w-52 overflow-y-auto"
+            className="ph-no-capture max-h-64 min-w-52 overflow-y-auto"
           >
             <DropdownMenuItem onClick={() => onSiteChange(null)}>
               <span className="flex-1">All</span>

--- a/packages/browseros-agent/apps/claw-app/components/audit/ManageAuditFilesDialog.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ManageAuditFilesDialog.tsx
@@ -112,7 +112,7 @@ export function ManageAuditFilesDialog() {
           </Button>
         }
       />
-      <DialogContent className="max-w-md">
+      <DialogContent className="ph-no-capture max-w-md">
         <DialogHeader>
           <DialogTitle>Manage audit files</DialogTitle>
           <DialogDescription>
@@ -155,7 +155,7 @@ export function ManageAuditFilesDialog() {
             <SelectTrigger id="audit-retention">
               <SelectValue />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent className="ph-no-capture">
               <SelectItem value="7" label="7 days">
                 7 days
               </SelectItem>
@@ -202,7 +202,7 @@ export function ManageAuditFilesDialog() {
               </Button>
             }
           />
-          <AlertDialogContent>
+          <AlertDialogContent className="ph-no-capture">
             <AlertDialogHeader>
               <AlertDialogTitle>Clean up audit data now?</AlertDialogTitle>
               <AlertDialogDescription>

--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { parseHTML } from 'linkedom'
+import { act, type ComponentProps, type ReactNode } from 'react'
+import type { Root } from 'react-dom/client'
+import * as _auditHooks from '@/modules/api/audit.hooks'
+
+mock.module('@/modules/api/audit.hooks', () => ({
+  ..._auditHooks,
+  useTaskScreenshotBaseUrl: () => 'http://127.0.0.1:9200',
+}))
+
+mock.module('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  DialogClose: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  DialogContent: ({
+    children,
+    showCloseButton: _showCloseButton,
+    ...props
+  }: ComponentProps<'div'> & { showCloseButton?: boolean }) => (
+    <div data-slot="dialog-content" {...props}>
+      {children}
+    </div>
+  ),
+  DialogTitle: (props: ComponentProps<'h2'>) => <h2 {...props} />,
+}))
+
+const GLOBAL_NAMES = [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'Element',
+  'Node',
+  'Event',
+] as const
+const globalDescriptors = new Map(
+  GLOBAL_NAMES.map((name) => [
+    name,
+    Object.getOwnPropertyDescriptor(globalThis, name),
+  ]),
+)
+
+const { ScreenshotLightbox } = await import('./ScreenshotLightbox')
+
+let root: Root
+let container: HTMLElement
+
+beforeEach(async () => {
+  const dom = parseHTML(
+    '<!doctype html><html><body><div id="root"></div></body></html>',
+  )
+  const globals = {
+    window: dom.window,
+    document: dom.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Element: dom.window.Element,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+  }
+  for (const [name, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    })
+  }
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  })
+  container = dom.document.getElementById('root') as unknown as HTMLElement
+  const { createRoot } = await import('react-dom/client')
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  for (const [name, descriptor] of globalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor)
+    else Reflect.deleteProperty(globalThis, name)
+  }
+  Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
+})
+
+describe('ScreenshotLightbox', () => {
+  it('blocks the opened screenshot portal from PostHog replay', async () => {
+    await act(async () => {
+      root.render(
+        <ScreenshotLightbox
+          sessionId="session-private"
+          screenshotId={42}
+          sourceUrl="https://private.example/secret"
+          offsetMs={1200}
+          onClose={() => undefined}
+        />,
+      )
+    })
+
+    const dialog = container.querySelector('[data-slot="dialog-content"]')
+    if (!dialog) {
+      throw new Error(`dialog portal missing: ${document.body.outerHTML}`)
+    }
+    expect(dialog.getAttribute('class') ?? '').toContain('ph-no-capture')
+    expect(dialog.textContent).toContain('private.example')
+    expect(dialog.querySelector('img')?.getAttribute('src')).toContain(
+      '/sessions/session-private/screenshots/42',
+    )
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { parseHTML } from 'linkedom'
 import { act, type ComponentProps, type ReactNode } from 'react'
 import type { Root } from 'react-dom/client'
+import * as _dialog from '@/components/ui/dialog'
 import * as _auditHooks from '@/modules/api/audit.hooks'
 
 mock.module('@/modules/api/audit.hooks', () => ({
@@ -10,6 +11,7 @@ mock.module('@/modules/api/audit.hooks', () => ({
 }))
 
 mock.module('@/components/ui/dialog', () => ({
+  ..._dialog,
   Dialog: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DialogClose: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DialogContent: ({

--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
@@ -48,7 +48,7 @@ export function ScreenshotLightbox({
     <Dialog open={screenshotId !== null} onOpenChange={(o) => !o && onClose()}>
       <DialogContent
         showCloseButton={false}
-        className="flex max-h-[92vh] w-auto max-w-[94vw] flex-col gap-2 bg-transparent p-0 shadow-none ring-0 sm:max-w-[94vw]"
+        className="ph-no-capture flex max-h-[92vh] w-auto max-w-[94vw] flex-col gap-2 bg-transparent p-0 shadow-none ring-0 sm:max-w-[94vw]"
       >
         <DialogTitle className="sr-only">Screenshot preview</DialogTitle>
         {screenshotId !== null && (

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.test.tsx
@@ -77,6 +77,7 @@ describe('RecentActivity', () => {
     const html = render()
     expect(html).toContain('Browsed example.com')
     expect(html).toContain('Claude Code')
+    expect(html).toContain('ph-no-capture')
     // DONE is the silent default in the editorial cockpit; the tile
     // instead carries a mono meta line with the dispatch count.
     expect(html).toContain('4 tools')

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
@@ -43,7 +43,7 @@ export function RecentActivity() {
   const tail = ordered.slice(5)
 
   return (
-    <section className="space-y-4">
+    <section className="ph-no-capture space-y-4">
       <SectionHeader />
       {query.isPending ? (
         <BentoSkeleton />

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
@@ -167,6 +167,9 @@ describe('RunningGrid', () => {
         card.getAttribute('data-session-card'),
       ),
     ).toEqual(['session-a', 'session-b'])
+    expect(container.querySelector('section')?.classList).toContain(
+      'ph-no-capture',
+    )
     const stopB = container.querySelector('[data-stop-session="session-b"]')
     if (!stopB) throw new Error('session-b Stop button missing')
     await act(async () => {

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { SessionBrowserTab } from '@browseros/claw-api'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { parseHTML } from 'linkedom'
-import { act } from 'react'
+import { act, type ComponentProps, type ReactNode } from 'react'
 import type { Root } from 'react-dom/client'
 import * as _auditHooks from '@/modules/api/audit.hooks'
 import * as _cancelHooks from '@/modules/api/cancel.hooks'
@@ -42,13 +42,21 @@ mock.module('@/modules/api/focus.hooks', () => ({
   }),
 }))
 
-const { RunningGrid } = await import('./RunningGrid')
+mock.module('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  PopoverTrigger: (props: ComponentProps<'button'>) => <button {...props} />,
+  PopoverContent: (props: ComponentProps<'div'>) => (
+    <div data-slot="popover-content" {...props} />
+  ),
+}))
 
 const globalDescriptors = new Map(
   ['window', 'document', 'navigator', 'HTMLElement', 'Node', 'Event'].map(
     (name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)],
   ),
 )
+
+const { RunningGrid } = await import('./RunningGrid')
 
 function browserTab(over: Partial<SessionBrowserTab> = {}): SessionBrowserTab {
   return {
@@ -227,6 +235,14 @@ describe('RunningGrid', () => {
 
     expect(container.textContent).toContain('2 tabs')
     expect(container.textContent).toContain('navigate -> snapshot -> act')
+    const trigger = container.querySelector('[data-tab-count="2"]')
+    if (!trigger) throw new Error('tab-count trigger missing')
+    const popover = container.querySelector('[data-slot="popover-content"]')
+    if (!popover) {
+      throw new Error(`tab popover missing: ${document.body.outerHTML}`)
+    }
+    expect(popover.getAttribute('class') ?? '').toContain('ph-no-capture')
+    expect(popover.textContent).toContain('Example')
   })
 
   it('watches the exact selected browser tab id', async () => {

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { parseHTML } from 'linkedom'
 import { act, type ComponentProps, type ReactNode } from 'react'
 import type { Root } from 'react-dom/client'
+import * as _popover from '@/components/ui/popover'
 import * as _auditHooks from '@/modules/api/audit.hooks'
 import * as _cancelHooks from '@/modules/api/cancel.hooks'
 import * as _focusHooks from '@/modules/api/focus.hooks'
@@ -43,6 +44,7 @@ mock.module('@/modules/api/focus.hooks', () => ({
 }))
 
 mock.module('@/components/ui/popover', () => ({
+  ..._popover,
   Popover: ({ children }: { children?: ReactNode }) => <>{children}</>,
   PopoverTrigger: (props: ComponentProps<'button'>) => <button {...props} />,
   PopoverContent: (props: ComponentProps<'div'>) => (

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
@@ -63,7 +63,7 @@ export function RunningGrid({ sessions }: RunningGridProps) {
       : undefined
 
   return (
-    <section className="space-y-4">
+    <section className="ph-no-capture space-y-4">
       <header className="flex items-baseline gap-3">
         <h2 className="font-semibold text-ink text-lg">Running now</h2>
         <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-accent uppercase tracking-[0.08em]">

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/TabCountChip.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/TabCountChip.tsx
@@ -30,7 +30,7 @@ export function TabCountChip({
         <Layers className="size-2.5" />
         {browserTabs.length} tabs
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-2" align="end">
+      <PopoverContent className="ph-no-capture w-72 p-2" align="end">
         <ul className="flex flex-col gap-1">
           {browserTabs.map((tab) => {
             const selected = tab.browserTabId === selectedBrowserTabId

--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarPrivacy.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarPrivacy.tsx
@@ -105,7 +105,10 @@ export function SidebarPrivacy({ expanded = false }: SidebarPrivacyProps) {
             BrowserClaw collects anonymous, aggregate usage (which agents
             connect and which screens you open) to improve the product. It never
             collects the pages you browse, your prompts, tool inputs or outputs,
-            or any page content. No account or personal data is used.
+            or any page content. One in five analytics sessions may also record
+            interactions with the BrowserClaw cockpit. All inputs are masked,
+            and task, audit, and replay content is blocked from those
+            recordings. No account or personal data is used.
           </DialogDescription>
         </DialogHeader>
         <label

--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/App.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/App.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { SensitiveRouteContent } from './App'
+
+describe('SensitiveRouteContent', () => {
+  it('blocks an entire route body from PostHog replay capture', () => {
+    const html = renderToStaticMarkup(
+      <SensitiveRouteContent>
+        <article>private task content</article>
+      </SensitiveRouteContent>,
+    )
+
+    expect(html).toContain('class="ph-no-capture contents"')
+    expect(html).toContain('private task content')
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/App.tsx
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/App.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { HashRouter, Navigate, Route, Routes } from 'react-router'
 import { CockpitShell } from '@/components/layout/CockpitShell'
 import { Analytics } from '@/modules/analytics/Analytics'
@@ -16,12 +17,38 @@ export function App() {
         <Route element={<CockpitShell />}>
           <Route path="/" element={<Cockpit />} />
           <Route path="/mcp" element={<Mcp />} />
-          <Route path="/audit" element={<Audit />} />
-          <Route path="/audit/:sessionId" element={<TaskDetailPage />} />
-          <Route path="/audit/:sessionId/replay" element={<Replay />} />
+          <Route
+            path="/audit"
+            element={
+              <SensitiveRouteContent>
+                <Audit />
+              </SensitiveRouteContent>
+            }
+          />
+          <Route
+            path="/audit/:sessionId"
+            element={
+              <SensitiveRouteContent>
+                <TaskDetailPage />
+              </SensitiveRouteContent>
+            }
+          />
+          <Route
+            path="/audit/:sessionId/replay"
+            element={
+              <SensitiveRouteContent>
+                <Replay />
+              </SensitiveRouteContent>
+            }
+          />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </HashRouter>
   )
+}
+
+/** Blocks task-bearing route bodies from PostHog session snapshots. */
+export function SensitiveRouteContent({ children }: { children: ReactNode }) {
+  return <div className="ph-no-capture contents">{children}</div>
 }

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  createPostHogConfig,
+  reconcileSessionRecording,
+  sanitizeProperties,
+} from './posthog'
+
+describe('BrowserClaw PostHog privacy', () => {
+  it('configures sampled replay with conservative capture boundaries', () => {
+    const config = createPostHogConfig('anonymous-install-id')
+
+    expect(config.bootstrap).toEqual({
+      distinctID: 'anonymous-install-id',
+    })
+    expect(config.disable_external_dependency_loading).toBe(true)
+    expect(config.disable_session_recording).toBe(true)
+    expect(config.session_recording).toEqual({
+      blockClass: 'ph-no-capture',
+      collectFonts: false,
+      maskAllInputs: true,
+      recordBody: false,
+      recordCrossOriginIframes: false,
+      recordHeaders: false,
+      sampleRate: 0.2,
+    })
+  })
+
+  it('strips location and referrer properties without changing safe fields', () => {
+    expect(
+      sanitizeProperties({
+        $current_url: 'chrome-extension://secret/newtab.html#/audit',
+        $pathname: '/audit',
+        $host: 'secret',
+        $referrer: 'https://private.example',
+        $referring_domain: 'private.example',
+        $initial_current_url: 'chrome-extension://secret/newtab.html',
+        $initial_pathname: '/',
+        $initial_referrer: 'https://private.example',
+        $initial_referring_domain: 'private.example',
+        screen: 'cockpit',
+      }),
+    ).toEqual({ screen: 'cockpit' })
+  })
+
+  it('starts sampled recording on opt-in and stops before capture opt-out', () => {
+    const calls: string[] = []
+    const client = {
+      opt_in_capturing: () => calls.push('opt-in'),
+      opt_out_capturing: () => calls.push('opt-out'),
+      startSessionRecording: (override?: unknown) =>
+        calls.push(`start:${String(override)}`),
+      stopSessionRecording: () => calls.push('stop'),
+    }
+
+    reconcileSessionRecording(client, true, true)
+    expect(calls).toEqual(['opt-in', 'start:undefined'])
+
+    calls.length = 0
+    reconcileSessionRecording(client, false, true)
+    expect(calls).toEqual(['stop', 'opt-out'])
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.test.ts
@@ -20,6 +20,7 @@ describe('BrowserClaw PostHog privacy', () => {
     expect(config.save_referrer).toBe(false)
     expect(config.disable_capture_url_hashes).toBe(true)
     expect(config.disable_external_dependency_loading).toBe(true)
+    expect(config.enable_recording_console_log).toBe(false)
     expect(config.disable_session_recording).toBe(true)
     expect(config.session_recording).toEqual({
       blockClass: 'ph-no-capture',

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.test.ts
@@ -12,6 +12,8 @@ describe('BrowserClaw PostHog privacy', () => {
     expect(config.bootstrap).toEqual({
       distinctID: 'anonymous-install-id',
     })
+    expect(config.advanced_disable_decide).toBeUndefined()
+    expect(config.advanced_disable_feature_flags_on_first_load).toBe(true)
     expect(config.disable_external_dependency_loading).toBe(true)
     expect(config.disable_session_recording).toBe(true)
     expect(config.session_recording).toEqual({

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import {
   createPostHogConfig,
+  maskCapturedReplayRequest,
   reconcileSessionRecording,
   sanitizeProperties,
 } from './posthog'
@@ -14,16 +15,30 @@ describe('BrowserClaw PostHog privacy', () => {
     })
     expect(config.advanced_disable_decide).toBeUndefined()
     expect(config.advanced_disable_feature_flags_on_first_load).toBe(true)
+    expect(config.remote_config_refresh_interval_ms).toBe(0)
+    expect(config.save_campaign_params).toBe(false)
+    expect(config.save_referrer).toBe(false)
+    expect(config.disable_capture_url_hashes).toBe(true)
     expect(config.disable_external_dependency_loading).toBe(true)
     expect(config.disable_session_recording).toBe(true)
     expect(config.session_recording).toEqual({
       blockClass: 'ph-no-capture',
       collectFonts: false,
       maskAllInputs: true,
+      maskCapturedNetworkRequestFn: maskCapturedReplayRequest,
       recordBody: false,
       recordCrossOriginIframes: false,
       recordHeaders: false,
       sampleRate: 0.2,
+    })
+    expect(
+      maskCapturedReplayRequest({
+        name: 'chrome-extension://private/newtab.html#/audit/session-secret',
+        initiatorType: 'fetch',
+      }),
+    ).toEqual({
+      name: 'browserclaw://redacted',
+      initiatorType: 'fetch',
     })
   })
 
@@ -47,15 +62,20 @@ describe('BrowserClaw PostHog privacy', () => {
   it('starts sampled recording on opt-in and stops before capture opt-out', () => {
     const calls: string[] = []
     const client = {
-      opt_in_capturing: () => calls.push('opt-in'),
+      opt_in_capturing: (options?: { captureEventName?: false }) =>
+        calls.push(`opt-in:${String(options?.captureEventName)}`),
       opt_out_capturing: () => calls.push('opt-out'),
       startSessionRecording: (override?: unknown) =>
         calls.push(`start:${String(override)}`),
       stopSessionRecording: () => calls.push('stop'),
     }
 
+    reconcileSessionRecording(client, true, false)
+    expect(calls).toEqual(['opt-in:false', 'start:undefined'])
+
+    calls.length = 0
     reconcileSessionRecording(client, true, true)
-    expect(calls).toEqual(['opt-in', 'start:undefined'])
+    expect(calls).toEqual(['opt-in:false', 'start:undefined'])
 
     calls.length = 0
     reconcileSessionRecording(client, false, true)

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
@@ -11,13 +11,13 @@
  * analytics never runs on the pages the user browses.
  *
  * posthog-js defaults are aggressively disabled: no autocapture (would
- * read DOM text), no automatic pageviews, no `/decide` calls, and no
- * person profiles. A 20% sample of consenting cockpit sessions may be
- * recorded with inputs masked and task-bearing DOM blocked. Auto-captured
- * location properties (`$current_url` etc.) are stripped so even the
- * cockpit's own extension URL never leaves. Identity is the server's
- * anonymous install UUID, set via `bootstrap.distinctID` (no `identify`,
- * no PII).
+ * read DOM text), no automatic pageviews, no feature-flag polling, and
+ * no person profiles. A 20% sample of consenting cockpit sessions may be
+ * recorded with inputs masked, task-bearing DOM blocked, and replay URLs
+ * replaced by a fixed token. Auto-captured location properties
+ * (`$current_url` etc.) are stripped so even the cockpit's own extension
+ * URL never leaves. Identity is the server's anonymous install UUID, set
+ * via `bootstrap.distinctID` (no `identify`, no PII).
  *
  * Gated on a build-time project write key (`VITE_CLAW_POSTHOG_KEY`) and
  * the user's consent. With no key, or before consent, nothing is
@@ -31,6 +31,7 @@ const KEY = import.meta.env.VITE_CLAW_POSTHOG_KEY as string | undefined
 const HOST =
   (import.meta.env.VITE_CLAW_POSTHOG_HOST as string | undefined) ??
   'https://us.i.posthog.com'
+const REDACTED_REPLAY_URL = 'browserclaw://redacted'
 
 /** Auto-added properties that could carry a url/referrer; always removed. */
 const STRIPPED_PROPS = [
@@ -55,6 +56,13 @@ export function sanitizeProperties(
   return cleaned
 }
 
+/** Removes route, session, and local API identifiers from replay URLs. */
+export function maskCapturedReplayRequest<T extends { name: string }>(
+  request: T,
+): T {
+  return { ...request, name: REDACTED_REPLAY_URL }
+}
+
 export function createPostHogConfig(
   distinctId: string,
 ): Partial<PostHogConfig> {
@@ -64,12 +72,17 @@ export function createPostHogConfig(
     capture_pageview: false,
     capture_pageleave: false,
     disable_external_dependency_loading: true,
+    disable_capture_url_hashes: true,
     // Reconciled explicitly after effective consent is known.
     disable_session_recording: true,
     disable_surveys: true,
     // Session replay needs PostHog's remote config, but BrowserClaw does not use
-    // feature flags and should not evaluate them during initialization.
+    // feature flags. Fetch config once, without evaluating or polling flags.
     advanced_disable_feature_flags_on_first_load: true,
+    remote_config_refresh_interval_ms: 0,
+    // Do not persist browser location metadata outside the event sanitizer.
+    save_campaign_params: false,
+    save_referrer: false,
     // We never call identify(), so never create a person profile.
     person_profiles: 'never',
     persistence: 'localStorage',
@@ -81,6 +94,7 @@ export function createPostHogConfig(
       blockClass: 'ph-no-capture',
       collectFonts: false,
       maskAllInputs: true,
+      maskCapturedNetworkRequestFn: maskCapturedReplayRequest,
       recordBody: false,
       recordCrossOriginIframes: false,
       recordHeaders: false,
@@ -90,7 +104,7 @@ export function createPostHogConfig(
 }
 
 interface RecordingConsentClient {
-  opt_in_capturing(): void
+  opt_in_capturing(options?: { captureEventName?: string | null | false }): void
   opt_out_capturing(): void
   startSessionRecording(): void
   stopSessionRecording(): void
@@ -106,7 +120,9 @@ export function reconcileSessionRecording(
   isInitialised: boolean,
 ): void {
   if (enabled) {
-    if (isInitialised) client.opt_in_capturing()
+    // The server state is authoritative, so clear any stale SDK-local opt-out.
+    // Suppress PostHog's own opt-in event; BrowserClaw sends its allowlisted one.
+    client.opt_in_capturing({ captureEventName: false })
     client.startSessionRecording()
   } else if (isInitialised) {
     client.stopSessionRecording()

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
@@ -67,8 +67,9 @@ export function createPostHogConfig(
     // Reconciled explicitly after effective consent is known.
     disable_session_recording: true,
     disable_surveys: true,
-    // No feature-flag / /decide round-trips: we only send events.
-    advanced_disable_decide: true,
+    // Session replay needs PostHog's remote config, but BrowserClaw does not use
+    // feature flags and should not evaluate them during initialization.
+    advanced_disable_feature_flags_on_first_load: true,
     // We never call identify(), so never create a person profile.
     person_profiles: 'never',
     persistence: 'localStorage',

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
@@ -11,18 +11,21 @@
  * analytics never runs on the pages the user browses.
  *
  * posthog-js defaults are aggressively disabled: no autocapture (would
- * read DOM text), no session recording, no automatic pageviews, no
- * `/decide` calls, and no person profiles. Auto-captured location
- * properties (`$current_url` etc.) are stripped so even the cockpit's
- * own extension URL never leaves. Identity is the server's anonymous
- * install UUID, set via `bootstrap.distinctID` (no `identify`, no PII).
+ * read DOM text), no automatic pageviews, no `/decide` calls, and no
+ * person profiles. A 20% sample of consenting cockpit sessions may be
+ * recorded with inputs masked and task-bearing DOM blocked. Auto-captured
+ * location properties (`$current_url` etc.) are stripped so even the
+ * cockpit's own extension URL never leaves. Identity is the server's
+ * anonymous install UUID, set via `bootstrap.distinctID` (no `identify`,
+ * no PII).
  *
  * Gated on a build-time project write key (`VITE_CLAW_POSTHOG_KEY`) and
  * the user's consent. With no key, or before consent, nothing is
  * initialised and every capture no-ops.
  */
 
-import posthog from 'posthog-js'
+import posthog, { type PostHogConfig } from 'posthog-js'
+import 'posthog-js/dist/posthog-recorder'
 
 const KEY = import.meta.env.VITE_CLAW_POSTHOG_KEY as string | undefined
 const HOST =
@@ -44,13 +47,24 @@ const STRIPPED_PROPS = [
 
 let initialised = false
 
-function init(distinctId: string): void {
-  initialised = true
-  posthog.init(KEY as string, {
+export function sanitizeProperties(
+  properties: Record<string, unknown>,
+): Record<string, unknown> {
+  const cleaned = { ...properties }
+  for (const key of STRIPPED_PROPS) delete cleaned[key]
+  return cleaned
+}
+
+export function createPostHogConfig(
+  distinctId: string,
+): Partial<PostHogConfig> {
+  return {
     api_host: HOST,
     autocapture: false,
     capture_pageview: false,
     capture_pageleave: false,
+    disable_external_dependency_loading: true,
+    // Reconciled explicitly after effective consent is known.
     disable_session_recording: true,
     disable_surveys: true,
     // No feature-flag / /decide round-trips: we only send events.
@@ -61,12 +75,47 @@ function init(distinctId: string): void {
     // Share the server's anonymous install id so both surfaces map to
     // one install, without identify().
     bootstrap: { distinctID: distinctId },
-    sanitize_properties: (props) => {
-      const cleaned: Record<string, unknown> = { ...props }
-      for (const key of STRIPPED_PROPS) delete cleaned[key]
-      return cleaned
+    sanitize_properties: sanitizeProperties,
+    session_recording: {
+      blockClass: 'ph-no-capture',
+      collectFonts: false,
+      maskAllInputs: true,
+      recordBody: false,
+      recordCrossOriginIframes: false,
+      recordHeaders: false,
+      sampleRate: 0.2,
     },
-  })
+  }
+}
+
+interface RecordingConsentClient {
+  opt_in_capturing(): void
+  opt_out_capturing(): void
+  startSessionRecording(): void
+  stopSessionRecording(): void
+}
+
+/**
+ * Keeps capture consent and session recording in lockstep. Starting without
+ * an override is important: it lets session_recording.sampleRate decide.
+ */
+export function reconcileSessionRecording(
+  client: RecordingConsentClient,
+  enabled: boolean,
+  isInitialised: boolean,
+): void {
+  if (enabled) {
+    if (isInitialised) client.opt_in_capturing()
+    client.startSessionRecording()
+  } else if (isInitialised) {
+    client.stopSessionRecording()
+    client.opt_out_capturing()
+  }
+}
+
+function init(distinctId: string): void {
+  initialised = true
+  posthog.init(KEY as string, createPostHogConfig(distinctId))
 }
 
 /**
@@ -82,10 +131,11 @@ export function applyTelemetry(input: {
 }): void {
   if (!KEY || !input.distinctId) return
   if (input.enabled) {
-    if (!initialised) init(input.distinctId)
-    else posthog.opt_in_capturing()
-  } else if (initialised) {
-    posthog.opt_out_capturing()
+    const wasInitialised = initialised
+    if (!wasInitialised) init(input.distinctId)
+    reconcileSessionRecording(posthog, true, wasInitialised)
+  } else {
+    reconcileSessionRecording(posthog, false, initialised)
   }
 }
 

--- a/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/analytics/posthog.ts
@@ -11,10 +11,10 @@
  * analytics never runs on the pages the user browses.
  *
  * posthog-js defaults are aggressively disabled: no autocapture (would
- * read DOM text), no automatic pageviews, no feature-flag polling, and
- * no person profiles. A 20% sample of consenting cockpit sessions may be
- * recorded with inputs masked, task-bearing DOM blocked, and replay URLs
- * replaced by a fixed token. Auto-captured location properties
+ * read DOM text), no automatic pageviews, no feature-flag polling, no
+ * console recording, and no person profiles. A 20% sample of consenting
+ * cockpit sessions may be recorded with inputs masked, task-bearing DOM
+ * blocked, and replay URLs replaced by a fixed token. Auto-captured location properties
  * (`$current_url` etc.) are stripped so even the cockpit's own extension
  * URL never leaves. Identity is the server's anonymous install UUID, set
  * via `bootstrap.distinctID` (no `identify`, no PII).
@@ -73,6 +73,7 @@ export function createPostHogConfig(
     capture_pageleave: false,
     disable_external_dependency_loading: true,
     disable_capture_url_hashes: true,
+    enable_recording_console_log: false,
     // Reconciled explicitly after effective consent is known.
     disable_session_recording: true,
     disable_surveys: true,

--- a/packages/browseros-agent/apps/claw-server-rust/src/analytics/events.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/analytics/events.rs
@@ -51,6 +51,13 @@ const KNOWN_CLIENTS: [&str; 15] = [
     "browseros-cli",
 ];
 
+const CLIENT_ALIASES: [(&str, &str); 4] = [
+    ("codex-mcp-client", "codex"),
+    ("codex-posthog-dashboard", "codex"),
+    ("codex-browserclaw", "codex"),
+    ("browserclaw-claude-desktop-wrapper", "claude-desktop"),
+];
+
 pub(crate) const HARNESS_VALUES: [&str; 7] = [
     "Claude Code",
     "Codex",
@@ -285,11 +292,17 @@ fn bucket_client_name(raw: &str) -> String {
             separator_pending = true;
         }
     }
-    match slug.as_str() {
-        "browserclaw-claude-desktop-wrapper" => "claude-desktop".to_string(),
-        value if value.starts_with("codex-") => "codex".to_string(),
-        value if KNOWN_CLIENTS.contains(&value) => slug,
-        _ => "unrecognized-client".to_string(),
+    if let Some((_, canonical)) = CLIENT_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == slug.as_str())
+    {
+        return (*canonical).to_string();
+    }
+
+    if KNOWN_CLIENTS.contains(&slug.as_str()) {
+        slug
+    } else {
+        "unrecognized-client".to_string()
     }
 }
 
@@ -427,6 +440,9 @@ mod tests {
             "user@example.com",
             "/home/user/secret",
             r"C:\Users\someone",
+            "codex@example.com",
+            "codex://private",
+            "/codex/home/user",
         ] {
             assert_eq!(
                 AGENT_SESSION_STARTED.sanitize(&json!({ "client_name": raw })),

--- a/packages/browseros-agent/apps/claw-server-rust/src/analytics/events.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/analytics/events.rs
@@ -33,7 +33,7 @@ const SCREENSHOT_TOKENS_PER_DISPATCH: &str = "screenshot_tokens_per_dispatch";
 
 pub(crate) const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
-const KNOWN_CLIENTS: [&str; 14] = [
+const KNOWN_CLIENTS: [&str; 15] = [
     "claude-desktop",
     "claude-code",
     "claude-ai",
@@ -48,6 +48,7 @@ const KNOWN_CLIENTS: [&str; 14] = [
     "cline",
     "continue",
     "goose",
+    "browseros-cli",
 ];
 
 pub(crate) const HARNESS_VALUES: [&str; 7] = [
@@ -284,10 +285,11 @@ fn bucket_client_name(raw: &str) -> String {
             separator_pending = true;
         }
     }
-    if KNOWN_CLIENTS.contains(&slug.as_str()) {
-        slug
-    } else {
-        "other".to_string()
+    match slug.as_str() {
+        "browserclaw-claude-desktop-wrapper" => "claude-desktop".to_string(),
+        value if value.starts_with("codex-") => "codex".to_string(),
+        value if KNOWN_CLIENTS.contains(&value) => slug,
+        _ => "unrecognized-client".to_string(),
     }
 }
 
@@ -369,6 +371,7 @@ mod tests {
             "Cline",
             "Continue",
             "Goose",
+            "browseros-cli",
         ];
         let expected = [
             "claude-desktop",
@@ -385,6 +388,7 @@ mod tests {
             "cline",
             "continue",
             "goose",
+            "browseros-cli",
         ];
 
         for (raw, expected) in known.into_iter().zip(expected) {
@@ -396,7 +400,26 @@ mod tests {
     }
 
     #[test]
-    fn unknown_or_content_shaped_client_names_become_other() {
+    fn known_mcp_aliases_collapse_to_stable_client_buckets() {
+        for raw in [
+            "codex-mcp-client",
+            "codex-posthog-dashboard",
+            "Codex BrowserClaw",
+        ] {
+            assert_eq!(
+                AGENT_SESSION_STARTED.sanitize(&json!({ "client_name": raw })),
+                Some(json!({ "client_name": "codex" }))
+            );
+        }
+        assert_eq!(
+            AGENT_SESSION_STARTED
+                .sanitize(&json!({ "client_name": "browserclaw-claude-desktop-wrapper" })),
+            Some(json!({ "client_name": "claude-desktop" }))
+        );
+    }
+
+    #[test]
+    fn unknown_or_content_shaped_client_names_become_unrecognized_client() {
         for raw in [
             "",
             "my-secret-internal-tool",
@@ -407,7 +430,7 @@ mod tests {
         ] {
             assert_eq!(
                 AGENT_SESSION_STARTED.sanitize(&json!({ "client_name": raw })),
-                Some(json!({ "client_name": "other" }))
+                Some(json!({ "client_name": "unrecognized-client" }))
             );
         }
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/analytics/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/analytics/service.rs
@@ -26,7 +26,6 @@ const MAX_QUEUE_SIZE: usize = 256;
 const SERVER_VERSION: &str = "server_version";
 const OS_PLATFORM: &str = "os_platform";
 const PROCESS_PERSON_PROFILE: &str = "$process_person_profile";
-const GEOIP_DISABLE: &str = "$geoip_disable";
 const IS_SERVER: &str = "$is_server";
 
 #[derive(Debug, Clone)]
@@ -210,7 +209,6 @@ impl AnalyticsService {
                 Value::String(events::platform_token().to_string()),
             ),
             (PROCESS_PERSON_PROFILE, Value::Bool(false)),
-            (GEOIP_DISABLE, Value::Bool(true)),
             (IS_SERVER, Value::Bool(true)),
         ] {
             if event.insert_prop(key, value).is_err() {
@@ -272,7 +270,6 @@ async fn build_client(config: &AnalyticsConfig, distinct_id: &str) -> AppResult<
         .api_key(project_key.clone())
         .host(config.host.clone())
         .request_timeout_seconds(REQUEST_TIMEOUT_SECONDS)
-        .disable_geoip(true)
         .is_server(true)
         .flush_at(1usize)
         .max_queue_size(MAX_QUEUE_SIZE)
@@ -290,7 +287,6 @@ fn final_allowlist(mut event: Event) -> Option<Event> {
     let definition = events::by_wire_name(event.event_name())?;
     if !definition.required_values_are_normalized(event.properties())
         || event.properties().get(PROCESS_PERSON_PROFILE) != Some(&Value::Bool(false))
-        || event.properties().get(GEOIP_DISABLE) != Some(&Value::Bool(true))
         || event.properties().get(IS_SERVER) != Some(&Value::Bool(true))
     {
         return None;
@@ -303,11 +299,7 @@ fn final_allowlist(mut event: Event) -> Option<Event> {
             !definition.allows_property(key)
                 && !matches!(
                     key.as_str(),
-                    SERVER_VERSION
-                        | OS_PLATFORM
-                        | PROCESS_PERSON_PROFILE
-                        | GEOIP_DISABLE
-                        | IS_SERVER
+                    SERVER_VERSION | OS_PLATFORM | PROCESS_PERSON_PROFILE | IS_SERVER
                 )
         })
         .cloned()
@@ -371,7 +363,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wire_payload_is_personless_and_exactly_allowlisted() -> anyhow::Result<()> {
+    async fn wire_payload_is_personless_geoip_enabled_and_exactly_allowlisted() -> anyhow::Result<()>
+    {
         let directory = tempdir()?;
         let stable_id = "2e087632-1f4e-4ee7-b8bb-cf8ad53e91a8";
         persist_state(
@@ -406,7 +399,6 @@ mod tests {
                 "server_version": env!("CARGO_PKG_VERSION"),
                 "os_platform": events::platform_token(),
                 "$process_person_profile": false,
-                "$geoip_disable": true,
                 "$is_server": true
             })
         );
@@ -463,7 +455,6 @@ mod tests {
                 "server_version": env!("CARGO_PKG_VERSION"),
                 "os_platform": events::platform_token(),
                 "$process_person_profile": false,
-                "$geoip_disable": true,
                 "$is_server": true,
             })
         );
@@ -478,7 +469,7 @@ mod tests {
             (SERVER_VERSION, json!("1")),
             (OS_PLATFORM, json!("linux")),
             (PROCESS_PERSON_PROFILE, json!(false)),
-            (GEOIP_DISABLE, json!(true)),
+            ("$geoip_disable", json!(true)),
             (IS_SERVER, json!(true)),
             ("$os_version", json!("private")),
             ("$lib", json!("posthog-rs")),
@@ -488,7 +479,8 @@ mod tests {
         }
         let filtered = final_allowlist(valid)
             .ok_or_else(|| anyhow::anyhow!("catalog event was unexpectedly dropped"))?;
-        assert_eq!(filtered.properties().len(), 5);
+        assert_eq!(filtered.properties().len(), 4);
+        assert!(!filtered.properties().contains_key("$geoip_disable"));
         assert!(!filtered.properties().contains_key("$os_version"));
         assert!(!filtered.properties().contains_key("$lib"));
         assert!(!filtered.properties().contains_key("unexpected"));

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
@@ -543,7 +543,6 @@ mod tests {
                 "server_version": env!("CARGO_PKG_VERSION"),
                 "os_platform": events::platform_token(),
                 "$process_person_profile": false,
-                "$geoip_disable": true,
                 "$is_server": true,
             })
         );
@@ -571,7 +570,6 @@ mod tests {
                 "server_version": env!("CARGO_PKG_VERSION"),
                 "os_platform": events::platform_token(),
                 "$process_person_profile": false,
-                "$geoip_disable": true,
                 "$is_server": true,
             })
         );


### PR DESCRIPTION
## Summary

- normalize verified BrowserClaw MCP client aliases into stable analytics buckets, preserve `browseros-cli`, and use `unrecognized-client` for unknown/content-shaped names
- enable server-side PostHog GeoIP enrichment while retaining the strict event/property allowlists
- add 20% sampled, consent-gated cockpit session recording with anonymous install identity, masked inputs, redacted URLs, and blocked task/audit/replay surfaces (including portals)
- update the visible analytics disclosure and add focused Rust/TypeScript regression coverage

## Privacy boundaries

- no account/person profiles or `identify()` calls
- no PostHog mount outside the BrowserClaw new-tab cockpit
- no prompts, tool inputs/outputs, browsed-page content, task/audit/replay DOM, replay route identifiers, request bodies, headers, referrers, or campaign metadata
- dashboard/API mutations intentionally remain outside this code PR

## Test plan

- `cargo test --manifest-path apps/claw-server-rust/Cargo.toml -p claw-server-rust analytics`
- `cargo test --manifest-path apps/claw-server-rust/Cargo.toml -p claw-server-rust runtime::tests`
- `cargo clippy --manifest-path apps/claw-server-rust/Cargo.toml -p claw-server-rust --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `bun run --cwd packages/browseros-agent/apps/claw-app test`
- `bun run --cwd packages/browseros-agent/apps/claw-app typecheck`
- `bun run --cwd packages/browseros-agent/apps/claw-app lint`
- `bun run --cwd packages/browseros-agent/apps/claw-app build`
