### PR TITLE
fix: install lefthook hooks at repo level, not a global core.hooksPath

### DIFF
--- a/packages/browseros-agent/apps/app/package.json
+++ b/packages/browseros-agent/apps/app/package.json
@@ -111,7 +111,6 @@
     "wxt": "^0.20.27"
   },
   "trustedDependencies": [
-    "esbuild",
-    "lefthook"
+    "esbuild"
   ]
 }

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -9,6 +9,7 @@
     "packages/*"
   ],
   "scripts": {
+    "postinstall": "lefthook install || true",
     "dev:watch": "./tools/dev/run.sh watch",
     "dev:watch:new": "./tools/dev/run.sh watch --new",
     "dev:claw:watch": "./tools/dev/run.sh watch --claw",
@@ -92,9 +93,6 @@
     "typescript": "^7.0.2",
     "yaml": "2.9.0"
   },
-  "trustedDependencies": [
-    "lefthook"
-  ],
   "engines": {
     "bun": "1.3.6",
     "node": "please-use-bun",


### PR DESCRIPTION
## Problem

`bun install` was overwriting a developer's **global** git hooks. On a machine with a global `core.hooksPath` configured, running `bun install` replaced the hooks in that global directory with this project's lefthook hooks (backing up the originals as `.mintbak`), which then made these hooks run in **every** repository on the machine.

## Root cause

`lefthook` was listed in `trustedDependencies`, which lets bun run the `lefthook` package's `postinstall`. That postinstall runs:

```
lefthook install -f
```

The `-f` flag means *"proceed even if core.hooksPath is set"*. So instead of installing into the repo's own `.git/hooks`, it force-installs into whatever `core.hooksPath` resolves to. When a developer has a global `core.hooksPath`, that is their global hooks directory, and it gets overwritten on every install.

Without `-f`, `lefthook install` already does the right thing: it declines and prints guidance when `core.hooksPath` points somewhere external, rather than clobbering it.

## Fix

- Remove `lefthook` from `trustedDependencies` (in the monorepo root and in `apps/app`) so bun no longer runs the forced `lefthook install -f`.
- Add a repo `postinstall` that runs `lefthook install` **without** `-f`:
  - No global `core.hooksPath` set (the common case): installs into the repo's own `.git/hooks`, exactly as before.
  - Global `core.hooksPath` set: lefthook declines instead of overwriting it; the `|| true` guard keeps `bun install` from failing.

Net effect: hooks are still installed automatically at the repo level, and the project can no longer touch a contributor's global hooks.

## Validation

- Both edited `package.json` files parse as valid JSON.
- `lefthook install` with `-f` writes into an external `core.hooksPath`; without `-f` it refuses and leaves it untouched (exit 1, guarded to 0 by `|| true`).
- Confirmed on a machine with a global `core.hooksPath`: the new postinstall command leaves the global hooks directory byte-for-byte untouched.
- Confirmed `bun install` runs the root `postinstall` script.

## Impact on contributors

None for the common setup (no global `core.hooksPath`): hooks continue to auto-install into `.git/hooks`. Contributors who intentionally use a global `core.hooksPath` will no longer have it overwritten; if they want this repo's hooks, they can opt in explicitly (e.g. `bunx lefthook install --force` after pointing `core.hooksPath` at the repo).
