### PR TITLE
fix(claw-app): require click to play onboarding video

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitOnboarding.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitOnboarding.test.tsx
@@ -24,15 +24,14 @@ function render(
 }
 
 describe('CockpitOnboarding', () => {
-  it('first-run: hero, a focused video, and the start panel render', () => {
+  it('first-run: hero, a paused video, and the start panel render', () => {
     const html = render('first-run')
     expect(html).toContain('You watch. Your agent')
     expect(html).toContain('works.')
-    // The hero plays the onboarding recording inline and autoplays; there is no
-    // poster-to-lightbox step and no youtube embed (blocked from the extension
-    // origin).
+    // The hero plays inline on demand, without a poster-to-lightbox step or a
+    // youtube embed (blocked from the extension origin).
     expect(html).toContain('<video')
-    expect(html.toLowerCase()).toContain('autoplay')
+    expect(html.toLowerCase()).not.toContain('autoplay')
     expect(html).toContain('onboarding-recording/video.mp4')
     expect(html).not.toContain('youtube-nocookie.com/embed')
     expect(html).toContain('Hand off your first task')

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/VideoFeature.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/VideoFeature.tsx
@@ -3,14 +3,11 @@
  * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * First-run onboarding hero: the recording plays inline and autoplays with
- * sound. A browser that blocks unmuted autoplay (no user gesture yet, and stock
- * Chromium applies this to extension pages too) makes play() reject; we then
- * fall back to a muted autoplay so the demo always starts, and the reader can
- * unmute via the controls. A single focused player reads as "watch this first".
+ * First-run onboarding hero: the recording stays paused behind its poster
+ * until the reader starts it with the native video controls. A single focused
+ * player reads as "watch this first".
  */
 
-import { useEffect, useRef } from 'react'
 import {
   ONBOARDING_VIDEOS,
   type OnboardingVideo,
@@ -27,25 +24,12 @@ export function VideoFeature() {
 
 function FeatureVideo({ video }: { video: OnboardingVideo }) {
   const tracking = useOnboardingVideoTracking(video)
-  const videoRef = useRef<HTMLVideoElement>(null)
-  // External-system side effect: kick off playback and, if the browser blocks
-  // unmuted autoplay, retry muted so the demo always starts. Cannot be done
-  // declaratively because we need the play() promise to detect the block.
-  useEffect(() => {
-    const el = videoRef.current
-    if (!el) return
-    el.play().catch(() => {
-      el.muted = true
-      el.play().catch(() => {})
-    })
-  }, [])
+  // Playback stays user-driven; mounting onboarding must not start the video.
   return (
     <div className="relative aspect-video w-full overflow-hidden rounded-3xl border border-border-2 bg-black shadow-sm ring-1 ring-foreground/5 md:aspect-auto md:h-full">
       <video
-        ref={videoRef}
         src={videoUrlFor(video)}
         poster={posterFor(video)}
-        autoPlay
         playsInline
         controls
         className="h-full w-full object-cover"


### PR DESCRIPTION
## Summary
- Keep the first-run onboarding video paused until the user starts it.
- Preserve the poster, native controls, inline playback, and analytics tracking.

## Design
Removed both autoplay paths: the video autoplay attribute and the mount-time play call with its muted retry. The existing native controls now exclusively initiate playback, and the rendering assertion verifies that autoplay is absent.

## Test plan
- [x] bun run --filter @browseros/claw-app test
- [x] bun run --filter @browseros/claw-app typecheck
- [x] bunx @biomejs/biome check apps/claw-app/components/cockpit/VideoFeature.tsx apps/claw-app/components/cockpit/CockpitOnboarding.test.tsx
- [x] bun run --filter @browseros/claw-app build