### PR TITLE
fix(claw-server): preserve useful browser pages

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
@@ -13,6 +13,8 @@ Shared with other agents:
   tabs action="list" shows yours vs other agents' vs the user's.
 - If the user points you at a tab you don't own, open its URL with
   tabs action="new" and work on that copy; leave the original untouched.
+- Preserve useful pages: leave anything the user may want to inspect open
+  instead of closing it when the task ends.
 - Rename your session early with name_session using a 2-3 word task label;
   tabs group as <client>/<name>.
 - The user oversees this browser from the BrowserOS neo cockpit (live view,

--- a/packages/browseros-agent/crates/browseros-mcp/src/service.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/service.rs
@@ -28,7 +28,6 @@ pub const BROWSER_MCP_INSTRUCTIONS: &str = r#"BrowserOS MCP - you are driving th
 Shared environment. The user (and possibly other agents) are using this browser right now:
 - Open your own tab with tabs action="new" (returns its page id + first snapshot); touch an existing tab only when the user points you at it.
 - Don't steal focus, close tabs you didn't open, or rearrange the user's windows.
-- Close your tabs when done.
 
 Core loop: snapshot -> act -> verify.
 - snapshot renders the page as an accessibility tree; interactive elements carry [ref=eN] handles.

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -538,7 +538,6 @@ fn history_schema_stays_narrow_and_defaults_to_100() {
 fn instructions_do_not_request_manual_tab_grouping() {
     assert!(!BROWSER_MCP_INSTRUCTIONS.contains("tab_groups"));
     assert!(!BROWSER_MCP_INSTRUCTIONS.contains("hidden window"));
-    assert!(BROWSER_MCP_INSTRUCTIONS.contains("Close your tabs when done."));
 }
 
 #[test]

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -32,12 +32,12 @@ const MAX_RETURN_VALUE_BYTES: usize = 2_000_000;
 
 const DESCRIPTION: &str = r#"Do multi-step flows - pagination, bulk extraction, repeated act/read loops - in ONE call: async JavaScript against the `browser` SDK in the server runtime. console.log is captured; return a value to read it back; exceptions come back as a result, not thrown. Every call is `await`-able.
 
-The return shapes below are stable. Do NOT probe them at runtime (no typeof / Object.keys / getOwnPropertyNames) and do NOT re-open a page to inspect what a call returned; that just piles up duplicate tabs. Reuse a pageId across steps, and close a page with browser.pages.close(pageId) when you are done with it.
+The return shapes below are stable. Do NOT probe them at runtime (no typeof / Object.keys / getOwnPropertyNames) and do NOT re-open a page to inspect what a call returned; that just piles up duplicate tabs. Reuse a pageId across steps.
 
 Pages (pageId is a NUMBER):
   browser.pages.newPage(url)   -> pageId (number). Use it directly; it is not an object. Opens in the background so it does not steal the user's focus; pass { background: false } only when the user asks to bring the tab to the front.
-  browser.pages.close(pageId)  -> undefined. Call this when finished with a page. Close ONLY tabs you own (ownership "mine"); never close the user's or another agent's tabs.
-  browser.pages.list()         -> [{ pageId, url, title, ownership, ownerLabel, ... }] for EVERY open tab in the browser, including the user's and other agents'. `ownership` is "mine" | "user" | "other-agent"; "other-agent" tabs also carry ownerLabel. Act on and clean up only your own ("mine") tabs. Leave "user" and "other-agent" tabs alone unless the user explicitly asks you to work on one. When you loop to close tabs, filter to ownership === "mine" first.
+  browser.pages.close(pageId)  -> undefined. Closes a page you own.
+  browser.pages.list()         -> [{ pageId, url, title, ownership, ownerLabel, ... }] for EVERY open tab in the browser, including the user's and other agents'. `ownership` is "mine" | "user" | "other-agent"; "other-agent" tabs also carry ownerLabel. Act only on your own ("mine") tabs. Leave "user" and "other-agent" tabs alone unless the user explicitly asks you to work on one.
   browser.pages.getInfo(pageId)-> { pageId, url, title, ... } or null
 Observe / act (refs eN come from a snapshot's text/refs):
   browser.observe(pageId).snapshot() -> { text, refs, url }
@@ -58,7 +58,6 @@ Do the whole task in as few run calls as possible: loop over all the items in on
   const ids = await Promise.all(urls.map(u => browser.pages.newPage(u)));
   await Promise.all(ids.map(id => browser.wait(id, { value: 2500 })));
   const docs = await Promise.all(ids.map(id => browser.read(id)));
-  await Promise.all(ids.map(id => browser.pages.close(id)));
   return docs;"#;
 
 const BOOTSTRAP_JS: &str = r#"


### PR DESCRIPTION
## Summary

- Tell Claw agents to leave pages open when users may want to inspect them.
- Remove "close when done" guidance from the shared BrowserOS MCP instructions and `run` tool.
- Stop the bulk-flow example from closing every page it opens.

## Design

The one-hour reconciliation sweep remains the cleanup backstop. This change removes the separate, immediate agent guidance that bypassed that grace period. Close APIs remain available, but their descriptions are capability-only.

## Test plan

- `cargo fmt --all --check`
- `cargo check -p browseros-mcp -p claw-server-rust`
- `git diff --check`
- Unit tests not run per repository instructions.
