### PR TITLE
fix(ota): allow unbound server resources explicitly

### DIFF
--- a/packages/browseros/bos_build/cli/ota.py
+++ b/packages/browseros/bos_build/cli/ota.py
@@ -192,12 +192,17 @@ def server_release(
         "browseros", "--product", help="Product whose server bundle to release"
     ),
     release_sha: str = typer.Option(
-        ...,
+        "",
         "--release-sha",
-        help="Immutable source commit bound to the versioned resources",
+        help="Source commit to enforce; omit with --allow-unbound",
+    ),
+    allow_unbound: bool = typer.Option(
+        False,
+        "--allow-unbound",
+        help="Allow versioned resources without source-binding metadata",
     ),
 ):
-    """Publish source-bound server OTA payloads."""
+    """Publish server OTA payloads from versioned resources."""
     log_info(f"🚀 BrowserOS Server OTA v{version}")
     log_info("=" * 70)
 
@@ -209,6 +214,7 @@ def server_release(
         platform_filter=platform,
         product_id=product,
         release_sha=release_sha,
+        allow_unbound=allow_unbound,
     )
 
     execute_module(ctx, module)

--- a/packages/browseros/bos_build/lib/r2.py
+++ b/packages/browseros/bos_build/lib/r2.py
@@ -64,12 +64,27 @@ def download_file_from_r2(
     r2_key: str,
     dest_path: Path,
     bucket: str,
+    expected_etag: Optional[str] = None,
 ) -> bool:
     """Download one file from R2."""
     try:
         log_info(f"Downloading {r2_key}...")
         dest_path.parent.mkdir(parents=True, exist_ok=True)
-        client.download_file(bucket, r2_key, str(dest_path))
+        if expected_etag:
+            response = client.get_object(
+                Bucket=bucket,
+                Key=r2_key,
+                IfMatch=expected_etag,
+            )
+            body = response["Body"]
+            try:
+                with dest_path.open("wb") as output:
+                    for chunk in iter(lambda: body.read(1024 * 1024), b""):
+                        output.write(chunk)
+            finally:
+                body.close()
+        else:
+            client.download_file(bucket, r2_key, str(dest_path))
         log_success(f"Downloaded: {dest_path.name}")
         return True
     except Exception as e:

--- a/packages/browseros/bos_build/release/ota/server.py
+++ b/packages/browseros/bos_build/release/ota/server.py
@@ -80,12 +80,14 @@ class ServerOTAModule(Step):
         platform_filter: Optional[str] = None,
         product_id: str = "browseros",
         release_sha: str = "",
+        allow_unbound: bool = False,
     ):
         self.version = version
         self.channel = channel
         self.platform_filter = platform_filter
         self.product_id = product_id
         self.release_sha = release_sha
+        self.allow_unbound = allow_unbound
         self._download_dir: Optional[Path] = None
 
     @property
@@ -114,8 +116,13 @@ class ServerOTAModule(Step):
         if not server_ota_bundles_for_product(self.product_id):
             raise ValidationError(f"Product '{self.product_id}' has no server bundle")
 
-        if _SOURCE_SHA_RE.fullmatch(self.release_sha) is None:
-            raise ValidationError("A full lowercase release SHA is required")
+        if not self.release_sha and not self.allow_unbound:
+            raise ValidationError(
+                "A full lowercase release SHA is required unless "
+                "--allow-unbound is supplied"
+            )
+        if self.release_sha and _SOURCE_SHA_RE.fullmatch(self.release_sha) is None:
+            raise ValidationError("Release SHA must be a full lowercase commit SHA")
 
         if IS_MACOS():
             if not context.env.macos_certificate_name:
@@ -144,7 +151,7 @@ class ServerOTAModule(Step):
         r2_client,
         source_pin: ResourcePin,
     ) -> None:
-        """Download checksum-verified immutable server resources."""
+        """Download snapshot-pinned immutable server resources."""
         bucket = ctx.env.r2_bucket
         platforms = self._get_platforms()
         pinned = {item.target: item for item in source_pin.objects}
@@ -161,7 +168,17 @@ class ServerOTAModule(Step):
             extract_dir = download_dir / target
 
             log_info(f"  Downloading {target}...")
-            if not download_file_from_r2(r2_client, r2_key, zip_path, bucket):
+            if resource.sha256:
+                downloaded = download_file_from_r2(r2_client, r2_key, zip_path, bucket)
+            else:
+                downloaded = download_file_from_r2(
+                    r2_client,
+                    r2_key,
+                    zip_path,
+                    bucket,
+                    expected_etag=resource.etag,
+                )
+            if not downloaded:
                 raise RuntimeError(f"Failed to download artifact: {r2_key}")
 
             digest = hashlib.sha256()
@@ -170,7 +187,7 @@ class ServerOTAModule(Step):
                     digest.update(chunk)
             if zip_path.stat().st_size != resource.size:
                 raise RuntimeError(f"Immutable source size mismatch: {r2_key}")
-            if digest.hexdigest() != resource.sha256:
+            if resource.sha256 and digest.hexdigest() != resource.sha256:
                 raise RuntimeError(f"Immutable source checksum mismatch: {r2_key}")
 
             extract_artifact_zip(zip_path, extract_dir)
@@ -194,6 +211,17 @@ class ServerOTAModule(Step):
             self.version,
             self.release_sha,
         )
