### PR TITLE
chore: drop Rust from claw server release name

### DIFF
--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -1,7 +1,7 @@
 # Required secrets: CLAW_POSTHOG_KEY, R2_ACCOUNT_ID, R2_ACCESS_KEY_ID,
 # R2_SECRET_ACCESS_KEY, R2_BUCKET. SPARKLE_PRIVATE_KEY is also required when
 # publish_ota is true.
-name: "Release: BrowserClaw Server (Rust)"
+name: "Release: BrowserClaw Server"
 
 on:
   push:
@@ -106,7 +106,7 @@ jobs:
           NOTES_FILE="/tmp/release-notes.md"
 
           if [ -z "$PREVIOUS_TAG" ]; then
-            echo "Initial BrowserClaw Server Rust release." > "$CHANGELOG_FILE"
+            echo "Initial BrowserClaw Server release." > "$CHANGELOG_FILE"
           else
             git log "$PREVIOUS_TAG..$RELEASE_SHA" --pretty=format:"- %s (%h)" > "$CHANGELOG_FILE"
             if [ ! -s "$CHANGELOG_FILE" ]; then
@@ -129,7 +129,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          TITLE="BrowserClaw Server (Rust) - v$VERSION"
+          TITLE="BrowserClaw Server - v$VERSION"
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh release edit "$RELEASE_TAG" \

--- a/packages/browseros-agent/scripts/release/prepare-claw-server-rust-release.sh
+++ b/packages/browseros-agent/scripts/release/prepare-claw-server-rust-release.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 exec "$script_dir/prepare-server-bundle-release.sh" \
-  --release-name "BrowserClaw Server (Rust)" \
+  --release-name "BrowserClaw Server" \
   --component-name "claw server" \
   --tag-prefix "claw-server/v" \
   --cargo-toml "packages/browseros-agent/apps/claw-server-rust/Cargo.toml" \

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -49,7 +49,7 @@ function buildRustBinaryStep(): string {
 
 describe('release-claw-server-rust workflow', () => {
   it('uses the BrowserClaw product tag trigger and workflow_call contract', () => {
-    expect(workflow).toContain('name: "Release: BrowserClaw Server (Rust)"')
+    expect(workflow).toContain('name: "Release: BrowserClaw Server"')
     expect(workflow).toContain('"claw-server/v*"')
     expect(workflow).not.toContain('"claw-server-rust/v*"')
     expect(workflow).toContain('workflow_call:')


### PR DESCRIPTION
## Summary
- Rename the BrowserClaw server release workflow without the obsolete Rust qualifier
- Use the same single-server name for release titles, initial notes, and release preparation
- Update the existing workflow assertion

## Design
This changes only the public release display name. Rust-specific crate names, workflow filenames, artifact names, tags, and R2 paths remain unchanged for compatibility.

## Test plan
- [x] `bun test scripts/release/release-claw-server-rust-workflow.test.ts`
- [x] `actionlint .github/workflows/release-claw-server-rust.yml`