### PR TITLE
fix: move launch banners to main-page promo slots

### DIFF
--- a/packages/browseros-agent/apps/app/components/promo/ProductHuntBanner.tsx
+++ b/packages/browseros-agent/apps/app/components/promo/ProductHuntBanner.tsx
@@ -1,5 +1,5 @@
 import { ArrowRight, X } from 'lucide-react'
-import { type FC, useEffect, useState } from 'react'
+import { type FC, type ReactNode, useEffect, useState } from 'react'
 import ProductHuntLogo from '@/assets/producthunt.svg'
 import { Button } from '@/components/ui/button'
 import {
@@ -58,7 +58,9 @@ export const ProductHuntBannerCard: FC<{
   </div>
 )
 
-export const ProductHuntBanner: FC = () => {
+export const ProductHuntBanner: FC<{ fallback?: ReactNode }> = ({
+  fallback = null,
+}) => {
   const [dismissed, setDismissed] = useState<boolean | null>(null)
 
   useEffect(() => {
@@ -69,6 +71,7 @@ export const ProductHuntBanner: FC = () => {
         sentry.captureException(error, {
           extra: { message: 'Failed to read Product Hunt banner dismissal' },
         })
+        setDismissed(true)
       })
 
     const unwatch = productHuntBannerDismissedStorage.watch(setDismissed)
@@ -77,12 +80,12 @@ export const ProductHuntBanner: FC = () => {
 
   const visible = dismissed === false && withinLaunchWindow()
 
-  // Record the impression once the banner is actually shown.
   useEffect(() => {
     if (visible) track(PRODUCT_HUNT_BANNER_SHOWN_EVENT)
   }, [visible])
 
-  if (!visible) return null
+  if (dismissed === null) return null
+  if (!visible) return fallback
 
   const handleOpen = () => {
     track(PRODUCT_HUNT_BANNER_CLICKED_EVENT)

--- a/packages/browseros-agent/apps/app/screens/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/app/screens/agent-command/AgentCommandHome.tsx
@@ -122,7 +122,6 @@ export const AgentCommandHome: FC = () => {
   return (
     <div className="min-h-full px-4 py-6">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
-        <ProductHuntBanner />
         <div className="flex flex-col items-center gap-5 pt-[max(10vh,24px)] text-center">
           <div className="space-y-3">
             <h1 className="font-semibold text-[clamp(2.25rem,4.5vw,3.5rem)] leading-[1.08] tracking-[-0.025em] [text-wrap:balance]">
@@ -162,7 +161,7 @@ export const AgentCommandHome: FC = () => {
 
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-10 pb-12">
           <RecentSites />
-          <BrowserClawPromoBanner />
+          <ProductHuntBanner fallback={<BrowserClawPromoBanner />} />
           <ScheduleResults />
         </div>
       </div>

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitOnboarding.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitOnboarding.tsx
@@ -2,22 +2,6 @@
  * @license
  * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * First-run welcome rendered by the Cockpit screen when the reader has no
- * session activity yet. A two-column layout: a focused demo video on one
- * side and a "start here" panel on the other (connected-agent chips, the
- * first-task prompt, and a tie-back to the cockpit). Agents auto-connect at
- * launch, so onboarding is about learning and running the first task, not
- * installing.
- *
- * Two variants keyed off `state`:
- *   first-run  no connections + no activity.
- *   waiting    at least one connection + no activity.
- * Both share one layout; only the panel's fixed-height status line changes
- * text (tie-back, waiting, or copied-confirmation) so copying never reflows.
- *
- * State transitions are handled by the parent (Cockpit) via query refetches;
- * the component is a stateless presenter.
  */
 
 import { Check } from 'lucide-react'
@@ -40,7 +24,6 @@ import { VideoFeature } from './VideoFeature'
 
 interface CockpitOnboardingProps {
   state: Exclude<OnboardingState, 'ready'>
-  /** User-facing harnesses BrowserClaw is registered in (from the live list). */
   connectedHarnesses?: readonly string[]
 }
 
@@ -63,7 +46,7 @@ export function CockpitOnboarding({
   }
   return (
     <section
-      className="flex min-h-[calc(100dvh-6rem)] flex-col justify-center gap-8"
+      className="flex flex-col gap-8"
       aria-label={HERO_COPY.eyebrow.toLowerCase()}
     >
       <OnboardingHero />
@@ -104,7 +87,6 @@ function OnboardingHero() {
 interface StartPanelProps {
   className?: string
   harnesses: readonly string[]
-  /** True once the reader is connected or has copied the prompt: shows the live dot. */
   listening: boolean
   statusText: string
   onPromptCopied: () => void

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.tsx
@@ -74,7 +74,6 @@ export function ProductHuntBanner() {
   const [dismissed, setDismissed] = useState(readDismissed)
   const visible = !dismissed && withinLaunchWindow()
 
-  // Record the impression once the banner is actually shown.
   useEffect(() => {
     if (visible) track(AnalyticsEvent.ProductHuntBannerShown)
   }, [visible])
@@ -93,7 +92,7 @@ export function ProductHuntBanner() {
   }
 
   return (
-    <div className="mx-auto max-w-7xl px-8 pt-6">
+    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col justify-center px-8 py-12">
       <ProductHuntBannerCard onOpen={handleOpen} onDismiss={handleDismiss} />
     </div>
   )

--- a/packages/browseros-agent/apps/claw-app/components/layout/CockpitShell.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/layout/CockpitShell.tsx
@@ -1,19 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Outlet } from 'react-router'
-import { ProductHuntBanner } from '@/components/cockpit/ProductHuntBanner'
 import { AppSidebar } from '@/components/sidebar/AppSidebar'
 
 const COLLAPSE_DELAY = 150
 
-/**
- * Cockpit root layout. Fixed sidebar pinned to the left edge with the
- * main route content offset by w-14 (the collapsed sidebar's width)
- * so it never sits under the rail. Hover expands the sidebar; mouse
- * leave starts a 150ms collapse timer that is cancelled if the user
- * comes back in time. Matches the existing apps/app SidebarLayout
- * idiom; mobile sheet path dropped since this is a new-tab page on
- * desktop only.
- */
 export function CockpitShell() {
   const [expanded, setExpanded] = useState(false)
   const collapseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -53,7 +43,6 @@ export function CockpitShell() {
         <AppSidebar expanded={expanded} />
       </div>
       <main className="min-h-screen overflow-y-auto">
-        <ProductHuntBanner />
         <Outlet />
       </main>
     </div>

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.tsx
@@ -1,5 +1,6 @@
 import { CockpitHero } from '@/components/cockpit/CockpitHero'
 import { CockpitOnboarding } from '@/components/cockpit/CockpitOnboarding'
+import { ProductHuntBanner } from '@/components/cockpit/ProductHuntBanner'
 import { RecentActivity } from '@/components/cockpit/RecentActivity'
 import { RunningGrid } from '@/components/cockpit/RunningGrid'
 import { SavedStatsBand } from '@/components/cockpit/SavedStatsBand'
@@ -70,26 +71,30 @@ export function Cockpit() {
     enabled: shouldLoadStats,
   })
 
-  if (state !== 'ready') {
-    return (
-      <div className="mx-auto flex max-w-7xl flex-col px-8 pt-8 pb-16">
+  const content =
+    state !== 'ready' ? (
+      <div className="mx-auto flex w-full max-w-7xl flex-col px-8 pt-8 pb-16">
         <CockpitOnboarding
           state={state}
           connectedHarnesses={connectedHarnesses}
         />
       </div>
+    ) : (
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-8 pt-8 pb-16">
+        <CockpitHero />
+        {shouldLoadStats && stats.data?.hasMeasuredStats ? (
+          <SavedStatsBand stats={stats.data} />
+        ) : (
+          <RunningGrid sessions={sessions} />
+        )}
+        <RecentActivity />
+      </div>
     )
-  }
 
   return (
-    <div className="mx-auto flex max-w-7xl flex-col gap-8 px-8 pt-8 pb-16">
-      <CockpitHero />
-      {shouldLoadStats && stats.data?.hasMeasuredStats ? (
-        <SavedStatsBand stats={stats.data} />
-      ) : (
-        <RunningGrid sessions={sessions} />
-      )}
-      <RecentActivity />
+    <div className="flex min-h-screen flex-col">
+      {content}
+      <ProductHuntBanner />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- move the Product Hunt launch banner from the top of each new-tab experience into the main-page promotion area
- show BrowserClaw only as the standard app fallback after the Product Hunt banner is dismissed or expires
- scope the Claw banner to Cockpit so MCP, Audit, task detail, and replay remain focused

## Design
The promotion now belongs to each main page instead of a shared shell. The standard app reuses its existing `max-w-3xl` promotion slot, while Cockpit uses the same `max-w-7xl` grid and horizontal padding as its primary content and centers the banner within the remaining lower viewport space.

## Test plan
- [x] run full app and claw-app lint commands
- [x] run full app and claw-app test suites
- [x] run app and claw-app typechecks
- [x] visually verify Cockpit alignment in BrowserOS neo via CDP
- [x] confirm MCP and Audit render no Product Hunt controls
