### PR TITLE
fix(release): migrate BrowserOS neo appcast metadata

### DIFF
--- a/packages/browseros/bos_build/release/feeds/publisher.py
+++ b/packages/browseros/bos_build/release/feeds/publisher.py
@@ -610,27 +610,36 @@ class FeedPublisher:
             return False
         title, link = extract_channel_metadata(live)
         if title != spec.title or link != spec.link:
-            reason = f"live channel metadata mismatch (title={title!r}, link={link!r})"
-            if repair_invalid_live:
-                live_versions = _strict_appcast_versions(live)
-                if not live_versions:
-                    log_error(
-                        f"{spec.key}: wrong-channel live appcast has no "
-                        "strict version; refusing repair."
-                    )
-                    return False
-                return self._repair_invalid_appcast(
-                    spec,
-                    content,
-                    live,
-                    new_version,
-                    reason,
-                    allow_downgrade,
-                    require_live_version=True,
-                    known_live_versions=live_versions,
+            if title in spec.legacy_titles and link == spec.link:
+                log_warning(
+                    f"{spec.key}: migrating live channel title {title!r} "
+                    f"to {spec.title!r}"
                 )
-            self._check_channel_metadata(spec, live)
-            return False
+            else:
+                reason = (
+                    f"live channel metadata mismatch "
+                    f"(title={title!r}, link={link!r})"
+                )
+                if repair_invalid_live:
+                    live_versions = _strict_appcast_versions(live)
+                    if not live_versions:
+                        log_error(
+                            f"{spec.key}: wrong-channel live appcast has no "
+                            "strict version; refusing repair."
+                        )
+                        return False
+                    return self._repair_invalid_appcast(
+                        spec,
+                        content,
+                        live,
+                        new_version,
+                        reason,
+                        allow_downgrade,
+                        require_live_version=True,
+                        known_live_versions=live_versions,
+                    )
+                self._check_channel_metadata(spec, live)
+                return False
 
         live_versions = _strict_appcast_versions(live)
         if not live_versions:

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -17,13 +17,20 @@ from .render import (
     ExistingAppcast,
     SignedArtifact,
     extract_appcast_version,
+    extract_channel_metadata,
     extract_manifest_versions,
     render_browser_appcast,
     render_extensions_json,
     render_server_appcast,
     render_update_manifest,
 )
-from .spec import all_feeds, feed_by_key, server_feed, update_manifest_feed
+from .spec import (
+    all_feeds,
+    browser_feeds_for_product,
+    feed_by_key,
+    server_feed,
+    update_manifest_feed,
+)
 
 FIXED_NOW = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
 EXTENSION_VERSIONS = {
@@ -84,6 +91,25 @@ def _mac_appcast(sparkle_version="10000.0.47.0.2"):
         "0.47.0.2",
         sparkle_version,
         "2026-06-19T06:41:33Z",
+    )
+
+
+def _browserclaw_appcast(sparkle_version="10000.0.47.0.2"):
+    return render_browser_appcast(
+        feed_by_key("appcast-claw.xml"),
+        _artifact(
+            "https://cdn.browseros.com/releases/browserclaw/0.47.0.2/"
+            "macos/BrowserOS_neo_v0.47.0.2_universal.dmg"
+        ),
+        "0.47.0.2",
+        sparkle_version,
+        "2026-06-19T06:41:33Z",
+    )
+
+
+def _legacy_browserclaw_appcast(sparkle_version="10000.0.47.0.2"):
+    return _browserclaw_appcast(sparkle_version).replace(
+        "BrowserOS neo", "BrowserClaw"
     )
 
 
@@ -424,6 +450,50 @@ class PublisherTestCase(unittest.TestCase):
             _mac_appcast(),
             publish=True,
         )
