### PR TITLE
fix(cli): normalize trailing MCP URL slashes

### DIFF
--- a/packages/browseros-agent/apps/cli/cmd/root.go
+++ b/packages/browseros-agent/apps/cli/cmd/root.go
@@ -367,8 +367,8 @@ func normalizeServerURL(raw string) string {
 		normalized = "http://127.0.0.1:" + normalized
 	}
 
-	normalized = strings.TrimSuffix(normalized, "/mcp")
-	return strings.TrimSuffix(normalized, "/")
+	normalized = strings.TrimRight(normalized, "/")
+	return strings.TrimSuffix(normalized, "/mcp")
 }
 
 func isPortOnly(s string) bool {

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -405,9 +405,34 @@ func TestDefaultServerURLIgnoresBrowserOSServerJSON(t *testing.T) {
 }
 
 func TestNormalizeServerURLAcceptsMCPEndpoint(t *testing.T) {
-	got := normalizeServerURL(" http://127.0.0.1:9115/mcp ")
-	if got != "http://127.0.0.1:9115" {
-		t.Fatalf("normalizeServerURL() = %q, want %q", got, "http://127.0.0.1:9115")
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "endpoint",
+			input: " http://127.0.0.1:9115/mcp ",
+			want:  "http://127.0.0.1:9115",
+		},
+		{
+			name:  "endpoint with trailing slash",
+			input: "http://127.0.0.1:9115/mcp/",
+			want:  "http://127.0.0.1:9115",
+		},
+		{
+			name:  "endpoint with multiple trailing slashes",
+			input: "http://127.0.0.1:9115/mcp///",
+			want:  "http://127.0.0.1:9115",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeServerURL(tt.input); got != tt.want {
+				t.Fatalf("normalizeServerURL() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- normalize trailing slashes before removing the MCP path suffix
- cover endpoint URLs ending in `/mcp/` and `/mcp///`

This keeps CLI MCP connections at the canonical `/mcp?structured=1` endpoint instead of constructing `/mcp/mcp?structured=1`.

## Validation

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
