### PR TITLE
fix(claw-app): finish BrowserOS neo UI branding

### DIFF
--- a/packages/browseros-agent/apps/claw-app/wxt.config.ts
+++ b/packages/browseros-agent/apps/claw-app/wxt.config.ts
@@ -12,12 +12,11 @@ export default defineConfig({
   modules: ['@wxt-dev/module-react'],
   manifest: {
     name: 'BrowserOS neo',
+    description: 'BrowserOS neo — the browser for AI agents.',
     key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyXbY2XVCs1/yJqGd53ei1rHdoUGIvZ8uq+x9YKmUc+jnb6NogIrq0USPeRNb6uzszio45GR8BW0O0pgbFKmhlhrCwgs9gEW8mufksE29E1g8Q2ug1sowzj38X6jmitO4I9cBbQMx7+gJZJS8pS5DZ+V7Bl8Uka2LWHMTP/Pf10YjbeNNCA0wj6kQkkTb8lg80r5Vm+gFqyo2xDFaxj8lN2kE73yFBjCt6B4ycntXvnnUTPX4IJqH+eQuwsFWPuqdYEwdvaaIOQ+lCxcYyZusX58zhxr0pkMxQjnEoJqAk6Av5O/JiNIOZYzbwUjm6aA+p9j9/6xzvmG+Lvp74Dk9pwIDAQAB',
     update_url: 'https://cdn.browseros.com/extensions/update-manifest.xml',
-    // update_url: 'https://cdn.browseros.com/extensions/update-manifest.alpha.xml',
-    // Mirrors apps/app/wxt.config.ts permissions (keep in sync — adding
-    // permissions later re-prompts/disables existing installs on update),
-    // followed by claw-specific extras.
+    // Keep shared permissions in sync with apps/app/wxt.config.ts; additions
+    // re-prompt or disable existing installs on update.
     permissions: [
       'topSites',
       'storage',


### PR DESCRIPTION
## Summary
- replace the old BrowserClaw description exposed by the generated claw extension manifest with BrowserOS neo copy
- keep internal BrowserClaw package, API, path, and protocol identifiers unchanged
- confirm the standalone onboarding build emits no old BrowserClaw UI text

## Design
WXT falls back to `package.json` for manifest descriptions, which leaked an internal BrowserClaw package description into Chrome's extension UI. The extension now sets an explicit user-facing manifest description at the existing branding boundary while preserving internal names.

## Test plan
- [x] `bun run --filter @browseros/claw-app lint`
- [x] `bun run --filter @browseros/claw-app typecheck`
- [x] `bun run --filter @browseros/claw-app test`
- [x] `bun run --filter @browseros/claw-app build`
- [x] assert the generated manifest contains the BrowserOS neo name/description and no `BrowserClaw`
- [x] `bun run --filter @browseros/claw-onboard lint`
- [x] `bun run --filter @browseros/claw-onboard typecheck`
- [x] `bun run --filter @browseros/claw-onboard build`
- [x] assert the onboarding production artifact contains no `BrowserClaw`/`Browserclaw`
