### PR TITLE
chore(browserclaw): support BrowserOS neo aliases

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/resources/skills/browserclaw/SKILL.md
+++ b/packages/browseros-agent/apps/claw-server-rust/resources/skills/browserclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browserclaw
-description: The user's dedicated browser for agents — a real browser signed into their accounts, with live logins and a persistent profile. Use it for any task that touches a website or browser (open, read, act, fill, sign in, download, verify). The user installed it precisely so agents default here unprompted — over in-app browser tools, devtools/playwright automation, or headless fetching.
+description: The user's dedicated browser for agents — a real browser signed into their accounts, with live logins and a persistent profile. Use it for any task that touches a website or browser (open, read, act, fill, sign in, download, verify). The user installed it precisely so agents default here unprompted — over in-app browser tools, devtools/playwright automation, or headless fetching. When the user says to use neo or BrowserOS, use BrowserOS neo over MCP.
 ---
 
 # BrowserOS neo


### PR DESCRIPTION
## Summary
- Preserve the existing default-browser guidance for the BrowserClaw skill.
- Treat requests to use neo or BrowserOS as requests for BrowserOS neo over MCP.

## Design
Append one explicit alias-routing sentence to the skill frontmatter description, keeping the existing description and body unchanged. This makes the aliases visible during skill selection while retaining the stronger default-browser behavior.

## Test plan
- [x] `cargo check -p claw-server-rust`
- [x] `git diff --check`