### PR TITLE
fix(release): skip unavailable default publish platforms

### DIFF
--- a/packages/browseros/bos_build/cli/release_test.py
+++ b/packages/browseros/bos_build/cli/release_test.py
@@ -734,12 +734,30 @@ class PublishCliIntegrityTest(unittest.TestCase):
         ):
             yield
 
-    def test_missing_requested_platform_makes_actual_cli_exit_nonzero(self):
+    def test_missing_default_platform_warns_and_cli_succeeds(self):
+        with (
+            self.patches(_github_metadata()),
+            mock.patch.object(publish_module, "get_r2_client", return_value=object()),
+            mock.patch.object(
+                publish_module,
+                "copy_to_download_path",
+                return_value=True,
+            ),
+        ):
+            result = self.invoke_publish()
+
+        self.assertEqual(result.exit_code, 0, plain_output(result))
+        self.assertIn(
+            "Skipping platforms with no release metadata: macos, linux",
+            plain_output(result),
+        )
+
+    def test_missing_explicit_platform_makes_actual_cli_exit_nonzero(self):
         with (
             self.patches(_github_metadata()),
             mock.patch.object(publish_module, "get_r2_client", return_value=object()),
         ):
-            result = self.invoke_publish()
+            result = self.invoke_publish("--platform", "linux")
 
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("missing release metadata", plain_output(result).lower())

--- a/packages/browseros/bos_build/release/publish.py
+++ b/packages/browseros/bos_build/release/publish.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Tuple
 
 from ..core.context import Context
 from ..core.step import Step, ValidationError
-from ..lib.utils import log_info, log_error, log_success
+from ..lib.utils import log_error, log_info, log_success, log_warning
 from ..lib.r2 import BOTO3_AVAILABLE, get_r2_client
 from .common import (
     PLATFORMS,
@@ -50,37 +50,54 @@ class PublishModule(Step):
         workflow_run_id: str = "",
         workflow_run_attempt: str = "",
     ):
-        self.platforms = platforms or PLATFORMS
+        self.selected_platforms = platforms or PLATFORMS
+        self.allow_missing_platforms = platforms is None
         self.macos_arch = macos_arch
         self.source_sha = source_sha
         self.workflow_run_id = workflow_run_id
         self.workflow_run_attempt = workflow_run_attempt
 
-    def validate(self, ctx: Context) -> None:
+    def validate(self, context: Context) -> None:
         if not BOTO3_AVAILABLE:
             raise ValidationError(
                 "boto3 library not installed - run: pip install boto3"
             )
 
-        if not ctx.env.has_r2_config():
+        if not context.env.has_r2_config():
             raise ValidationError("R2 configuration not set")
 
-        if not ctx.release_version:
+        if not context.release_version:
             raise ValidationError("--version is required")
-        invalid = sorted(set(self.platforms) - set(PLATFORMS))
+        invalid = sorted(set(self.selected_platforms) - set(PLATFORMS))
         if invalid:
             raise ValidationError(
                 f"Unknown platform(s): {', '.join(invalid)}. "
                 f"Valid: {', '.join(PLATFORMS)}"
             )
 
-    def execute(self, ctx: Context) -> None:
-        version = ctx.release_version
-        env = ctx.env
+    def execute(self, context: Context) -> None:
+        version = context.release_version
+        env = context.env
 
-        metadata = fetch_all_release_metadata(version, env, ctx.product.id)
+        metadata = fetch_all_release_metadata(version, env, context.product.id)
         if not metadata:
             raise RuntimeError(f"No release metadata found for version {version}")
+        missing_platforms = [
+            platform for platform in self.selected_platforms if platform not in metadata
+        ]
+        if missing_platforms and not self.allow_missing_platforms:
+            raise RuntimeError(
+                "Missing release metadata for requested platform(s): "
+                f"{', '.join(missing_platforms)}"
+            )
+        if missing_platforms:
+            log_warning(
+                "Skipping platforms with no release metadata: "
+                f"{', '.join(missing_platforms)}"
+            )
+        loaded_platforms = [
+            platform for platform in self.selected_platforms if platform in metadata
+        ]
         if any(
             (
                 self.source_sha,
@@ -89,13 +106,13 @@ class PublishModule(Step):
             )
         ):
             validated: Dict[str, dict] = {}
-            for platform in self.platforms:
+            for platform in loaded_platforms:
                 selection = "windows" if platform == "win" else platform
                 validated.update(
                     validate_release_metadata(
                         metadata,
                         version=version,
-                        product_id=ctx.product.id,
+                        product_id=context.product.id,
                         platforms=selection,
                         macos_arch=self.macos_arch,
                         source_sha=self.source_sha,
@@ -104,26 +121,20 @@ class PublishModule(Step):
                     )
                 )
             metadata = validated
-        missing_platforms = [
-            platform for platform in self.platforms if platform not in metadata
-        ]
-        if missing_platforms:
-            raise RuntimeError(
-                "Missing release metadata for requested platform(s): "
-                f"{', '.join(missing_platforms)}"
-            )
 
         candidates: Dict[str, List[Tuple[str, str, str]]] = {}
-        for platform in self.platforms:
+        for platform in loaded_platforms:
             release = metadata[platform]
             artifacts = release.get("artifacts", {})
-            platform_mapping = get_download_path_mapping(ctx.product).get(platform, {})
+            platform_mapping = get_download_path_mapping(context.product).get(
+                platform, {}
+            )
             platform_candidates: List[Tuple[str, str, str]] = []
             for artifact_key, artifact in artifacts.items():
                 if artifact_key not in platform_mapping:
                     continue
                 dest_path = platform_mapping[artifact_key]
-                source_key = _release_source_key(ctx, platform, version, artifact)
+                source_key = _release_source_key(context, platform, version, artifact)
                 platform_candidates.append(
                     (artifact["filename"], source_key, dest_path)
                 )
