### PR TITLE
feat(claw): store rrweb replay payloads as files, not SQLite blobs

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/app.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/app.rs
@@ -66,6 +66,7 @@ impl AppState {
         session_tabs.release_all_open().await?;
         let recordings = RecordingStore::new(
             config.browserclaw_dir.join("recordings"),
+            config.browserclaw_dir.join("replays"),
             recording_index.clone(),
             50,
             Duration::from_secs(30),

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/entities/recording_streams.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/entities/recording_streams.rs
@@ -12,6 +12,11 @@ pub struct Model {
     pub size_bytes: i64,
     pub event_count: i64,
     pub has_gap: bool,
+    /// Committed byte length of the on-disk `replays/` NDJSON file for this
+    /// document. 0 means the payload is not (yet) in a file: either the stream
+    /// is empty or it predates the file migration and its payload still lives in
+    /// `recording_payloads`. Readers trust this as the file's valid length.
+    pub payload_bytes: i64,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
@@ -18,7 +18,44 @@ impl MigratorTrait for Migrator {
             Box::new(m0009_rebase_screenshot_baseline::Migration),
             Box::new(m0010_sum_session_efficiency_durations::Migration),
             Box::new(m0011_use_session_durations_for_efficiency::Migration),
+            Box::new(m0012_recording_payload_files::Migration),
         ]
+    }
+}
+
+mod m0012_recording_payload_files {
+    use super::*;
+
+    pub struct Migration;
+
+    impl MigrationName for Migration {
+        fn name(&self) -> &str {
+            "m0012_recording_payload_files"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for Migration {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            // Committed length of each recording's on-disk replay file. 0 for
+            // existing rows, whose payload still lives in recording_payloads
+            // until the background migration extracts it to a file.
+            manager
+                .get_connection()
+                .execute_unprepared(
+                    "ALTER TABLE recording_streams ADD COLUMN payload_bytes INTEGER NOT NULL DEFAULT 0",
+                )
+                .await?;
+            Ok(())
+        }
+
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .get_connection()
+                .execute_unprepared("ALTER TABLE recording_streams DROP COLUMN payload_bytes")
+                .await?;
+            Ok(())
+        }
     }
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
@@ -319,7 +319,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 11);
+        assert_eq!(migrations.len(), 12);
         assert_eq!(
             migrations[0].try_get::<String>("", "version")?,
             "m0001_baseline"
@@ -403,7 +403,7 @@ mod tests {
         let migration_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM seaql_migrations")
             .fetch_one(&mut conn)
             .await?;
-        assert_eq!(migration_count, 11);
+        assert_eq!(migration_count, 12);
         conn.close().await?;
         Ok(())
     }
@@ -467,7 +467,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations ORDER BY version".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 11);
+        assert_eq!(migrations.len(), 12);
         assert_eq!(
             migrations
                 .iter()
@@ -490,7 +490,7 @@ mod tests {
             .await?
             .ok_or_else(|| anyhow::anyhow!("migration count missing"))?
             .try_get::<i64>("", "count")?;
-        assert_eq!(migration_count, 11);
+        assert_eq!(migration_count, 12);
         Ok(())
     }
 
@@ -626,7 +626,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 11);
+        assert_eq!(migrations.len(), 12);
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
@@ -16,8 +16,9 @@ use crate::{
     error::{AppError, AppResult},
 };
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DbBackend, EntityTrait, FromQueryResult,
-    IntoActiveModel, QueryFilter, QuerySelect, Statement, TransactionTrait, sea_query::Expr,
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, ConnectionTrait, DbBackend, EntityTrait,
+    FromQueryResult, IntoActiveModel, QueryFilter, QueryOrder, QuerySelect, Statement,
+    TransactionTrait, sea_query::Expr,
 };
 
 #[derive(Clone)]
@@ -182,6 +183,123 @@ impl RecordingIndex {
             .one(self.db.connection())
             .await?
             .map_or(0, |row| row.payload_bytes))
+    }
+
+    /// The un-migrated document with the smallest DB-blob payload (smallest first,
+    /// so extraction relieves the database quickly). Returns (document_id, bytes).
+    pub async fn smallest_unmigrated_document(&self) -> AppResult<Option<(String, i64)>> {
+        let row = self
+            .db
+            .connection()
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT document_id AS document_id, LENGTH(events_ndjson) AS sz \
+                 FROM recording_payloads ORDER BY sz ASC LIMIT 1",
+            ))
+            .await?;
+        match row {
+            Some(row) => Ok(Some((
+                row.try_get::<String>("", "document_id")?,
+                row.try_get::<i64>("", "sz")?,
+            ))),
+            None => Ok(None),
+        }
+    }
+
+    /// Number of documents whose payload still lives in the DB blob.
+    pub async fn unmigrated_document_count(&self) -> AppResult<i64> {
+        let row = self
+            .db
+            .connection()
+            .query_one(Statement::from_string(
+                DbBackend::Sqlite,
+                "SELECT COUNT(*) AS n FROM recording_payloads",
+            ))
+            .await?;
+        Ok(row.map_or(0, |row| row.try_get::<i64>("", "n").unwrap_or(0)))
+    }
+
+    /// Sets the committed on-disk length for a document once its blob is written
+    /// to a file.
+    pub async fn set_payload_bytes(&self, document_id: &str, bytes: i64) -> AppResult<()> {
+        RecordingStreams::update_many()
+            .col_expr(recording_streams::Column::PayloadBytes, Expr::value(bytes))
+            .filter(recording_streams::Column::DocumentId.eq(document_id))
+            .exec(self.db.connection())
+            .await?;
+        Ok(())
+    }
+
+    /// Removes the DB-blob payload once it has been written to a file.
+    pub async fn delete_payload_blob(&self, document_id: &str) -> AppResult<()> {
+        RecordingPayloads::delete_by_id(document_id.to_string())
+            .exec(self.db.connection())
+            .await?;
+        Ok(())
+    }
+
+    /// The oldest recording document, used to free space during disk-full recovery.
+    pub async fn oldest_document_id(&self) -> AppResult<Option<String>> {
+        Ok(RecordingStreams::find()
+            .order_by_asc(recording_streams::Column::LastEventAt)
+            .one(self.db.connection())
+            .await?
+            .map(|row| row.document_id))
+    }
+
+    /// Returns freed pages to the OS when the database is in incremental
+    /// auto-vacuum mode; a no-op on a legacy database (which needs a full VACUUM).
+    pub async fn incremental_reclaim(&self) -> AppResult<()> {
+        self.db
+            .connection()
+            .execute(Statement::from_string(
+                DbBackend::Sqlite,
+                "PRAGMA incremental_vacuum",
+            ))
+            .await?;
+        Ok(())
+    }
+
+    /// Seeds a pre-migration document (metadata with `payload_bytes = 0` plus a DB
+    /// blob) to exercise the file migration in tests.
+    #[cfg(test)]
+    pub async fn seed_legacy_payload(
+        &self,
+        document_id: &str,
+        tab_id: i64,
+        events_ndjson: &str,
+        first_event_at: i64,
+        last_event_at: i64,
+        event_count: i64,
+    ) -> AppResult<()> {
+        let conn = self.db.connection();
+        conn.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO recording_streams (document_id, tab_id, target_id, first_event_at, \
+             last_event_at, size_bytes, event_count, has_gap, payload_bytes) \
+             VALUES (?, ?, NULL, ?, ?, ?, ?, 0, 0)",
+            [
+                document_id.to_string().into(),
+                tab_id.into(),
+                first_event_at.into(),
+                last_event_at.into(),
+                i64::try_from(events_ndjson.len())
+                    .unwrap_or(i64::MAX)
+                    .into(),
+                event_count.into(),
+            ],
+        ))
+        .await?;
+        conn.execute(Statement::from_sql_and_values(
+            DbBackend::Sqlite,
+            "INSERT INTO recording_payloads (document_id, events_ndjson) VALUES (?, ?)",
+            [
+                document_id.to_string().into(),
+                events_ndjson.to_string().into(),
+            ],
+        ))
+        .await?;
+        Ok(())
     }
 
     /// Records a batch's metadata after its events were appended to the document's

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
@@ -219,23 +219,26 @@ impl RecordingIndex {
         Ok(row.map_or(0, |row| row.try_get::<i64>("", "n").unwrap_or(0)))
     }
 
