### PR TITLE
feat(release): publish standalone server alpha feeds

### DIFF
--- a/.github/workflows/publish-server-ota.yml
+++ b/.github/workflows/publish-server-ota.yml
@@ -1,0 +1,264 @@
+name: Publish server alpha OTA
+
+on:
+  workflow_call:
+    inputs:
+      product:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      release_sha:
+        required: true
+        type: string
+      snapshot_path:
+        required: true
+        type: string
+    secrets:
+      R2_ACCOUNT_ID:
+        required: true
+      R2_ACCESS_KEY_ID:
+        required: true
+      R2_SECRET_ACCESS_KEY:
+        required: true
+      R2_BUCKET:
+        required: true
+      SPARKLE_PRIVATE_KEY:
+        required: true
+      MACOS_CERTIFICATE_P12:
+        required: true
+      MACOS_CERTIFICATE_PWD:
+        required: true
+      MACOS_CERTIFICATE_NAME:
+        required: true
+      MACOS_KEYCHAIN_PASSWORD:
+        required: true
+      PROD_MACOS_NOTARIZATION_APPLE_ID:
+        required: true
+      PROD_MACOS_NOTARIZATION_TEAM_ID:
+        required: true
+      PROD_MACOS_NOTARIZATION_PWD:
+        required: true
+      ESIGNER_USERNAME:
+        required: true
+      ESIGNER_PASSWORD:
+        required: true
+      ESIGNER_TOTP_SECRET:
+        required: true
+      ESIGNER_CREDENTIAL_ID:
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate product snapshot ownership
+        env:
+          PRODUCT: ${{ inputs.product }}
+          SNAPSHOT_PATH: ${{ inputs.snapshot_path }}
+        run: |
+          set -euo pipefail
+          case "$PRODUCT:$SNAPSHOT_PATH" in
+            browseros:updates/server/appcast-server.alpha.xml) ;;
+            browserclaw:updates/server/appcast-claw-server.alpha.xml) ;;
+            *)
+              echo "::error::Invalid product snapshot ownership"
+              exit 1
+              ;;
+          esac
+
+  build-payloads:
+    needs: validate
+    name: Sign OTA / ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: darwin_arm64
+            target: darwin-arm64
+            runner: macos-14
+          - platform: darwin_x64
+            target: darwin-x64
+            runner: macos-14
+          - platform: linux_arm64
+            target: linux-arm64
+            runner: ubuntu-latest
+          - platform: linux_x64
+            target: linux-x64
+            runner: ubuntu-latest
+          - platform: windows_x64
+            target: windows-x64
+            runner: windows-latest
+    env:
+      ESIGNER_CREDENTIAL_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
+      ESIGNER_PASSWORD: ${{ secrets.ESIGNER_PASSWORD }}
+      ESIGNER_TOTP_SECRET: ${{ secrets.ESIGNER_TOTP_SECRET }}
+      ESIGNER_USERNAME: ${{ secrets.ESIGNER_USERNAME }}
+      MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      PLATFORM: ${{ matrix.platform }}
+      PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+      PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+      PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+      PRODUCT: ${{ inputs.product }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      SNAPSHOT_PATH: ${{ inputs.snapshot_path }}
+      SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_sha }}
+
+      - name: Preflight signing credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          required=(R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_BUCKET SPARKLE_PRIVATE_KEY)
+          case "$RUNNER_OS" in
+            macOS)
+              required+=(MACOS_CERTIFICATE_NAME MACOS_KEYCHAIN_PASSWORD PROD_MACOS_NOTARIZATION_APPLE_ID PROD_MACOS_NOTARIZATION_TEAM_ID PROD_MACOS_NOTARIZATION_PWD)
+              ;;
+            Windows)
+              required+=(ESIGNER_USERNAME ESIGNER_PASSWORD ESIGNER_TOTP_SECRET)
+              ;;
+          esac
+          missing=()
+          for name in "${required[@]}"; do
+            if [ -z "${!name:-}" ]; then missing+=("$name"); fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required secret(s): ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.3.2
+
+      - name: Import macOS signing certificate
+        if: runner.os == 'macOS'
+        env:
+          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${MACOS_CERTIFICATE_P12:-}" ] || missing+=(MACOS_CERTIFICATE_P12)
+          [ -n "${MACOS_CERTIFICATE_PWD:-}" ] || missing+=(MACOS_CERTIFICATE_PWD)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required secret(s): ${missing[*]}"
+            exit 1
+          fi
+          cert_path="$RUNNER_TEMP/browseros-signing-cert.p12"
+          keychain_path="$RUNNER_TEMP/browseros-ci-signing.keychain-db"
+          printf '%s' "$MACOS_CERTIFICATE_P12" | base64 --decode > "$cert_path"
+          security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$keychain_path"
+          security import "$cert_path" -P "$MACOS_CERTIFICATE_PWD" -A -t cert -f pkcs12 -k "$keychain_path"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_KEYCHAIN_PASSWORD" "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+          security default-keychain -d user -s "$keychain_path"
+
+      - name: Install SSL.com CodeSignTool
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $uri = 'https://github.com/SSLcom/CodeSignTool/releases/download/v1.3.2/CodeSignTool-v1.3.2-windows.zip'
+          $zipPath = Join-Path $env:RUNNER_TEMP 'CodeSignTool-v1.3.2-windows.zip'
+          $extractRoot = Join-Path $env:RUNNER_TEMP 'CodeSignTool-v1.3.2-windows'
+          Invoke-WebRequest -Uri $uri -OutFile $zipPath
+          Expand-Archive -Path $zipPath -DestinationPath $extractRoot -Force
+          $tool = Get-ChildItem -Path $extractRoot -Filter CodeSignTool.bat -Recurse | Select-Object -First 1
+          if (-not $tool) {
+            throw "CodeSignTool.bat was not found after extracting $zipPath"
+          }
+          "CODE_SIGN_TOOL_PATH=$($tool.Directory.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Sign and upload platform OTA payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros browseros ota server release \
+            --version "$VERSION" \
+            --channel alpha \
+            --product "$PRODUCT" \
+            --platform "$PLATFORM"
+
+      - name: Upload platform appcast fragment
+        uses: actions/upload-artifact@v7
+        with:
+          name: server-ota-fragment-${{ matrix.target }}
+          path: ${{ inputs.snapshot_path }}
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs:
+      - validate
+      - build-payloads
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PRODUCT: ${{ inputs.product }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      SNAPSHOT_PATH: ${{ inputs.snapshot_path }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.release_sha }}
+
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: server-ota-fragment-*
+          path: server-ota-fragments
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.3.2
+
+      - name: Assemble and publish live alpha appcast
+        run: |
+          set -euo pipefail
+          snapshot_name="$(basename "$SNAPSHOT_PATH")"
+          fragments=()
+          for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64 windows-x64; do
+            platform="${target//-/_}"
+            fragment="server-ota-fragments/server-ota-fragment-${target}/${snapshot_name}"
+            if [ ! -f "$fragment" ]; then
+              echo "::error::Missing OTA fragment for $target"
+              exit 1
+            fi
+            fragments+=(--fragment "$platform=$fragment")
+          done
+          uv run --project packages/browseros browseros ota server assemble-appcast \
+            --version "$VERSION" \
+            --channel alpha \
+            --product "$PRODUCT" \
+            "${fragments[@]}"
+          uv run --project packages/browseros browseros ota server release-appcast --channel alpha --product "$PRODUCT" --publish
+
+      - name: Persist alpha appcast snapshot
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+        run: |
+          set -euo pipefail
+          packages/browseros-agent/scripts/release/commit-update-snapshot.sh \
+            "$SNAPSHOT_PATH" \
+            "$DEFAULT_BRANCH" \
+            "chore(release): snapshot ${PRODUCT} server alpha v${VERSION}"

--- a/.github/workflows/publish-server-ota.yml
+++ b/.github/workflows/publish-server-ota.yml
@@ -96,24 +96,10 @@ jobs:
             target: windows-x64
             runner: windows-latest
     env:
-      ESIGNER_CREDENTIAL_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
-      ESIGNER_PASSWORD: ${{ secrets.ESIGNER_PASSWORD }}
-      ESIGNER_TOTP_SECRET: ${{ secrets.ESIGNER_TOTP_SECRET }}
-      ESIGNER_USERNAME: ${{ secrets.ESIGNER_USERNAME }}
-      MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
-      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
       PLATFORM: ${{ matrix.platform }}
-      PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
-      PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
-      PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
       PRODUCT: ${{ inputs.product }}
-      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-      R2_BUCKET: ${{ secrets.R2_BUCKET }}
-      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       RELEASE_SHA: ${{ inputs.release_sha }}
       SNAPSHOT_PATH: ${{ inputs.snapshot_path }}
-      SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
       VERSION: ${{ inputs.version }}
     steps:
       - uses: actions/checkout@v7
@@ -121,19 +107,56 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.release_sha }}
 
-      - name: Preflight signing credentials
+      - name: Preflight storage and payload signing credentials
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         shell: bash
         run: |
           set -euo pipefail
           required=(R2_ACCOUNT_ID R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY R2_BUCKET SPARKLE_PRIVATE_KEY)
-          case "$RUNNER_OS" in
-            macOS)
-              required+=(MACOS_CERTIFICATE_NAME MACOS_KEYCHAIN_PASSWORD PROD_MACOS_NOTARIZATION_APPLE_ID PROD_MACOS_NOTARIZATION_TEAM_ID PROD_MACOS_NOTARIZATION_PWD)
-              ;;
-            Windows)
-              required+=(ESIGNER_USERNAME ESIGNER_PASSWORD ESIGNER_TOTP_SECRET)
-              ;;
-          esac
+          missing=()
+          for name in "${required[@]}"; do
+            if [ -z "${!name:-}" ]; then missing+=("$name"); fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required secret(s): ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Preflight macOS signing credentials
+        if: runner.os == 'macOS'
+        env:
+          MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+          PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+          PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+          PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          required=(MACOS_CERTIFICATE_NAME MACOS_KEYCHAIN_PASSWORD PROD_MACOS_NOTARIZATION_APPLE_ID PROD_MACOS_NOTARIZATION_TEAM_ID PROD_MACOS_NOTARIZATION_PWD)
+          missing=()
+          for name in "${required[@]}"; do
+            if [ -z "${!name:-}" ]; then missing+=("$name"); fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required secret(s): ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Preflight Windows signing credentials
+        if: runner.os == 'Windows'
+        env:
+          ESIGNER_PASSWORD: ${{ secrets.ESIGNER_PASSWORD }}
+          ESIGNER_TOTP_SECRET: ${{ secrets.ESIGNER_TOTP_SECRET }}
+          ESIGNER_USERNAME: ${{ secrets.ESIGNER_USERNAME }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          required=(ESIGNER_USERNAME ESIGNER_PASSWORD ESIGNER_TOTP_SECRET)
           missing=()
           for name in "${required[@]}"; do
             if [ -z "${!name:-}" ]; then missing+=("$name"); fi
@@ -151,6 +174,7 @@ jobs:
         env:
           MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
           missing=()
@@ -187,7 +211,59 @@ jobs:
           }
           "CODE_SIGN_TOOL_PATH=$($tool.Directory.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
