### PR TITLE
fix(server): accept legacy chat requests

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/package.json
+++ b/packages/browseros-agent/apps/claw-onboard/package.json
@@ -9,7 +9,7 @@
     "build": "tsc --noEmit && vite build",
     "build:chromium": "tsc --noEmit && vite build --mode chromium && bun scripts/verify-chromium-build.ts",
     "preview": "vite preview",
-    "test": "bun run ../../scripts/run-bun-test.ts ./apps/claw-onboard",
+    "test": "bun run ../../scripts/run-bun-test.ts --cwd=./apps/claw-onboard ./apps/claw-onboard",
     "typecheck": "tsc --noEmit",
     "lint": "bunx biome check",
     "lint:fix": "bunx biome check --write --unsafe"

--- a/packages/browseros-agent/apps/server/src/api/types.ts
+++ b/packages/browseros-agent/apps/server/src/api/types.ts
@@ -72,11 +72,17 @@ const ChatInputSchema = z.object({
     .optional(),
 })
 
-const BrowserOsChatRequestSchema = AgentLLMConfigSchema.merge(
-  ChatInputSchema,
-).extend({
-  target: BrowserOsAgentTargetSchema,
-})
+const BrowserOsChatRequestSchema = AgentLLMConfigSchema.merge(ChatInputSchema)
+  .extend({
+    target: BrowserOsAgentTargetSchema.optional(),
+  })
+  .transform((request) => ({
+    ...request,
+    target: request.target ?? {
+      type: 'browseros' as const,
+      providerId: request.providerId || request.provider,
+    },
+  }))
 
 const AcpChatRequestSchema = ChatInputSchema.extend({
   target: AcpAgentTargetSchema,

--- a/packages/browseros-agent/apps/server/tests/api/chat-request-schema.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/chat-request-schema.test.ts
@@ -8,6 +8,38 @@ import { describe, expect, it } from 'bun:test'
 import { ChatRequestSchema } from '../../src/api/types'
 
 describe('ChatRequestSchema agent targets', () => {
+  it('normalizes a legacy BrowserOS request without a target', () => {
+    const parsed = ChatRequestSchema.parse({
+      conversationId: crypto.randomUUID(),
+      message: 'hello',
+      provider: 'openai',
+      providerId: 'provider-1',
+      model: 'gpt-5',
+    })
+
+    expect(parsed.target).toEqual({
+      type: 'browseros',
+      providerId: 'provider-1',
+    })
+  })
+
+  for (const providerId of [undefined, '']) {
+    it(`uses the provider type when a legacy provider ID is ${providerId === undefined ? 'missing' : 'empty'}`, () => {
+      const parsed = ChatRequestSchema.parse({
+        conversationId: crypto.randomUUID(),
+        message: 'hello',
+        provider: 'openai',
+        providerId,
+        model: 'gpt-5',
+      })
+
+      expect(parsed.target).toEqual({
+        type: 'browseros',
+        providerId: 'openai',
+      })
+    })
+  }
+
   it('accepts a BrowserOS target with ordinary provider configuration', () => {
     const parsed = ChatRequestSchema.parse({
       target: { type: 'browseros', providerId: 'provider-1' },
@@ -36,6 +68,32 @@ describe('ChatRequestSchema agent targets', () => {
       expect('provider' in parsed).toBe(false)
     })
   }
+
+  it('rejects a malformed explicit target', () => {
+    const parsed = ChatRequestSchema.safeParse({
+      target: { type: 'browseros' },
+      conversationId: crypto.randomUUID(),
+      message: 'hello',
+      provider: 'openai',
+      providerId: 'provider-1',
+      model: 'gpt-5',
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it('rejects an untargeted legacy ACP provider request', () => {
+    const parsed = ChatRequestSchema.safeParse({
+      conversationId: crypto.randomUUID(),
+      message: 'hello',
+      provider: 'claude-code',
+      providerId: 'provider-1',
+      model: 'opus',
+      acpAgentId: 'claude',
+    })
+
+    expect(parsed.success).toBe(false)
+  })
 
   it('rejects ACP fields disguised as an LLM provider request', () => {
     const parsed = ChatRequestSchema.safeParse({

--- a/packages/browseros-agent/scripts/run-bun-test.ts
+++ b/packages/browseros-agent/scripts/run-bun-test.ts
@@ -41,7 +41,22 @@ import { dirname, join, relative, resolve } from 'node:path'
 
 const projectRoot = resolve(import.meta.dir, '..')
 const junitPath = process.env.BROWSEROS_JUNIT_PATH?.trim()
-const testArgs = process.argv.slice(2)
+const args = process.argv.slice(2)
+const cwdArgs = args.filter((arg) => arg.startsWith('--cwd='))
+
+if (cwdArgs.length > 1) {
+  console.error('run-bun-test: expected at most one --cwd argument')
+  process.exit(2)
+}
+
+const testCwdArg = cwdArgs[0]?.slice('--cwd='.length)
+if (cwdArgs.length === 1 && !testCwdArg) {
+  console.error('run-bun-test: --cwd requires a directory')
+  process.exit(2)
+}
+
+const testCwd = testCwdArg ? resolve(projectRoot, testCwdArg) : projectRoot
+const testArgs = args.filter((arg) => !arg.startsWith('--cwd='))
 
 if (testArgs.length === 0) {
   console.error(
@@ -80,7 +95,7 @@ for (const [i, file] of files.entries()) {
   cmd.push(file)
 
   const result = spawnSync(cmd[0], cmd.slice(1), {
-    cwd: projectRoot,
+    cwd: testCwd,
     env: process.env,
     stdio: 'inherit',
   })
@@ -104,8 +119,6 @@ if (failed > 0) {
   console.error(`run-bun-test: ${failed} of ${files.length} test files failed`)
   process.exit(1)
 }
-
-// ------------------------------------------------------------------
 
 function collectTestFiles(args: string[]): string[] {
   const out: string[] = []


### PR DESCRIPTION
## Summary
- restore BrowserOS chat when an OTA-updated server receives the pre-refactor extension payload without `target`
- normalize only valid untargeted LLM requests to an explicit BrowserOS target
- keep malformed targets and legacy ACP-provider requests rejected so ACP authorization remains explicit
- run `claw-onboard` tests from that app's project root so Bun resolves its TypeScript path aliases

## Design
The BrowserOS branch of `ChatRequestSchema` accepts an optional target on input and transforms every successful parse into the canonical required target shape. The target uses `providerId`, falling back to the validated provider type, while the ACP schema and trusted-origin checks remain unchanged.

The shared per-file Bun runner now accepts an optional child-process working directory. Only `claw-onboard` opts into it, matching the app root already used by its TypeScript and Vite builds.

## Test plan
- [x] `bun test apps/server/tests/api/chat-request-schema.test.ts` (9 passed)
- [x] `bun run --filter @browseros/server typecheck`
- [x] `bun run --cwd apps/claw-onboard test`
- [x] `bun run check`
- [x] `bun run test`