### PR TITLE
chore(mcp): hide window activate action

### DIFF
--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -459,7 +459,7 @@ fn tab_and_window_schemas_omit_hidden_controls() {
     let windows_schema = Value::Object(windows.input_schema.as_ref().clone());
     assert_eq!(
         windows_schema.pointer("/properties/action/enum"),
-        Some(&json!(["list", "create", "close", "activate"]))
+        Some(&json!(["list", "create", "close"]))
     );
     for property in ["hidden", "visible", "activate"] {
         assert!(
@@ -470,6 +470,7 @@ fn tab_and_window_schemas_omit_hidden_controls() {
         );
     }
     assert!(!windows.description.contains("hidden"));
+    assert!(!windows.description.contains("activate"));
 }
 
 #[test]
@@ -744,6 +745,20 @@ async fn retired_hidden_inputs_are_rejected() {
             "{name} accepted retired hidden input"
         );
     }
+}
+
+#[tokio::test]
+async fn retired_window_activate_action_is_rejected() {
+    let tool = tool_by_name("windows");
+    let result = execute_tool(
+        &tool,
+        json!({ "action": "activate", "windowId": 1 }),
+        &fake_ctx(),
+    )
+    .await
+    .unwrap_or_else(|err| panic!("execute should return a tool result: {err}"));
+    assert!(result.is_error);
+    assert!(result_text(&result).starts_with("Invalid arguments for windows:"));
 }
 
 #[tokio::test]

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/windows.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/windows.rs
@@ -7,7 +7,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-const DESCRIPTION: &str = "Manage browser windows: list, create, close, or activate windows.";
+const DESCRIPTION: &str = "Manage browser windows: list, create, or close windows.";
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -16,7 +16,7 @@ enum WindowsAction {
     List,
     Create,
     Close,
-    Activate,
+    // Intentionally omit Activate so MCP callers cannot steal window focus.
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -24,7 +24,7 @@ enum WindowsAction {
 struct WindowsArgs {
     #[serde(default)]
     action: WindowsAction,
-    /// Window id for close and activate.
+    /// Window id for close.
     #[serde(rename = "windowId")]
     window_id: Option<i64>,
 }
@@ -68,18 +68,6 @@ fn handler<'a>(
                 text_result(
                     format!("closed window {window_id}"),
                     Some(json!({ "action": "close", "windowId": window_id })),
-                )
-            }
-            WindowsAction::Activate => {
-                let Some(window_id) = args.window_id else {
-                    return Ok(Some(error_result(
-                        "windows activate: windowId is required.",
-                    )));
-                };
-                ctx.session.windows.activate(WindowId(window_id)).await?;
-                text_result(
-                    format!("activated window {window_id}"),
-                    Some(json!({ "action": "activate", "windowId": window_id })),
                 )
             }
         };


### PR DESCRIPTION
## Summary
- remove `activate` from the published `windows` MCP action schema and handler
- keep the underlying core window activation capability intact and document the MCP omission as intentional
- add regression coverage for the schema and rejected retired action

## Design
The MCP-facing description, action enum, `windowId` documentation, and handler now expose only list, create, and close. `WindowManager::activate` remains unchanged in `browseros-core` for non-MCP callers.

## Test plan
- [x] `cargo test -p browseros-mcp`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p browseros-mcp --all-targets -- -D warnings`
