### PR TITLE
feat(claw): live per-tab session preview over rrweb SSE (server + running card)

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
@@ -1,11 +1,19 @@
 import { ExternalLink, RefreshCw, Square } from 'lucide-react'
 import type { LiveSessionCardRecord } from '@/screens/cockpit/cockpit.helpers'
 import { formatToolTrail, siteOf } from '@/screens/cockpit/cockpit.helpers'
-import { MiniScreencast } from './MiniScreencast'
+import { LivePreview } from './LivePreview'
 import { TabCountChip } from './TabCountChip'
 
 interface SessionRunningCardProps {
   session: LiveSessionCardRecord
+  /** The owned tab shown on the card: the reader's pick, else the live target. */
+  selectedBrowserTabId?: number
+  /** The session's current live target tab, for the live-versus-last-frame marker. */
+  liveBrowserTabId?: number
+  /** True once the reader pins a tab instead of following the live target. */
+  pinned?: boolean
+  onSelectTab?: (browserTabId: number) => void
+  onFollowLive?: () => void
   onWatch?: () => void
   onStop: () => void
   isFocusPending?: boolean
@@ -13,25 +21,37 @@ interface SessionRunningCardProps {
 }
 
 /**
- * One card per connected session in the Running now strip. The selected
- * browser-tab preview dominates the top; the caption carries parent session
- * identity, recent tools, and Watch / Stop actions. Sessions without browser
- * tabs keep the same card shell so Stop remains available.
+ * One card per connected session in the Running now strip. The shown browser
+ * tab's live rrweb preview dominates the top; the caption carries parent session
+ * identity, recent tools, and Watch / Stop actions. The tab chip switches which
+ * owned tab the card previews. A pinned tab that is no longer the agent's live
+ * target shows its last frame rather than a false live view.
  *
- * The LIVE indicator uses light blue rather than the vivid brand accent,
- * which is near-invisible on the dark caption block.
+ * The LIVE indicator uses light blue rather than the vivid brand accent, which
+ * is near-invisible on the dark caption block.
  */
 export function AgentRunningCard({
   session,
+  selectedBrowserTabId,
+  liveBrowserTabId,
+  pinned,
+  onSelectTab,
+  onFollowLive,
   onWatch,
   onStop,
   isFocusPending,
   isCancelPending,
 }: SessionRunningCardProps) {
-  const selectedTab = session.selectedTab
+  const shownTab =
+    session.browserTabs.find(
+      (tab) => tab.browserTabId === selectedBrowserTabId,
+    ) ?? session.browserTabs[0]
   const active = session.state === 'active'
+  const isLiveTab =
+    shownTab != null && shownTab.browserTabId === liveBrowserTabId
+  const showingLive = active && isLiveTab
   const trail = formatToolTrail(session.recentTools)
-  const site = selectedTab ? siteOf(selectedTab.url) : 'No browser activity'
+  const site = shownTab ? siteOf(shownTab.url) : 'No browser activity'
 
   return (
     <div
@@ -39,17 +59,20 @@ export function AgentRunningCard({
       className="group relative flex h-[300px] flex-col overflow-hidden rounded-2xl border border-border-2 bg-bg-sunken transition-[border-color] duration-150 hover:border-accent/40"
     >
       <div className="relative flex-1 overflow-hidden">
-        <MiniScreencast
+        <LivePreview
           site={site}
-          live={active}
+          live={showingLive}
           sessionId={session.sessionId}
+          browserTabId={pinned ? shownTab?.browserTabId : undefined}
           className="h-full w-full"
         />
-        {selectedTab && (
+        {shownTab && onSelectTab && (
           <div className="absolute top-3 right-3">
             <TabCountChip
               browserTabs={session.browserTabs}
-              selectedBrowserTabId={selectedTab.browserTabId}
+              selectedBrowserTabId={shownTab.browserTabId}
+              liveBrowserTabId={liveBrowserTabId}
+              onSelectTab={onSelectTab}
             />
           </div>
         )}
@@ -65,33 +88,43 @@ export function AgentRunningCard({
             <span className="truncate text-white">{session.label}</span>
             <span className="shrink-0 text-white/45">{session.harness}</span>
           </span>
-          <span
-            className={
-              active
-                ? 'inline-flex shrink-0 items-center gap-1.5 text-[#8fb4ff]'
-                : 'shrink-0 text-white/45'
-            }
-          >
-            {active && (
+          {showingLive ? (
+            <span className="inline-flex shrink-0 items-center gap-1.5 text-[#8fb4ff]">
               <span
                 aria-hidden
                 className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-[#8fb4ff] shadow-[0_0_8px_hsl(221_100%_78%/0.6)]"
               />
-            )}
-            {active ? 'LIVE' : 'Idle'}
-          </span>
+              LIVE
+            </span>
+          ) : active && pinned && !isLiveTab ? (
+            <span className="inline-flex shrink-0 items-center gap-2 text-white/45">
+              Last frame
+              {onFollowLive && (
+                <button
+                  type="button"
+                  data-follow-live={session.sessionId}
+                  onClick={onFollowLive}
+                  className="text-[#8fb4ff] uppercase tracking-[0.08em] transition hover:text-white"
+                >
+                  Follow live
+                </button>
+              )}
+            </span>
+          ) : (
+            <span className="shrink-0 text-white/45">Idle</span>
+          )}
         </div>
         <h3 className="truncate font-semibold text-[14px] text-white leading-tight">
-          {selectedTab?.title || session.name || site}
+          {shownTab?.title || session.name || site}
         </h3>
         <p className="truncate font-mono text-[11px] text-white/60">
-          {trail || (selectedTab ? site : 'Waiting for browser activity')}
+          {trail || (shownTab ? site : 'Waiting for browser activity')}
         </p>
         <div className="mt-1 flex items-center gap-2 border-white/10 border-t pt-2">
-          {selectedTab && onWatch && (
+          {shownTab && onWatch && (
             <button
               type="button"
-              data-watch-browser-tab={selectedTab.browserTabId}
+              data-watch-browser-tab={shownTab.browserTabId}
               onClick={onWatch}
               disabled={isFocusPending}
               className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md bg-white/10 px-2 py-1.5 font-mono text-[10.5px] text-white/90 uppercase tracking-[0.08em] transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-60"

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/LivePreview.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/LivePreview.tsx
@@ -1,0 +1,230 @@
+import { Globe } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { Replayer } from 'rrweb'
+import { cn } from '@/lib/utils'
+import { useApiBaseUrl } from '@/modules/api/audit.hooks'
+
+// rrweb-player's CSS positions the `.replayer-wrapper` we scale below.
+import 'rrweb-player/dist/style.css'
+
+const FULL_SNAPSHOT = 2
+const META = 4
+const DEFAULT_SIZE = { width: 1280, height: 720 }
+
+interface LivePreviewProps {
+  site: string
+  sessionId: string
+  /** Preview a specific owned tab; omitted follows the session's live target. */
+  browserTabId?: number
+  live?: boolean
+  className?: string
+}
+
+interface RrwebEvent {
+  type: number
+  data: unknown
+  timestamp: number
+}
+
+/**
+ * Streams a live session's own rrweb recording into an rrweb Replayer in live
+ * mode, so the running card shows a real, moving preview without the browser
+ * ever capturing a screenshot. Remounts on tab change so one tab's stream is
+ * never briefly shown as another.
+ */
+export function LivePreview({
+  sessionId,
+  browserTabId,
+  ...props
+}: LivePreviewProps) {
+  return (
+    <SessionLivePreview
+      key={`${sessionId}:${browserTabId ?? ''}`}
+      sessionId={sessionId}
+      browserTabId={browserTabId}
+      {...props}
+    />
+  )
+}
+
+function SessionLivePreview({
+  site,
+  sessionId,
+  browserTabId,
+  live,
+  className,
+}: LivePreviewProps) {
+  const baseUrl = useApiBaseUrl()
+  const mountRef = useRef<HTMLDivElement>(null)
+  const [rendering, setRendering] = useState(false)
+
+  useEffect(() => {
+    const mount = mountRef.current
+    if (!mount || baseUrl === null) return
+
+    const query =
+      browserTabId === undefined ? '' : `?browserTabId=${browserTabId}`
+    const url = `${baseUrl}/api/v1/sessions/${sessionId}/recording/live${query}`
+    const source = new EventSource(url)
+
+    let replayer: Replayer | null = null
+    let observer: ResizeObserver | null = null
+    // Events accumulated before rrweb can start: it needs a full snapshot to
+    // build the DOM, so append batches buffer here until one arrives.
+    let pending: RrwebEvent[] = []
+
+    const teardown = (): void => {
+      observer?.disconnect()
+      observer = null
+      if (replayer) {
+        try {
+          replayer.destroy()
+        } catch {
+          // already gone; we are resetting anyway
+        }
+        replayer = null
+      }
+      pending = []
+      mount.replaceChildren()
+      setRendering(false)
+    }
+
+    const toRrweb = (raw: string): RrwebEvent[] => {
+      const parsed = JSON.parse(raw) as {
+        ts: number
+        type: number
+        data: unknown
+      }[]
+      return parsed.map((event) => ({
+        type: event.type,
+        data: event.data,
+        timestamp: event.ts,
+      }))
+    }
+
+    const buildIfReady = (): void => {
+      const lastSnapshot = pending.findLastIndex(
+        (event) => event.type === FULL_SNAPSHOT,
+      )
+      if (lastSnapshot === -1) return
+      const metaBefore = pending
+        .slice(0, lastSnapshot + 1)
+        .findLastIndex((event) => event.type === META)
+      const start = metaBefore === -1 ? lastSnapshot : metaBefore
+      const initial = pending.slice(start)
+      pending = []
+      mount.replaceChildren()
+      try {
+        replayer = new Replayer(initial as never, {
+          root: mount,
+          liveMode: true,
+          skipInactive: false,
+          showWarning: false,
+        })
+        replayer.startLive(initial[0]?.timestamp)
+      } catch {
+        replayer = null
+        return
+      }
+      scaleToFit(mount, recordedSize(initial), (next) => {
+        observer = next
+      })
+      setRendering(true)
+    }
+
+    const ingest = (events: RrwebEvent[]): void => {
+      if (replayer) {
+        for (const event of events) replayer.addEvent(event as never)
+        return
+      }
+      pending.push(...events)
+      buildIfReady()
+    }
+
+    source.addEventListener('switch', () => {
+      // A new document (navigation or tab switch): tear down; the bootstrap
+      // that follows rebuilds the player for the new DOM.
+      teardown()
+    })
+    source.addEventListener('bootstrap', (event) => ingest(toRrweb(event.data)))
+    source.addEventListener('append', (event) => ingest(toRrweb(event.data)))
+    // The server fell behind and will re-send a fresh switch + bootstrap on this
+    // same connection; reset so the rebuild is clean.
+    source.addEventListener('reset', () => teardown())
+    // No recording yet (or a pinned tab with none): hold the placeholder.
+    source.addEventListener('idle', () => teardown())
+
+    return () => {
+      source.close()
+      teardown()
+    }
+  }, [baseUrl, sessionId, browserTabId])
+
+  return (
+    <div
+      data-live-preview={sessionId}
+      className={cn(
+        'relative flex items-center justify-center overflow-hidden bg-bg-sunken',
+        className ?? 'h-[132px] w-full',
+      )}
+    >
+      <div ref={mountRef} className="absolute inset-0 overflow-hidden" />
+      {!rendering && (
+        <div className="flex flex-col items-center gap-1.5 text-ink-3">
+          <Globe className="size-7" />
+          <code className="font-mono text-[11px] text-ink-2">{site}</code>
+        </div>
+      )}
+      {live && rendering && (
+        <span
+          aria-hidden
+          className={cn(
+            'absolute top-2.5 right-2.5 size-2 animate-pulse-dot rounded-full bg-green',
+            'ring-2 ring-bg-canvas/70',
+          )}
+        />
+      )}
+    </div>
+  )
+}
+
+function recordedSize(events: readonly RrwebEvent[]): {
+  width: number
+  height: number
+} {
+  const meta = events.find((event) => event.type === META)
+  const data = meta?.data as { width?: unknown; height?: unknown } | undefined
+  const width =
+    typeof data?.width === 'number' && data.width > 0
+      ? data.width
+      : DEFAULT_SIZE.width
+  const height =
+    typeof data?.height === 'number' && data.height > 0
+      ? data.height
+      : DEFAULT_SIZE.height
+  return { width, height }
+}
+
+/** Scales rrweb's fixed-size player to cover the card, tracking resizes. */
+function scaleToFit(
+  mount: HTMLElement,
+  size: { width: number; height: number },
+  registerObserver: (observer: ResizeObserver) => void,
+): void {
+  const wrapper = mount.querySelector<HTMLElement>('.replayer-wrapper')
+  if (!wrapper) return
+  wrapper.style.position = 'absolute'
+  wrapper.style.transformOrigin = 'top left'
+  const apply = (): void => {
+    const rect = mount.getBoundingClientRect()
+    if (rect.width === 0 || rect.height === 0) return
+    const scale = Math.max(rect.width / size.width, rect.height / size.height)
+    wrapper.style.transform = `scale(${scale})`
+    wrapper.style.left = `${(rect.width - size.width * scale) / 2}px`
+    wrapper.style.top = `${(rect.height - size.height * scale) / 2}px`
+  }
+  apply()
+  const observer = new ResizeObserver(apply)
+  observer.observe(mount)
+  registerObserver(observer)
+}

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
@@ -17,6 +17,8 @@ const invalidatedQueryKeys: unknown[] = []
 mock.module('@/modules/api/audit.hooks', () => ({
   ..._auditHooks,
   useSessionPreviewUrl: () => null,
+  // Null base keeps LivePreview from opening a real EventSource under linkedom.
+  useApiBaseUrl: () => null,
 }))
 
 mock.module('@/modules/api/cancel.hooks', () => ({

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
 import { useLiveSessions, useSessions } from '@/modules/api/audit.hooks'
 import { useCancelSession } from '@/modules/api/cancel.hooks'
 import { useFocusBrowserTab } from '@/modules/api/focus.hooks'
@@ -14,22 +15,19 @@ export function RunningGrid({ sessions }: RunningGridProps) {
   const queryClient = useQueryClient()
   const focus = useFocusBrowserTab()
   const cancel = useCancelSession()
+  const [pinnedTabBySession, setPinnedTabBySession] = useState<
+    Record<string, number>
+  >({})
 
   if (sessions.length === 0) return null
 
-  const onWatch = (session: LiveSessionCardRecord) => {
-    const browserTabId = session.selectedTab?.browserTabId
-    if (browserTabId === undefined) return
+  const onWatch = (browserTabId: number) => {
     focus.mutate(
       { browserTabId },
       {
         onError: (err) => {
           // eslint-disable-next-line no-console
-          console.warn('focus browser tab failed', {
-            sessionId: session.sessionId,
-            browserTabId,
-            err,
-          })
+          console.warn('focus browser tab failed', { browserTabId, err })
         },
       },
     )
@@ -75,18 +73,46 @@ export function RunningGrid({ sessions }: RunningGridProps) {
         </span>
       </header>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {sessions.map((session) => (
-          <AgentRunningCard
-            key={session.sessionId}
-            session={session}
-            onWatch={session.selectedTab ? () => onWatch(session) : undefined}
-            onStop={() => onStop(session.sessionId)}
-            isFocusPending={
-              pendingBrowserTabId === session.selectedTab?.browserTabId
-            }
-            isCancelPending={cancelPendingSessionId === session.sessionId}
-          />
-        ))}
+        {sessions.map((session) => {
+          const rawPin = pinnedTabBySession[session.sessionId]
+          const pinned =
+            rawPin !== undefined &&
+            session.browserTabs.some((tab) => tab.browserTabId === rawPin)
+          // The live target is the most recently active owned tab (browserTabs
+          // is activity-sorted); a sticky selection would lag tab switches.
+          const liveTabId = session.browserTabs[0]?.browserTabId
+          const shownTabId = pinned ? rawPin : liveTabId
+          return (
+            <AgentRunningCard
+              key={session.sessionId}
+              session={session}
+              selectedBrowserTabId={shownTabId}
+              liveBrowserTabId={liveTabId}
+              pinned={pinned}
+              onSelectTab={(browserTabId) =>
+                setPinnedTabBySession((prev) => {
+                  const next = { ...prev }
+                  if (browserTabId === liveTabId) delete next[session.sessionId]
+                  else next[session.sessionId] = browserTabId
+                  return next
+                })
+              }
+              onFollowLive={() =>
+                setPinnedTabBySession((prev) => {
+                  const next = { ...prev }
+                  delete next[session.sessionId]
+                  return next
+                })
+              }
+              onWatch={
+                shownTabId !== undefined ? () => onWatch(shownTabId) : undefined
+              }
+              onStop={() => onStop(session.sessionId)}
+              isFocusPending={pendingBrowserTabId === shownTabId}
+              isCancelPending={cancelPendingSessionId === session.sessionId}
+            />
+          )
+        })}
       </div>
     </section>
   )

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/TabCountChip.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/TabCountChip.tsx
@@ -1,5 +1,6 @@
 import type { SessionBrowserTab } from '@browseros/claw-api'
 import { Layers } from 'lucide-react'
+import { useState } from 'react'
 import {
   Popover,
   PopoverContent,
@@ -9,20 +10,27 @@ import { siteOf } from '@/screens/cockpit/cockpit.helpers'
 
 interface TabCountChipProps {
   browserTabs: SessionBrowserTab[]
+  /** The tab currently surfaced on the card. */
   selectedBrowserTabId: number
+  /** The session's live target tab, marked "on screen" in the list. */
+  liveBrowserTabId?: number
+  onSelectTab: (browserTabId: number) => void
 }
 
 /**
- * Lists every browser tab owned by one live session, highlighting the tab
- * currently surfaced on the card and showing its last tool when available.
+ * Switches which owned tab the card previews. Each row selects that tab; the
+ * shown tab is highlighted and the session's live target is marked "on screen".
  */
 export function TabCountChip({
   browserTabs,
   selectedBrowserTabId,
+  liveBrowserTabId,
+  onSelectTab,
 }: TabCountChipProps) {
+  const [open, setOpen] = useState(false)
   if (browserTabs.length <= 1) return null
   return (
-    <Popover>
+    <Popover onOpenChange={setOpen} open={open}>
       <PopoverTrigger
         data-tab-count={browserTabs.length}
         className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border-2 bg-card px-1.5 py-[1.5px] font-bold text-[10px] text-ink-2 uppercase tracking-wider transition hover:border-border-strong"
@@ -30,37 +38,51 @@ export function TabCountChip({
         <Layers className="size-2.5" />
         {browserTabs.length} tabs
       </PopoverTrigger>
-      <PopoverContent className="ph-no-capture w-72 p-2" align="end">
-        <ul className="flex flex-col gap-1">
+      <PopoverContent className="ph-no-capture w-72 p-1.5" align="end">
+        <ul className="flex flex-col gap-0.5">
           {browserTabs.map((tab) => {
             const selected = tab.browserTabId === selectedBrowserTabId
+            const isLive = tab.browserTabId === liveBrowserTabId
             return (
-              <li
-                key={tab.browserTabId}
-                className={
-                  selected
-                    ? 'flex items-start gap-2 rounded-md bg-card-tint px-2 py-1.5'
-                    : 'flex items-start gap-2 rounded-md px-2 py-1.5 hover:bg-bg-sunken'
-                }
-              >
-                <span
-                  aria-hidden
+              <li key={tab.browserTabId}>
+                <button
+                  type="button"
+                  aria-current={selected}
+                  data-select-browser-tab={tab.browserTabId}
+                  onClick={() => {
+                    onSelectTab(tab.browserTabId)
+                    setOpen(false)
+                  }}
                   className={
                     selected
-                      ? 'mt-1 size-1.5 shrink-0 rounded-full bg-accent'
-                      : 'mt-1 size-1.5 shrink-0 rounded-full bg-ink-4'
+                      ? 'flex w-full items-start gap-2 rounded-md bg-card-tint px-2 py-1.5 text-left'
+                      : 'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left transition hover:bg-bg-sunken'
                   }
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="truncate font-semibold text-[12px]">
-                    {tab.title || siteOf(tab.url)}
+                >
+                  <span
+                    aria-hidden
+                    className={
+                      selected
+                        ? 'mt-1 size-1.5 shrink-0 rounded-full bg-accent'
+                        : 'mt-1 size-1.5 shrink-0 rounded-full bg-ink-4'
+                    }
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-semibold text-[12px]">
+                      {tab.title || siteOf(tab.url)}
+                    </div>
+                    <div className="truncate font-mono text-[10.5px] text-ink-3">
+                      {[tab.lastToolName, siteOf(tab.url)]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </div>
                   </div>
-                  <div className="truncate font-mono text-[10.5px] text-ink-3">
-                    {[tab.lastToolName, siteOf(tab.url)]
-                      .filter(Boolean)
-                      .join(' . ')}
-                  </div>
-                </div>
+                  {isLive && (
+                    <span className="mt-0.5 shrink-0 font-mono text-[9px] text-accent uppercase tracking-[0.08em]">
+                      on screen
+                    </span>
+                  )}
+                </button>
               </li>
             )
           })}

--- a/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/audit.hooks.ts
@@ -147,6 +147,11 @@ export function useTaskScreenshotBaseUrl(): string | null {
   return useResolvedApiBaseUrl()
 }
 
+/** The resolved claw-server API base, or null until the server-port pref loads. */
+export function useApiBaseUrl(): string | null {
+  return useResolvedApiBaseUrl()
+}
+
 export function useSessionPreviewUrl(
   sessionId: string,
   refresh: number,

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/live.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/live.rs
@@ -1,0 +1,207 @@
+//! Live recording-preview stream (Server-Sent Events). Streams a session's
+//! currently-active rrweb document to the cockpit so the running card can render
+//! a live preview from the recording it already captures, without taking any
+//! screenshots.
+
+use super::replay::require_known_session;
+use crate::{
+    AppState,
+    error::{CanonicalError, RequestId},
+    services::{recordings::RecordedEvent, replay::LiveDocument},
+};
+use axum::{
+    Extension,
+    extract::{Path, Query, State},
+    response::sse::{Event, KeepAlive, Sse},
+};
+use futures_util::Stream;
+use serde::Deserialize;
+use serde_json::json;
+use std::convert::Infallible;
+use tokio::sync::{broadcast, mpsc};
+
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct LiveParams {
+    /// Pin the preview to one owned browser tab; absent follows the live target.
+    #[serde(rename = "browserTabId")]
+    browser_tab_id: Option<i64>,
+}
+
+/// GET /api/v1/sessions/{session_id}/recording/live
+pub(super) async fn live(
+    Extension(request_id): Extension<RequestId>,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    Query(params): Query<LiveParams>,
+) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, CanonicalError> {
+    require_known_session(&state, &request_id, &session_id).await?;
+    let (tx, rx) = mpsc::channel::<Result<Event, Infallible>>(64);
+    tokio::spawn(stream_session_preview(
+        state,
+        session_id,
+        params.browser_tab_id,
+        tx,
+    ));
+    let stream =
+        futures_util::stream::unfold(rx, |mut rx| async move { rx.recv().await.map(|e| (e, rx)) });
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+/// Resolves the session's live document, bootstraps a late joiner from the most
+/// recent full snapshot, then forwards freshly ingested batches. Ends when the
+/// client disconnects (the mpsc receiver drops) or the subscriber falls behind.
+async fn stream_session_preview(
+    state: AppState,
+    session_id: String,
+    browser_tab_id: Option<i64>,
+    tx: mpsc::Sender<Result<Event, Infallible>>,
+) {
+    let document = match state
+        .replay
+        .live_document(&session_id, browser_tab_id)
+        .await
+    {
+        Ok(Some(document)) => document,
+        Ok(None) => {
+            let _ = tx.send(Ok(control("idle", "no-recording"))).await;
+            return;
+        }
+        Err(_) => return,
+    };
+
+    // Subscribe before the bootstrap read so no batch is lost in the gap between
+    // reading stored events and forwarding live ones.
+    let mut receiver = state.live_recordings.subscribe(&document.document_id).await;
+
+    let bootstrap = match state.replay.document_events(&document.document_id).await {
+        Ok(events) => bootstrap_from_last_snapshot(events),
+        Err(_) => return,
+    };
+    let mut last_ts = bootstrap.last().map_or(i64::MIN, |event| event.ts);
+
+    if send_switch(&tx, &document).await.is_err() {
+        return;
+    }
+    if !bootstrap.is_empty() && send_events(&tx, "bootstrap", &bootstrap).await.is_err() {
+        return;
+    }
+
+    loop {
+        tokio::select! {
+            () = tx.closed() => return,
+            received = receiver.recv() => match received {
+                Ok(batch) => {
+                    // Drop anything already covered by the bootstrap so a batch
+                    // that landed during the read gap is never applied twice.
+                    let fresh: Vec<RecordedEvent> = batch
+                        .events
+                        .iter()
+                        .filter(|event| event.ts > last_ts)
+                        .cloned()
+                        .collect();
+                    if fresh.is_empty() {
+                        continue;
+                    }
+                    last_ts = fresh.last().map_or(last_ts, |event| event.ts);
+                    if send_events(&tx, "append", &fresh).await.is_err() {
+                        return;
+                    }
+                }
+                // Fell too far behind the writer: reconnect and re-bootstrap
+                // instead of applying stale, gapped frames.
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    let _ = tx.send(Ok(control("reset", "lagged"))).await;
+                    return;
+                }
+                Err(broadcast::error::RecvError::Closed) => return,
+            },
+        }
+    }
+}
+
+fn control(event: &str, message: &str) -> Event {
+    Event::default().event(event).data(message)
+}
+
+async fn send_switch(
+    tx: &mpsc::Sender<Result<Event, Infallible>>,
+    document: &LiveDocument,
+) -> Result<(), ()> {
+    let data = json!({ "documentId": document.document_id, "tabId": document.tab_id }).to_string();
+    tx.send(Ok(Event::default().event("switch").data(data)))
+        .await
+        .map_err(|_| ())
+}
+
+async fn send_events(
+    tx: &mpsc::Sender<Result<Event, Infallible>>,
+    name: &str,
+    events: &[RecordedEvent],
+) -> Result<(), ()> {
+    let data = serde_json::to_string(events).map_err(|_| ())?;
+    tx.send(Ok(Event::default().event(name).data(data)))
+        .await
+        .map_err(|_| ())
+}
+
+/// rrweb needs a Meta (type 4) then FullSnapshot (type 2) to initialize. Stream
+/// from the most recent snapshot so a late joiner renders immediately rather than
+/// replaying the whole document. Empty when no snapshot has been recorded yet.
+fn bootstrap_from_last_snapshot(events: Vec<RecordedEvent>) -> Vec<RecordedEvent> {
+    let Some(full) = events
+        .iter()
+        .rposition(|event| rrweb_type(event) == Some(2))
+    else {
+        return Vec::new();
+    };
+    let start = events[..=full]
+        .iter()
+        .rposition(|event| rrweb_type(event) == Some(4))
+        .unwrap_or(full)
+        .min(full);
+    events[start..].to_vec()
+}
+
+fn rrweb_type(event: &RecordedEvent) -> Option<u64> {
+    event
+        .event_type
+        .as_ref()
+        .and_then(serde_json::Value::as_u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn event(ts: i64, rrweb_type: u64) -> RecordedEvent {
+        RecordedEvent {
+            ts,
+            event_type: Some(json!(rrweb_type)),
+            data: Some(json!({})),
+        }
+    }
+
+    #[test]
+    fn bootstrap_starts_at_the_last_meta_and_full_snapshot() {
+        let events = vec![
+            event(1, 4),  // stale meta
+            event(2, 2),  // stale snapshot
+            event(3, 3),  // incremental
+            event(10, 4), // latest meta
+            event(11, 2), // latest snapshot
+            event(12, 3), // incremental after snapshot
+        ];
+        let boot = bootstrap_from_last_snapshot(events);
+        assert_eq!(
+            boot.iter().map(|e| e.ts).collect::<Vec<_>>(),
+            vec![10, 11, 12]
+        );
+    }
+
+    #[test]
+    fn bootstrap_is_empty_without_a_full_snapshot() {
+        let events = vec![event(1, 4), event(2, 3)];
+        assert!(bootstrap_from_last_snapshot(events).is_empty());
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/live.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/live.rs
@@ -94,19 +94,21 @@ async fn stream_session_preview(
 
         // Subscribe before the bootstrap reads so no batch is lost in the gap.
         let mut receiver = state.live_recordings.subscribe(&document.document_id).await;
-        let bootstrap = match state.replay.document_events(&document.document_id).await {
-            Ok(events) => bootstrap_from_last_snapshot(events),
-            Err(_) => return,
-        };
-        // Read the accepted batch ids AFTER the events so this set is a superset:
-        // a batch whose events are in the bootstrap is guaranteed to be listed
-        // here, so forwarding can skip it and never double-apply a batch that
-        // raced the read.
+        // Read the accepted batch ids BEFORE the events so the id set is a SUBSET
+        // of what the bootstrap covers. A batch that lands between the two reads
+        // is then carried by the bootstrap AND forwarded live (a harmless
+        // duplicate) rather than dropped: rrweb tolerates a repeated incremental
+        // event far better than a gap. Reading the ids after the events would
+        // instead drop such a batch (id present, events missing from bootstrap).
         let bootstrapped: HashSet<String> =
             match state.replay.accepted_batch_ids(&document.document_id).await {
                 Ok(ids) => ids.into_iter().collect(),
                 Err(_) => return,
             };
+        let bootstrap = match state.replay.document_events(&document.document_id).await {
+            Ok(events) => bootstrap_from_last_snapshot(events),
+            Err(_) => return,
+        };
 
         if send_switch(&tx, &document).await.is_err() {
             return;
@@ -122,8 +124,12 @@ async fn stream_session_preview(
                 () = tx.closed() => return,
                 _ = ticker.tick() => {
                     match state.replay.live_document(&session_id, browser_tab_id).await {
+                        // Document moved, or the session released its last owned
+                        // tab (None): stop forwarding the now-stale document and
+                        // let the outer loop re-resolve, or go idle.
                         Ok(Some(next)) if next.document_id != document.document_id => break,
-                        Ok(_) => {}
+                        Ok(None) => break,
+                        Ok(Some(_)) => {}
                         Err(_) => return,
                     }
                 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/live.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/live.rs
@@ -17,7 +17,7 @@ use axum::{
 use futures_util::Stream;
 use serde::Deserialize;
 use serde_json::json;
-use std::{collections::HashSet, convert::Infallible};
+use std::convert::Infallible;
 use tokio::{
     sync::{broadcast, mpsc},
     time::{Duration, MissedTickBehavior, interval},
@@ -92,23 +92,24 @@ async fn stream_session_preview(
         };
         announced_idle = false;
 
-        // Subscribe before the bootstrap reads so no batch is lost in the gap.
+        // Subscribe before the bootstrap read so no batch is lost between the
+        // read and the live feed.
         let mut receiver = state.live_recordings.subscribe(&document.document_id).await;
-        // Read the accepted batch ids BEFORE the events so the id set is a SUBSET
-        // of what the bootstrap covers. A batch that lands between the two reads
-        // is then carried by the bootstrap AND forwarded live (a harmless
-        // duplicate) rather than dropped: rrweb tolerates a repeated incremental
-        // event far better than a gap. Reading the ids after the events would
-        // instead drop such a batch (id present, events missing from bootstrap).
-        let bootstrapped: HashSet<String> =
-            match state.replay.accepted_batch_ids(&document.document_id).await {
-                Ok(ids) => ids.into_iter().collect(),
-                Err(_) => return,
-            };
-        let bootstrap = match state.replay.document_events(&document.document_id).await {
-            Ok(events) => bootstrap_from_last_snapshot(events),
+        // The bootstrap reads the file up to a committed byte length; a live
+        // batch is forwarded only when its end offset exceeds that length.
+        // Batches are atomic and contiguous, so this cutoff is exact: the
+        // bootstrap never re-applies a batch it already carried (no duplicate)
+        // and never skips one it did not (no gap). Reading the length and the
+        // events together keeps the cutoff and the bootstrap consistent.
+        let (events, committed_len) = match state
+            .replay
+            .document_events_committed(&document.document_id)
+            .await
+        {
+            Ok(pair) => pair,
             Err(_) => return,
         };
+        let bootstrap = bootstrap_from_last_snapshot(events);
 
         if send_switch(&tx, &document).await.is_err() {
             return;
@@ -134,10 +135,10 @@ async fn stream_session_preview(
                     }
                 }
                 received = receiver.recv() => match received {
-                    // Skip whole batches the bootstrap already covered (batch id
-                    // is the durable accept identity); every other batch is new
-                    // and forwarded intact, so no distinct event is ever dropped.
-                    Ok(batch) if bootstrapped.contains(batch.batch_id.as_ref()) => {}
+                    // Skip batches the bootstrap already covered; anything past
+                    // the committed cutoff is new and forwarded intact, so no
+                    // distinct event is dropped or double-applied.
+                    Ok(batch) if batch.end_offset <= committed_len => {}
                     Ok(batch) => {
                         if send_events(&tx, "append", &batch.events).await.is_err() {
                             return;

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/live.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/live.rs
@@ -17,8 +17,15 @@ use axum::{
 use futures_util::Stream;
 use serde::Deserialize;
 use serde_json::json;
-use std::convert::Infallible;
-use tokio::sync::{broadcast, mpsc};
+use std::{collections::HashSet, convert::Infallible};
+use tokio::{
+    sync::{broadcast, mpsc},
+    time::{Duration, MissedTickBehavior, interval},
+};
+
+/// How often an auto-following stream re-checks which document the session is
+/// live on, so it switches when the agent navigates or changes tabs.
+const RESOLVE_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Default, Deserialize)]
 pub(super) struct LiveParams {
@@ -47,74 +54,100 @@ pub(super) async fn live(
     Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
 }
 
-/// Resolves the session's live document, bootstraps a late joiner from the most
-/// recent full snapshot, then forwards freshly ingested batches. Ends when the
-/// client disconnects (the mpsc receiver drops) or the subscriber falls behind.
+/// Follows the session's live document: (re)resolves which document to show,
+/// bootstraps a late joiner from the most recent full snapshot, then forwards
+/// freshly ingested batches until the followed document moves (auto-follow) or
+/// the client disconnects. Auto-follow re-resolves on a timer so navigating or
+/// switching tabs re-points the preview instead of freezing on a stale document.
 async fn stream_session_preview(
     state: AppState,
     session_id: String,
     browser_tab_id: Option<i64>,
     tx: mpsc::Sender<Result<Event, Infallible>>,
 ) {
-    let document = match state
-        .replay
-        .live_document(&session_id, browser_tab_id)
-        .await
-    {
-        Ok(Some(document)) => document,
-        Ok(None) => {
-            let _ = tx.send(Ok(control("idle", "no-recording"))).await;
-            return;
-        }
-        Err(_) => return,
-    };
-
-    // Subscribe before the bootstrap read so no batch is lost in the gap between
-    // reading stored events and forwarding live ones.
-    let mut receiver = state.live_recordings.subscribe(&document.document_id).await;
-
-    let bootstrap = match state.replay.document_events(&document.document_id).await {
-        Ok(events) => bootstrap_from_last_snapshot(events),
-        Err(_) => return,
-    };
-    let mut last_ts = bootstrap.last().map_or(i64::MIN, |event| event.ts);
-
-    if send_switch(&tx, &document).await.is_err() {
-        return;
-    }
-    if !bootstrap.is_empty() && send_events(&tx, "bootstrap", &bootstrap).await.is_err() {
-        return;
-    }
+    let mut ticker = interval(RESOLVE_INTERVAL);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut announced_idle = false;
 
     loop {
-        tokio::select! {
-            () = tx.closed() => return,
-            received = receiver.recv() => match received {
-                Ok(batch) => {
-                    // Drop anything already covered by the bootstrap so a batch
-                    // that landed during the read gap is never applied twice.
-                    let fresh: Vec<RecordedEvent> = batch
-                        .events
-                        .iter()
-                        .filter(|event| event.ts > last_ts)
-                        .cloned()
-                        .collect();
-                    if fresh.is_empty() {
-                        continue;
-                    }
-                    last_ts = fresh.last().map_or(last_ts, |event| event.ts);
-                    if send_events(&tx, "append", &fresh).await.is_err() {
-                        return;
-                    }
-                }
-                // Fell too far behind the writer: reconnect and re-bootstrap
-                // instead of applying stale, gapped frames.
-                Err(broadcast::error::RecvError::Lagged(_)) => {
-                    let _ = tx.send(Ok(control("reset", "lagged"))).await;
+        let document = match state
+            .replay
+            .live_document(&session_id, browser_tab_id)
+            .await
+        {
+            Ok(Some(document)) => document,
+            Ok(None) => {
+                // No recorded document yet; wait for one to appear (or a pinned
+                // tab to come back) rather than closing the stream.
+                if !announced_idle && tx.send(Ok(control("idle", "no-recording"))).await.is_err() {
                     return;
                 }
-                Err(broadcast::error::RecvError::Closed) => return,
-            },
+                announced_idle = true;
+                tokio::select! {
+                    () = tx.closed() => return,
+                    _ = ticker.tick() => continue,
+                }
+            }
+            Err(_) => return,
+        };
+        announced_idle = false;
+
+        // Subscribe before the bootstrap reads so no batch is lost in the gap.
+        let mut receiver = state.live_recordings.subscribe(&document.document_id).await;
+        let bootstrap = match state.replay.document_events(&document.document_id).await {
+            Ok(events) => bootstrap_from_last_snapshot(events),
+            Err(_) => return,
+        };
+        // Read the accepted batch ids AFTER the events so this set is a superset:
+        // a batch whose events are in the bootstrap is guaranteed to be listed
+        // here, so forwarding can skip it and never double-apply a batch that
+        // raced the read.
+        let bootstrapped: HashSet<String> =
+            match state.replay.accepted_batch_ids(&document.document_id).await {
+                Ok(ids) => ids.into_iter().collect(),
+                Err(_) => return,
+            };
+
+        if send_switch(&tx, &document).await.is_err() {
+            return;
+        }
+        if !bootstrap.is_empty() && send_events(&tx, "bootstrap", &bootstrap).await.is_err() {
+            return;
+        }
+
+        // Forward live batches until the followed document changes or the client
+        // leaves; then the outer loop re-resolves and re-bootstraps.
+        loop {
+            tokio::select! {
+                () = tx.closed() => return,
+                _ = ticker.tick() => {
+                    match state.replay.live_document(&session_id, browser_tab_id).await {
+                        Ok(Some(next)) if next.document_id != document.document_id => break,
+                        Ok(_) => {}
+                        Err(_) => return,
+                    }
+                }
+                received = receiver.recv() => match received {
+                    // Skip whole batches the bootstrap already covered (batch id
+                    // is the durable accept identity); every other batch is new
+                    // and forwarded intact, so no distinct event is ever dropped.
+                    Ok(batch) if bootstrapped.contains(batch.batch_id.as_ref()) => {}
+                    Ok(batch) => {
+                        if send_events(&tx, "append", &batch.events).await.is_err() {
+                            return;
+                        }
+                    }
+                    // Fell behind the writer: re-bootstrap from a fresh snapshot
+                    // instead of applying gapped frames.
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        if tx.send(Ok(control("reset", "lagged"))).await.is_err() {
+                            return;
+                        }
+                        break;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                },
+            }
         }
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
@@ -20,6 +20,7 @@ use ulid::Ulid;
 pub(crate) mod audit;
 mod cockpit;
 mod connections;
+mod live;
 mod previews;
 mod recordings;
 mod replay;
@@ -70,6 +71,10 @@ pub fn router(state: AppState) -> Router<AppState> {
         .route(
             "/api/v1/sessions/{session_id}/recording/events",
             get(replay::download_events),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/recording/live",
+            get(live::live),
         )
         .route(
             "/api/v1/recordings/events",

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/replay.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/replay.rs
@@ -92,7 +92,7 @@ pub(super) async fn download_events(
     Ok(response)
 }
 
-async fn require_known_session(
+pub(super) async fn require_known_session(
     state: &AppState,
     request_id: &RequestId,
     session_id: &str,

--- a/packages/browseros-agent/apps/claw-server-rust/src/app.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/app.rs
@@ -12,7 +12,7 @@ use crate::{
         harness::HarnessService,
         harness_skills::load_browserclaw_skill,
         profiles::ProfileService,
-        recordings::{RecordingIngestService, RecordingStore},
+        recordings::{LiveRecordingBus, RecordingIngestService, RecordingStore},
         replay::ReplayService,
         screenshots::ScreenshotService,
         session_efficiency::SessionEfficiencyService,
@@ -32,6 +32,7 @@ pub struct AppState {
     pub session_tabs: Arc<SessionTabLedger>,
     pub recordings: Arc<RecordingStore>,
     pub recording_ingest: Arc<RecordingIngestService>,
+    pub live_recordings: Arc<LiveRecordingBus>,
     pub replay: Arc<ReplayService>,
     pub screenshots: Arc<ScreenshotService>,
     pub tab_activity: Arc<TabActivityService>,
@@ -108,8 +109,13 @@ impl AppState {
         let tab_registry = TabRegistry::new(session_tabs.clone());
         let browser =
             BrowserService::new(config.cdp_port, sessions.ownership(), tab_registry.clone());
-        let recording_ingest =
-            RecordingIngestService::new(recordings.clone(), browser.clone(), tab_registry.clone());
+        let live_recordings = LiveRecordingBus::new();
+        let recording_ingest = RecordingIngestService::new(
+            recordings.clone(),
+            browser.clone(),
+            tab_registry.clone(),
+            live_recordings.clone(),
+        );
         let tab_activity = Arc::new(TabActivityService::default());
         let visuals = SessionVisualService::new(
             sessions.clone(),
@@ -148,6 +154,7 @@ impl AppState {
             session_tabs,
             recordings,
             recording_ingest,
+            live_recordings,
             replay,
             screenshots,
             tab_activity,

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/recording_index.rs
@@ -176,6 +176,18 @@ impl RecordingIndex {
         )
     }
 
+    /// Every batch id already durably accepted for a document, so a live
+    /// subscriber can skip forwarding a batch its bootstrap already captured.
+    pub async fn accepted_batch_ids(&self, document_id: &str) -> AppResult<Vec<String>> {
+        Ok(RecordingBatches::find()
+            .select_only()
+            .column(recording_batches::Column::BatchId)
+            .filter(recording_batches::Column::DocumentId.eq(document_id))
+            .into_tuple::<String>()
+            .all(self.db.connection())
+            .await?)
+    }
+
     /// Committed byte length of the document's on-disk replay file (0 when the
     /// stream does not exist yet or predates the file migration).
     pub async fn committed_payload_bytes(&self, document_id: &str) -> AppResult<i64> {

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/ingest.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/ingest.rs
@@ -40,7 +40,7 @@ impl RecordingIngestService {
             .tabs
             .resolve(tab_id, session, self.browser.state().epoch)
             .await;
-        let accepted = self
+        let outcome = self
             .recordings
             .append_batch(
                 document_id,
@@ -51,14 +51,17 @@ impl RecordingIngestService {
                 has_gap,
             )
             .await?;
-        // Fan the freshly accepted events out to any live-preview subscribers.
-        // A duplicate (already-accepted) batch is not republished so a
-        // reconnecting subscriber never double-applies it.
-        if accepted && !events.is_empty() {
+        // Fan the freshly accepted events out to any live-preview subscribers,
+        // tagged with the document's committed length after this batch. A
+        // subscriber forwards the batch only when that length exceeds what its
+        // bootstrap already read, so a batch the bootstrap captured is never
+        // double-applied. `committed_len` is `Some` only for a newly accepted,
+        // non-empty batch, so a duplicate or empty batch is never republished.
+        if let Some(committed_len) = outcome.committed_len {
             self.live
-                .publish(document_id, batch_id, Arc::from(events))
+                .publish(document_id, committed_len, Arc::from(events))
                 .await;
         }
-        Ok(accepted)
+        Ok(outcome.accepted)
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/ingest.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/ingest.rs
@@ -1,4 +1,4 @@
-use super::{RecordingEventInput, RecordingStore};
+use super::{LiveRecordingBus, RecordingEventInput, RecordingStore};
 use crate::{
     error::AppResult,
     services::browser::{BrowserService, TabRegistry},
@@ -9,6 +9,7 @@ pub struct RecordingIngestService {
     recordings: Arc<RecordingStore>,
     browser: Arc<BrowserService>,
     tabs: Arc<TabRegistry>,
+    live: Arc<LiveRecordingBus>,
 }
 
 impl RecordingIngestService {
@@ -16,11 +17,13 @@ impl RecordingIngestService {
         recordings: Arc<RecordingStore>,
         browser: Arc<BrowserService>,
         tabs: Arc<TabRegistry>,
+        live: Arc<LiveRecordingBus>,
     ) -> Arc<Self> {
         Arc::new(Self {
             recordings,
             browser,
             tabs,
+            live,
         })
     }
 
@@ -37,7 +40,8 @@ impl RecordingIngestService {
             .tabs
             .resolve(tab_id, session, self.browser.state().epoch)
             .await;
-        self.recordings
+        let accepted = self
+            .recordings
             .append_batch(
                 document_id,
                 tab_id,
@@ -46,6 +50,13 @@ impl RecordingIngestService {
                 batch_id,
                 has_gap,
             )
-            .await
+            .await?;
+        // Fan the freshly accepted events out to any live-preview subscribers.
+        // A duplicate (already-accepted) batch is not republished so a
+        // reconnecting subscriber never double-applies it.
+        if accepted && !events.is_empty() {
+            self.live.publish(document_id, Arc::from(events)).await;
+        }
+        Ok(accepted)
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/ingest.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/ingest.rs
@@ -55,7 +55,9 @@ impl RecordingIngestService {
         // A duplicate (already-accepted) batch is not republished so a
         // reconnecting subscriber never double-applies it.
         if accepted && !events.is_empty() {
-            self.live.publish(document_id, Arc::from(events)).await;
+            self.live
+                .publish(document_id, batch_id, Arc::from(events))
+                .await;
         }
         Ok(accepted)
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/live.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/live.rs
@@ -1,0 +1,103 @@
+//! In-process fan-out of freshly ingested rrweb batches to live-preview
+//! subscribers, keyed by recording document id. Publishing is best-effort and
+//! never blocks ingest; a subscriber that falls behind is dropped and expected
+//! to reconnect (which re-bootstraps from stored events).
+
+use super::RecordingEventInput;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::{Mutex, broadcast};
+
+/// Per-document broadcast depth. A subscriber more than this many batches behind
+/// receives `Lagged` and is closed so it reconnects rather than replay stale
+/// frames.
+const LIVE_CHANNEL_CAPACITY: usize = 256;
+
+/// One freshly accepted batch of rrweb events for a single recording document.
+#[derive(Clone)]
+pub struct LiveBatch {
+    pub events: Arc<[RecordingEventInput]>,
+}
+
+/// Routes newly accepted rrweb batches from the ingest path to any live-preview
+/// subscribers watching the same document.
+#[derive(Default)]
+pub struct LiveRecordingBus {
+    channels: Mutex<HashMap<String, broadcast::Sender<LiveBatch>>>,
+}
+
+impl LiveRecordingBus {
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Subscribes to a document's live batches, creating the channel on first
+    /// interest. The returned receiver keeps the channel alive until dropped.
+    pub async fn subscribe(&self, document_id: &str) -> broadcast::Receiver<LiveBatch> {
+        let mut channels = self.channels.lock().await;
+        channels
+            .entry(document_id.to_string())
+            .or_insert_with(|| broadcast::channel(LIVE_CHANNEL_CAPACITY).0)
+            .subscribe()
+    }
+
+    /// Publishes a batch to a document's subscribers. A no-op when nobody is
+    /// listening; the channel is dropped once its last receiver is gone so idle
+    /// documents do not accumulate.
+    pub async fn publish(&self, document_id: &str, events: Arc<[RecordingEventInput]>) {
+        let mut channels = self.channels.lock().await;
+        let Some(sender) = channels.get(document_id) else {
+            return;
+        };
+        if sender.send(LiveBatch { events }).is_err() {
+            channels.remove(document_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn event(ts: i64) -> RecordingEventInput {
+        RecordingEventInput {
+            ts,
+            event_type: Some(json!(3)),
+            data: Some(json!({ "ts": ts })),
+        }
+    }
+
+    #[tokio::test]
+    async fn delivers_batches_to_a_document_subscriber() -> anyhow::Result<()> {
+        let bus = LiveRecordingBus::new();
+        let mut rx = bus.subscribe("doc").await;
+        bus.publish("doc", Arc::from(vec![event(1), event(2)]))
+            .await;
+        let batch = rx.recv().await?;
+        assert_eq!(batch.events.len(), 2);
+        assert_eq!(batch.events[0].ts, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn publish_without_subscribers_is_a_noop() -> anyhow::Result<()> {
+        let bus = LiveRecordingBus::new();
+        bus.publish("doc", Arc::from(vec![event(1)])).await;
+        // A later subscriber only sees batches published after it subscribes.
+        let mut rx = bus.subscribe("doc").await;
+        bus.publish("doc", Arc::from(vec![event(2)])).await;
+        assert_eq!(rx.recv().await?.events[0].ts, 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn a_document_is_isolated_from_other_documents() -> anyhow::Result<()> {
+        let bus = LiveRecordingBus::new();
+        let mut rx = bus.subscribe("a").await;
+        bus.publish("b", Arc::from(vec![event(1)])).await;
+        bus.publish("a", Arc::from(vec![event(2)])).await;
+        assert_eq!(rx.recv().await?.events[0].ts, 2);
+        Ok(())
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/live.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/live.rs
@@ -15,6 +15,9 @@ const LIVE_CHANNEL_CAPACITY: usize = 256;
 /// One freshly accepted batch of rrweb events for a single recording document.
 #[derive(Clone)]
 pub struct LiveBatch {
+    /// The batch's durable accept identity, used to skip a batch a reconnecting
+    /// subscriber already captured in its bootstrap.
+    pub batch_id: Arc<str>,
     pub events: Arc<[RecordingEventInput]>,
 }
 
@@ -44,12 +47,21 @@ impl LiveRecordingBus {
     /// Publishes a batch to a document's subscribers. A no-op when nobody is
     /// listening; the channel is dropped once its last receiver is gone so idle
     /// documents do not accumulate.
-    pub async fn publish(&self, document_id: &str, events: Arc<[RecordingEventInput]>) {
+    pub async fn publish(
+        &self,
+        document_id: &str,
+        batch_id: &str,
+        events: Arc<[RecordingEventInput]>,
+    ) {
         let mut channels = self.channels.lock().await;
         let Some(sender) = channels.get(document_id) else {
             return;
         };
-        if sender.send(LiveBatch { events }).is_err() {
+        let batch = LiveBatch {
+            batch_id: Arc::from(batch_id),
+            events,
+        };
+        if sender.send(batch).is_err() {
             channels.remove(document_id);
         }
     }
@@ -69,12 +81,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delivers_batches_to_a_document_subscriber() -> anyhow::Result<()> {
+    async fn delivers_batches_with_their_id_to_a_document_subscriber() -> anyhow::Result<()> {
         let bus = LiveRecordingBus::new();
         let mut rx = bus.subscribe("doc").await;
-        bus.publish("doc", Arc::from(vec![event(1), event(2)]))
+        bus.publish("doc", "batch-a", Arc::from(vec![event(1), event(2)]))
             .await;
         let batch = rx.recv().await?;
+        assert_eq!(batch.batch_id.as_ref(), "batch-a");
         assert_eq!(batch.events.len(), 2);
         assert_eq!(batch.events[0].ts, 1);
         Ok(())
@@ -83,10 +96,12 @@ mod tests {
     #[tokio::test]
     async fn publish_without_subscribers_is_a_noop() -> anyhow::Result<()> {
         let bus = LiveRecordingBus::new();
-        bus.publish("doc", Arc::from(vec![event(1)])).await;
+        bus.publish("doc", "batch-a", Arc::from(vec![event(1)]))
+            .await;
         // A later subscriber only sees batches published after it subscribes.
         let mut rx = bus.subscribe("doc").await;
-        bus.publish("doc", Arc::from(vec![event(2)])).await;
+        bus.publish("doc", "batch-b", Arc::from(vec![event(2)]))
+            .await;
         assert_eq!(rx.recv().await?.events[0].ts, 2);
         Ok(())
     }
@@ -95,8 +110,8 @@ mod tests {
     async fn a_document_is_isolated_from_other_documents() -> anyhow::Result<()> {
         let bus = LiveRecordingBus::new();
         let mut rx = bus.subscribe("a").await;
-        bus.publish("b", Arc::from(vec![event(1)])).await;
-        bus.publish("a", Arc::from(vec![event(2)])).await;
+        bus.publish("b", "batch-b", Arc::from(vec![event(1)])).await;
+        bus.publish("a", "batch-a", Arc::from(vec![event(2)])).await;
         assert_eq!(rx.recv().await?.events[0].ts, 2);
         Ok(())
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/live.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/live.rs
@@ -15,9 +15,12 @@ const LIVE_CHANNEL_CAPACITY: usize = 256;
 /// One freshly accepted batch of rrweb events for a single recording document.
 #[derive(Clone)]
 pub struct LiveBatch {
-    /// The batch's durable accept identity, used to skip a batch a reconnecting
-    /// subscriber already captured in its bootstrap.
-    pub batch_id: Arc<str>,
+    /// The document's committed byte length after this batch. A subscriber
+    /// forwards the batch only when this exceeds the length its bootstrap
+    /// already read, so a batch the bootstrap captured is never re-applied and
+    /// none is skipped: batches are atomic and contiguous, so the cutoff is
+    /// exact.
+    pub end_offset: i64,
     pub events: Arc<[RecordingEventInput]>,
 }
 
@@ -50,17 +53,14 @@ impl LiveRecordingBus {
     pub async fn publish(
         &self,
         document_id: &str,
-        batch_id: &str,
+        end_offset: i64,
         events: Arc<[RecordingEventInput]>,
     ) {
         let mut channels = self.channels.lock().await;
         let Some(sender) = channels.get(document_id) else {
             return;
         };
-        let batch = LiveBatch {
-            batch_id: Arc::from(batch_id),
-            events,
-        };
+        let batch = LiveBatch { end_offset, events };
         if sender.send(batch).is_err() {
             channels.remove(document_id);
         }
@@ -81,13 +81,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delivers_batches_with_their_id_to_a_document_subscriber() -> anyhow::Result<()> {
+    async fn delivers_batches_with_their_offset_to_a_document_subscriber() -> anyhow::Result<()> {
         let bus = LiveRecordingBus::new();
         let mut rx = bus.subscribe("doc").await;
-        bus.publish("doc", "batch-a", Arc::from(vec![event(1), event(2)]))
+        bus.publish("doc", 64, Arc::from(vec![event(1), event(2)]))
             .await;
         let batch = rx.recv().await?;
-        assert_eq!(batch.batch_id.as_ref(), "batch-a");
+        assert_eq!(batch.end_offset, 64);
         assert_eq!(batch.events.len(), 2);
         assert_eq!(batch.events[0].ts, 1);
         Ok(())
@@ -96,12 +96,10 @@ mod tests {
     #[tokio::test]
     async fn publish_without_subscribers_is_a_noop() -> anyhow::Result<()> {
         let bus = LiveRecordingBus::new();
-        bus.publish("doc", "batch-a", Arc::from(vec![event(1)]))
-            .await;
+        bus.publish("doc", 32, Arc::from(vec![event(1)])).await;
         // A later subscriber only sees batches published after it subscribes.
         let mut rx = bus.subscribe("doc").await;
-        bus.publish("doc", "batch-b", Arc::from(vec![event(2)]))
-            .await;
+        bus.publish("doc", 64, Arc::from(vec![event(2)])).await;
         assert_eq!(rx.recv().await?.events[0].ts, 2);
         Ok(())
     }
@@ -110,8 +108,8 @@ mod tests {
     async fn a_document_is_isolated_from_other_documents() -> anyhow::Result<()> {
         let bus = LiveRecordingBus::new();
         let mut rx = bus.subscribe("a").await;
-        bus.publish("b", "batch-b", Arc::from(vec![event(1)])).await;
-        bus.publish("a", "batch-a", Arc::from(vec![event(2)])).await;
+        bus.publish("b", 32, Arc::from(vec![event(1)])).await;
+        bus.publish("a", 32, Arc::from(vec![event(2)])).await;
         assert_eq!(rx.recv().await?.events[0].ts, 2);
         Ok(())
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/mod.rs
@@ -1,7 +1,9 @@
 mod ingest;
+mod live;
 mod store;
 
 pub use ingest::RecordingIngestService;
+pub use live::{LiveBatch, LiveRecordingBus};
 pub use store::{
     LegacyRecordedEvent, RECORDING_ORPHAN_TTL_MS, RecordedEvent, RecordingEventInput,
     RecordingStore, RetentionSweepResult, legacy_document_id,

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/recordings/store.rs
@@ -65,6 +65,17 @@ pub struct RetentionSweepResult {
     pub claims_deleted: u64,
 }
 
+/// Outcome of appending a batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatchAppend {
+    /// True when this batch was newly persisted (false for a duplicate accept).
+    pub accepted: bool,
+    /// The document's committed byte length after this batch, when it added
+    /// events; `None` for a duplicate or an empty batch. Live subscribers fan a
+    /// batch out only when this exceeds the length their bootstrap already read.
+    pub committed_len: Option<i64>,
+}
+
 /// One step of migrating a document's rrweb payload from the SQLite blob to its
 /// on-disk replay file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -112,7 +123,7 @@ impl RecordingStore {
         events: &[RecordingEventInput],
         batch_id: &str,
         has_gap: bool,
-    ) -> AppResult<bool> {
+    ) -> AppResult<BatchAppend> {
         let document_lock = self.lock_for(document_id).await;
         let guard = document_lock.lock().await;
         let result = self
@@ -131,12 +142,18 @@ impl RecordingStore {
         events: &[RecordingEventInput],
         batch_id: &str,
         has_gap: bool,
-    ) -> AppResult<bool> {
+    ) -> AppResult<BatchAppend> {
         if self.index.batch_accepted(document_id, batch_id).await? {
-            return Ok(false);
+            return Ok(BatchAppend {
+                accepted: false,
+                committed_len: None,
+            });
         }
         if events.is_empty() {
-            return Ok(true);
+            return Ok(BatchAppend {
+                accepted: true,
+                committed_len: None,
+            });
         }
         let mut payload = String::new();
         for event in events {
@@ -183,7 +200,10 @@ impl RecordingStore {
                 payload_bytes,
             })
             .await?;
-        Ok(true)
+        Ok(BatchAppend {
+            accepted: true,
+            committed_len: Some(payload_bytes),
+        })
     }
 
     /// Appends the batch payload to the document's `replays/` file. Truncates to
@@ -224,6 +244,17 @@ impl RecordingStore {
     /// the DB blob for a document that predates the file migration.
     async fn load_payload(&self, document_id: &str) -> AppResult<Option<String>> {
         let committed = self.index.committed_payload_bytes(document_id).await?;
+        self.load_payload_at(document_id, committed).await
+    }
+
+    /// Loads the committed payload bounded to an already-read committed length,
+    /// so a caller that also needs the length reads it once and the file view
+    /// and the length can never disagree.
+    async fn load_payload_at(
+        &self,
+        document_id: &str,
+        committed: i64,
+    ) -> AppResult<Option<String>> {
         if committed > 0 {
             let path = self.replay_path_for(document_id);
             let bytes = match fs::read(&path).await {
@@ -261,6 +292,21 @@ impl RecordingStore {
             return Ok(Vec::new());
         };
         Ok(read_payload_range(&payload, from, to))
+    }
+
+    /// Reads a document's committed events together with the committed byte
+    /// length the read was bounded to. A live subscriber forwards only batches
+    /// whose end offset exceeds this length: batches are atomic and contiguous,
+    /// so the cutoff is exact and the bootstrap never overlaps or gaps the live
+    /// tail. Reads the length once and reuses it for the file view so the two
+    /// cannot drift.
+    pub async fn read_committed(&self, document_id: &str) -> AppResult<(Vec<RecordedEvent>, i64)> {
+        let committed = self.index.committed_payload_bytes(document_id).await?;
+        let events = match self.load_payload_at(document_id, committed).await? {
+            Some(payload) => read_payload_range(&payload, i64::MIN, i64::MAX),
+            None => Vec::new(),
+        };
+        Ok((events, committed))
     }
 
     pub async fn read_legacy_range(
@@ -734,6 +780,7 @@ mod tests {
                     false
                 )
                 .await?
+                .accepted
         );
         let recreated = RecordingStore::new(
             store.root.clone(),
@@ -746,10 +793,46 @@ mod tests {
             !recreated
                 .append_batch(document_id, 11, None, &[event(100)], "batch-a", false)
                 .await?
+                .accepted
         );
         assert_eq!(index.stream_count().await?, 1);
         assert!(index.batch_exists(document_id, "batch-a").await?);
         assert_eq!(recreated.read_range(document_id, 100, 150).await?.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn read_committed_cutoff_is_the_appended_batch_boundary() -> anyhow::Result<()> {
+        let (_dir, _index, store) = setup().await?;
+        let doc = "018f47a7-1c2b-7def-8123-0123456789ab";
+
+        let a = store
+            .append_batch(doc, 11, None, &[event(100), event(150)], "batch-a", false)
+            .await?;
+        let (events_a, cutoff_a) = store.read_committed(doc).await?;
+        assert_eq!(events_a.len(), 2);
+        // A live batch tags itself with the committed length the bootstrap reads
+        // back, so the subscriber's `end_offset <= cutoff` test is on one scale.
+        assert_eq!(a.committed_len, Some(cutoff_a));
+
+        let b = store
+            .append_batch(doc, 11, None, &[event(200)], "batch-b", false)
+            .await?;
+        let (events_ab, cutoff_b) = store.read_committed(doc).await?;
+        assert_eq!(events_ab.len(), 3);
+        assert_eq!(b.committed_len, Some(cutoff_b));
+        // Monotonic: batch-b lies entirely past batch-a's cutoff, so a subscriber
+        // bootstrapped at cutoff_a forwards it exactly once (no gap, no dupe).
+        assert!(cutoff_b > cutoff_a);
+        assert!(b.committed_len > a.committed_len);
+
+        // A duplicate re-accept advances nothing and is never fanned out.
+        let dup = store
+            .append_batch(doc, 11, None, &[event(200)], "batch-b", false)
+            .await?;
+        assert!(!dup.accepted);
+        assert_eq!(dup.committed_len, None);
+        assert_eq!(store.read_committed(doc).await?.1, cutoff_b);
         Ok(())
     }
 
@@ -891,6 +974,7 @@ mod tests {
             store
                 .append_batch(doc, 11, None, &[event(30)], "new-batch", false)
                 .await?
+                .accepted
         );
 
         // The inline extraction consumed the blob, so migration has nothing left

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
@@ -60,10 +60,50 @@ pub struct ReplayService {
     index: Arc<RecordingIndex>,
 }
 
+/// The recording document a session's live preview should currently follow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveDocument {
+    pub document_id: String,
+    pub tab_id: i64,
+    pub target_id: Option<String>,
+}
+
 impl ReplayService {
     #[must_use]
     pub fn new(recordings: Arc<RecordingStore>, index: Arc<RecordingIndex>) -> Arc<Self> {
         Arc::new(Self { recordings, index })
+    }
+
+    /// The document a session's live preview should follow: the most recently
+    /// active document the session owns, optionally pinned to one browser tab.
+    /// Returns None when the session has no recorded document yet. Resolution is
+    /// scoped to the session's own tab-ownership windows, so it cannot surface
+    /// another session's recording.
+    pub async fn live_document(
+        &self,
+        session_id: &str,
+        browser_tab_id: Option<i64>,
+    ) -> AppResult<Option<LiveDocument>> {
+        let best = self
+            .index
+            .stream_matches(session_id)
+            .await?
+            .into_iter()
+            .filter(|row| browser_tab_id.is_none_or(|tab| row.tab_id == tab))
+            .max_by_key(|row| row.last_event_at);
+        Ok(best.map(|row| LiveDocument {
+            document_id: row.document_id,
+            tab_id: row.tab_id,
+            target_id: row.target_id,
+        }))
+    }
+
+    /// All committed rrweb events for one document, oldest first, for
+    /// bootstrapping a live preview.
+    pub async fn document_events(&self, document_id: &str) -> AppResult<Vec<RecordedEvent>> {
+        self.recordings
+            .read_range(document_id, i64::MIN, i64::MAX)
+            .await
     }
 
     pub async fn read_session(&self, session_id: &str) -> AppResult<Vec<ReplayEvent>> {
@@ -395,6 +435,95 @@ mod tests {
         assert_eq!(meta.tabs.len(), 1);
         assert_eq!(meta.tabs[0].segments.len(), 2);
         assert!(!meta.complete);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn live_document_follows_newest_owned_tab_can_pin_and_never_leaks_sessions()
+    -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let index = Arc::new(RecordingIndex::new(
+            Database::open(dir.path().join(DATABASE_FILENAME)).await?,
+        ));
+        let recordings = RecordingStore::new(
+            dir.path().join("recordings"),
+            dir.path().join("replays"),
+            index.clone(),
+            10,
+            Duration::from_secs(1),
+        );
+        // session-a owns tab 11 (older) and tab 12 (newest). session-b owns tab
+        // 13, whose newest event predates session-a's tab 12: a global max would
+        // wrongly pick tab 12, so returning tab 13 proves per-session scoping.
+        recordings
+            .append_batch(
+                "018f47a7-1c2b-7def-8123-0123456789ab",
+                11,
+                Some("target-a"),
+                &[event(100, "a")],
+                "batch-a",
+                false,
+            )
+            .await?;
+        recordings
+            .append_batch(
+                "018f47a7-1c2b-7def-8123-0123456789ac",
+                12,
+                Some("target-b"),
+                &[event(200, "b")],
+                "batch-b",
+                false,
+            )
+            .await?;
+        recordings
+            .append_batch(
+                "018f47a7-1c2b-7def-8123-0123456789ad",
+                13,
+                Some("target-c"),
+                &[event(150, "c")],
+                "batch-c",
+                false,
+            )
+            .await?;
+        index
+            .insert_session_tab("session-a", "agent-a", 11, Some("target-a"), 0, None)
+            .await?;
+        index
+            .insert_session_tab("session-a", "agent-a", 12, Some("target-b"), 0, None)
+            .await?;
+        index
+            .insert_session_tab("session-b", "agent-b", 13, Some("target-c"), 0, None)
+            .await?;
+        let replay = ReplayService::new(recordings, index);
+
+        // Auto-follow resolves to the most recently active owned document.
+        let Some(live) = replay.live_document("session-a", None).await? else {
+            anyhow::bail!("expected a live document");
+        };
+        assert_eq!(live.tab_id, 12);
+        assert_eq!(live.document_id, "018f47a7-1c2b-7def-8123-0123456789ac");
+
+        // Pinning follows the requested owned tab instead.
+        let Some(pinned) = replay.live_document("session-a", Some(11)).await? else {
+            anyhow::bail!("expected a pinned document");
+        };
+        assert_eq!(pinned.tab_id, 11);
+        assert_eq!(pinned.document_id, "018f47a7-1c2b-7def-8123-0123456789ab");
+
+        // Scoping: session-b sees only its own tab 13, never session-a's newer tab.
+        let Some(other) = replay.live_document("session-b", None).await? else {
+            anyhow::bail!("expected session-b's own document");
+        };
+        assert_eq!(other.tab_id, 13);
+
+        // An unknown session and an unowned tab both resolve to nothing.
+        assert!(
+            replay
+                .live_document("session-unknown", None)
+                .await?
+                .is_none()
+        );
+        assert!(replay.live_document("session-a", Some(99)).await?.is_none());
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
@@ -106,10 +106,13 @@ impl ReplayService {
 
     /// All committed rrweb events for one document, oldest first, for
     /// bootstrapping a live preview.
-    pub async fn document_events(&self, document_id: &str) -> AppResult<Vec<RecordedEvent>> {
-        self.recordings
-            .read_range(document_id, i64::MIN, i64::MAX)
-            .await
+    /// A document's committed events with the committed byte length they were
+    /// read at, so a live subscriber forwards only batches past that cutoff.
+    pub async fn document_events_committed(
+        &self,
+        document_id: &str,
+    ) -> AppResult<(Vec<RecordedEvent>, i64)> {
+        self.recordings.read_committed(document_id).await
     }
 
     /// Batch ids already durably accepted for a document, so a live subscriber

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
@@ -84,11 +84,17 @@ impl ReplayService {
         session_id: &str,
         browser_tab_id: Option<i64>,
     ) -> AppResult<Option<LiveDocument>> {
+        // stream_matches carries every window the session ever owned, including
+        // released ones, because replay reconstruction needs them. Live follow
+        // wants only the tab the session is currently driving, so an open claim
+        // (released_at IS NULL) is required; a fully released session yields None
+        // and the caller transitions the stream to idle.
         let best = self
             .index
             .stream_matches(session_id)
             .await?
             .into_iter()
+            .filter(|row| row.released_at.is_none())
             .filter(|row| browser_tab_id.is_none_or(|tab| row.tab_id == tab))
             .max_by_key(|row| row.last_event_at);
         Ok(best.map(|row| LiveDocument {
@@ -500,6 +506,50 @@ mod tests {
         index
             .insert_session_tab("session-b", "agent-b", 13, Some("target-c"), 0, None)
             .await?;
+        // Released ownership windows are historical, not live. Both tabs below
+        // have release timestamps at or after their events, so stream_matches
+        // still returns them for replay; only live follow must exclude them.
+        recordings
+            .append_batch(
+                "018f47a7-1c2b-7def-8123-0123456789ae",
+                14,
+                Some("target-d"),
+                &[event(300, "d")],
+                "batch-d",
+                false,
+            )
+            .await?;
+        recordings
+            .append_batch(
+                "018f47a7-1c2b-7def-8123-0123456789af",
+                15,
+                Some("target-e"),
+                &[event(200, "e")],
+                "batch-e",
+                false,
+            )
+            .await?;
+        recordings
+            .append_batch(
+                "018f47a7-1c2b-7def-8123-0123456789b0",
+                16,
+                Some("target-f"),
+                &[event(100, "f")],
+                "batch-f",
+                false,
+            )
+            .await?;
+        // session-c: tab 14 released (newer event), tab 15 open (older event).
+        index
+            .insert_session_tab("session-c", "agent-c", 14, Some("target-d"), 0, Some(500))
+            .await?;
+        index
+            .insert_session_tab("session-c", "agent-c", 15, Some("target-e"), 0, None)
+            .await?;
+        // session-d: its only tab is released.
+        index
+            .insert_session_tab("session-d", "agent-d", 16, Some("target-f"), 0, Some(200))
+            .await?;
         let replay = ReplayService::new(recordings, index);
 
         // Auto-follow resolves to the most recently active owned document.
@@ -530,6 +580,15 @@ mod tests {
                 .is_none()
         );
         assert!(replay.live_document("session-a", Some(99)).await?.is_none());
+
+        // Auto-follow skips the newer released tab 14 for the still-open tab 15.
+        let Some(open_only) = replay.live_document("session-c", None).await? else {
+            anyhow::bail!("expected the still-open tab");
+        };
+        assert_eq!(open_only.tab_id, 15);
+        // A fully released session resolves to nothing, so the SSE stream goes
+        // idle instead of replaying its former document.
+        assert!(replay.live_document("session-d", None).await?.is_none());
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/replay/builder.rs
@@ -106,6 +106,12 @@ impl ReplayService {
             .await
     }
 
+    /// Batch ids already durably accepted for a document, so a live subscriber
+    /// can de-duplicate a forwarded batch against what its bootstrap captured.
+    pub async fn accepted_batch_ids(&self, document_id: &str) -> AppResult<Vec<String>> {
+        self.index.accepted_batch_ids(document_id).await
+    }
+
     pub async fn read_session(&self, session_id: &str) -> AppResult<Vec<ReplayEvent>> {
         let matches = self.matches(session_id).await?;
         let mut events = Vec::new();
@@ -524,6 +530,35 @@ mod tests {
                 .is_none()
         );
         assert!(replay.live_document("session-a", Some(99)).await?.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn accepted_batch_ids_lists_every_committed_batch_for_a_document() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let index = Arc::new(RecordingIndex::new(
+            Database::open(dir.path().join(DATABASE_FILENAME)).await?,
+        ));
+        let recordings = RecordingStore::new(
+            dir.path().join("recordings"),
+            dir.path().join("replays"),
+            index.clone(),
+            10,
+            Duration::from_secs(1),
+        );
+        let doc = "018f47a7-1c2b-7def-8123-0123456789ab";
+        recordings
+            .append_batch(doc, 11, None, &[event(1, "a")], "batch-a", false)
+            .await?;
+        recordings
+            .append_batch(doc, 11, None, &[event(2, "b")], "batch-b", false)
+            .await?;
+        let replay = ReplayService::new(recordings, index);
+
+        let mut ids = replay.accepted_batch_ids(doc).await?;
+        ids.sort();
+        assert_eq!(ids, vec!["batch-a".to_string(), "batch-b".to_string()]);
+        assert!(replay.accepted_batch_ids("other-doc").await?.is_empty());
         Ok(())
     }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/replay/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/replay/mod.rs
@@ -1,3 +1,5 @@
 mod builder;
 
-pub use builder::{ReplayEvent, ReplayMeta, ReplaySegmentMeta, ReplayService, ReplayTabMeta};
+pub use builder::{
+    LiveDocument, ReplayEvent, ReplayMeta, ReplaySegmentMeta, ReplayService, ReplayTabMeta,
+};

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -1243,6 +1243,21 @@ async fn live_projection_filters_external_close() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn recording_live_stream_rejects_an_unknown_session() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    assert_eq!(
+        request_status(
+            &app.router,
+            "GET",
+            "/api/v1/sessions/does-not-exist/recording/live",
+        )
+        .await?,
+        StatusCode::NOT_FOUND,
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn live_projection_refreshes_metadata_and_preview_uses_current_target() -> anyhow::Result<()>
 {
     let mock = MockCdp::start().await?;


### PR DESCRIPTION
## What

Server foundation for a **live agent preview driven by the rrweb recording** the extension already captures, instead of periodic screenshot capture. This is the first, additive step toward a running-card preview that never makes the browser hold a screen-capture wake lock.

## Why

The running card's live preview is currently populated by repeated `Page.captureScreenshot`. That capture path is what makes the browser acquire (and, on an interrupted session, leak) a `NoDisplaySleepAssertion "Capturing"`, keeping the machine awake. Since every agent tab is already recorded with rrweb, the preview can be rendered from that stream with no screen capture at all.

## What's in this PR (server only)

- **`LiveRecordingBus`** — an in-process, per-document fan-out. Each freshly accepted ingest batch is published to any live subscribers watching that document. Best-effort: publishing never blocks ingest, and an idle document's channel is dropped once its last subscriber leaves.
- **`GET /api/v1/sessions/{session_id}/recording/live`** (Server-Sent Events, optional `browserTabId`):
  - Resolves the session's **most recently active owned document** (or the one pinned by `browserTabId`). Resolution is scoped to the session's own tab-ownership windows, so it cannot surface another session's recording; an unowned tab or unknown session resolves to nothing.
  - **Bootstraps** a late joiner by replaying from the most recent rrweb Meta + FullSnapshot, so the preview renders immediately rather than blank or from the whole document.
  - **Forwards** newly ingested batches live, de-duplicating anything already covered by the bootstrap (so a batch that lands during the read gap is never applied twice).
  - Emits a `switch` control frame (which document/tab) and, if a subscriber falls behind, a `reset` frame so the client reconnects instead of applying gapped frames. Axum keep-alive holds the connection open during quiet periods; the stream ends when the client disconnects.

The existing screenshot preview endpoint is **untouched** — this is purely additive. Swapping the card to consume this stream (rrweb `Replayer` in live mode) and removing the screenshot capture are follow-up PRs.

## Tests

- Unit: bus delivery / isolation / no-subscriber no-op; bootstrap slicing (starts at the last snapshot; empty without one); live-document resolution (newest owned tab, pinning, cross-session scoping, unknown session/tab).
- Integration: the endpoint rejects an unknown session with 404.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -D warnings`, and the full `claw-server-rust` suite pass.

## Manual verification (worthwhile follow-up)

Drive an agent, open the SSE endpoint for its session, and confirm bootstrap + live frames arrive and track the agent; confirm a late joiner renders immediately. This end-to-end streaming behavior is exercised by the unit-tested pieces but a live pass against a running browser is still worth doing (as with the preview work generally).

---

## Update: running-card UI added (supersedes #2066)

This PR now also includes the claw-app side that consumes the stream, replacing the screenshot-polling preview and reimplementing #2066's tab switcher on SSE:

- `LivePreview` subscribes over EventSource and feeds bootstrap/append frames into an rrweb Replayer in live mode (buffering until a full snapshot), scaled into the card; tears down on switch/reset/idle. No screenshots.
- `TabCountChip` is now functional (each row selects that owned tab); the card re-points its preview to the selected tab via the stream's `browserTabId`, marks the live target "on screen", and shows Last frame + Follow live for a pinned non-live tab.

Tab switching verified working end-to-end against a live session. #2066 is closed in favor of this.