+        if not self.release_sha:
+            release_shas = {
+                item.release_sha for item in source_pin.objects if item.release_sha
+            }
+            if release_shas:
+                self.release_sha = release_shas.pop()
+            else:
+                log_warning(
+                    f"{family_name} {self.version} has no source binding; "
+                    "continuing with ETag-pinned objects"
+                )
         if self._reuse_live_release(ctx):
             return
 
@@ -352,7 +380,6 @@ class ServerOTAModule(Step):
             "binding-schema": _PAYLOAD_BINDING_SCHEMA,
             "bundle-id": self.bundle.id,
             "version": self.version,
-            "release-sha": self.release_sha,
             "platform": artifact.platform,
             "os": artifact.os,
             "arch": artifact.arch,
@@ -360,6 +387,8 @@ class ServerOTAModule(Step):
             "sparkle-signature": artifact.signature,
             "length": str(len(data)),
         }
+        if self.release_sha:
+            metadata["release-sha"] = self.release_sha
         try:
             r2_client.put_object(
                 Bucket=ctx.env.r2_bucket,
@@ -420,13 +449,14 @@ class ServerOTAModule(Step):
             "binding-schema": _PAYLOAD_BINDING_SCHEMA,
             "bundle-id": self.bundle.id,
             "version": self.version,
-            "release-sha": self.release_sha,
             "platform": platform,
             "os": os_type,
             "arch": arch,
             "sha256": actual_sha256,
             "length": str(len(data)),
         }
+        if self.release_sha:
+            expected["release-sha"] = self.release_sha
         mismatches = {
             name: {"expected": value, "actual": metadata.get(name)}
             for name, value in expected.items()

--- a/packages/browseros/bos_build/release/resource_pins.py
+++ b/packages/browseros/bos_build/release/resource_pins.py
@@ -190,22 +190,44 @@ def _verify_prepared(
     bucket: str,
     family: ResourceFamily,
     version: str,
-    release_sha: str,
+    release_sha: str = "",
 ) -> ResourcePin:
     _validate_version(version, family)
-    if not _SHA_RE.fullmatch(release_sha):
+    if release_sha and not _SHA_RE.fullmatch(release_sha):
         raise RuntimeError(f"{family.name} prepared source SHA is invalid")
-    objects = []
-    for target in family.targets:
-        snapshot = _head(client, bucket, family.version_key(version, target))
-        _binding(
-            snapshot,
-            family,
-            target,
-            version=version,
-            release_sha=release_sha,
-        )
-        objects.append(_object_pin(family, target, version, snapshot))
+    snapshots = {
+        target: _head(client, bucket, family.version_key(version, target))
+        for target in family.targets
+    }
+    if release_sha:
+        for target, snapshot in snapshots.items():
+            _binding(
+                snapshot,
+                family,
+                target,
+                version=version,
+                release_sha=release_sha,
+            )
+    else:
+        metadata_states = {bool(snapshot.metadata) for snapshot in snapshots.values()}
+        if metadata_states == {True}:
+            bindings = {
+                target: _binding(snapshot, family, target, version=version)
+                for target, snapshot in snapshots.items()
+            }
+            release_shas = {binding["release-sha"] for binding in bindings.values()}
+            if len(release_shas) != 1:
+                raise _IncoherentSnapshot(
+                    f"{family.name} prepared objects are source-skewed"
+                )
+        elif metadata_states != {False}:
+            raise _IncoherentSnapshot(
+                f"{family.name} prepared objects have mixed bindings"
+            )
+    objects = [
+        _object_pin(family, target, version, snapshots[target])
+        for target in family.targets
+    ]
     return ResourcePin(family.name, version, tuple(objects))
 
 
@@ -214,9 +236,9 @@ def verify_prepared_resource_pin(
     bucket: str,
     family_name: str,
     version: str,
-    release_sha: str,
+    release_sha: str = "",
 ) -> ResourcePin:
-    """Verify one prepared resource family against its immutable bindings."""
+    """Verify one exact prepared resource family."""
     family = next(
         (item for item in RESOURCE_FAMILIES if item.name == family_name),
         None,


### PR DESCRIPTION
## Summary
- make `--release-sha` optional only when `--allow-unbound` is explicit
- accept coherent metadata-free versioned server artifacts while rejecting mixed bindings
- pin unbound downloads to their inspected R2 ETags and omit unavailable source metadata

## Design
Strict source-bound releases keep their existing behavior. The escape hatch accepts only a complete, consistently unbound resource family and conditionally downloads each exact object with `IfMatch`; bound resources auto-discover and retain their source SHA.

## Test plan
- [x] `uv run --group dev ruff check bos_build/cli/ota.py bos_build/lib/r2.py bos_build/release/resource_pins.py bos_build/release/ota/server.py`
- [x] `uv run --group dev pyright bos_build/cli/ota.py bos_build/lib/r2.py bos_build/release/resource_pins.py bos_build/release/ota/server.py`
- [x] verified the live `browseros_server` 0.0.128 family resolves as five coherent unbound objects
- [x] verified Cloudflare R2 accepts `IfMatch` against the inspected object ETag
- [x] verified CLI validation accepts `--allow-unbound` and rejects omission of both provenance options

Unit tests were not run per repository instructions.