### PR TITLE
fix(release): allow server version reflection

### DIFF
--- a/.github/workflows/release-browserclaw.yml
+++ b/.github/workflows/release-browserclaw.yml
@@ -205,6 +205,7 @@ jobs:
     uses: ./.github/workflows/release-claw-server-rust.yml
     permissions:
       contents: write
+      pull-requests: write
     with:
       mode: build
       defer_finalize: true

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -765,6 +765,11 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
                 self.assertIn("unexpectedly ran", gate["run"])
                 self.assertIn("source mismatch", gate["run"])
 
+    def test_rust_server_calls_allow_version_reflection(self):
+        jobs = self.load_workflow("release-browserclaw.yml")["jobs"]
+        for job_name in ("build_server", "finalize_server"):
+            self.assertEqual(jobs[job_name]["permissions"]["pull-requests"], "write")
+
     def test_every_browser_call_receives_every_resource_plan_pin(self):
         all_pins = {
             "browseros_server_version",


### PR DESCRIPTION
The full BrowserOS neo workflow is rejected at startup because the Rust reusable workflow requests pull-request write access for version reflection, while its build caller grants none.

This grants the same permission already present on the finalize caller and adds a regression assertion for both calls.

Verification:
- actionlint on both workflows
- focused release-integrity tests

Unblocks failed run 31048671234.