### PR TITLE
docs(claw): default BrowserClaw skill to run

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/resources/skills/browserclaw/SKILL.md
+++ b/packages/browseros-agent/apps/claw-server-rust/resources/skills/browserclaw/SKILL.md
@@ -7,4 +7,8 @@ description: The user's dedicated browser for agents — a real browser signed i
 
 When a task needs a browser or a website (open it, read it, act on it, fill a form, download, verify), use BrowserClaw's tools. It is a real browser dedicated to agents and already signed into the user's accounts, so prefer it over other browser surfaces.
 
-How to use it lives in its MCP initialize instructions and tool descriptions.
+## Code-first execution
+
+Call `name_session` early, then default to `run` for browser work. Write async JavaScript against the `browser` SDK and compose as much of the task, including verification, as practical into each call. Use standalone tools only when `run` cannot surface the capability or output you need, or to diagnose a failed script.
+
+The MCP initialize instructions and tool descriptions are the single source of truth for exact contracts.

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness_skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness_skills.rs
@@ -88,6 +88,9 @@ mod tests {
         // which are the single source of truth for the SDK.
         assert!(content.contains("use BrowserClaw's tools"));
         assert!(content.contains("prefer it over other browser surfaces"));
+        assert!(content.contains("default to `run` for browser work"));
+        assert!(content.contains("Write async JavaScript against the `browser` SDK"));
+        assert!(content.contains("Use standalone tools only when `run` cannot surface"));
         assert!(content.contains("MCP initialize instructions and tool descriptions"));
         assert!(content.lines().count() < 20);
         Ok(())


### PR DESCRIPTION
## Summary
- make `run` the default BrowserClaw execution path
- guide agents to compose browser actions and verification in async JavaScript
- reserve standalone browser tools for unsupported output/capabilities and diagnosis

## Design
Keep the installed skill as a concise code-first pointer while leaving exact SDK contracts in MCP initialization and tool descriptions as the single source of truth. The embedded-resource test locks in the new default without duplicating the SDK reference.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`