### PR TITLE
feat(server): add optional AgentPond tracing

### DIFF
--- a/packages/browseros-agent/.agents/skills/agentpond-instrumentation/SKILL.md
+++ b/packages/browseros-agent/.agents/skills/agentpond-instrumentation/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: agentpond-instrumentation
+description: Add OpenInference tracing to trusted Firebase, Supabase, Vercel, or Files SDK-backed applications and export spans directly to AgentPond storage. Use when instrumenting an untraced AI server, adding a missing OpenInference integration, or adapting existing OpenTelemetry setup for direct object storage.
+---
+
+# AgentPond Instrumentation
+
+Instrument trusted server-side AI applications without changing business behavior. Analyze the target service first, reuse existing tracing infrastructure, and keep storage credentials and trace export strictly server-side.
+
+Read the lifecycle and OpenInference references for every task, plus only the
+provider reference relevant to the detected deployment:
+
+- Application-owned shutdown and request-lifetime flushing: [references/lifecycle.md](references/lifecycle.md)
+- Firebase exporter and Storage Rules: [references/firebase.md](references/firebase.md)
+- Supabase exporter, Storage bucket, RLS, and Edge lifecycle: [references/supabase.md](references/supabase.md)
+- Vercel exporter, Blob setup, targets, and lifecycle: [references/vercel.md](references/vercel.md)
+- Files SDK local verification and production handoff: [references/files-sdk.md](references/files-sdk.md)
+- OpenInference routing, custom spans, sessions, and verification: [references/openinference.md](references/openinference.md)
+
+## Core principles
+
+- Inspect before editing. Confirm the service, runtime, package manager, AI SDK, framework, provider, and existing telemetry.
+- Instrument only trusted server code. Supabase Edge Functions are supported through their built-in secret variables; other Edge and middleware runtimes are not. Never put AgentPond storage exporters in browser, client, or static bundles.
+- Prefer framework or provider auto-instrumentation. Add manual spans only for application logic, chains, tools, or gaps.
+- Reuse the existing storage SDK and global OpenTelemetry provider. Do not register a competing provider.
+- Initialize tracing before importing or constructing instrumented AI clients.
+- Export directly to the selected object store. Do not add an ingestion HTTP route.
+- Keep tracing additive and follow the repository's conventions.
+- Never add credentials to source code or ask the user to paste secrets into chat.
+
+## Phase 0: preflight
+
+1. Detect Firebase, Supabase, or Vercel project markers. If none exists, use the Files SDK workflow. If multiple exist, ask which platform owns the deployed service; do not persist that choice.
+2. Confirm which trusted Node.js service or Supabase Edge Function is in scope. Files SDK direct export requires trusted Node.js. In a monorepo, do not assume every server package should be instrumented.
+3. Identify the build, typecheck, start, emulator or deployment, real-request,
+   and application lifecycle commands needed for verification.
+4. Stop if the target is only client, middleware, unsupported Edge, or static code and ask whether the user wants to add a trusted server runtime.
+5. Read the matching platform or Files SDK reference before proposing changes.
+
+## Phase 1: read-only analysis
+
+Do not write files, install packages, link projects, or provision storage during this phase.
+
+1. Inspect platform configuration, AgentPond environments, package manifests, lockfiles, server entrypoints, and existing storage connections.
+2. Scan imports to identify AI providers, agent frameworks, existing OpenInference or OpenTelemetry setup, provider SDK initialization, and request, conversation, and tool boundaries.
+3. Review the selected storage path's privacy and credential requirements from its reference.
+4. Prefer a framework-native OpenInference integration when it captures model and tool spans. Add a provider instrumentor only for a documented gap.
+5. Return a concise proposal containing the target service, runtime, package manager, AI SDKs, packages, storage resources, existing initialization to reuse, files, and verification commands.
+
+Stop after presenting the proposal and ask for explicit confirmation before installing packages, editing files, linking a Vercel project, provisioning Blob, or changing Firebase Storage Rules.
+
+## Phase 2: implementation
+
+1. Read current official integration documentation for the detected framework or AI client.
+2. Install the platform package (`@agentpond/firebase`, `@agentpond/supabase`, or `@agentpond/vercel`) or the Files SDK packages from its reference, required OpenTelemetry packages, and the matching `@arizeai/openinference-*` package. Use exact versions verified against the target lockfile. In generated scripts or workflow commands, invoke `npx agentpond@<verified-version>` instead of an unqualified package download.
+3. Create or update one centralized server instrumentation module.
+4. Reuse existing storage and OpenTelemetry initialization, following the matching reference.
+5. Create the direct span exporter and attach it to the existing provider. When none exists, prefer NodeSDK's batched `traceExporter` configuration or an explicit `BatchSpanProcessor` supported by the installed version.
+6. Register OpenInference instrumentation before AI clients are created.
+7. Add manual CHAIN and TOOL spans only where auto-instrumentation leaves important behavior invisible.
+8. Preserve one `session.id` across all turns in the same conversation.
+9. Apply the storage-specific privacy and target requirements, then follow the
+   application-owned lifecycle pattern in
+   [references/lifecycle.md](references/lifecycle.md).
+
+## Verification
+
+Treat the work as complete only when the project builds or typechecks, the trusted runtime loads without duplicate-provider errors, one real AI request exports OpenInference spans, the real lifecycle boundary finishes exporting them, and the trace appears after the sync workflow in the matching reference.
+
+Inspect the trace and confirm applicable model, CHAIN, TOOL, input/output, parent-child, and session attributes. For short-lived processes, force-flush before exit. Do not shut down a reusable module-level provider after every request.
+
+Inspect the raw stored object and ensure it does not expose credentials or unnecessary personal data.
+
+## Attribution
+
+This workflow is adapted from Arize AI's MIT-licensed [arize-instrumentation skill](https://github.com/Arize-ai/arize-skills/tree/main/skills/arize-instrumentation). It replaces Arize-specific export and verification with AgentPond direct export to Firebase Storage, Supabase Storage, Vercel Blob, or Files SDK while retaining the analyze-then-implement workflow.

--- a/packages/browseros-agent/.agents/skills/agentpond-instrumentation/agents/openai.yaml
+++ b/packages/browseros-agent/.agents/skills/agentpond-instrumentation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AgentPond Instrumentation"
+  short_description: "Trace provider-hosted AI apps"
+  default_prompt: "Use $agentpond-instrumentation to add OpenInference tracing to this Firebase, Supabase, or Vercel application."

