### PR TITLE
ci(browseros-agent): Turborepo typecheck caching + bun install cache

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Cache bun install
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('packages/browseros-agent/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun ci
 
@@ -60,6 +68,16 @@ jobs:
 
       - name: Run codegen
         run: bun run --cwd apps/app codegen
+
+      # Turbo caches typecheck per package, keyed by each package's source; the
+      # GHA cache carries `.turbo` across runs so unchanged packages are hits.
+      - name: Cache Turbo
+        uses: actions/cache@v6.1.0
+        with:
+          path: packages/browseros-agent/.turbo
+          key: turbo-typecheck-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-typecheck-${{ runner.os }}-
 
       - name: Run Typecheck
         run: bun run typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,14 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Cache bun install
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('packages/browseros-agent/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
       - name: Setup Rust
         if: matrix.needs_rust == true
         # Pinned so the clippy lint set is deterministic and matches local dev;

--- a/packages/browseros-agent/.gitignore
+++ b/packages/browseros-agent/.gitignore
@@ -204,3 +204,6 @@ test-results/
 .agent/
 .llm/
 .grove/
+
+# Turborepo local cache
+.turbo

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -17,6 +17,7 @@
         "lefthook": "^2.1.10",
         "openapi-typescript": "7.13.0",
         "picocolors": "^1.1.1",
+        "turbo": "^2.10.8",
         "typedoc": "^0.28.20",
         "typescript": "^7.0.2",
         "yaml": "2.9.0",
@@ -1660,6 +1661,18 @@
     "@tokenlens/models": ["@tokenlens/models@1.3.0", "", { "dependencies": { "@tokenlens/core": "1.3.0" } }, "sha512-9mx7ZGeewW4ndXAiD7AT1bbCk4OpJeortbjHHyNkgap+pMPPn1chY6R5zqe1ggXIUzZ2l8VOAKfPqOvpcrisJw=="],
 
     "@tsconfig/svelte": ["@tsconfig/svelte@1.0.13", "", {}, "sha512-5lYJP45Xllo4yE/RUBccBT32eBlRDbqN8r1/MIvQbKxW3aFqaYPCNgm8D5V20X4ShHcwvYWNlKg3liDh1MlBoA=="],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-po+7rfJfUnFXjWlcoN2RwhErgzCdRtBc1T26vYPcywHlggmCQiQe1uWaE4j+BibI2uY9/2pDoFzMN0rmSaPFOw=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+zB2btDJ00lnPRuqOvpVvgl4x34k/djZQGZTTCfjn7JgNCl8QFY5Njo5+dqkY1g/+9gbbsnAvWm9CmJg9ebcXA=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.8", "", { "os": [ "linux", "android", ], "cpu": "x64" }, "sha512-K1dxqiVisyN7cViVsfQLs6xscQbYuI8aO2nbUhFURDACgEDfZRdP/b4CCxeosBJpcMfhYyiibWqJorCnvz9kKg=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.8", "", { "os": [ "linux", "android", ], "cpu": "arm64" }, "sha512-Gi77ibVnrE1fEmvr+/wBD/yvRqhwp/RQuCp2+//lv1U1wNFFyVg0V7Wj8FG9FXPFAw5QHReo8rxc9+wBSDZjzA=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.8", "", { "os": "win32", "cpu": "x64" }, "sha512-znnLO1haJPYTHoKMKwlAvlkjRiYbbhBzME6wIGaMd+fwir23U6jVd1ecaTWWi1fbnRVqxMfgDBKseQ/hLKb83g=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-VN30vh3b3Czh2WzYHNTfF1FE0YMZ5aHsLO8dBMGHJewA6792wX6iJR8ZxlzFW6WdOu0gEAKIvlYhfyT81Wkm4Q=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
@@ -3928,6 +3941,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
+
+    "turbo": ["turbo@2.10.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.8", "@turbo/darwin-arm64": "2.10.8", "@turbo/linux-64": "2.10.8", "@turbo/linux-arm64": "2.10.8", "@turbo/windows-64": "2.10.8", "@turbo/windows-arm64": "2.10.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-9+8YX5QOkGXzZxcIykTHgaooRHGMWO+jfdyRK0o+rN0U7hBIig2MrJ8r/aNzIPDPhdA73SGb0O+tIztaModTMg=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -54,7 +54,8 @@
     "test:fixtures": "bun apps/server/tests/__fixtures__/browser-fixtures/serve.ts",
     "test:main": "bun run ./scripts/run-test-suite.ts main",
     "check": "bun run lint && bun run typecheck && bun run fallow",
-    "typecheck": "bun run --filter '*' typecheck",
+    "typecheck": "turbo run typecheck",
+    "typecheck:all": "bun run --filter '*' typecheck",
     "lint": "bunx @biomejs/biome check",
     "fallow": "fallow check",
     "lint:fix": "bunx @biomejs/biome check --write --unsafe",
@@ -89,6 +90,7 @@
     "lefthook": "^2.1.10",
     "openapi-typescript": "7.13.0",
     "picocolors": "^1.1.1",
+    "turbo": "^2.10.8",
     "typedoc": "^0.28.20",
     "typescript": "^7.0.2",
     "yaml": "2.9.0"

--- a/packages/browseros-agent/turbo.json
+++ b/packages/browseros-agent/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "ui": "stream",
+  "tasks": {
+    "codegen": {
+      "outputs": ["generated/**"]
+    },
+    "typecheck": {
+      "dependsOn": ["^typecheck"],
+      "outputs": []
+    },
+    "build": {
+      "dependsOn": ["^build", "codegen"],
+      "outputs": ["dist/**", ".output/**", "build/**", "lib/**", "out/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build", "codegen"],
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds Turborepo to the `packages/browseros-agent` bun workspace and uses the GitHub Actions cache to speed CI:

- **Typecheck via Turborepo** — the root `typecheck` now runs `turbo run typecheck`, so each package's `tsc --noEmit` is cached per package (keyed by that package's source). The Code Quality job persists `.turbo` across runs via `actions/cache`, so unchanged packages become cache hits.
- **bun install cache** — every job that runs `bun ci` (the 14-suite test matrix + the Typecheck job) now caches `~/.bun/install/cache`, keyed on `bun.lock`, so dependencies aren't re-downloaded from scratch on each leg.
- `.turbo` is gitignored; `typecheck:all` keeps the previous raw `bun run --filter '*' typecheck` as an escape hatch.

## Honest scope / ROI

- Turbo does **not** touch the Rust suites (`claw-server-rust`, `claw-mcp`), which are the actual CI long pole and stay on `Swatinem/rust-cache`. Their levers (sccache, cargo-nextest) are out of scope here.
- The wins here are the JS/TS `typecheck` caching and the bun-install cache across the many jobs.
- Affected-only runs (skipping the Rust legs on a JS-only PR, and vice-versa) are the biggest wall-clock win and are a deliberate later phase, since they require reworking the suite matrix.

## Known limitation (documented, cache-safe)

The workspace root `package.json` depends on `@browseros/shared` and `@browseros/build-server-tools`, so Turbo folds those into its **global hash** — editing either busts the *entire* typecheck cache. Every other package caches correctly per-package (verified: changing `cdp-protocol` re-ran only its transitive dependents). A later phase can move the root scripts into a package so the root stops depending on internal packages.

## Correctness

Caching is keyed by each package's tracked source, which includes the committed graphql schema and `.gql` documents, so a schema change invalidates the affected package's typecheck. Codegen still runs as an explicit CI step before typecheck (unchanged), so generated code is fresh. Turbo hashes content, not mtime.

## Verification (local)

- `turbo run typecheck` passes for all packages; a second run is `>>> FULL TURBO` (14/14 cached).
- Changing one package's source invalidates only that package and its transitive dependents; unrelated packages stay cached.
- Both workflow files parse; lockfile diff is only Turbo + its platform binaries.

CI timing before/after will show on this PR's runs.
