### PR TITLE
feat: migrate MCP identity to BrowserOS neo

### DIFF
--- a/docs/browserclaw/mcp/index.mdx
+++ b/docs/browserclaw/mcp/index.mdx
@@ -24,7 +24,7 @@ Under the endpoint URL you'll see the list of AI tools we support out of the box
   <img src="/images/browserclaw--mcp-install-board.png" alt="BrowserOS neo connect page showing an endpoint URL at the top and the supported AI tools listed underneath, each with a Connect button on the right." />
 </Frame>
 
-Today the supported AI tools are **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Antigravity**, **VS Code**, and **Zed**. Behind the scenes, BrowserOS neo writes a single entry named `BrowserClaw` into the AI tool's own MCP config file, pointing at the endpoint URL above. That compatibility key stays unchanged, so existing connections keep working.
+Today the supported AI tools are **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Antigravity**, **VS Code**, and **Zed**. Behind the scenes, BrowserOS neo writes a single entry named `BrowserOS neo` into the AI tool's own MCP config file, pointing at the endpoint URL above. Existing managed `BrowserClaw` entries are recognized and migrated automatically.
 
 <Tip>
 The board updates as soon as your AI tool actually loads the config. If you don't see the row flip to **Connected**, restart the AI tool once and come back.

--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -1560,6 +1560,9 @@ name = "jsonc-parser"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "362fdb0bfedf94ebd31e4e82ff38ba705b6b82417b3b25f0c4bbb024dd11f552"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "lazy_static"

--- a/packages/browseros-agent/Cargo.toml
+++ b/packages/browseros-agent/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1"
 serde_repr = "0.1"
 serde-saphyr = { version = "0.0.29", default-features = false, features = ["deserialize"] }
 sha2 = "0.10"
-jsonc-parser = { version = "0.33", features = ["cst"] }
+jsonc-parser = { version = "0.33", features = ["cst", "serde_json"] }
 toml_edit = "0.22"
 rmcp = { version = "2.1", features = ["server", "transport-io", "transport-streamable-http-server"] }
 schemars = "1.0"

