### PR TITLE
fix: update Product Hunt banner destination

### DIFF
--- a/packages/browseros-agent/apps/app/components/promo/ProductHuntBanner.tsx
+++ b/packages/browseros-agent/apps/app/components/promo/ProductHuntBanner.tsx
@@ -11,8 +11,7 @@ import { track } from '@/lib/metrics/track'
 import { sentry } from '@/lib/sentry/sentry'
 import { productHuntBannerDismissedStorage } from './product-hunt-banner.storage'
 
-const PRODUCT_HUNT_URL =
-  'https://www.producthunt.com/products/browseros_ai?launch=browseros-neo&utm_source=browseros-newtab&utm_medium=extension&utm_campaign=ph-launch'
+const PRODUCT_HUNT_URL = 'https://bit.ly/browseros-ext'
 
 // The banner is available immediately and auto-hides after the end of Aug 14
 // 2026 (PDT), so it never lingers past the launch window.

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.tsx
@@ -4,8 +4,7 @@ import { Button } from '@/components/ui/button'
 import { ProductHuntIcon } from '@/components/ui/svgs/productHuntIcon'
 import { AnalyticsEvent, track } from '@/modules/analytics/events'
 
-const PRODUCT_HUNT_URL =
-  'https://www.producthunt.com/products/browseros_ai?launch=browseros-neo&utm_source=browseros-neo-newtab&utm_medium=extension&utm_campaign=ph-launch'
+const PRODUCT_HUNT_URL = 'https://bit.ly/browseros-ext'
 
 // The banner is available immediately and auto-hides after the end of Aug 14
 // 2026 (PDT), so it never lingers past the launch window.


### PR DESCRIPTION
## Summary
- update the standard app Product Hunt launch CTA to `https://bit.ly/browseros-ext`
- update the Claw app launch CTA to the same canonical destination
- leave analytics, dismissal behavior, presentation, and launch timing unchanged

## Design
Both extension surfaces continue to own their existing banner implementations. This change only replaces each local destination constant so the two CTAs remain behaviorally identical without expanding the component API or coupling the bundles.

## Test plan
- [x] run full app and claw-app lint commands
- [x] run app and claw-app typechecks
- [x] run full app and claw-app test suites
