### PR TITLE
fix(release): bind draft upload repository

### DIFF
--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -739,6 +739,7 @@ jobs:
 
       - name: Attach zips to private draft
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -79,6 +79,10 @@ describe('release-claw-server-rust workflow', () => {
 
   it('uploads only immutable version keys and attaches all draft assets', () => {
     const publish = section('  publish-versioned:', '  finalize:')
+    const attach = section(
+      '      - name: Attach zips to private draft',
+      '  finalize:',
+    )
     expect(publish).toContain('actions/setup-python@v6')
     expect(publish).toContain('python -m pip install "boto3>=1.35.1,<2"')
     expect(publish).not.toContain('pip install --user')
@@ -96,6 +100,7 @@ describe('release-claw-server-rust workflow', () => {
     expect(publish).toContain(
       `gh release upload "$RELEASE_TAG" "${dollar}{assets[@]}" --clobber`,
     )
+    expect(attach).toContain(`GH_REPO: ${dollar}{{ github.repository }}`)
   })
 
   it('recovers completed targets before rebuilding missing targets', () => {


### PR DESCRIPTION
## Summary

- Give the asset-upload step an explicit GitHub repository context when it runs without a checkout.
- Assert that the Rust server release workflow keeps that context.
- Preserve the existing `0.0.24` release source binding and immutable R2 objects.

## Design

The terminal retry proved the managed Python correction works: `Upload immutable Rust server resources` passed. The next step failed because `gh release` could not infer a repository without a checkout. Setting `GH_REPO` on that step is the smallest durable correction and covers its view, create, and upload commands.

## Test plan

- [x] `actionlint .github/workflows/release-claw-server-rust.yml`
- [x] `bun test packages/browseros-agent/scripts/release`
- [x] Run `gh release view` outside a Git worktree with `GH_REPO=browseros-ai/BrowserOS`