--- a/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.test.ts
@@ -92,10 +92,8 @@ describe('buildCanonicalMcpEndpointUrl', () => {
 describe('buildCanonicalMcpCliCommand', () => {
   it('produces the standard `claude mcp add` shape with the canonical URL', () => {
     installWindow('')
-    const cli = buildCanonicalMcpCliCommand()
-    expect(cli).toContain('claude mcp add BrowserOS neo')
-    expect(cli).toContain('http://127.0.0.1:9200/mcp')
-    expect(cli).toContain('--transport http')
-    expect(cli).toContain('--scope user')
+    expect(buildCanonicalMcpCliCommand()).toBe(
+      'claude mcp add "BrowserOS neo" http://127.0.0.1:9200/mcp --transport http --scope user',
+    )
   })
 })

--- a/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.test.ts
@@ -93,7 +93,7 @@ describe('buildCanonicalMcpCliCommand', () => {
   it('produces the standard `claude mcp add` shape with the canonical URL', () => {
     installWindow('')
     const cli = buildCanonicalMcpCliCommand()
-    expect(cli).toContain('claude mcp add BrowserClaw')
+    expect(cli).toContain('claude mcp add BrowserOS neo')
     expect(cli).toContain('http://127.0.0.1:9200/mcp')
     expect(cli).toContain('--transport http')
     expect(cli).toContain('--scope user')

--- a/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.ts
@@ -2,14 +2,6 @@
  * @license
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * Canonical source for the URL the UI advertises as the MCP endpoint
- * and the CLI snippets shown alongside it. Every "copy URL" widget
- * and every "add to host agent" config the wizard / directory pages
- * render flows through these helpers.
- *
- * BrowserOS-managed builds read the MCP proxy pref; dev and
- * standalone builds keep the existing launcher/fallback resolution.
  */
 
 import {
@@ -22,7 +14,6 @@ import {
 } from './browseros-ports'
 import { resolveApiBaseUrlFromSources } from './client.helpers'
 
-/** Resolves the MCP proxy base URL from BrowserOS prefs or trusted fallbacks. */
 export async function resolveMcpBaseUrl(): Promise<string> {
   return resolveBrowserOSMcpBaseUrl(apiBaseUrlSourcesFromWindow())
 }
@@ -31,34 +22,19 @@ function mcpBaseUrlFallback(): string {
   return resolveApiBaseUrlFromSources(apiBaseUrlSourcesFromWindow())
 }
 
-/**
- * CLI snippet shown next to the URL widgets and copied as the
- * "add to host agent" command. The slug is the host-visible server
- * name, not part of the endpoint URL.
- */
 export function buildMcpCliCommand(slug: string): string {
   return `mcp add ${slug}`
 }
 
-/**
- * Canonical v2 URL the MCP page advertises: one slugless endpoint
- * for the whole cockpit.
- */
 export function buildCanonicalMcpEndpointUrl(): string {
   return `${mcpBaseUrlFallback()}${MCP_PATH}`
 }
 
-/** Builds the canonical MCP endpoint after BrowserOS proxy-port resolution. */
 export async function resolveCanonicalMcpEndpointUrl(): Promise<string> {
   return `${await resolveMcpBaseUrl()}${MCP_PATH}`
 }
 
-/**
- * Canonical CLI snippet for one-click harnesses that ship their own
- * MCP CLI. Anthropic's `claude` CLI is the lead consumer; other
- * harnesses get the "Connect" button on the MCP page instead.
- */
 export function buildCanonicalMcpCliCommand(): string {
   const url = buildCanonicalMcpEndpointUrl()
-  return `claude mcp add ${BROWSEROS_MCP_SERVER_NAME} ${url} --transport http --scope user`
+  return `claude mcp add "${BROWSEROS_MCP_SERVER_NAME}" ${url} --transport http --scope user`
 }

--- a/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.test.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.test.ts
@@ -64,10 +64,8 @@ describe('buildCanonicalMcpEndpointUrl', () => {
 describe('buildCanonicalMcpCliCommand', () => {
   it('produces the standard Claude MCP registration command', () => {
     installWindow('')
-    const cli = buildCanonicalMcpCliCommand()
-    expect(cli).toContain('claude mcp add BrowserOS neo')
-    expect(cli).toContain('http://127.0.0.1:9200/mcp')
-    expect(cli).toContain('--transport http')
-    expect(cli).toContain('--scope user')
+    expect(buildCanonicalMcpCliCommand()).toBe(
+      'claude mcp add "BrowserOS neo" http://127.0.0.1:9200/mcp --transport http --scope user',
+    )
   })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.test.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.test.ts
@@ -65,7 +65,7 @@ describe('buildCanonicalMcpCliCommand', () => {
   it('produces the standard Claude MCP registration command', () => {
     installWindow('')
     const cli = buildCanonicalMcpCliCommand()
-    expect(cli).toContain('claude mcp add BrowserClaw')
+    expect(cli).toContain('claude mcp add BrowserOS neo')
     expect(cli).toContain('http://127.0.0.1:9200/mcp')
     expect(cli).toContain('--transport http')
     expect(cli).toContain('--scope user')

--- a/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.ts
@@ -19,7 +19,6 @@ function fallbackBaseUrl(): string {
   return `http://127.0.0.1:${CLAW_API_PORT_DEFAULT}`
 }
 
-/** Resolves the API base URL used by the onboarding MCP CLI snippet. */
 function resolveMcpBaseUrl(): string {
   const fallback = fallbackBaseUrl()
   if (typeof window === 'undefined') return fallback
@@ -52,18 +51,15 @@ function resolveMcpBaseUrl(): string {
   }
 }
 
-/** Builds the cockpit home URL that standalone onboarding hands back to. */
 export function buildCockpitHomeUrl(): string {
   return resolveMcpBaseUrl()
 }
 
-/** Builds the slugless MCP URL shown in the standalone onboarding CLI snippet. */
 export function buildCanonicalMcpEndpointUrl(): string {
   return `${buildCockpitHomeUrl()}${MCP_PATH}`
 }
 
-/** Builds the Claude CLI command that registers BrowserOS over HTTP MCP. */
 export function buildCanonicalMcpCliCommand(): string {
   const url = buildCanonicalMcpEndpointUrl()
-  return `claude mcp add ${BROWSEROS_MCP_SERVER_NAME} ${url} --transport http --scope user`
+  return `claude mcp add "${BROWSEROS_MCP_SERVER_NAME}" ${url} --transport http --scope user`
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -178,10 +178,7 @@ async fn ready_after<T, E>(
     Ok(running)
 }
 
-/// On the very first launch, register BrowserClaw in every detected harness so
-/// the user does not have to connect each one by hand. Runs once, guarded by a
-/// marker in the BrowserClaw dir; an existing install is seeded without sweeping
-/// so a returning user's manual disconnects are preserved.
+/// Auto-connects harnesses once while preserving existing user choices.
 async fn run_first_launch_auto_connect(state: &AppState) {
     use claw_server_rust::services::first_run;
     if first_run::is_first_run_connect_done(&state.config.browserclaw_dir).await {
@@ -213,6 +210,19 @@ async fn run_first_launch_auto_connect(state: &AppState) {
 }
 
 async fn heal_boot_config(state: &AppState) {
+    match state
+        .harness
+        .migrate_browseros_identity(&state.config.public_mcp_url())
+        .await
+    {
+        Ok(outcome) => info!(
+            migrated = outcome.migrated,
+            skipped = outcome.skipped,
+            failed = outcome.failed,
+            "completed BrowserOS MCP identity migration"
+        ),
+        Err(err) => error!(error = %err, "BrowserOS MCP identity migration failed"),
+    }
     run_first_launch_auto_connect(state).await;
     // Re-point every connected agent at the current canonical URL first (the
     // proxy port may have moved on this app launch), then repair any config

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
@@ -3,10 +3,10 @@ use crate::{
     error::{AppError, AppResult},
 };
 use harness_integrations::{
-    AgentId, AgentScope, DisconnectInput, Error as ManagerError, LinkInput, ListLinksFilter,
-    ManifestLinkEntry, ManifestServerEntry, McpManager, McpServer, McpServerSpec, ServerManifest,
-    SkillEnvironment, SkillReconcileOutcome, SkillReconciler, SkillSpec, is_installed,
-    resolve_agent_mcp_config_path, resolve_agent_surface,
+    AgentId, AgentScope, DisconnectInput, Error as ManagerError, InspectEntryInput, LinkInput,
+    ListLinksFilter, ListedLink, ManifestLinkEntry, ManifestServerEntry, McpManager, McpServer,
+    McpServerSpec, MigrateServerInput, ServerManifest, SkillEnvironment, SkillReconcileOutcome,
+    SkillReconciler, SkillSpec, is_installed, resolve_agent_surface,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -22,8 +22,13 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::Mutex;
+use url::Url;
 
-pub const BROWSEROS_MCP_SERVER_NAME: &str = "BrowserClaw";
+pub const BROWSEROS_MCP_SERVER_NAME: &str = "BrowserOS neo";
+pub const BROWSEROS_LEGACY_MCP_SERVER_NAME: &str = "BrowserClaw";
+
+const BROWSEROS_MCP_SERVER_NAMES: [&str; 2] =
+    [BROWSEROS_MCP_SERVER_NAME, BROWSEROS_LEGACY_MCP_SERVER_NAME];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum Harness {
@@ -131,12 +136,18 @@ pub struct UrlMigrationOutcome {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct IdentityMigrationOutcome {
+    pub migrated: usize,
+    pub skipped: usize,
+    pub failed: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct FirstRunConnectOutcome {
     pub connected: usize,
     pub failed: usize,
     pub already_linked: usize,
-    /// True when this was an existing install (a harness was already linked) so
-    /// the sweep was skipped and only the first-run marker gets seeded.
+    /// True when an existing link makes the first-run sweep unnecessary.
     pub seeded_existing: bool,
 }
 
@@ -204,7 +215,7 @@ impl HarnessService {
         }
     }
 
-    /// Registers BrowserClaw in one harness while restoring the previous spec on relink failure.
+    /// Registers BrowserOS neo while restoring the prior spec on relink failure.
     pub async fn connect_browseros(
         &self,
         harness: Harness,
@@ -213,10 +224,38 @@ impl HarnessService {
         let _guard = self.mutex.lock().await;
         let agent = harness.agent_id();
         let spec = spec_for(agent, mcp_url).map_err(manager_app_error)?;
+        let target_mcp_url = mcp_url.to_string();
         let manager = self.manager.clone();
         let workspace_dir = self.workspace_dir.clone();
         let managed_skill = self.managed_skill.clone();
         let result = tokio::task::spawn_blocking(move || {
+            let was_connected = recognized_browseros_links(&manager, &workspace_dir)
+                .map_err(HarnessOperationError::Manager)?
+                .into_iter()
+                .any(|link| link.agent == agent);
+            let legacy_link = managed_browseros_links(&manager, &workspace_dir)
+                .map_err(HarnessOperationError::Manager)?
+                .into_iter()
+                .find(|link| {
+                    link.agent == agent
+                        && link.server_name == BROWSEROS_LEGACY_MCP_SERVER_NAME
+                });
+            if let Err(error) = migrate_browseros_agent(
+                &manager,
+                &workspace_dir,
+                agent,
+                &target_mcp_url,
+                legacy_link.as_ref(),
+            ) {
+                tracing::warn!(harness = %harness, agent = %agent, %error, "BrowserOS MCP identity migration before connect failed");
+            }
+            let canonical_path = managed_browseros_links(&manager, &workspace_dir)
+                .map_err(HarnessOperationError::Manager)?
+                .into_iter()
+                .find(|link| {
+                    link.agent == agent && link.server_name == BROWSEROS_MCP_SERVER_NAME
+                })
+                .map(|link| link.config_path);
             let summary = relink_managed_server(
                 &manager,
                 &workspace_dir,
@@ -224,13 +263,21 @@ impl HarnessService {
                 agent,
                 spec,
                 true,
+                canonical_path.as_deref(),
             )?;
+            let config_path = managed_browseros_links(&manager, &workspace_dir)
+                .map_err(HarnessOperationError::Manager)?
+                .into_iter()
+                .find(|link| {
+                    link.agent == agent && link.server_name == BROWSEROS_MCP_SERVER_NAME
+                })
+                .map(|link| link.config_path);
             let skill_warning = managed_skill.as_ref().and_then(|managed_skill| {
                 reconcile_skill_warning(&manager, &workspace_dir, managed_skill)
             });
             Ok((
-                summary.created,
-                resolve_agent_mcp_config_path(agent, AgentScope::System).ok(),
+                summary.created && !was_connected,
+                config_path,
                 skill_warning,
             ))
         })
@@ -238,7 +285,7 @@ impl HarnessService {
 
         match result {
             Ok((created, config_path, skill_warning)) => {
-                tracing::info!(harness = %harness, agent = %agent, "connected BrowserClaw to harness");
+                tracing::info!(harness = %harness, agent = %agent, "connected BrowserOS neo to harness");
                 if created {
                     self.analytics.capture(
                         events::HARNESS_CONNECTED,
@@ -260,7 +307,7 @@ impl HarnessService {
         }
     }
 
-    /// Removes BrowserClaw from one harness and drops its last-link manifest entry.
+    /// Removes both managed BrowserOS MCP aliases from one harness.
     pub async fn disconnect_browseros(&self, harness: Harness) -> AppResult<ConnectionState> {
         let _guard = self.mutex.lock().await;
         let agent = harness.agent_id();
@@ -268,27 +315,43 @@ impl HarnessService {
         let workspace_dir = self.workspace_dir.clone();
         let managed_skill = self.managed_skill.clone();
         let result = tokio::task::spawn_blocking(move || {
-            let summary = with_legacy_manifest_migration(&workspace_dir, || {
-                manager.disconnect(DisconnectInput::new(BROWSEROS_MCP_SERVER_NAME, agent))
-            })
-            .map_err(HarnessOperationError::Manager)?;
+            adopt_config_only_legacy_for_disconnect(&manager, &workspace_dir, agent)
+                .map_err(HarnessOperationError::Manager)?;
+            let mut unlinked = false;
+            let mut removed_manifest = false;
+            let mut first_error = None;
+            for server_name in BROWSEROS_MCP_SERVER_NAMES {
+                match with_legacy_manifest_migration(&workspace_dir, || {
+                    manager.disconnect(DisconnectInput::new(server_name, agent))
+                }) {
+                    Ok(summary) => {
+                        unlinked |= summary.unlinked;
+                        removed_manifest |= summary.removed_manifest;
+                    }
+                    Err(error) if first_error.is_none() => first_error = Some(error),
+                    Err(_) => {}
+                }
+            }
+            if let Some(error) = first_error {
+                return Err(HarnessOperationError::Manager(error));
+            }
             let skill_warning = managed_skill.as_ref().and_then(|managed_skill| {
                 reconcile_skill_warning(&manager, &workspace_dir, managed_skill)
             });
-            Ok((summary, skill_warning))
+            Ok((unlinked, removed_manifest, skill_warning))
         })
         .await?;
 
         match result {
-            Ok((summary, skill_warning)) => {
+            Ok((unlinked, removed_manifest, skill_warning)) => {
                 tracing::info!(
                     harness = %harness,
                     agent = %agent,
-                    unlinked = summary.unlinked,
-                    removed_manifest = summary.removed_manifest,
-                    "disconnected BrowserClaw from harness"
+                    unlinked,
+                    removed_manifest,
+                    "disconnected BrowserOS neo from harness"
                 );
-                if summary.unlinked {
+                if unlinked {
                     self.analytics.capture(
                         events::HARNESS_DISCONNECTED,
                         json!({ "harness": harness.as_str() }),
@@ -309,19 +372,14 @@ impl HarnessService {
         }
     }
 
-    /// Lists installed harnesses, using manifest links as the configured source of truth.
+    /// Lists one logical BrowserOS connection per installed harness.
     pub async fn list_browseros_connections(&self) -> AppResult<Vec<ConnectionState>> {
         let _guard = self.mutex.lock().await;
         let manager = self.manager.clone();
         let workspace_dir = self.workspace_dir.clone();
         let agents = Harness::ALL.map(Harness::agent_id);
         let (links_result, installed_result) = tokio::task::spawn_blocking(move || {
-            let links = with_legacy_manifest_migration(&workspace_dir, || {
-                manager.list_links(ListLinksFilter {
-                    server_names: Some(vec![BROWSEROS_MCP_SERVER_NAME.to_string()]),
-                    agents: None,
-                })
-            });
+            let links = recognized_browseros_links(&manager, &workspace_dir);
             (links, is_installed(&agents))
         })
         .await?;
@@ -329,7 +387,7 @@ impl HarnessService {
         let links = match links_result {
             Ok(links) => links,
             Err(error) => {
-                tracing::warn!(error = %error, "list BrowserClaw links failed");
+                tracing::warn!(error = %error, "list BrowserOS MCP links failed");
                 Vec::new()
             }
         };
@@ -340,10 +398,7 @@ impl HarnessService {
                 agents.into_iter().map(|agent| (agent, true)).collect()
             }
         };
-        let by_agent = links
-            .into_iter()
-            .map(|link| (link.agent, link))
-            .collect::<BTreeMap<_, _>>();
+        let by_agent = deduplicate_browseros_links(links);
 
         Ok(Harness::ALL
             .into_iter()
@@ -376,11 +431,7 @@ impl HarnessService {
             .collect())
     }
 
-    /// First-launch sweep: registers BrowserClaw in every detected-but-unlinked
-    /// harness so a new user does not have to connect each one by hand. An
-    /// existing install (any harness already linked) is left untouched and only
-    /// seeded, so a returning user's disconnect choices are never overridden.
-    /// Best-effort: a single harness failing does not abort the sweep.
+    /// Auto-connects detected harnesses only when no BrowserOS link exists.
     pub async fn first_run_connect(&self, mcp_url: &str) -> AppResult<FirstRunConnectOutcome> {
         let connections = self.list_browseros_connections().await?;
         let already_linked = connections.iter().filter(|state| state.installed).count();
@@ -429,12 +480,23 @@ impl HarnessService {
         .map_err(manager_app_error)
     }
 
-    /// Re-links every connected harness to `target_mcp_url`. Called on boot so a
-    /// proxy-port change (native re-resolves ports at app launch) re-points all
-    /// already-connected agents at the new URL. Harnesses already on the URL are
-    /// verified without rewriting their config (relink is write-on-change);
-    /// per-harness failures are isolated so one unwritable config never blocks
-    /// the rest.
+    /// Migrates eligible BrowserClaw entries independently on every startup.
+    pub async fn migrate_browseros_identity(
+        &self,
+        target_mcp_url: &str,
+    ) -> AppResult<IdentityMigrationOutcome> {
+        let _guard = self.mutex.lock().await;
+        let manager = self.manager.clone();
+        let workspace_dir = self.workspace_dir.clone();
+        let target = target_mcp_url.to_string();
+        tokio::task::spawn_blocking(move || {
+            migrate_browseros_identity(&manager, &workspace_dir, &target)
+        })
+        .await?
+        .map_err(manager_app_error)
+    }
+
+    /// Re-links every managed BrowserOS connection to the current MCP URL.
     pub async fn migrate_connected_urls(
         &self,
         target_mcp_url: &str,
@@ -505,15 +567,10 @@ fn reconcile_managed_skill(
     workspace_dir: &Path,
     managed_skill: &ManagedSkill,
 ) -> Result<SkillReconcileOutcome, ManagerError> {
-    let consumers = with_legacy_manifest_migration(workspace_dir, || {
-        manager.list_links(ListLinksFilter {
-            server_names: Some(vec![BROWSEROS_MCP_SERVER_NAME.to_string()]),
-            agents: None,
-        })
-    })?
-    .into_iter()
-    .map(|link| link.agent)
-    .collect::<BTreeSet<_>>();
+    let consumers = recognized_browseros_links(manager, workspace_dir)?
+        .into_iter()
+        .map(|link| link.agent)
+        .collect::<BTreeSet<_>>();
     managed_skill
         .reconciler
         .reconcile(&managed_skill.spec, &consumers, &managed_skill.environment)
@@ -571,6 +628,193 @@ pub fn spec_for(agent: AgentId, mcp_url: &str) -> Result<McpServerSpec, ManagerE
     })
 }
 
+fn managed_browseros_links(
+    manager: &McpManager,
+    workspace_dir: &Path,
+) -> Result<Vec<ListedLink>, ManagerError> {
+    with_legacy_manifest_migration(workspace_dir, || {
+        manager.list_links(ListLinksFilter {
+            server_names: Some(
+                BROWSEROS_MCP_SERVER_NAMES
+                    .into_iter()
+                    .map(ToString::to_string)
+                    .collect(),
+            ),
+            agents: None,
+        })
+    })
+}
+
+fn recognized_browseros_links(
+    manager: &McpManager,
+    workspace_dir: &Path,
+) -> Result<Vec<ListedLink>, ManagerError> {
+    let mut links = managed_browseros_links(manager, workspace_dir)?;
+    let linked_agents = links.iter().map(|link| link.agent).collect::<BTreeSet<_>>();
+    for harness in Harness::ALL {
+        let agent = harness.agent_id();
+        if linked_agents.contains(&agent) {
+            continue;
+        }
+        match manager.inspect_entry(InspectEntryInput::new(
+            BROWSEROS_LEGACY_MCP_SERVER_NAME,
+            agent,
+        )) {
+            Ok(Some(entry)) if is_historical_browseros_spec(&entry.spec) => {
+                links.push(ListedLink {
+                    server_name: BROWSEROS_LEGACY_MCP_SERVER_NAME.to_string(),
+                    agent,
+                    config_path: entry.config_path,
+                });
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!(agent = %agent, %error, "legacy BrowserOS MCP entry inspection failed");
+            }
+        }
+    }
+    Ok(links)
+}
+
+fn deduplicate_browseros_links(links: Vec<ListedLink>) -> BTreeMap<AgentId, ListedLink> {
+    let mut by_agent = BTreeMap::new();
+    for link in links {
+        let replace =
+            !by_agent.contains_key(&link.agent) || link.server_name == BROWSEROS_MCP_SERVER_NAME;
+        if replace {
+            by_agent.insert(link.agent, link);
+        }
+    }
+    by_agent
+}
+
+fn adopt_config_only_legacy_for_disconnect(
+    manager: &McpManager,
+    workspace_dir: &Path,
+    agent: AgentId,
+) -> Result<(), ManagerError> {
+    let entry = match manager.inspect_entry(InspectEntryInput::new(
+        BROWSEROS_LEGACY_MCP_SERVER_NAME,
+        agent,
+    )) {
+        Ok(Some(entry)) if is_historical_browseros_spec(&entry.spec) => entry,
+        Ok(_) => return Ok(()),
+        Err(error) => {
+            tracing::warn!(agent = %agent, %error, "legacy BrowserOS MCP disconnect inspection failed");
+            return Ok(());
+        }
+    };
+    let mut input = MigrateServerInput::new(
+        BROWSEROS_LEGACY_MCP_SERVER_NAME,
+        McpServer {
+            name: BROWSEROS_MCP_SERVER_NAME.to_string(),
+            spec: entry.spec.clone(),
+        },
+        agent,
+    );
+    input.config_path = Some(entry.config_path);
+    input.unmanaged_source_spec = Some(entry.spec);
+    with_legacy_manifest_migration(workspace_dir, || manager.migrate_server(input.clone()))?;
+    Ok(())
+}
+
+fn migrate_browseros_identity(
+    manager: &McpManager,
+    workspace_dir: &Path,
+    target_mcp_url: &str,
+) -> Result<IdentityMigrationOutcome, ManagerError> {
+    let legacy_links = managed_browseros_links(manager, workspace_dir)?
+        .into_iter()
+        .filter(|link| link.server_name == BROWSEROS_LEGACY_MCP_SERVER_NAME)
+        .map(|link| (link.agent, link))
+        .collect::<BTreeMap<_, _>>();
+    let mut outcome = IdentityMigrationOutcome::default();
+    for harness in Harness::ALL {
+        let agent = harness.agent_id();
+        let legacy_link = legacy_links.get(&agent);
+        match migrate_browseros_agent(manager, workspace_dir, agent, target_mcp_url, legacy_link) {
+            Ok(true) => {
+                outcome.migrated += 1;
+                tracing::info!(harness = %harness, agent = %agent, "migrated BrowserOS neo MCP identity");
+            }
+            Ok(false) => outcome.skipped += 1,
+            Err(error) => {
+                outcome.failed += 1;
+                tracing::warn!(harness = %harness, agent = %agent, %error, "BrowserOS MCP identity migration failed");
+            }
+        }
+    }
+    Ok(outcome)
+}
+
+fn migrate_browseros_agent(
+    manager: &McpManager,
+    workspace_dir: &Path,
+    agent: AgentId,
+    target_mcp_url: &str,
+    legacy_link: Option<&ListedLink>,
+) -> Result<bool, ManagerError> {
+    let unmanaged_source = if legacy_link.is_none() {
+        match manager.inspect_entry(InspectEntryInput::new(
+            BROWSEROS_LEGACY_MCP_SERVER_NAME,
+            agent,
+        ))? {
+            Some(entry) if is_historical_browseros_spec(&entry.spec) => Some(entry),
+            _ => return Ok(false),
+        }
+    } else {
+        None
+    };
+    let mut input = MigrateServerInput::new(
+        BROWSEROS_LEGACY_MCP_SERVER_NAME,
+        McpServer {
+            name: BROWSEROS_MCP_SERVER_NAME.to_string(),
+            spec: spec_for(agent, target_mcp_url)?,
+        },
+        agent,
+    );
+    input.config_path = legacy_link
+        .map(|link| link.config_path.clone())
+        .or_else(|| {
+            unmanaged_source
+                .as_ref()
+                .map(|entry| entry.config_path.clone())
+        });
+    input.unmanaged_source_spec = unmanaged_source.map(|entry| entry.spec);
+    with_legacy_manifest_migration(workspace_dir, || manager.migrate_server(input.clone()))
+        .map(|summary| summary.migrated)
+}
+
+fn is_historical_browseros_spec(spec: &McpServerSpec) -> bool {
+    match spec {
+        McpServerSpec::Http { url, headers } => {
+            headers.is_empty() && is_historical_browseros_url(url)
+        }
+        McpServerSpec::Stdio { command, args, env } => {
+            command == "npx"
+                && env.is_empty()
+                && args.len() == 2
+                && args[0] == "mcp-remote"
+                && is_historical_browseros_url(&args[1])
+        }
+        McpServerSpec::Sse { .. } => false,
+    }
+}
+
+fn is_historical_browseros_url(raw: &str) -> bool {
+    let Ok(url) = Url::parse(raw) else {
+        return false;
+    };
+    url.scheme() == "http"
+        && url.host_str() == Some("127.0.0.1")
+        && url.port().is_some()
+        && url.path() == "/mcp"
+        && url.query().is_none()
+        && url.fragment().is_none()
+        && url.username().is_empty()
+        && url.password().is_none()
+}
+
 fn relink_managed_server(
     manager: &McpManager,
     workspace_dir: &Path,
@@ -578,6 +822,7 @@ fn relink_managed_server(
     agent: AgentId,
     spec: McpServerSpec,
     allow_overwrite: bool,
+    config_path: Option<&Path>,
 ) -> Result<harness_integrations::LinkSummary, HarnessOperationError> {
     let previous_spec = with_legacy_manifest_migration(workspace_dir, || manager.list())
         .map_err(HarnessOperationError::Manager)?
@@ -594,6 +839,7 @@ fn relink_managed_server(
                 agent,
             );
             input.allow_overwrite = allow_overwrite;
+            input.config_path = config_path.map(Path::to_path_buf);
             manager.link(input)
         })
     };
@@ -820,12 +1066,8 @@ fn migrate_connected_urls(
     // stale agents keep the old port; a manifest-level skip would strand them,
     // and the integrity scan only checks server-name presence, not the URL.
     // relink is write-on-change, so agents already on the target aren't rewritten.
-    let links = with_legacy_manifest_migration(workspace_dir, || {
-        manager.list_links(ListLinksFilter {
-            server_names: Some(vec![BROWSEROS_MCP_SERVER_NAME.to_string()]),
-            agents: None,
-        })
-    })?;
+    let links =
+        deduplicate_browseros_links(managed_browseros_links(manager, workspace_dir)?).into_values();
 
     let mut outcome = UrlMigrationOutcome::default();
     for link in links {
@@ -841,10 +1083,11 @@ fn migrate_connected_urls(
         match relink_managed_server(
             manager,
             workspace_dir,
-            BROWSEROS_MCP_SERVER_NAME,
+            &link.server_name,
             agent,
             spec,
             true,
+            Some(&link.config_path),
         ) {
             Ok(_) => outcome.migrated += 1,
             Err(error) => {

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
@@ -693,6 +693,12 @@ fn adopt_config_only_legacy_for_disconnect(
     workspace_dir: &Path,
     agent: AgentId,
 ) -> Result<(), ManagerError> {
+    if managed_browseros_links(manager, workspace_dir)?
+        .iter()
+        .any(|link| link.agent == agent && link.server_name == BROWSEROS_LEGACY_MCP_SERVER_NAME)
+    {
+        return Ok(());
+    }
     let entry = match manager.inspect_entry(InspectEntryInput::new(
         BROWSEROS_LEGACY_MCP_SERVER_NAME,
         agent,

--- a/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
@@ -8,11 +8,13 @@ use claw_server_rust::{
     analytics::{AnalyticsSink, events},
     build_router,
     config::Config,
-    services::harness::{Harness, HarnessService},
+    services::harness::{
+        BROWSEROS_LEGACY_MCP_SERVER_NAME, BROWSEROS_MCP_SERVER_NAME, Harness, HarnessService,
+    },
 };
 use harness_integrations::{
-    AgentId, AgentScope, LinkInput, McpManager, McpServer, McpServerSpec, SkillSpec,
-    resolve_agent_mcp_config_path,
+    AgentId, AgentScope, InspectEntryInput, LinkInput, McpManager, McpServer, McpServerSpec,
+    SkillSpec, resolve_agent_mcp_config_path,
 };
 use serde_json::{Value, json};
 use std::{
@@ -104,6 +106,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
         }
     }
 
+    assert_identity_migration(&home, &paths, analytics.clone()).await?;
     assert_legacy_manifest_migration(&home, &paths).await?;
 
     let not_installed = service
@@ -140,7 +143,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
     let claude_path = path_for(&paths, AgentId::ClaudeCode)?;
     fs::write(
         claude_path,
-        r#"{"mcpServers":{"BrowserClaw":{"command":"foreign"}}}"#,
+        r#"{"mcpServers":{"BrowserOS neo":{"command":"foreign"},"BrowserClaw":{"command":"unrelated"}}}"#,
     )?;
     let claude = service
         .connect_browseros(Harness::ClaudeCode, MCP_URL)
@@ -181,21 +184,25 @@ async fn run_connections_case() -> anyhow::Result<()> {
 
     let claude_json: Value = serde_json::from_str(&fs::read_to_string(claude_path)?)?;
     assert_eq!(
-        claude_json["mcpServers"]["BrowserClaw"],
+        claude_json["mcpServers"][BROWSEROS_MCP_SERVER_NAME],
         json!({ "type": "http", "url": MCP_URL })
+    );
+    assert_eq!(
+        claude_json["mcpServers"][BROWSEROS_LEGACY_MCP_SERVER_NAME],
+        json!({ "command": "unrelated" })
     );
 
     let codex_toml: toml::Value =
         toml::from_str(&fs::read_to_string(path_for(&paths, AgentId::Codex)?)?)?;
     assert_eq!(
-        codex_toml["mcp_servers"]["BrowserClaw"]["url"].as_str(),
+        codex_toml["mcp_servers"][BROWSEROS_MCP_SERVER_NAME]["url"].as_str(),
         Some(MCP_URL)
     );
 
     let zed_json: Value =
         serde_json::from_str(&fs::read_to_string(path_for(&paths, AgentId::Zed)?)?)?;
     assert_eq!(
-        zed_json["context_servers"]["BrowserClaw"],
+        zed_json["context_servers"][BROWSEROS_MCP_SERVER_NAME],
         json!({ "url": MCP_URL, "source": "custom", "enabled": true })
     );
 
@@ -204,13 +211,16 @@ async fn run_connections_case() -> anyhow::Result<()> {
     )?)?;
     assert_eq!(manifest["version"], 1);
     assert_eq!(
-        manifest["servers"]["BrowserClaw"]["links"]
+        manifest["servers"][BROWSEROS_MCP_SERVER_NAME]["links"]
             .as_object()
             .map(serde_json::Map::len),
         Some(3)
     );
-    assert!(manifest["servers"]["BrowserClaw"]["addedAt"].is_string());
-    assert!(manifest["servers"]["BrowserClaw"]["links"]["claude-code"]["createdAt"].is_string());
+    assert!(manifest["servers"][BROWSEROS_MCP_SERVER_NAME]["addedAt"].is_string());
+    assert!(
+        manifest["servers"][BROWSEROS_MCP_SERVER_NAME]["links"]["claude-code"]["createdAt"]
+            .is_string()
+    );
 
     let configured = service.list_browseros_connections().await?;
     assert_eq!(configured.len(), 7);
@@ -277,19 +287,19 @@ async fn run_connections_case() -> anyhow::Result<()> {
 
     let claude_json: Value = serde_json::from_str(&fs::read_to_string(claude_path)?)?;
     assert_eq!(
-        claude_json["mcpServers"]["BrowserClaw"]["url"], NEW_MCP_URL,
+        claude_json["mcpServers"][BROWSEROS_MCP_SERVER_NAME]["url"], NEW_MCP_URL,
         "claude config re-pointed to the new URL"
     );
     let codex_toml: toml::Value =
         toml::from_str(&fs::read_to_string(path_for(&paths, AgentId::Codex)?)?)?;
     assert_eq!(
-        codex_toml["mcp_servers"]["BrowserClaw"]["url"].as_str(),
+        codex_toml["mcp_servers"][BROWSEROS_MCP_SERVER_NAME]["url"].as_str(),
         Some(NEW_MCP_URL)
     );
     let zed_json: Value =
         serde_json::from_str(&fs::read_to_string(path_for(&paths, AgentId::Zed)?)?)?;
     assert_eq!(
-        zed_json["context_servers"]["BrowserClaw"]["url"],
+        zed_json["context_servers"][BROWSEROS_MCP_SERVER_NAME]["url"],
         NEW_MCP_URL
     );
 
@@ -300,14 +310,16 @@ async fn run_connections_case() -> anyhow::Result<()> {
     const STALE_MCP_URL: &str = "http://127.0.0.1:8888/mcp";
     fs::write(
         claude_path,
-        format!(r#"{{"mcpServers":{{"BrowserClaw":{{"type":"http","url":"{STALE_MCP_URL}"}}}}}}"#),
+        format!(
+            r#"{{"mcpServers":{{"BrowserOS neo":{{"type":"http","url":"{STALE_MCP_URL}"}}}}}}"#
+        ),
     )?;
     let repaired = service.migrate_connected_urls(NEW_MCP_URL).await?;
     assert_eq!(repaired.migrated, 3);
     assert_eq!(repaired.failed, 0);
     let claude_json: Value = serde_json::from_str(&fs::read_to_string(claude_path)?)?;
     assert_eq!(
-        claude_json["mcpServers"]["BrowserClaw"]["url"], NEW_MCP_URL,
+        claude_json["mcpServers"][BROWSEROS_MCP_SERVER_NAME]["url"], NEW_MCP_URL,
         "a straggler left on a stale port is repaired, not skipped"
     );
 
@@ -324,12 +336,17 @@ async fn run_connections_case() -> anyhow::Result<()> {
     assert_eq!(scan.healed, 1);
     assert_eq!(scan.failed, 0);
     let healed: Value = serde_json::from_str(&fs::read_to_string(claude_path)?)?;
-    assert_eq!(healed["mcpServers"]["BrowserClaw"]["type"], "http");
+    assert_eq!(
+        healed["mcpServers"][BROWSEROS_MCP_SERVER_NAME]["type"],
+        "http"
+    );
 
     let disconnected = service.disconnect_browseros(Harness::Codex).await?;
     assert!(!disconnected.installed);
     assert_eq!(disconnected.message, "BrowserOS unregistered from Codex.");
-    assert!(!fs::read_to_string(path_for(&paths, AgentId::Codex)?)?.contains("BrowserClaw"));
+    assert!(
+        !fs::read_to_string(path_for(&paths, AgentId::Codex)?)?.contains(BROWSEROS_MCP_SERVER_NAME)
+    );
     assert!(shared_skill.exists());
     let skill_manifest: Value = serde_json::from_str(&fs::read_to_string(&skill_manifest_path)?)?;
     let shared_record = skill_manifest["targets"]
@@ -459,12 +476,28 @@ async fn run_connections_case() -> anyhow::Result<()> {
         let repeated = service.connect_browseros(harness, MCP_URL).await?;
         assert!(repeated.installed, "{}", repeated.message);
     }
+    let mut claude_with_foreign_legacy: Value =
+        serde_json::from_str(&fs::read_to_string(claude_path)?)?;
+    claude_with_foreign_legacy["mcpServers"]
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("missing Claude MCP object"))?
+        .insert(
+            BROWSEROS_LEGACY_MCP_SERVER_NAME.to_string(),
+            json!({ "command": "unrelated" }),
+        );
+    fs::write(
+        claude_path,
+        serde_json::to_string_pretty(&claude_with_foreign_legacy)?,
+    )?;
     for harness in Harness::ALL {
         let state = service.disconnect_browseros(harness).await?;
         assert!(!state.installed, "{}", state.message);
         let repeated = service.disconnect_browseros(harness).await?;
         assert!(!repeated.installed, "{}", repeated.message);
     }
+    let claude_after_disconnect = fs::read_to_string(claude_path)?;
+    assert!(claude_after_disconnect.contains(BROWSEROS_LEGACY_MCP_SERVER_NAME));
+    assert!(!claude_after_disconnect.contains(BROWSEROS_MCP_SERVER_NAME));
     let captured = analytics.take();
     assert_eq!(captured.len(), Harness::ALL.len() * 2);
     for (index, harness) in Harness::ALL.into_iter().enumerate() {
@@ -483,6 +516,217 @@ async fn run_connections_case() -> anyhow::Result<()> {
             )
         );
     }
+    Ok(())
+}
+
+async fn assert_identity_migration(
+    home: &Path,
+    paths: &[(AgentId, std::path::PathBuf)],
+    analytics: Arc<RecordingAnalytics>,
+) -> anyhow::Result<()> {
+    const STALE_URL: &str = "http://127.0.0.1:7777/mcp";
+    let workspace = home.join("claw/identity-mcp-manager");
+    let manager = McpManager::new(&workspace);
+    let seed_manager = McpManager::new(home.join("claw/identity-seed-manager"));
+    let custom_claude = home.join("custom/claude.json");
+    fs::create_dir_all(parent(&custom_claude)?)?;
+    let source_spec = McpServerSpec::Http {
+        url: STALE_URL.to_string(),
+        headers: Default::default(),
+    };
+    let antigravity_parent = parent(path_for(paths, AgentId::Antigravity)?)?;
+    let antigravity_parent_existed = antigravity_parent.exists();
+    let mut migration_paths = Vec::new();
+    for agent in AgentId::ALL {
+        let config_path = if agent == AgentId::ClaudeCode {
+            custom_claude.clone()
+        } else {
+            path_for(paths, agent)?.to_path_buf()
+        };
+        fs::create_dir_all(parent(&config_path)?)?;
+        let mut input = LinkInput::new(
+            McpServer {
+                name: BROWSEROS_LEGACY_MCP_SERVER_NAME.to_string(),
+                spec: source_spec.clone(),
+            },
+            agent,
+        );
+        input.config_path = Some(config_path.clone());
+        if agent == AgentId::ClaudeCode {
+            manager.link(input)?;
+        } else {
+            seed_manager.link(input)?;
+        }
+        migration_paths.push((agent, config_path));
+    }
+    let legacy = manager.list()?.remove(0);
+    let legacy_added_at = legacy.added_at;
+    let legacy_created_at = legacy.links[&AgentId::ClaudeCode].created_at.clone();
+
+    let vscode_path = path_for(&migration_paths, AgentId::VsCode)?;
+    let mut collision = LinkInput::new(
+        McpServer {
+            name: BROWSEROS_MCP_SERVER_NAME.to_string(),
+            spec: McpServerSpec::Http {
+                url: "http://127.0.0.1:7000/mcp".to_string(),
+                headers: Default::default(),
+            },
+        },
+        AgentId::VsCode,
+    );
+    collision.config_path = Some(vscode_path.to_path_buf());
+    seed_manager.link(collision)?;
+
+    let service = HarnessService::new_with_analytics(
+        workspace.clone(),
+        home.to_path_buf(),
+        analytics.clone(),
+    );
+    let outcome = service.migrate_browseros_identity(MCP_URL).await?;
+    assert_eq!(outcome.migrated, 7);
+    assert_eq!(outcome.failed, 0);
+    assert_eq!(outcome.skipped, 0);
+    let reconnected = service
+        .connect_browseros(Harness::ClaudeCode, MCP_URL)
+        .await?;
+    assert_eq!(
+        reconnected.config_path.as_deref(),
+        Some("~/custom/claude.json")
+    );
+    assert!(!path_for(paths, AgentId::ClaudeCode)?.exists());
+    assert!(analytics.take().is_empty());
+    for (agent, config_path) in &migration_paths {
+        assert!(
+            manager
+                .inspect_entry(
+                    InspectEntryInput::new(BROWSEROS_LEGACY_MCP_SERVER_NAME, *agent)
+                        .at_path(config_path),
+                )?
+                .is_none(),
+            "{agent}"
+        );
+        assert_eq!(
+            manager
+                .inspect_entry(
+                    InspectEntryInput::new(BROWSEROS_MCP_SERVER_NAME, *agent).at_path(config_path),
+                )?
+                .map(|entry| entry.spec),
+            Some(McpServerSpec::Http {
+                url: MCP_URL.to_string(),
+                headers: Default::default(),
+            }),
+            "{agent}"
+        );
+    }
+    let canonical = manager.list()?.remove(0);
+    assert_eq!(canonical.name, BROWSEROS_MCP_SERVER_NAME);
+    assert_eq!(canonical.links.len(), 7);
+    assert_eq!(canonical.added_at, legacy_added_at);
+    assert_eq!(
+        canonical.links[&AgentId::ClaudeCode].created_at,
+        legacy_created_at
+    );
+    assert_eq!(
+        canonical.links[&AgentId::ClaudeCode].config_path,
+        custom_claude
+    );
+    let repeated = service.migrate_browseros_identity(MCP_URL).await?;
+    assert_eq!(repeated.migrated, 0);
+    assert_eq!(repeated.failed, 0);
+    assert_eq!(repeated.skipped, 7);
+    assert!(analytics.take().is_empty());
+
+    for (_, config_path) in &migration_paths {
+        fs::remove_file(config_path)?;
+    }
+    if !antigravity_parent_existed {
+        fs::remove_dir_all(home.join(".gemini"))?;
+    }
+
+    let foreign_workspace = home.join("claw/identity-foreign-manager");
+    let foreign_service = HarnessService::new(foreign_workspace.clone(), home.to_path_buf());
+    let cursor_path = path_for(paths, AgentId::Cursor)?;
+    let foreign_raw = r#"{"mcpServers":{"BrowserClaw":{"command":"foreign"},"BrowserOS neo":{"command":"standalone"}},"keep":true}"#;
+    fs::write(cursor_path, foreign_raw)?;
+    let foreign = foreign_service.migrate_browseros_identity(MCP_URL).await?;
+    assert_eq!(foreign.migrated, 0);
+    assert_eq!(foreign.failed, 0);
+    assert_eq!(fs::read_to_string(cursor_path)?, foreign_raw);
+    assert!(!foreign_workspace.join("manifest.json").exists());
+    fs::remove_file(cursor_path)?;
+
+    let failure_workspace = home.join("claw/identity-failure-manager");
+    let failure_seed = McpManager::new(home.join("claw/identity-failure-seed"));
+    let claude_path = path_for(paths, AgentId::ClaudeCode)?;
+    let mut legacy = LinkInput::new(
+        McpServer {
+            name: BROWSEROS_LEGACY_MCP_SERVER_NAME.to_string(),
+            spec: source_spec,
+        },
+        AgentId::ClaudeCode,
+    );
+    legacy.config_path = Some(claude_path.to_path_buf());
+    failure_seed.link(legacy)?;
+    let malformed = "{ definitely not json";
+    fs::write(cursor_path, malformed)?;
+    let failure_service = HarnessService::new(failure_workspace, home.to_path_buf());
+    let partial = failure_service.migrate_browseros_identity(MCP_URL).await?;
+    assert_eq!(partial.migrated, 1);
+    assert_eq!(partial.failed, 1);
+    assert_eq!(fs::read_to_string(cursor_path)?, malformed);
+    fs::remove_file(claude_path)?;
+    fs::remove_file(cursor_path)?;
+
+    let compatibility_workspace = home.join("claw/identity-compatibility-manager");
+    let compatibility_manager = McpManager::new(&compatibility_workspace);
+    let mut legacy = LinkInput::new(
+        McpServer {
+            name: BROWSEROS_LEGACY_MCP_SERVER_NAME.to_string(),
+            spec: McpServerSpec::Http {
+                url: STALE_URL.to_string(),
+                headers: Default::default(),
+            },
+        },
+        AgentId::Cursor,
+    );
+    legacy.config_path = Some(cursor_path.to_path_buf());
+    compatibility_manager.link(legacy)?;
+    let compatibility_analytics = Arc::new(RecordingAnalytics::default());
+    let compatibility = HarnessService::new_with_analytics(
+        compatibility_workspace,
+        home.to_path_buf(),
+        compatibility_analytics.clone(),
+    );
+    let listed = compatibility.list_browseros_connections().await?;
+    assert!(
+        listed
+            .iter()
+            .any(|state| state.harness == Harness::Cursor && state.installed)
+    );
+    let url_outcome = compatibility.migrate_connected_urls(MCP_URL).await?;
+    assert_eq!(url_outcome.migrated, 1);
+    let updated = compatibility_manager
+        .inspect_entry(
+            InspectEntryInput::new(BROWSEROS_LEGACY_MCP_SERVER_NAME, AgentId::Cursor)
+                .at_path(cursor_path),
+        )?
+        .ok_or_else(|| anyhow::anyhow!("missing compatible legacy entry"))?;
+    assert_eq!(
+        updated.spec,
+        McpServerSpec::Http {
+            url: MCP_URL.to_string(),
+            headers: Default::default(),
+        }
+    );
+    let disconnected = compatibility.disconnect_browseros(Harness::Cursor).await?;
+    assert!(!disconnected.installed);
+    assert!(
+        compatibility_manager
+            .list_links(Default::default())?
+            .is_empty()
+    );
+    assert_eq!(compatibility_analytics.take().len(), 1);
+    fs::remove_file(cursor_path)?;
     Ok(())
 }
 
@@ -532,7 +776,7 @@ async fn assert_legacy_manifest_migration(
 
     let migrated = McpManager::new(&workspace).list()?;
     assert_eq!(migrated.len(), 1);
-    assert_eq!(migrated[0].name, "BrowserClaw");
+    assert_eq!(migrated[0].name, BROWSEROS_MCP_SERVER_NAME);
     assert_eq!(migrated[0].added_at, added_at);
     assert_eq!(migrated[0].links[&AgentId::ClaudeCode].created_at, added_at);
 

--- a/packages/browseros-agent/crates/harness-integrations/src/error.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/error.rs
@@ -36,6 +36,9 @@ pub enum Error {
     #[error("Invalid MCP server spec: {reason}")]
     InvalidServerSpec { reason: String },
 
+    #[error("MCP server migration verification failed: {reason}")]
+    MigrationVerification { reason: String },
+
     #[error("Invalid managed skill spec: {reason}")]
     InvalidSkillSpec { reason: String },
 

--- a/packages/browseros-agent/crates/harness-integrations/src/lib.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/lib.rs
@@ -10,11 +10,11 @@ pub use catalog::{
 };
 pub use error::Error;
 pub use mcp::{
-    AgentInfo, AgentScope, AgentSurface, DisconnectInput, DisconnectSummary, LinkInput,
-    LinkSummary, ListLinksFilter, ListedLink, ManifestLinkEntry, ManifestServerEntry, McpManager,
-    McpServer, McpServerSpec, RescanEntry, RescanReport, ServerManifest, UnlinkInput,
-    UnlinkSummary, detect_installed_agents, is_installed, resolve_agent_mcp_config_path,
-    resolve_agent_surface,
+    AgentInfo, AgentScope, AgentSurface, DisconnectInput, DisconnectSummary, InspectEntryInput,
+    InspectedEntry, LinkInput, LinkSummary, ListLinksFilter, ListedLink, ManifestLinkEntry,
+    ManifestServerEntry, McpManager, McpServer, McpServerSpec, MigrateServerInput,
+    MigrateServerSummary, RescanEntry, RescanReport, ServerManifest, UnlinkInput, UnlinkSummary,
+    detect_installed_agents, is_installed, resolve_agent_mcp_config_path, resolve_agent_surface,
 };
 pub use skills::{
     SkillEnvironment, SkillReconcileOutcome, SkillReconciler, SkillSpec, SkillWarning,

--- a/packages/browseros-agent/crates/harness-integrations/src/mcp/emitter.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/mcp/emitter.rs
@@ -17,7 +17,7 @@ pub(crate) struct Emitter {
     surface: AgentSurface,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum EntryValue {
     String(String),
     Bool(bool),
@@ -35,6 +35,17 @@ impl Emitter {
             ConfigFormat::Json | ConfigFormat::Jsonc => Ok(json_read(raw, self.surface.stdio)),
             ConfigFormat::Toml => toml_read(raw, self.surface.stdio),
         }
+    }
+
+    pub(crate) fn inspect(&self, raw: &str, name: &str) -> Result<Option<McpServerSpec>, Error> {
+        let key = transform_key(name, self.surface.stdio);
+        let entry = match self.surface.mcp.format {
+            ConfigFormat::Json | ConfigFormat::Jsonc => {
+                json_entry(raw, self.surface.stdio.top_level_key, &key)?
+            }
+            ConfigFormat::Toml => toml_entry(raw, self.surface.stdio.top_level_key, &key)?,
+        };
+        Ok(entry.and_then(|entry| decode_entry(&entry, self.surface.stdio, self.surface.http)))
     }
 
     pub(crate) fn add(&self, raw: &str, name: &str, spec: &McpServerSpec) -> Result<String, Error> {
@@ -57,6 +68,77 @@ impl Emitter {
             ConfigFormat::Toml => toml_remove(raw, self.surface.stdio.top_level_key, &key),
         }
     }
+}
+
+fn decode_entry(
+    entry: &BTreeMap<String, EntryValue>,
+    stdio: StdioShape,
+    http: Option<HttpShape>,
+) -> Option<McpServerSpec> {
+    if let Some(http) = http {
+        let url_field = http.url_field.unwrap_or("url");
+        if let Some(EntryValue::String(url)) = entry.get(url_field) {
+            let headers = match http.header_field.unwrap_or("headers") {
+                field if !entry.contains_key(field) => BTreeMap::new(),
+                field => match entry.get(field) {
+                    Some(EntryValue::StringMap(headers)) => headers.clone(),
+                    _ => return None,
+                },
+            };
+            let is_sse = http
+                .tag_key
+                .zip(http.sse_tag_value)
+                .is_some_and(|(key, value)| {
+                    entry.get(key) == Some(&EntryValue::String(value.to_string()))
+                });
+            let spec = if is_sse {
+                McpServerSpec::Sse {
+                    url: url.clone(),
+                    headers,
+                }
+            } else {
+                McpServerSpec::Http {
+                    url: url.clone(),
+                    headers,
+                }
+            };
+            if entry == &entry_map(build_entry(&spec, stdio, Some(http)).ok()?) {
+                return Some(spec);
+            }
+        }
+    }
+
+    let command_field = stdio.command_field.unwrap_or("command");
+    let (command, args) = if stdio.command_as_array {
+        let EntryValue::Strings(parts) = entry.get(command_field)? else {
+            return None;
+        };
+        let (command, args) = parts.split_first()?;
+        (command.clone(), args.to_vec())
+    } else {
+        let EntryValue::String(command) = entry.get(command_field)? else {
+            return None;
+        };
+        let args_field = stdio.args_field.unwrap_or("args");
+        let args = match entry.get(args_field) {
+            None => Vec::new(),
+            Some(EntryValue::Strings(args)) => args.clone(),
+            _ => return None,
+        };
+        (command.clone(), args)
+    };
+    let env_field = stdio.env_field.unwrap_or("env");
+    let env = match entry.get(env_field) {
+        None => BTreeMap::new(),
+        Some(EntryValue::StringMap(env)) => env.clone(),
+        _ => return None,
+    };
+    let spec = McpServerSpec::Stdio { command, args, env };
+    (entry == &entry_map(build_entry(&spec, stdio, http).ok()?)).then_some(spec)
+}
+
+fn entry_map(entry: Vec<(String, EntryValue)>) -> BTreeMap<String, EntryValue> {
+    entry.into_iter().collect()
 }
 
 fn transform_key(name: &str, shape: StdioShape) -> String {
@@ -192,6 +274,57 @@ fn json_read(raw: &str, shape: StdioShape) -> Vec<String> {
         .collect()
 }
 
+fn json_entry(
+    raw: &str,
+    top_level_key: &str,
+    name: &str,
+) -> Result<Option<BTreeMap<String, EntryValue>>, Error> {
+    if raw.trim().is_empty() {
+        return Ok(None);
+    }
+    let root =
+        CstRootNode::parse(raw, &ParseOptions::default()).map_err(|error| Error::Config {
+            format: "JSON/JSONC",
+            message: error.to_string(),
+        })?;
+    let Some(value) = root
+        .object_value()
+        .and_then(|object| object.object_value(top_level_key))
+        .and_then(|container| container.get(name))
+        .and_then(|property| property.value())
+        .and_then(|value| value.to_serde_value())
+    else {
+        return Ok(None);
+    };
+    Ok(json_entry_map(value))
+}
+
+fn json_entry_map(value: serde_json::Value) -> Option<BTreeMap<String, EntryValue>> {
+    value
+        .as_object()?
+        .iter()
+        .map(|(key, value)| json_entry_value(value.clone()).map(|value| (key.clone(), value)))
+        .collect()
+}
+
+fn json_entry_value(value: serde_json::Value) -> Option<EntryValue> {
+    match value {
+        serde_json::Value::String(value) => Some(EntryValue::String(value)),
+        serde_json::Value::Bool(value) => Some(EntryValue::Bool(value)),
+        serde_json::Value::Array(values) => values
+            .into_iter()
+            .map(|value| value.as_str().map(ToString::to_string))
+            .collect::<Option<Vec<_>>>()
+            .map(EntryValue::Strings),
+        serde_json::Value::Object(values) => values
+            .into_iter()
+            .map(|(key, value)| value.as_str().map(|value| (key, value.to_string())))
+            .collect::<Option<BTreeMap<_, _>>>()
+            .map(EntryValue::StringMap),
+        _ => None,
+    }
+}
+
 fn json_add(
     raw: &str,
     top_level_key: &str,
@@ -277,6 +410,54 @@ fn toml_read(raw: &str, shape: StdioShape) -> Result<Vec<String>, Error> {
         .and_then(Item::as_table_like)
         .map(|table| table.iter().map(|(key, _)| key.to_string()).collect())
         .unwrap_or_default())
+}
+
+fn toml_entry(
+    raw: &str,
+    top_level_key: &str,
+    name: &str,
+) -> Result<Option<BTreeMap<String, EntryValue>>, Error> {
+    let document = parse_toml(raw)?;
+    let Some(entry) = document
+        .get(top_level_key)
+        .and_then(Item::as_table_like)
+        .and_then(|table| table.get(name))
+        .and_then(Item::as_table_like)
+    else {
+        return Ok(None);
+    };
+    Ok(entry
+        .iter()
+        .map(|(key, item)| decode_toml_entry_value(item).map(|value| (key.to_string(), value)))
+        .collect())
+}
+
+fn decode_toml_entry_value(item: &Item) -> Option<EntryValue> {
+    let value = item.as_value()?;
+    if let Some(value) = value.as_str() {
+        return Some(EntryValue::String(value.to_string()));
+    }
+    if let Some(value) = value.as_bool() {
+        return Some(EntryValue::Bool(value));
+    }
+    if let Some(values) = value.as_array() {
+        return values
+            .iter()
+            .map(|value| value.as_str().map(ToString::to_string))
+            .collect::<Option<Vec<_>>>()
+            .map(EntryValue::Strings);
+    }
+    value.as_inline_table().and_then(|values| {
+        values
+            .iter()
+            .map(|(key, value)| {
+                value
+                    .as_str()
+                    .map(|value| (key.to_string(), value.to_string()))
+            })
+            .collect::<Option<BTreeMap<_, _>>>()
+            .map(EntryValue::StringMap)
+    })
 }
 
 fn toml_add(

--- a/packages/browseros-agent/crates/harness-integrations/src/mcp/manager.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/mcp/manager.rs
@@ -97,12 +97,19 @@ impl McpManager {
             .get(&input.source_name)
             .and_then(|server| server.links.get(&input.agent))
             .map(|link| link.config_path.clone());
-        let selected_path = recorded_path.or_else(|| input.config_path.clone());
-        let overrides = selected_path
+        let destination_path = manifest_state
+            .manifest
+            .servers
+            .get(input.destination.name.trim())
+            .and_then(|server| server.links.get(&input.agent))
+            .map(|link| link.config_path.clone());
+        let selected_source_path = recorded_path.or_else(|| input.config_path.clone());
+        let overrides = selected_source_path
             .map(|path| BTreeMap::from([(input.agent, path)]))
             .unwrap_or_default();
-        let state = read_state(&self.workspace_dir, &[input.agent], input.scope, &overrides)?;
-        let config_path = state
+        let source_state =
+            read_state(&self.workspace_dir, &[input.agent], input.scope, &overrides)?;
+        let source_path = source_state
             .agents
             .first()
             .ok_or_else(|| Error::InvalidServerSpec {
@@ -113,16 +120,23 @@ impl McpManager {
             })?
             .config_path
             .clone();
+        let destination_path = destination_path.unwrap_or_else(|| source_path.clone());
+        let mut paths = vec![(input.agent, destination_path.clone())];
+        if source_path != destination_path {
+            paths.push((input.agent, source_path.clone()));
+        }
+        let state = read_state_at_paths(&self.workspace_dir, &paths, input.scope)?;
         let now = current_timestamp()?;
-        let Some(install) = plan_migration_install(&state, &input, &now)? else {
+        let Some(install) =
+            plan_migration_install(&state, &input, &source_path, &destination_path, &now)?
+        else {
             return Ok(no_op());
         };
         let overwrote_foreign = install.overwrote_foreign;
         apply_plan(&install.plan)?;
 
-        let paths = [(input.agent, config_path)];
         let installed = read_state_at_paths(&self.workspace_dir, &paths, input.scope)?;
-        if !verify_migration_destination(&installed, &input)? {
+        if !verify_migration_destination(&installed, &input, &destination_path)? {
             return Err(Error::MigrationVerification {
                 reason: format!(
                     "{} was not readable after installation for {}",
@@ -130,7 +144,7 @@ impl McpManager {
                 ),
             });
         }
-        let cleanup = plan_migration_cleanup(&installed, &input)?;
+        let cleanup = plan_migration_cleanup(&installed, &input, &source_path, &destination_path)?;
         apply_plan(&cleanup)?;
         Ok(MigrateServerSummary {
             source_name: input.source_name,

--- a/packages/browseros-agent/crates/harness-integrations/src/mcp/manager.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/mcp/manager.rs
@@ -5,11 +5,17 @@ use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 use crate::error::Error;
 
 use super::{
+    emitter::Emitter,
     io::{apply_plan, read_state, read_state_at_paths},
-    planner::{plan_disconnect, plan_link, plan_rescan, plan_unlink},
+    paths::resolve_agent_surface,
+    planner::{
+        plan_disconnect, plan_link, plan_migration_cleanup, plan_migration_install, plan_rescan,
+        plan_unlink, verify_migration_destination,
+    },
     types::{
-        AgentScope, DisconnectInput, DisconnectSummary, LinkInput, LinkSummary, ListLinksFilter,
-        ListedLink, ManifestServerEntry, RescanReport, UnlinkInput, UnlinkSummary,
+        AgentScope, DisconnectInput, DisconnectSummary, InspectEntryInput, InspectedEntry,
+        LinkInput, LinkSummary, ListLinksFilter, ListedLink, ManifestServerEntry,
+        MigrateServerInput, MigrateServerSummary, RescanReport, UnlinkInput, UnlinkSummary,
     },
 };
 
@@ -38,6 +44,102 @@ impl McpManager {
         let planned = plan_link(&state, &input, &now)?;
         apply_plan(&planned.plan)?;
         Ok(planned.summary)
+    }
+
+    /// Inspects one entry only when it exactly matches an emitted MCP shape.
+    pub fn inspect_entry(&self, input: InspectEntryInput) -> Result<Option<InspectedEntry>, Error> {
+        let overrides = input
+            .config_path
+            .clone()
+            .map(|path| BTreeMap::from([(input.agent, path)]))
+            .unwrap_or_default();
+        let state = read_state(&self.workspace_dir, &[input.agent], input.scope, &overrides)?;
+        let file = state
+            .agents
+            .first()
+            .ok_or_else(|| Error::InvalidServerSpec {
+                reason: format!(
+                    "agent {} was not included in the state snapshot",
+                    input.agent
+                ),
+            })?;
+        let emitter = Emitter::new(resolve_agent_surface(input.agent, input.scope)?);
+        Ok(emitter
+            .inspect(&file.raw_content, &input.server_name)?
+            .map(|spec| InspectedEntry {
+                server_name: input.server_name,
+                agent: input.agent,
+                scope: input.scope,
+                config_path: file.config_path.clone(),
+                spec,
+            }))
+    }
+
+    /// Installs and verifies a destination before removing one eligible source link.
+    pub fn migrate_server(&self, input: MigrateServerInput) -> Result<MigrateServerSummary, Error> {
+        let no_op = || MigrateServerSummary {
+            source_name: input.source_name.clone(),
+            destination_name: input.destination.name.trim().to_string(),
+            agent: input.agent,
+            scope: input.scope,
+            migrated: false,
+            overwrote_foreign: false,
+        };
+        let manifest_state = read_state(
+            &self.workspace_dir,
+            &[],
+            AgentScope::System,
+            &BTreeMap::new(),
+        )?;
+        let recorded_path = manifest_state
+            .manifest
+            .servers
+            .get(&input.source_name)
+            .and_then(|server| server.links.get(&input.agent))
+            .map(|link| link.config_path.clone());
+        let selected_path = recorded_path.or_else(|| input.config_path.clone());
+        let overrides = selected_path
+            .map(|path| BTreeMap::from([(input.agent, path)]))
+            .unwrap_or_default();
+        let state = read_state(&self.workspace_dir, &[input.agent], input.scope, &overrides)?;
+        let config_path = state
+            .agents
+            .first()
+            .ok_or_else(|| Error::InvalidServerSpec {
+                reason: format!(
+                    "agent {} was not included in the state snapshot",
+                    input.agent
+                ),
+            })?
+            .config_path
+            .clone();
+        let now = current_timestamp()?;
+        let Some(install) = plan_migration_install(&state, &input, &now)? else {
+            return Ok(no_op());
+        };
+        let overwrote_foreign = install.overwrote_foreign;
+        apply_plan(&install.plan)?;
+
+        let paths = [(input.agent, config_path)];
+        let installed = read_state_at_paths(&self.workspace_dir, &paths, input.scope)?;
+        if !verify_migration_destination(&installed, &input)? {
+            return Err(Error::MigrationVerification {
+                reason: format!(
+                    "{} was not readable after installation for {}",
+                    input.destination.name, input.agent
+                ),
+            });
+        }
+        let cleanup = plan_migration_cleanup(&installed, &input)?;
+        apply_plan(&cleanup)?;
+        Ok(MigrateServerSummary {
+            source_name: input.source_name,
+            destination_name: input.destination.name.trim().to_string(),
+            agent: input.agent,
+            scope: input.scope,
+            migrated: true,
+            overwrote_foreign,
+        })
     }
 
     /// Unlinks one manifest-recorded agent entry without touching other agents.

--- a/packages/browseros-agent/crates/harness-integrations/src/mcp/mod.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/mcp/mod.rs
@@ -10,7 +10,8 @@ pub use paths::{
     detect_installed_agents, is_installed, resolve_agent_mcp_config_path, resolve_agent_surface,
 };
 pub use types::{
-    AgentInfo, AgentScope, AgentSurface, DisconnectInput, DisconnectSummary, LinkInput,
-    LinkSummary, ListLinksFilter, ListedLink, ManifestLinkEntry, ManifestServerEntry, McpServer,
-    McpServerSpec, RescanEntry, RescanReport, ServerManifest, UnlinkInput, UnlinkSummary,
+    AgentInfo, AgentScope, AgentSurface, DisconnectInput, DisconnectSummary, InspectEntryInput,
+    InspectedEntry, LinkInput, LinkSummary, ListLinksFilter, ListedLink, ManifestLinkEntry,
+    ManifestServerEntry, McpServer, McpServerSpec, MigrateServerInput, MigrateServerSummary,
+    RescanEntry, RescanReport, ServerManifest, UnlinkInput, UnlinkSummary,
 };

--- a/packages/browseros-agent/crates/harness-integrations/src/mcp/planner.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/mcp/planner.rs
@@ -47,7 +47,10 @@ pub(crate) fn plan_link(state: &State, input: &LinkInput, now: &str) -> Result<P
     validate_spec(&input.server.spec)?;
     let surface =
         ensure_transport_supported(input.agent, input.scope, input.server.spec.transport())?;
-    let agent_file = require_agent_file(state, input.agent, input.scope)?;
+    let agent_file = match input.config_path.as_deref() {
+        Some(config_path) => require_agent_file_at(state, input.agent, input.scope, config_path)?,
+        None => require_agent_file(state, input.agent, input.scope)?,
+    };
     ensure_agent_installed(input.agent, agent_file)?;
     let emitter = Emitter::new(surface);
 
@@ -107,6 +110,8 @@ pub(crate) fn plan_link(state: &State, input: &LinkInput, now: &str) -> Result<P
 pub(crate) fn plan_migration_install(
     state: &State,
     input: &MigrateServerInput,
+    source_path: &Path,
+    destination_path: &Path,
     now: &str,
 ) -> Result<Option<PlannedMigrationInstall>, Error> {
     if input.source_name == input.destination.name {
@@ -114,14 +119,15 @@ pub(crate) fn plan_migration_install(
             reason: "migration source and destination names must differ".to_string(),
         });
     }
-    let agent_file = require_agent_file(state, input.agent, input.scope)?;
+    let agent_file = require_agent_file_at(state, input.agent, input.scope, destination_path)?;
+    let source_file = require_agent_file_at(state, input.agent, input.scope, source_path)?;
     let surface = resolve_agent_surface(input.agent, input.scope)?;
     let emitter = Emitter::new(surface);
     let source_server = state.manifest.servers.get(&input.source_name);
     let source_link = source_server
         .and_then(|server| server.links.get(&input.agent))
-        .filter(|link| link.config_path == agent_file.config_path);
-    let observed_source = emitter.inspect(&agent_file.raw_content, &input.source_name)?;
+        .filter(|link| link.config_path == source_file.config_path);
+    let observed_source = emitter.inspect(&source_file.raw_content, &input.source_name)?;
     let unmanaged_source_matches = input
         .unmanaged_source_spec
         .as_ref()
@@ -169,8 +175,9 @@ pub(crate) fn plan_migration_install(
 pub(crate) fn verify_migration_destination(
     state: &State,
     input: &MigrateServerInput,
+    destination_path: &Path,
 ) -> Result<bool, Error> {
-    let agent_file = require_agent_file(state, input.agent, input.scope)?;
+    let agent_file = require_agent_file_at(state, input.agent, input.scope, destination_path)?;
     let destination_name = input.destination.name.trim();
     let owned = state
         .manifest
@@ -189,8 +196,10 @@ pub(crate) fn verify_migration_destination(
 pub(crate) fn plan_migration_cleanup(
     state: &State,
     input: &MigrateServerInput,
+    source_path: &Path,
+    destination_path: &Path,
 ) -> Result<Plan, Error> {
-    if !verify_migration_destination(state, input)? {
+    if !verify_migration_destination(state, input, destination_path)? {
         return Err(Error::MigrationVerification {
             reason: format!(
                 "{} was not persisted for {} at the selected config path",
@@ -198,7 +207,7 @@ pub(crate) fn plan_migration_cleanup(
             ),
         });
     }
-    let agent_file = require_agent_file(state, input.agent, input.scope)?;
+    let agent_file = require_agent_file_at(state, input.agent, input.scope, source_path)?;
     let emitter = Emitter::new(resolve_agent_surface(input.agent, input.scope)?);
     let source_link_owned = state
         .manifest
@@ -468,6 +477,20 @@ fn require_agent_file(
                 "agent {agent}@{scope} was not included in readState; add it to the agents list before planning"
             ),
         })
+}
+
+fn require_agent_file_at<'a>(
+    state: &'a State,
+    agent: AgentId,
+    scope: AgentScope,
+    config_path: &Path,
+) -> Result<&'a AgentFileState, Error> {
+    find_agent_file(state, agent, scope, config_path).ok_or_else(|| Error::InvalidServerSpec {
+        reason: format!(
+            "agent {agent}@{scope} at {} was not included in readState",
+            config_path.display()
+        ),
+    })
 }
 
 fn ensure_agent_installed(agent: AgentId, file: &AgentFileState) -> Result<(), Error> {

--- a/packages/browseros-agent/crates/harness-integrations/src/mcp/planner.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/mcp/planner.rs
@@ -11,8 +11,8 @@ use super::{
     paths::resolve_agent_surface,
     types::{
         AgentScope, AgentSurface, DisconnectInput, DisconnectSummary, LinkInput, LinkSummary,
-        ListedLink, ManifestLinkEntry, ManifestServerEntry, McpServerSpec, RescanEntry,
-        RescanReport, ServerManifest, UnlinkInput, UnlinkSummary,
+        ListedLink, ManifestLinkEntry, ManifestServerEntry, McpServerSpec, MigrateServerInput,
+        RescanEntry, RescanReport, ServerManifest, UnlinkInput, UnlinkSummary,
     },
 };
 
@@ -29,6 +29,11 @@ pub(crate) struct PlannedUnlink {
 pub(crate) struct PlannedDisconnect {
     pub(crate) plan: Plan,
     pub(crate) summary: DisconnectSummary,
+}
+
+pub(crate) struct PlannedMigrationInstall {
+    pub(crate) plan: Plan,
+    pub(crate) overwrote_foreign: bool,
 }
 
 /// Computes a link plan without touching the filesystem or mutating the state snapshot.
@@ -97,6 +102,146 @@ pub(crate) fn plan_link(state: &State, input: &LinkInput, now: &str) -> Result<P
             overwrote_foreign: is_foreign,
         },
     })
+}
+
+pub(crate) fn plan_migration_install(
+    state: &State,
+    input: &MigrateServerInput,
+    now: &str,
+) -> Result<Option<PlannedMigrationInstall>, Error> {
+    if input.source_name == input.destination.name {
+        return Err(Error::InvalidServerSpec {
+            reason: "migration source and destination names must differ".to_string(),
+        });
+    }
+    let agent_file = require_agent_file(state, input.agent, input.scope)?;
+    let surface = resolve_agent_surface(input.agent, input.scope)?;
+    let emitter = Emitter::new(surface);
+    let source_server = state.manifest.servers.get(&input.source_name);
+    let source_link = source_server
+        .and_then(|server| server.links.get(&input.agent))
+        .filter(|link| link.config_path == agent_file.config_path);
+    let observed_source = emitter.inspect(&agent_file.raw_content, &input.source_name)?;
+    let unmanaged_source_matches = input
+        .unmanaged_source_spec
+        .as_ref()
+        .is_some_and(|allowed| observed_source.as_ref() == Some(allowed));
+    if source_link.is_none() && !unmanaged_source_matches {
+        return Ok(None);
+    }
+
+    let mut link_input = LinkInput::new(input.destination.clone(), input.agent);
+    link_input.scope = input.scope;
+    link_input.config_path = Some(agent_file.config_path.clone());
+    link_input.allow_overwrite = true;
+    let mut planned = plan_link(state, &link_input, now)?;
+    let destination_name = planned.summary.server_name.clone();
+    let existing_destination = state.manifest.servers.get(&destination_name);
+    if let (Some(source_server), Some(destination)) = (
+        source_server,
+        planned
+            .plan
+            .next_manifest
+            .servers
+            .get_mut(&destination_name),
+    ) {
+        if existing_destination.is_none() {
+            destination.added_at.clone_from(&source_server.added_at);
+        }
+        if existing_destination
+            .and_then(|server| server.links.get(&input.agent))
+            .is_none()
+            && let Some(source_link) = source_link
+            && let Some(destination_link) = destination.links.get_mut(&input.agent)
+        {
+            destination_link
+                .created_at
+                .clone_from(&source_link.created_at);
+        }
+        replace_manifest_write(state, &mut planned.plan)?;
+    }
+    Ok(Some(PlannedMigrationInstall {
+        plan: planned.plan,
+        overwrote_foreign: planned.summary.overwrote_foreign,
+    }))
+}
+
+pub(crate) fn verify_migration_destination(
+    state: &State,
+    input: &MigrateServerInput,
+) -> Result<bool, Error> {
+    let agent_file = require_agent_file(state, input.agent, input.scope)?;
+    let destination_name = input.destination.name.trim();
+    let owned = state
+        .manifest
+        .servers
+        .get(destination_name)
+        .and_then(|server| server.links.get(&input.agent))
+        .is_some_and(|link| link.config_path == agent_file.config_path);
+    if !owned {
+        return Ok(false);
+    }
+    let emitter = Emitter::new(resolve_agent_surface(input.agent, input.scope)?);
+    Ok(emitter.inspect(&agent_file.raw_content, destination_name)?
+        == Some(input.destination.spec.clone()))
+}
+
+pub(crate) fn plan_migration_cleanup(
+    state: &State,
+    input: &MigrateServerInput,
+) -> Result<Plan, Error> {
+    if !verify_migration_destination(state, input)? {
+        return Err(Error::MigrationVerification {
+            reason: format!(
+                "{} was not persisted for {} at the selected config path",
+                input.destination.name, input.agent
+            ),
+        });
+    }
+    let agent_file = require_agent_file(state, input.agent, input.scope)?;
+    let emitter = Emitter::new(resolve_agent_surface(input.agent, input.scope)?);
+    let source_link_owned = state
+        .manifest
+        .servers
+        .get(&input.source_name)
+        .and_then(|server| server.links.get(&input.agent))
+        .is_some_and(|link| link.config_path == agent_file.config_path);
+    let observed_source = emitter.inspect(&agent_file.raw_content, &input.source_name)?;
+    let unmanaged_source_matches = input
+        .unmanaged_source_spec
+        .as_ref()
+        .is_some_and(|allowed| observed_source.as_ref() == Some(allowed));
+    let can_remove_source = source_link_owned || unmanaged_source_matches;
+    if !can_remove_source {
+        return Ok(Plan {
+            ops: Vec::new(),
+            next_manifest: state.manifest.clone(),
+        });
+    }
+
+    let mut ops = Vec::new();
+    let next_raw = emitter.remove(&agent_file.raw_content, &input.source_name)?;
+    if next_raw != agent_file.raw_content {
+        ops.push(FsOp::WriteFile {
+            path: agent_file.config_path.clone(),
+            content: next_raw,
+        });
+    }
+    let mut next_manifest = state.manifest.clone();
+    if source_link_owned {
+        let remove_source_server = next_manifest
+            .servers
+            .get_mut(&input.source_name)
+            .is_some_and(|server| {
+                server.links.remove(&input.agent);
+                server.links.is_empty()
+            });
+        if remove_source_server {
+            next_manifest.servers.remove(&input.source_name);
+        }
+        ops.push(manifest_write_op(state, &next_manifest)?);
+    }
+    Ok(Plan { ops, next_manifest })
 }
 
 /// Computes an unlink plan using the manifest-recorded config path.
@@ -363,6 +508,23 @@ fn manifest_write_op(state: &State, manifest: &ServerManifest) -> Result<FsOp, E
         path: state.manifest_path.clone(),
         content: serialize_manifest(manifest)?,
     })
+}
+
+fn replace_manifest_write(state: &State, plan: &mut Plan) -> Result<(), Error> {
+    let serialized = serialize_manifest(&plan.next_manifest)?;
+    for op in &mut plan.ops {
+        if let FsOp::WriteFile { path, content } = op
+            && path == &state.manifest_path
+        {
+            *content = serialized;
+            return Ok(());
+        }
+    }
+    plan.ops.push(FsOp::WriteFile {
+        path: state.manifest_path.clone(),
+        content: serialized,
+    });
+    Ok(())
 }
 
 #[cfg(test)]

--- a/packages/browseros-agent/crates/harness-integrations/src/mcp/types.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/mcp/types.rs
@@ -113,6 +113,75 @@ impl LinkInput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InspectEntryInput {
+    pub server_name: String,
+    pub agent: AgentId,
+    pub scope: AgentScope,
+    pub config_path: Option<PathBuf>,
+}
+
+impl InspectEntryInput {
+    /// Creates a system-scope entry inspection at the catalog path.
+    pub fn new(server_name: impl Into<String>, agent: AgentId) -> Self {
+        Self {
+            server_name: server_name.into(),
+            agent,
+            scope: AgentScope::System,
+            config_path: None,
+        }
+    }
+
+    #[must_use]
+    pub fn at_path(mut self, config_path: impl Into<PathBuf>) -> Self {
+        self.config_path = Some(config_path.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InspectedEntry {
+    pub server_name: String,
+    pub agent: AgentId,
+    pub scope: AgentScope,
+    pub config_path: PathBuf,
+    pub spec: McpServerSpec,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrateServerInput {
+    pub source_name: String,
+    pub destination: McpServer,
+    pub agent: AgentId,
+    pub scope: AgentScope,
+    pub config_path: Option<PathBuf>,
+    pub unmanaged_source_spec: Option<McpServerSpec>,
+}
+
+impl MigrateServerInput {
+    /// Creates a system-scope server migration request.
+    pub fn new(source_name: impl Into<String>, destination: McpServer, agent: AgentId) -> Self {
+        Self {
+            source_name: source_name.into(),
+            destination,
+            agent,
+            scope: AgentScope::System,
+            config_path: None,
+            unmanaged_source_spec: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrateServerSummary {
+    pub source_name: String,
+    pub destination_name: String,
+    pub agent: AgentId,
+    pub scope: AgentScope,
+    pub migrated: bool,
+    pub overwrote_foreign: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnlinkInput {
     pub server_name: String,
     pub agent: AgentId,

--- a/packages/browseros-agent/crates/harness-integrations/tests/api.rs
+++ b/packages/browseros-agent/crates/harness-integrations/tests/api.rs
@@ -410,19 +410,16 @@ fn migration_converges_from_interrupted_install_and_cleanup_states()
 
     let installed_workspace = root.path().join("installed-workspace");
     let installed_manager = McpManager::new(&installed_workspace);
-    let installed_config = root.path().join("installed/cursor.json");
-    fs::create_dir_all(
-        installed_config
-            .parent()
-            .ok_or("missing installed parent")?,
-    )?;
+    let legacy_config = root.path().join("installed/legacy-cursor.json");
+    let canonical_config = root.path().join("installed/canonical-cursor.json");
+    fs::create_dir_all(legacy_config.parent().ok_or("missing installed parent")?)?;
     installed_manager.link(link_input(
         McpServer {
             name: "BrowserClaw".to_string(),
             spec: legacy_spec.clone(),
         },
         AgentId::Cursor,
-        &installed_config,
+        &legacy_config,
     ))?;
     installed_manager.link(link_input(
         McpServer {
@@ -430,7 +427,7 @@ fn migration_converges_from_interrupted_install_and_cleanup_states()
             spec: canonical_spec.clone(),
         },
         AgentId::Cursor,
-        &installed_config,
+        &canonical_config,
     ))?;
     let canonical_before = installed_manager
         .list()?
@@ -445,7 +442,7 @@ fn migration_converges_from_interrupted_install_and_cleanup_states()
         },
         AgentId::Cursor,
     );
-    installed_migration.config_path = Some(installed_config.clone());
+    installed_migration.config_path = Some(legacy_config.clone());
     assert!(
         installed_manager
             .migrate_server(installed_migration)?
@@ -459,9 +456,16 @@ fn migration_converges_from_interrupted_install_and_cleanup_states()
         installed_servers[0].links[&AgentId::Cursor].created_at,
         canonical_before.links[&AgentId::Cursor].created_at
     );
-    let installed_raw = fs::read_to_string(installed_config)?;
-    assert!(installed_raw.contains("BrowserOS neo"));
-    assert!(!installed_raw.contains("BrowserClaw"));
+    assert_eq!(
+        installed_servers[0].links[&AgentId::Cursor].config_path,
+        canonical_config
+    );
+    let legacy_raw = fs::read_to_string(legacy_config)?;
+    assert!(!legacy_raw.contains("BrowserClaw"));
+    assert!(!legacy_raw.contains("BrowserOS neo"));
+    let canonical_raw = fs::read_to_string(canonical_config)?;
+    assert!(canonical_raw.contains("BrowserOS neo"));
+    assert!(!canonical_raw.contains("BrowserClaw"));
 
     let cleaned_workspace = root.path().join("cleaned-workspace");
     let cleaned_manager = McpManager::new(&cleaned_workspace);

--- a/packages/browseros-agent/crates/harness-integrations/tests/api.rs
+++ b/packages/browseros-agent/crates/harness-integrations/tests/api.rs
@@ -6,9 +6,10 @@ use std::{
 };
 
 use harness_integrations::{
-    AgentId, AgentScope, DisconnectInput, Error, LinkInput, ListLinksFilter, McpManager, McpServer,
-    McpServerSpec, UnlinkInput, detect_installed_agents, is_agent_supported, is_installed,
-    list_supported_agents, resolve_agent_surface, resolve_harness_definition,
+    AgentId, AgentScope, DisconnectInput, Error, InspectEntryInput, LinkInput, ListLinksFilter,
+    McpManager, McpServer, McpServerSpec, MigrateServerInput, UnlinkInput, detect_installed_agents,
+    is_agent_supported, is_installed, list_supported_agents, resolve_agent_surface,
+    resolve_harness_definition,
 };
 use serde_json::Value;
 use tempfile::tempdir;
@@ -224,6 +225,173 @@ fn rescan_reads_each_manifest_recorded_config_path() -> Result<(), Box<dyn std::
     );
     assert!(report.drifted.is_empty());
     assert!(report.missing.is_empty());
+    Ok(())
+}
+
+#[test]
+fn inspect_and_migrate_generated_entries_across_every_harness_shape()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = tempdir()?;
+    let manager = McpManager::new(root.path().join("workspace"));
+    let legacy_spec = McpServerSpec::Http {
+        url: "http://127.0.0.1:9100/mcp".to_string(),
+        headers: BTreeMap::new(),
+    };
+    let canonical_spec = McpServerSpec::Http {
+        url: "http://127.0.0.1:9200/mcp".to_string(),
+        headers: BTreeMap::new(),
+    };
+
+    for agent in AgentId::ALL {
+        let config = root.path().join(format!("configs/{agent}"));
+        fs::create_dir_all(config.parent().ok_or("missing config parent")?)?;
+        manager.link(link_input(
+            McpServer {
+                name: "BrowserClaw".to_string(),
+                spec: legacy_spec.clone(),
+            },
+            agent,
+            &config,
+        ))?;
+        let inspected = manager
+            .inspect_entry(InspectEntryInput::new("BrowserClaw", agent).at_path(&config))?
+            .ok_or("missing generated entry")?;
+        assert_eq!(inspected.spec, legacy_spec);
+
+        let mut input = MigrateServerInput::new(
+            "BrowserClaw",
+            McpServer {
+                name: "BrowserOS neo".to_string(),
+                spec: canonical_spec.clone(),
+            },
+            agent,
+        );
+        input.config_path = Some(config.clone());
+        let summary = manager.migrate_server(input)?;
+        assert!(summary.migrated, "{agent}");
+        assert!(
+            manager
+                .inspect_entry(InspectEntryInput::new("BrowserClaw", agent).at_path(&config))?
+                .is_none(),
+            "{agent}"
+        );
+        assert_eq!(
+            manager
+                .inspect_entry(InspectEntryInput::new("BrowserOS neo", agent).at_path(&config))?
+                .map(|entry| entry.spec),
+            Some(canonical_spec.clone()),
+            "{agent}"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn migration_scopes_foreign_authority_and_preserves_timestamps_and_formatting()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = tempdir()?;
+    let workspace = root.path().join("workspace");
+    let manager = McpManager::new(&workspace);
+    let config = root.path().join("custom/cursor.json");
+    fs::create_dir_all(config.parent().ok_or("missing config parent")?)?;
+    fs::write(
+        &config,
+        "{\n  // keep this\n  \"theme\": \"dark\",\n  \"mcpServers\": {}\n}\n",
+    )?;
+    let legacy_spec = McpServerSpec::Http {
+        url: "http://127.0.0.1:9100/mcp".to_string(),
+        headers: BTreeMap::new(),
+    };
+    manager.link(link_input(
+        McpServer {
+            name: "BrowserClaw".to_string(),
+            spec: legacy_spec.clone(),
+        },
+        AgentId::Cursor,
+        &config,
+    ))?;
+    let legacy = manager.list()?.remove(0);
+    let legacy_added_at = legacy.added_at;
+    let legacy_created_at = legacy.links[&AgentId::Cursor].created_at.clone();
+    let with_collision = fs::read_to_string(&config)?.replace(
+        "\"BrowserClaw\":",
+        "\"BrowserOS neo\": { \"command\": \"foreign\" },\n    \"BrowserClaw\":",
+    );
+    fs::write(&config, with_collision)?;
+
+    let mut migration = MigrateServerInput::new(
+        "BrowserClaw",
+        McpServer {
+            name: "BrowserOS neo".to_string(),
+            spec: McpServerSpec::Http {
+                url: "http://127.0.0.1:9200/mcp".to_string(),
+                headers: BTreeMap::new(),
+            },
+        },
+        AgentId::Cursor,
+    );
+    migration.config_path = Some(config.clone());
+    let summary = manager.migrate_server(migration.clone())?;
+    assert!(summary.migrated);
+    assert!(summary.overwrote_foreign);
+    let raw = fs::read_to_string(&config)?;
+    assert!(raw.contains("// keep this"));
+    assert!(raw.contains("\"theme\": \"dark\""));
+    assert!(!raw.contains("BrowserClaw"));
+    let canonical = manager.list()?.remove(0);
+    assert_eq!(canonical.name, "BrowserOS neo");
+    assert_eq!(canonical.added_at, legacy_added_at);
+    assert_eq!(
+        canonical.links[&AgentId::Cursor].created_at,
+        legacy_created_at
+    );
+    assert!(!manager.migrate_server(migration)?.migrated);
+
+    let foreign_workspace = root.path().join("foreign-workspace");
+    let foreign_manager = McpManager::new(&foreign_workspace);
+    let foreign_config = root.path().join("foreign/cursor.json");
+    fs::create_dir_all(foreign_config.parent().ok_or("missing foreign parent")?)?;
+    let foreign_raw = r#"{"mcpServers":{"BrowserClaw":{"command":"foreign"},"BrowserOS neo":{"command":"also-foreign"}},"keep":true}"#;
+    fs::write(&foreign_config, foreign_raw)?;
+    let mut unmatched = MigrateServerInput::new(
+        "BrowserClaw",
+        McpServer {
+            name: "BrowserOS neo".to_string(),
+            spec: legacy_spec.clone(),
+        },
+        AgentId::Cursor,
+    );
+    unmatched.config_path = Some(foreign_config.clone());
+    assert!(!foreign_manager.migrate_server(unmatched)?.migrated);
+    assert_eq!(fs::read_to_string(&foreign_config)?, foreign_raw);
+    assert!(!foreign_workspace.join("manifest.json").exists());
+
+    let exact_workspace = root.path().join("exact-workspace");
+    let exact_manager = McpManager::new(&exact_workspace);
+    let exact_config = root.path().join("exact/cursor.json");
+    fs::create_dir_all(exact_config.parent().ok_or("missing exact parent")?)?;
+    fs::write(
+        &exact_config,
+        r#"{"mcpServers":{"BrowserClaw":{"url":"http://127.0.0.1:9100/mcp","type":"http"}}}"#,
+    )?;
+    let observed = exact_manager
+        .inspect_entry(
+            InspectEntryInput::new("BrowserClaw", AgentId::Cursor).at_path(&exact_config),
+        )?
+        .ok_or("missing exact source")?;
+    let mut exact = MigrateServerInput::new(
+        "BrowserClaw",
+        McpServer {
+            name: "BrowserOS neo".to_string(),
+            spec: legacy_spec,
+        },
+        AgentId::Cursor,
+    );
+    exact.config_path = Some(exact_config.clone());
+    exact.unmanaged_source_spec = Some(observed.spec);
+    assert!(exact_manager.migrate_server(exact)?.migrated);
+    assert!(fs::read_to_string(exact_config)?.contains("BrowserOS neo"));
     Ok(())
 }
 

--- a/packages/browseros-agent/crates/harness-integrations/tests/api.rs
+++ b/packages/browseros-agent/crates/harness-integrations/tests/api.rs
@@ -396,6 +396,106 @@ fn migration_scopes_foreign_authority_and_preserves_timestamps_and_formatting()
 }
 
 #[test]
+fn migration_converges_from_interrupted_install_and_cleanup_states()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = tempdir()?;
+    let legacy_spec = McpServerSpec::Http {
+        url: "http://127.0.0.1:9100/mcp".to_string(),
+        headers: BTreeMap::new(),
+    };
+    let canonical_spec = McpServerSpec::Http {
+        url: "http://127.0.0.1:9200/mcp".to_string(),
+        headers: BTreeMap::new(),
+    };
+
+    let installed_workspace = root.path().join("installed-workspace");
+    let installed_manager = McpManager::new(&installed_workspace);
+    let installed_config = root.path().join("installed/cursor.json");
+    fs::create_dir_all(
+        installed_config
+            .parent()
+            .ok_or("missing installed parent")?,
+    )?;
+    installed_manager.link(link_input(
+        McpServer {
+            name: "BrowserClaw".to_string(),
+            spec: legacy_spec.clone(),
+        },
+        AgentId::Cursor,
+        &installed_config,
+    ))?;
+    installed_manager.link(link_input(
+        McpServer {
+            name: "BrowserOS neo".to_string(),
+            spec: canonical_spec.clone(),
+        },
+        AgentId::Cursor,
+        &installed_config,
+    ))?;
+    let canonical_before = installed_manager
+        .list()?
+        .into_iter()
+        .find(|server| server.name == "BrowserOS neo")
+        .ok_or("missing canonical manifest entry")?;
+    let mut installed_migration = MigrateServerInput::new(
+        "BrowserClaw",
+        McpServer {
+            name: "BrowserOS neo".to_string(),
+            spec: canonical_spec.clone(),
+        },
+        AgentId::Cursor,
+    );
+    installed_migration.config_path = Some(installed_config.clone());
+    assert!(
+        installed_manager
+            .migrate_server(installed_migration)?
+            .migrated
+    );
+    let installed_servers = installed_manager.list()?;
+    assert_eq!(installed_servers.len(), 1);
+    assert_eq!(installed_servers[0].name, "BrowserOS neo");
+    assert_eq!(installed_servers[0].added_at, canonical_before.added_at);
+    assert_eq!(
+        installed_servers[0].links[&AgentId::Cursor].created_at,
+        canonical_before.links[&AgentId::Cursor].created_at
+    );
+    let installed_raw = fs::read_to_string(installed_config)?;
+    assert!(installed_raw.contains("BrowserOS neo"));
+    assert!(!installed_raw.contains("BrowserClaw"));
+
+    let cleaned_workspace = root.path().join("cleaned-workspace");
+    let cleaned_manager = McpManager::new(&cleaned_workspace);
+    let cleaned_config = root.path().join("cleaned/cursor.json");
+    fs::create_dir_all(cleaned_config.parent().ok_or("missing cleaned parent")?)?;
+    cleaned_manager.link(link_input(
+        McpServer {
+            name: "BrowserClaw".to_string(),
+            spec: legacy_spec,
+        },
+        AgentId::Cursor,
+        &cleaned_config,
+    ))?;
+    fs::write(&cleaned_config, r#"{"mcpServers":{}}"#)?;
+    let mut cleaned_migration = MigrateServerInput::new(
+        "BrowserClaw",
+        McpServer {
+            name: "BrowserOS neo".to_string(),
+            spec: canonical_spec,
+        },
+        AgentId::Cursor,
+    );
+    cleaned_migration.config_path = Some(cleaned_config.clone());
+    assert!(cleaned_manager.migrate_server(cleaned_migration)?.migrated);
+    let cleaned_servers = cleaned_manager.list()?;
+    assert_eq!(cleaned_servers.len(), 1);
+    assert_eq!(cleaned_servers[0].name, "BrowserOS neo");
+    let cleaned_raw = fs::read_to_string(cleaned_config)?;
+    assert!(cleaned_raw.contains("BrowserOS neo"));
+    assert!(!cleaned_raw.contains("BrowserClaw"));
+    Ok(())
+}
+
+#[test]
 fn install_gate_and_project_scope_return_typed_errors() -> Result<(), Box<dyn std::error::Error>> {
     let root = tempdir()?;
     let manager = McpManager::new(root.path().join("workspace"));

--- a/packages/browseros-agent/packages/shared/src/constants/browserclaw.test.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/browserclaw.test.ts
@@ -23,7 +23,7 @@ describe('BrowserClaw runtime constants', () => {
 
   test('preserves the canonical MCP identity and loopback URL', () => {
     expect(MCP_PATH).toBe('/mcp')
-    expect(BROWSEROS_MCP_SERVER_NAME).toBe('BrowserClaw')
+    expect(BROWSEROS_MCP_SERVER_NAME).toBe('BrowserOS neo')
     expect(canonicalMcpUrlForPort()).toBe('http://127.0.0.1:9200/mcp')
     expect(canonicalMcpUrlForPort(9100)).toBe('http://127.0.0.1:9100/mcp')
   })

--- a/packages/browseros-agent/packages/shared/src/constants/urls.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/urls.ts
@@ -9,7 +9,7 @@
 import { CLAW_API_PORT_DEFAULT } from './ports'
 
 export const MCP_PATH = '/mcp'
-export const BROWSEROS_MCP_SERVER_NAME = 'BrowserClaw'
+export const BROWSEROS_MCP_SERVER_NAME = 'BrowserOS neo'
 
 export function canonicalMcpUrlForPort(port = CLAW_API_PORT_DEFAULT): string {
   return `http://127.0.0.1:${port}${MCP_PATH}`


### PR DESCRIPTION
## Summary

- make `BrowserOS neo` the canonical MCP connection key while retaining `BrowserClaw` as a hidden compatibility alias
- add a narrowly scoped, two-phase migration that recognizes BrowserOS-generated legacy specs, adopts eligible destination collisions, and converges after partial writes
- run the migration per harness before first-run and existing boot reconciliation, preserving custom paths, formatting, comments, timestamps, and manual disconnect choices
- update shared UI constants, generated Claude CLI commands, integration coverage, and user documentation

## Design

The generic harness manager now supports exact semantic entry inspection and install/verify/cleanup migration planning across all seven JSON, JSONC, and TOML config shapes. Product orchestration grants broader migration authority only when a legacy entry is manifest-owned or exactly matches BrowserOS's historical generated HTTP/stdio shape. Each harness migrates independently: the canonical entry and manifest ownership are persisted and reread before legacy config or manifest state is removed, so failed or interrupted runs retain a working entry and retry on the next boot.

Runtime listing and skill reconciliation collapse the two names into one logical connection, prefer the canonical entry, and continue recognizing a matching config-only legacy alias. Disconnect clears both managed names without emitting migration connect/disconnect analytics.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bun run check` (exit 0; existing Biome/Fallow diagnostics remain)
- [x] focused shared/app/onboarding MCP tests (13 passed)
- [x] `bun test` from `apps/claw-onboard` (87 passed)
- [ ] monorepo-root `bun run test` launches four existing claw-onboard UI tests from the wrong cwd, so their `@/components/ui/*` aliases do not resolve; the complete claw-onboard package suite passes from its package cwd