-    /// Sets the committed on-disk length for a document once its blob is written
-    /// to a file.
-    pub async fn set_payload_bytes(&self, document_id: &str, bytes: i64) -> AppResult<()> {
-        RecordingStreams::update_many()
-            .col_expr(recording_streams::Column::PayloadBytes, Expr::value(bytes))
-            .filter(recording_streams::Column::DocumentId.eq(document_id))
-            .exec(self.db.connection())
-            .await?;
-        Ok(())
-    }
-
-    /// Removes the DB-blob payload once it has been written to a file.
-    pub async fn delete_payload_blob(&self, document_id: &str) -> AppResult<()> {
-        RecordingPayloads::delete_by_id(document_id.to_string())
-            .exec(self.db.connection())
-            .await?;
-        Ok(())
+    /// Marks a document's replay file authoritative in one transaction: sets the
+    /// committed length and drops the now-redundant DB blob together. Atomic so a
+    /// crash can never leave `payload_bytes` set while the blob survives, a state
+    /// a later append plus background migration would resolve by truncating the
+    /// appended events off the file.
+    pub async fn finalize_extraction(&self, document_id: &str, bytes: i64) -> AppResult<()> {
+        let txn = self.db.connection().begin().await?;
+        async {
+            RecordingStreams::update_many()
+                .col_expr(recording_streams::Column::PayloadBytes, Expr::value(bytes))
+                .filter(recording_streams::Column::DocumentId.eq(document_id))
+                .exec(&txn)
+                .await?;
+            RecordingPayloads::delete_by_id(document_id.to_string())
+                .exec(&txn)
+                .await?;
+            txn.commit().await?;
+            Ok::<(), AppError>(())
+        }
+        .await
     }
 
     /// The oldest recording document, used to free space during disk-full recovery.

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
@@ -54,6 +54,7 @@ pub struct RecordingStreamRow {
     pub size_bytes: i64,
     pub event_count: i64,
     pub has_gap: bool,
+    pub payload_bytes: i64,
 }
 
 impl From<recording_streams::Model> for RecordingStreamRow {
@@ -67,6 +68,7 @@ impl From<recording_streams::Model> for RecordingStreamRow {
             size_bytes: row.size_bytes,
             event_count: row.event_count,
             has_gap: row.has_gap,
+            payload_bytes: row.payload_bytes,
         }
     }
 }
@@ -213,6 +215,7 @@ impl RecordingIndex {
                     size_bytes: Set(input.size_bytes),
                     event_count: Set(input.event_count),
                     has_gap: Set(input.has_gap),
+                    payload_bytes: Set(0),
                 })
                 .exec(&txn)
                 .await?;

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
@@ -10,8 +10,7 @@ use crate::{
                 RecordingBatches, RecordingPayloads, RecordingStreams, SessionTabs, TabClaims,
                 TabRecordings,
             },
-            recording_batches, recording_payloads, recording_streams, session_tabs, tab_claims,
-            tab_recordings,
+            recording_batches, recording_streams, session_tabs, tab_claims, tab_recordings,
         },
     },
     error::{AppError, AppResult},
@@ -33,7 +32,6 @@ pub struct AppendDocumentBatch<'a> {
     /// Best-effort target attribution: a later persisted batch may fill an initial absence but
     /// never replace a stored target id.
     pub target_id: Option<&'a str>,
-    pub payload: String,
     pub first_event_at: i64,
     pub last_event_at: i64,
     pub size_bytes: i64,
@@ -42,6 +40,9 @@ pub struct AppendDocumentBatch<'a> {
     /// On a newly accepted non-empty batch, recorder gap evidence or malformed lines dropped by the
     /// server become sticky for the document stream; any replay selecting that stream is incomplete.
     pub has_gap: bool,
