### PR TITLE
fix: retain agent tabs and groups for one hour

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/config.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/config.rs
@@ -11,7 +11,8 @@ use std::{
 const DEFAULT_SERVER_PORT: u16 = 9200;
 const DEFAULT_CDP_PORT: u16 = 49337;
 const DEFAULT_SESSION_IDLE_MS: u64 = 30 * 60 * 1000;
-const DEFAULT_SESSION_RETENTION_MS: u64 = 2 * 60 * 60 * 1000;
+// Retain results so users can inspect agent-opened tabs and browser-side work can settle.
+const DEFAULT_SESSION_RETENTION_MS: u64 = 60 * 60 * 1000;
 const DEFAULT_SESSION_SWEEP_INTERVAL_MS: u64 = 60 * 1000;
 const DEFAULT_REPLAY_RETENTION_DAYS: u64 = 7;
 const BROWSERCLAW_DIR_NAME: &str = ".browserclaw";
@@ -443,14 +444,14 @@ mod tests {
                 "garbage",
                 "-500",
                 Duration::from_secs(30 * 60),
-                Duration::from_millis(7_200_000),
+                Duration::from_millis(3_600_000),
                 Duration::from_millis(60_000),
             ),
             (
                 "0",
                 "0x10",
                 Duration::from_secs(30 * 60),
-                Duration::from_millis(7_200_000),
+                Duration::from_millis(3_600_000),
                 Duration::from_millis(60_000),
             ),
             // Number.parseInt parity: integer prefix wins, trailing garbage
@@ -492,7 +493,7 @@ mod tests {
             &ConfigEnv::with_vars(BTreeMap::new(), home.clone()),
         )?;
         assert_eq!(cfg.session_idle, Duration::from_secs(30 * 60));
-        assert_eq!(cfg.session_retention, Duration::from_millis(7_200_000));
+        assert_eq!(cfg.session_retention, Duration::from_millis(3_600_000));
         assert_eq!(cfg.session_sweep_interval, Duration::from_millis(60_000));
         Ok(())
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
@@ -78,6 +78,7 @@ impl AppRuntime {
                                         &state.session_tabs,
                                         &state.browser,
                                         crate::clock::now_epoch_ms(),
+                                        state.config.session_retention,
                                     )
                                     .await
                                     {

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/tab_cleanup.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/tab_cleanup.rs
@@ -2,7 +2,7 @@
 //!
 //! Releasing a session's tab ownership stamps the ledger but never closes the
 //! Chrome tab. This reconciliation sweep closes any tab that was agent-owned but
-//! now has no live owner, once a short grace has elapsed, sparing the tab the
+//! now has no live owner, once the retention window has elapsed, sparing the tab the
 //! user is currently viewing. It is idempotent and only acts on tabs the browser
 //! still reports open, so it survives crashes, disconnects, ungrouped tabs, and
 //! popup children.
@@ -11,10 +11,6 @@ use crate::{db::SessionTabLedger, error::AppResult, services::browser::BrowserSe
 use browseros_core::PageId;
 use std::{collections::HashMap, time::Duration};
 use tracing::warn;
-
-/// Grace after a session finishes before its still-open tabs are closed, so the
-/// user can glance at the result before the tabs disappear.
-const CLEANUP_GRACE: Duration = Duration::from_secs(3 * 60);
 
 /// One tab the browser currently reports open.
 struct LiveTab {
@@ -43,8 +39,9 @@ pub async fn sweep_orphaned_tabs(
     session_tabs: &SessionTabLedger,
     browser: &BrowserService,
     now: i64,
+    cleanup_grace: Duration,
 ) -> AppResult<usize> {
-    let cutoff = now.saturating_sub(i64::try_from(CLEANUP_GRACE.as_millis()).unwrap_or(i64::MAX));
+    let cutoff = now.saturating_sub(i64::try_from(cleanup_grace.as_millis()).unwrap_or(i64::MAX));
     let orphaned = session_tabs.list_orphaned_owned_tabs(cutoff).await?;
     if orphaned.is_empty() {
         return Ok(0);
@@ -115,8 +112,6 @@ mod tests {
     fn closes_orphaned_live_inactive_tabs_only() {
         let orphaned = [11, 12, 13, 99];
         let live = [live(11, false), live(12, true), live(13, false)];
-        // 11 and 13 are orphaned, live, and inactive -> close; 12 is the
-        // foreground tab -> spared; 99 is no longer listed -> already gone.
         assert_eq!(tabs_to_close(&orphaned, &live), vec![11, 13]);
     }
 


### PR DESCRIPTION
## Summary
- Retain finished-session agent tabs for one hour instead of three minutes.
- Align retained tab-group closure to the same one-hour policy.
- Document that retention lets users inspect agent-opened tabs while browser-side work settles.

## Design
The existing session retention setting is now the single source of truth for both retained groups and orphaned-tab cleanup. Its default is one hour, and CLAW_SESSION_RETENTION_MS continues to override the policy for both paths. The cleanup sweep remains at its independent 60-second polling interval.

## Test plan
- [x] cargo fmt --all --check
- [x] cargo check -p claw-server-rust
- [x] cargo clippy --workspace --all-targets --locked -- -D warnings

Unit tests were intentionally not run per workspace instructions.