### PR TITLE
feat(claw-app): add audit lightbox navigation

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
@@ -214,9 +214,15 @@ describe('ScreenshotLightbox', () => {
     expect(dialog.getAttribute('class') ?? '').toContain('sm:max-w-[94vw]')
     expect(dialog.textContent).toContain('private.example')
     expect(dialog.textContent).toContain('1 / 1')
-    expect(dialog.querySelector('img')?.getAttribute('src')).toContain(
+    const image = dialog.querySelector('img')
+    expect(image?.getAttribute('src')).toContain(
       '/sessions/session-private/screenshots/42',
     )
+    const imageClass = image?.getAttribute('class') ?? ''
+    expect(imageClass).toContain('max-h-[calc(92vh-3.5rem)]')
+    expect(imageClass).toContain('w-auto')
+    expect(imageClass).toContain('max-w-[94vw]')
+    expect(imageClass).toContain('object-contain')
     const previous = getButton('Previous screenshot')
     expect(previous.getAttribute('type')).toBe('button')
     expect(previous.getAttribute('class') ?? '').toContain('focus-visible')
@@ -225,6 +231,8 @@ describe('ScreenshotLightbox', () => {
     )
     expect(position?.getAttribute('class') ?? '').toContain('tabular-nums')
     expect(position?.getAttribute('class') ?? '').toContain('min-w-[7ch]')
+    const toolbar = previous.parentElement?.parentElement
+    expect(toolbar?.nextElementSibling).toBe(image)
     expect(previous.disabled).toBe(true)
     expect(getButton('Next screenshot').disabled).toBe(true)
   })
@@ -288,15 +296,23 @@ describe('ScreenshotLightbox', () => {
     expect(left.defaultPrevented).toBe(true)
     expect(onNavigate.mock.calls[1]?.[0]).toBe(22)
 
-    const modified = await pressKey(getDialog(), 'ArrowRight', {
-      metaKey: true,
-    })
+    const modifiedEvents: Event[] = []
+    for (const options of [
+      { altKey: true },
+      { ctrlKey: true },
+      { metaKey: true },
+      { shiftKey: true },
+    ]) {
+      modifiedEvents.push(await pressKey(getDialog(), 'ArrowRight', options))
+    }
     const composing = await pressKey(getDialog(), 'ArrowRight', {
       isComposing: true,
     })
     const escapeEvent = await pressKey(getDialog(), 'Escape')
     expect(onNavigate).toHaveBeenCalledTimes(2)
-    expect(modified.defaultPrevented).toBe(false)
+    for (const event of modifiedEvents) {
+      expect(event.defaultPrevented).toBe(false)
+    }
     expect(composing.defaultPrevented).toBe(false)
     expect(escapeEvent.defaultPrevented).toBe(false)
   })
@@ -307,13 +323,29 @@ describe('ScreenshotLightbox', () => {
     const dialog = getDialog()
 
     const input = document.createElement('input')
+    const textarea = document.createElement('textarea')
+    const select = document.createElement('select')
     const editable = document.createElement('div')
     editable.setAttribute('contenteditable', 'true')
-    const slider = document.createElement('div')
-    slider.setAttribute('role', 'slider')
-    dialog.append(input, editable, slider)
+    const editableChild = document.createElement('span')
+    editable.append(editableChild)
+    const roleTargets = ['textbox', 'combobox', 'slider', 'spinbutton'].map(
+      (role) => {
+        const target = document.createElement('div')
+        target.setAttribute('role', role)
+        return target
+      },
+    )
+    const protectedTargets = [
+      input,
+      textarea,
+      select,
+      editableChild,
+      ...roleTargets,
+    ]
+    dialog.append(input, textarea, select, editable, ...roleTargets)
 
-    for (const target of [input, editable, slider]) {
+    for (const target of protectedTargets) {
       const event = await pressKey(target, 'ArrowRight')
       expect(event.defaultPrevented).toBe(false)
     }

--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { parseHTML } from 'linkedom'
-import { act, type ComponentProps, type ReactNode } from 'react'
+import { act, type ComponentProps, type ReactNode, useState } from 'react'
 import type { Root } from 'react-dom/client'
 import * as _dialog from '@/components/ui/dialog'
 import * as _auditHooks from '@/modules/api/audit.hooks'
@@ -10,9 +10,20 @@ mock.module('@/modules/api/audit.hooks', () => ({
   useTaskScreenshotBaseUrl: () => 'http://127.0.0.1:9200',
 }))
 
+let dialogOnOpenChange: ((open: boolean) => void) | undefined
+
 mock.module('@/components/ui/dialog', () => ({
   ..._dialog,
-  Dialog: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  Dialog: ({
+    children,
+    onOpenChange,
+  }: {
+    children?: ReactNode
+    onOpenChange?: (open: boolean) => void
+  }) => {
+    dialogOnOpenChange = onOpenChange
+    return <>{children}</>
+  },
   DialogClose: ({ children }: { children?: ReactNode }) => <>{children}</>,
   DialogContent: ({
     children,
@@ -79,6 +90,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await act(async () => root.unmount())
+  dialogOnOpenChange = undefined
   for (const [name, descriptor] of globalDescriptors) {
     if (descriptor) Object.defineProperty(globalThis, name, descriptor)
     else Reflect.deleteProperty(globalThis, name)
@@ -86,28 +98,255 @@ afterEach(async () => {
   Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
 })
 
-describe('ScreenshotLightbox', () => {
-  it('blocks the opened screenshot portal from PostHog replay', async () => {
-    await act(async () => {
-      root.render(
-        <ScreenshotLightbox
-          sessionId="session-private"
-          screenshotId={42}
-          sourceUrl="https://private.example/secret"
-          offsetMs={1200}
-          onClose={() => undefined}
-        />,
-      )
-    })
+const ORDERED_IDS = [11, 22, 33] as const
+const META = {
+  11: { sourceUrl: 'https://first.example/start', offsetMs: 400 },
+  22: { sourceUrl: 'https://second.example/middle', offsetMs: 4300 },
+  33: { sourceUrl: 'https://third.example/end', offsetMs: 11700 },
+} as const
 
-    const dialog = container.querySelector('[data-slot="dialog-content"]')
-    if (!dialog) {
-      throw new Error(`dialog portal missing: ${document.body.outerHTML}`)
-    }
+interface ControlledLightboxProps {
+  initialId?: number
+  screenshotIds?: readonly number[]
+  onNavigate?: (screenshotId: number) => void
+  onClose?: () => void
+}
+
+function ControlledLightbox({
+  initialId = 22,
+  screenshotIds = ORDERED_IDS,
+  onNavigate = () => undefined,
+  onClose = () => undefined,
+}: ControlledLightboxProps) {
+  const [screenshotId, setScreenshotId] = useState(initialId)
+  const meta = META[screenshotId as keyof typeof META] ?? {
+    sourceUrl: 'https://unlisted.example/current',
+    offsetMs: 9900,
+  }
+  return (
+    <ScreenshotLightbox
+      sessionId="session-navigation"
+      screenshotId={screenshotId}
+      screenshotIds={screenshotIds}
+      sourceUrl={meta.sourceUrl}
+      offsetMs={meta.offsetMs}
+      onNavigate={(nextId) => {
+        onNavigate(nextId)
+        setScreenshotId(nextId)
+      }}
+      onClose={onClose}
+    />
+  )
+}
+
+async function render(node: ReactNode) {
+  await act(async () => root.render(node))
+}
+
+function getDialog(): HTMLElement {
+  const dialog = container.querySelector<HTMLElement>(
+    '[data-slot="dialog-content"]',
+  )
+  if (!dialog)
+    throw new Error(`dialog portal missing: ${document.body.outerHTML}`)
+  return dialog
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`,
+  )
+  if (!button) throw new Error(`button missing: ${label}`)
+  return button
+}
+
+async function click(element: Element) {
+  await act(async () => {
+    element.dispatchEvent(new window.Event('click', { bubbles: true }))
+  })
+}
+
+interface KeyOptions {
+  altKey?: boolean
+  ctrlKey?: boolean
+  metaKey?: boolean
+  shiftKey?: boolean
+  isComposing?: boolean
+}
+
+async function pressKey(
+  target: Element,
+  key: string,
+  options: KeyOptions = {},
+) {
+  const event = new window.Event('keydown', {
+    bubbles: true,
+    cancelable: true,
+  })
+  Object.defineProperties(event, {
+    key: { value: key },
+    altKey: { value: options.altKey ?? false },
+    ctrlKey: { value: options.ctrlKey ?? false },
+    metaKey: { value: options.metaKey ?? false },
+    shiftKey: { value: options.shiftKey ?? false },
+    isComposing: { value: options.isComposing ?? false },
+  })
+  await act(async () => target.dispatchEvent(event))
+  return event
+}
+
+describe('ScreenshotLightbox', () => {
+  it('keeps the privacy and responsive-width controls on the opened portal', async () => {
+    await render(
+      <ScreenshotLightbox
+        sessionId="session-private"
+        screenshotId={42}
+        screenshotIds={[42]}
+        sourceUrl="https://private.example/secret"
+        offsetMs={1200}
+        onNavigate={() => undefined}
+        onClose={() => undefined}
+      />,
+    )
+
+    const dialog = getDialog()
     expect(dialog.getAttribute('class') ?? '').toContain('ph-no-capture')
+    expect(dialog.getAttribute('class') ?? '').toContain('sm:max-w-[94vw]')
     expect(dialog.textContent).toContain('private.example')
+    expect(dialog.textContent).toContain('1 / 1')
     expect(dialog.querySelector('img')?.getAttribute('src')).toContain(
       '/sessions/session-private/screenshots/42',
     )
+    const previous = getButton('Previous screenshot')
+    expect(previous.getAttribute('type')).toBe('button')
+    expect(previous.getAttribute('class') ?? '').toContain('focus-visible')
+    const position = Array.from(dialog.querySelectorAll('span')).find(
+      (span) => span.textContent?.trim() === '1 / 1',
+    )
+    expect(position?.getAttribute('class') ?? '').toContain('tabular-nums')
+    expect(position?.getAttribute('class') ?? '').toContain('min-w-[7ch]')
+    expect(previous.disabled).toBe(true)
+    expect(getButton('Next screenshot').disabled).toBe(true)
+  })
+
+  it('moves to adjacent ids and updates the image, caption, alt, and position together', async () => {
+    const onNavigate = mock((_screenshotId: number) => undefined)
+    await render(<ControlledLightbox onNavigate={onNavigate} />)
+
+    expect(getDialog().textContent).toContain('second.example · T+4.3s')
+    expect(getDialog().textContent).toContain('2 / 3')
+    expect(getDialog().querySelector('img')?.getAttribute('alt')).toBe(
+      'Screenshot of second.example',
+    )
+
+    await click(getButton('Next screenshot'))
+    expect(onNavigate.mock.calls[0]?.[0]).toBe(33)
+    expect(getDialog().textContent).toContain('third.example · T+11.7s')
+    expect(getDialog().textContent).toContain('3 / 3')
+    expect(getDialog().querySelector('img')?.getAttribute('src')).toContain(
+      '/sessions/session-navigation/screenshots/33',
+    )
+    expect(getDialog().querySelector('img')?.getAttribute('alt')).toBe(
+      'Screenshot of third.example',
+    )
+
+    await click(getButton('Previous screenshot'))
+    await click(getButton('Previous screenshot'))
+    expect(onNavigate.mock.calls.map((call) => call[0])).toEqual([33, 22, 11])
+    expect(getDialog().textContent).toContain('first.example · T+400ms')
+    expect(getDialog().textContent).toContain('1 / 3')
+  })
+
+  it('disables both boundaries without wrapping or firing navigation', async () => {
+    const onNavigate = mock((_screenshotId: number) => undefined)
+    await render(<ControlledLightbox initialId={11} onNavigate={onNavigate} />)
+
+    const previous = getButton('Previous screenshot')
+    expect(previous.disabled).toBe(true)
+    await click(previous)
+    expect(onNavigate).toHaveBeenCalledTimes(0)
+
+    await click(getButton('Next screenshot'))
+    await click(getButton('Next screenshot'))
+    const next = getButton('Next screenshot')
+    expect(next.disabled).toBe(true)
+    expect(onNavigate).toHaveBeenCalledTimes(2)
+    await click(next)
+    expect(onNavigate).toHaveBeenCalledTimes(2)
+    expect(getDialog().textContent).toContain('3 / 3')
+  })
+
+  it('navigates on bare arrow keys and leaves modified, composing, and Escape keys alone', async () => {
+    const onNavigate = mock((_screenshotId: number) => undefined)
+    await render(<ControlledLightbox onNavigate={onNavigate} />)
+
+    const right = await pressKey(getDialog(), 'ArrowRight')
+    expect(right.defaultPrevented).toBe(true)
+    expect(onNavigate.mock.calls[0]?.[0]).toBe(33)
+
+    const left = await pressKey(getDialog(), 'ArrowLeft')
+    expect(left.defaultPrevented).toBe(true)
+    expect(onNavigate.mock.calls[1]?.[0]).toBe(22)
+
+    const modified = await pressKey(getDialog(), 'ArrowRight', {
+      metaKey: true,
+    })
+    const composing = await pressKey(getDialog(), 'ArrowRight', {
+      isComposing: true,
+    })
+    const escapeEvent = await pressKey(getDialog(), 'Escape')
+    expect(onNavigate).toHaveBeenCalledTimes(2)
+    expect(modified.defaultPrevented).toBe(false)
+    expect(composing.defaultPrevented).toBe(false)
+    expect(escapeEvent.defaultPrevented).toBe(false)
+  })
+
+  it('does not hijack arrow keys from editable or arrow-driven controls', async () => {
+    const onNavigate = mock((_screenshotId: number) => undefined)
+    await render(<ControlledLightbox onNavigate={onNavigate} />)
+    const dialog = getDialog()
+
+    const input = document.createElement('input')
+    const editable = document.createElement('div')
+    editable.setAttribute('contenteditable', 'true')
+    const slider = document.createElement('div')
+    slider.setAttribute('role', 'slider')
+    dialog.append(input, editable, slider)
+
+    for (const target of [input, editable, slider]) {
+      const event = await pressKey(target, 'ArrowRight')
+      expect(event.defaultPrevented).toBe(false)
+    }
+    expect(onNavigate).toHaveBeenCalledTimes(0)
+  })
+
+  it('keeps an active id missing from the polled list previewable as 1 / 1', async () => {
+    const onNavigate = mock((_screenshotId: number) => undefined)
+    await render(
+      <ControlledLightbox
+        initialId={99}
+        screenshotIds={[11, 22]}
+        onNavigate={onNavigate}
+      />,
+    )
+
+    expect(getDialog().textContent).toContain('unlisted.example · T+9.9s')
+    expect(getDialog().textContent).toContain('1 / 1')
+    expect(getDialog().querySelector('img')?.getAttribute('src')).toContain(
+      '/sessions/session-navigation/screenshots/99',
+    )
+    expect(getButton('Previous screenshot').disabled).toBe(true)
+    expect(getButton('Next screenshot').disabled).toBe(true)
+    expect(onNavigate).toHaveBeenCalledTimes(0)
+  })
+
+  it('preserves the close callback contract through dialog open changes', async () => {
+    const onClose = mock(() => undefined)
+    await render(<ControlledLightbox onClose={onClose} />)
+
+    await act(async () => dialogOnOpenChange?.(true))
+    expect(onClose).toHaveBeenCalledTimes(0)
+    await act(async () => dialogOnOpenChange?.(false))
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
@@ -1,4 +1,5 @@
-import { IconX } from '@tabler/icons-react'
+import { IconChevronLeft, IconChevronRight, IconX } from '@tabler/icons-react'
+import type { KeyboardEventHandler } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -15,8 +16,10 @@ import { formatOffset, hostOf } from './screenshot.helpers'
 interface ScreenshotLightboxProps {
   sessionId: string
   screenshotId: number | null
+  screenshotIds: readonly number[]
   sourceUrl?: string | null
   offsetMs?: number | null
+  onNavigate: (screenshotId: number) => void
   onClose: () => void
 }
 
@@ -33,8 +36,10 @@ interface ScreenshotLightboxProps {
 export function ScreenshotLightbox({
   sessionId,
   screenshotId,
+  screenshotIds,
   sourceUrl = null,
   offsetMs = null,
+  onNavigate,
   onClose,
 }: ScreenshotLightboxProps) {
   const screenshotBaseUrl = useTaskScreenshotBaseUrl()
@@ -43,24 +48,102 @@ export function ScreenshotLightbox({
     [host, offsetMs != null ? `T+${formatOffset(offsetMs)}` : null]
       .filter(Boolean)
       .join(' · ') || 'Screenshot'
+  const orderedScreenshotIds =
+    screenshotId !== null && !screenshotIds.includes(screenshotId)
+      ? [screenshotId]
+      : screenshotIds
+  const activeIndex =
+    screenshotId === null ? -1 : orderedScreenshotIds.indexOf(screenshotId)
+  const previousId =
+    activeIndex > 0 ? (orderedScreenshotIds[activeIndex - 1] ?? null) : null
+  const nextId =
+    activeIndex >= 0 && activeIndex < orderedScreenshotIds.length - 1
+      ? (orderedScreenshotIds[activeIndex + 1] ?? null)
+      : null
+
+  const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (
+      event.nativeEvent.isComposing ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return
+    }
+
+    const target = event.target
+    if (
+      target instanceof Element &&
+      target.closest(
+        'input, textarea, select, [contenteditable]:not([contenteditable="false"]), [role="textbox"], [role="combobox"], [role="slider"], [role="spinbutton"]',
+      )
+    ) {
+      return
+    }
+
+    const destinationId =
+      event.key === 'ArrowLeft'
+        ? previousId
+        : event.key === 'ArrowRight'
+          ? nextId
+          : null
+    if (destinationId === null) return
+
+    event.preventDefault()
+    onNavigate(destinationId)
+  }
 
   return (
     <Dialog open={screenshotId !== null} onOpenChange={(o) => !o && onClose()}>
       <DialogContent
         showCloseButton={false}
         className="ph-no-capture flex max-h-[92vh] w-auto max-w-[94vw] flex-col gap-2 bg-transparent p-0 shadow-none ring-0 sm:max-w-[94vw]"
+        onKeyDown={handleKeyDown}
       >
         <DialogTitle className="sr-only">Screenshot preview</DialogTitle>
         {screenshotId !== null && (
           <>
-            <div className="flex items-center justify-between gap-3 rounded-lg bg-popover/95 px-3 py-2 ring-1 ring-foreground/10 supports-backdrop-filter:backdrop-blur">
-              <span className="min-w-0 truncate font-mono text-[12.5px] text-ink-2">
+            <div className="flex items-center gap-3 rounded-lg bg-popover/95 px-3 py-2 ring-1 ring-foreground/10 supports-backdrop-filter:backdrop-blur">
+              <span className="min-w-0 flex-1 truncate font-mono text-[12.5px] text-ink-2">
                 {caption}
               </span>
-              <DialogClose render={<Button variant="ghost" size="icon-sm" />}>
-                <IconX />
-                <span className="sr-only">Close</span>
-              </DialogClose>
+              <div className="flex shrink-0 items-center gap-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Previous screenshot"
+                  disabled={previousId === null}
+                  className="text-ink-2 hover:bg-card-tint hover:text-ink"
+                  onClick={() => previousId !== null && onNavigate(previousId)}
+                >
+                  <IconChevronLeft aria-hidden />
+                </Button>
+                <span className="min-w-[7ch] text-center font-mono text-[11.5px] text-ink-3 tabular-nums">
+                  {activeIndex + 1} / {orderedScreenshotIds.length}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Next screenshot"
+                  disabled={nextId === null}
+                  className="text-ink-2 hover:bg-card-tint hover:text-ink"
+                  onClick={() => nextId !== null && onNavigate(nextId)}
+                >
+                  <IconChevronRight aria-hidden />
+                </Button>
+                <span aria-hidden className="mx-1 h-4 w-px bg-border-2" />
+                <DialogClose
+                  render={
+                    <Button type="button" variant="ghost" size="icon-sm" />
+                  }
+                >
+                  <IconX aria-hidden />
+                  <span className="sr-only">Close</span>
+                </DialogClose>
+              </div>
             </div>
             {screenshotBaseUrl !== null ? (
               <img

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.navigation.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.navigation.test.tsx
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { parseHTML } from 'linkedom'
+import { act, type ComponentProps, type ReactNode } from 'react'
+import type { Root } from 'react-dom/client'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import * as _dialog from '@/components/ui/dialog'
+import * as _auditHooks from '@/modules/api/audit.hooks'
+import type { TaskDetailScreenData } from './task-detail.data'
+
+mock.module('@/modules/api/audit.hooks', () => ({
+  ..._auditHooks,
+  useTaskScreenshotBaseUrl: () => 'http://127.0.0.1:9200',
+}))
+
+mock.module('@/components/ui/dialog', () => ({
+  ..._dialog,
+  Dialog: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  DialogClose: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  DialogContent: ({
+    children,
+    showCloseButton: _showCloseButton,
+    ...props
+  }: ComponentProps<'div'> & { showCloseButton?: boolean }) => (
+    <div data-slot="dialog-content" {...props}>
+      {children}
+    </div>
+  ),
+  DialogTitle: (props: ComponentProps<'h2'>) => <h2 {...props} />,
+}))
+
+mock.module('@/components/audit/TaskHeader', () => ({
+  TaskHeader: () => <div data-testid="task-header" />,
+}))
+
+mock.module('@/components/ui/tabs-auto-hide', () => ({
+  AutoHideTabs: ({
+    items,
+  }: {
+    items: Array<{ id: string; content: ReactNode }>
+  }) => (
+    <>
+      {items.map((item) => (
+        <section key={item.id} data-testid={`tab-${item.id}`}>
+          {item.content}
+        </section>
+      ))}
+    </>
+  ),
+}))
+
+mock.module('./TabView', () => ({
+  TabView: ({
+    group,
+    onScreenshotClick,
+  }: {
+    group: {
+      id: string
+      screenshots: Array<{ screenshotId: number }>
+    }
+    onScreenshotClick: (screenshotId: number) => void
+  }) => (
+    <div data-testid={`group-${group.id}`}>
+      {group.screenshots.map((screenshot) => (
+        <button
+          key={screenshot.screenshotId}
+          type="button"
+          data-testid={`open-${group.id}-${screenshot.screenshotId}`}
+          onClick={() => onScreenshotClick(screenshot.screenshotId)}
+        >
+          Open {screenshot.screenshotId}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+const STARTED_AT = 1_000
+const SCREENSHOTS = [10, 20, 30, 40, 50].map((screenshotId) => ({
+  screenshotId,
+  capturedAt: STARTED_AT + screenshotId * 10,
+  toolName: 'screenshot',
+}))
+
+function screenData(moveLastScreenshot = false): TaskDetailScreenData {
+  const pageByScreenshotId = new Map([
+    [10, 1],
+    [20, 2],
+    [30, 1],
+    [40, 2],
+    [50, moveLastScreenshot ? 2 : 1],
+  ])
+  return {
+    detail: {
+      session: {
+        sessionId: 'session-navigation',
+        slug: 'codex',
+        label: 'Codex',
+        name: 'Navigation fixture',
+        site: 'example.test',
+        startedAt: STARTED_AT,
+        endedAt: STARTED_AT + 1_000,
+        durationMs: 1_000,
+        dispatchCount: SCREENSHOTS.length,
+        toolSequence: ['screenshot'],
+        status: 'done',
+        errorCount: 0,
+        latestScreenshotId: 50,
+      },
+      dispatches: SCREENSHOTS.map((screenshot) => ({
+        dispatchId: screenshot.screenshotId,
+        createdAt: screenshot.capturedAt,
+        slug: 'codex',
+        label: 'Codex',
+        sessionId: 'session-navigation',
+        toolName: 'screenshot',
+        pageId: pageByScreenshotId.get(screenshot.screenshotId),
+        url: `https://${screenshot.screenshotId}.example/path`,
+        durationMs: 5,
+        screenshotId: screenshot.screenshotId,
+      })),
+    },
+    screenshots: SCREENSHOTS,
+    isPending: false,
+    isError: false,
+    error: null,
+  }
+}
+
+let dataOverride = screenData()
+
+mock.module('./task-detail.data', () => ({
+  useTaskDetailScreenData: () => dataOverride,
+}))
+
+const GLOBAL_NAMES = [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'Element',
+  'Node',
+  'Event',
+] as const
+const globalDescriptors = new Map(
+  GLOBAL_NAMES.map((name) => [
+    name,
+    Object.getOwnPropertyDescriptor(globalThis, name),
+  ]),
+)
+
+const { TaskDetailPage } = await import('./TaskDetailPage')
+
+let root: Root
+let container: HTMLElement
+
+beforeEach(async () => {
+  dataOverride = screenData()
+  const dom = parseHTML(
+    '<!doctype html><html><body><div id="root"></div></body></html>',
+  )
+  const globals = {
+    window: dom.window,
+    document: dom.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Element: dom.window.Element,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+  }
+  for (const [name, value] of Object.entries(globals)) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    })
+  }
+  Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+    configurable: true,
+    writable: true,
+    value: true,
+  })
+  container = dom.document.getElementById('root') as unknown as HTMLElement
+  const { createRoot } = await import('react-dom/client')
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  for (const [name, descriptor] of globalDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor)
+    else Reflect.deleteProperty(globalThis, name)
+  }
+  Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
+})
+
+function Page() {
+  return (
+    <MemoryRouter initialEntries={['/audit/session-navigation']}>
+      <Routes>
+        <Route path="/audit/:sessionId" element={<TaskDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+async function renderPage() {
+  await act(async () => root.render(<Page />))
+}
+
+async function click(element: Element) {
+  await act(async () => {
+    element.dispatchEvent(new window.Event('click', { bubbles: true }))
+  })
+}
+
+function getByTestId(testId: string): HTMLElement {
+  const element = container.querySelector<HTMLElement>(
+    `[data-testid="${testId}"]`,
+  )
+  if (!element) throw new Error(`missing test id: ${testId}`)
+  return element
+}
+
+function getDialog(): HTMLElement {
+  const dialog = container.querySelector<HTMLElement>(
+    '[data-slot="dialog-content"]',
+  )
+  if (!dialog) throw new Error('missing screenshot lightbox')
+  return dialog
+}
+
+function getNavigationButton(label: string): HTMLButtonElement {
+  const button = getDialog().querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`,
+  )
+  if (!button) throw new Error(`missing navigation button: ${label}`)
+  return button
+}
+
+describe('TaskDetailPage screenshot navigation', () => {
+  it('keeps navigation scoped to the clicked group across navigation and polling', async () => {
+    await renderPage()
+
+    await click(getByTestId('open-page-1-30'))
+
+    expect(getDialog().textContent).toContain('30.example · T+300ms')
+    expect(getDialog().textContent).toContain('2 / 3')
+    expect(getDialog().querySelector('img')?.getAttribute('src')).toContain(
+      '/sessions/session-navigation/screenshots/30',
+    )
+
+    await click(getNavigationButton('Next screenshot'))
+
+    expect(getDialog().textContent).toContain('50.example · T+500ms')
+    expect(getDialog().textContent).toContain('3 / 3')
+    expect(getDialog().querySelector('img')?.getAttribute('src')).toContain(
+      '/sessions/session-navigation/screenshots/50',
+    )
+    expect(getDialog().querySelector('img')?.getAttribute('alt')).toBe(
+      'Screenshot of 50.example',
+    )
+
+    dataOverride = screenData(true)
+    await renderPage()
+
+    expect(getDialog().textContent).toContain('50.example · T+500ms')
+    expect(getDialog().textContent).toContain('1 / 1')
+    expect(getDialog().querySelector('img')?.getAttribute('src')).toContain(
+      '/sessions/session-navigation/screenshots/50',
+    )
+    expect(getNavigationButton('Previous screenshot').disabled).toBe(true)
+    expect(getNavigationButton('Next screenshot').disabled).toBe(true)
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
@@ -28,7 +28,10 @@ export function TaskDetailPage() {
   const { sessionId = '' } = useParams()
   const { detail, screenshots, isPending, isError, error } =
     useTaskDetailScreenData(sessionId)
-  const [lightboxId, setLightboxId] = useState<number | null>(null)
+  const [lightbox, setLightbox] = useState<{
+    groupId: string
+    screenshotId: number
+  } | null>(null)
 
   const groups = useMemo(
     () => (detail ? groupDispatchesByTab(detail.dispatches, screenshots) : []),
@@ -59,6 +62,14 @@ export function TaskDetailPage() {
     )
   }
 
+  const lightboxId = lightbox?.screenshotId ?? null
+  const lightboxGroup =
+    lightbox !== null
+      ? (groups.find((group) => group.id === lightbox.groupId) ?? null)
+      : null
+  const lightboxScreenshotIds =
+    lightboxGroup?.screenshots.map((screenshot) => screenshot.screenshotId) ??
+    []
   const selectedDispatch =
     lightboxId !== null
       ? (detail.dispatches.find((d) => d.screenshotId === lightboxId) ?? null)
@@ -98,7 +109,9 @@ export function TaskDetailPage() {
         group={g}
         startedAt={session.startedAt}
         endEvent={endEvent}
-        onScreenshotClick={setLightboxId}
+        onScreenshotClick={(screenshotId) =>
+          setLightbox({ groupId: g.id, screenshotId })
+        }
       />
     ),
   }))
@@ -114,13 +127,19 @@ export function TaskDetailPage() {
       <ScreenshotLightbox
         sessionId={sessionId}
         screenshotId={lightboxId}
+        screenshotIds={lightboxScreenshotIds}
         sourceUrl={selectedDispatch?.url ?? null}
         offsetMs={
           selectedScreenshot
             ? Math.max(0, selectedScreenshot.capturedAt - session.startedAt)
             : null
         }
-        onClose={() => setLightboxId(null)}
+        onNavigate={(screenshotId) =>
+          setLightbox((current) =>
+            current === null ? null : { ...current, screenshotId },
+          )
+        }
+        onClose={() => setLightbox(null)}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

- add bounded previous and next controls with a stable position indicator above audit screenshots
- support bare left and right arrow navigation while preserving native editing and control behavior
- retain the exact clicked task-detail group across navigation and independent screenshot polling
- update image, caption, and alt metadata together, with focused mutation-resistant coverage

## Design

`TaskDetailPage` owns the active screenshot and originating group identity, then passes the current ordered screenshot IDs into a controlled `ScreenshotLightbox`. The lightbox computes bounded adjacency, renders real disabled buttons, and handles only eligible unmodified arrow keys. If polling temporarily removes the active ID from the originating group, the image remains previewable as a disabled `1 / 1` singleton instead of drifting to Session order.

## Test plan

- [x] `cd packages/browseros-agent/apps/claw-app && bun run typecheck`
- [x] `cd packages/browseros-agent/apps/claw-app && bunx biome check`
- [x] `cd packages/browseros-agent/apps/claw-app && bun run test`
- [x] `cd packages/browseros-agent/apps/claw-app && bun run build:dev`
- [x] `cd packages/browseros-agent && bun run check`
- [x] `cd packages/browseros-agent && bun run test`
- [x] two independent review rounds; final round clean
- [x] `git diff --check` and generated `components/ui/**` scope audit