### PR TITLE
feat(mcp): add recent browser history tool

### DIFF
--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "thiserror",
+ "time",
  "tokio",
  "tokio-util",
  "tower",

--- a/packages/browseros-agent/crates/browseros-mcp/Cargo.toml
+++ b/packages/browseros-agent/crates/browseros-mcp/Cargo.toml
@@ -18,6 +18,7 @@ rmcp.workspace = true
 schemars.workspace = true
 http.workspace = true
 thiserror.workspace = true
+time.workspace = true
 tracing.workspace = true
 base64.workspace = true
 imagesize.workspace = true

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -183,6 +183,37 @@ impl CdpConnection for HarnessConnection {
                     Ok(json!({ "tab": tab }))
                 }
                 "Browser.createTab" => Ok(json!({ "tab": new_harness_tab() })),
+                "History.getRecent" => {
+                    if params.get("maxResults") == Some(&json!(2)) {
+                        Ok(json!({
+                            "entries": [
+                                {
+                                    "id": "entry-1",
+                                    "url": "https://example.test/first",
+                                    "title": "First visit",
+                                    "lastVisitTime": 1_785_456_000_000_f64,
+                                    "visitCount": 4,
+                                    "typedCount": 1
+                                },
+                                {
+                                    "id": "entry-2",
+                                    "url": "https://example.test/second",
+                                    "title": "",
+                                    "lastVisitTime": 1_785_369_600_000_f64,
+                                    "visitCount": 1,
+                                    "typedCount": 0
+                                }
+                            ]
+                        }))
+                    } else if params.get("maxResults") == Some(&json!(100)) {
+                        Ok(json!({ "entries": [] }))
+                    } else {
+                        Err(CdpError::Protocol {
+                            code: -1,
+                            message: format!("unexpected History.getRecent params: {params}"),
+                        })
+                    }
+                }
                 "Target.attachToTarget" => {
                     let session =
                         if params.get("targetId").and_then(Value::as_str) == Some("target-2") {
@@ -402,6 +433,7 @@ fn catalog_order_matches_typescript_registry() {
         vec![
             "tabs",
             "tab_groups",
+            "history",
             "navigate",
             "snapshot",
             "diff",
@@ -431,6 +463,7 @@ fn catalog_page_metadata_matches_host_dispatch_contract() {
         vec![
             ("tabs", true),
             ("tab_groups", false),
+            ("history", false),
             ("navigate", true),
             ("snapshot", true),
             ("diff", true),
@@ -470,6 +503,34 @@ fn tab_and_window_schemas_omit_hidden_controls() {
         );
     }
     assert!(!windows.description.contains("hidden"));
+}
+
+#[test]
+fn history_schema_stays_narrow_and_defaults_to_100() {
+    let history = tool_by_name("history");
+    let schema = Value::Object(history.input_schema.as_ref().clone());
+    let properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| panic!("history schema should have properties"));
+    assert_eq!(properties.keys().collect::<Vec<_>>(), vec!["maxResults"]);
+    assert_eq!(
+        schema.pointer("/properties/maxResults/type"),
+        Some(&json!("integer"))
+    );
+    assert_eq!(
+        schema.pointer("/properties/maxResults/minimum"),
+        Some(&json!(1))
+    );
+    assert_eq!(
+        schema.pointer("/properties/maxResults/default"),
+        Some(&json!(100))
+    );
+    assert_eq!(
+        schema.get("additionalProperties"),
+        Some(&json!({ "not": {} }))
+    );
+    assert!(schema.get("required").is_none());
 }
 
 #[test]
@@ -742,6 +803,91 @@ async fn retired_hidden_inputs_are_rejected() {
         assert!(
             result_text(&result).starts_with(&format!("Invalid arguments for {name}:")),
             "{name} accepted retired hidden input"
+        );
+    }
+}
+
+#[tokio::test]
+async fn history_forwards_max_results_and_returns_full_entries() {
+    let (ctx, connection, _page) = harness_ctx().await;
+    let result = execute_tool(&tool_by_name("history"), json!({ "maxResults": 2 }), &ctx)
+        .await
+        .unwrap_or_else(|err| panic!("history should return a tool result: {err}"));
+
+    assert!(!result.is_error);
+    assert_eq!(
+        result.structured_content,
+        Some(json!({
+            "entries": [
+                {
+                    "id": "entry-1",
+                    "url": "https://example.test/first",
+                    "title": "First visit",
+                    "lastVisitTime": 1_785_456_000_000_f64,
+                    "visitCount": 4,
+                    "typedCount": 1
+                },
+                {
+                    "id": "entry-2",
+                    "url": "https://example.test/second",
+                    "title": "",
+                    "lastVisitTime": 1_785_369_600_000_f64,
+                    "visitCount": 1,
+                    "typedCount": 0
+                }
+            ],
+            "count": 2
+        }))
+    );
+    let text = result_text(&result);
+    assert!(text.contains("First visit"));
+    assert!(text.contains("https://example.test/first"));
+    assert!(text.contains("4 visits"));
+    assert!(text.contains("https://example.test/second"));
+    assert!(connection.calls().iter().any(|call| {
+        call.method == "History.getRecent"
+            && call.params == json!({ "maxResults": 2 })
+            && call.session.is_none()
+    }));
+}
+
+#[tokio::test]
+async fn history_defaults_to_100_and_handles_empty_history() {
+    let (ctx, connection, _page) = harness_ctx().await;
+    let result = execute_tool(&tool_by_name("history"), json!({}), &ctx)
+        .await
+        .unwrap_or_else(|err| panic!("history should return a tool result: {err}"));
+
+    assert!(!result.is_error);
+    assert_eq!(result_text(&result), "(no history)");
+    assert_eq!(
+        result.structured_content,
+        Some(json!({ "entries": [], "count": 0 }))
+    );
+    assert!(connection.calls().iter().any(|call| {
+        call.method == "History.getRecent"
+            && call.params == json!({ "maxResults": 100 })
+            && call.session.is_none()
+    }));
+}
+
+#[tokio::test]
+async fn history_rejects_invalid_or_unknown_inputs() {
+    for args in [
+        json!({ "maxResults": 0 }),
+        json!({ "maxResults": -1 }),
+        json!({ "maxResults": 1.5 }),
+        json!({ "maxResults": "10" }),
+        json!({ "query": "example" }),
+    ] {
+        let result = execute_tool(&tool_by_name("history"), args, &fake_ctx())
+            .await
+            .unwrap_or_else(|err| panic!("history should return a tool result: {err}"));
+        assert!(result.is_error);
+        assert!(
+            result_text(&result).starts_with("Invalid arguments for history:"),
+            "unexpected validation result: {}",
+            result_text(&result)
         );
     }
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -842,6 +842,7 @@ async fn history_forwards_max_results_and_returns_full_entries() {
     let text = result_text(&result);
     assert!(text.contains("First visit"));
     assert!(text.contains("https://example.test/first"));
+    assert!(text.contains("last visited 2026-07-31T00:00:00Z"));
     assert!(text.contains("4 visits"));
     assert!(text.contains("https://example.test/second"));
     assert!(connection.calls().iter().any(|call| {

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/history.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/history.rs
@@ -1,0 +1,115 @@
+use crate::framework::{
+    ArgIssue, ToolCtx, ToolError, ToolExecResult, ToolResult, parse_args, text_result,
+};
+use futures_util::future::BoxFuture;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+const DEFAULT_MAX_RESULTS: u32 = 100;
+const DESCRIPTION: &str = "\
+Get recent browser history entries, including URLs, titles, visit times, and visit counts. \
+Use maxResults to limit how many entries are returned.";
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct HistoryArgs {
+    /// Maximum number of recent entries to return. Defaults to 100.
+    #[serde(default = "default_max_results")]
+    #[schemars(range(min = 1))]
+    max_results: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct HistoryResult {
+    entries: Vec<HistoryEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HistoryEntry {
+    id: String,
+    url: String,
+    title: String,
+    last_visit_time: f64,
+    visit_count: i64,
+    typed_count: i64,
+}
+
+pub fn definition() -> crate::framework::ToolDef {
+    super::def::<HistoryArgs>(
+        "history",
+        DESCRIPTION,
+        Some(super::read_only_annotations()),
+        handler,
+    )
+}
+
+fn handler<'a>(
+    raw: Value,
+    ctx: &'a ToolCtx,
+    _response: &'a mut crate::response::ToolResponse,
+) -> BoxFuture<'a, ToolExecResult<Option<ToolResult>>> {
+    Box::pin(async move {
+        let args: HistoryArgs = parse_args(raw)?;
+        validate_args(&args)?;
+        let HistoryResult { entries } = serde_json::from_value(
+            ctx.session
+                .cdp(
+                    "History.getRecent",
+                    json!({ "maxResults": args.max_results }),
+                    None,
+                )
+                .await?,
+        )?;
+        let count = entries.len();
+        Ok(Some(text_result(
+            format_history(&entries),
+            Some(json!({ "entries": entries, "count": count })),
+        )))
+    })
+}
+
+fn validate_args(args: &HistoryArgs) -> ToolExecResult<()> {
+    if args.max_results == 0 {
+        return Err(ToolError::InvalidArguments(vec![ArgIssue {
+            path: "maxResults".to_string(),
+            message: "Number must be greater than or equal to 1".to_string(),
+        }]));
+    }
+    Ok(())
+}
+
+fn format_history(entries: &[HistoryEntry]) -> String {
+    if entries.is_empty() {
+        return "(no history)".to_string();
+    }
+
+    let mut lines = vec![
+        format!("Recent history ({}):", entries.len()),
+        String::new(),
+    ];
+    for entry in entries {
+        let destination = if entry.title.is_empty() {
+            entry.url.clone()
+        } else {
+            format!("{} ({})", entry.title, entry.url)
+        };
+        lines.push(format!(
+            "- {destination} — last visited {}; {} {}; {} typed",
+            entry.last_visit_time,
+            entry.visit_count,
+            pluralize(entry.visit_count, "visit", "visits"),
+            entry.typed_count,
+        ));
+    }
+    lines.join("\n")
+}
+
+fn pluralize(value: i64, singular: &'static str, plural: &'static str) -> &'static str {
+    if value == 1 { singular } else { plural }
+}
+
+fn default_max_results() -> u32 {
+    DEFAULT_MAX_RESULTS
+}

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/history.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/history.rs
@@ -5,6 +5,7 @@ use futures_util::future::BoxFuture;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 const DEFAULT_MAX_RESULTS: u32 = 100;
 const DESCRIPTION: &str = "\
@@ -97,13 +98,26 @@ fn format_history(entries: &[HistoryEntry]) -> String {
         };
         lines.push(format!(
             "- {destination} — last visited {}; {} {}; {} typed",
-            entry.last_visit_time,
+            format_visit_time(entry.last_visit_time),
             entry.visit_count,
             pluralize(entry.visit_count, "visit", "visits"),
             entry.typed_count,
         ));
     }
     lines.join("\n")
+}
+
+fn format_visit_time(milliseconds: f64) -> String {
+    if !milliseconds.is_finite() {
+        return milliseconds.to_string();
+    }
+    let Some(nanoseconds) = (milliseconds.trunc() as i128).checked_mul(1_000_000) else {
+        return milliseconds.to_string();
+    };
+    OffsetDateTime::from_unix_timestamp_nanos(nanoseconds)
+        .ok()
+        .and_then(|timestamp| timestamp.format(&Rfc3339).ok())
+        .unwrap_or_else(|| milliseconds.to_string())
 }
 
 fn pluralize(value: i64, singular: &'static str, plural: &'static str) -> &'static str {

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/mod.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/mod.rs
@@ -6,6 +6,7 @@ pub mod diff;
 pub mod download;
 pub mod evaluate;
 pub mod grep;
+pub mod history;
 pub mod navigate;
 pub mod pdf;
 pub mod read;
@@ -23,6 +24,7 @@ pub fn catalog() -> Vec<ToolDef> {
     vec![
         tabs::definition(),
         tab_groups::definition(),
+        history::definition(),
         navigate::definition(),
         snapshot::definition(),
         diff::definition(),

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/history.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/history.test.ts
@@ -53,6 +53,7 @@ describe('history tool', () => {
     expect(result.structuredContent).toEqual({ entries, count: 2 })
     expect(textOf(result)).toContain('First visit')
     expect(textOf(result)).toContain('https://example.test/first')
+    expect(textOf(result)).toContain('last visited 2026-07-31T00:00:00Z')
     expect(textOf(result)).toContain('4 visits')
     expect(textOf(result)).toContain('https://example.test/second')
     expect(calls).toEqual([

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/history.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/history.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'bun:test'
+import type { BrowserSession } from '@browseros/browser-core/core/session'
+import { executeTool } from './framework'
+import { history } from './history'
+
+const entries = [
+  {
+    id: 'entry-1',
+    url: 'https://example.test/first',
+    title: 'First visit',
+    lastVisitTime: 1_785_456_000_000,
+    visitCount: 4,
+    typedCount: 1,
+  },
+  {
+    id: 'entry-2',
+    url: 'https://example.test/second',
+    title: '',
+    lastVisitTime: 1_785_369_600_000,
+    visitCount: 1,
+    typedCount: 0,
+  },
+]
+
+function fakeSession(resultEntries: typeof entries) {
+  const calls: Array<{ method: string; params: unknown }> = []
+  const session = {
+    cdp: async (method: string, params: unknown) => {
+      calls.push({ method, params })
+      return { entries: resultEntries }
+    },
+  } as unknown as BrowserSession
+  return { session, calls }
+}
+
+function textOf(result: Awaited<ReturnType<typeof executeTool>>) {
+  return result.content
+    .filter(
+      (item): item is { type: 'text'; text: string } =>
+        item.type === 'text' && typeof item.text === 'string',
+    )
+    .map((item) => item.text)
+    .join('\n')
+}
+
+describe('history tool', () => {
+  it('forwards maxResults and returns full entries', async () => {
+    const { session, calls } = fakeSession(entries)
+
+    const result = await executeTool(history, { maxResults: 2 }, { session })
+
+    expect(result.isError).toBeFalsy()
+    expect(result.structuredContent).toEqual({ entries, count: 2 })
+    expect(textOf(result)).toContain('First visit')
+    expect(textOf(result)).toContain('https://example.test/first')
+    expect(textOf(result)).toContain('4 visits')
+    expect(textOf(result)).toContain('https://example.test/second')
+    expect(calls).toEqual([
+      { method: 'History.getRecent', params: { maxResults: 2 } },
+    ])
+  })
+
+  it('defaults maxResults to 100 and handles empty history', async () => {
+    const { session, calls } = fakeSession([])
+
+    const result = await executeTool(history, {}, { session })
+
+    expect(result.isError).toBeFalsy()
+    expect(textOf(result)).toBe('(no history)')
+    expect(result.structuredContent).toEqual({ entries: [], count: 0 })
+    expect(calls).toEqual([
+      { method: 'History.getRecent', params: { maxResults: 100 } },
+    ])
+  })
+
+  it('rejects invalid and unknown inputs', async () => {
+    const { session, calls } = fakeSession([])
+
+    for (const args of [
+      { maxResults: 0 },
+      { maxResults: -1 },
+      { maxResults: 1.5 },
+      { maxResults: '10' },
+      { query: 'example' },
+    ]) {
+      const result = await executeTool(history, args, { session })
+      expect(result.isError).toBe(true)
+      expect(textOf(result)).toStartWith('Invalid arguments for history:')
+    }
+    expect(calls).toEqual([])
+  })
+})

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/history.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/history.ts
@@ -48,8 +48,14 @@ function formatHistory(entries: HistoryEntry[]): string {
       : entry.url
     const visits = entry.visitCount === 1 ? 'visit' : 'visits'
     lines.push(
-      `- ${destination} — last visited ${entry.lastVisitTime}; ${entry.visitCount} ${visits}; ${entry.typedCount} typed`,
+      `- ${destination} — last visited ${formatVisitTime(entry.lastVisitTime)}; ${entry.visitCount} ${visits}; ${entry.typedCount} typed`,
     )
   }
   return lines.join('\n')
+}
+
+function formatVisitTime(milliseconds: number): string {
+  const timestamp = new Date(milliseconds)
+  if (Number.isNaN(timestamp.getTime())) return String(milliseconds)
+  return timestamp.toISOString().replace('.000Z', 'Z')
 }

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/history.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/history.ts
@@ -1,0 +1,55 @@
+import type {
+  GetRecentResult,
+  HistoryEntry,
+} from '@browseros/cdp-protocol/domains/history'
+import { z } from 'zod'
+import { defineTool, textResult } from './framework'
+
+const DEFAULT_MAX_RESULTS = 100
+
+export const history = defineTool({
+  name: 'history',
+  description:
+    'Get recent browser history entries, including URLs, titles, visit times, and visit counts. Use maxResults to limit how many entries are returned.',
+  input: z
+    .object({
+      maxResults: z
+        .number()
+        .int()
+        .positive()
+        .default(DEFAULT_MAX_RESULTS)
+        .describe(
+          'Maximum number of recent entries to return. Defaults to 100.',
+        ),
+    })
+    .strict(),
+  annotations: {
+    title: 'Get recent browser history',
+    readOnlyHint: true,
+  },
+  handler: async (args, ctx) => {
+    const { entries } = (await ctx.session.cdp('History.getRecent', {
+      maxResults: args.maxResults,
+    })) as GetRecentResult
+    return textResult(formatHistory(entries), {
+      entries,
+      count: entries.length,
+    })
+  },
+})
+
+function formatHistory(entries: HistoryEntry[]): string {
+  if (entries.length === 0) return '(no history)'
+
+  const lines = [`Recent history (${entries.length}):`, '']
+  for (const entry of entries) {
+    const destination = entry.title
+      ? `${entry.title} (${entry.url})`
+      : entry.url
+    const visits = entry.visitCount === 1 ? 'visit' : 'visits'
+    lines.push(
+      `- ${destination} — last visited ${entry.lastVisitTime}; ${entry.visitCount} ${visits}; ${entry.typedCount} typed`,
+    )
+  }
+  return lines.join('\n')
+}

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/registry.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/registry.ts
@@ -4,6 +4,7 @@ import { download } from './download'
 import { evaluate } from './evaluate'
 import type { ToolDefinition } from './framework'
 import { grep } from './grep'
+import { history } from './history'
 import { navigate } from './navigate'
 import { pdf } from './pdf'
 import { read } from './read'
@@ -19,6 +20,7 @@ import { windows } from './windows'
 export const BROWSER_TOOLS: readonly ToolDefinition[] = [
   tabs,
   tab_groups,
+  history,
   navigate,
   snapshot,
   diff,

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/structured-contract.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/structured-contract.test.ts
@@ -142,6 +142,20 @@ function createContractSession(): BrowserSession {
           ],
         }
       }
+      if (method === 'History.getRecent') {
+        return {
+          entries: [
+            {
+              id: 'history-1',
+              url: 'https://example.com/history',
+              title: 'History',
+              lastVisitTime: 1_785_456_000_000,
+              visitCount: 2,
+              typedCount: 1,
+            },
+          ],
+        }
+      }
       if (
         method === 'Browser.createTabGroup' ||
         method === 'Browser.addTabsToGroup' ||
@@ -213,6 +227,7 @@ describe('browser tool structured contract', () => {
           action: 'close',
           groupId: 'group-1',
         }),
+        history: await call('history', { maxResults: 1 }),
         navigate: await call('navigate', {
           page: 1,
           action: 'url',
@@ -272,6 +287,7 @@ describe('browser tool structured contract', () => {
         'tab_groups.update': ['group'],
         'tab_groups.ungroup': ['count', 'pageIds'],
         'tab_groups.close': ['groupId'],
+        history: ['count', 'entries'],
         navigate: ['page', 'url'],
         snapshot: ['contentLength', 'page', 'tokenEstimate', 'writtenToFile'],
         diff: ['added', 'changed', 'removed'],


### PR DESCRIPTION
## Summary

- add a narrow read-only `history` MCP tool backed by `History.getRecent`
- expose only positive-integer `maxResults` with a deterministic default of 100
- return readable RFC 3339 history text plus lossless structured entries/count
- keep Rust and TypeScript MCP catalogs, ordering, metadata, schemas, and tests aligned

## Design

The tool is a dedicated browser-global module in both current MCP implementations. Each handler validates/defaults `maxResults`, makes one browser-level CDP call, formats populated or empty text, and preserves every generated History entry field in structured content. Generated protocol files remain unchanged.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test -p browseros-mcp` (59 unit + 3 integration)
- [x] `bun run typecheck && bun test` in `packages/browser-mcp` (33 tests)
- [x] `bun run check`
- [x] adversarial review round 2 clean
- [x] `git diff --check`

The repository-wide `bun run test` continues to hit an existing root-runner alias-resolution issue in four unchanged `claw-onboard` files. Those same four files pass from their package directory (41 tests); no `apps/claw-onboard` file differs from `origin/main`.
