### PR TITLE
fix(claw): sync history tool catalog tests

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -385,6 +385,7 @@ async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
         vec![
             "tabs",
             "tab_groups",
+            "history",
             "navigate",
             "snapshot",
             "diff",

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -113,7 +113,7 @@ describe('registerBrowserTools', () => {
     registerBrowserTools(fake.server as never, session)
 
     expect([...fake.handlers.keys()]).toEqual(BROWSER_TOOLS.map((t) => t.name))
-    expect(fake.handlers.size).toBe(16)
+    expect(fake.handlers.size).toBe(17)
     expect(fake.configs.get('tabs')?.inputSchema).toBeDefined()
   })
 

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-tabs.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-tabs.ts
@@ -296,18 +296,18 @@ export const tabsCases: ContractCase[] = [
     },
   },
   {
-    name: 'windows: activate focuses the target window',
+    name: 'windows: retired activate action is rejected',
     async run(ctx) {
-      const created = expectOk(
-        await ctx.mcp.callTool('windows', { action: 'create' }),
+      const error = expectError(
+        await ctx.mcp.callTool('windows', {
+          action: 'activate',
+          windowId: 99_999,
+        }),
+        'windows activate',
       )
-      const windowId = Number(created.match(/\b(\d+)\b/)?.[1])
-      const activated = await ctx.mcp.callTool('windows', {
-        action: 'activate',
-        windowId,
-      })
-      expectOk(activated, 'windows activate')
-      await ctx.mcp.callTool('windows', { action: 'close', windowId })
+      if (!error.includes('unknown variant `activate`')) {
+        throw new Error(`unexpected windows activate error: ${error}`)
+      }
     },
   },
   {

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-transport.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-transport.ts
@@ -13,6 +13,7 @@ const EXPECTED_TOOLS = [
   'download',
   'evaluate',
   'grep',
+  'history',
   'name_session',
   'navigate',
   'pdf',


### PR DESCRIPTION
## Summary
- fix the release `cargo test --workspace --locked` failure in `claw-server-rust`
- align the Rust and real-browser `tools/list` expectations with the intentionally added `history` MCP tool
- align the directly related TypeScript server registration count uncovered by PR CI
- update the real-browser contract for the intentionally retired `windows.activate` action
- preserve production behavior; all changes are test expectations and contracts

## Design
The shared Rust MCP catalog intentionally advertises `history` between `tab_groups` and `navigate`, while the claw server appends its local `name_session` tool. The TypeScript `BROWSER_TOOLS` registry likewise grew from 16 to 17 entries. Separately, `windows.activate` was intentionally removed from the Rust MCP action enum. This PR synchronizes the stale tests with those shipped interfaces and asserts the specific validation rejection for the retired action.

## Test plan
- [x] reproduce `mcp_initialize_list_guard_audit_and_delete` failure locally
- [x] `cargo test -p claw-server-rust --test routes mcp_initialize_list_guard_audit_and_delete -- --exact`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] reproduce `Tests / server-tools` expected-16/received-17 failure locally
- [x] `bun run test:tools` (254 passed)
- [x] server `bun run typecheck`
- [x] Biome on all touched TypeScript contract/test files
- [x] load the real-browser contract suite locally (110 discovered; skipped without `BROWSEROS_BINARY`)
- [x] three adversarial review rounds; one minor coverage finding fixed

## Existing local baseline
- Root `bun run check` reaches Fallow and reports the existing repository-wide dead-code/dependency baseline; lint and all workspace typechecks pass first.
- Root `bun run test` hits the same four unchanged `claw-onboard` alias-resolution failures documented on #2071. PR CI runs these suites in their configured package contexts.