+
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
+
+    def test_browserclaw_legacy_title_migrates_with_backup(self):
+        spec = feed_by_key("appcast-claw.xml")
+        publisher = self._publisher(
+            {spec.key: _legacy_browserclaw_appcast("10000.0.46.0.0").encode()}
+        )
+
+        ok = publisher.publish(spec, _browserclaw_appcast(), publish=True)
+
+        self.assertTrue(ok)
+        self.assertEqual(
+            self.client.calls,
+            [
+                (
+                    "copy",
+                    spec.key,
+                    f"feeds-history/{spec.key}.20260701T120000Z",
+                ),
+                ("put", spec.key, "application/xml"),
+            ],
+        )
+
+    def test_browserclaw_legacy_title_migration_refuses_downgrade(self):
+        spec = feed_by_key("appcast-claw.xml")
+        publisher = self._publisher(
+            {spec.key: _legacy_browserclaw_appcast("10000.0.48.0.0").encode()}
+        )
+
+        ok = publisher.publish(spec, _browserclaw_appcast(), publish=True)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
+
+    def test_browserclaw_legacy_title_requires_canonical_link(self):
+        spec = feed_by_key("appcast-claw.xml")
+        live = _legacy_browserclaw_appcast().replace(
+            spec.link, "https://cdn.browseros.com/appcast.xml"
+        )
+        publisher = self._publisher({spec.key: live.encode()})
+
+        ok = publisher.publish(spec, _browserclaw_appcast(), publish=True)
 
         self.assertFalse(ok)
         self.assertEqual(self.client.calls, [])
@@ -1070,6 +1140,18 @@ class PublisherTestCase(unittest.TestCase):
             hashlib.sha256(original.encode()).hexdigest(),
             "e5fa3c6cde0ae05f2e15d1c52139094c4e1c738a01b9b3d63106ac255ca8357d",
         )
+
+    def test_browserclaw_snapshots_use_current_product_title(self):
+        updates = Path(__file__).resolve().parents[5] / "updates" / "browser"
+
+        for spec in browser_feeds_for_product("browserclaw"):
+            with self.subTest(key=spec.key):
+                content = (updates / spec.key).read_text()
+                self.assertEqual(
+                    extract_channel_metadata(content),
+                    (spec.title, spec.link),
+                )
+                self.assertNotIn("<title>BrowserClaw", content)
 
     def test_extensions_json_skips_head_and_publishes(self):
         spec = feed_by_key("extensions/extensions.alpha.json")

--- a/packages/browseros/bos_build/release/feeds/spec.py
+++ b/packages/browseros/bos_build/release/feeds/spec.py
@@ -64,6 +64,7 @@ class FeedSpec:
     link: str = ""  # channel <link> ("" for extensions kind)
     platform: str = ""  # browser feeds: "macos" | "win"
     artifact_keys: Tuple[str, ...] = ()  # browser feeds: release.json priority
+    legacy_titles: Tuple[str, ...] = ()
     bundle_id: str = ""  # server feeds: owning ServerBundle id
     publishable: bool = True
 
@@ -74,6 +75,7 @@ class FeedSpec:
 
 # Browser feed key infix per product ("" keeps today's browseros keys).
 _BROWSER_FEED_SLUGS = {"browseros": "", "browserclaw": "claw"}
+_BROWSER_FEED_LEGACY_DISPLAY_NAMES = {"browserclaw": "BrowserClaw"}
 
 # Products whose shipping updater selects this feed by browseros::GetProduct()
 # (sparkle_glue.mm / winsparkle_glue.cc). A product listed in
@@ -102,6 +104,7 @@ def _browser_feeds(product_id: str) -> Tuple[FeedSpec, ...]:
         )
     infix = f"-{slug}" if slug else ""
     display = get_product_descriptor(product_id).display_name
+    legacy_display = _BROWSER_FEED_LEGACY_DISPLAY_NAMES.get(product_id)
     publishable = product_id in _BROWSER_FEED_CLIENTS
 
     def feed(suffix: str, platform: str, artifact_keys: Tuple[str, ...],
@@ -116,6 +119,15 @@ def _browser_feeds(product_id: str) -> Tuple[FeedSpec, ...]:
             link=f"{CDN_BASE_URL}/{key}",
             platform=platform,
             artifact_keys=artifact_keys,
+            legacy_titles=(
+                (
+                    f"{legacy_display} Windows Updates"
+                    if platform == "win"
+                    else legacy_display
+                ),
+            )
+            if legacy_display
+            else (),
             publishable=publishable,
         )
 