--- a/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/files-sdk.md
+++ b/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/files-sdk.md
@@ -1,0 +1,85 @@
+# Files SDK direct export
+
+Use this workflow when the project is not managed by Firebase, Supabase, or
+Vercel. It applies only to trusted Node.js services; never load object-storage
+credentials or the exporter in browser, client, middleware, or static code.
+
+## Analyze before setup
+
+Inspect the service, existing OpenTelemetry provider, package manager, AI SDKs,
+start command, and current AgentPond environments. Run `npx agentpond env list`
+before proposing storage changes. Do not replace an existing environment file.
+
+For a new setup, propose a dependency-free local verification environment. Add
+`.agentpond/` to the repository's ignore file if it is not already ignored.
+After the user confirms implementation, resolve the absolute project root and
+run:
+
+```bash
+npx agentpond env init local \
+  --provider fs \
+  --root <absolute-project-root>/.agentpond/envs/local/objects
+npx agentpond env use local
+```
+
+If `local` already exists, inspect it with `npx agentpond env get local`. Reuse
+it only when it is a valid `fs` environment for this project; otherwise report
+the conflict and ask before choosing another name or editing it.
+
+## Instrument the trusted runtime
+
+Install `@agentpond/files-sdk`, `@agentpond/otel`, `files-sdk`, the existing
+OpenTelemetry runtime packages, and the appropriate OpenInference
+instrumentation. Use one centralized server-only instrumentation module:
+
+```ts
+import { createFilesSpanExporterFromRuntimeEnv } from "@agentpond/files-sdk/otel";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+const sdk = new NodeSDK({
+  traceExporter: createFilesSpanExporterFromRuntimeEnv(),
+  instrumentations: [/* matching OpenInference instrumentations */],
+});
+
+sdk.start();
+```
+
+Load the selected environment into the application process rather than copying
+the filesystem root into source code:
+
+```bash
+eval "$(npx agentpond env get local)"
+```
+
+Start the application from that shell, exercise one real AI request, and flush
+at the application's real lifecycle boundary.
+
+## Verify and hand off to production
+
+```bash
+npx agentpond env use local
+npx agentpond sync
+npx agentpond traces list --limit 10
+npx agentpond traces get <trace-id>
+```
+
+Confirm model or LLM spans, important CHAIN and TOOL spans, parent-child
+relationships, inputs and outputs allowed by the privacy policy, and
+`session.id` where applicable.
+
+The `fs` adapter is persistent across local processes but is for development
+and verification only. After the trace is verified, tell the user to choose a
+production adapter from the [Files SDK provider catalog](https://files-sdk.dev/docs/providers).
+Install its peer SDK. If the current CLI does not offer that compatible
+adapter, install `agentpond` locally alongside the peer SDK so `npx` uses the
+project-local CLI. Initialize a separate environment with
+`npx agentpond env init production --provider <provider>` and its typed flags,
+and supply credentials through the runtime environment. Keep
+`createFilesSpanExporterFromRuntimeEnv()` in application code so changing
+storage requires environment configuration rather than another code change.
+
+For Azure Blob Storage, install `@azure/storage-blob`, initialize with
+`npx agentpond env init production --provider azure --container <container>`,
+and provide `AZURE_STORAGE_CONNECTION_STRING` or the matching
+`AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_ACCOUNT_KEY` variables to both
+the trusted application runtime and AgentPond CLI shell.

--- a/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/firebase.md
+++ b/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/firebase.md
@@ -1,0 +1,95 @@
+# Firebase instrumentation and storage
+
+Use this reference for every Firebase instrumentation task.
+
+## Trusted runtime boundary
+
+`createFirebaseSpanExporter()` uses Firebase Admin and must run in trusted server code such as Cloud Functions for Firebase or another Node.js server with Firebase Admin credentials. Never add it to web, mobile, or other client bundles.
+
+If the repository has no trusted server runtime, stop and ask whether the user wants to add one. Do not work around the boundary with client credentials.
+
+## Default Firebase app
+
+The exporter derives the project ID and storage bucket from the default Firebase Admin app. Reuse the project's existing initialization whenever possible:
+
+```ts
+import { createFirebaseSpanExporter } from "@agentpond/firebase";
+
+const exporter = createFirebaseSpanExporter();
+```
+
+Add `initializeApp()` only when the server has no default app initialization. When a shared module genuinely needs defensive initialization, check the default app specifically:
+
+```ts
+import { getApp, initializeApp } from "firebase-admin/app";
+
+try {
+  getApp();
+} catch {
+  initializeApp();
+}
+```
+
+Do not use `getApps().length` for this decision. A named app can exist while the required default app is absent.
+
+## OpenTelemetry provider
+
+Inspect the installed OpenTelemetry version and existing provider before editing. Add the exporter to the existing provider rather than registering another global provider.
+
+When no provider exists, a typical Node SDK shape is:
+
+```ts
+import { createFirebaseSpanExporter } from "@agentpond/firebase";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+const sdk = new NodeSDK({
+  traceExporter: createFirebaseSpanExporter(),
+  instrumentations: [
+    // Add the integration selected for the detected AI SDK or framework.
+  ],
+});
+
+sdk.start();
+```
+
+NodeSDK wraps `traceExporter` in a `BatchSpanProcessor`, so each exporter invocation can contain multiple spans and AgentPond writes one object per exported batch. When constructing a provider manually or tuning queue and batch settings, create a `BatchSpanProcessor` explicitly instead. Do not use `SimpleSpanProcessor` for normal production export because it invokes the exporter separately for every ended span.
+
+Adapt the construction to the installed SDK API and project lifecycle. Initialize the module before instrumented clients. Force-flush at a real lifecycle boundary when required so queued batches finish exporting; do not shut down a reusable Functions instance after every request.
+
+## Storage Rules review
+
+AgentPond writes trace objects below `agentpond/` in the Firebase Storage bucket. Firebase Admin access from the exporter and local CLI is trusted and bypasses Firebase client Storage Rules. Client SDKs must not be able to read, list, create, update, or delete those objects.
+
+1. Read `firebase.json` and locate every configured Storage Rules file.
+2. Review every `match` and `allow` expression that can overlap `agentpond/**`, including recursive wildcard rules.
+3. Remember that Firebase Rules are allow-only. If any overlapping allow condition evaluates to true, access is granted.
+4. A nested block such as this is not a deny override:
+
+```rules
+match /agentpond/{allPaths=**} {
+  allow read, write: if false;
+}
+```
+
+5. If no allow matches `agentpond/**`, leave the default-deny rules unchanged.
+6. If a broad allow matches the prefix, report a blocker. Narrow the broad match to application-owned prefixes or change its actual condition so AgentPond objects are excluded. Base the edit on the repository's rule structure; do not invent a universal exclusion snippet.
+7. When the emulator and Rules tests are configured, add or run tests proving representative authenticated and unauthenticated client requests cannot access `agentpond/**` while intended application paths still work.
+
+Do not declare setup complete while a broad client allow still exposes AgentPond trace data.
+
+## Firebase project selection and verification
+
+Select the Firebase project through AgentPond, which delegates to Firebase's
+active-project selection:
+
+```bash
+npx agentpond env use <alias-or-project-id>
+npx agentpond sync
+npx agentpond traces list --limit 10
+```
+
+Confirm the active project at any time with `npx agentpond env current`.
+
+AgentPond manual environment operations (`get`, `list`, and `init`) and the
+local testing server are unavailable for Firebase projects. Use `env use` and
+the Firebase runtime instead.

--- a/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/lifecycle.md
+++ b/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/lifecycle.md
@@ -1,0 +1,87 @@
+# Application lifecycle and trace draining
+
+The application or deployment runtime owns termination. Reuse its existing
+lifecycle mechanism and make AgentPond the final telemetry step after the
+application stops producing spans. Do not add a second signal owner when the
+framework, process manager, or application already has one.
+
+Classify the runtime before choosing a pattern.
+
+## One-shot scripts, jobs, and tests
+
+Start the SDK once and await shutdown in `finally` so success and handled-error
+paths both drain queued spans:
+
+```ts
+sdk.start();
+
+try {
+	await runApplication();
+} finally {
+	await sdk.shutdown();
+}
+```
+
+Use the corresponding provider or processor shutdown when the application
+constructs OpenTelemetry manually. Do not call `process.exit()` after starting
+shutdown; an immediate exit can abandon the pending promise and trace writes.
+
+## Long-running Node.js servers
+
+Prefer the framework's existing graceful-shutdown hook. For example, a
+Fastify-owned provider can shut down after the server stops accepting work:
+
+```ts
+sdk.start();
+
+app.addHook("onClose", async () => {
+	await sdk.shutdown();
+});
+```
+
+Follow the application's established shutdown order: stop accepting requests,
+finish in-flight work, close other span-producing resources, and then shut down
+OpenTelemetry. If the application owns `SIGINT` or `SIGTERM`, extend that one
+central path instead of registering AgentPond signal handlers in a reusable
+module. Keep its existing error logging and exit semantics.
+
+Do not use an async `process.on("exit", ...)` handler; Node cannot await it.
+`beforeExit` is also not a substitute for graceful shutdown because it is not
+emitted for every termination path and asynchronous work can cause it to run
+again.
+
+## Reusable request and serverless runtimes
+
+Keep the module-level provider alive between requests. End the request's spans,
+then attach `forceFlush()` to the platform's native request-lifetime primitive:
+
+```ts
+after(() => processor.forceFlush());
+```
+
+```ts
+context.waitUntil(processor.forceFlush());
+```
+
+```ts
+EdgeRuntime.waitUntil(processor.forceFlush());
+```
+
+Retain the explicit `BatchSpanProcessor` used by these calls. Handle rejected
+flushes through the application's normal logging conventions. Do not shut down
+a reusable provider after every request, and do not block the response when the
+runtime supplies a supported background-lifetime primitive.
+
+## End-to-end validation
+
+Validate the same boundary production uses after a representative AI request:
+
+- Let a one-shot process reach and await its `finally` shutdown.
+- Invoke a server's normal graceful-stop path rather than calling telemetry
+  shutdown directly from the test.
+- Run or mock the serverless request-lifetime primitive and await the promise or
+  deferred callback it received.
+
+Then sync AgentPond and read the new trace back from the selected store. A
+build, typecheck, unit test, or direct call to `forceFlush()` without exercising
+the application's real boundary does not validate lifecycle integration.

--- a/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/openinference.md
+++ b/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/openinference.md
@@ -1,0 +1,42 @@
+# OpenInference integration
+
+Use current official OpenInference documentation to select packages and initialization for the detected AI SDK or framework.
+
+## Routing
+
+1. Prefer a framework-native integration when it captures model, chain, and tool activity.
+2. Otherwise select the provider-specific `@arizeai/openinference-*` instrumentor matching imports actually used by the server.
+3. Do not add both framework and provider instrumentation when that would duplicate spans.
+4. If no auto-instrumentor exists, retain normal OpenTelemetry tracing and add OpenInference semantic attributes to manual spans.
+
+Common JavaScript surfaces include OpenAI, Anthropic, LangChain, Bedrock, Vercel AI SDK, MCP, and GenAI semantic-convention adapters. Verify the current package name and version before installation rather than guessing from this list.
+
+## Initialization order
+
+Set up the selected provider's AgentPond exporter and tracer provider, register instrumentations, and only then import or construct AI clients. Respect any framework-specific preload or bootstrap mechanism.
+
+If the application already has a global provider, add the AgentPond exporter to it. Do not replace existing exporters unless the user explicitly asks.
+
+## Manual spans
+
+Use manual spans for custom application steps that auto-instrumentation cannot see:
+
+- `CHAIN`: orchestration or agent-loop boundaries
+- `TOOL`: each tool invocation, including input, output, and error status
+- `AGENT`: a meaningful agent execution boundary when the framework does not emit one
+
+Set `openinference.span.kind` and the applicable `input.value`, `output.value`, and MIME-type attributes. Avoid recording secrets or unnecessary personal data.
+
+## Sessions
+
+Set `session.id` on the outer CHAIN or AGENT span. Generate it once at the conversation boundary and reuse it for every turn in that conversation. Auto-instrumented model and tool spans should be children of that outer span.
+
+## Flush and verification
+
+- Long-running servers: keep the provider alive and flush at supported lifecycle boundaries.
+- Short-lived scripts and test commands: force-flush and shut down before process exit.
+- Reusable Firebase, Supabase, or Vercel request handlers: do not shut down a module-level provider after every request.
+
+Run a real application request and verify the resulting trace rather than treating compilation alone as success. Confirm span kinds, inputs/outputs, parent-child relationships, tool results, and session grouping.
+
+Read back the raw stored object and ensure it does not expose credentials or unnecessary personal data.

--- a/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/supabase.md
+++ b/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/supabase.md
@@ -1,0 +1,130 @@
+# Supabase instrumentation and Storage
+
+Use this reference for every Supabase instrumentation task. Version 1 supports
+hosted Supabase projects and their branch project refs; do not document local
+Docker or self-hosted Supabase as verified paths.
+
+## Trusted runtime boundary
+
+`createSupabaseSpanExporter()` requires a modern Supabase secret key or a
+legacy `service_role` key. It may run in Supabase Edge Functions or in a
+trusted Node.js backend. Never add it to browser, mobile, or other client code,
+and never expose its key through public environment variables or responses.
+
+Supabase Edge Functions provide `SUPABASE_URL` and `SUPABASE_SECRET_KEYS` as
+built-in secrets. The exporter reads `SUPABASE_SECRET_KEYS.default`; it also
+accepts `SUPABASE_SECRET_KEY` and temporarily supports
+`SUPABASE_SERVICE_ROLE_KEY`. Node backends must receive the same values through
+server-only secret configuration.
+
+## Dedicated private bucket
+
+During read-only analysis, inspect `supabase/config.toml`, migrations, and the
+Storage bucket list without changing them. After explicit confirmation, create
+or reuse a dedicated private bucket named `agentpond`. A migration can make the
+requirement reproducible:
+
+```sql
+insert into storage.buckets (id, name, public)
+values ('agentpond', 'agentpond', false)
+on conflict (id) do update set public = false;
+```
+
+Do not share an application bucket. AgentPond writes directly below:
+
+```text
+otel/<project-ref>/...
+```
+
+Private buckets are not an unconditional deny. Supabase Storage still applies
+RLS policies on `storage.objects` to authenticated Storage API requests. Review
+every migration and dashboard-created policy whose `using` or `with check`
+condition can match `bucket_id = 'agentpond'`, including broad policies that
+do not constrain `bucket_id`. Narrow or remove policies that grant application
+roles access to this bucket, and add database tests when the project already
+tests Storage policies. The exporter and CLI use secret/service-role access;
+do not weaken RLS to make them work.
+
+## Supabase Edge Functions
+
+Install `@agentpond/supabase`, `@opentelemetry/api`, and
+`@opentelemetry/sdk-trace-base` plus the matching OpenInference integration.
+Reuse an existing provider when present. Otherwise, the explicit Edge shape is:
+
+```ts
+import { createSupabaseSpanExporter } from "npm:@agentpond/supabase";
+import { trace } from "npm:@opentelemetry/api";
+import {
+  BasicTracerProvider,
+  BatchSpanProcessor,
+} from "npm:@opentelemetry/sdk-trace-base";
+
+const exporter = createSupabaseSpanExporter();
+const processor = new BatchSpanProcessor(exporter);
+const provider = new BasicTracerProvider({
+  spanProcessors: [processor],
+});
+trace.setGlobalTracerProvider(provider);
+
+Deno.serve(async (request) => {
+  const response = await handleRequest(request);
+  EdgeRuntime.waitUntil(processor.forceFlush());
+  return response;
+});
+```
+
+Register OpenInference instrumentation before constructing AI clients. Attach
+the flush promise with `EdgeRuntime.waitUntil()` so the response can return
+while the runtime keeps the batch alive. Handle rejections through the
+function's logging conventions. Do not shut down the module-level provider
+after every request.
+
+## Trusted Node.js backends
+
+Keep Supabase secrets in server-only environment configuration. NodeSDK uses a
+batch processor for `traceExporter`:
+
+```ts
+import { createSupabaseSpanExporter } from "@agentpond/supabase";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+const sdk = new NodeSDK({
+  traceExporter: createSupabaseSpanExporter(),
+  instrumentations: [
+    // Add the integration selected for the detected AI SDK or framework.
+  ],
+});
+
+sdk.start();
+```
+
+For short-lived jobs, force-flush at the real lifecycle boundary. Do not send a
+Supabase secret key to a browser even if the `agentpond` bucket is private.
+
+## Linking, verification, and troubleshooting
+
+Link the hosted project and verify a real request:
+
+```bash
+supabase login
+npx agentpond env use <project-ref>
+npx agentpond env current
+npx agentpond sync
+npx agentpond traces list --limit 10
+```
+
+AgentPond asks the Supabase CLI for a default modern secret or legacy
+`service_role` key while resolving storage. It captures the CLI output only in
+memory and never prints or persists it. Use a stateless override for another
+hosted project or branch:
+
+```bash
+npx agentpond --env <branch-project-ref> sync
+npx agentpond --env <branch-project-ref> traces list --limit 10
+```
+
+If setup fails, confirm `supabase/.temp/project-ref` contains the expected
+20-letter ref, the CLI account can access that project, the `agentpond` bucket
+exists and is private, no application RLS policy exposes it, the trusted code
+has a secret/service-role key, the batch was flushed, and the query used the
+same project ref.

--- a/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/vercel.md
+++ b/packages/browseros-agent/.agents/skills/agentpond-instrumentation/references/vercel.md
@@ -1,0 +1,68 @@
+# Vercel instrumentation and Blob storage
+
+Use this reference for every Vercel instrumentation task.
+
+## Trusted runtime boundary
+
+`createVercelSpanExporter()` must run in trusted Node.js server code such as a Vercel Function or a Next.js Node.js route or server action. Never add it to browser or client bundles, Routing Middleware, Edge Runtime code, or static builds. Do not create an AgentPond ingestion route; the exporter writes directly to Vercel Blob.
+
+## Link and provision
+
+During read-only analysis, inspect `.vercel/project.json` and existing Blob connections without changing them. After explicit confirmation:
+
+1. Confirm Vercel CLI version 50.20 or newer with `vercel --version`.
+2. Run `vercel link` only when the intended app is not linked.
+3. Inspect the project's Storage tab in the Vercel dashboard and identify connected Vercel Blob stores. Reuse the sole connected private store; it may also hold application data because AgentPond stays below `agentpond/`. Do not use `vercel integration list` for this check because it omits native Blob stores.
+4. If no store is connected, create one with `vercel blob create-store agentpond --access private`. If multiple private stores are connected, ask which to use. Never use a public store for traces.
+5. Ensure the store is connected to every Vercel target that should export or be queried. If a target lacks the connection, direct the user to connect it in the Vercel dashboard before continuing.
+
+Do not save the provider choice in `.agentpond/`. The linked Vercel project is
+authoritative, and `npx agentpond env use <target>` stores the selected target in
+`.vercel/agentpond.json`.
+
+## Direct span exporter
+
+Install `@agentpond/vercel` in the trusted server package. Confirm that the Vercel project setting for access to System Environment Variables is enabled so `VERCEL_PROJECT_ID` and `VERCEL_TARGET_ENV` are available at runtime. The connected Blob integration supplies a read-write token or store ID plus OIDC credentials:
+
+```ts
+import { createVercelSpanExporter } from "@agentpond/vercel";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+const sdk = new NodeSDK({
+  traceExporter: createVercelSpanExporter(),
+  instrumentations: [
+    // Add the integration selected for the detected AI SDK or framework.
+  ],
+});
+
+sdk.start();
+```
+
+The exporter resolves `VERCEL_PROJECT_ID` and `VERCEL_TARGET_ENV`, falling back to `VERCEL_ENV` for the target. It writes to:
+
+```text
+agentpond/otel/<vercel-project-id>-<target>/...
+```
+
+Targets are exact Vercel target names: `production`, `preview`, `development`, or a custom target such as `staging`. All preview branches share the `preview` partition.
+
+NodeSDK batches spans. If the request lifecycle requires an explicit flush, construct and retain an explicit `BatchSpanProcessor`, then call its `forceFlush()` from Next.js `after()` or Vercel `waitUntil()`. Attach the promise without blocking the response, handle rejection through the application's logging conventions, and do not shut down the module-level provider after each request.
+
+## Verification
+
+Run one real request on each target in scope, then query that exact target:
+
+```bash
+npx agentpond sync
+npx agentpond traces list --limit 10
+
+npx agentpond env use staging
+npx agentpond sync
+npx agentpond traces list --limit 10
+```
+
+No selection means `production`; `--env` overrides the selected target for one
+command. Use `vercel target list --format json` to discover built-in and custom
+Vercel targets. AgentPond manual environment initialization and its local
+testing server are unavailable in Vercel projects. Confirm that the trace
+appears only under the linked project and selected target.

--- a/packages/browseros-agent/.agents/skills/agentpond/SKILL.md
+++ b/packages/browseros-agent/.agents/skills/agentpond/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: agentpond
+description: Inspect and analyze AgentPond traces, observations, sessions, and scores with focused CLI commands and DuckDB SQL. Use when investigating agent behavior, querying trace data, comparing sessions, reviewing annotations, or diagnosing failures after traces have already been collected.
+---
+
+# AgentPond trace analytics
+
+Use AgentPond to inspect collected trace data.
+
+Read only the references relevant to the current task. Provider-specific
+references are authoritative for project selection, target selection, and
+credential access:
+
+- Provider-neutral query commands: [references/cli.md](references/cli.md)
+- Firebase data access: [references/firebase.md](references/firebase.md)
+- Supabase data access: [references/supabase.md](references/supabase.md)
+- Vercel data access: [references/vercel.md](references/vercel.md)
+- DuckDB tables and SQL examples: [references/duckdb-schema.md](references/duckdb-schema.md)
+- Trace investigation workflow: [references/error-analysis.md](references/error-analysis.md)
+
+## Select the data source
+
+Determine the provider before syncing:
+
+- For a Firebase project, read [references/firebase.md](references/firebase.md).
+- For a Supabase project, read [references/supabase.md](references/supabase.md).
+- For a Vercel-linked project, read [references/vercel.md](references/vercel.md).
+- Otherwise, use an existing manual AgentPond environment. Every manual
+  environment is backed by a supported Node-compatible Files SDK provider, as
+  described in [references/cli.md](references/cli.md). Azure Blob, Netlify
+  Blobs, and Oracle Cloud environments use their corresponding Files SDK
+  adapters.
+
+Firebase Storage, Supabase Storage, and Vercel Blob also run through
+AgentPond's shared Files SDK object-store layer. Keep using their detected
+provider contexts: those contexts own credentials, bucket selection, project
+identity, and the platform-specific `agentpond/` prefix instead of a manual
+Files SDK environment.
+
+Do not create provider-choice state. Select the provider's environment with
+`npx agentpond env use <name>`: a Firebase alias or project ID, a Supabase
+project ref, an exact Vercel target, or a manual AgentPond environment. Use
+`--env <name>` only for a one-command override. Confirm the selection with
+`npx agentpond env current`. If multiple provider markers are present, add the
+stateless `--platform firebase`, `--platform supabase`, or `--platform vercel`
+override to each AgentPond command.
+
+## Inspect traces
+
+Start with focused commands:
+
+```bash
+npx agentpond traces list --limit 25
+npx agentpond traces get <trace-id>
+npx agentpond observations list --traceId <trace-id>
+npx agentpond scores list --traceId <trace-id>
+```
+
+Inspect a session when behavior spans multiple traces:
+
+```bash
+npx agentpond sessions list
+npx agentpond sessions get <session-id>
+```
+
+Use SQL for joins, aggregation, time windows, raw event inspection, or cost analysis:
+
+```bash
+npx agentpond sql "select id, name, session_id, total_cost from traces order by start_time desc limit 10"
+```
+
+## Report findings
+
+Separate confirmed observations from inference. Include the provider and target inspected, trace or session IDs, commands or SQL used, the observed pattern, the likely cause, and the smallest useful code, prompt, or workflow change.

--- a/packages/browseros-agent/.agents/skills/agentpond/references/cli.md
+++ b/packages/browseros-agent/.agents/skills/agentpond/references/cli.md
@@ -1,0 +1,93 @@
+# AgentPond data-access CLI
+
+Run AgentPond through `npx` unless it is installed globally.
+
+## Select data
+
+Use the provider-specific reference for Firebase, Supabase, or Vercel. Environment
+selection uses the same commands for every provider:
+
+```bash
+npx agentpond env current
+npx agentpond env use <environment>
+npx agentpond --env staging sync
+```
+
+`env use` persists through the detected provider. `--env` overrides that
+selection for one command. The provider-specific meaning and persistence are
+documented in the Firebase, Supabase, and Vercel references. Sync before querying when
+recent data matters.
+
+When multiple provider markers are present, use `--platform firebase`,
+`--platform supabase`, or `--platform vercel` on each AgentPond command. This
+override is stateless and does not create provider-choice state:
+
+```bash
+npx agentpond env current --platform supabase
+npx agentpond sync --platform supabase
+```
+
+For manually configured Files SDK deployments, `env list`, `env init`, and
+`env get` manage Files SDK-backed AgentPond environment files. Those manual
+operations and the local testing server are unavailable when AgentPond detects
+Firebase, Supabase, or Vercel.
+
+Detected Firebase, Supabase, and Vercel projects use the same shared
+Files SDK object-store layer internally, but their provider contexts choose the
+adapter, credentials, bucket, project identity, and prefix. Do not replace a
+detected provider context with a manual Files SDK environment.
+
+Select and sync an existing Files SDK environment:
+
+```bash
+npx agentpond env use production
+npx agentpond sync
+```
+
+The environment file stores `FILES_SDK_PROVIDER` plus the selected adapter's
+typed configuration: `AGENTPOND_FILES_BUCKET`,
+`AGENTPOND_FILES_CONTAINER`, `AGENTPOND_FILES_NAMESPACE`,
+`AGENTPOND_FILES_STORE_NAME`, `FILES_SDK_ENDPOINT`, `FILES_SDK_REGION`, or
+`FILES_SDK_ROOT`. `env init` exposes the matching `--bucket`, `--container`,
+`--endpoint`, `--namespace`, `--region`, `--root`, and `--store-name` flags. It
+does not store credentials. Run AgentPond with the selected provider's
+credential variables available in the process environment. Keep
+`AGENTPOND_PROJECT_ID` and `AGENTPOND_PREFIX` identical to the application
+runtime; `default-project` and an empty prefix are the defaults. Memory,
+Bun-only, unknown, malformed, and unsupported adapter configurations are
+rejected. The CLI also rejects adapters whose peer SDKs it cannot resolve.
+
+Azure Blob uses Files SDK's `AZURE_STORAGE_*` variables. Netlify runtimes detect
+their site and token automatically; external runtimes use `NETLIFY_SITE_ID` and
+`NETLIFY_API_TOKEN`. Oracle Cloud uses `OCI_ACCESS_KEY_ID` and
+`OCI_SECRET_ACCESS_KEY` HMAC Customer Secret Keys.
+
+`env init` refuses to replace an existing environment file; edit that file
+deliberately or initialize a different name.
+
+`npx agentpond init` installs both AgentPond skills and prints either a
+platform-specific or Files SDK coding-agent prompt. It does not initialize an
+environment itself. Cancelling skill installation stops setup without printing
+a success message or prompt.
+
+## Query commands
+
+```bash
+npx agentpond sync
+npx agentpond sync --json
+
+npx agentpond traces list --limit 25
+npx agentpond traces get <trace-id>
+npx agentpond observations list --traceId <trace-id>
+
+npx agentpond sessions list
+npx agentpond sessions get <session-id>
+
+npx agentpond scores list --traceId <trace-id>
+npx agentpond scores list --observationId <observation-id>
+
+npx agentpond sql "select * from traces limit 10"
+npx agentpond sql "select * from scores where trace_id = '<trace-id>'" --json
+```
+
+Use JSON output when another tool needs to consume the result. Use focused commands for individual resources and SQL for aggregation, joins, time filtering, raw events, and cost analysis.

--- a/packages/browseros-agent/.agents/skills/agentpond/references/duckdb-schema.md
+++ b/packages/browseros-agent/.agents/skills/agentpond/references/duckdb-schema.md
@@ -1,0 +1,127 @@
+# DuckDB Schema
+
+AgentPond stores raw accepted events and projected analysis tables in the configured DuckDB cache. Use `npx agentpond sync` before querying when object storage may contain new events.
+
+## Queryable Structures
+
+`events_raw` keeps every accepted event payload:
+
+```text
+event_id TEXT PRIMARY KEY
+project_id TEXT
+manifest_key TEXT
+object_key TEXT
+event_type TEXT
+event_timestamp TIMESTAMP
+entity_id TEXT
+body_json TEXT
+event_json TEXT
+```
+
+`events_raw.body_json` and `events_raw.event_json` can contain the complete raw
+telemetry payload. The projected `traces.input_json`, `traces.output_json`,
+`observations.input_json`, and `observations.output_json` fields can also contain
+prompts, responses, tool arguments, tool results, or provider error details.
+Treat these columns as sensitive: do not paste them into issues, review
+comments, logs, or reports. Select only the fields needed for the analysis and
+redact values before sharing query output.
+
+`traces` contains projected trace rows:
+
+```text
+id TEXT PRIMARY KEY
+project_id TEXT
+name TEXT
+user_id TEXT
+session_id TEXT
+start_time TIMESTAMP
+end_time TIMESTAMP
+metadata_json TEXT
+input_json TEXT
+output_json TEXT
+total_cost DOUBLE
+updated_at TIMESTAMP
+```
+
+`observations` contains projected span, generation, and observation rows:
+
+```text
+id TEXT PRIMARY KEY
+project_id TEXT
+trace_id TEXT
+parent_observation_id TEXT
+type TEXT
+name TEXT
+start_time TIMESTAMP
+end_time TIMESTAMP
+metadata_json TEXT
+input_json TEXT
+output_json TEXT
+usage_details_json TEXT
+cost_details_json TEXT
+total_cost DOUBLE
+updated_at TIMESTAMP
+```
+
+`scores` contains projected trace, observation, and session scores:
+
+```text
+id TEXT PRIMARY KEY
+project_id TEXT
+trace_id TEXT
+observation_id TEXT
+session_id TEXT
+name TEXT
+value DOUBLE
+string_value TEXT
+data_type TEXT
+source TEXT
+comment TEXT
+metadata_json TEXT
+timestamp TIMESTAMP
+updated_at TIMESTAMP
+```
+
+`sessions` is a view derived from traces with session IDs:
+
+```text
+id TEXT
+project_id TEXT
+first_seen_at TIMESTAMP
+last_seen_at TIMESTAMP
+trace_count BIGINT
+```
+
+## SQL Patterns
+
+Recent high-cost traces:
+
+```bash
+npx agentpond sql "select id, name, session_id, total_cost from traces order by total_cost desc nulls last limit 20"
+```
+
+Observation timeline for one trace:
+
+```bash
+npx agentpond sql "select id, parent_observation_id, type, name, start_time, end_time, total_cost from observations where trace_id = '<trace-id>' order by start_time asc"
+```
+
+Scores attached to a trace:
+
+```bash
+npx agentpond sql "select name, value, string_value, data_type, source, comment, timestamp from scores where trace_id = '<trace-id>' order by timestamp desc"
+```
+
+Sessions with repeated trace activity:
+
+```bash
+npx agentpond sql "select id, trace_count, first_seen_at, last_seen_at from sessions order by trace_count desc, last_seen_at desc limit 20"
+```
+
+Raw event inspection:
+
+```bash
+npx agentpond sql "select event_type, event_timestamp, entity_id, body_json from events_raw where entity_id = '<entity-id>' order by event_timestamp asc"
+```
+
+JSON columns are stored as text. Use DuckDB JSON functions when a query needs fields inside `metadata_json`, `input_json`, `output_json`, `usage_details_json`, `cost_details_json`, `body_json`, or `event_json`.

--- a/packages/browseros-agent/.agents/skills/agentpond/references/error-analysis.md
+++ b/packages/browseros-agent/.agents/skills/agentpond/references/error-analysis.md
@@ -1,0 +1,72 @@
+# Error Analysis
+
+Use AgentPond to inspect real agent traces, build a failure picture, and identify concrete improvements. Start from the focused CLI commands, then use SQL when the question requires aggregation or cross-table context.
+
+## Basic Investigation Flow
+
+1. Sync fresh data:
+
+```bash
+npx agentpond sync
+```
+
+2. Find recent traces:
+
+```bash
+npx agentpond traces list --limit 25
+```
+
+3. Read the trace and its timeline:
+
+```bash
+npx agentpond traces get <trace-id>
+npx agentpond observations list --traceId <trace-id>
+```
+
+4. Check quality signals and annotations:
+
+```bash
+npx agentpond scores list --traceId <trace-id>
+```
+
+## SQL Investigation
+
+Find traces with low numeric scores:
+
+```bash
+npx agentpond sql "select t.id, t.name, t.session_id, s.name as score_name, s.value, s.comment from traces t join scores s on s.trace_id = t.id where s.value is not null and s.value < 0.5 order by s.timestamp desc limit 50"
+```
+
+Inspect observation trees for a trace:
+
+```bash
+npx agentpond sql "select id, parent_observation_id, type, name, start_time, end_time, total_cost from observations where trace_id = '<trace-id>' order by start_time asc"
+```
+
+Find expensive traces:
+
+```bash
+npx agentpond sql "select id, name, user_id, session_id, total_cost, start_time from traces order by total_cost desc nulls last limit 25"
+```
+
+Find repeated sessions:
+
+```bash
+npx agentpond sql "select id, trace_count, first_seen_at, last_seen_at from sessions where trace_count > 1 order by last_seen_at desc"
+```
+
+Inspect raw payloads when projected columns do not explain the behavior:
+
+```bash
+npx agentpond sql "select event_type, event_timestamp, body_json from events_raw where entity_id = '<trace-or-observation-id>' order by event_timestamp asc"
+```
+
+## Recording Findings
+
+When a user asks for analysis, report:
+
+- the trace or session IDs inspected
+- the commands or SQL used
+- the observed failure pattern
+- the likely root cause, stated separately from confirmed facts
+- the smallest code, prompt, or workflow change that would address the pattern

--- a/packages/browseros-agent/.agents/skills/agentpond/references/firebase.md
+++ b/packages/browseros-agent/.agents/skills/agentpond/references/firebase.md
@@ -1,0 +1,32 @@
+# Firebase data access
+
+Use this reference only for Firebase-backed AgentPond data.
+
+AgentPond detects the Firebase root from `.firebaserc` or `firebase.json`.
+Select a Firebase alias or project ID through AgentPond:
+
+```bash
+npx agentpond env use <alias-or-project-id>
+npx agentpond env current
+npx agentpond sync
+npx agentpond traces list --limit 10
+```
+
+`env use` delegates to the Firebase CLI, so Firebase and AgentPond share the
+same active project. The selected project ID identifies both the remote Storage
+data and the local cache. To inspect another alias or project ID without
+changing that selection, override it for one command:
+
+```bash
+npx agentpond --env staging sync
+npx agentpond --env staging traces list --limit 10
+```
+
+Do not initialize AgentPond environment files for Firebase projects.
+
+AgentPond manual environment operations (`get`, `list`, and `init`) and the
+local testing server are unavailable in Firebase projects. Run the application
+with Firebase and export spans directly to Firebase Storage.
+
+If AgentPond cannot resolve the default project, run
+`npx agentpond env use <alias-or-project-id>` from inside the Firebase project.

--- a/packages/browseros-agent/.agents/skills/agentpond/references/supabase.md
+++ b/packages/browseros-agent/.agents/skills/agentpond/references/supabase.md
@@ -1,0 +1,37 @@
+# Supabase data access
+
+Use this reference only for AgentPond data in Supabase Storage.
+
+Run commands inside a Supabase project containing `supabase/config.toml`.
+AgentPond reads the linked hosted project ref from
+`supabase/.temp/project-ref`. Link or persist another hosted project through
+AgentPond:
+
+```bash
+npx agentpond env use <project-ref>
+npx agentpond env current
+npx agentpond sync
+npx agentpond traces list --limit 10
+```
+
+`env use` delegates to `supabase link --project-ref <project-ref>`, so Supabase
+and AgentPond share the same link. A branch is selected through its distinct
+Supabase project ref. To inspect another hosted project or branch without
+changing the persisted link, override it for one command:
+
+```bash
+npx agentpond --env <project-ref> sync
+npx agentpond --env <project-ref> traces list --limit 10
+```
+
+AgentPond reads the dedicated private `agentpond` bucket. Objects for each
+hosted project are isolated below:
+
+```text
+otel/<project-ref>/...
+```
+
+AgentPond manual environment operations (`get`, `list`, and `init`) and the
+local testing server are unavailable in Supabase projects. If access fails,
+confirm the project is hosted, `supabase login` has access to it, the project is
+linked, and the `agentpond` bucket exists and is private.

--- a/packages/browseros-agent/.agents/skills/agentpond/references/vercel.md
+++ b/packages/browseros-agent/.agents/skills/agentpond/references/vercel.md
@@ -1,0 +1,44 @@
+# Vercel data access
+
+Use this reference only for AgentPond data in Vercel Blob.
+
+Run commands inside a project linked by `.vercel/project.json`. AgentPond uses the linked Vercel project ID plus the exact deployment target to isolate data in a shared private Blob store:
+
+```text
+agentpond/otel/<vercel-project-id>-<target>/...
+```
+
+The default target is `production`. Persist another exact target with `env use`:
+
+```bash
+npx agentpond env use staging
+npx agentpond env current
+npx agentpond sync
+npx agentpond traces list --limit 10
+```
+
+Override the selected target for one command with `--env`:
+
+```bash
+npx agentpond --env preview sync
+npx agentpond --env staging traces list --limit 10
+```
+
+Targets include `production`, `preview`, `development`, and project-defined custom targets such as `staging`. Preview deployments share one `preview` partition; AgentPond does not partition by branch. List available targets with:
+
+```bash
+vercel target list --format json
+```
+
+AgentPond manual environment operations (`get`, `list`, and `init`) and the
+local testing server are unavailable in Vercel projects. Run the application on
+Vercel and select the target with `env use` before sync and query commands.
+
+AgentPond stores the linked project ID and selected target in the ignored
+`.vercel/agentpond.json` file. `--env` does not change that file. AgentPond
+temporarily pulls the effective target's Vercel environment, reads the connected
+private Blob credentials, then removes the temporary file. A private Blob store
+may be shared by multiple projects and application data because AgentPond writes
+only below `agentpond/` and includes the project ID and target in its keys.
+
+If access fails, confirm that the directory is linked with `vercel link`, the Blob store is private and connected to the selected target, and `vercel env pull --environment <target>` receives either a Blob read-write token or the store ID plus Vercel OIDC credentials.

--- a/packages/browseros-agent/.gitignore
+++ b/packages/browseros-agent/.gitignore
@@ -63,6 +63,7 @@ web_modules/
 .claude/*
 !.claude/skills/
 !.claude/commands/
+.agentpond/
 .llm/
 .worktrees/
 

--- a/packages/browseros-agent/apps/server/README.md
+++ b/packages/browseros-agent/apps/server/README.md
@@ -78,6 +78,14 @@ The agent loop uses the [Vercel AI SDK](https://sdk.vercel.ai) to orchestrate mu
 - **MCP client** — connects to external MCP servers for additional tool access (40+ app integrations)
 - **Tool adapter** — bridges MCP tool definitions to AI SDK tool format
 
+### Optional AI tracing
+
+Set `FILES_SDK_PROVIDER=fs` and `FILES_SDK_ROOT` before startup to export
+content-free OpenInference traces to a local AgentPond store. Tracing is
+otherwise disabled. The integration records model, operation, timing, and token
+metadata, but not prompts or responses. Shutdown waits for pending trace writes
+before the server process exits.
+
 ### Provider Factory
 
 The provider factory (`src/agent/provider-factory.ts`) creates AI SDK providers from runtime configuration, supporting hot-swapping between providers without restart.

--- a/packages/browseros-agent/apps/server/package.json
+++ b/packages/browseros-agent/apps/server/package.json
@@ -61,6 +61,8 @@
     }
   },
   "dependencies": {
+    "@agentpond/core": "0.7.0",
+    "@agentpond/otel": "0.1.5",
     "@ai-sdk/amazon-bedrock": "^4.0.140",
     "@ai-sdk/anthropic": "^3.0.85",
     "@ai-sdk/azure": "^3.0.93",
@@ -70,6 +72,7 @@
     "@ai-sdk/openai": "^3.0.73",
     "@ai-sdk/openai-compatible": "^2.0.62",
     "@ai-sdk/provider": "^3.0.10",
+    "@arizeai/openinference-vercel": "2.8.1",
     "@browseros/acpx-ai-provider": "workspace:*",
     "@browseros/agent-mcp-manager": "workspace:*",
     "@browseros/browser-core": "workspace:*",
@@ -80,6 +83,8 @@
     "@hono/zod-validator": "^0.9.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openrouter/ai-sdk-provider": "^2.10.0",
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/sdk-trace-base": "2.9.0",
     "@sentry/bun": "^10.67.0",
     "acp-probe": "^0.0.2",
     "acpx": "^0.12.1",
@@ -87,6 +92,7 @@
     "commander": "^14.0.3",
     "core-js": "3.49.0",
     "drizzle-orm": "^0.45.2",
+    "files-sdk": "2.2.2",
     "hono": "^4.12.31",
     "jimp": "^1.6.1",
     "jsonc-parser": "^3.3.1",

--- a/packages/browseros-agent/apps/server/src/agent/agentpond-tracing.ts
+++ b/packages/browseros-agent/apps/server/src/agent/agentpond-tracing.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {
+  configFromRuntimeEnv,
+  type IngestionSink,
+  type ObjectStoreIngestionSinkOptions,
+  sinkFromStore,
+} from '@agentpond/core'
+import { AgentPondSpanExporter } from '@agentpond/otel'
+import {
+  isOpenInferenceSpan,
+  OpenInferenceBatchSpanProcessor,
+} from '@arizeai/openinference-vercel'
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base'
+import type { TelemetrySettings } from 'ai'
+import { Files } from 'files-sdk'
+import { fs } from 'files-sdk/fs'
+import { logger } from '../lib/logger'
+
+const AGENTPOND_TRACING_STATE = Symbol.for('browseros.agentpond-tracing')
+
+interface AgentPondTracingState {
+  provider: BasicTracerProvider
+  telemetry: TelemetrySettings
+}
+
+type AgentPondGlobal = typeof globalThis & {
+  [AGENTPOND_TRACING_STATE]?: AgentPondTracingState
+}
+
+class LocalAgentPondObjectStore {
+  private readonly files: Files
+
+  constructor(root: string) {
+    this.files = new Files({
+      adapter: fs({ root }),
+      retries: 3,
+      timeout: 10_000,
+    })
+  }
+
+  toSink(options?: ObjectStoreIngestionSinkOptions): IngestionSink {
+    return sinkFromStore(this, options)
+  }
+
+  async putJson(key: string, value: unknown): Promise<void> {
+    await this.files.upload(key, JSON.stringify(value), {
+      contentType: 'application/json',
+    })
+  }
+
+  async getJson<T>(key: string): Promise<T> {
+    return JSON.parse(await (await this.files.download(key)).text()) as T
+  }
+
+  async listKeys(prefix: string): Promise<string[]> {
+    const keys: string[] = []
+    for await (const file of this.files.listAll({ prefix })) {
+      keys.push(file.key)
+    }
+    return keys.sort()
+  }
+}
+
+function createAgentPondTracingState(): AgentPondTracingState | undefined {
+  const providerName = process.env.FILES_SDK_PROVIDER?.trim()
+  if (!providerName) return undefined
+
+  if (providerName !== 'fs') {
+    logger.warn(
+      'BrowserOS AgentPond tracing only supports FILES_SDK_PROVIDER=fs',
+    )
+    return undefined
+  }
+
+  const root = process.env.FILES_SDK_ROOT?.trim()
+  if (!root) {
+    logger.warn('BrowserOS AgentPond tracing requires FILES_SDK_ROOT')
+    return undefined
+  }
+
+  try {
+    const config = configFromRuntimeEnv()
+    const provider = new BasicTracerProvider({
+      spanProcessors: [
+        new OpenInferenceBatchSpanProcessor({
+          exporter: new AgentPondSpanExporter({
+            prefix: config.prefix,
+            projectId: config.projectId,
+            store: new LocalAgentPondObjectStore(root),
+          }),
+          spanFilter: isOpenInferenceSpan,
+          reparentOrphanedSpans: true,
+        }),
+      ],
+    })
+
+    return {
+      provider,
+      telemetry: {
+        functionId: 'browseros-agent',
+        isEnabled: true,
+        recordInputs: false,
+        recordOutputs: false,
+        tracer: provider.getTracer('@browseros/server'),
+      },
+    }
+  } catch (error) {
+    logger.warn('Failed to initialize AgentPond tracing', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return undefined
+  }
+}
+
+const agentPondGlobal = globalThis as AgentPondGlobal
+const tracingState =
+  agentPondGlobal[AGENTPOND_TRACING_STATE] ?? createAgentPondTracingState()
+if (tracingState) {
+  agentPondGlobal[AGENTPOND_TRACING_STATE] = tracingState
+}
+
+export const agentPondTelemetry = tracingState?.telemetry
+
+export async function flushAgentPondTracing(): Promise<void> {
+  try {
+    await tracingState?.provider.forceFlush()
+  } catch (error) {
+    logger.warn('Failed to flush AgentPond tracing', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+let shutdownPromise: Promise<void> | undefined
+
+export function shutdownAgentPondTracing(): Promise<void> {
+  if (!shutdownPromise) {
+    shutdownPromise = (async () => {
+      try {
+        await tracingState?.provider.shutdown()
+      } catch (error) {
+        logger.warn('Failed to shut down AgentPond tracing', {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      } finally {
+        delete agentPondGlobal[AGENTPOND_TRACING_STATE]
+      }
+    })()
+  }
+  return shutdownPromise
+}

--- a/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
+++ b/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
@@ -26,6 +26,7 @@ import { metrics } from '../lib/metrics'
 import { buildFilesystemToolSet } from '../tools/filesystem/build-toolset'
 import { createReadTool } from '../tools/filesystem/read'
 import { isAcpProvider } from './acp-providers'
+import { agentPondTelemetry } from './agentpond-tracing'
 import { CHAT_MODE_ALLOWED_TOOLS } from './chat-mode'
 import { createCompactionPrepareStep, type StepWithUsage } from './compaction'
 import { buildMcpServerSpecs, createMcpClients } from './mcp-builder'
@@ -373,6 +374,9 @@ export class AiSdkAgent {
       tools,
       stopWhen: [stepCountIs(AGENT_LIMITS.MAX_TURNS)],
       prepareStep,
+      ...(agentPondTelemetry
+        ? { experimental_telemetry: agentPondTelemetry }
+        : {}),
       ...(isChatGPTPro && {
         providerOptions: {
           openai: {

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -135,6 +135,7 @@ export async function createHttpServer(config: HttpServerConfig) {
   return {
     app,
     server,
+    activity,
     config,
   }
 }

--- a/packages/browseros-agent/apps/server/src/api/services/server-activity.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/server-activity.ts
@@ -85,4 +85,10 @@ export class ServerActivity {
       this.turnRegistry.hasRunning()
     )
   }
+
+  async waitUntilIdle(): Promise<void> {
+    while (this.isBusy()) {
+      await Bun.sleep(25)
+    }
+  }
 }

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -39,6 +39,7 @@ import { VERSION } from './version'
 
 export class Application {
   private config: ServerConfig
+  private httpServer?: Awaited<ReturnType<typeof createHttpServer>>
   private stopping = false
 
   constructor(config: ServerConfig) {
@@ -74,7 +75,7 @@ export class Application {
     const browserSession = browser.session
 
     try {
-      await createHttpServer({
+      this.httpServer = await createHttpServer({
         port: this.config.serverPort,
         host: '0.0.0.0',
         version: VERSION,
@@ -148,12 +149,35 @@ export class Application {
     logger.info('Shutting down server...', { reason })
     removeServerConfigSync()
 
-    // Immediate exit keeps the port free; signal exits stay non-zero so Chromium restarts us.
+    // Signal exits stay non-zero so Chromium restarts us.
     const code =
       reason === 'SIGTERM' || reason === 'SIGINT'
         ? EXIT_CODES.SIGNAL_KILL
         : EXIT_CODES.SUCCESS
-    void shutdownAgentPondTracing().finally(() => process.exit(code))
+    void this.drainAndExit(code)
+  }
+
+  private async drainAndExit(code: number): Promise<void> {
+    try {
+      if (this.httpServer) {
+        void this.httpServer.server.stop().catch((error) => {
+          logger.warn('Failed to stop accepting HTTP connections', {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        })
+        await this.httpServer.activity.waitUntilIdle()
+      }
+    } catch (error) {
+      logger.warn('Failed to drain active server work', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    } finally {
+      try {
+        await shutdownAgentPondTracing()
+      } finally {
+        process.exit(code)
+      }
+    }
   }
 
   private async initCoreServices(): Promise<void> {

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -13,6 +13,7 @@ import path from 'node:path'
 import { CdpBackend } from '@browseros/browser-core/backends/cdp'
 import { Browser } from '@browseros/browser-core/browser'
 import { EXIT_CODES } from '@browseros/shared/constants/exit-codes'
+import { shutdownAgentPondTracing } from './agent/agentpond-tracing'
 import { createHttpServer } from './api/server'
 import type { ServerConfig } from './config'
 import { INLINED_ENV } from './env'
@@ -38,6 +39,7 @@ import { VERSION } from './version'
 
 export class Application {
   private config: ServerConfig
+  private stopping = false
 
   constructor(config: ServerConfig) {
     this.config = config
@@ -140,6 +142,9 @@ export class Application {
   }
 
   stop(reason?: string): void {
+    if (this.stopping) return
+    this.stopping = true
+
     logger.info('Shutting down server...', { reason })
     removeServerConfigSync()
 
@@ -148,7 +153,7 @@ export class Application {
       reason === 'SIGTERM' || reason === 'SIGINT'
         ? EXIT_CODES.SIGNAL_KILL
         : EXIT_CODES.SUCCESS
-    process.exit(code)
+    void shutdownAgentPondTracing().finally(() => process.exit(code))
   }
 
   private async initCoreServices(): Promise<void> {

--- a/packages/browseros-agent/apps/server/tests/agent/agentpond-tracing.e2e.fixture.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/agentpond-tracing.e2e.fixture.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mock } from 'bun:test'
+import { MockLanguageModelV3 } from 'ai/test'
+
+const PROMPT_SENTINEL = 'browseros-agentpond-private-prompt'
+const RESPONSE_SENTINEL = 'browseros-agentpond-private-response'
+
+const model = new MockLanguageModelV3({
+  provider: 'browseros-agentpond-e2e',
+  modelId: 'browseros-agentpond-test-model',
+  doGenerate: {
+    content: [{ type: 'text', text: RESPONSE_SENTINEL }],
+    finishReason: { raw: 'stop', unified: 'stop' },
+    usage: {
+      inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 7, total: 7 },
+      outputTokens: { reasoning: 0, text: 4, total: 4 },
+    },
+    warnings: [],
+  },
+})
+
+mock.module('../../src/agent/provider-factory', () => ({
+  createLanguageModel: async () => ({ model }),
+}))
+
+const { AiSdkAgent } = await import('../../src/agent/ai-sdk-agent')
+const { flushAgentPondTracing, shutdownAgentPondTracing } = await import(
+  '../../src/agent/agentpond-tracing'
+)
+
+const agent = await AiSdkAgent.create({
+  browserSession: {} as never,
+  resolvedConfig: {
+    apiKey: 'fixture',
+    baseUrl: 'http://127.0.0.1',
+    chatMode: true,
+    conversationId: 'agentpond-e2e',
+    model: 'browseros-agentpond-test-model',
+    provider: 'openai-compatible',
+  },
+})
+
+try {
+  const result = await agent.toolLoopAgent.generate({
+    prompt: PROMPT_SENTINEL,
+  })
+  if (result.text !== RESPONSE_SENTINEL) {
+    throw new Error('AgentPond E2E fixture returned an unexpected response')
+  }
+  if (result.totalUsage.totalTokens !== 11) {
+    throw new Error('AgentPond E2E fixture returned unexpected token usage')
+  }
+  await flushAgentPondTracing()
+} finally {
+  await agent.dispose()
+  await shutdownAgentPondTracing()
+  mock.restore()
+}

--- a/packages/browseros-agent/apps/server/tests/agent/agentpond-tracing.e2e.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/agentpond-tracing.e2e.test.ts
@@ -4,101 +4,62 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { afterAll, describe, expect, it, mock } from 'bun:test'
-import { mkdir, mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { afterAll, describe, expect, it } from 'bun:test'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { MockLanguageModelV3 } from 'ai/test'
 
 const PROMPT_SENTINEL = 'browseros-agentpond-private-prompt'
 const RESPONSE_SENTINEL = 'browseros-agentpond-private-response'
-const originalEnvironment = {
-  projectId: process.env.AGENTPOND_PROJECT_ID,
-  provider: process.env.FILES_SDK_PROVIDER,
-  root: process.env.FILES_SDK_ROOT,
-}
 const configuredRoot = process.env.AGENTPOND_E2E_ROOT
 const traceRoot =
-  configuredRoot ?? (await mkdtemp(join(tmpdir(), 'browseros-agentpond-')))
+  configuredRoot ?? mkdtempSync(join(tmpdir(), 'browseros-agentpond-'))
 
-await mkdir(traceRoot, { recursive: true })
-process.env.AGENTPOND_PROJECT_ID = 'default-project'
-process.env.FILES_SDK_PROVIDER = 'fs'
-process.env.FILES_SDK_ROOT = traceRoot
+mkdirSync(traceRoot, { recursive: true })
 
-const model = new MockLanguageModelV3({
-  provider: 'browseros-agentpond-e2e',
-  modelId: 'browseros-agentpond-test-model',
-  doGenerate: {
-    content: [{ type: 'text', text: RESPONSE_SENTINEL }],
-    finishReason: { raw: 'stop', unified: 'stop' },
-    usage: {
-      inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 7, total: 7 },
-      outputTokens: { reasoning: 0, text: 4, total: 4 },
-    },
-    warnings: [],
-  },
-})
-
-mock.module('../../src/agent/provider-factory', () => ({
-  createLanguageModel: async () => ({ model }),
-}))
-
-const { AiSdkAgent } = await import('../../src/agent/ai-sdk-agent')
-const { flushAgentPondTracing, shutdownAgentPondTracing } = await import(
-  '../../src/agent/agentpond-tracing'
-)
-
-afterAll(async () => {
-  mock.restore()
-  for (const [name, value] of Object.entries({
-    AGENTPOND_PROJECT_ID: originalEnvironment.projectId,
-    FILES_SDK_PROVIDER: originalEnvironment.provider,
-    FILES_SDK_ROOT: originalEnvironment.root,
-  })) {
-    if (value === undefined) delete process.env[name]
-    else process.env[name] = value
-  }
-  if (!configuredRoot) await rm(traceRoot, { force: true, recursive: true })
+afterAll(() => {
+  if (!configuredRoot) rmSync(traceRoot, { force: true, recursive: true })
 })
 
 describe('BrowserOS AgentPond tracing', () => {
   it('reads back a content-free trace from the production agent path', async () => {
-    const agent = await AiSdkAgent.create({
-      browserSession: {} as never,
-      resolvedConfig: {
-        apiKey: 'fixture',
-        baseUrl: 'http://127.0.0.1',
-        chatMode: true,
-        conversationId: 'agentpond-e2e',
-        model: 'browseros-agentpond-test-model',
-        provider: 'openai-compatible',
+    const fixture = join(import.meta.dir, 'agentpond-tracing.e2e.fixture.ts')
+    const child = Bun.spawn([process.execPath, 'run', fixture], {
+      env: {
+        ...process.env,
+        AGENTPOND_E2E_ROOT: traceRoot,
+        AGENTPOND_PROJECT_ID: 'default-project',
+        FILES_SDK_PROVIDER: 'fs',
+        FILES_SDK_ROOT: traceRoot,
       },
+      stderr: 'pipe',
+      stdout: 'pipe',
     })
+    const [exitCode, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stderr).text(),
+      new Response(child.stdout).text(),
+    ])
+    expect(exitCode, stderr).toBe(0)
 
-    const result = await agent.toolLoopAgent.generate({
-      prompt: PROMPT_SENTINEL,
-    })
-    expect(result.text).toBe(RESPONSE_SENTINEL)
-    expect(result.totalUsage.totalTokens).toBe(11)
-
-    await flushAgentPondTracing()
-    const traceKeys = (await readdir(traceRoot, { recursive: true })).filter(
-      (key) => key.endsWith('.json') && !key.endsWith('.meta.json'),
-    )
+    const traceKeys = readdirSync(traceRoot, {
+      encoding: 'utf8',
+      recursive: true,
+    }).filter((key) => key.endsWith('.json') && !key.endsWith('.meta.json'))
     expect(traceKeys.length).toBeGreaterThan(0)
-    const rawPayload = (
-      await Promise.all(
-        traceKeys.map((key) => readFile(join(traceRoot, key), 'utf8')),
-      )
-    ).join('\n')
+    const rawPayload = traceKeys
+      .map((key) => readFileSync(join(traceRoot, key), 'utf8'))
+      .join('\n')
 
     expect(rawPayload).toContain('browseros-agentpond-test-model')
     expect(rawPayload).toContain('llm.token_count.total')
     expect(rawPayload).not.toContain(PROMPT_SENTINEL)
     expect(rawPayload).not.toContain(RESPONSE_SENTINEL)
-
-    await agent.dispose()
-    await shutdownAgentPondTracing()
   })
 })

--- a/packages/browseros-agent/apps/server/tests/agent/agentpond-tracing.e2e.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/agentpond-tracing.e2e.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterAll, describe, expect, it, mock } from 'bun:test'
+import { mkdir, mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { MockLanguageModelV3 } from 'ai/test'
+
+const PROMPT_SENTINEL = 'browseros-agentpond-private-prompt'
+const RESPONSE_SENTINEL = 'browseros-agentpond-private-response'
+const originalEnvironment = {
+  projectId: process.env.AGENTPOND_PROJECT_ID,
+  provider: process.env.FILES_SDK_PROVIDER,
+  root: process.env.FILES_SDK_ROOT,
+}
+const configuredRoot = process.env.AGENTPOND_E2E_ROOT
+const traceRoot =
+  configuredRoot ?? (await mkdtemp(join(tmpdir(), 'browseros-agentpond-')))
+
+await mkdir(traceRoot, { recursive: true })
+process.env.AGENTPOND_PROJECT_ID = 'default-project'
+process.env.FILES_SDK_PROVIDER = 'fs'
+process.env.FILES_SDK_ROOT = traceRoot
+
+const model = new MockLanguageModelV3({
+  provider: 'browseros-agentpond-e2e',
+  modelId: 'browseros-agentpond-test-model',
+  doGenerate: {
+    content: [{ type: 'text', text: RESPONSE_SENTINEL }],
+    finishReason: { raw: 'stop', unified: 'stop' },
+    usage: {
+      inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 7, total: 7 },
+      outputTokens: { reasoning: 0, text: 4, total: 4 },
+    },
+    warnings: [],
+  },
+})
+
+mock.module('../../src/agent/provider-factory', () => ({
+  createLanguageModel: async () => ({ model }),
+}))
+
+const { AiSdkAgent } = await import('../../src/agent/ai-sdk-agent')
+const { flushAgentPondTracing, shutdownAgentPondTracing } = await import(
+  '../../src/agent/agentpond-tracing'
+)
+
+afterAll(async () => {
+  mock.restore()
+  for (const [name, value] of Object.entries({
+    AGENTPOND_PROJECT_ID: originalEnvironment.projectId,
+    FILES_SDK_PROVIDER: originalEnvironment.provider,
+    FILES_SDK_ROOT: originalEnvironment.root,
+  })) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+  if (!configuredRoot) await rm(traceRoot, { force: true, recursive: true })
+})
+
+describe('BrowserOS AgentPond tracing', () => {
+  it('reads back a content-free trace from the production agent path', async () => {
+    const agent = await AiSdkAgent.create({
+      browserSession: {} as never,
+      resolvedConfig: {
+        apiKey: 'fixture',
+        baseUrl: 'http://127.0.0.1',
+        chatMode: true,
+        conversationId: 'agentpond-e2e',
+        model: 'browseros-agentpond-test-model',
+        provider: 'openai-compatible',
+      },
+    })
+
+    const result = await agent.toolLoopAgent.generate({
+      prompt: PROMPT_SENTINEL,
+    })
+    expect(result.text).toBe(RESPONSE_SENTINEL)
+    expect(result.totalUsage.totalTokens).toBe(11)
+
+    await flushAgentPondTracing()
+    const traceKeys = (await readdir(traceRoot, { recursive: true })).filter(
+      (key) => key.endsWith('.json') && !key.endsWith('.meta.json'),
+    )
+    expect(traceKeys.length).toBeGreaterThan(0)
+    const rawPayload = (
+      await Promise.all(
+        traceKeys.map((key) => readFile(join(traceRoot, key), 'utf8')),
+      )
+    ).join('\n')
+
+    expect(rawPayload).toContain('browseros-agentpond-test-model')
+    expect(rawPayload).toContain('llm.token_count.total')
+    expect(rawPayload).not.toContain(PROMPT_SENTINEL)
+    expect(rawPayload).not.toContain(RESPONSE_SENTINEL)
+
+    await agent.dispose()
+    await shutdownAgentPondTracing()
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/main.test.ts
+++ b/packages/browseros-agent/apps/server/tests/main.test.ts
@@ -86,6 +86,33 @@ describe('Application.start', () => {
     )
     expect(warnedAboutIdentity).toBe(true)
   })
+
+  it('waits for AgentPond shutdown and ignores duplicate stop requests', async () => {
+    const { Application, shutdownAgentPondTracing } =
+      await setupApplicationTest()
+    let finishShutdown: (() => void) | undefined
+    shutdownAgentPondTracing.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishShutdown = resolve
+        }),
+    )
+    const exit = spyOn(process, 'exit').mockImplementation(
+      (() => undefined) as never,
+    )
+    const app = new Application(config)
+
+    app.stop('SIGTERM')
+    app.stop('SIGTERM')
+
+    expect(shutdownAgentPondTracing).toHaveBeenCalledTimes(1)
+    expect(exit).not.toHaveBeenCalled()
+
+    finishShutdown?.()
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(exit).toHaveBeenCalledTimes(1)
+  })
 })
 
 async function setupApplicationTest() {
@@ -94,6 +121,7 @@ async function setupApplicationTest() {
   const cdpModule = await import('@browseros/browser-core/backends/cdp')
   const runtimeModule = await import('../src/lib/agents/runtime')
   const browserosDir = await import('../src/lib/browseros-dir')
+  const agentPondModule = await import('../src/agent/agentpond-tracing')
   const dbModule = await import('../src/lib/db')
   const identityModule = await import('../src/lib/identity')
   const loggerModule = await import('../src/lib/logger')
@@ -143,6 +171,11 @@ async function setupApplicationTest() {
   spyOn(metricsModule.metrics, 'isEnabled').mockImplementation(() => true)
   spyOn(metricsModule.metrics, 'log').mockImplementation(() => {})
 
+  const shutdownAgentPondTracing = spyOn(
+    agentPondModule,
+    'shutdownAgentPondTracing',
+  ).mockImplementation(async () => {})
+
   spyOn(sentryModule.Sentry, 'setContext').mockImplementation(() => {})
   spyOn(sentryModule.Sentry, 'setUser').mockImplementation(() => {})
   spyOn(sentryModule.Sentry, 'captureException').mockImplementation(() => {})
@@ -164,5 +197,6 @@ async function setupApplicationTest() {
     loggerInfo,
     loggerWarn,
     initializeDb,
+    shutdownAgentPondTracing,
   }
 }

--- a/packages/browseros-agent/apps/server/tests/main.test.ts
+++ b/packages/browseros-agent/apps/server/tests/main.test.ts
@@ -113,6 +113,41 @@ describe('Application.start', () => {
 
     expect(exit).toHaveBeenCalledTimes(1)
   })
+
+  it('stops new requests and drains active work before AgentPond shutdown', async () => {
+    const {
+      Application,
+      activityWaitUntilIdle,
+      serverStop,
+      shutdownAgentPondTracing,
+    } = await setupApplicationTest()
+    let finishDrain: (() => void) | undefined
+    activityWaitUntilIdle.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDrain = resolve
+        }),
+    )
+    const exit = spyOn(process, 'exit').mockImplementation(
+      (() => undefined) as never,
+    )
+    const app = new Application(config)
+    await app.start()
+
+    app.stop('SIGTERM')
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(serverStop).toHaveBeenCalledTimes(1)
+    expect(activityWaitUntilIdle).toHaveBeenCalledTimes(1)
+    expect(shutdownAgentPondTracing).not.toHaveBeenCalled()
+    expect(exit).not.toHaveBeenCalled()
+
+    finishDrain?.()
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(shutdownAgentPondTracing).toHaveBeenCalledTimes(1)
+    expect(exit).toHaveBeenCalledTimes(1)
+  })
 })
 
 async function setupApplicationTest() {
@@ -129,7 +164,15 @@ async function setupApplicationTest() {
   const sentryModule = await import('../src/lib/sentry')
 
   const createHttpServer = spyOn(apiServer, 'createHttpServer')
-  createHttpServer.mockImplementation(async () => ({}) as never)
+  const serverStop = mock(async () => {})
+  const activityWaitUntilIdle = mock(async () => {})
+  createHttpServer.mockImplementation(
+    async () =>
+      ({
+        server: { stop: serverStop },
+        activity: { waitUntilIdle: activityWaitUntilIdle },
+      }) as never,
+  )
 
   const cdpConnect = mock(async () => {})
   spyOn(cdpModule.CdpBackend.prototype, 'connect').mockImplementation(
@@ -190,12 +233,14 @@ async function setupApplicationTest() {
   const { Application } = await import('../src/main')
   return {
     Application,
+    activityWaitUntilIdle,
     browserModule,
     cdpConnect,
     createHttpServer,
     loggerError,
     loggerInfo,
     loggerWarn,
+    serverStop,
     initializeDb,
     shutdownAgentPondTracing,
   }

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -215,6 +215,8 @@
         "browseros-server": "./src/index.ts",
       },
       "dependencies": {
+        "@agentpond/core": "0.7.0",
+        "@agentpond/otel": "0.1.5",
         "@ai-sdk/amazon-bedrock": "^4.0.140",
         "@ai-sdk/anthropic": "^3.0.85",
         "@ai-sdk/azure": "^3.0.93",
@@ -224,6 +226,7 @@
         "@ai-sdk/openai": "^3.0.73",
         "@ai-sdk/openai-compatible": "^2.0.62",
         "@ai-sdk/provider": "^3.0.10",
+        "@arizeai/openinference-vercel": "2.8.1",
         "@browseros/acpx-ai-provider": "workspace:*",
         "@browseros/agent-mcp-manager": "workspace:*",
         "@browseros/browser-core": "workspace:*",
@@ -234,6 +237,8 @@
         "@hono/zod-validator": "^0.9.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@openrouter/ai-sdk-provider": "^2.10.0",
+        "@opentelemetry/api": "1.9.1",
+        "@opentelemetry/sdk-trace-base": "2.9.0",
         "@sentry/bun": "^10.67.0",
         "acp-probe": "^0.0.2",
         "acpx": "^0.12.1",
@@ -241,6 +246,7 @@
         "commander": "^14.0.3",
         "core-js": "3.49.0",
         "drizzle-orm": "^0.45.2",
+        "files-sdk": "2.2.2",
         "hono": "^4.12.31",
         "jimp": "^1.6.1",
         "jsonc-parser": "^3.3.1",
@@ -382,6 +388,10 @@
 
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.2.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA=="],
 
+    "@agentpond/core": ["@agentpond/core@0.7.0", "", { "dependencies": { "protobufjs": "^7.6.5", "zod": "^4.3.6" } }, "sha512-+8er2ZNQMMX59+FhWnnMwqx9DNrHMmfTYXWF2OX0SVN6tRQstDYhj7eLg6Bq8RM3H3ukHNXfChD6gKMYdmgT2A=="],
+
+    "@agentpond/otel": ["@agentpond/otel@0.1.5", "", { "dependencies": { "@agentpond/core": "0.7.0", "@opentelemetry/core": "^2.9.0", "@opentelemetry/otlp-transformer": "^0.220.0", "@opentelemetry/sdk-trace-base": "^2.9.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-x54qB6+f34KZSjAfy+34Qmdp1a/S22vObvTOHO5I+5JejIIiu6OBoZMFhk7hZ1jm1jIv49QmHkcpapTet3uxWw=="],
+
     "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@4.0.140", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.101", "@ai-sdk/openai": "3.0.88", "@ai-sdk/provider": "3.0.14", "@ai-sdk/provider-utils": "4.0.40", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TQQNlXVJUWRFU25iUD+OBk9qj8WyPvp1IPT6J9LXCgjyOkVkZ0+JrdM93Lncfo/fPY3QVyW4bed9HxtvNHdcUA=="],
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.101", "", { "dependencies": { "@ai-sdk/provider": "3.0.14", "@ai-sdk/provider-utils": "4.0.40" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-XQrdBwGffgAnqJk1DCYfigNSXNucvzfPuMoLXl0E/GOsHL0cWxEn73nXZJ1b7lcPI77jP4VAt5ZDhKJ47tBVWQ=="],
@@ -433,6 +443,14 @@
     "@apm-js-collab/tracing-hooks": ["@apm-js-collab/tracing-hooks@0.13.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.18.0", "debug": "^4.4.1", "module-details-from-path": "^1.0.4" } }, "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw=="],
 
     "@ardatan/relay-compiler": ["@ardatan/relay-compiler@13.0.1", "", { "dependencies": { "@babel/runtime": "^7.29.2", "immutable": "^5.1.5", "invariant": "^2.2.4" }, "peerDependencies": { "graphql": "*" } }, "sha512-afG3YPwuSA0E5foouZusz5GlXKs74dObv4cuWyLyfKsYFj2r7oGRNB28v18HvwuLSQtQFCi+DpIe0TZkgQDYyg=="],
+
+    "@arizeai/openinference-core": ["@arizeai/openinference-core@2.3.0", "", { "dependencies": { "@arizeai/openinference-semantic-conventions": "2.5.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.25.1" } }, "sha512-oDLMjWvUmfA4dAlxWzXb2zJ+oHdRoFoNRTWuIt1w+p9KYeOk5ssmDV/cylFnAeLVJDimXvqG3Wl9s93f/HEeAw=="],
+
+    "@arizeai/openinference-genai": ["@arizeai/openinference-genai@0.2.0", "", { "dependencies": { "@arizeai/openinference-semantic-conventions": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0", "@opentelemetry/semantic-conventions": ">=1.41.1" } }, "sha512-WHAT0aLZ1VTosbZIK10geKp39sm4Ml7Awiv1xFS2uJIw+8EB163plGq74LEHP5h/yjBprewELwjBuvDB+wtTqQ=="],
+
+    "@arizeai/openinference-semantic-conventions": ["@arizeai/openinference-semantic-conventions@2.5.0", "", {}, "sha512-4ZeSwiFX3YxB0WSE6x568wM4PVHiYmz3yiOxic6WGKVrE/KIGggMFP/eqUNQhikBKP68IDV0qiILlZAIYnheAQ=="],
+
+    "@arizeai/openinference-vercel": ["@arizeai/openinference-vercel@2.8.1", "", { "dependencies": { "@arizeai/openinference-core": "2.3.0", "@arizeai/openinference-genai": "0.2.0", "@arizeai/openinference-semantic-conventions": "2.5.0", "@opentelemetry/core": "^1.30.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.7.0 <2.0.0" } }, "sha512-gTgUSJd9HHTfNyI2ZoorPGHt1ID5LFtZZCDFmosXzdPzYoAzwknEC9Ja3iKKs+c27uvNiS6N5P8iyxf8qC+sDg=="],
 
     "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
 
@@ -1152,7 +1170,13 @@
 
     "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.220.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.220.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw=="],
 
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.220.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.220.0", "@opentelemetry/core": "2.9.0", "@opentelemetry/resources": "2.9.0", "@opentelemetry/sdk-logs": "0.220.0", "@opentelemetry/sdk-metrics": "2.9.0", "@opentelemetry/sdk-trace": "2.9.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A=="],
+
     "@opentelemetry/resources": ["@opentelemetry/resources@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.220.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.220.0", "@opentelemetry/core": "2.9.0", "@opentelemetry/resources": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/resources": "2.9.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q=="],
 
     "@opentelemetry/sdk-trace": ["@opentelemetry/sdk-trace@2.9.0", "", { "dependencies": { "@opentelemetry/core": "2.9.0", "@opentelemetry/resources": "2.9.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw=="],
 
@@ -2522,6 +2546,8 @@
 
     "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
+    "files-sdk": ["files-sdk@2.2.2", "", { "dependencies": { "aws4fetch": "^1.0.20", "commander": "^15.0.0", "picomatch": "^4.0.5", "safe-regex2": "^5.1.1" }, "optionalDependencies": { "@modelcontextprotocol/sdk": "^1.29.0" }, "peerDependencies": { "@anthropic-ai/claude-agent-sdk": "^0.3.0", "@aws-sdk/client-s3": "^3.700.0", "@aws-sdk/lib-storage": "^3.700.0", "@aws-sdk/s3-presigned-post": "^3.700.0", "@aws-sdk/s3-request-presigner": "^3.700.0", "@azure/core-auth": "^1.9.0", "@azure/identity": "^4.5.0", "@azure/storage-blob": "^12.26.0", "@bunny.net/storage-sdk": "^0.3.1", "@google-cloud/storage": "^7.19.0", "@googleapis/drive": "^20.0.0", "@microsoft/microsoft-graph-client": "^3.0.7", "@nestjs/common": "^10.0.0 || ^11.0.0", "@netlify/blobs": "^10.7.4", "@openai/agents": "^0.11.0", "@opentelemetry/api": "^1.9.0", "@supabase/storage-js": "^2.105.4", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@vercel/blob": "^2.4.0", "ai": "^6.0.0", "astro": "^4.0.0 || ^5.0.0 || ^6.0.0", "basic-ftp": "^6.0.1", "box-typescript-sdk-gen": "^1.19.1", "cloudinary": "^2.10.0", "convex": "^1.16.0", "disk": "^0.8.18", "dropbox": "^10.34.0", "fastify": "^4.0.0 || ^5.0.0", "firebase-admin": "^14.1.0", "google-auth-library": "^10.0.0", "h3": "^1.0.0", "hono": "^4.0.0", "koa": "^2.0.0 || ^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "node-appwrite": "^26.0.0", "openai": "^6.0.0", "pocketbase": "^0.27.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "ssh2-sftp-client": "^12.1.1", "svelte": "^4.0.0 || ^5.0.0", "uploadthing": "^7", "vue": "^3.4.0", "webdav": "^5.10.0", "zod": "^3.23.0 || ^4.0.0" }, "optionalPeers": ["@anthropic-ai/claude-agent-sdk", "@aws-sdk/client-s3", "@aws-sdk/lib-storage", "@aws-sdk/s3-presigned-post", "@aws-sdk/s3-request-presigner", "@azure/core-auth", "@azure/identity", "@azure/storage-blob", "@bunny.net/storage-sdk", "@google-cloud/storage", "@googleapis/drive", "@microsoft/microsoft-graph-client", "@nestjs/common", "@netlify/blobs", "@openai/agents", "@opentelemetry/api", "@supabase/storage-js", "@sveltejs/kit", "@tanstack/react-start", "@vercel/blob", "ai", "astro", "basic-ftp", "box-typescript-sdk-gen", "cloudinary", "convex", "disk", "dropbox", "fastify", "firebase-admin", "google-auth-library", "h3", "hono", "koa", "next", "node-appwrite", "openai", "pocketbase", "react", "react-dom", "ssh2-sftp-client", "svelte", "uploadthing", "vue", "webdav", "zod"], "bin": { "files": "dist/cli/index.js" } }, "sha512-KB9UaBfju7ZwPGZwJzEXXzNaZ7GdntQ81ki0ZZhZmrFelMoKyXhA9yyOL8e86adnNBklP5QSQFikVWJfXHll2g=="],
+
     "filesize": ["filesize@11.0.17", "", {}, "sha512-oHLTvMLw6imZUl1se/RBQrFlyy50nXce4sU7yGR6Qc0JgCwqnfiFsAnEwotdGmfKLD7SArGUk2/5STU0k8LOBQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -3666,6 +3692,8 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+    "ret": ["ret@0.5.0", "", {}, "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
@@ -3697,6 +3725,8 @@
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-regex2": ["safe-regex2@5.1.1", "", { "dependencies": { "ret": "~0.5.0" }, "bin": { "safe-regex2": "bin/safe-regex2.js" } }, "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
@@ -4138,6 +4168,10 @@
 
     "@apm-js-collab/code-transformer/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "@arizeai/openinference-core/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
+
+    "@arizeai/openinference-vercel/@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
+
     "@aws-crypto/crc32/@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
 
     "@aws-crypto/util/@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
@@ -4550,6 +4584,10 @@
 
     "extend-shallow/is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
+    "files-sdk/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
+
+    "files-sdk/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
     "firefox-profile/minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
@@ -4777,6 +4815,10 @@
     "@aklinker1/rollup-plugin-visualizer/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "@aklinker1/rollup-plugin-visualizer/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@arizeai/openinference-core/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
+    "@arizeai/openinference-vercel/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
     "@aws-crypto/crc32/@aws-sdk/types/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
 

--- a/packages/browseros-agent/skills-lock.json
+++ b/packages/browseros-agent/skills-lock.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "skills": {
+    "agentpond": {
+      "source": "marcusschiesser/agentpond",
+      "sourceType": "github",
+      "skillPath": "skills/agentpond/SKILL.md",
+      "computedHash": "c4640a4854f6feca75e4e4471f18ffde9e269abbb997003bae4e09f0154cb7b5"
+    },
+    "agentpond-instrumentation": {
+      "source": "marcusschiesser/agentpond",
+      "sourceType": "github",
+      "skillPath": "skills/agentpond-instrumentation/SKILL.md",
+      "computedHash": "5ad9643eeddf83b8dbc5b83bd18418f5855387df23491eb3701259ea29dffd54"
+    },
     "ai-sdk": {
       "source": "vercel/ai",
       "sourceType": "github",


### PR DESCRIPTION
## Summary

- add optional AgentPond/OpenInference tracing to BrowserOS's real Vercel AI SDK `ToolLoopAgent` path
- keep tracing disabled unless a local Files SDK store is explicitly configured
- flush pending trace writes during server shutdown
- add an end-to-end test that runs the production `AiSdkAgent.create(...).toolLoopAgent.generate(...)` path and reads the resulting trace store

## Why AgentPond

BrowserOS already centralizes provider execution in the Vercel AI SDK agent loop. AgentPond can therefore capture provider/model, operation, timing, and token metadata at that boundary without changing individual model adapters.

## Configuration and privacy

Set both variables before starting the server:

```sh
FILES_SDK_PROVIDER=fs
FILES_SDK_ROOT=/path/to/local/agentpond-store
```

Tracing is otherwise off. This integration intentionally supports only the built-in local `fs` store, records neither prompts nor responses (`recordInputs: false`, `recordOutputs: false`), and waits for pending writes before process exit.

## Validation

Based on upstream `main` commit `5a4a9ef8f64522a9f20ccc212642ee4bba35ad49`.

```sh
npx --yes --min-release-age=0 agentpond@latest init
bun install --frozen-lockfile
bun run check
bun run test
AGENTPOND_E2E_ROOT=/private/tmp/browseros-agentpond-e2e-20260802-final-child \
  bun test apps/server/tests/agent/agentpond-tracing.e2e.test.ts
```

All commands passed. The repository-wide test command includes the compiled server tests and the signed BrowserOS HTTP/CDP/MCP/chat integration (10/10).

For the AgentPond E2E, only the model provider is mocked; the production agent construction, `ToolLoopAgent.generate`, OpenInference processor, exporter, local object store, flush, and shutdown paths are real. CLI read-back processed 1 object / 4 events and returned:

- LLM trace: `56a3a986564a1890eb6431e8dcbd734e`
- provider/model: `browseros-agentpond-e2e` / `browseros-agentpond-test-model`
- tokens: 7 prompt / 4 completion / 11 total
- `input_json: null`, `output_json: null`
- the raw store contains neither the prompt nor response sentinel

## Limitation

The initial integration deliberately targets only local filesystem storage so the self-contained BrowserOS server does not bundle optional cloud storage SDKs.