### PR TITLE
fix(claw-app): surface Product Hunt announcement

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.tsx
@@ -53,7 +53,7 @@ export function ProductHuntBannerCard({
         size="sm"
         onClick={onOpen}
         aria-label="Check out our Product Hunt launch"
-        className="shrink-0 bg-[#ff6154] text-white hover:bg-[#e5563f]"
+        className="shrink-0 bg-[#ff6154] text-[#18181b] hover:bg-[#e5563f]"
       >
         Check out our launch
       </Button>
@@ -91,8 +91,11 @@ export function ProductHuntBanner() {
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col justify-center px-8 py-12">
+    <section className="space-y-4" aria-labelledby="announcements-heading">
+      <h2 id="announcements-heading" className="font-semibold text-ink text-lg">
+        Announcements
+      </h2>
       <ProductHuntBannerCard onOpen={handleOpen} onDismiss={handleDismiss} />
-    </div>
+    </section>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.tsx
@@ -13,7 +13,6 @@ import { getOnboardingState } from './cockpit-onboarding.helpers'
 
 const ONBOARDING_PROBE_LIMIT = 1
 
-/** Renders the Claw cockpit homepage. */
 export function Cockpit() {
   const { sessions } = useCockpitData()
 
@@ -73,7 +72,8 @@ export function Cockpit() {
 
   const content =
     state !== 'ready' ? (
-      <div className="mx-auto flex w-full max-w-7xl flex-col px-8 pt-8 pb-16">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-8 pt-8 pb-16">
+        <ProductHuntBanner />
         <CockpitOnboarding
           state={state}
           connectedHarnesses={connectedHarnesses}
@@ -87,14 +87,10 @@ export function Cockpit() {
         ) : (
           <RunningGrid sessions={sessions} />
         )}
+        <ProductHuntBanner />
         <RecentActivity />
       </div>
     )
 
-  return (
-    <div className="flex min-h-screen flex-col">
-      {content}
-      <ProductHuntBanner />
-    </div>
-  )
+  return <div className="flex min-h-screen flex-col">{content}</div>
 }


### PR DESCRIPTION
## Summary
- move the Product Hunt launch banner into the visible cockpit content stack
- present the launch card under an Announcements heading above Recent activity
- preserve dismissal, launch-window, analytics, and destination behavior while improving CTA contrast

## Design
The banner now uses the cockpit's existing section-heading and spacing rhythm instead of a flex-filling wrapper below the main content. Ready-state users see it between stats or running sessions and Recent activity; onboarding users retain the announcement at the top of the main page.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