+    /// New absolute committed length of the document's on-disk replay file after
+    /// this batch's events were appended.
+    pub payload_bytes: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -164,7 +165,31 @@ impl RecordingIndex {
         Ok(total.unwrap_or(0))
     }
 
-    pub async fn append_document_batch(&self, input: AppendDocumentBatch<'_>) -> AppResult<bool> {
+    /// Whether this document has already durably accepted `batch_id`.
+    pub async fn batch_accepted(&self, document_id: &str, batch_id: &str) -> AppResult<bool> {
+        Ok(
+            RecordingBatches::find_by_id((document_id.to_string(), batch_id.to_string()))
+                .one(self.db.connection())
+                .await?
+                .is_some(),
+        )
+    }
+
+    /// Committed byte length of the document's on-disk replay file (0 when the
+    /// stream does not exist yet or predates the file migration).
+    pub async fn committed_payload_bytes(&self, document_id: &str) -> AppResult<i64> {
+        Ok(RecordingStreams::find_by_id(document_id.to_string())
+            .one(self.db.connection())
+            .await?
+            .map_or(0, |row| row.payload_bytes))
+    }
+
+    /// Records a batch's metadata after its events were appended to the document's
+    /// on-disk replay file, where `input.payload_bytes` is the file's new committed
+    /// length. Idempotent: an already-accepted batch is a no-op, so a duplicate
+    /// append leaves only uncommitted trailing file bytes that the next append
+    /// truncates away. Callers serialize per document.
+    pub async fn commit_batch(&self, input: AppendDocumentBatch<'_>) -> AppResult<()> {
         let txn = self.db.connection().begin().await?;
         async {
             if RecordingBatches::find_by_id((
@@ -175,10 +200,7 @@ impl RecordingIndex {
             .await?
             .is_some()
             {
-                return Ok(false);
-            }
-            if input.event_count == 0 {
-                return Ok(true);
+                return Ok(());
             }
             if let Some(existing) = RecordingStreams::find_by_id(input.document_id.to_string())
                 .one(&txn)
@@ -204,6 +226,7 @@ impl RecordingIndex {
                     .unwrap()
                     .saturating_add(input.event_count));
                 update.has_gap = Set(update.has_gap.unwrap() || input.has_gap);
+                update.payload_bytes = Set(input.payload_bytes);
                 update.update(&txn).await?;
             } else {
                 RecordingStreams::insert(recording_streams::ActiveModel {
@@ -215,24 +238,7 @@ impl RecordingIndex {
                     size_bytes: Set(input.size_bytes),
                     event_count: Set(input.event_count),
                     has_gap: Set(input.has_gap),
-                    payload_bytes: Set(0),
-                })
-                .exec(&txn)
-                .await?;
-            }
-            if let Some(existing) = RecordingPayloads::find_by_id(input.document_id.to_string())
-                .one(&txn)
-                .await?
-            {
-                let mut update = existing.into_active_model();
-                let mut events_ndjson = update.events_ndjson.take().unwrap_or_default();
-                events_ndjson.push_str(&input.payload);
-                update.events_ndjson = Set(events_ndjson);
-                update.update(&txn).await?;
-            } else {
-                RecordingPayloads::insert(recording_payloads::ActiveModel {
-                    document_id: Set(input.document_id.to_string()),
-                    events_ndjson: Set(input.payload),
+                    payload_bytes: Set(input.payload_bytes),
                 })
                 .exec(&txn)
                 .await?;
@@ -245,7 +251,7 @@ impl RecordingIndex {
             .exec(&txn)
             .await?;
             txn.commit().await?;
-            Ok::<bool, AppError>(true)
+            Ok::<(), AppError>(())
         }
         .await
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
@@ -399,6 +399,17 @@ impl RecordingIndex {
         Ok((claims, streams))
     }
 
+    /// Every live recording stream's document id, for the replay-file orphan
+    /// sweep to distinguish tracked files from drift left by a crashed writer.
+    pub async fn all_document_ids(&self) -> AppResult<Vec<String>> {
+        Ok(RecordingStreams::find()
+            .select_only()
+            .column(recording_streams::Column::DocumentId)
+            .into_tuple::<String>()
+            .all(self.db.connection())
+            .await?)
+    }
+
     pub async fn legacy_recordings_before(
         &self,
         cutoff: i64,

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
@@ -97,6 +97,13 @@ impl AppRuntime {
                 }),
             },
             BackgroundTask {
+                name: "recording payload migration",
+                handle: state
+                    .recordings
+                    .clone()
+                    .spawn_payload_migration(shutdown.child_token()),
+            },
+            BackgroundTask {
                 name: "session efficiency reconciliation",
                 handle: tokio::spawn({
                     let session_efficiency = state.session_efficiency.clone();

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
@@ -53,6 +53,18 @@ pub struct RetentionSweepResult {
     pub claims_deleted: u64,
 }
 
+/// One step of migrating a document's rrweb payload from the SQLite blob to its
+/// on-disk replay file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MigrationStep {
+    /// A document's blob was extracted to its file (with its byte length).
+    Migrated(i64),
+    /// The disk was full; the oldest recording was dropped to recover space.
+    Recovered,
+    /// No un-migrated documents remain.
+    Done,
+}
+
 /// Stores each Chrome document stream (metadata in SQLite, rrweb payload on disk
 /// under `replays_root`) and its durable batch acceptance ledger.
 pub struct RecordingStore {
@@ -323,6 +335,104 @@ impl RecordingStore {
         })
     }
 
+    /// Migrates every remaining DB-blob payload to its file, smallest first, then
+    /// stops. Yields between documents so it never starves live recording traffic.
+    pub fn spawn_payload_migration(self: Arc<Self>, cancel: CancellationToken) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut migrated = 0u64;
+            let mut since_reclaim = 0u64;
+            loop {
+                if cancel.is_cancelled() {
+                    return;
+                }
+                match self.migrate_next_document().await {
+                    Ok(MigrationStep::Done) => {
+                        if migrated > 0 {
+                            let _ = self.index.incremental_reclaim().await;
+                            info!(migrated, "recording payload migration finished");
+                        }
+                        return;
+                    }
+                    Ok(MigrationStep::Migrated(_)) => {
+                        migrated += 1;
+                        since_reclaim += 1;
+                        if since_reclaim >= 64 {
+                            let _ = self.index.incremental_reclaim().await;
+                            since_reclaim = 0;
+                        }
+                    }
+                    Ok(MigrationStep::Recovered) => {
+                        tokio::select! {
+                            () = cancel.cancelled() => return,
+                            () = tokio::time::sleep(Duration::from_secs(5)) => {}
+                        }
+                    }
+                    Err(error) => {
+                        warn!(error = %error, "recording payload migration step failed");
+                        tokio::select! {
+                            () = cancel.cancelled() => return,
+                            () = tokio::time::sleep(Duration::from_secs(30)) => {}
+                        }
+                    }
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+    }
+
+    /// Extracts one un-migrated document's blob to its replay file (smallest
+    /// first). Falls into disk-full recovery (drop the oldest recording) when a
+    /// write runs out of space, restoring functionality rather than failing.
+    pub async fn migrate_next_document(&self) -> AppResult<MigrationStep> {
+        let Some((document_id, _size)) = self.index.smallest_unmigrated_document().await? else {
+            return Ok(MigrationStep::Done);
+        };
+        match self.migrate_document(&document_id).await {
+            Ok(bytes) => Ok(MigrationStep::Migrated(bytes)),
+            Err(AppError::Io { source, .. }) if is_disk_full(&source) => {
+                self.recover_disk_space().await?;
+                Ok(MigrationStep::Recovered)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn migrate_document(&self, document_id: &str) -> AppResult<i64> {
+        let lock = self.lock_for(document_id).await;
+        let guard = lock.lock().await;
+        let result = async {
+            let Some(payload) = self.index.payload(document_id).await? else {
+                // No blob left (already migrated): drop any stale marker so it is
+                // not reprocessed.
+                self.index.delete_payload_blob(document_id).await?;
+                return Ok(0);
+            };
+            // The blob is the whole payload, so write from a committed length of 0.
+            let bytes = self.append_payload_file(document_id, 0, &payload).await?;
+            self.index.set_payload_bytes(document_id, bytes).await?;
+            self.index.delete_payload_blob(document_id).await?;
+            Ok(bytes)
+        }
+        .await;
+        drop(guard);
+        self.release_lock(document_id, &lock).await;
+        result
+    }
+
+    /// Drops the oldest recording (blob, file, and row) to reclaim space when the
+    /// disk is full, then returns freed pages to the OS where possible.
+    async fn recover_disk_space(&self) -> AppResult<()> {
+        if let Some(document_id) = self.index.oldest_document_id().await? {
+            warn!(
+                document_id,
+                "audit disk full: dropping oldest recording to recover functionality"
+            );
+            self.delete_document(&document_id).await?;
+        }
+        let _ = self.index.incremental_reclaim().await;
+        Ok(())
+    }
+
     pub async fn close(&self) {}
 
     async fn delete_document(&self, document_id: &str) -> AppResult<bool> {
@@ -434,6 +544,12 @@ async fn remove_file(path: &PathBuf, id: &str) -> bool {
             false
         }
     }
+}
+
+/// Whether an IO error is an out-of-disk condition.
+fn is_disk_full(error: &std::io::Error) -> bool {
+    // ENOSPC (28) on unix; ERROR_HANDLE_DISK_FULL (39) / ERROR_DISK_FULL (112) on windows.
+    matches!(error.raw_os_error(), Some(28 | 39 | 112))
 }
 
 #[must_use]
@@ -625,6 +741,61 @@ mod tests {
         assert!(index.stream(orphan).await?.is_none());
         assert!(!index.batch_exists(orphan, "orphan").await?);
         assert!(!index.payload_exists(orphan).await?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn migrates_a_db_blob_to_its_replay_file() -> anyhow::Result<()> {
+        let (_dir, index, store) = setup().await?;
+        let ndjson = "{\"ts\":10}\n{\"ts\":20}\n";
+        index
+            .seed_legacy_payload("doc-legacy", 7, ndjson, 10, 20, 2)
+            .await?;
+        // Before migration the read falls back to the DB blob.
+        assert_eq!(store.read_range("doc-legacy", 0, 100).await?.len(), 2);
+
+        assert!(matches!(
+            store.migrate_next_document().await?,
+            MigrationStep::Migrated(_)
+        ));
+        assert_eq!(index.unmigrated_document_count().await?, 0);
+        assert!(matches!(
+            store.migrate_next_document().await?,
+            MigrationStep::Done
+        ));
+
+        // After migration the same events are served from the file.
+        assert!(store.replay_path_for("doc-legacy").exists());
+        assert_eq!(store.read_range("doc-legacy", 0, 100).await?.len(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn uncommitted_file_residue_is_truncated_on_next_append() -> anyhow::Result<()> {
+        use tokio::io::AsyncWriteExt as _;
+        let (_dir, _index, store) = setup().await?;
+        store
+            .append_batch("doc", 3, None, &[event(10)], "batch-a", false)
+            .await?;
+        // Simulate a crash after a file append that never committed its batch:
+        // extra bytes past the committed length.
+        let path = store.replay_path_for("doc");
+        let mut residue = fs::OpenOptions::new().append(true).open(&path).await?;
+        residue.write_all(b"{\"ts\":999}\n").await?;
+        residue.sync_all().await?;
+        drop(residue);
+
+        // The next real append truncates the residue back to the committed length.
+        store
+            .append_batch("doc", 3, None, &[event(20)], "batch-b", false)
+            .await?;
+        let timestamps: Vec<i64> = store
+            .read_range("doc", 0, 1000)
+            .await?
+            .into_iter()
+            .map(|event| event.ts)
+            .collect();
+        assert_eq!(timestamps, vec![10, 20]);
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
@@ -158,7 +158,14 @@ impl RecordingStore {
         // Append to the on-disk replay file, then record the batch. The
         // per-document lock serializes this; a crash between the two truncates
         // back to the committed length on the next append (see append_payload_file).
-        let committed = self.index.committed_payload_bytes(document_id).await?;
+        // A legacy document may still hold its whole payload in the DB blob with
+        // payload_bytes == 0; extract it to the file first so this batch appends
+        // after those events, otherwise the background migration would later
+        // truncate the file back to the blob and lose this batch.
+        let committed = match self.index.committed_payload_bytes(document_id).await? {
+            0 => self.extract_blob_locked(document_id).await?,
+            committed => committed,
+        };
         let payload_bytes = self
             .append_payload_file(document_id, committed, &payload)
             .await?;
@@ -472,23 +479,26 @@ impl RecordingStore {
     async fn migrate_document(&self, document_id: &str) -> AppResult<i64> {
         let lock = self.lock_for(document_id).await;
         let guard = lock.lock().await;
-        let result = async {
-            let Some(payload) = self.index.payload(document_id).await? else {
-                // No blob left (already migrated): drop any stale marker so it is
-                // not reprocessed.
-                self.index.delete_payload_blob(document_id).await?;
-                return Ok(0);
-            };
-            // The blob is the whole payload, so write from a committed length of 0.
-            let bytes = self.append_payload_file(document_id, 0, &payload).await?;
-            self.index.set_payload_bytes(document_id, bytes).await?;
-            self.index.delete_payload_blob(document_id).await?;
-            Ok(bytes)
-        }
-        .await;
+        let result = self.extract_blob_locked(document_id).await;
         drop(guard);
         self.release_lock(document_id, &lock).await;
         result
+    }
+
+    /// Extracts a document's entire DB-blob payload to the start of its replay
+    /// file and deletes the blob, assuming the caller holds the document lock.
+    /// Returns the committed file length, or 0 when no blob remains (a new
+    /// document, or one a concurrent step already migrated). Idempotent.
+    async fn extract_blob_locked(&self, document_id: &str) -> AppResult<i64> {
+        let Some(payload) = self.index.payload(document_id).await? else {
+            return Ok(0);
+        };
+        // The blob predates any file append, so it always occupies the file from
+        // committed length 0.
+        let bytes = self.append_payload_file(document_id, 0, &payload).await?;
+        self.index.set_payload_bytes(document_id, bytes).await?;
+        self.index.delete_payload_blob(document_id).await?;
+        Ok(bytes)
     }
 
     /// Drops the oldest recording (blob, file, and row) to reclaim space when the
@@ -860,6 +870,44 @@ mod tests {
         // After migration the same events are served from the file.
         assert!(store.replay_path_for("doc-legacy").exists());
         assert_eq!(store.read_range("doc-legacy", 0, 100).await?.len(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn appending_to_an_unmigrated_legacy_document_preserves_both_payloads()
+    -> anyhow::Result<()> {
+        let (_dir, index, store) = setup().await?;
+        let doc = "018f47a7-1c2b-7def-8123-0123456789ab";
+        // Pre-upgrade state: a stream row with its whole payload still in the DB
+        // blob, never file-migrated (payload_bytes == 0).
+        index
+            .seed_legacy_payload(doc, 11, "{\"ts\":10}\n{\"ts\":20}\n", 10, 20, 2)
+            .await?;
+
+        // A new batch for the SAME document arrives before background migration
+        // reaches it. The blob must be extracted first, not overwritten.
+        assert!(
+            store
+                .append_batch(doc, 11, None, &[event(30)], "new-batch", false)
+                .await?
+        );
+
+        // The inline extraction consumed the blob, so migration has nothing left
+        // to move and cannot truncate the file back to the blob.
+        assert_eq!(index.unmigrated_document_count().await?, 0);
+        assert!(matches!(
+            store.migrate_next_document().await?,
+            MigrationStep::Done
+        ));
+
+        // Every event survives, legacy first then the new batch.
+        let timestamps: Vec<i64> = store
+            .read_range(doc, 0, 1000)
+            .await?
+            .into_iter()
+            .map(|event| event.ts)
+            .collect();
+        assert_eq!(timestamps, vec![10, 20, 30]);
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
@@ -3,13 +3,15 @@
 use crate::{
     clock::now_epoch_ms,
     db::{AppendDocumentBatch, RecordingIndex},
-    error::{AppError, AppResult},
+    error::{AppError, AppResult, IoPath},
 };
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{collections::HashMap, io::SeekFrom, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{
-    fs,
+    fs::{self, OpenOptions},
+    io::{AsyncSeekExt, AsyncWriteExt},
     sync::Mutex,
     task::JoinHandle,
     time::{MissedTickBehavior, interval},
@@ -51,9 +53,11 @@ pub struct RetentionSweepResult {
     pub claims_deleted: u64,
 }
 
-/// Stores each Chrome document stream and its durable batch acceptance ledger.
+/// Stores each Chrome document stream (metadata in SQLite, rrweb payload on disk
+/// under `replays_root`) and its durable batch acceptance ledger.
 pub struct RecordingStore {
     root: PathBuf,
+    replays_root: PathBuf,
     index: Arc<RecordingIndex>,
     document_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
 }
@@ -62,12 +66,14 @@ impl RecordingStore {
     #[must_use]
     pub fn new(
         root: PathBuf,
+        replays_root: PathBuf,
         index: Arc<RecordingIndex>,
         _max_open_handles: usize,
         _idle_handle: Duration,
     ) -> Arc<Self> {
         Arc::new(Self {
             root,
+            replays_root,
             index,
             document_locks: Mutex::new(HashMap::new()),
         })
@@ -102,6 +108,12 @@ impl RecordingStore {
         batch_id: &str,
         has_gap: bool,
     ) -> AppResult<bool> {
+        if self.index.batch_accepted(document_id, batch_id).await? {
+            return Ok(false);
+        }
+        if events.is_empty() {
+            return Ok(true);
+        }
         let mut payload = String::new();
         for event in events {
             payload.push_str(&serde_json::to_string(event)?);
@@ -119,20 +131,93 @@ impl RecordingStore {
             .unwrap_or_default();
         let size_bytes = i64::try_from(payload.len()).unwrap_or(i64::MAX);
         let event_count = i64::try_from(events.len()).unwrap_or(i64::MAX);
+        // Append to the on-disk replay file, then record the batch. The
+        // per-document lock serializes this; a crash between the two truncates
+        // back to the committed length on the next append (see append_payload_file).
+        let committed = self.index.committed_payload_bytes(document_id).await?;
+        let payload_bytes = self
+            .append_payload_file(document_id, committed, &payload)
+            .await?;
         self.index
-            .append_document_batch(AppendDocumentBatch {
+            .commit_batch(AppendDocumentBatch {
                 document_id,
                 tab_id,
                 target_id,
-                payload,
                 first_event_at,
                 last_event_at,
                 size_bytes,
                 event_count,
                 batch_id,
                 has_gap,
+                payload_bytes,
             })
+            .await?;
+        Ok(true)
+    }
+
+    /// Appends the batch payload to the document's `replays/` file. Truncates to
+    /// `committed` first (dropping bytes an interrupted prior append never
+    /// committed) and clamps to the file's actual length (an externally
+    /// deleted/truncated file never zero-pads). Returns the new committed length.
+    async fn append_payload_file(
+        &self,
+        document_id: &str,
+        committed: i64,
+        payload: &str,
+    ) -> AppResult<i64> {
+        let path = self.replay_path_for(document_id);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await.with_path(parent)?;
+        }
+        let mut file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)
             .await
+            .with_path(&path)?;
+        let current = file.metadata().await.with_path(&path)?.len();
+        let base = committed.clamp(0, i64::try_from(current).unwrap_or(i64::MAX));
+        let base_u64 = u64::try_from(base).unwrap_or(0);
+        file.set_len(base_u64).await.with_path(&path)?;
+        file.seek(SeekFrom::Start(base_u64))
+            .await
+            .with_path(&path)?;
+        file.write_all(payload.as_bytes()).await.with_path(&path)?;
+        file.sync_all().await.with_path(&path)?;
+        Ok(base.saturating_add(i64::try_from(payload.len()).unwrap_or(i64::MAX)))
+    }
+
+    /// Loads a document's committed NDJSON payload, file-first, falling back to
+    /// the DB blob for a document that predates the file migration.
+    async fn load_payload(&self, document_id: &str) -> AppResult<Option<String>> {
+        let committed = self.index.committed_payload_bytes(document_id).await?;
+        if committed > 0 {
+            let path = self.replay_path_for(document_id);
+            let bytes = match fs::read(&path).await {
+                Ok(bytes) => bytes,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(source) => {
+                    return Err(AppError::Io {
+                        path: Some(path),
+                        source,
+                    });
+                }
+            };
+            let limit = usize::try_from(committed)
+                .unwrap_or(usize::MAX)
+                .min(bytes.len());
+            return Ok(Some(String::from_utf8_lossy(&bytes[..limit]).into_owned()));
+        }
+        self.index.payload(document_id).await
+    }
+
+    fn replay_path_for(&self, document_id: &str) -> PathBuf {
+        let key = replay_key(document_id);
+        self.replays_root
+            .join(replay_shard(&key))
+            .join(format!("{key}.ndjson"))
     }
 
     pub async fn read_range(
@@ -141,7 +226,7 @@ impl RecordingStore {
         from: i64,
         to: i64,
     ) -> AppResult<Vec<RecordedEvent>> {
-        let Some(payload) = self.index.payload(document_id).await? else {
+        let Some(payload) = self.load_payload(document_id).await? else {
             return Ok(Vec::new());
         };
         Ok(read_payload_range(&payload, from, to))
@@ -243,7 +328,14 @@ impl RecordingStore {
     async fn delete_document(&self, document_id: &str) -> AppResult<bool> {
         let lock = self.lock_for(document_id).await;
         let guard = lock.lock().await;
-        let result = async { self.index.delete_document(document_id).await }.await;
+        let result = async {
+            let deleted = self.index.delete_document(document_id).await?;
+            if deleted {
+                remove_file(&self.replay_path_for(document_id), document_id).await;
+            }
+            Ok(deleted)
+        }
+        .await;
         drop(guard);
         self.release_lock(document_id, &lock).await;
         result
@@ -361,6 +453,23 @@ fn sanitize_id(id: &str) -> String {
         .collect()
 }
 
+/// Collision-free, filesystem-safe single-segment key for a document id (the
+/// replay file stem). base64url yields only `[A-Za-z0-9_-]`.
+fn replay_key(document_id: &str) -> String {
+    URL_SAFE_NO_PAD.encode(document_id.as_bytes())
+}
+
+/// Two-character shard directory for a replay key so `replays/` never becomes a
+/// single directory with one file per recording.
+fn replay_shard(key: &str) -> String {
+    let prefix: String = key.chars().take(2).collect();
+    if prefix.is_empty() {
+        "_".to_string()
+    } else {
+        prefix
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -375,6 +484,7 @@ mod tests {
         ));
         let store = RecordingStore::new(
             dir.path().join("recordings"),
+            dir.path().join("replays"),
             index.clone(),
             10,
             Duration::from_secs(1),
@@ -408,6 +518,7 @@ mod tests {
         );
         let recreated = RecordingStore::new(
             store.root.clone(),
+            store.replays_root.clone(),
             index.clone(),
             10,
             Duration::from_secs(1),

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
@@ -486,18 +486,19 @@ impl RecordingStore {
     }
 
     /// Extracts a document's entire DB-blob payload to the start of its replay
-    /// file and deletes the blob, assuming the caller holds the document lock.
+    /// file and drops the blob, assuming the caller holds the document lock.
     /// Returns the committed file length, or 0 when no blob remains (a new
     /// document, or one a concurrent step already migrated). Idempotent.
     async fn extract_blob_locked(&self, document_id: &str) -> AppResult<i64> {
         let Some(payload) = self.index.payload(document_id).await? else {
             return Ok(0);
         };
-        // The blob predates any file append, so it always occupies the file from
-        // committed length 0.
+        // A blob only ever exists while payload_bytes is 0, so it always occupies
+        // the file from committed length 0. Setting the committed length and
+        // dropping the blob commit atomically, so no crash can leave the blob
+        // behind for a later append and migration to truncate over.
         let bytes = self.append_payload_file(document_id, 0, &payload).await?;
-        self.index.set_payload_bytes(document_id, bytes).await?;
-        self.index.delete_payload_blob(document_id).await?;
+        self.index.finalize_extraction(document_id, bytes).await?;
         Ok(bytes)
     }
 
@@ -908,6 +909,26 @@ mod tests {
             .map(|event| event.ts)
             .collect();
         assert_eq!(timestamps, vec![10, 20, 30]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn finalizing_extraction_commits_length_and_blob_removal_atomically() -> anyhow::Result<()>
+    {
+        let (_dir, index, _store) = setup().await?;
+        index
+            .seed_legacy_payload("doc", 11, "{\"ts\":1}\n{\"ts\":2}\n", 1, 2, 2)
+            .await?;
+        assert_eq!(index.unmigrated_document_count().await?, 1);
+        assert_eq!(index.committed_payload_bytes("doc").await?, 0);
+
+        index.finalize_extraction("doc", 18).await?;
+
+        // Both effects land together. Were they not one transaction, a crash
+        // between them could leave a nonzero committed length with the blob still
+        // present, which a later append and migration would truncate over.
+        assert_eq!(index.committed_payload_bytes("doc").await?, 18);
+        assert_eq!(index.unmigrated_document_count().await?, 0);
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
@@ -8,7 +8,13 @@ use crate::{
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, io::SeekFrom, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    io::SeekFrom,
+    path::PathBuf,
+    sync::Arc,
+    time::Duration,
+};
 use tokio::{
     fs::{self, OpenOptions},
     io::{AsyncSeekExt, AsyncWriteExt},
@@ -22,6 +28,11 @@ use tracing::{info, warn};
 const DAY_MS: i64 = 24 * 60 * 60 * 1000;
 const RETENTION_INTERVAL: Duration = Duration::from_secs(60 * 60);
 pub const RECORDING_ORPHAN_TTL_MS: i64 = 60 * 60 * 1000;
+/// Grace window before a replay file with no stream row is treated as orphaned,
+/// so a fresh append whose stream commit is still in flight is never swept.
+const ORPHAN_FILE_GRACE_MS: i64 = 5 * 60 * 1000;
+/// Per-run scan cap so a pathological `replays/` directory cannot hang the sweep.
+const MAX_ORPHAN_FILE_SCAN: usize = 100_000;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -50,6 +61,7 @@ pub struct LegacyRecordedEvent {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RetentionSweepResult {
     pub recordings_deleted: u64,
+    pub orphan_files_deleted: u64,
     pub claims_deleted: u64,
 }
 
@@ -299,13 +311,72 @@ impl RecordingStore {
             }
         }
 
+        let known: HashSet<String> = self.index.all_document_ids().await?.into_iter().collect();
+        let orphan_files_deleted = self.sweep_orphan_replays(&known, now).await;
+
         Ok(RetentionSweepResult {
             recordings_deleted,
+            orphan_files_deleted,
             claims_deleted: self
                 .index
                 .delete_released_claims_before(retention_cutoff)
                 .await?,
         })
+    }
+
+    /// Deletes replay files whose document has no live stream row (drift from a
+    /// crashed writer or a best-effort partial unlink that removed the row but
+    /// not the file). Skips files younger than the grace window so an in-flight
+    /// append is never mistaken for an orphan, and caps the scan. Best-effort:
+    /// unreadable directories and failed unlinks are ignored, never surfaced.
+    async fn sweep_orphan_replays(&self, known: &HashSet<String>, now: i64) -> u64 {
+        let mut deleted = 0u64;
+        let mut scanned = 0usize;
+        let Ok(mut shards) = fs::read_dir(&self.replays_root).await else {
+            return 0;
+        };
+        while scanned <= MAX_ORPHAN_FILE_SCAN
+            && let Ok(Some(shard)) = shards.next_entry().await
+        {
+            if !shard
+                .file_type()
+                .await
+                .map(|file_type| file_type.is_dir())
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let Ok(mut files) = fs::read_dir(shard.path()).await else {
+                continue;
+            };
+            while let Ok(Some(entry)) = files.next_entry().await {
+                scanned += 1;
+                if scanned > MAX_ORPHAN_FILE_SCAN {
+                    return deleted;
+                }
+                let name = entry.file_name();
+                let Some(document_id) = name
+                    .to_str()
+                    .and_then(|name| name.strip_suffix(".ndjson"))
+                    .and_then(decode_replay_key)
+                else {
+                    continue; // foreign / non-key file: leave alone
+                };
+                if known.contains(&document_id) {
+                    continue;
+                }
+                let Ok(meta) = entry.metadata().await else {
+                    continue;
+                };
+                if !meta.is_file() || replay_file_too_young(&meta, now) {
+                    continue;
+                }
+                if fs::remove_file(entry.path()).await.is_ok() {
+                    deleted += 1;
+                }
+            }
+        }
+        deleted
     }
 
     /// Runs recording retention immediately and then hourly.
@@ -324,6 +395,7 @@ impl RecordingStore {
                         match self.sweep_retention(retention_days, now_epoch_ms()).await {
                             Ok(result) => info!(
                                 recordings_deleted = result.recordings_deleted,
+                                orphan_files_deleted = result.orphan_files_deleted,
                                 claims_deleted = result.claims_deleted,
                                 "recording retention sweep finished"
                             ),
@@ -575,6 +647,26 @@ fn replay_key(document_id: &str) -> String {
     URL_SAFE_NO_PAD.encode(document_id.as_bytes())
 }
 
+/// Decodes a replay file stem (base64url of the document id) back to the
+/// document id. Returns None for a foreign file whose name is not a replay key.
+fn decode_replay_key(stem: &str) -> Option<String> {
+    String::from_utf8(URL_SAFE_NO_PAD.decode(stem).ok()?).ok()
+}
+
+/// Whether a replay file is within the orphan grace window, i.e. recent enough
+/// to still be an in-flight append whose stream row has not committed yet.
+fn replay_file_too_young(meta: &std::fs::Metadata, now: i64) -> bool {
+    let Some(mtime_ms) = meta
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|since| i64::try_from(since.as_millis()).unwrap_or(i64::MAX))
+    else {
+        return false;
+    };
+    now.saturating_sub(mtime_ms) < ORPHAN_FILE_GRACE_MS
+}
+
 /// Two-character shard directory for a replay key so `replays/` never becomes a
 /// single directory with one file per recording.
 fn replay_shard(key: &str) -> String {
@@ -734,6 +826,7 @@ mod tests {
             store.sweep_retention(7, now).await?,
             RetentionSweepResult {
                 recordings_deleted: 1,
+                orphan_files_deleted: 0,
                 claims_deleted: 0,
             }
         );
@@ -767,6 +860,37 @@ mod tests {
         // After migration the same events are served from the file.
         assert!(store.replay_path_for("doc-legacy").exists());
         assert_eq!(store.read_range("doc-legacy", 0, 100).await?.len(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn orphan_replay_files_are_swept_while_tracked_files_are_kept() -> anyhow::Result<()> {
+        let (_dir, index, store) = setup().await?;
+        // A tracked recording: its replay file must survive the sweep.
+        store
+            .append_batch("keep-doc", 5, None, &[event(10)], "batch-a", false)
+            .await?;
+        let kept = store.replay_path_for("keep-doc");
+        assert!(kept.exists());
+
+        // An orphan replay file: a valid replay key with no stream row behind it.
+        let orphan = store.replay_path_for("ghost-doc");
+        if let Some(parent) = orphan.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        fs::write(&orphan, b"{\"ts\":1}\n").await?;
+        // A foreign file whose stem is not a replay key (the `.` is outside the
+        // base64url alphabet, so decoding fails) must be left alone.
+        let foreign = store.replays_root.join("zz").join("my.notes.ndjson");
+        fs::create_dir_all(store.replays_root.join("zz")).await?;
+        fs::write(&foreign, b"keep me\n").await?;
+
+        let known: HashSet<String> = index.all_document_ids().await?.into_iter().collect();
+        // now = i64::MAX so neither file is inside the young-file grace window.
+        assert_eq!(store.sweep_orphan_replays(&known, i64::MAX).await, 1);
+        assert!(kept.exists());
+        assert!(!orphan.exists());
+        assert!(foreign.exists());
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
@@ -352,6 +352,7 @@ mod tests {
         ));
         let recordings = RecordingStore::new(
             dir.path().join("recordings"),
+            dir.path().join("replays"),
             index.clone(),
             10,
             Duration::from_secs(1),


### PR DESCRIPTION
## Problem

rrweb replay payloads were stored as NDJSON blobs inside the BrowserClaw SQLite database (`recording_payloads.events_ndjson`). This is the only large data in the DB and it grows at gigabytes per day. The only way to return that space to the OS is a full `VACUUM`, which on a legacy database (`auto_vacuum=NONE`) needs free disk greater than or equal to the whole database size. Once the DB is large and the disk is tight, the VACUUM fails, nothing reclaims, and every audit storage endpoint (usage / retention / cleanup) fails with it. A Windows user hit ~18GB with a full disk and could no longer manage storage from the UI.

## What changed

Replay payloads now live as one NDJSON file per recording under a new `replays/` subdirectory (sibling to `screenshots/`), which a user can safely delete to reclaim space. SQLite keeps only small metadata and index rows, so the database stays tiny and never balloons again. Pruning a replay becomes a cheap file delete, and the pathological full-VACUUM-on-a-huge-DB path is gone for new data.

## How it stays correct

- **Crash-safe append.** Files cannot join the DB transaction that gave the old blob its atomic append + dedupe, so a committed-length invariant replaces it: `recording_streams.payload_bytes` records the valid byte length of the on-disk file. Each append truncates to that length first (dropping any trailing bytes a crash left uncommitted), appends, `fsync`s, then commits the batch row. Readers only ever read up to the committed length. Net: idempotent, no duplicated events, self-healing after a crash.
- **No data loss during rollout.** From first run the write path only ever writes files, so no new blobs are created. The read path serves a document from its file if present and falls back to the DB blob for any not-yet-extracted document, so replays stay fully readable while the migration runs.

## Migration for existing users

A resumable, disk-aware background task extracts remaining DB-blob payloads to files, smallest first (fast relief for the database), setting `payload_bytes` and deleting each blob, and periodically runs a bounded `PRAGMA incremental_vacuum` so an existing large database shrinks as it goes without ever needing multiple times its size in free disk. Progress is implicit in the remaining blob rows, so a crash simply resumes.

## Disk-full recovery

If a write runs out of space while the disk is already stuck, the task drops the oldest recording (blob, file, and row) to restore functionality, since replay data is explicitly safe to delete, then reclaims freed pages and retries. The goal is to get storage management working again rather than fail.

## Retention

Pruning a recording now also unlinks its replay file. A new orphan-file sweep removes replay files that have no live stream row (drift from a crashed writer or a partial unlink), mirroring the existing screenshot orphan sweep: it skips files inside a short grace window so an in-flight append is never mistaken for an orphan, leaves foreign files alone, and caps the per-run scan.

## Follow-up (intentionally not in this PR)

The `recording_payloads` table is kept for now because the read fallback and the background extraction still need it until existing installs finish draining. A later change drops the table and removes the fallback once drainage is confirmed.

## Testing

`cargo test -p claw-server-rust` (lib + integration) is green. New coverage: DB-blob to replay-file round-trip, crash-residue truncation via the committed-length invariant, and the orphan replay-file sweep (tracked kept, orphan removed, foreign left alone).
