### PR TITLE
chore: update BrowserClaw onboarding recording

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/FirstRunVideo.tsx
@@ -2,60 +2,13 @@
  * @license
  * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * Renders the ~20-second cockpit first-run motion demo. Ships as a
- * native `<video autoplay muted loop playsinline>` that streams from
- * versioned Cloudflare R2 objects through the BrowserOS CDN. Chromium
- * always allows muted autoplay without a user gesture. Reduced-motion
- * readers get the same video with autoplay and looping disabled, plus
- * native controls so playback starts from an explicit interaction.
- *
- * How the video URL got here
- *
- * The MP4 + poster are NOT tracked in git. The source composition is
- * versioned in `packages/browseros-agent/packages/onboarding-video/`;
- * rendered assets are uploaded to versioned R2 keys under
- * `artifacts/claw/onboarding-video/v<version>/` and served publicly from
- * `https://cdn.browseros.com`. That indirection keeps the extension
- * bundle small and the repo history clean.
- *
- * To bump the video:
- *
- *   1. Edit the composition source in
- *      `packages/browseros-agent/packages/onboarding-video/`.
- *
- *   2. Bump `packages/onboarding-video/package.json` to a new version.
- *      Never reuse an existing version: the upload script guards against
- *      overwriting R2 objects, and the versioned CDN URL is the cache
- *      buster clients see.
- *
- *   3. Render locally:
- *        cd packages/browseros-agent
- *        bun run --cwd packages/onboarding-video render
- *        bun run --cwd packages/onboarding-video render:poster
- *
- *   4. Upload the rendered MP4 + poster to R2:
- *        bun run upload:onboarding-video
- *
- *      The script reads R2 credentials from process env or
- *      `apps/server/.env.production`, writes keys below
- *      `artifacts/claw/onboarding-video/v<version>/`, and prints the
- *      public CDN URLs. Use `--force` only for an intentional overwrite.
- *
- *   5. Update `ASSET_VERSION` below to the uploaded package version.
- *
- * Because clients request versioned CDN URLs, a URL bump should come from
- * a package-version bump plus fresh R2 objects. Overwriting an existing
- * version can leave clients on the cached old asset.
  */
 
 import { useEffect, useRef, useState } from 'react'
 
 const CDN_BASE_URL = 'https://cdn.browseros.com'
-const ASSET_VERSION = '0.2.0'
-const ASSET_BASE = `${CDN_BASE_URL}/artifacts/claw/onboarding-video/v${ASSET_VERSION}`
-const VIDEO_SRC = `${ASSET_BASE}/first-run-demo.mp4`
-const POSTER_SRC = `${ASSET_BASE}/first-run-demo-poster.png`
+const VIDEO_SRC = `${CDN_BASE_URL}/artifacts/claw/onboarding-recording/video.mp4`
+const POSTER_SRC = `${CDN_BASE_URL}/artifacts/claw/onboarding-video/v0.2.0/first-run-demo-poster.png`
 
 export function FirstRunVideo() {
   const reducedMotion = usePrefersReducedMotion()

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
@@ -251,7 +251,7 @@ describe('Cockpit (v2)', () => {
     expect(firstRun).toContain('You watch. Your agent')
     expect(firstRun).toContain('Set up MCP endpoint')
     expect(firstRun).toContain(
-      'https://cdn.browseros.com/artifacts/claw/onboarding-video/v0.2.0/first-run-demo.mp4',
+      'https://cdn.browseros.com/artifacts/claw/onboarding-recording/video.mp4',
     )
     expect(firstRun).not.toContain('Since you started')
     expect(statsQueryEnabled()).toBe(false)


### PR DESCRIPTION
## Summary
- upload the new onboarding recording to the BrowserOS R2 bucket
- point the BrowserClaw first-run video and its cockpit assertion at the new CDN URL
- preserve the existing first-run poster

## Design
The first-run video now streams from the requested unversioned onboarding-recording key while the existing versioned poster remains unchanged.

## Test plan
- [x] verify the CDN response is video/mp4 with byte-range support
- [x] compare local and CDN SHA-256 checksums
- [x] build the BrowserClaw extension
- [x] typecheck the BrowserClaw extension
- [x] run Biome on both changed files
- [x] skip unit tests per repository instructions