--- a/packages/browseros/bos_build/release/feeds/spec_test.py
+++ b/packages/browseros/bos_build/release/feeds/spec_test.py
@@ -64,6 +64,27 @@ class FeedTableTest(unittest.TestCase):
         # sparkle_glue.mm and winsparkle_glue.cc select the claw feed.
         self.assertTrue(all(feed.publishable for feed in claw_feeds))
 
+    def test_browserclaw_browser_feed_titles_include_legacy_migration(self):
+        claw_feeds = browser_feeds_for_product("browserclaw")
+        self.assertEqual(
+            [feed.title for feed in claw_feeds],
+            [
+                "BrowserOS neo",
+                "BrowserOS neo",
+                "BrowserOS neo Windows Updates",
+                "BrowserOS neo Windows Updates",
+            ],
+        )
+        self.assertEqual(
+            [feed.legacy_titles for feed in claw_feeds],
+            [
+                ("BrowserClaw",),
+                ("BrowserClaw",),
+                ("BrowserClaw Windows Updates",),
+                ("BrowserClaw Windows Updates",),
+            ],
+        )
+
     def test_browseros_browser_feeds_are_publishable(self):
         feeds = browser_feeds_for_product("browseros")
         self.assertTrue(all(feed.publishable for feed in feeds))

--- a/updates/browser/appcast-claw-win-arm64.xml
+++ b/updates/browser/appcast-claw-win-arm64.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
-    <title>BrowserClaw Windows Updates</title>
+    <title>BrowserOS neo Windows Updates</title>
     <link>https://cdn.browseros.com/appcast-claw-win-arm64.xml</link>
     <description>Most recent changes with links to updates.</description>
     <language>en</language>

--- a/updates/browser/appcast-claw-win.xml
+++ b/updates/browser/appcast-claw-win.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
-    <title>BrowserClaw Windows Updates</title>
+    <title>BrowserOS neo Windows Updates</title>
     <link>https://cdn.browseros.com/appcast-claw-win.xml</link>
     <description>Most recent changes with links to updates.</description>
     <language>en</language>

--- a/updates/browser/appcast-claw-x86_64.xml
+++ b/updates/browser/appcast-claw-x86_64.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
   <channel>
-    <title>BrowserClaw</title>
+    <title>BrowserOS neo</title>
     <link>https://cdn.browseros.com/appcast-claw-x86_64.xml</link>
     <description>Most recent changes with links to updates.</description>
     <language>en</language>
 
     <item>
-      <title>BrowserClaw - 0.48.1</title>
+      <title>BrowserOS neo - 0.48.1</title>
       <description sparkle:format="plain-text">
       </description>
       <sparkle:version>10000.0.48.1.0</sparkle:version>

--- a/updates/browser/appcast-claw.xml
+++ b/updates/browser/appcast-claw.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
   <channel>
-    <title>BrowserClaw</title>
+    <title>BrowserOS neo</title>
     <link>https://cdn.browseros.com/appcast-claw.xml</link>
     <description>Most recent changes with links to updates.</description>
     <language>en</language>
 
     <item>
-      <title>BrowserClaw - 0.48.1</title>
+      <title>BrowserOS neo - 0.48.1</title>
       <description sparkle:format="plain-text">
       </description>
       <sparkle:version>10000.0.48.1.0</sparkle:version>


### PR DESCRIPTION
## Summary
- brand all tracked BrowserClaw browser appcasts as BrowserOS neo
- allow the publisher to cross only the exact BrowserClaw title migration on the canonical feed link
- preserve version downgrade, download URL, backup, and unrelated-invalid-content protections

## Design
Feed specs declare the exact predecessor channel title for BrowserOS neo browser feeds. The publisher accepts that predecessor only when the live object still uses the same canonical link, then continues through the existing structural, strict-version, URL, and backup rails before writing.

## Test plan
- [x] `uv run --group dev ruff check bos_build`
- [x] `uv run --group dev pyright bos_build/release/feeds/spec.py bos_build/release/feeds/publisher.py`
- [x] `uv run python -m unittest bos_build.release.appcast_test bos_build.release.feeds.publisher_test bos_build.release.feeds.render_test bos_build.release.feeds.spec_test` (126 tests)
- [x] `uv run python -m unittest discover -s . -t . -p "*_test.py"` (1,047 tests; 2 skipped)