@@ -147,7 +158,9 @@ class PublishModule(Step):
             log_info(f"\n{PLATFORM_DISPLAY_NAMES[platform]}:")
             for filename, source_key, dest_path in platform_candidates:
                 log_info(f"  Copying {filename} → {dest_path}")
-                success = copy_to_download_path(client, env.r2_bucket, source_key, dest_path)
+                success = copy_to_download_path(
+                    client, env.r2_bucket, source_key, dest_path
+                )
                 results.append((filename, dest_path, success))
 
                 if success:

--- a/packages/browseros/bos_build/release/publish_test.py
+++ b/packages/browseros/bos_build/release/publish_test.py
@@ -56,6 +56,133 @@ class ReleaseSourceKeyTest(unittest.TestCase):
 
 
 class PublishModuleIntegrityTest(unittest.TestCase):
+    def test_default_selection_skips_every_missing_platform(self):
+        module = PublishModule()
+        ctx = SimpleNamespace(
+            release_version="0.49.0",
+            env=SimpleNamespace(
+                r2_cdn_base_url="https://cdn.browseros.com",
+                r2_bucket="bucket",
+            ),
+            product=get_product_descriptor("browserclaw"),
+        )
+
+        with (
+            mock.patch(
+                "bos_build.release.publish.fetch_all_release_metadata",
+                return_value={
+                    "win": {
+                        "artifacts": {
+                            "x64_installer": {
+                                "filename": "BrowserOS_neo_installer.exe",
+                                "url": "https://cdn.browseros.com/installer.exe",
+                            }
+                        }
+                    }
+                },
+            ),
+            mock.patch(
+                "bos_build.release.publish.get_r2_client",
+                return_value=object(),
+            ),
+            mock.patch(
+                "bos_build.release.publish.copy_to_download_path",
+                return_value=True,
+            ) as copy,
+            mock.patch("bos_build.release.publish.log_warning") as warning,
+        ):
+            module.execute(ctx)
+
+        warning.assert_called_once_with(
+            "Skipping platforms with no release metadata: macos, linux"
+        )
+        copy.assert_called_once_with(
+            mock.ANY,
+            "bucket",
+            "installer.exe",
+            "download/BrowserOS_neo_installer.exe",
+        )
+
+    def test_default_selection_validates_only_loaded_platforms(self):
+        module = PublishModule(
+            source_sha="a" * 40,
+            workflow_run_id="123",
+            workflow_run_attempt="1",
+        )
+        ctx = SimpleNamespace(
+            release_version="0.49.0",
+            env=SimpleNamespace(
+                r2_cdn_base_url="https://cdn.browseros.com",
+                r2_bucket="bucket",
+            ),
+            product=get_product_descriptor("browserclaw"),
+        )
+        metadata = {
+            "win": {
+                "product": "browserclaw",
+                "version": "0.49.0",
+                "platform": "win",
+                "source_sha": "a" * 40,
+                "workflow_run_id": "123",
+                "workflow_run_attempt": "1",
+                "artifacts": {
+                    "x64_installer": {
+                        "filename": "BrowserOS_neo_installer.exe",
+                        "url": "https://cdn.browseros.com/installer.exe",
+                    },
+                    "x64_zip": {
+                        "filename": "BrowserOS_neo_installer.zip",
+                        "url": "https://cdn.browseros.com/installer.zip",
+                    },
+                },
+            }
+        }
+
+        with (
+            mock.patch(
+                "bos_build.release.publish.fetch_all_release_metadata",
+                return_value=metadata,
+            ),
+            mock.patch(
+                "bos_build.release.publish.get_r2_client",
+                return_value=object(),
+            ),
+            mock.patch(
+                "bos_build.release.publish.copy_to_download_path",
+                return_value=True,
+            ) as copy,
+            mock.patch("bos_build.release.publish.log_warning"),
+        ):
+            module.execute(ctx)
+
+        copy.assert_called_once()
+
+    def test_explicit_missing_platform_raises_before_copy(self):
+        module = PublishModule(platforms=["linux"])
+        ctx = SimpleNamespace(
+            release_version="0.49.0",
+            env=SimpleNamespace(
+                r2_cdn_base_url="https://cdn.browseros.com",
+                r2_bucket="bucket",
+            ),
+            product=get_product_descriptor("browserclaw"),
+        )
+
+        with (
+            mock.patch(
+                "bos_build.release.publish.fetch_all_release_metadata",
+                return_value={"win": {"artifacts": {}}},
+            ),
+            mock.patch(
+                "bos_build.release.publish.copy_to_download_path",
+                return_value=True,
+            ) as copy,
+            self.assertRaisesRegex(RuntimeError, "requested platform.*linux"),
+        ):
+            module.execute(ctx)
+
+        copy.assert_not_called()
+
     def test_missing_r2_client_raises(self):
         module = PublishModule(platforms=["win"])
         ctx = SimpleNamespace(


### PR DESCRIPTION
## Summary
- publish every available platform when `--platform` is omitted
- warn with all missing platform metadata while keeping explicit platform requests strict
- validate and build candidates only from metadata that was actually loaded

## Design
`PublishModule` now preserves whether platform selection was omitted, partitions the default selection into loaded and missing platforms, and limits validation and promotion to loaded metadata. Explicit selections retain the prior fail-closed behavior.

## Test plan
- [x] `uv run python -m unittest bos_build.release.publish_test bos_build.cli.release_test -v`
- [x] `uv run python -m unittest discover -s bos_build -t . -p "*_test.py" -v`
- [x] `uv run ruff check bos_build`
- [x] CI-equivalent CLI smoke and product doctor
- [x] `uv run pyright bos_build/release/publish.py`