### PR TITLE
chore: sync bun.lock trustedDependencies after dropping lefthook

### DIFF
--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -356,7 +356,6 @@
   },
   "trustedDependencies": [
     "esbuild",
-    "lefthook",
   ],
   "overrides": {
     "@vitejs/plugin-react": "^5.0.0",


### PR DESCRIPTION
## What

Regenerates `packages/browseros-agent/bun.lock` so its `trustedDependencies` matches the workspace package.json.

## Why

PR #2074 removed `lefthook` from `trustedDependencies` in the package.json files but did not regenerate the lockfile, so `bun.lock` still listed `lefthook` there. Every `bun install` reconciled it away, leaving the lockfile dirty in every worktree. `--frozen-lockfile` did not catch it because `trustedDependencies` metadata drift does not fail a frozen install (only dependency-graph changes do).

## How

`bun install` on a clean checkout. The only change is dropping the stale `lefthook` line from the lock's `trustedDependencies`; no dependency versions change, and `bun install --frozen-lockfile` reports no changes against the updated lock.