### PR TITLE
fix(release): isolate Rust server publish Python

### DIFF
--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -629,15 +629,19 @@ jobs:
           path: dist/claw-server-rust
           merge-multiple: true
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
       - name: Install R2 client
-        run: python3 -m pip install --user boto3
+        run: python -m pip install "boto3>=1.35.1,<2"
 
       - name: Upload immutable Rust server resources
         env:
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
         run: |
           set -euo pipefail
-          python3 <<'PY'
+          python <<'PY'
           import hashlib
           import os
           from pathlib import Path
@@ -772,10 +776,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.prepare.outputs.release_sha }}
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
       - name: Install AWS CLI
-        run: |
-          python3 -m pip install --user awscli
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        run: python -m pip install awscli
 
       - name: Verify prepared release
         env:

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -79,6 +79,9 @@ describe('release-claw-server-rust workflow', () => {
 
   it('uploads only immutable version keys and attaches all draft assets', () => {
     const publish = section('  publish-versioned:', '  finalize:')
+    expect(publish).toContain('actions/setup-python@v6')
+    expect(publish).toContain('python -m pip install "boto3>=1.35.1,<2"')
+    expect(publish).not.toContain('pip install --user')
     expect(publish).toContain('Expected 5 Rust server resource zips')
     expect(publish).toContain('IfNoneMatch')
     expect(publish).toContain('status not in {409, 412}')
@@ -111,6 +114,9 @@ describe('release-claw-server-rust workflow', () => {
 
   it('moves every latest alias before publishing during finalization', () => {
     const finalize = section('  finalize:', '  publish-ota:')
+    expect(finalize).toContain('actions/setup-python@v6')
+    expect(finalize).toContain('python -m pip install awscli')
+    expect(finalize).not.toContain('pip install --user')
     expect(finalize).toContain('Expected 5 draft assets')
     expect(finalize).toContain(
       '--arg component "claw-server-rust/prod-resources"',


### PR DESCRIPTION
## Summary

- use actions/setup-python for Rust server R2 publication and finalization
- require a Boto3 release whose S3 model supports conditional PutObject
- prevent runner system Python packages from shadowing installed release dependencies

## Verification

- actionlint .github/workflows/release-claw-server-rust.yml
- bun test packages/browseros-agent/scripts/release (65 pass)

Fixes the publication failure in run 31043344099.