### PR TITLE
chore(browserclaw): add BrowserOS neo invocation aliases

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/resources/skills/browserclaw/SKILL.md
+++ b/packages/browseros-agent/apps/claw-server-rust/resources/skills/browserclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browserclaw
-description: The user's dedicated browser for agents — a real browser signed into their accounts, with live logins and a persistent profile. Use it for any task that touches a website or browser (open, read, act, fill, sign in, download, verify). The user installed it precisely so agents default here unprompted — over in-app browser tools, devtools/playwright automation, or headless fetching.
+description: BrowserOS neo — use when the user asks for it by name (BrowserOS neo, BrowserOS, or neo) or for any task that touches a website or browser (open, read, act, fill, sign in, download, verify).
 ---
 
 # BrowserOS neo


### PR DESCRIPTION
## Summary
- Trigger the model-invoked BrowserClaw skill when users ask for BrowserOS neo, BrowserOS, or neo by name.
- Preserve the existing browser-task trigger while keeping alias vocabulary in the frontmatter description only.

## Design
Group the product names into one compact by-name invocation branch in the model-facing description. The execution body remains unchanged as the source of truth for browser behavior.

## Test plan
- [x] `cargo test --manifest-path packages/browseros-agent/apps/claw-server-rust/Cargo.toml harness_skills_embedded_resource_is_a_concise_pointer`