-      - name: Sign and upload platform OTA payload
+      - name: Sign and upload macOS OTA payload
+        if: runner.os == 'macOS'
+        env:
+          MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+          PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+          PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+          PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros browseros ota server release \
+            --version "$VERSION" \
+            --release-sha "$RELEASE_SHA" \
+            --channel alpha \
+            --product "$PRODUCT" \
+            --platform "$PLATFORM"
+
+      - name: Sign and upload Windows OTA payload
+        if: runner.os == 'Windows'
+        env:
+          ESIGNER_CREDENTIAL_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
+          ESIGNER_PASSWORD: ${{ secrets.ESIGNER_PASSWORD }}
+          ESIGNER_TOTP_SECRET: ${{ secrets.ESIGNER_TOTP_SECRET }}
+          ESIGNER_USERNAME: ${{ secrets.ESIGNER_USERNAME }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros browseros ota server release \
+            --version "$VERSION" \
+            --release-sha "$RELEASE_SHA" \
+            --channel alpha \
+            --product "$PRODUCT" \
+            --platform "$PLATFORM"
+
+      - name: Upload Linux OTA payload
+        if: runner.os == 'Linux'
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -214,10 +290,6 @@ jobs:
     timeout-minutes: 20
     env:
       PRODUCT: ${{ inputs.product }}
-      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-      R2_BUCKET: ${{ secrets.R2_BUCKET }}
-      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       SNAPSHOT_PATH: ${{ inputs.snapshot_path }}
       VERSION: ${{ inputs.version }}
     steps:
@@ -235,6 +307,11 @@ jobs:
         uses: astral-sh/setup-uv@v8.3.2
 
       - name: Assemble and publish live alpha appcast
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
           set -euo pipefail
           snapshot_name="$(basename "$SNAPSHOT_PATH")"

--- a/.github/workflows/publish-server-ota.yml
+++ b/.github/workflows/publish-server-ota.yml
@@ -111,6 +111,7 @@ jobs:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      RELEASE_SHA: ${{ inputs.release_sha }}
       SNAPSHOT_PATH: ${{ inputs.snapshot_path }}
       SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
       VERSION: ${{ inputs.version }}
@@ -192,6 +193,7 @@ jobs:
           set -euo pipefail
           uv run --project packages/browseros browseros ota server release \
             --version "$VERSION" \
+            --release-sha "$RELEASE_SHA" \
             --channel alpha \
             --product "$PRODUCT" \
             --platform "$PLATFORM"

--- a/.github/workflows/release-browserclaw.yml
+++ b/.github/workflows/release-browserclaw.yml
@@ -202,7 +202,7 @@ jobs:
     name: Prepare BrowserClaw server resources
     needs: preflight
     if: ${{ inputs.include_servers }}
-    uses: ./.github/workflows/release-claw-server-rust.yml
+    uses: ./.github/workflows/release-claw-server.yml
     permissions:
       contents: write
       pull-requests: write
@@ -638,7 +638,7 @@ jobs:
     name: Finalize BrowserClaw server resources
     needs: [release_plan, browser_gate, stage_updates]
     if: ${{ always() && inputs.include_servers && needs.release_plan.result == 'success' && needs.browser_gate.result == 'success' && needs.stage_updates.result == 'success' }}
-    uses: ./.github/workflows/release-claw-server-rust.yml
+    uses: ./.github/workflows/release-claw-server.yml
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -17,10 +17,10 @@ on:
         type: string
         default: ""
       publish_ota:
-        description: "Publish alpha-channel BrowserClaw server OTA artifacts after finalization"
+        description: "Publish the live alpha-channel BrowserClaw server OTA release after finalization"
         required: false
         type: boolean
-        default: false
+        default: true
   workflow_call:
     inputs:
       mode:
@@ -44,7 +44,7 @@ on:
         type: string
         default: ""
       publish_ota:
-        description: "Publish alpha-channel BrowserClaw server OTA artifacts after finalization"
+        description: "Publish the live alpha-channel BrowserClaw server OTA release after finalization"
         required: false
         type: boolean
         default: false
@@ -893,7 +893,7 @@ jobs:
     needs:
       - prepare
       - finalize
-    if: ${{ needs.finalize.result == 'success' && inputs.publish_ota == true }}
+    if: ${{ needs.finalize.result == 'success' && github.event_name != 'push' && inputs.publish_ota == true }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -919,9 +919,22 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v8.3.2
 
-      - name: Publish alpha BrowserClaw server OTA artifacts
+      - name: Publish live alpha BrowserClaw server OTA release
         working-directory: packages/browseros
-        run: uv run browseros ota server release --version "$VERSION" --channel alpha --product browserclaw
+        run: |
+          set -euo pipefail
+          uv run browseros ota server release --version "$VERSION" --channel alpha --product browserclaw
+          uv run browseros ota server release-appcast --channel alpha --product browserclaw --publish
+
+      - name: Persist alpha BrowserClaw server appcast snapshot
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+        run: |
+          set -euo pipefail
+          packages/browseros-agent/scripts/release/commit-update-snapshot.sh \
+            updates/server/appcast-claw-server.alpha.xml \
+            "$DEFAULT_BRANCH" \
+            "chore(release): snapshot BrowserClaw server alpha v${VERSION}"
 
   reflect-version:
     needs:

--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -894,47 +894,15 @@ jobs:
       - prepare
       - finalize
     if: ${{ needs.finalize.result == 'success' && github.event_name != 'push' && inputs.publish_ota == true }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      VERSION: ${{ needs.prepare.outputs.version }}
-      SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      R2_BUCKET: ${{ secrets.R2_BUCKET }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.prepare.outputs.release_sha }}
-
-      - name: Preflight OTA signing key
-        run: |
-          if [ -z "${SPARKLE_PRIVATE_KEY:-}" ]; then
-            echo "::error::SPARKLE_PRIVATE_KEY is required when publish_ota is true"
-            exit 1
-          fi
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v8.3.2
-
-      - name: Publish live alpha BrowserClaw server OTA release
-        working-directory: packages/browseros
-        run: |
-          set -euo pipefail
-          uv run browseros ota server release --version "$VERSION" --channel alpha --product browserclaw
-          uv run browseros ota server release-appcast --channel alpha --product browserclaw --publish
-
-      - name: Persist alpha BrowserClaw server appcast snapshot
-        env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
-        run: |
-          set -euo pipefail
-          packages/browseros-agent/scripts/release/commit-update-snapshot.sh \
-            updates/server/appcast-claw-server.alpha.xml \
-            "$DEFAULT_BRANCH" \
-            "chore(release): snapshot BrowserClaw server alpha v${VERSION}"
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-server-ota.yml
+    with:
+      product: browserclaw
+      version: ${{ needs.prepare.outputs.version }}
+      release_sha: ${{ needs.prepare.outputs.release_sha }}
+      snapshot_path: updates/server/appcast-claw-server.alpha.xml
+    secrets: inherit
 
   reflect-version:
     needs:

--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -76,7 +76,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-claw-server-rust
+  group: release-claw-server
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -76,7 +76,8 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-claw-server
+  # The legacy key keeps in-flight revisions of the renamed workflow serialized.
+  group: release-claw-server-rust
   cancel-in-progress: false
 
 jobs:
@@ -238,7 +239,7 @@ jobs:
           rustc --version
           cargo --version
 
-      - name: Run Rust workspace tests
+      - name: Run server workspace tests
         working-directory: packages/browseros-agent
         run: cargo test --workspace --locked
 
@@ -446,7 +447,7 @@ jobs:
           lockfile.write_text(lock_text)
           PY
 
-      - name: Build Rust binary
+      - name: Build BrowserClaw server
         if: ${{ steps.recover.outputs.recovered != 'true' }}
         shell: bash
         working-directory: packages/browseros-agent
@@ -469,7 +470,7 @@ jobs:
           binary_path = Path("target") / os.environ["RUST_TARGET"] / "release" / binary_name
           project_key = os.environ["CLAW_POSTHOG_KEY"].encode()
           if project_key not in binary_path.read_bytes():
-              raise SystemExit("Compiled Rust server does not contain CLAW_POSTHOG_KEY")
+              raise SystemExit("Compiled BrowserClaw server does not contain CLAW_POSTHOG_KEY")
           PY
 
       - name: Verify stamped binary version
@@ -636,7 +637,7 @@ jobs:
       - name: Install R2 client
         run: python -m pip install "boto3>=1.35.1,<2"
 
-      - name: Upload immutable Rust server resources
+      - name: Upload immutable BrowserClaw server resources
         env:
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
         run: |
@@ -700,7 +701,7 @@ jobs:
           for target in targets:
               path = Path(f"dist/claw-server-rust/browseros-claw-server-rust-resources-{target}.zip")
               if not path.is_file():
-                  raise SystemExit(f"Missing Rust server resource zip: {path}")
+                  raise SystemExit(f"Missing BrowserClaw server resource zip: {path}")
               data = path.read_bytes()
               key = f"claw-server-rust/prod-resources/{version}/{path.name}"
               existing = canonical_bytes(key, target)
@@ -745,7 +746,7 @@ jobs:
           set -euo pipefail
           mapfile -t assets < <(find dist/claw-server-rust -maxdepth 1 -name 'browseros-claw-server-rust-resources-*.zip' | sort)
           if [ "${#assets[@]}" -ne 5 ]; then
-            echo "::error::Expected 5 Rust server resource zips, found ${#assets[@]}"
+            echo "::error::Expected 5 BrowserClaw server resource zips, found ${#assets[@]}"
             exit 1
           fi
           if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -17,10 +17,10 @@ on:
         type: string
         default: ""
       publish_ota:
-        description: "Publish alpha-channel server OTA artifacts after finalization"
+        description: "Publish the live alpha-channel server OTA release after finalization"
         required: false
         type: boolean
-        default: false
+        default: true
   workflow_call:
     inputs:
       mode:
@@ -44,7 +44,7 @@ on:
         type: string
         default: ""
       publish_ota:
-        description: "Publish alpha-channel server OTA artifacts after finalization"
+        description: "Publish the live alpha-channel server OTA release after finalization"
         required: false
         type: boolean
         default: false
@@ -462,7 +462,7 @@ jobs:
     needs:
       - prepare
       - finalize
-    if: ${{ needs.finalize.result == 'success' && inputs.publish_ota == true }}
+    if: ${{ needs.finalize.result == 'success' && github.event_name != 'push' && inputs.publish_ota == true }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -475,6 +475,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           ref: ${{ needs.prepare.outputs.release_sha }}
       - name: Preflight OTA signing key
         run: |
@@ -484,9 +485,22 @@ jobs:
           fi
       - name: Setup uv
         uses: astral-sh/setup-uv@v8.3.2
-      - name: Publish alpha server OTA artifacts
+      - name: Publish live alpha server OTA release
         working-directory: packages/browseros
-        run: uv run browseros ota server release --version "$VERSION" --channel alpha --product browseros
+        run: |
+          set -euo pipefail
+          uv run browseros ota server release --version "$VERSION" --channel alpha --product browseros
+          uv run browseros ota server release-appcast --channel alpha --product browseros --publish
+
+      - name: Persist alpha server appcast snapshot
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+        run: |
+          set -euo pipefail
+          packages/browseros-agent/scripts/release/commit-update-snapshot.sh \
+            updates/server/appcast-server.alpha.xml \
+            "$DEFAULT_BRANCH" \
+            "chore(release): snapshot BrowserOS server alpha v${VERSION}"
 
   reflect-version:
     needs:

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -419,15 +419,6 @@ jobs:
             git push origin "refs/tags/$RELEASE_TAG"
           fi
 
-      - name: Publish private draft
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "true" ]; then
-            gh release edit "$RELEASE_TAG" --draft=false
-          fi
-
       - name: Copy versioned objects to latest
         env:
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
@@ -458,49 +449,29 @@ jobs:
             fi
           done
 
+      - name: Publish private draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft')" = "true" ]; then
+            gh release edit "$RELEASE_TAG" --draft=false
+          fi
+
   publish-ota:
     needs:
       - prepare
       - finalize
     if: ${{ needs.finalize.result == 'success' && github.event_name != 'push' && inputs.publish_ota == true }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-      R2_BUCKET: ${{ secrets.R2_BUCKET }}
-      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-      VERSION: ${{ needs.prepare.outputs.version }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.prepare.outputs.release_sha }}
-      - name: Preflight OTA signing key
-        run: |
-          if [ -z "${SPARKLE_PRIVATE_KEY:-}" ]; then
-            echo "::error::SPARKLE_PRIVATE_KEY is required when publish_ota is true"
-            exit 1
-          fi
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v8.3.2
-      - name: Publish live alpha server OTA release
-        working-directory: packages/browseros
-        run: |
-          set -euo pipefail
-          uv run browseros ota server release --version "$VERSION" --channel alpha --product browseros
-          uv run browseros ota server release-appcast --channel alpha --product browseros --publish
-
-      - name: Persist alpha server appcast snapshot
-        env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
-        run: |
-          set -euo pipefail
-          packages/browseros-agent/scripts/release/commit-update-snapshot.sh \
-            updates/server/appcast-server.alpha.xml \
-            "$DEFAULT_BRANCH" \
-            "chore(release): snapshot BrowserOS server alpha v${VERSION}"
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-server-ota.yml
+    with:
+      product: browseros
+      version: ${{ needs.prepare.outputs.version }}
+      release_sha: ${{ needs.prepare.outputs.release_sha }}
+      snapshot_path: updates/server/appcast-server.alpha.xml
+    secrets: inherit
 
   reflect-version:
     needs:

--- a/packages/browseros-agent/scripts/release/commit-update-snapshot.sh
+++ b/packages/browseros-agent/scripts/release/commit-update-snapshot.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <updates/path> <remote-branch> <commit-message>" >&2
+  exit 2
+fi
+
+snapshot_path="$1"
+branch="$2"
+commit_message="$3"
+
+case "$snapshot_path" in
+  updates/*) ;;
+  *)
+    echo "Snapshot path must be under updates/: $snapshot_path" >&2
+    exit 2
+    ;;
+esac
+
+case "/$snapshot_path/" in
+  */../*|*/./*)
+    echo "Snapshot path must not contain relative traversal: $snapshot_path" >&2
+    exit 2
+    ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel)"
+source_path="$repo_root/$snapshot_path"
+if [ ! -f "$source_path" ]; then
+  echo "Snapshot does not exist: $snapshot_path" >&2
+  exit 2
+fi
+
+temp_root="$(mktemp -d)"
+worktree="$temp_root/repo"
+
+cleanup() {
+  git -C "$repo_root" worktree remove --force "$worktree" >/dev/null 2>&1 || true
+  rm -rf "$temp_root"
+}
+trap cleanup EXIT
+
+git -C "$repo_root" fetch origin "$branch" --no-tags
+git -C "$repo_root" worktree add --detach "$worktree" "origin/$branch"
+mkdir -p "$worktree/$(dirname "$snapshot_path")"
+cp "$source_path" "$worktree/$snapshot_path"
+
+if git -C "$worktree" diff --quiet -- "$snapshot_path"; then
+  echo "Snapshot already current: $snapshot_path"
+  exit 0
+fi
+
+git -C "$worktree" config user.name "github-actions[bot]"
+git -C "$worktree" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git -C "$worktree" add -- "$snapshot_path"
+git -C "$worktree" commit -m "$commit_message"
+
+for attempt in 1 2 3 4 5; do
+  if git -C "$worktree" push origin "HEAD:$branch"; then
+    echo "Snapshot committed: $snapshot_path"
+    exit 0
+  fi
+  if [ "$attempt" -eq 5 ]; then
+    echo "Snapshot push failed after $attempt attempts: $snapshot_path" >&2
+    exit 1
+  fi
+  echo "Snapshot push rejected; retrying against the latest $branch ($attempt/5)"
+  git -C "$worktree" fetch origin "$branch" --no-tags
+  if ! git -C "$worktree" rebase "origin/$branch"; then
+    git -C "$worktree" rebase --abort || true
+    echo "Snapshot commit conflicts with the latest $branch: $snapshot_path" >&2
+    exit 1
+  fi
+done

--- a/packages/browseros-agent/scripts/release/commit-update-snapshot.test.ts
+++ b/packages/browseros-agent/scripts/release/commit-update-snapshot.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dir, '../../../..')
+const script = resolve(import.meta.dir, 'commit-update-snapshot.sh')
+
+function run(cwd: string, command: string[], env: Record<string, string> = {}) {
+  const result = spawnSync(command[0], command.slice(1), {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  })
+  return {
+    code: result.status ?? 1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  }
+}
+
+function mustRun(cwd: string, command: string[]) {
+  const result = run(cwd, command)
+  expect(result.code, result.stderr || result.stdout).toBe(0)
+  return result.stdout.trim()
+}
+
+function configureGit(dir: string) {
+  mustRun(dir, ['git', 'config', 'user.name', 'Release Test'])
+  mustRun(dir, ['git', 'config', 'user.email', 'release-test@example.com'])
+}
+
+function initFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'commit-update-snapshot-'))
+  const remote = join(root, 'remote.git')
+  const source = join(root, 'source')
+  const competitor = join(root, 'competitor')
+
+  mkdirSync(source)
+  mustRun(root, ['git', 'init', '--bare', '--initial-branch=main', remote])
+  mustRun(source, ['git', 'init', '--initial-branch=main'])
+  configureGit(source)
+  mkdirSync(join(source, 'updates/server'), { recursive: true })
+  writeFileSync(
+    join(source, 'updates/server/appcast-server.alpha.xml'),
+    'server-old\n',
+  )
+  writeFileSync(
+    join(source, 'updates/server/appcast-claw-server.alpha.xml'),
+    'claw-old\n',
+  )
+  mustRun(source, ['git', 'add', 'updates'])
+  mustRun(source, ['git', 'commit', '-m', 'initial snapshots'])
+  mustRun(source, ['git', 'remote', 'add', 'origin', remote])
+  mustRun(source, ['git', 'push', '-u', 'origin', 'main'])
+  mustRun(root, ['git', 'clone', remote, competitor])
+  configureGit(competitor)
+
+  return { root, remote, source, competitor }
+}
+
+describe('commit-update-snapshot', () => {
+  it('rebases and retries when an unrelated snapshot wins the first push', () => {
+    const fixture = initFixture()
+    try {
+      writeFileSync(
+        join(fixture.source, 'updates/server/appcast-server.alpha.xml'),
+        'server-new\n',
+      )
+      writeFileSync(
+        join(
+          fixture.competitor,
+          'updates/server/appcast-claw-server.alpha.xml',
+        ),
+        'claw-new\n',
+      )
+      mustRun(fixture.competitor, [
+        'git',
+        'add',
+        'updates/server/appcast-claw-server.alpha.xml',
+      ])
+      mustRun(fixture.competitor, [
+        'git',
+        'commit',
+        '-m',
+        'snapshot competing claw feed',
+      ])
+
+      const realGit = mustRun(repoRoot, ['which', 'git'])
+      const wrapperDir = join(fixture.root, 'bin')
+      const wrapper = join(wrapperDir, 'git')
+      const marker = join(fixture.root, 'raced')
+      mkdirSync(wrapperDir)
+      writeFileSync(
+        wrapper,
+        `#!/bin/sh
+case " $* " in
+  *" push "*)
+    if [ ! -e "$SNAPSHOT_RACE_MARKER" ]; then
+      : > "$SNAPSHOT_RACE_MARKER"
+      "$SNAPSHOT_REAL_GIT" -C "$SNAPSHOT_RACE_REPO" push origin HEAD:main || exit $?
+    fi
+    ;;
+esac
+exec "$SNAPSHOT_REAL_GIT" "$@"
+`,
+      )
+      chmodSync(wrapper, 0o755)
+
+      const result = run(
+        fixture.source,
+        [
+          script,
+          'updates/server/appcast-server.alpha.xml',
+          'main',
+          'snapshot BrowserOS server alpha 1.2.3',
+        ],
+        {
+          PATH: `${wrapperDir}:${process.env.PATH}`,
+          SNAPSHOT_RACE_MARKER: marker,
+          SNAPSHOT_RACE_REPO: fixture.competitor,
+          SNAPSHOT_REAL_GIT: realGit,
+        },
+      )
+
+      expect(result.code, result.stderr || result.stdout).toBe(0)
+      expect(result.stdout).toContain('Snapshot push rejected; retrying')
+      expect(
+        mustRun(fixture.root, [
+          'git',
+          `--git-dir=${fixture.remote}`,
+          'show',
+          'main:updates/server/appcast-server.alpha.xml',
+        ]),
+      ).toBe('server-new')
+      expect(
+        mustRun(fixture.root, [
+          'git',
+          `--git-dir=${fixture.remote}`,
+          'show',
+          'main:updates/server/appcast-claw-server.alpha.xml',
+        ]),
+      ).toBe('claw-new')
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true })
+    }
+  })
+
+  it('succeeds without a commit when the snapshot is already current', () => {
+    const fixture = initFixture()
+    try {
+      const before = mustRun(fixture.remote, ['git', 'rev-parse', 'main'])
+      const result = run(fixture.source, [
+        script,
+        'updates/server/appcast-server.alpha.xml',
+        'main',
+        'snapshot BrowserOS server alpha 1.2.3',
+      ])
+
+      expect(result.code, result.stderr || result.stdout).toBe(0)
+      expect(result.stdout).toContain('Snapshot already current')
+      expect(mustRun(fixture.remote, ['git', 'rev-parse', 'main'])).toBe(before)
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects paths outside updates and missing snapshots', () => {
+    const fixture = initFixture()
+    try {
+      const outside = run(fixture.source, [
+        script,
+        'README.md',
+        'main',
+        'invalid snapshot',
+      ])
+      const missing = run(fixture.source, [
+        script,
+        'updates/server/missing.xml',
+        'main',
+        'missing snapshot',
+      ])
+
+      expect(outside.code).not.toBe(0)
+      expect(outside.stderr).toContain('must be under updates/')
+      expect(missing.code).not.toBe(0)
+      expect(missing.stderr).toContain('Snapshot does not exist')
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/browseros-agent/scripts/release/prepare-claw-server-rust-release.test.ts
+++ b/packages/browseros-agent/scripts/release/prepare-claw-server-rust-release.test.ts
@@ -134,7 +134,7 @@ async function prepare(
 }
 
 describe('prepare-claw-server-rust-release', () => {
-  it('continues the product sequence despite the historical Rust tag', async () => {
+  it('continues the product sequence despite the historical legacy tag', async () => {
     const { dir, bareDir } = await initFixture('0.0.12')
     try {
       await tag(dir, 'claw-server/v0.0.12')
@@ -241,7 +241,7 @@ describe('prepare-claw-server-rust-release', () => {
     }
   })
 
-  it('rejects finalizing a prepared Rust server older than a public release', async () => {
+  it('rejects finalizing a prepared BrowserClaw server older than a public release', async () => {
     const { dir, bareDir } = await initFixture('0.0.13')
     try {
       const releaseSha = await revParse(dir, 'HEAD')

--- a/packages/browseros-agent/scripts/release/publish-server-ota-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/publish-server-ota-workflow.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dir, '../../../..')
+const workflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/publish-server-ota.yml'),
+  'utf8',
+)
+
+function section(start: string, end?: string): string {
+  const startIndex = workflow.indexOf(start)
+  expect(startIndex).toBeGreaterThanOrEqual(0)
+  const endIndex = end ? workflow.indexOf(end, startIndex + start.length) : -1
+  if (end) expect(endIndex).toBeGreaterThan(startIndex)
+  return workflow.slice(startIndex, endIndex === -1 ? undefined : endIndex)
+}
+
+describe('publish-server-ota workflow', () => {
+  it('signs every platform on its native runner', () => {
+    const build = section('  build-payloads:', '  publish:')
+    for (const platform of [
+      'darwin_arm64',
+      'darwin_x64',
+      'linux_arm64',
+      'linux_x64',
+      'windows_x64',
+    ]) {
+      expect(build).toContain(`platform: ${platform}`)
+    }
+    expect(build).toContain('runner: macos-14')
+    expect(build).toContain('runner: windows-latest')
+    expect(build).toContain('runner: ubuntu-latest')
+    expect(build).toContain('Import macOS signing certificate')
+    expect(build).toContain('Install SSL.com CodeSignTool')
+    expect(build).toContain('MACOS_CERTIFICATE_NAME:')
+    expect(build).toContain('ESIGNER_USERNAME:')
+    expect(build).toContain('SPARKLE_PRIVATE_KEY:')
+    expect(build).toContain('--platform "$PLATFORM"')
+    expect(build).toContain('actions/upload-artifact@v7')
+  })
+
+  it('assembles all fragments before one guarded live publication', () => {
+    const publish = section('  publish:')
+    expect(publish).toContain('- build-payloads')
+    expect(publish).toContain('actions/download-artifact@v7')
+    expect(publish).toContain('pattern: server-ota-fragment-*')
+    expect(publish).toContain('ota server assemble-appcast')
+    expect(publish).toContain(
+      'ota server release-appcast --channel alpha --product "$PRODUCT" --publish',
+    )
+    expect(publish).toContain('commit-update-snapshot.sh')
+
+    const assembleIndex = publish.indexOf('ota server assemble-appcast')
+    const liveIndex = publish.indexOf('ota server release-appcast')
+    const snapshotIndex = publish.indexOf('commit-update-snapshot.sh')
+    expect(liveIndex).toBeGreaterThan(assembleIndex)
+    expect(snapshotIndex).toBeGreaterThan(liveIndex)
+  })
+
+  it('accepts only product-owned snapshot inputs from its callers', () => {
+    const call = section('  workflow_call:', '\npermissions:')
+    expect(call).toContain('product:')
+    expect(call).toContain('version:')
+    expect(call).toContain('release_sha:')
+    expect(call).toContain('snapshot_path:')
+    expect(workflow).not.toContain('--channel prod')
+  })
+})

--- a/packages/browseros-agent/scripts/release/publish-server-ota-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/publish-server-ota-workflow.test.ts
@@ -69,4 +69,32 @@ describe('publish-server-ota workflow', () => {
     expect(call).toContain('snapshot_path:')
     expect(workflow).not.toContain('--channel prod')
   })
+
+  it('scopes credentials to the platform and publication steps that use them', () => {
+    const build = section('  build-payloads:', '  publish:')
+    const buildEnvStart = build.indexOf('    env:')
+    const buildStepsStart = build.indexOf('    steps:')
+    const buildJobEnv = build.slice(buildEnvStart, buildStepsStart)
+    expect(buildJobEnv).not.toContain(`${dollar}{{ secrets.`)
+
+    const checkoutStart = build.indexOf('      - uses: actions/checkout@v7')
+    const commonPreflightStart = build.indexOf(
+      '      - name: Preflight storage and payload signing credentials',
+    )
+    expect(build.slice(checkoutStart, commonPreflightStart)).not.toContain(
+      `${dollar}{{ secrets.`,
+    )
+    expect(build).toContain("if: runner.os == 'macOS'")
+    expect(build).toContain("if: runner.os == 'Windows'")
+    expect(build).toContain("if: runner.os == 'Linux'")
+
+    const publish = section('  publish:')
+    const publishEnvStart = publish.indexOf('    env:')
+    const publishStepsStart = publish.indexOf('    steps:')
+    const publishJobEnv = publish.slice(publishEnvStart, publishStepsStart)
+    expect(publishJobEnv).not.toContain(`${dollar}{{ secrets.`)
+    expect(publish).toContain(
+      `R2_ACCOUNT_ID: ${dollar}{{ secrets.R2_ACCOUNT_ID }}`,
+    )
+  })
 })

--- a/packages/browseros-agent/scripts/release/publish-server-ota-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/publish-server-ota-workflow.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 const repoRoot = resolve(import.meta.dir, '../../../..')
+const dollar = '$'
 const workflow = readFileSync(
   resolve(repoRoot, '.github/workflows/publish-server-ota.yml'),
   'utf8',
@@ -36,7 +37,9 @@ describe('publish-server-ota workflow', () => {
     expect(build).toContain('MACOS_CERTIFICATE_NAME:')
     expect(build).toContain('ESIGNER_USERNAME:')
     expect(build).toContain('SPARKLE_PRIVATE_KEY:')
+    expect(build).toContain(`RELEASE_SHA: ${dollar}{{ inputs.release_sha }}`)
     expect(build).toContain('--platform "$PLATFORM"')
+    expect(build).toContain('--release-sha "$RELEASE_SHA"')
     expect(build).toContain('actions/upload-artifact@v7')
   })
 

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -7,6 +7,10 @@ const workflow = readFileSync(
   resolve(repoRoot, '.github/workflows/release-claw-server-rust.yml'),
   'utf8',
 )
+const browserclawWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/release-browserclaw.yml'),
+  'utf8',
+)
 const localStaging = readFileSync(
   resolve(
     repoRoot,
@@ -27,10 +31,16 @@ function section(start: string, end?: string): string {
 describe('release-claw-server-rust workflow', () => {
   it('exposes the reusable build/finalize interface and outputs', () => {
     const call = section('  workflow_call:', '\npermissions:')
+    const publishOta = call.slice(
+      call.indexOf('      publish_ota:'),
+      call.indexOf('    outputs:'),
+    )
     expect(call).toContain('mode:')
     expect(call).toContain('default: "build"')
     expect(call).toContain('defer_finalize:')
     expect(call).toContain('default: false')
+    expect(call).toContain('publish_ota:')
+    expect(publishOta).toContain('default: false')
     expect(call).toContain(`value: ${dollar}{{ jobs.prepare.outputs.version }}`)
     expect(call).toContain(`value: ${dollar}{{ jobs.prepare.outputs.tag }}`)
     expect(call).toContain(
@@ -158,10 +168,34 @@ describe('release-claw-server-rust workflow', () => {
   it('gates OTA publication on successful finalization', () => {
     const ota = section('  publish-ota:', '  reflect-version:')
     expect(ota).toContain('- finalize')
+    expect(ota).toContain("github.event_name != 'push'")
     expect(ota).toContain('inputs.publish_ota == true')
     expect(ota).toContain(
       'uv run browseros ota server release --version "$VERSION" --channel alpha --product browserclaw',
     )
+  })
+
+  it('publishes and persists standalone alpha releases by default', () => {
+    const dispatch = section('  workflow_dispatch:', '  workflow_call:')
+    const ota = section('  publish-ota:', '  reflect-version:')
+    expect(dispatch).toContain('publish_ota:')
+    expect(dispatch).toContain('default: true')
+    expect(browserclawWorkflow.match(/publish_ota: false/g)).toHaveLength(2)
+    expect(ota).toContain(
+      'uv run browseros ota server release-appcast --channel alpha --product browserclaw --publish',
+    )
+    expect(ota).toContain(
+      'packages/browseros-agent/scripts/release/commit-update-snapshot.sh',
+    )
+    expect(ota).toContain('updates/server/appcast-claw-server.alpha.xml')
+    expect(ota).not.toContain('updates/server/appcast-server.alpha.xml')
+    expect(ota).not.toContain('--channel prod')
+
+    const generateIndex = ota.indexOf('ota server release --version')
+    const publishIndex = ota.indexOf('ota server release-appcast')
+    const snapshotIndex = ota.indexOf('commit-update-snapshot.sh')
+    expect(publishIndex).toBeGreaterThan(generateIndex)
+    expect(snapshotIndex).toBeGreaterThan(publishIndex)
   })
 
   it('reflects the version only after finalization', () => {

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -170,9 +170,15 @@ describe('release-claw-server-rust workflow', () => {
     expect(ota).toContain('- finalize')
     expect(ota).toContain("github.event_name != 'push'")
     expect(ota).toContain('inputs.publish_ota == true')
+    expect(ota).toContain('uses: ./.github/workflows/publish-server-ota.yml')
+    expect(ota).toContain('product: browserclaw')
     expect(ota).toContain(
-      'uv run browseros ota server release --version "$VERSION" --channel alpha --product browserclaw',
+      `version: ${dollar}{{ needs.prepare.outputs.version }}`,
     )
+    expect(ota).toContain(
+      `release_sha: ${dollar}{{ needs.prepare.outputs.release_sha }}`,
+    )
+    expect(ota).toContain('secrets: inherit')
   })
 
   it('publishes and persists standalone alpha releases by default', () => {
@@ -181,21 +187,8 @@ describe('release-claw-server-rust workflow', () => {
     expect(dispatch).toContain('publish_ota:')
     expect(dispatch).toContain('default: true')
     expect(browserclawWorkflow.match(/publish_ota: false/g)).toHaveLength(2)
-    expect(ota).toContain(
-      'uv run browseros ota server release-appcast --channel alpha --product browserclaw --publish',
-    )
-    expect(ota).toContain(
-      'packages/browseros-agent/scripts/release/commit-update-snapshot.sh',
-    )
     expect(ota).toContain('updates/server/appcast-claw-server.alpha.xml')
     expect(ota).not.toContain('updates/server/appcast-server.alpha.xml')
-    expect(ota).not.toContain('--channel prod')
-
-    const generateIndex = ota.indexOf('ota server release --version')
-    const publishIndex = ota.indexOf('ota server release-appcast')
-    const snapshotIndex = ota.indexOf('commit-update-snapshot.sh')
-    expect(publishIndex).toBeGreaterThan(generateIndex)
-    expect(snapshotIndex).toBeGreaterThan(publishIndex)
   })
 
   it('reflects the version only after finalization', () => {

--- a/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
@@ -62,7 +62,7 @@ describe('release-claw-server workflow', () => {
 
   it('checks public allocations under the component lock before mutations', () => {
     const prepare = section('  prepare:', '  cargo-test:')
-    expect(workflow).toContain('group: release-claw-server')
+    expect(workflow).toContain('group: release-claw-server-rust')
     expect(prepare.indexOf('Read allocated GitHub releases')).toBeLessThan(
       prepare.indexOf('Resolve release'),
     )
@@ -96,7 +96,7 @@ describe('release-claw-server workflow', () => {
     expect(publish).toContain('actions/setup-python@v6')
     expect(publish).toContain('python -m pip install "boto3>=1.35.1,<2"')
     expect(publish).not.toContain('pip install --user')
-    expect(publish).toContain('Expected 5 Rust server resource zips')
+    expect(publish).toContain('Expected 5 BrowserClaw server resource zips')
     expect(publish).toContain('IfNoneMatch')
     expect(publish).toContain('status not in {409, 412}')
     expect(publish).toContain('Metadata={')

--- a/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path'
 
 const repoRoot = resolve(import.meta.dir, '../../../..')
 const workflow = readFileSync(
-  resolve(repoRoot, '.github/workflows/release-claw-server-rust.yml'),
+  resolve(repoRoot, '.github/workflows/release-claw-server.yml'),
   'utf8',
 )
 const browserclawWorkflow = readFileSync(
@@ -28,7 +28,7 @@ function section(start: string, end?: string): string {
   return workflow.slice(startIndex, endIndex === -1 ? undefined : endIndex)
 }
 
-describe('release-claw-server-rust workflow', () => {
+describe('release-claw-server workflow', () => {
   it('exposes the reusable build/finalize interface and outputs', () => {
     const call = section('  workflow_call:', '\npermissions:')
     const publishOta = call.slice(
@@ -62,7 +62,7 @@ describe('release-claw-server-rust workflow', () => {
 
   it('checks public allocations under the component lock before mutations', () => {
     const prepare = section('  prepare:', '  cargo-test:')
-    expect(workflow).toContain('group: release-claw-server-rust')
+    expect(workflow).toContain('group: release-claw-server')
     expect(prepare.indexOf('Read allocated GitHub releases')).toBeLessThan(
       prepare.indexOf('Resolve release'),
     )

--- a/packages/browseros-agent/scripts/release/release-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-server-workflow.test.ts
@@ -8,6 +8,10 @@ const workflow = readFileSync(
   resolve(repoRoot, '.github/workflows/release-server.yml'),
   'utf8',
 )
+const browserosWorkflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/release-browseros.yml'),
+  'utf8',
+)
 const dollar = '$'
 
 function section(start: string, end?: string): string {
@@ -21,12 +25,18 @@ function section(start: string, end?: string): string {
 describe('release-server workflow', () => {
   it('exposes the reusable build/finalize interface and outputs', () => {
     const call = section('  workflow_call:', '\npermissions:')
+    const publishOta = call.slice(
+      call.indexOf('      publish_ota:'),
+      call.indexOf('    outputs:'),
+    )
     expect(call).toContain('mode:')
     expect(call).toContain('default: "build"')
     expect(call).toContain('defer_finalize:')
     expect(call).toContain('default: false')
     expect(call).toContain('version:')
     expect(call).toContain('ref:')
+    expect(call).toContain('publish_ota:')
+    expect(publishOta).toContain('default: false')
     expect(call).toContain('outputs:')
     expect(call).toContain(`value: ${dollar}{{ jobs.prepare.outputs.version }}`)
     expect(call).toContain(`value: ${dollar}{{ jobs.prepare.outputs.tag }}`)
@@ -103,5 +113,33 @@ describe('release-server workflow', () => {
       '- finalize',
     )
     expect(section('  reflect-version:')).toContain('- finalize')
+    expect(browserosWorkflow.match(/publish_ota: false/g)).toHaveLength(2)
+  })
+
+  it('publishes and persists standalone alpha releases by default', () => {
+    const dispatch = section('  workflow_dispatch:', '  workflow_call:')
+    const ota = section('  publish-ota:', '  reflect-version:')
+    expect(dispatch).toContain('publish_ota:')
+    expect(dispatch).toContain('default: true')
+    expect(ota).toContain("github.event_name != 'push'")
+    expect(ota).toContain('inputs.publish_ota == true')
+    expect(ota).toContain(
+      'uv run browseros ota server release --version "$VERSION" --channel alpha --product browseros',
+    )
+    expect(ota).toContain(
+      'uv run browseros ota server release-appcast --channel alpha --product browseros --publish',
+    )
+    expect(ota).toContain(
+      'packages/browseros-agent/scripts/release/commit-update-snapshot.sh',
+    )
+    expect(ota).toContain('updates/server/appcast-server.alpha.xml')
+    expect(ota).not.toContain('updates/server/appcast-claw-server.alpha.xml')
+    expect(ota).not.toContain('--channel prod')
+
+    const generateIndex = ota.indexOf('ota server release --version')
+    const publishIndex = ota.indexOf('ota server release-appcast')
+    const snapshotIndex = ota.indexOf('commit-update-snapshot.sh')
+    expect(publishIndex).toBeGreaterThan(generateIndex)
+    expect(snapshotIndex).toBeGreaterThan(publishIndex)
   })
 })

--- a/packages/browseros-agent/scripts/release/release-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-server-workflow.test.ts
@@ -101,8 +101,8 @@ describe('release-server workflow', () => {
     const latestIndex = finalize.indexOf('Copy versioned objects to latest')
     expect(verifyIndex).toBeGreaterThanOrEqual(0)
     expect(tagIndex).toBeGreaterThan(verifyIndex)
-    expect(publishIndex).toBeGreaterThan(tagIndex)
-    expect(latestIndex).toBeGreaterThan(publishIndex)
+    expect(latestIndex).toBeGreaterThan(tagIndex)
+    expect(publishIndex).toBeGreaterThan(latestIndex)
   })
 
   it('defers finalization for full releases and gates side effects on it', () => {
@@ -123,23 +123,16 @@ describe('release-server workflow', () => {
     expect(dispatch).toContain('default: true')
     expect(ota).toContain("github.event_name != 'push'")
     expect(ota).toContain('inputs.publish_ota == true')
+    expect(ota).toContain('uses: ./.github/workflows/publish-server-ota.yml')
+    expect(ota).toContain('product: browseros')
     expect(ota).toContain(
-      'uv run browseros ota server release --version "$VERSION" --channel alpha --product browseros',
+      `version: ${dollar}{{ needs.prepare.outputs.version }}`,
     )
     expect(ota).toContain(
-      'uv run browseros ota server release-appcast --channel alpha --product browseros --publish',
+      `release_sha: ${dollar}{{ needs.prepare.outputs.release_sha }}`,
     )
-    expect(ota).toContain(
-      'packages/browseros-agent/scripts/release/commit-update-snapshot.sh',
-    )
+    expect(ota).toContain('secrets: inherit')
     expect(ota).toContain('updates/server/appcast-server.alpha.xml')
     expect(ota).not.toContain('updates/server/appcast-claw-server.alpha.xml')
-    expect(ota).not.toContain('--channel prod')
-
-    const generateIndex = ota.indexOf('ota server release --version')
-    const publishIndex = ota.indexOf('ota server release-appcast')
-    const snapshotIndex = ota.indexOf('commit-update-snapshot.sh')
-    expect(publishIndex).toBeGreaterThan(generateIndex)
-    expect(snapshotIndex).toBeGreaterThan(publishIndex)
   })
 })

--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -173,7 +173,7 @@ CRX versions are independent of the browser version.
 
 ### What CI does, and where it stops
 
-A BrowserClaw run can produce onboarding resources, Rust claw-server resources,
+A BrowserClaw run can produce onboarding resources, BrowserClaw server resources,
 browser builds for three platforms, the BrowserClaw extension CRX, staged
 update feeds, and draft GitHub release assets.
 
@@ -286,12 +286,12 @@ file:
 | Bundle | Version source | Workflow | Tag |
 | --- | --- | --- | --- |
 | BrowserOS agent server | `packages/browseros-agent/apps/server/package.json` | `release-server.yml` | `agent-server/v*` |
-| BrowserClaw server (Rust) | `.../apps/claw-server-rust/Cargo.toml` | `release-claw-server-rust.yml` | `claw-server-rust/v*` |
+| BrowserClaw server | `.../apps/claw-server-rust/Cargo.toml` | `release-claw-server.yml` | `claw-server-rust/v*` |
 | BrowserClaw onboarding | `.../apps/claw-onboard/package.json` | `release-claw-onboard.yml` | `claw-onboard/v*` |
 
-BrowserClaw browser builds and server OTA both consume the Rust server bundles
-published under `claw-server-rust/prod-resources`. Packaging normalizes the Rust
-binary name to `browseros-claw-server` for compatibility with the browser.
+BrowserClaw browser builds and server OTA both consume the server bundles
+published under the historical `claw-server-rust/prod-resources` key. Packaging
+normalizes the binary name to `browseros-claw-server` for browser compatibility.
 
 Two signed macOS nightlies run on the self-hosted Mac and publish rolling
 prereleases anyone can download: `nightly-browseros` (04:00 UTC) and

--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -211,7 +211,9 @@ browseros release appcast --version <version> --product browseros --publish
 Swap in `--product browserclaw` for the other product. If you need to recreate
 the draft GitHub release by hand, that is
 `browseros release github create --version <version> --draft --product <id>`.
-Server OTA promotion is separate, and also manual.
+Server OTA publication stays separate from a full browser release. A bare
+standalone server workflow publishes its alpha appcast; production still
+requires an explicit `browseros ota server promote --product <id> --publish`.
 
 Lane-by-lane detail, required secrets, runner cost, and troubleshooting:
 [`docs/release-ci.md`](docs/release-ci.md).

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -644,12 +644,12 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
             "extension": "browserclaw",
             "builds": {
                 "build_onboarding": "release-claw-onboard.yml",
-                "build_server": "release-claw-server-rust.yml",
+                "build_server": "release-claw-server.yml",
                 "build_extension": "release-extensions.yml",
             },
             "finalizers": {
                 "finalize_onboarding": "release-claw-onboard.yml",
-                "finalize_server": "release-claw-server-rust.yml",
+                "finalize_server": "release-claw-server.yml",
                 "finalize_extension": "release-extensions.yml",
             },
             "pins": {

--- a/packages/browseros/bos_build/cli/ota.py
+++ b/packages/browseros/bos_build/cli/ota.py
@@ -191,24 +191,13 @@ def server_release(
     product: str = typer.Option(
         "browseros", "--product", help="Product whose server bundle to release"
     ),
+    release_sha: str = typer.Option(
+        ...,
+        "--release-sha",
+        help="Immutable source commit bound to the versioned resources",
+    ),
 ):
-    """Publish BrowserOS server OTA update
-
-    Downloads server binaries from R2 (artifacts/server/latest/),
-    signs them, creates Sparkle update packages, and uploads to R2.
-
-    \b
-    Full Release (all platforms):
-      browseros ota server release --version 0.0.69 --channel alpha
-
-    \b
-    Single Platform:
-      browseros ota server release --version 0.0.69 --platform darwin_arm64
-
-    \b
-    Multiple Platforms:
-      browseros ota server release --version 0.0.69 --platform darwin_arm64,darwin_x64
-    """
+    """Publish source-bound server OTA payloads."""
     log_info(f"🚀 BrowserOS Server OTA v{version}")
     log_info("=" * 70)
 
@@ -219,6 +208,7 @@ def server_release(
         channel=channel,
         platform_filter=platform,
         product_id=product,
+        release_sha=release_sha,
     )
 
     execute_module(ctx, module)
@@ -420,20 +410,7 @@ def test_signing(
 
 @server_app.callback(invoke_without_command=True)
 def server_main(ctx: typer.Context):
-    """BrowserOS Server OTA commands
-
-    \b
-    Release (upload artifacts):
-      browseros ota server release --version 0.0.36
-
-    \b
-    Release Appcast (make live):
-      browseros ota server release-appcast --channel alpha
-
-    \b
-    List Platforms:
-      browseros ota server list-platforms
-    """
+    """Expose BrowserOS server OTA commands."""
     if ctx.invoked_subcommand is None:
         typer.echo("Use --help for usage information")
         typer.echo(
@@ -445,14 +422,7 @@ def server_main(ctx: typer.Context):
 
 @app.callback(invoke_without_command=True)
 def main(ctx: typer.Context):
-    """OTA update automation for BrowserOS
-
-    \b
-    Server OTA:
-      browseros ota server release --version 0.0.36
-      browseros ota server release-appcast --channel alpha
-      browseros ota server list-platforms
-    """
+    """Expose BrowserOS OTA automation."""
     if ctx.invoked_subcommand is None:
         typer.echo("Use --help for usage information")
         typer.echo("Available subcommands: server")

--- a/packages/browseros/bos_build/cli/ota.py
+++ b/packages/browseros/bos_build/cli/ota.py
@@ -16,6 +16,7 @@ from ..lib.utils import log_info, log_error, log_success
 from ..release.ota import ServerOTAModule
 from ..release.ota.common import (
     get_appcast_path,
+    merge_base_appcast,
     promote_appcast_content,
     SERVER_PLATFORMS,
 )
@@ -23,6 +24,8 @@ from ..release.feeds.publisher import FeedPublisher
 from ..release.feeds.render import (
     extract_appcast_item_count,
     extract_appcast_version,
+    parse_server_appcast_content,
+    render_server_appcast,
 )
 from ..release.feeds.spec import server_feed
 from ..products import SERVER_BUNDLES
@@ -112,6 +115,67 @@ def _log_alternate_product_appcasts(
             )
 
 
+def _assemble_server_appcast(
+    *,
+    version: str,
+    bundle_id: str,
+    channel: str,
+    fragments: list[str],
+    publisher: FeedPublisher,
+    output_path: Path,
+) -> Path:
+    platforms = {platform["name"]: platform for platform in SERVER_PLATFORMS}
+    artifacts = {}
+
+    for value in fragments:
+        platform_name, separator, raw_path = value.partition("=")
+        if not separator or not platform_name or not raw_path:
+            raise ValueError(f"Invalid fragment assignment: {value!r}")
+        platform = platforms.get(platform_name)
+        if platform is None:
+            raise ValueError(f"Unknown server platform: {platform_name}")
+        if platform_name in artifacts:
+            raise ValueError(f"Duplicate appcast fragment: {platform_name}")
+
+        fragment_path = Path(raw_path).resolve()
+        try:
+            content = fragment_path.read_text()
+        except (OSError, UnicodeError) as error:
+            raise ValueError(f"Cannot read {platform_name} fragment: {error}") from error
+        parsed = parse_server_appcast_content(content)
+        if parsed is None:
+            raise ValueError(f"Invalid appcast fragment: {fragment_path}")
+        if parsed.version != version:
+            raise ValueError(
+                f"{platform_name} fragment carries version {parsed.version}, "
+                f"expected {version}"
+            )
+        artifact = parsed.artifacts.get(platform_name)
+        if artifact is None:
+            raise ValueError(
+                f"{platform_name} fragment does not contain {platform_name}"
+            )
+        if artifact.os != platform["os"] or artifact.arch != platform["arch"]:
+            raise ValueError(f"{platform_name} fragment has mismatched OS or architecture")
+        artifacts[platform_name] = artifact
+
+    missing = sorted(set(platforms) - set(artifacts))
+    if missing:
+        raise ValueError(f"Missing appcast fragments: {', '.join(missing)}")
+
+    spec = server_feed(bundle_id, channel)
+    existing = merge_base_appcast(publisher, spec, output_path)
+    content = render_server_appcast(
+        spec,
+        version,
+        list(artifacts.values()),
+        existing=existing,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content)
+    return output_path
+
+
 @server_app.command("release")
 def server_release(
     version: str = typer.Option(
@@ -158,6 +222,32 @@ def server_release(
     )
 
     execute_module(ctx, module)
+
+
+@server_app.command("assemble-appcast")
+def server_assemble_appcast(
+    version: str = typer.Option(..., "--version", "-v"),
+    fragment: list[str] = typer.Option(..., "--fragment"),
+    channel: str = typer.Option("alpha", "--channel", "-c"),
+    product: str = typer.Option("browseros", "--product"),
+    output: Optional[Path] = typer.Option(None, "--output"),
+):
+    """Assemble a complete appcast from native platform fragments."""
+    bundle_id = _server_bundle_id(product)
+    output_path = (output or get_appcast_path(channel, bundle_id)).resolve()
+    try:
+        _assemble_server_appcast(
+            version=version,
+            bundle_id=bundle_id,
+            channel=channel,
+            fragments=fragment,
+            publisher=_feed_publisher(),
+            output_path=output_path,
+        )
+    except ValueError as error:
+        log_error(str(error))
+        raise typer.Exit(1)
+    log_success(f"Assembled appcast: {output_path}")
 
 
 @server_app.command("release-appcast")
@@ -346,7 +436,10 @@ def server_main(ctx: typer.Context):
     """
     if ctx.invoked_subcommand is None:
         typer.echo("Use --help for usage information")
-        typer.echo("Available commands: release, release-appcast, list-platforms")
+        typer.echo(
+            "Available commands: release, assemble-appcast, release-appcast, "
+            "list-platforms"
+        )
         raise typer.Exit(0)
 
 

--- a/packages/browseros/bos_build/cli/ota_test.py
+++ b/packages/browseros/bos_build/cli/ota_test.py
@@ -12,7 +12,13 @@ from typer.testing import CliRunner
 from bos_build.browseros import app
 from bos_build.cli import ota as ota_cli
 from bos_build.release.feeds.publisher import FeedPublisher
+from bos_build.release.feeds.render import (
+    SignedArtifact,
+    parse_server_appcast_content,
+    render_server_appcast,
+)
 from bos_build.release.feeds.spec import server_feed
+from bos_build.release.ota.common import SERVER_PLATFORMS
 
 runner = CliRunner()
 
@@ -172,6 +178,119 @@ class ReleaseAppcastCliTest(unittest.TestCase):
         self.assertIn(f"source={custom.resolve()}", output)
         self.assertNotIn("Did you mean --product", output)
         publisher_factory.assert_not_called()
+
+
+class AssembleServerAppcastTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.output = self.root / "appcast-server.alpha.xml"
+        self.publisher = FeedPublisher(
+            env=SimpleNamespace(r2_bucket="browseros"),
+            r2_client=_MissingR2Client(),
+            http_head=lambda _: 200,
+            appcast_staging_dir=self.root / "staged",
+        )
+
+    def _fragment(
+        self,
+        platform_name: str,
+        version: str = "0.0.129",
+        bundle_id: str = "browseros-server",
+    ) -> str:
+        platform = next(
+            item for item in SERVER_PLATFORMS if item["name"] == platform_name
+        )
+        artifact = SignedArtifact(
+            platform=platform_name,
+            zip_path=Path(f"{platform_name}.zip"),
+            signature=f"signature-{platform_name}",
+            length=1234,
+            os=platform["os"],
+            arch=platform["arch"],
+        )
+        path = self.root / f"{platform_name}.xml"
+        path.write_text(
+            render_server_appcast(
+                server_feed(bundle_id, "alpha"),
+                version,
+                [artifact],
+            )
+        )
+        return f"{platform_name}={path}"
+
+    def test_assembles_exactly_one_native_fragment_per_platform(self):
+        fragments = [self._fragment(item["name"]) for item in SERVER_PLATFORMS]
+
+        result = ota_cli._assemble_server_appcast(
+            version="0.0.129",
+            bundle_id="browseros-server",
+            channel="alpha",
+            fragments=fragments,
+            publisher=self.publisher,
+            output_path=self.output,
+        )
+
+        self.assertEqual(result, self.output)
+        parsed = parse_server_appcast_content(self.output.read_text())
+        self.assertIsNotNone(parsed)
+        assert parsed is not None
+        self.assertEqual(parsed.version, "0.0.129")
+        self.assertEqual(
+            set(parsed.artifacts),
+            {item["name"] for item in SERVER_PLATFORMS},
+        )
+
+    def test_refuses_incomplete_native_fragment_set(self):
+        fragments = [
+            self._fragment(item["name"])
+            for item in SERVER_PLATFORMS
+            if item["name"] != "windows_x64"
+        ]
+
+        with self.assertRaisesRegex(ValueError, "Missing appcast fragments"):
+            ota_cli._assemble_server_appcast(
+                version="0.0.129",
+                bundle_id="browseros-server",
+                channel="alpha",
+                fragments=fragments,
+                publisher=self.publisher,
+                output_path=self.output,
+            )
+
+    def test_refuses_fragment_without_its_assigned_platform(self):
+        linux = self._fragment("linux_x64")
+        path = linux.split("=", 1)[1]
+
+        with self.assertRaisesRegex(ValueError, "does not contain darwin_arm64"):
+            ota_cli._assemble_server_appcast(
+                version="0.0.129",
+                bundle_id="browseros-server",
+                channel="alpha",
+                fragments=[f"darwin_arm64={path}"],
+                publisher=self.publisher,
+                output_path=self.output,
+            )
+
+    def test_refuses_fragment_for_another_version(self):
+        fragments = [
+            self._fragment(
+                item["name"],
+                version="0.0.128" if item["name"] == "linux_x64" else "0.0.129",
+            )
+            for item in SERVER_PLATFORMS
+        ]
+
+        with self.assertRaisesRegex(ValueError, "carries version 0.0.128"):
+            ota_cli._assemble_server_appcast(
+                version="0.0.129",
+                bundle_id="browseros-server",
+                channel="alpha",
+                fragments=fragments,
+                publisher=self.publisher,
+                output_path=self.output,
+            )
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -20,7 +20,7 @@ preflight
 ```
 
 BrowserOS prepares the BrowserOS server and agent extension. BrowserClaw
-prepares the Rust server, onboarding resources, and BrowserClaw extension.
+prepares the BrowserClaw server, onboarding resources, and BrowserClaw extension.
 Preparation uploads immutable versioned objects and leaves private GitHub
 drafts. Public component tags/releases and mutable server `latest` aliases are
 not created or moved until every selected browser build and the feed preview
@@ -288,7 +288,7 @@ move `latest` backward.
 | Workflow | Purpose |
 | --- | --- |
 | `release-server.yml` | BrowserOS server resources and live alpha OTA by default |
-| `release-claw-server-rust.yml` | BrowserClaw Rust server resources and live alpha OTA by default |
+| `release-claw-server.yml` | BrowserClaw server resources and live alpha OTA by default |
 | `release-claw-onboard.yml` | BrowserClaw onboarding resources |
 | `release-extensions.yml` | CRX preparation/finalization without feed publication |
 | `release-extension-feeds.yml` | Extension feed preview or explicit publication |

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -266,9 +266,11 @@ Production server promotion remains explicit.
 A bare dispatch of either standalone server workflow defaults
 `publish_ota=true`. After finalization has updated every resource `latest` alias,
 the workflow signs macOS and Windows payloads on native runners, generates both
-Linux payloads, requires all five appcast fragments, publishes the product's
-live alpha appcast through the guarded feed publisher, and commits the deployed
-snapshot under `updates/server/`. Pass `publish_ota=false` only when a
+Linux payloads, and requires all five appcast fragments. Each job reads the
+immutable versioned resource whose metadata matches the finalized source SHA;
+a same-version retry reuses the live signed payload instead of replacing it.
+The final job publishes the product's live alpha appcast through the guarded
+feed publisher and commits the deployed snapshot under `updates/server/`. Pass `publish_ota=false` only when a
 standalone run should stop after component finalization. Reusable calls remain
 opt-in, and the release tag created by finalization cannot enter the OTA
 publication job.

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -265,7 +265,8 @@ Production server promotion remains explicit.
 
 A bare dispatch of either standalone server workflow defaults
 `publish_ota=true`. After finalization has updated every resource `latest` alias,
-the workflow generates all five alpha OTA payloads, publishes the product's
+the workflow signs macOS and Windows payloads on native runners, generates both
+Linux payloads, requires all five appcast fragments, publishes the product's
 live alpha appcast through the guarded feed publisher, and commits the deployed
 snapshot under `updates/server/`. Pass `publish_ota=false` only when a
 standalone run should stop after component finalization. Reusable calls remain
@@ -273,7 +274,8 @@ opt-in, and the release tag created by finalization cannot enter the OTA
 publication job.
 
 Promote the live alpha appcast to production only with the product-specific
-`browseros ota server promote --publish` command.
+`browseros ota server promote --product <browseros|browserclaw> --publish`
+command.
 
 The server finalizers also enforce monotonic publication. If a newer version
 became public while browsers were building, an older prepared release cannot

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -261,8 +261,19 @@ separate explicit operation.
 Full browser releases pass `publish_ota=false`. A successful server finalizer
 publishes its component release and promotes versioned browser resources to the
 resource `latest` alias, but it does not publish `updates/server` OTA appcasts.
-Server OTA promotion remains an explicit standalone operation with the
-appropriate server workflow or OTA command.
+Production server promotion remains explicit.
+
+A bare dispatch of either standalone server workflow defaults
+`publish_ota=true`. After finalization has updated every resource `latest` alias,
+the workflow generates all five alpha OTA payloads, publishes the product's
+live alpha appcast through the guarded feed publisher, and commits the deployed
+snapshot under `updates/server/`. Pass `publish_ota=false` only when a
+standalone run should stop after component finalization. Reusable calls remain
+opt-in, and the release tag created by finalization cannot enter the OTA
+publication job.
+
+Promote the live alpha appcast to production only with the product-specific
+`browseros ota server promote --publish` command.
 
 The server finalizers also enforce monotonic publication. If a newer version
 became public while browsers were building, an older prepared release cannot
@@ -272,8 +283,8 @@ move `latest` backward.
 
 | Workflow | Purpose |
 | --- | --- |
-| `release-server.yml` | BrowserOS server resources and optional server OTA |
-| `release-claw-server-rust.yml` | BrowserClaw Rust server resources and optional server OTA |
+| `release-server.yml` | BrowserOS server resources and live alpha OTA by default |
+| `release-claw-server-rust.yml` | BrowserClaw Rust server resources and live alpha OTA by default |
 | `release-claw-onboard.yml` | BrowserClaw onboarding resources |
 | `release-extensions.yml` | CRX preparation/finalization without feed publication |
 | `release-extension-feeds.yml` | Extension feed preview or explicit publication |

--- a/packages/browseros/bos_build/products/server_binaries.py
+++ b/packages/browseros/bos_build/products/server_binaries.py
@@ -39,10 +39,16 @@ class ServerBundle:
     unsigned_artifact_prefix: str = "artifacts/server"
     unsigned_artifact_base_name: Optional[str] = None
 
-    def unsigned_artifact_key(self, target: str) -> str:
+    def unsigned_artifact_key(
+        self,
+        target: str,
+        *,
+        version: Optional[str] = None,
+    ) -> str:
         """R2 source key of the unsigned resource zip consumed by OTA."""
         base_name = self.unsigned_artifact_base_name or f"{self.id}-resources"
-        return f"{self.unsigned_artifact_prefix}/latest/{base_name}-{target}.zip"
+        source = version or "latest"
+        return f"{self.unsigned_artifact_prefix}/{source}/{base_name}-{target}.zip"
 
 
 def all_server_bundles() -> Tuple[ServerBundle, ...]:

--- a/packages/browseros/bos_build/products/server_binaries_test.py
+++ b/packages/browseros/bos_build/products/server_binaries_test.py
@@ -65,6 +65,12 @@ class MacosServerBinariesTest(unittest.TestCase):
             "artifacts/server/latest/browseros-server-resources-darwin-arm64.zip",
         )
         self.assertEqual(
+            BROWSEROS_SERVER_BUNDLE.unsigned_artifact_key(
+                "darwin-arm64", version="0.0.9"
+            ),
+            "artifacts/server/0.0.9/browseros-server-resources-darwin-arm64.zip",
+        )
+        self.assertEqual(
             BROWSERCLAW_SERVER_BUNDLE.unsigned_artifact_key("darwin-arm64"),
             "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
         )

--- a/packages/browseros/bos_build/release/feeds/publisher.py
+++ b/packages/browseros/bos_build/release/feeds/publisher.py
@@ -122,7 +122,7 @@ def _strict_appcast_versions(content: str) -> Optional[List[str]]:
         if len(version_elements) != 1:
             return None
         value = version_elements[0].text
-        if _strict_dotted_version(value) is None:
+        if value is None or _strict_dotted_version(value) is None:
             return None
         versions.append(value.strip())
     return versions

--- a/packages/browseros/bos_build/release/feeds/publisher.py
+++ b/packages/browseros/bos_build/release/feeds/publisher.py
@@ -436,6 +436,11 @@ class FeedPublisher:
         ):
             return False
 
+        if publish and live == content:
+            staging = self.stage(spec, content)
+            log_success(f"Already published {spec.url} (staging: {staging})")
+            return True
+
         if verbose:
             self._print_content_and_diff(spec, content, live)
 

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -236,6 +236,17 @@ class PublisherTestCase(unittest.TestCase):
         staged = self.staging_root / "browser" / "appcast.xml"
         self.assertEqual(staged.read_text(), _mac_appcast())
 
+    def test_publish_identical_live_feed_is_idempotent(self):
+        content = _mac_appcast()
+        publisher = self._publisher({"appcast.xml": content.encode()})
+
+        ok = publisher.publish(feed_by_key("appcast.xml"), content, publish=True)
+
+        self.assertTrue(ok)
+        self.assertEqual(self.client.calls, [])
+        staged = self.staging_root / "browser" / "appcast.xml"
+        self.assertEqual(staged.read_text(), content)
+
     def test_publish_without_live_object_skips_backup(self):
         publisher = self._publisher()
 
@@ -984,7 +995,7 @@ class PublisherTestCase(unittest.TestCase):
                 repair_invalid_live=True,
             )
         )
-        self.assertEqual(len(self.client.calls), 4)
+        self.assertEqual(len(self.client.calls), 2)
 
         self.client.calls.clear()
         self.assertTrue(
@@ -994,7 +1005,7 @@ class PublisherTestCase(unittest.TestCase):
                 repair_invalid_live=True,
             )
         )
-        self.assertEqual(len(self.client.calls), 4)
+        self.assertEqual(self.client.calls, [])
 
     def test_repaired_snapshots_preserve_versions_and_original_payloads(self):
         updates = Path(__file__).resolve().parents[5] / "updates"

--- a/packages/browseros/bos_build/release/ota/feeds_alignment_test.py
+++ b/packages/browseros/bos_build/release/ota/feeds_alignment_test.py
@@ -49,7 +49,7 @@ class BundleDerivationTest(unittest.TestCase):
 
         self.assertEqual(
             module.artifact_key("darwin-arm64"),
-            "artifacts/server/latest/browseros-server-resources-darwin-arm64.zip",
+            "artifacts/server/0.0.9/browseros-server-resources-darwin-arm64.zip",
         )
         self.assertEqual(
             module.zip_filename("darwin_arm64"),
@@ -63,7 +63,7 @@ class BundleDerivationTest(unittest.TestCase):
 
         self.assertEqual(
             module.artifact_key("darwin-arm64"),
-            "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
+            "claw-server-rust/prod-resources/0.0.9/browseros-claw-server-rust-resources-darwin-arm64.zip",
         )
         self.assertEqual(
             module.zip_filename("darwin_arm64"),
@@ -116,6 +116,22 @@ class BundleDerivationTest(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(ValidationError, "nope"):
+            module.validate(ctx)
+
+    def test_validate_requires_the_finalized_release_sha(self):
+        module = ServerOTAModule(version="0.0.9", channel="alpha")
+        ctx = cast(
+            Context,
+            SimpleNamespace(
+                env=SimpleNamespace(
+                    macos_certificate_name="cert",
+                    code_sign_tool_path="tool",
+                    has_r2_config=lambda: True,
+                )
+            ),
+        )
+
+        with self.assertRaisesRegex(ValidationError, "release SHA"):
             module.validate(ctx)
 
 

--- a/packages/browseros/bos_build/release/ota/server.py
+++ b/packages/browseros/bos_build/release/ota/server.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Mapping, Optional
 
 from ...core.step import Step, ValidationError
 from ...core.context import Context
@@ -36,7 +36,7 @@ from .sign_binary import (
 from ..feeds.render import parse_server_appcast_content, render_server_appcast
 from ..feeds.spec import CDN_BASE_URL, server_feed
 from ...products.server_binaries import ServerBundle, server_ota_bundles_for_product
-from ...lib.r2 import get_r2_client, upload_file_to_r2, download_file_from_r2
+from ...lib.r2 import get_r2_client, download_file_from_r2
 from ...steps.storage.download import extract_artifact_zip
 from ..resource_pins import (
     COMPONENT_RESOURCE_FAMILY,
@@ -46,6 +46,24 @@ from ..resource_pins import (
 
 
 _SOURCE_SHA_RE = re.compile(r"[0-9a-f]{40}")
+_PAYLOAD_BINDING_SCHEMA = "browseros-server-ota-v1"
+
+
+def _error_response(error: Exception) -> tuple[str, Optional[int]]:
+    response = getattr(error, "response", {})
+    code = str(response.get("Error", {}).get("Code", ""))
+    status = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    return code, status
+
+
+def _is_precondition_failure(error: Exception) -> bool:
+    code, status = _error_response(error)
+    return code in {
+        "409",
+        "412",
+        "ConditionalRequestConflict",
+        "PreconditionFailed",
+    } or status in {409, 412}
 
 
 class ServerOTAModule(Step):
@@ -74,9 +92,7 @@ class ServerOTAModule(Step):
     def bundle(self) -> ServerBundle:
         bundles = server_ota_bundles_for_product(self.product_id)
         if not bundles:
-            raise RuntimeError(
-                f"Product '{self.product_id}' has no server bundle"
-            )
+            raise RuntimeError(f"Product '{self.product_id}' has no server bundle")
         return bundles[0]
 
     def artifact_key(self, target: str) -> str:
@@ -96,9 +112,7 @@ class ServerOTAModule(Step):
             raise ValidationError("Channel must be 'alpha' or 'prod'")
 
         if not server_ota_bundles_for_product(self.product_id):
-            raise ValidationError(
-                f"Product '{self.product_id}' has no server bundle"
-            )
+            raise ValidationError(f"Product '{self.product_id}' has no server bundle")
 
         if _SOURCE_SHA_RE.fullmatch(self.release_sha) is None:
             raise ValidationError("A full lowercase release SHA is required")
@@ -183,8 +197,10 @@ class ServerOTAModule(Step):
         if self._reuse_live_release(ctx):
             return
 
-        with tempfile.TemporaryDirectory(prefix="ota_artifacts_") as dl, \
-             tempfile.TemporaryDirectory(prefix="ota_staging_") as st:
+        with (
+            tempfile.TemporaryDirectory(prefix="ota_artifacts_") as dl,
+            tempfile.TemporaryDirectory(prefix="ota_staging_") as st,
+        ):
             binaries_dir = Path(dl)
             temp_dir = Path(st)
             log_info(f"Temp directory: {temp_dir}")
@@ -235,9 +251,7 @@ class ServerOTAModule(Step):
 
             source_resources = find_server_resources_dir(binaries_dir, platform)
             if not source_resources:
-                raise RuntimeError(
-                    f"Resources dir not found for {platform['name']}"
-                )
+                raise RuntimeError(f"Resources dir not found for {platform['name']}")
 
             staging_resources = temp_dir / platform["name"] / "resources"
             shutil.copytree(source_resources, staging_resources)
@@ -253,9 +267,7 @@ class ServerOTAModule(Step):
 
             if platform["os"] == "macos" and IS_MACOS():
                 if not notarize_macos_zip(zip_path, ctx.env):
-                    raise RuntimeError(
-                        f"Notarization failed for {platform['name']}"
-                    )
+                    raise RuntimeError(f"Notarization failed for {platform['name']}")
 
             log_info(f"Signing {zip_name} with Sparkle...")
             signature, length = sparkle_sign_file(zip_path, ctx.env)
@@ -263,14 +275,16 @@ class ServerOTAModule(Step):
                 raise RuntimeError(f"Sparkle signing failed for {platform['name']}")
 
             log_success(f"  {platform['name']}: {length} bytes")
-            signed_artifacts.append(SignedArtifact(
-                platform=platform["name"],
-                zip_path=zip_path,
-                signature=signature,
-                length=length,
-                os=platform["os"],
-                arch=platform["arch"],
-            ))
+            signed_artifacts.append(
+                SignedArtifact(
+                    platform=platform["name"],
+                    zip_path=zip_path,
+                    signature=signature,
+                    length=length,
+                    os=platform["os"],
+                    arch=platform["arch"],
+                )
+            )
 
         if not signed_artifacts:
             raise RuntimeError("OTA failed - no artifacts processed")
@@ -280,6 +294,15 @@ class ServerOTAModule(Step):
         self, ctx: Context, signed_artifacts: List[SignedArtifact]
     ) -> None:
         """Write the appcast, upload every signed zip to R2, and surface URLs."""
+        log_info("\n📤 Uploading artifacts to R2...")
+        r2_client = get_r2_client(ctx.env)
+        if not r2_client:
+            raise RuntimeError("Failed to create R2 client")
+        canonical_artifacts = [
+            self._upload_bound_payload(ctx, r2_client, artifact)
+            for artifact in signed_artifacts
+        ]
+
         log_info("\n📝 Generating appcast...")
         spec = server_feed(self.bundle.id, self.channel)
         appcast_path = get_appcast_path(self.channel, self.bundle.id)
@@ -290,25 +313,14 @@ class ServerOTAModule(Step):
         appcast_content = render_server_appcast(
             spec,
             self.version,
-            signed_artifacts,
+            canonical_artifacts,
             existing=existing_appcast,
         )
         appcast_path.parent.mkdir(parents=True, exist_ok=True)
         appcast_path.write_text(appcast_content)
         log_success(f"Appcast saved to: {appcast_path}")
 
-        log_info("\n📤 Uploading artifacts to R2...")
-        r2_client = get_r2_client(ctx.env)
-        if not r2_client:
-            raise RuntimeError("Failed to create R2 client")
-
-        bucket = ctx.env.r2_bucket
-        for artifact in signed_artifacts:
-            r2_key = f"server/{artifact.zip_path.name}"
-            if not upload_file_to_r2(r2_client, artifact.zip_path, r2_key, bucket):
-                raise RuntimeError(f"Failed to upload {artifact.zip_path.name}")
-
-        ctx.artifact_registry.add("server_ota_artifacts", signed_artifacts)
+        ctx.artifact_registry.add("server_ota_artifacts", canonical_artifacts)
         ctx.artifact_registry.add("server_appcast", appcast_path)
 
         log_info("\n" + "=" * 70)
@@ -316,13 +328,130 @@ class ServerOTAModule(Step):
         log_info("=" * 70)
 
         log_info("\nArtifact URLs:")
-        for artifact in signed_artifacts:
+        for artifact in canonical_artifacts:
             log_info(f"  {CDN_BASE_URL}/server/{artifact.zip_path.name}")
 
         log_info(f"\nAppcast saved to: {appcast_path}")
         log_info(
             "\n📋 Next step: Run 'browseros ota server release-appcast "
             f"--channel {self.channel} --publish' to make the release live"
+        )
+
+    def _upload_bound_payload(
+        self,
+        ctx: Context,
+        r2_client,
+        artifact: SignedArtifact,
+    ) -> SignedArtifact:
+        """Create one immutable signed payload or reuse its canonical object."""
+        data = artifact.zip_path.read_bytes()
+        key = f"server/{artifact.zip_path.name}"
+        if artifact.length != len(data):
+            raise RuntimeError(f"Signed payload length mismatch: {key}")
+        metadata = {
+            "binding-schema": _PAYLOAD_BINDING_SCHEMA,
+            "bundle-id": self.bundle.id,
+            "version": self.version,
+            "release-sha": self.release_sha,
+            "platform": artifact.platform,
+            "os": artifact.os,
+            "arch": artifact.arch,
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "sparkle-signature": artifact.signature,
+            "length": str(len(data)),
+        }
+        try:
+            r2_client.put_object(
+                Bucket=ctx.env.r2_bucket,
+                Key=key,
+                Body=data,
+                ContentType="application/zip",
+                Metadata=metadata,
+                IfNoneMatch="*",
+            )
+        except Exception as error:
+            if not _is_precondition_failure(error):
+                raise RuntimeError(
+                    f"Failed to create source-bound server payload {key}: {error}"
+                ) from error
+            return self._read_bound_payload(
+                ctx,
+                r2_client,
+                key,
+                artifact.platform,
+                artifact.os,
+                artifact.arch,
+            )
+        log_success(f"Uploaded source-bound server payload: {key}")
+        return artifact
+
+    def _read_bound_payload(
+        self,
+        ctx: Context,
+        r2_client,
+        key: str,
+        platform: str,
+        os_type: str,
+        arch: str,
+    ) -> SignedArtifact:
+        """Read and validate a canonical signed payload after a write race."""
+        try:
+            response = r2_client.get_object(Bucket=ctx.env.r2_bucket, Key=key)
+        except Exception as error:
+            raise RuntimeError(
+                f"Failed to read canonical server payload {key}: {error}"
+            ) from error
+
+        body = response.get("Body")
+        if body is None or not hasattr(body, "read"):
+            raise RuntimeError(f"Canonical server payload {key} has no readable body")
+        try:
+            data = body.read()
+        finally:
+            close = getattr(body, "close", None)
+            if close:
+                close()
+
+        metadata = response.get("Metadata")
+        if not isinstance(metadata, Mapping):
+            metadata = {}
+        actual_sha256 = hashlib.sha256(data).hexdigest()
+        expected = {
+            "binding-schema": _PAYLOAD_BINDING_SCHEMA,
+            "bundle-id": self.bundle.id,
+            "version": self.version,
+            "release-sha": self.release_sha,
+            "platform": platform,
+            "os": os_type,
+            "arch": arch,
+            "sha256": actual_sha256,
+            "length": str(len(data)),
+        }
+        mismatches = {
+            name: {"expected": value, "actual": metadata.get(name)}
+            for name, value in expected.items()
+            if metadata.get(name) != value
+        }
+        signature = metadata.get("sparkle-signature")
+        if not isinstance(signature, str) or not signature:
+            mismatches["sparkle-signature"] = {
+                "expected": "non-empty",
+                "actual": signature,
+            }
+        if mismatches:
+            raise RuntimeError(
+                f"Canonical server payload binding mismatch for {key}: {mismatches}"
+            )
+        assert isinstance(signature, str)
+
+        log_success(f"Reused source-bound server payload: {key}")
+        return SignedArtifact(
+            platform=platform,
+            zip_path=Path(key.rsplit("/", 1)[-1]),
+            signature=signature,
+            length=len(data),
+            os=os_type,
+            arch=arch,
         )
 
     def _sign_bundle(

--- a/packages/browseros/bos_build/release/ota/server.py
+++ b/packages/browseros/bos_build/release/ota/server.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Server OTA module for BrowserOS Server binary updates"""
 
+import hashlib
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -31,19 +33,23 @@ from .sign_binary import (
     sign_server_bundle_macos,
     sign_server_bundle_windows,
 )
-from ..feeds.render import render_server_appcast
+from ..feeds.render import parse_server_appcast_content, render_server_appcast
 from ..feeds.spec import CDN_BASE_URL, server_feed
 from ...products.server_binaries import ServerBundle, server_ota_bundles_for_product
 from ...lib.r2 import get_r2_client, upload_file_to_r2, download_file_from_r2
 from ...steps.storage.download import extract_artifact_zip
+from ..resource_pins import (
+    COMPONENT_RESOURCE_FAMILY,
+    ResourcePin,
+    verify_prepared_resource_pin,
+)
+
+
+_SOURCE_SHA_RE = re.compile(r"[0-9a-f]{40}")
 
 
 class ServerOTAModule(Step):
-    """OTA update module for BrowserOS Server binaries
-
-    Downloads server binaries from R2 (artifacts/server/latest/),
-    signs them, creates Sparkle update zips, and uploads to R2.
-    """
+    """Create signed server OTA payloads from immutable release resources."""
 
     produces = ["server_ota_artifacts", "server_appcast"]
     requires = []
@@ -55,11 +61,13 @@ class ServerOTAModule(Step):
         channel: str = "alpha",
         platform_filter: Optional[str] = None,
         product_id: str = "browseros",
+        release_sha: str = "",
     ):
         self.version = version
         self.channel = channel
         self.platform_filter = platform_filter
         self.product_id = product_id
+        self.release_sha = release_sha
         self._download_dir: Optional[Path] = None
 
     @property
@@ -73,7 +81,7 @@ class ServerOTAModule(Step):
 
     def artifact_key(self, target: str) -> str:
         """R2 source key of the unsigned server resources zip for a target."""
-        return self.bundle.unsigned_artifact_key(target)
+        return self.bundle.unsigned_artifact_key(target, version=self.version)
 
     def zip_filename(self, platform_name: str) -> str:
         """Sparkle payload zip name (also the enclosure URL basename)."""
@@ -91,6 +99,9 @@ class ServerOTAModule(Step):
             raise ValidationError(
                 f"Product '{self.product_id}' has no server bundle"
             )
+
+        if _SOURCE_SHA_RE.fullmatch(self.release_sha) is None:
+            raise ValidationError("A full lowercase release SHA is required")
 
         if IS_MACOS():
             if not context.env.macos_certificate_name:
@@ -112,26 +123,41 @@ class ServerOTAModule(Step):
             return [p for p in SERVER_PLATFORMS if p["name"] in requested]
         return SERVER_PLATFORMS
 
-    def _download_artifacts(self, ctx: Context, download_dir: Path) -> None:
-        """Download and extract server artifact zips from R2 into ``download_dir``."""
-        r2_client = get_r2_client(ctx.env)
-        if not r2_client:
-            raise RuntimeError("Failed to create R2 client")
-
+    def _download_artifacts(
+        self,
+        ctx: Context,
+        download_dir: Path,
+        r2_client,
+        source_pin: ResourcePin,
+    ) -> None:
+        """Download checksum-verified immutable server resources."""
         bucket = ctx.env.r2_bucket
         platforms = self._get_platforms()
+        pinned = {item.target: item for item in source_pin.objects}
 
         log_info("📥 Downloading server artifacts from R2...")
 
         for platform in platforms:
             target = platform["target"]
-            r2_key = self.artifact_key(target)
+            resource = pinned.get(target)
+            if resource is None:
+                raise RuntimeError(f"Immutable source pin is missing {target}")
+            r2_key = resource.key
             zip_path = download_dir / f"{target}.zip"
             extract_dir = download_dir / target
 
             log_info(f"  Downloading {target}...")
             if not download_file_from_r2(r2_client, r2_key, zip_path, bucket):
                 raise RuntimeError(f"Failed to download artifact: {r2_key}")
+
+            digest = hashlib.sha256()
+            with zip_path.open("rb") as artifact_file:
+                for chunk in iter(lambda: artifact_file.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            if zip_path.stat().st_size != resource.size:
+                raise RuntimeError(f"Immutable source size mismatch: {r2_key}")
+            if digest.hexdigest() != resource.sha256:
+                raise RuntimeError(f"Immutable source checksum mismatch: {r2_key}")
 
             extract_artifact_zip(zip_path, extract_dir)
             zip_path.unlink()
@@ -143,27 +169,65 @@ class ServerOTAModule(Step):
         log_info(f"\n🚀 BrowserOS Server OTA v{self.version} ({self.channel})")
         log_info("=" * 70)
 
+        r2_client = get_r2_client(ctx.env)
+        if not r2_client:
+            raise RuntimeError("Failed to create R2 client")
+        family_name = COMPONENT_RESOURCE_FAMILY[self.bundle.id]
+        source_pin = verify_prepared_resource_pin(
+            r2_client,
+            ctx.env.r2_bucket,
+            family_name,
+            self.version,
+            self.release_sha,
+        )
+        if self._reuse_live_release(ctx):
+            return
+
         with tempfile.TemporaryDirectory(prefix="ota_artifacts_") as dl, \
              tempfile.TemporaryDirectory(prefix="ota_staging_") as st:
             binaries_dir = Path(dl)
             temp_dir = Path(st)
             log_info(f"Temp directory: {temp_dir}")
 
-            self._download_artifacts(ctx, binaries_dir)
+            self._download_artifacts(ctx, binaries_dir, r2_client, source_pin)
             signed_artifacts = self._build_platform_artifacts(
                 ctx, binaries_dir, temp_dir
             )
             self._finalize_release(ctx, signed_artifacts)
 
+    def _reuse_live_release(self, ctx: Context) -> bool:
+        """Stage an already-live same-version release without replacing payloads."""
+        spec = server_feed(self.bundle.id, self.channel)
+        live = FeedPublisher(env=ctx.env).fetch_live(spec.key)
+        if live is None:
+            return False
+        existing = parse_server_appcast_content(live)
+        if existing is None or existing.version != self.version:
+            return False
+
+        requested = {platform["name"] for platform in self._get_platforms()}
+        missing = sorted(requested.difference(existing.artifacts))
+        if missing:
+            raise RuntimeError(
+                f"Live {spec.key} is missing same-version payloads: "
+                f"{', '.join(missing)}"
+            )
+
+        appcast_path = get_appcast_path(self.channel, self.bundle.id)
+        appcast_path.parent.mkdir(parents=True, exist_ok=True)
+        appcast_path.write_text(live)
+        artifacts = [existing.artifacts[name] for name in sorted(requested)]
+        ctx.artifact_registry.add("server_ota_artifacts", artifacts)
+        ctx.artifact_registry.add("server_appcast", appcast_path)
+        log_success(
+            f"Reused live server OTA v{self.version} without replacing payloads"
+        )
+        return True
+
     def _build_platform_artifacts(
         self, ctx: Context, binaries_dir: Path, temp_dir: Path
     ) -> List[SignedArtifact]:
-        """Sign + zip + Sparkle-sign each platform; fail fast on any error.
-
-        Any per-platform failure raises ``RuntimeError`` so a broken
-        credential or unregistered binary cannot silently omit a platform
-        from a published release.
-        """
+        """Sign, archive, and Sparkle-sign each selected platform."""
         signed_artifacts: List[SignedArtifact] = []
 
         for platform in self._get_platforms():
@@ -264,10 +328,7 @@ class ServerOTAModule(Step):
     def _sign_bundle(
         self, staging_resources: Path, platform: dict, ctx: Context
     ) -> bool:
-        """Codesign every binary in the staged resources tree for a platform.
-
-        macOS notarization happens separately, on the outer Sparkle zip.
-        """
+        """Codesign every binary in the staged resources tree."""
         os_type = platform["os"]
 
         if os_type == "macos":

--- a/packages/browseros/bos_build/release/ota/server_test.py
+++ b/packages/browseros/bos_build/release/ota/server_test.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Tests for immutable and idempotent server OTA payload generation."""
+
+import hashlib
+import json
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest import mock
+
+from ...core.context import Context
+from ..feeds.render import ExistingAppcast, SignedArtifact, render_server_appcast
+from ..feeds.spec import server_feed
+from ..resource_pins import ResourceObjectPin, ResourcePin
+from . import server as ota_server
+from .common import SERVER_PLATFORMS
+from .server import ServerOTAModule
+
+
+SOURCE_SHA = "a" * 40
+
+
+def _complete_appcast(version: str = "0.0.9") -> str:
+    artifacts = [
+        SignedArtifact(
+            platform=platform["name"],
+            zip_path=Path(f"{platform['name']}.zip"),
+            signature=f"signature-{platform['name']}",
+            length=100,
+            os=platform["os"],
+            arch=platform["arch"],
+        )
+        for platform in SERVER_PLATFORMS
+    ]
+    return render_server_appcast(
+        server_feed("browseros-server", "alpha"),
+        version,
+        artifacts,
+        ExistingAppcast(
+            version=version,
+            pub_date="Wed, 05 Aug 2026 12:00:00 +0000",
+            artifacts={},
+        ),
+    )
+
+
+class LiveReleaseReuseTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.output = Path(self._tmp.name) / "appcast-server.alpha.xml"
+        self.registry = SimpleNamespace(add=mock.Mock())
+        self.ctx = cast(
+            Context,
+            SimpleNamespace(
+                env=SimpleNamespace(r2_bucket="browseros"),
+                artifact_registry=self.registry,
+            ),
+        )
+
+    def test_stages_same_version_live_feed_without_rebuilding_payloads(self):
+        live = _complete_appcast()
+        module = ServerOTAModule(
+            version="0.0.9",
+            channel="alpha",
+            platform_filter="darwin_arm64",
+            release_sha=SOURCE_SHA,
+        )
+        publisher = SimpleNamespace(fetch_live=lambda _: live)
+
+        with (
+            mock.patch.object(ota_server, "FeedPublisher", return_value=publisher),
+            mock.patch.object(
+                ota_server, "get_appcast_path", return_value=self.output
+            ),
+        ):
+            reused = module._reuse_live_release(self.ctx)
+
+        self.assertTrue(reused)
+        self.assertEqual(self.output.read_text(), live)
+        payloads = self.registry.add.call_args_list[0].args[1]
+        self.assertEqual([item.platform for item in payloads], ["darwin_arm64"])
+
+    def test_refuses_to_replace_incomplete_same_version_live_payloads(self):
+        live = render_server_appcast(
+            server_feed("browseros-server", "alpha"),
+            "0.0.9",
+            [],
+            ExistingAppcast(
+                version="0.0.9",
+                pub_date="Wed, 05 Aug 2026 12:00:00 +0000",
+                artifacts={},
+            ),
+        )
+        module = ServerOTAModule(
+            version="0.0.9",
+            platform_filter="darwin_arm64",
+            release_sha=SOURCE_SHA,
+        )
+        publisher = SimpleNamespace(fetch_live=lambda _: live)
+
+        with mock.patch.object(
+            ota_server, "FeedPublisher", return_value=publisher
+        ):
+            with self.assertRaisesRegex(RuntimeError, "missing same-version"):
+                module._reuse_live_release(self.ctx)
+
+    def test_execute_verifies_source_binding_before_live_reuse(self):
+        module = ServerOTAModule(
+            version="0.0.9",
+            platform_filter="linux_x64",
+            release_sha=SOURCE_SHA,
+        )
+        client = object()
+        pin = ResourcePin("browseros_server", "0.0.9", ())
+
+        with (
+            mock.patch.object(ota_server, "get_r2_client", return_value=client),
+            mock.patch.object(
+                ota_server,
+                "verify_prepared_resource_pin",
+                return_value=pin,
+            ) as verify,
+            mock.patch.object(
+                module, "_reuse_live_release", return_value=True
+            ) as reuse,
+            mock.patch.object(module, "_download_artifacts") as download,
+        ):
+            module.execute(self.ctx)
+
+        verify.assert_called_once_with(
+            client,
+            "browseros",
+            "browseros_server",
+            "0.0.9",
+            SOURCE_SHA,
+        )
+        reuse.assert_called_once_with(self.ctx)
+        download.assert_not_called()
+
+
+class ImmutableSourceDownloadTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.archive = self.root / "source.zip"
+        server = b"server"
+        metadata = {
+            "files": [
+                {
+                    "path": "resources/bin/browseros-server",
+                    "sha256": hashlib.sha256(server).hexdigest(),
+                    "size": len(server),
+                }
+            ]
+        }
+        with zipfile.ZipFile(self.archive, "w") as output:
+            output.writestr("artifact-metadata.json", json.dumps(metadata))
+            output.writestr("resources/bin/browseros-server", server)
+        self.data = self.archive.read_bytes()
+        self.key = (
+            "artifacts/server/0.0.9/"
+            "browseros-server-resources-linux-x64.zip"
+        )
+        self.pin = ResourcePin(
+            "browseros_server",
+            "0.0.9",
+            (
+                ResourceObjectPin(
+                    target="linux-x64",
+                    key=self.key,
+                    etag='"etag"',
+                    size=len(self.data),
+                    sha256=hashlib.sha256(self.data).hexdigest(),
+                    release_sha=SOURCE_SHA,
+                ),
+            ),
+        )
+        self.ctx = cast(
+            Context,
+            SimpleNamespace(env=SimpleNamespace(r2_bucket="browseros")),
+        )
+        self.module = ServerOTAModule(
+            version="0.0.9",
+            platform_filter="linux_x64",
+            release_sha=SOURCE_SHA,
+        )
+
+    def test_downloads_the_pinned_versioned_object_and_checks_checksum(self):
+        def download(_client, key, destination, bucket):
+            self.assertEqual(key, self.key)
+            self.assertEqual(bucket, "browseros")
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(self.data)
+            return True
+
+        destination = self.root / "download"
+        with mock.patch.object(
+            ota_server, "download_file_from_r2", side_effect=download
+        ):
+            self.module._download_artifacts(
+                self.ctx,
+                destination,
+                object(),
+                self.pin,
+            )
+
+        self.assertEqual(
+            (destination / "linux-x64/resources/bin/browseros-server").read_bytes(),
+            b"server",
+        )
+
+    def test_refuses_download_whose_bytes_do_not_match_the_binding(self):
+        bad_pin = ResourcePin(
+            self.pin.name,
+            self.pin.version,
+            (
+                ResourceObjectPin(
+                    target="linux-x64",
+                    key=self.key,
+                    etag='"etag"',
+                    size=len(self.data),
+                    sha256="0" * 64,
+                    release_sha=SOURCE_SHA,
+                ),
+            ),
+        )
+
+        def download(_client, _key, destination, _bucket):
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(self.data)
+            return True
+
+        with mock.patch.object(
+            ota_server, "download_file_from_r2", side_effect=download
+        ):
+            with self.assertRaisesRegex(RuntimeError, "checksum mismatch"):
+                self.module._download_artifacts(
+                    self.ctx,
+                    self.root / "bad-download",
+                    object(),
+                    bad_pin,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/release/ota/server_test.py
+++ b/packages/browseros/bos_build/release/ota/server_test.py
@@ -2,6 +2,7 @@
 """Tests for immutable and idempotent server OTA payload generation."""
 
 import hashlib
+import io
 import json
 import tempfile
 import unittest
@@ -21,6 +22,13 @@ from .server import ServerOTAModule
 
 
 SOURCE_SHA = "a" * 40
+
+
+class _PreconditionFailure(Exception):
+    response = {
+        "Error": {"Code": "PreconditionFailed"},
+        "ResponseMetadata": {"HTTPStatusCode": 412},
+    }
 
 
 def _complete_appcast(version: str = "0.0.9") -> str:
@@ -73,9 +81,7 @@ class LiveReleaseReuseTest(unittest.TestCase):
 
         with (
             mock.patch.object(ota_server, "FeedPublisher", return_value=publisher),
-            mock.patch.object(
-                ota_server, "get_appcast_path", return_value=self.output
-            ),
+            mock.patch.object(ota_server, "get_appcast_path", return_value=self.output),
         ):
             reused = module._reuse_live_release(self.ctx)
 
@@ -102,9 +108,7 @@ class LiveReleaseReuseTest(unittest.TestCase):
         )
         publisher = SimpleNamespace(fetch_live=lambda _: live)
 
-        with mock.patch.object(
-            ota_server, "FeedPublisher", return_value=publisher
-        ):
+        with mock.patch.object(ota_server, "FeedPublisher", return_value=publisher):
             with self.assertRaisesRegex(RuntimeError, "missing same-version"):
                 module._reuse_live_release(self.ctx)
 
@@ -162,10 +166,7 @@ class ImmutableSourceDownloadTest(unittest.TestCase):
             output.writestr("artifact-metadata.json", json.dumps(metadata))
             output.writestr("resources/bin/browseros-server", server)
         self.data = self.archive.read_bytes()
-        self.key = (
-            "artifacts/server/0.0.9/"
-            "browseros-server-resources-linux-x64.zip"
-        )
+        self.key = "artifacts/server/0.0.9/browseros-server-resources-linux-x64.zip"
         self.pin = ResourcePin(
             "browseros_server",
             "0.0.9",
@@ -245,6 +246,140 @@ class ImmutableSourceDownloadTest(unittest.TestCase):
                     object(),
                     bad_pin,
                 )
+
+
+class BoundPayloadUploadTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.path = self.root / "browseros_server_0.0.9_linux_x64.zip"
+        self.path.write_bytes(b"signed-payload")
+        self.artifact = SignedArtifact(
+            platform="linux_x64",
+            zip_path=self.path,
+            signature="local-signature",
+            length=self.path.stat().st_size,
+            os="linux",
+            arch="x86_64",
+        )
+        self.module = ServerOTAModule(
+            version="0.0.9",
+            release_sha=SOURCE_SHA,
+        )
+        self.ctx = cast(
+            Context,
+            SimpleNamespace(env=SimpleNamespace(r2_bucket="browseros")),
+        )
+
+    def _metadata(self, data: bytes, signature: str) -> dict[str, str]:
+        return {
+            "binding-schema": "browseros-server-ota-v1",
+            "bundle-id": "browseros-server",
+            "version": "0.0.9",
+            "release-sha": SOURCE_SHA,
+            "platform": "linux_x64",
+            "os": "linux",
+            "arch": "x86_64",
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "sparkle-signature": signature,
+            "length": str(len(data)),
+        }
+
+    def test_creates_payload_with_a_write_once_binding(self):
+        client = SimpleNamespace(put_object=mock.Mock())
+
+        result = self.module._upload_bound_payload(
+            self.ctx,
+            client,
+            self.artifact,
+        )
+
+        self.assertEqual(result, self.artifact)
+        request = client.put_object.call_args.kwargs
+        self.assertEqual(request["IfNoneMatch"], "*")
+        self.assertEqual(
+            request["Metadata"], self._metadata(b"signed-payload", "local-signature")
+        )
+
+    def test_reuses_the_canonical_payload_after_a_write_race(self):
+        canonical = b"canonical-payload"
+        client = SimpleNamespace(
+            put_object=mock.Mock(side_effect=_PreconditionFailure()),
+            get_object=mock.Mock(
+                return_value={
+                    "Body": io.BytesIO(canonical),
+                    "Metadata": self._metadata(canonical, "canonical-signature"),
+                }
+            ),
+        )
+
+        result = self.module._upload_bound_payload(
+            self.ctx,
+            client,
+            self.artifact,
+        )
+
+        self.assertEqual(result.signature, "canonical-signature")
+        self.assertEqual(result.length, len(canonical))
+        self.assertEqual(result.zip_path.name, self.path.name)
+
+    def test_rejects_a_colliding_payload_with_another_binding(self):
+        canonical = b"canonical-payload"
+        metadata = self._metadata(canonical, "canonical-signature")
+        metadata["release-sha"] = "b" * 40
+        client = SimpleNamespace(
+            put_object=mock.Mock(side_effect=_PreconditionFailure()),
+            get_object=mock.Mock(
+                return_value={
+                    "Body": io.BytesIO(canonical),
+                    "Metadata": metadata,
+                }
+            ),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "binding mismatch"):
+            self.module._upload_bound_payload(
+                self.ctx,
+                client,
+                self.artifact,
+            )
+
+    def test_appcast_uses_the_canonical_payload_after_collision(self):
+        canonical = SignedArtifact(
+            platform="linux_x64",
+            zip_path=Path(self.path.name),
+            signature="canonical-signature",
+            length=999,
+            os="linux",
+            arch="x86_64",
+        )
+        output = self.root / "appcast-server.alpha.xml"
+        publisher = SimpleNamespace(fetch_live=lambda _: None)
+        ctx = cast(
+            Context,
+            SimpleNamespace(
+                env=SimpleNamespace(r2_bucket="browseros"),
+                artifact_registry=SimpleNamespace(add=mock.Mock()),
+            ),
+        )
+
+        with (
+            mock.patch.object(ota_server, "get_r2_client", return_value=object()),
+            mock.patch.object(
+                self.module,
+                "_upload_bound_payload",
+                return_value=canonical,
+            ),
+            mock.patch.object(ota_server, "FeedPublisher", return_value=publisher),
+            mock.patch.object(ota_server, "get_appcast_path", return_value=output),
+        ):
+            self.module._finalize_release(ctx, [self.artifact])
+
+        content = output.read_text()
+        self.assertIn('sparkle:edSignature="canonical-signature"', content)
+        self.assertIn('length="999"', content)
+        self.assertNotIn("local-signature", content)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/release/resource_pins.py
+++ b/packages/browseros/bos_build/release/resource_pins.py
@@ -209,6 +209,28 @@ def _verify_prepared(
     return ResourcePin(family.name, version, tuple(objects))
 
 
+def verify_prepared_resource_pin(
+    client,
+    bucket: str,
+    family_name: str,
+    version: str,
+    release_sha: str,
+) -> ResourcePin:
+    """Verify one prepared resource family against its immutable bindings."""
+    family = next(
+        (item for item in RESOURCE_FAMILIES if item.name == family_name),
+        None,
+    )
+    if family is None:
+        raise ValueError(f"unknown prepared resource family: {family_name}")
+    try:
+        return _verify_prepared(client, bucket, family, version, release_sha)
+    except _IncoherentSnapshot as error:
+        raise RuntimeError(
+            f"Could not verify prepared {family_name} {version}: {error}"
+        ) from error
+
+
 def _list_objects(client, bucket: str, prefix: str) -> Iterable[dict]:
     token = None
     while True:

--- a/packages/browseros/bos_build/release/resource_pins_test.py
+++ b/packages/browseros/bos_build/release/resource_pins_test.py
@@ -3,7 +3,11 @@
 
 import unittest
 
-from .resource_pins import RESOURCE_FAMILIES, resolve_resource_pins
+from .resource_pins import (
+    RESOURCE_FAMILIES,
+    resolve_resource_pins,
+    verify_prepared_resource_pin,
+)
 
 
 SOURCE_SHA = "a" * 40
@@ -203,6 +207,46 @@ class ResourcePinsTest(unittest.TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "source binding mismatch"):
             self.resolve({family.name: ("0.0.2", "b" * 40)})
+
+    def test_verifies_one_prepared_family_without_reading_latest(self) -> None:
+        family = RESOURCE_FAMILIES[0]
+        self.client.add_family(family, "0.0.8", metadata=True)
+
+        pin = verify_prepared_resource_pin(
+            self.client,
+            "browseros",
+            family.name,
+            "0.0.8",
+            SOURCE_SHA,
+        )
+
+        self.assertEqual(pin.version, "0.0.8")
+        self.assertEqual(
+            {item.key for item in pin.objects},
+            {
+                family.version_key("0.0.8", target)
+                for target in family.targets
+            },
+        )
+        self.assertFalse(
+            any("/latest/" in key for key in self.client.head_reads)
+        )
+
+    def test_single_prepared_family_rejects_binding_mismatch(self) -> None:
+        family = RESOURCE_FAMILIES[1]
+        self.client.add_family(family, "0.0.8", metadata=True)
+        target = family.targets[0]
+        key = family.version_key("0.0.8", target)
+        self.client.objects[key]["Metadata"]["sha256"] = "invalid"
+
+        with self.assertRaisesRegex(RuntimeError, "invalid sha256 binding"):
+            verify_prepared_resource_pin(
+                self.client,
+                "browseros",
+                family.name,
+                "0.0.8",
+                SOURCE_SHA,
+            )
 
 
 if __name__ == "__main__":

--- a/tools/release_secrets/sync.py
+++ b/tools/release_secrets/sync.py
@@ -29,7 +29,8 @@ RELEASE_WORKFLOW_FILES = (
     Path(".github/workflows/release-extensions.yml"),
     Path(".github/workflows/release-server.yml"),
     Path(".github/workflows/release-claw-onboard.yml"),
-    Path(".github/workflows/release-claw-server-rust.yml"),
+    Path(".github/workflows/release-claw-server.yml"),
+    Path(".github/workflows/publish-server-ota.yml"),
 )
 
 KEY_RE = re.compile(r"[ \t]*(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*=")
@@ -74,7 +75,8 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browserclaw.yml",
             "release-server.yml",
             "release-claw-onboard.yml",
-            "release-claw-server-rust.yml",
+            "release-claw-server.yml",
+            "publish-server-ota.yml",
             "release-extension-feeds.yml",
             "release-extensions.yml",
         ),
@@ -87,7 +89,8 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browserclaw.yml",
             "release-server.yml",
             "release-claw-onboard.yml",
-            "release-claw-server-rust.yml",
+            "release-claw-server.yml",
+            "publish-server-ota.yml",
             "release-extension-feeds.yml",
             "release-extensions.yml",
         ),
@@ -100,7 +103,8 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browserclaw.yml",
             "release-server.yml",
             "release-claw-onboard.yml",
-            "release-claw-server-rust.yml",
+            "release-claw-server.yml",
+            "publish-server-ota.yml",
             "release-extension-feeds.yml",
             "release-extensions.yml",
         ),
@@ -113,7 +117,8 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browserclaw.yml",
             "release-server.yml",
             "release-claw-onboard.yml",
-            "release-claw-server-rust.yml",
+            "release-claw-server.yml",
+            "publish-server-ota.yml",
             "release-extension-feeds.yml",
             "release-extensions.yml",
         ),
@@ -137,6 +142,7 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browseros.yml",
             "release-browserclaw.yml",
             "release-windows.yml",
+            "publish-server-ota.yml",
         ),
     ),  # Windows signing preflight and CodeSignTool auth.
     SecretSpec(
@@ -146,6 +152,7 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browseros.yml",
             "release-browserclaw.yml",
             "release-windows.yml",
+            "publish-server-ota.yml",
         ),
     ),  # Windows signing preflight and CodeSignTool auth.
     SecretSpec(
@@ -155,11 +162,12 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browseros.yml",
             "release-browserclaw.yml",
             "release-windows.yml",
+            "publish-server-ota.yml",
         ),
     ),  # Windows signing preflight and CodeSignTool auth.
     SecretSpec(
         "ESIGNER_CREDENTIAL_ID",
-        ("build-browseros.yml",),
+        ("build-browseros.yml", "publish-server-ota.yml"),
     ),  # Optional SSL.com credential selector used by the builder.
     SecretSpec(
         "SPARKLE_PRIVATE_KEY",
@@ -169,24 +177,25 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
             "release-browserclaw.yml",
             "release-windows.yml",
             "release-server.yml",
-            "release-claw-server-rust.yml",
+            "release-claw-server.yml",
+            "publish-server-ota.yml",
         ),
     ),  # Sparkle/WinSparkle artifact signatures and optional server OTA.
     SecretSpec(
         "MACOS_CERTIFICATE_NAME",
-        ("build-browseros.yml",),
+        ("build-browseros.yml", "publish-server-ota.yml"),
     ),  # macOS signing certificate identity.
     SecretSpec(
         "PROD_MACOS_NOTARIZATION_APPLE_ID",
-        ("build-browseros.yml",),
+        ("build-browseros.yml", "publish-server-ota.yml"),
     ),  # macOS notarization account.
     SecretSpec(
         "PROD_MACOS_NOTARIZATION_TEAM_ID",
-        ("build-browseros.yml",),
+        ("build-browseros.yml", "publish-server-ota.yml"),
     ),  # macOS notarization team.
     SecretSpec(
         "PROD_MACOS_NOTARIZATION_PWD",
-        ("build-browseros.yml",),
+        ("build-browseros.yml", "publish-server-ota.yml"),
     ),  # macOS notarization app-specific password.
     SecretSpec(
         "BROWSEROS_AGENT_V2_KEY",

--- a/tools/release_secrets/sync_test.py
+++ b/tools/release_secrets/sync_test.py
@@ -96,6 +96,30 @@ class WorkflowSecretScannerTest(unittest.TestCase):
             consumers,
         )
 
+    def test_server_ota_workflow_is_registered_with_signing_secrets(self):
+        workflow = "publish-server-ota.yml"
+        self.assertIn(workflow, {path.name for path in RELEASE_WORKFLOW_FILES})
+
+        consumers = {spec.name for spec in ALLOWLIST if workflow in spec.consumers}
+        self.assertEqual(
+            {
+                "ESIGNER_CREDENTIAL_ID",
+                "ESIGNER_PASSWORD",
+                "ESIGNER_TOTP_SECRET",
+                "ESIGNER_USERNAME",
+                "MACOS_CERTIFICATE_NAME",
+                "PROD_MACOS_NOTARIZATION_APPLE_ID",
+                "PROD_MACOS_NOTARIZATION_PWD",
+                "PROD_MACOS_NOTARIZATION_TEAM_ID",
+                "R2_ACCESS_KEY_ID",
+                "R2_ACCOUNT_ID",
+                "R2_BUCKET",
+                "R2_SECRET_ACCESS_KEY",
+                "SPARKLE_PRIVATE_KEY",
+            },
+            consumers,
+        )
+
     def test_browserclaw_build_key_is_required_and_host_is_optional(self):
         expected_consumers = {
             "VITE_CLAW_POSTHOG_KEY": (


### PR DESCRIPTION
## Summary

- make standalone BrowserOS and BrowserClaw server dispatches finalize every `latest` resource alias, publish a complete live alpha OTA release, and persist the product-owned tracked snapshot by default
- sign five platform payloads on native runners from immutable version/source-bound resources, assemble one complete appcast, and preserve guarded backups, enclosure checks, monotonicity, and explicit production promotion
- make payload and feed retries idempotent, use write-once signed payload objects, and retry path-scoped snapshot commits across concurrent server/extension updates
- rename the product-facing BrowserClaw workflow to `release-claw-server.yml` while preserving compatibility identifiers and reusable full-release opt-out behavior

## Verification

- `132` focused Python OTA/feed/resource tests
- `78` Bun release workflow contract tests
- `42` Python CI workflow topology tests
- `10` release-secret scanner tests
- actionlint, shellcheck, Ruff, Pyright, and Biome

No Chromium source changed, so the Chromium build gate does not apply.
