### PR TITLE
fix(claw-onboard): broaden default import selection

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/ImportItemChecklist.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/ImportItemChecklist.tsx
@@ -10,12 +10,6 @@ interface ImportItemChecklistProps {
   onToggle: (item: BrowserOSImportItem) => void
 }
 
-/**
- * Per-item selector for the active profile. Logins stay in the open because
- * they are the only items an agent can use; the rest of Chromium's data is
- * browsing setup, so it collapses behind a disclosure instead of presenting
- * itself as part of the default ask.
- */
 export function ImportItemChecklist({
   items,
   checkedItems,
@@ -23,7 +17,7 @@ export function ImportItemChecklist({
 }: ImportItemChecklistProps) {
   const checklistId = useId()
   const checkedItemSet = new Set(checkedItems)
-  const { loginItems, extraItems } = splitImportSelection(items)
+  const { defaultItems, optionalItems } = splitImportSelection(items)
 
   function renderRow(item: BrowserOSImportItem) {
     const controlId = `${checklistId}-${item}`
@@ -52,19 +46,19 @@ export function ImportItemChecklist({
         </div>
       </div>
       <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">
-        {loginItems.map(renderRow)}
+        {defaultItems.map(renderRow)}
       </div>
-      {extraItems.length > 0 && (
+      {optionalItems.length > 0 && (
         <details className="group mt-3 border-border-2 border-t pt-3">
           <summary className="flex cursor-pointer list-none items-center gap-1.5 text-[12px] text-ink-3 transition-colors hover:text-ink-2">
             <ChevronRight className="size-3.5 transition-transform group-open:rotate-90" />
             Also copy my browsing setup
             <span className="text-ink-4">
-              ({extraItems.map(importItemLabel).join(', ').toLowerCase()})
+              ({optionalItems.map(importItemLabel).join(', ').toLowerCase()})
             </span>
           </summary>
           <div className="mt-2.5 grid grid-cols-2 gap-x-4 gap-y-2.5">
-            {extraItems.map(renderRow)}
+            {optionalItems.map(renderRow)}
           </div>
         </details>
       )}

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import type { BrowserOSImportSource } from './browseros-onboarding-api'
 import {
-  AGENT_LOGIN_ITEMS,
   completedImportItemCount,
   DEFAULT_BROWSEROS_IMPORT_SOURCE_ID,
   defaultImportItemsForSource,
@@ -9,11 +8,10 @@ import {
   importItemListLabel,
   importProgressTotal,
   importSourceSelectionChangeFor,
-  loginItemsForSource,
   MOCK_BROWSEROS_IMPORT_SOURCES,
+  OPTIONAL_IMPORT_ITEMS,
   STARTER_PROMPTS,
   sanitizeImportSelection,
-  selectableItemsForSource,
   selectedSourceById,
   splitImportSelection,
   startImportRequestFor,
@@ -78,15 +76,6 @@ describe('source selection helpers', () => {
     ).toBeNull()
   })
 
-  it('falls back to supported items when recommended items are empty', () => {
-    expect(
-      selectableItemsForSource({
-        ...MOCK_BROWSEROS_IMPORT_SOURCES[0],
-        recommendedItems: [],
-      }),
-    ).toEqual(MOCK_BROWSEROS_IMPORT_SOURCES[0].supportedItems)
-  })
-
   it('sanitizes explicit item selections against supported items in source order', () => {
     expect(
       sanitizeImportSelection(MOCK_BROWSEROS_IMPORT_SOURCES[0], [
@@ -118,7 +107,7 @@ describe('source selection helpers', () => {
   it('builds the Chromium start-import request for one source', () => {
     expect(startImportRequestFor(MOCK_BROWSEROS_IMPORT_SOURCES[0])).toEqual({
       sourceId: 'chrome-work',
-      items: ['cookies', 'passwords'],
+      items: ['history', 'bookmarks', 'cookies', 'passwords', 'autofill'],
     })
   })
 
@@ -154,48 +143,63 @@ describe('source selection helpers', () => {
   })
 })
 
-describe('login-scoped import defaults', () => {
-  it('treats only cookies and passwords as agent login items', () => {
-    expect([...AGENT_LOGIN_ITEMS]).toEqual(['cookies', 'passwords'])
+describe('default and optional import items', () => {
+  it('treats only search engines and extensions as optional', () => {
+    expect([...OPTIONAL_IMPORT_ITEMS]).toEqual(['searchEngines', 'extensions'])
   })
 
-  it('picks the login items a profile actually supports', () => {
-    expect(loginItemsForSource(MOCK_BROWSEROS_IMPORT_SOURCES[0])).toEqual([
-      'cookies',
-      'passwords',
+  it('defaults every supported non-optional item', () => {
+    expect(
+      defaultImportItemsForSource(MOCK_BROWSEROS_IMPORT_SOURCES[0]),
+    ).toEqual(['history', 'bookmarks', 'cookies', 'passwords', 'autofill'])
+    expect(
+      defaultImportItemsForSource(MOCK_BROWSEROS_IMPORT_SOURCES[1]),
+    ).toEqual(['history', 'bookmarks', 'cookies', 'passwords', 'autofill'])
+    expect(
+      defaultImportItemsForSource(MOCK_BROWSEROS_IMPORT_SOURCES[2]),
+    ).toEqual(['history', 'bookmarks', 'cookies', 'passwords'])
+  })
+
+  it('uses supported items instead of Chromium recommendations', () => {
+    const partiallyRecommended: BrowserOSImportSource = {
+      ...MOCK_BROWSEROS_IMPORT_SOURCES[0],
+      supportedItems: ['extensions', 'autofill', 'searchEngines', 'history'],
+      recommendedItems: ['extensions'],
+    }
+
+    expect(defaultImportItemsForSource(partiallyRecommended)).toEqual([
+      'autofill',
+      'history',
     ])
   })
 
-  // The whole point of the reframe: browsing setup must not ride along by
-  // default, because no MCP tool exposes any of it to an agent.
-  it('defaults to logins only, never the browsing setup', () => {
-    for (const source of MOCK_BROWSEROS_IMPORT_SOURCES) {
-      expect(defaultImportItemsForSource(source)).toEqual([
-        'cookies',
-        'passwords',
-      ])
-    }
-  })
-
-  // A profile with no logins must still offer something, or the step dead-ends
-  // on a disabled button the way it did before #1795.
-  it('falls back to the Chromium recommendation when a profile has no logins', () => {
-    const historyOnly: BrowserOSImportSource = {
+  it('leaves optional-only sources unchecked by default', () => {
+    const optionalOnly: BrowserOSImportSource = {
       ...MOCK_BROWSEROS_IMPORT_SOURCES[0],
-      supportedItems: ['history', 'bookmarks'],
-      recommendedItems: ['history'],
+      supportedItems: ['extensions', 'searchEngines'],
+      recommendedItems: ['extensions'],
     }
 
-    expect(loginItemsForSource(historyOnly)).toEqual([])
-    expect(defaultImportItemsForSource(historyOnly)).toEqual(['history'])
+    expect(defaultImportItemsForSource(optionalOnly)).toEqual([])
+    expect(startImportRequestFor(optionalOnly)).toBeNull()
+    expect(startImportRequestFor(optionalOnly, ['searchEngines'])).toEqual({
+      sourceId: 'chrome-work',
+      items: ['searchEngines'],
+    })
   })
 
-  it('splits a selection into logins and opted-in extras', () => {
+  it('splits default and optional items without changing their order', () => {
     expect(
-      splitImportSelection(['history', 'cookies', 'extensions', 'passwords']),
+      splitImportSelection([
+        'history',
+        'searchEngines',
+        'cookies',
+        'extensions',
+        'passwords',
+      ]),
     ).toEqual({
-      loginItems: ['cookies', 'passwords'],
-      extraItems: ['history', 'extensions'],
+      defaultItems: ['history', 'cookies', 'passwords'],
+      optionalItems: ['searchEngines', 'extensions'],
     })
   })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.ts
@@ -97,61 +97,32 @@ export function importItemListLabel(items: readonly string[]): string {
   return items.map(importItemLabel).join(', ')
 }
 
-export function selectableItemsForSource(
-  source: BrowserOSImportSource,
-): BrowserOSImportItem[] {
-  return [
-    ...(source.recommendedItems.length
-      ? source.recommendedItems
-      : source.supportedItems),
-  ]
-}
-
-/**
- * The only items that let an agent act inside your accounts. Everything else
- * Chromium offers is human-browser furniture — no MCP tool exposes history,
- * bookmarks, search engines, autofill or extensions to an agent, so copying
- * them buys nothing and makes the ask look bigger than it is.
- */
-export const AGENT_LOGIN_ITEMS: readonly BrowserOSImportItem[] = [
-  'cookies',
-  'passwords',
+export const OPTIONAL_IMPORT_ITEMS: readonly BrowserOSImportItem[] = [
+  'searchEngines',
+  'extensions',
 ]
 
-function isLoginItem(item: BrowserOSImportItem): boolean {
-  return AGENT_LOGIN_ITEMS.includes(item)
+function isOptionalImportItem(item: BrowserOSImportItem): boolean {
+  return OPTIONAL_IMPORT_ITEMS.includes(item)
 }
 
-export function loginItemsForSource(
-  source: BrowserOSImportSource,
-): BrowserOSImportItem[] {
-  return source.supportedItems.filter(isLoginItem)
-}
-
-/**
- * Default checked set for a profile: logins only. Falls back to Chromium's own
- * recommendation when a profile carries no logins at all, so a history-only
- * profile still offers something to copy instead of a dead Import button.
- */
 export function defaultImportItemsForSource(
   source: BrowserOSImportSource,
 ): BrowserOSImportItem[] {
-  const loginItems = loginItemsForSource(source)
-  return loginItems.length > 0 ? loginItems : selectableItemsForSource(source)
+  return source.supportedItems.filter((item) => !isOptionalImportItem(item))
 }
 
 export interface ImportSelectionSplit {
-  loginItems: BrowserOSImportItem[]
-  extraItems: BrowserOSImportItem[]
+  defaultItems: BrowserOSImportItem[]
+  optionalItems: BrowserOSImportItem[]
 }
 
-/** Splits a selection into logins and the optional browsing-setup extras. */
 export function splitImportSelection(
   items: readonly BrowserOSImportItem[],
 ): ImportSelectionSplit {
   return {
-    loginItems: items.filter(isLoginItem),
-    extraItems: items.filter((item) => !isLoginItem(item)),
+    defaultItems: items.filter((item) => !isOptionalImportItem(item)),
+    optionalItems: items.filter(isOptionalImportItem),
   }
 }
 

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
@@ -140,7 +140,7 @@ describe('ImportStep', () => {
         'aria-checked="true"',
       )
     }
-    expect(html).toContain('2 selected')
+    expect(html).toContain('5 selected')
     // JSX wraps "macOS will ask" in a semibold span, so the string
     // "macOS will ask to read" is split by a </span> boundary in the
     // rendered HTML. Assert on the positive plus a negative that
@@ -151,51 +151,66 @@ describe('ImportStep', () => {
     expect(html).not.toContain('macOS will ask permission')
     expect(html).toContain('Allow')
     expect(html).not.toContain('Always Allow')
-    expect(html).toContain('Copy logins from Work')
+    expect(html).toContain('Copy 5 items from Work')
     expect(html).not.toContain('Chrome is open')
     expect(html).not.toContain('Quit Chrome for me')
     expect(html).not.toContain('disabled=""')
   })
 
-  // No MCP tool exposes history, bookmarks, search engines, autofill or
-  // extensions to an agent, so they must never ride along by default.
-  it('checks logins only and leaves the browsing setup unchecked', () => {
+  it('checks every supported non-optional item by default', () => {
     const source = MOCK_BROWSEROS_IMPORT_SOURCES[1]
     const html = render('picker', readyState(), {
       selectedSourceId: source.id,
       selectedItems: defaultImportItemsForSource(source),
     })
 
-    expect(html).toContain('2 selected')
-    expect(html).toContain('Copy logins from Personal')
-    for (const item of ['Cookies', 'Passwords']) {
+    expect(html).toContain('5 selected')
+    expect(html).toContain('Copy 5 items from Personal')
+    for (const item of [
+      'History',
+      'Bookmarks',
+      'Cookies',
+      'Passwords',
+      'Autofill',
+    ]) {
       const row = checklistRowFor(html, item)
       expect(row).toContain('data-checked=""')
       expect(row).toContain('aria-checked="true"')
     }
-    for (const item of ['History', 'Bookmarks', 'Autofill']) {
-      const row = checklistRowFor(html, item)
-      expect(row).toContain('data-unchecked=""')
-      expect(row).toContain('aria-checked="false"')
+    expect(html).not.toContain('<details')
+  })
+
+  it('collapses only search engines and extensions behind a disclosure', () => {
+    const html = render('picker')
+    const detailsStart = html.indexOf('<details')
+    const detailsEnd = html.indexOf('</details>', detailsStart)
+    const details = html.slice(detailsStart, detailsEnd)
+
+    expect(detailsStart).toBeGreaterThan(-1)
+    expect(html).toContain('Also copy my browsing setup')
+    expect(details).toContain('Search engines')
+    expect(details).toContain('Extensions')
+    for (const item of [
+      'History',
+      'Bookmarks',
+      'Cookies',
+      'Passwords',
+      'Autofill',
+    ]) {
+      expect(details).not.toContain(item)
+    }
+    for (const item of ['Search engines', 'Extensions']) {
+      expect(checklistRowFor(html, item)).toContain('aria-checked="false"')
     }
   })
 
-  it('collapses the non-login items behind a disclosure', () => {
-    const html = render('picker')
-
-    expect(html).toContain('<details')
-    expect(html).toContain('Also copy my browsing setup')
-    // The extras stay reachable, just not part of the default ask.
-    expect(checklistRowFor(html, 'History')).toContain('aria-checked="false"')
-  })
-
-  it('counts opted-in extras separately from the logins', () => {
+  it('counts a custom mixed selection in the action label', () => {
     const html = render('picker', readyState(), {
       selectedItems: ['cookies', 'passwords', 'history'],
     })
 
     expect(html).toContain('3 selected')
-    expect(html).toContain('Copy logins + 1 more from Work')
+    expect(html).toContain('Copy 3 items from Work')
   })
 
   it('disables the copy action until at least one item is selected', () => {

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
@@ -21,7 +21,6 @@ import {
   importProgressTotal,
   sanitizeImportSelection,
   selectedSourceById,
-  splitImportSelection,
 } from '../onboarding-v2.helpers'
 import type { OnboardingFormValues } from '../onboarding-v2.schemas'
 import type { ImportPhase } from '../onboarding-v2.types'
@@ -35,11 +34,6 @@ interface ImportStepProps {
   onContinue: () => void
 }
 
-/**
- * Names the logins rather than counting them, so the default action reads as a
- * credential handover instead of a bulk browser import. Extras stay countable
- * because they are opt-in and the user should see what they added.
- */
 function importButtonLabelFor(
   hasSource: boolean,
   hasSupportedItems: boolean,
@@ -50,17 +44,11 @@ function importButtonLabelFor(
   if (!hasSupportedItems) return 'Nothing to copy from this profile'
   if (checkedItems.length === 0) return 'Select what to copy'
 
-  const { loginItems, extraItems } = splitImportSelection(checkedItems)
-  if (loginItems.length === 0) {
-    return `Copy ${extraItems.length} ${
-      extraItems.length === 1 ? 'item' : 'items'
-    } from ${sourceName}`
-  }
-  if (extraItems.length === 0) return `Copy logins from ${sourceName}`
-  return `Copy logins + ${extraItems.length} more from ${sourceName}`
+  return `Copy ${checkedItems.length} ${
+    checkedItems.length === 1 ? 'item' : 'items'
+  } from ${sourceName}`
 }
 
-/** Renders the browser import step across quit, picker, progress, and success states. */
 export function ImportStep({
   phase,
   state,


### PR DESCRIPTION
## Summary
- Default history, bookmarks, cookies, passwords, and autofill on when supported.
- Keep only search engines and extensions unchecked in the optional disclosure.
- Replace login-only grouping and CTA copy with accurate default/optional groups and item counts.

## Design
Centralize the two optional import categories in the onboarding helper layer, then derive profile defaults and checklist grouping from that policy. Existing initialization, source switching, sanitization, and request construction continue to share one source of truth.

## Test plan
- [x] `bun test src/onboarding/onboarding-v2.helpers.test.ts src/onboarding/steps/ImportStep.test.tsx` from `apps/claw-onboard` (45 passed)
- [x] All 11 claw-onboard test files run individually from the app cwd (64 passed)
- [x] `bun run --filter @browseros/claw-onboard typecheck`
- [x] `bun run check`
- [x] `bun run --filter @browseros/claw-onboard build:chromium`

## Test note
The unchanged root test wrapper still launches four claw-onboard JSX tests from the monorepo cwd and cannot resolve their existing `@/` aliases. The same four files pass from the app cwd; all other root suites passed.
