### PR TITLE
ci: move component releases to WarpBuild

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
+    - warp-*
     - browseros-builder

--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -86,7 +86,7 @@ jobs:
     concurrency:
       group: release-component-allocation
       cancel-in-progress: false
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 20
     outputs:
       mode: ${{ steps.lifecycle.outputs.mode }}
@@ -220,7 +220,7 @@ jobs:
   cargo-test:
     needs: prepare
     if: needs.prepare.outputs.mode == 'build'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 45
 
     steps:
@@ -251,8 +251,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14
-          - runner: windows-latest
+          - runner: warp-macos-14-arm64-6x
+          - runner: warp-windows-2025-x64-4x
 
     steps:
       - uses: actions/checkout@v7
@@ -289,23 +289,23 @@ jobs:
         include:
           - target: darwin-arm64
             rust_target: aarch64-apple-darwin
-            runner: macos-14
+            runner: warp-macos-14-arm64-6x
             binary_ext: ""
           - target: darwin-x64
             rust_target: x86_64-apple-darwin
-            runner: macos-14
+            runner: warp-macos-14-arm64-6x
             binary_ext: ""
           - target: linux-arm64
             rust_target: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
+            runner: warp-ubuntu-2404-arm64-4x
             binary_ext: ""
           - target: linux-x64
             rust_target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
+            runner: warp-ubuntu-2404-x64-4x
             binary_ext: ""
           - target: windows-x64
             rust_target: x86_64-pc-windows-msvc
-            runner: windows-latest
+            runner: warp-windows-2025-x64-4x
             binary_ext: ".exe"
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -577,7 +577,7 @@ jobs:
       - prepare
       - build
     if: needs.prepare.outputs.mode == 'build'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 30
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -728,7 +728,7 @@ jobs:
       - prepare
       - publish-versioned
     if: ${{ always() && needs.prepare.result == 'success' && (needs.prepare.outputs.mode == 'finalize' || (needs.prepare.outputs.mode == 'build' && inputs.defer_finalize != true && needs.publish-versioned.result == 'success')) }}
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 30
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -875,7 +875,7 @@ jobs:
       - prepare
       - finalize
     if: ${{ needs.finalize.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 20
     permissions:
       contents: write

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -134,7 +134,7 @@ jobs:
     concurrency:
       group: release-component-allocation
       cancel-in-progress: false
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 20
     outputs:
       mode: ${{ steps.validate.outputs.mode }}
@@ -344,7 +344,7 @@ jobs:
   build:
     needs: prepare
     if: needs.prepare.outputs.mode == 'build'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 45
     env:
       EXTENSION: ${{ inputs.extension }}
@@ -454,7 +454,7 @@ jobs:
       - prepare
       - build
     if: ${{ always() && needs.prepare.result == 'success' && (needs.prepare.outputs.mode == 'finalize' || (needs.prepare.outputs.mode == 'build' && inputs.defer_finalize != true && needs.build.result == 'success')) }}
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 10
     outputs:
       base_sha: ${{ steps.base.outputs.sha }}
@@ -544,7 +544,7 @@ jobs:
       - build
       - preflight_alpha
     if: ${{ always() && needs.prepare.result == 'success' && needs.preflight_alpha.result == 'success' && (needs.prepare.outputs.mode == 'finalize' || (needs.prepare.outputs.mode == 'build' && inputs.defer_finalize != true && needs.build.result == 'success')) }}
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 20
     env:
       EXTENSION: ${{ inputs.extension }}
@@ -667,7 +667,7 @@ jobs:
       - preflight_alpha
       - finalize
     if: ${{ always() && needs.prepare.result == 'success' && needs.preflight_alpha.result == 'success' && needs.preflight_alpha.outputs.should_publish == 'true' && needs.finalize.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 15
     env:
       VERSION: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
## Summary
- Move BrowserClaw server release jobs from GitHub-hosted runners to platform-matched WarpBuild runners.
- Move extension release jobs to the WarpBuild Ubuntu 24.04 x64 runner.
- Allow `warp-*` self-hosted runner labels in actionlint.

## Design
Use pinned WarpBuild images matching the current Ubuntu, macOS, and Windows environments while preserving each server build target. This is a temporary runner-only migration; the separate reusable `publish-server-ota.yml` workflow is unchanged.

## Test plan
- [x] Run actionlint across all workflows.
- [x] Parse the changed YAML files.
- [x] Run `git diff --check`.