### PR TITLE
fix(ci): use uv to provide boto3 in the claw server release

### DIFF
--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -344,8 +344,7 @@ jobs:
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
         run: |
           set -euo pipefail
-          "$PYTHON_BIN" -m pip install --user boto3
-          "$PYTHON_BIN" <<'PY'
+          uv run --no-project --with boto3 python <<'PY'
           import hashlib
           import os
           from pathlib import Path


### PR DESCRIPTION
Fixes #2104

## Problem

`Release: BrowserOS neo (full)` fails on both macOS matrix legs. Run [`30975212125`](https://github.com/browseros-ai/BrowserOS/actions/runs/30975212125) (2026-08-05), jobs `darwin-x64` (`92211393146`) and `darwin-arm64` (`92211393165`), both die in `Recover existing immutable target`:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to install.
##[error]Process completed with exit code 1.
```

`Setup Python` sets `PYTHON_BIN=python3` on every non-Windows runner. On the `macos-14` image that is Homebrew's Python, which is PEP 668 externally managed, so `pip install --user boto3` is refused. The `linux-x64` and `windows-x64` legs of the same matrix pass — this is macOS-only, and it reproduced on two independent runners, so it is deterministic rather than a flake.

The step was introduced in 211f94932 (#2096).

Because the release never completes, `release/publish.py` never writes the `download/BrowserOS_neo*` aliases that `release/common.py` derives from `artifact_prefix`. `https://cdn.browseros.com/download/BrowserOS_neo.dmg` and `.../BrowserOS_neo_installer.exe` both return 404 today, and those are the two URLs the README download badges point at.

## Fix

`astral-sh/setup-uv` already runs two steps earlier, and this file already invokes Python through `uv` further down. Doing the same here keeps the system interpreter untouched and behaves identically on macOS, Linux and Windows:

```diff
           set -euo pipefail
-          "$PYTHON_BIN" -m pip install --user boto3
-          "$PYTHON_BIN" <<'PY'
+          uv run --no-project --with boto3 python <<'PY'
```

`--no-project` keeps `uv` from trying to resolve a surrounding project for what is a standalone script.

## Scope

One line, one step. `PYTHON_BIN` and the `Setup Python` step stay as they are — the later `"$PYTHON_BIN"` blocks in this job (`Stamp release version`, `Build Rust binary`, `Package artifact zip`) import only stdlib modules, so dropping the `--user` install has no downstream effect. `boto3` was needed by this step alone.

## Not addressed here

The same `pip install --user` pattern appears at two more places in this file — `Install R2 client` (`boto3`) and `Install AWS CLI` (`awscli`). Both are on `ubuntu-latest`, so they aren't failing today, but they carry the same latent risk on a future runner image bump. Left out to keep this change minimal; happy to fold them in if you'd prefer.

## Testing

Not verified locally — the failure is specific to the macOS runner image and I don't have one. The change is confined to how a single step obtains `boto3`; the Python script it feeds is byte-for-byte unchanged.
