### PR TITLE
fix(release): preserve draft source fallback

### DIFF
--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -749,7 +749,11 @@ jobs:
             exit 1
           fi
           if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release create "$RELEASE_TAG" --verify-tag --draft --generate-notes --title "BrowserClaw Server - v$VERSION"
+            gh release create "$RELEASE_TAG" \
+              --draft \
+              --target "$RELEASE_SHA" \
+              --generate-notes \
+              --title "BrowserClaw Server - v$VERSION"
           fi
           gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
 

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -101,6 +101,8 @@ describe('release-claw-server-rust workflow', () => {
       `gh release upload "$RELEASE_TAG" "${dollar}{assets[@]}" --clobber`,
     )
     expect(attach).toContain(`GH_REPO: ${dollar}{{ github.repository }}`)
+    expect(attach).toContain('--target "$RELEASE_SHA"')
+    expect(attach).not.toContain('--verify-tag')
   })
 
   it('recovers completed targets before rebuilding missing targets', () => {


### PR DESCRIPTION
## Summary

- Remove the premature tag-existence requirement from the draft fallback.
- Bind fallback drafts to the resolved release source SHA.
- Assert that the fallback preserves the release lifecycle.

## Design

Run `31046662187` proved the checkout-free repository context fix works, then failed because the fallback passed `--verify-tag` before finalization creates the annotated tag. The fallback now mirrors the prepare job: it creates a private draft against `RELEASE_SHA`; finalization remains the only phase that creates the tag.

## Test plan

- [x] `actionlint .github/workflows/release-claw-server-rust.yml`
- [x] `bun test packages/browseros-agent/scripts/release`
- [x] Restore and verify the private `0.0.24` draft target as `07eeafb4f1d1bac52d06ffb4b615595f7325b161`
