### PR TITLE
fix(claw): use portable BrowserOS neo MCP identifier

### DIFF
--- a/docs/neo/mcp/index.mdx
+++ b/docs/neo/mcp/index.mdx
@@ -24,7 +24,7 @@ Under the endpoint URL you'll see the list of AI tools we support out of the box
   <img src="/images/browserclaw--mcp-install-board.png" alt="BrowserOS neo connect page showing an endpoint URL at the top and the supported AI tools listed underneath, each with a Connect button on the right." />
 </Frame>
 
-Today the supported AI tools are **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Antigravity**, **VS Code**, and **Zed**. Behind the scenes, BrowserOS neo writes a single entry named `BrowserOS neo` into the AI tool's own MCP config file, pointing at the endpoint URL above. Existing managed `BrowserClaw` entries are recognized and migrated automatically.
+Today the supported AI tools are **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Antigravity**, **VS Code**, and **Zed**. Behind the scenes, BrowserOS neo writes a single entry named `browseros-neo` into the AI tool's own MCP config file, pointing at the endpoint URL above. Existing managed `BrowserOS neo` and `BrowserClaw` entries are recognized and migrated automatically.
 
 <Tip>
 The board updates as soon as your AI tool actually loads the config. If you don't see the row flip to **Connected**, restart the AI tool once and come back.

--- a/docs/neo/mcp/manual.mdx
+++ b/docs/neo/mcp/manual.mdx
@@ -15,7 +15,7 @@ http://127.0.0.1:9200/mcp
 Now pick your AI tool below.
 
 <Note>
-The examples name the server `browserclaw`, the product's old name. That matches what the one-click setup writes, so keep it if you want both paths to agree. The name is yours to choose, but whatever you pick is the name your AI tool will know the browser by.
+The examples name the server `browseros-neo`, matching the one-click setup. The name is yours to choose, but whatever you pick is the name your AI tool will know the browser by.
 </Note>
 
 ## Hermes Agent
@@ -26,7 +26,7 @@ Open `~/.hermes/config.yaml` and add a `mcp_servers` entry:
 
 ```yaml
 mcp_servers:
-  browserclaw:
+  browseros-neo:
     url: "http://127.0.0.1:9200/mcp"
 ```
 
@@ -35,7 +35,7 @@ Then reload Hermes:
 - Inside an existing `hermes chat` session, run `/reload-mcp`.
 - Or restart Hermes.
 
-Hermes also has a CLI command that adds a server interactively: `hermes mcp add browserclaw`. Either path works.
+Hermes also has a CLI command that adds a server interactively: `hermes mcp add browseros-neo`. Either path works.
 
 ## Vercel AI SDK
 
@@ -73,7 +73,7 @@ The AI SDK docs recommend closing the client once you're done. In streaming code
 The fastest path is the CLI:
 
 ```bash
-openclaw mcp add browserclaw --url http://127.0.0.1:9200/mcp --transport streamable-http
+openclaw mcp add browseros-neo --url http://127.0.0.1:9200/mcp --transport streamable-http
 ```
 
 Or edit `~/.openclaw/openclaw.json` directly:
@@ -82,7 +82,7 @@ Or edit `~/.openclaw/openclaw.json` directly:
 {
   "mcp": {
     "servers": {
-      "browserclaw": {
+      "browseros-neo": {
         "url": "http://127.0.0.1:9200/mcp",
         "transport": "streamable-http"
       }
@@ -94,7 +94,7 @@ Or edit `~/.openclaw/openclaw.json` directly:
 Verify the connection with the built-in doctor:
 
 ```bash
-openclaw mcp doctor browserclaw --probe
+openclaw mcp doctor browseros-neo --probe
 ```
 
 ## Any other MCP-compatible AI tool

--- a/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.test.ts
@@ -93,7 +93,7 @@ describe('buildCanonicalMcpCliCommand', () => {
   it('produces the standard `claude mcp add` shape with the canonical URL', () => {
     installWindow('')
     expect(buildCanonicalMcpCliCommand()).toBe(
-      'claude mcp add "BrowserOS neo" http://127.0.0.1:9200/mcp --transport http --scope user',
+      'claude mcp add browseros-neo http://127.0.0.1:9200/mcp --transport http --scope user',
     )
   })
 })

--- a/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.ts
@@ -36,5 +36,5 @@ export async function resolveCanonicalMcpEndpointUrl(): Promise<string> {
 
 export function buildCanonicalMcpCliCommand(): string {
   const url = buildCanonicalMcpEndpointUrl()
-  return `claude mcp add "${BROWSEROS_MCP_SERVER_NAME}" ${url} --transport http --scope user`
+  return `claude mcp add ${BROWSEROS_MCP_SERVER_NAME} ${url} --transport http --scope user`
 }

--- a/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.test.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.test.ts
@@ -65,7 +65,7 @@ describe('buildCanonicalMcpCliCommand', () => {
   it('produces the standard Claude MCP registration command', () => {
     installWindow('')
     expect(buildCanonicalMcpCliCommand()).toBe(
-      'claude mcp add "BrowserOS neo" http://127.0.0.1:9200/mcp --transport http --scope user',
+      'claude mcp add browseros-neo http://127.0.0.1:9200/mcp --transport http --scope user',
     )
   })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.ts
@@ -61,5 +61,5 @@ export function buildCanonicalMcpEndpointUrl(): string {
 
 export function buildCanonicalMcpCliCommand(): string {
   const url = buildCanonicalMcpEndpointUrl()
-  return `claude mcp add "${BROWSEROS_MCP_SERVER_NAME}" ${url} --transport http --scope user`
+  return `claude mcp add ${BROWSEROS_MCP_SERVER_NAME} ${url} --transport http --scope user`
 }

--- a/packages/browseros-agent/apps/claw-server-rust/build.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/build.rs
@@ -1,5 +1,3 @@
-use std::fmt::Write;
-
 fn main() {
     println!("cargo:rerun-if-env-changed=CLAW_POSTHOG_KEY");
     let Some(key) = std::env::var_os("CLAW_POSTHOG_KEY").and_then(|value| value.into_string().ok())
@@ -7,8 +5,10 @@ fn main() {
         return;
     };
     let mut encoded = String::with_capacity(key.len() * 2);
-    for byte in key.as_bytes() {
-        write!(&mut encoded, "{byte:02x}").expect("writing to a string cannot fail");
+    let hex = b"0123456789abcdef";
+    for byte in key.bytes() {
+        encoded.push(char::from(hex[usize::from(byte >> 4)]));
+        encoded.push(char::from(hex[usize::from(byte & 0x0f)]));
     }
     println!("cargo:rustc-env=CLAW_POSTHOG_KEY_MARKER=browseros-claw-posthog-key={encoded};");
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -38,7 +38,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 use ulid::Ulid;
 
-const SERVER_NAME: &str = "browserclaw";
+const SERVER_NAME: &str = "browseros-neo";
 const SERVER_TITLE: &str = "BrowserOS neo";
 const NAME_SESSION_TOOL_NAME: &str = "name_session";
 const NAME_SESSION_DESCRIPTION: &str = "Rename this browser session: a small lowercase 2-3 word label for what this session is doing, e.g. \"invoice processing\". Tabs are grouped as <client>/<name>. Call again to rename.";
@@ -70,7 +70,6 @@ struct StartedSession {
 }
 
 impl ClawMcpService {
-    /// Creates the BrowserOS neo-owned rmcp server over the shared browser tool catalog.
     #[must_use]
     pub fn new(state: AppState) -> Self {
         Self {
@@ -428,7 +427,6 @@ struct SessionRename {
     response: String,
 }
 
-/// Validates and commits a session rename before any browser-side title synchronization.
 async fn rename_session(
     session: Option<&Session>,
     raw_args: &Value,
@@ -621,7 +619,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn initialize_info_uses_browserclaw_branding_and_prompt() -> anyhow::Result<()> {
+    async fn initialize_info_uses_browseros_neo_identity_and_prompt() -> anyhow::Result<()> {
         let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
         let service = ClawMcpService::new(call.state);
         let info = service.get_info();

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
@@ -24,11 +24,19 @@ use std::{
 use tokio::sync::Mutex;
 use url::Url;
 
-pub const BROWSEROS_MCP_SERVER_NAME: &str = "BrowserOS neo";
-pub const BROWSEROS_LEGACY_MCP_SERVER_NAME: &str = "BrowserClaw";
+pub const BROWSEROS_MCP_SERVER_NAME: &str = "browseros-neo";
+pub const BROWSEROS_NEO_LEGACY_MCP_SERVER_NAME: &str = "BrowserOS neo";
+pub const BROWSERCLAW_LEGACY_MCP_SERVER_NAME: &str = "BrowserClaw";
 
-const BROWSEROS_MCP_SERVER_NAMES: [&str; 2] =
-    [BROWSEROS_MCP_SERVER_NAME, BROWSEROS_LEGACY_MCP_SERVER_NAME];
+const BROWSEROS_LEGACY_MCP_SERVER_NAMES: [&str; 2] = [
+    BROWSEROS_NEO_LEGACY_MCP_SERVER_NAME,
+    BROWSERCLAW_LEGACY_MCP_SERVER_NAME,
+];
+const BROWSEROS_MCP_SERVER_NAMES: [&str; 3] = [
+    BROWSEROS_MCP_SERVER_NAME,
+    BROWSEROS_NEO_LEGACY_MCP_SERVER_NAME,
+    BROWSERCLAW_LEGACY_MCP_SERVER_NAME,
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum Harness {
@@ -215,7 +223,6 @@ impl HarnessService {
         }
     }
 
-    /// Registers BrowserOS neo while restoring the prior spec on relink failure.
     pub async fn connect_browseros(
         &self,
         harness: Harness,
@@ -233,20 +240,18 @@ impl HarnessService {
                 .map_err(HarnessOperationError::Manager)?
                 .into_iter()
                 .any(|link| link.agent == agent);
-            let legacy_link = managed_browseros_links(&manager, &workspace_dir)
-                .map_err(HarnessOperationError::Manager)?
-                .into_iter()
-                .find(|link| {
-                    link.agent == agent
-                        && link.server_name == BROWSEROS_LEGACY_MCP_SERVER_NAME
-                });
+            let managed_links = managed_browseros_links(&manager, &workspace_dir)
+                .map_err(HarnessOperationError::Manager)?;
             if let Err(error) = migrate_browseros_agent(
                 &manager,
                 &workspace_dir,
                 agent,
                 &target_mcp_url,
-                legacy_link.as_ref(),
+                &managed_links,
             ) {
+                if matches!(&error, ManagerError::ForeignEntry { .. }) {
+                    return Err(HarnessOperationError::Manager(error));
+                }
                 tracing::warn!(harness = %harness, agent = %agent, %error, "BrowserOS MCP identity migration before connect failed");
             }
             let canonical_path = managed_browseros_links(&manager, &workspace_dir)
@@ -256,13 +261,20 @@ impl HarnessService {
                     link.agent == agent && link.server_name == BROWSEROS_MCP_SERVER_NAME
                 })
                 .map(|link| link.config_path);
+            let allow_overwrite = allow_canonical_destination_overwrite(
+                &manager,
+                agent,
+                canonical_path.as_deref(),
+                canonical_path.is_some(),
+            )
+            .map_err(HarnessOperationError::Manager)?;
             let summary = relink_managed_server(
                 &manager,
                 &workspace_dir,
                 BROWSEROS_MCP_SERVER_NAME,
                 agent,
                 spec,
-                true,
+                allow_overwrite,
                 canonical_path.as_deref(),
             )?;
             let config_path = managed_browseros_links(&manager, &workspace_dir)
@@ -307,7 +319,6 @@ impl HarnessService {
         }
     }
 
-    /// Removes both managed BrowserOS MCP aliases from one harness.
     pub async fn disconnect_browseros(&self, harness: Harness) -> AppResult<ConnectionState> {
         let _guard = self.mutex.lock().await;
         let agent = harness.agent_id();
@@ -315,7 +326,7 @@ impl HarnessService {
         let workspace_dir = self.workspace_dir.clone();
         let managed_skill = self.managed_skill.clone();
         let result = tokio::task::spawn_blocking(move || {
-            adopt_config_only_legacy_for_disconnect(&manager, &workspace_dir, agent)
+            adopt_config_only_aliases_for_disconnect(&manager, &workspace_dir, agent)
                 .map_err(HarnessOperationError::Manager)?;
             let mut unlinked = false;
             let mut removed_manifest = false;
@@ -372,7 +383,6 @@ impl HarnessService {
         }
     }
 
-    /// Lists one logical BrowserOS connection per installed harness.
     pub async fn list_browseros_connections(&self) -> AppResult<Vec<ConnectionState>> {
         let _guard = self.mutex.lock().await;
         let manager = self.manager.clone();
@@ -431,7 +441,6 @@ impl HarnessService {
             .collect())
     }
 
-    /// Auto-connects detected harnesses only when no BrowserOS link exists.
     pub async fn first_run_connect(&self, mcp_url: &str) -> AppResult<FirstRunConnectOutcome> {
         let connections = self.list_browseros_connections().await?;
         let already_linked = connections.iter().filter(|state| state.installed).count();
@@ -455,7 +464,6 @@ impl HarnessService {
         Ok(outcome)
     }
 
-    /// Rescans managed entries and repairs drifted or missing files from manifest specs.
     pub async fn run_integrity_scan(&self) -> AppResult<IntegrityScanOutcome> {
         let _guard = self.mutex.lock().await;
         let manager = self.manager.clone();
@@ -465,7 +473,6 @@ impl HarnessService {
             .map_err(manager_app_error)
     }
 
-    /// Reconciles the product skill from the current MCP manifest links.
     pub async fn run_skill_reconciliation(&self) -> AppResult<SkillReconcileOutcome> {
         let _guard = self.mutex.lock().await;
         let Some(managed_skill) = self.managed_skill.clone() else {
@@ -480,7 +487,6 @@ impl HarnessService {
         .map_err(manager_app_error)
     }
 
-    /// Migrates eligible BrowserClaw entries independently on every startup.
     pub async fn migrate_browseros_identity(
         &self,
         target_mcp_url: &str,
@@ -496,7 +502,6 @@ impl HarnessService {
         .map_err(manager_app_error)
     }
 
-    /// Re-links every managed BrowserOS connection to the current MCP URL.
     pub async fn migrate_connected_urls(
         &self,
         target_mcp_url: &str,
@@ -609,7 +614,6 @@ fn with_skill_retry_message(message: String, warning: Option<String>) -> String 
     }
 }
 
-/// Selects HTTP when the catalog supports it, otherwise wraps the URL with `mcp-remote`.
 pub fn spec_for(agent: AgentId, mcp_url: &str) -> Result<McpServerSpec, ManagerError> {
     let surface = resolve_agent_surface(agent, AgentScope::System)?;
     if surface
@@ -656,20 +660,21 @@ fn recognized_browseros_links(
         if linked_agents.contains(&agent) {
             continue;
         }
-        match manager.inspect_entry(InspectEntryInput::new(
-            BROWSEROS_LEGACY_MCP_SERVER_NAME,
-            agent,
-        )) {
-            Ok(Some(entry)) if is_historical_browseros_spec(&entry.spec) => {
-                links.push(ListedLink {
-                    server_name: BROWSEROS_LEGACY_MCP_SERVER_NAME.to_string(),
-                    agent,
-                    config_path: entry.config_path,
-                });
-            }
-            Ok(_) => {}
-            Err(error) => {
-                tracing::warn!(agent = %agent, %error, "legacy BrowserOS MCP entry inspection failed");
+        for server_name in BROWSEROS_LEGACY_MCP_SERVER_NAMES {
+            match manager.inspect_entry(InspectEntryInput::new(server_name, agent)) {
+                Ok(Some(entry)) if is_historical_browseros_spec(&entry.spec) => {
+                    links.push(ListedLink {
+                        server_name: server_name.to_string(),
+                        agent,
+                        config_path: entry.config_path,
+                    });
+                    break;
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    tracing::warn!(agent = %agent, %server_name, %error, "legacy BrowserOS MCP entry inspection failed");
+                    break;
+                }
             }
         }
     }
@@ -688,39 +693,47 @@ fn deduplicate_browseros_links(links: Vec<ListedLink>) -> BTreeMap<AgentId, List
     by_agent
 }
 
-fn adopt_config_only_legacy_for_disconnect(
+fn adopt_config_only_aliases_for_disconnect(
     manager: &McpManager,
     workspace_dir: &Path,
     agent: AgentId,
 ) -> Result<(), ManagerError> {
-    if managed_browseros_links(manager, workspace_dir)?
-        .iter()
-        .any(|link| link.agent == agent && link.server_name == BROWSEROS_LEGACY_MCP_SERVER_NAME)
-    {
-        return Ok(());
-    }
-    let entry = match manager.inspect_entry(InspectEntryInput::new(
-        BROWSEROS_LEGACY_MCP_SERVER_NAME,
-        agent,
-    )) {
-        Ok(Some(entry)) if is_historical_browseros_spec(&entry.spec) => entry,
-        Ok(_) => return Ok(()),
-        Err(error) => {
-            tracing::warn!(agent = %agent, %error, "legacy BrowserOS MCP disconnect inspection failed");
-            return Ok(());
+    let linked_names = managed_browseros_links(manager, workspace_dir)?
+        .into_iter()
+        .filter(|link| link.agent == agent)
+        .map(|link| link.server_name)
+        .collect::<BTreeSet<_>>();
+    for source_name in BROWSEROS_LEGACY_MCP_SERVER_NAMES {
+        if linked_names.contains(source_name) {
+            continue;
         }
-    };
-    let mut input = MigrateServerInput::new(
-        BROWSEROS_LEGACY_MCP_SERVER_NAME,
-        McpServer {
-            name: BROWSEROS_MCP_SERVER_NAME.to_string(),
-            spec: entry.spec.clone(),
-        },
-        agent,
-    );
-    input.config_path = Some(entry.config_path);
-    input.unmanaged_source_spec = Some(entry.spec);
-    with_legacy_manifest_migration(workspace_dir, || manager.migrate_server(input.clone()))?;
+        let entry = match manager.inspect_entry(InspectEntryInput::new(source_name, agent)) {
+            Ok(Some(entry)) if is_historical_browseros_spec(&entry.spec) => entry,
+            Ok(_) => continue,
+            Err(error) => {
+                tracing::warn!(agent = %agent, %source_name, %error, "legacy BrowserOS MCP disconnect inspection failed");
+                continue;
+            }
+        };
+        let allow_destination_overwrite = allow_canonical_destination_overwrite(
+            manager,
+            agent,
+            Some(&entry.config_path),
+            linked_names.contains(BROWSEROS_MCP_SERVER_NAME),
+        )?;
+        let mut input = MigrateServerInput::new(
+            source_name,
+            McpServer {
+                name: BROWSEROS_MCP_SERVER_NAME.to_string(),
+                spec: entry.spec.clone(),
+            },
+            agent,
+        );
+        input.config_path = Some(entry.config_path);
+        input.unmanaged_source_spec = Some(entry.spec);
+        input.allow_destination_overwrite = allow_destination_overwrite;
+        with_legacy_manifest_migration(workspace_dir, || manager.migrate_server(input.clone()))?;
+    }
     Ok(())
 }
 
@@ -729,16 +742,17 @@ fn migrate_browseros_identity(
     workspace_dir: &Path,
     target_mcp_url: &str,
 ) -> Result<IdentityMigrationOutcome, ManagerError> {
-    let legacy_links = managed_browseros_links(manager, workspace_dir)?
-        .into_iter()
-        .filter(|link| link.server_name == BROWSEROS_LEGACY_MCP_SERVER_NAME)
-        .map(|link| (link.agent, link))
-        .collect::<BTreeMap<_, _>>();
+    let managed_links = managed_browseros_links(manager, workspace_dir)?;
     let mut outcome = IdentityMigrationOutcome::default();
     for harness in Harness::ALL {
         let agent = harness.agent_id();
-        let legacy_link = legacy_links.get(&agent);
-        match migrate_browseros_agent(manager, workspace_dir, agent, target_mcp_url, legacy_link) {
+        match migrate_browseros_agent(
+            manager,
+            workspace_dir,
+            agent,
+            target_mcp_url,
+            &managed_links,
+        ) {
             Ok(true) => {
                 outcome.migrated += 1;
                 tracing::info!(harness = %harness, agent = %agent, "migrated BrowserOS neo MCP identity");
@@ -758,37 +772,89 @@ fn migrate_browseros_agent(
     workspace_dir: &Path,
     agent: AgentId,
     target_mcp_url: &str,
+    managed_links: &[ListedLink],
+) -> Result<bool, ManagerError> {
+    let mut migrated = false;
+    for source_name in BROWSEROS_LEGACY_MCP_SERVER_NAMES {
+        let legacy_link = managed_links
+            .iter()
+            .find(|link| link.agent == agent && link.server_name == source_name);
+        migrated |= migrate_browseros_alias(
+            manager,
+            workspace_dir,
+            agent,
+            target_mcp_url,
+            source_name,
+            legacy_link,
+            managed_links,
+        )?;
+    }
+    Ok(migrated)
+}
+
+fn migrate_browseros_alias(
+    manager: &McpManager,
+    workspace_dir: &Path,
+    agent: AgentId,
+    target_mcp_url: &str,
+    source_name: &str,
     legacy_link: Option<&ListedLink>,
+    managed_links: &[ListedLink],
 ) -> Result<bool, ManagerError> {
     let unmanaged_source = if legacy_link.is_none() {
-        match manager.inspect_entry(InspectEntryInput::new(
-            BROWSEROS_LEGACY_MCP_SERVER_NAME,
-            agent,
-        ))? {
+        match manager.inspect_entry(InspectEntryInput::new(source_name, agent))? {
             Some(entry) if is_historical_browseros_spec(&entry.spec) => Some(entry),
             _ => return Ok(false),
         }
     } else {
         None
     };
-    let mut input = MigrateServerInput::new(
-        BROWSEROS_LEGACY_MCP_SERVER_NAME,
-        McpServer {
-            name: BROWSEROS_MCP_SERVER_NAME.to_string(),
-            spec: spec_for(agent, target_mcp_url)?,
-        },
-        agent,
-    );
-    input.config_path = legacy_link
+    let config_path = legacy_link
         .map(|link| link.config_path.clone())
         .or_else(|| {
             unmanaged_source
                 .as_ref()
                 .map(|entry| entry.config_path.clone())
         });
+    let allow_destination_overwrite = allow_canonical_destination_overwrite(
+        manager,
+        agent,
+        config_path.as_deref(),
+        managed_links
+            .iter()
+            .any(|link| link.agent == agent && link.server_name == BROWSEROS_MCP_SERVER_NAME),
+    )?;
+    let mut input = MigrateServerInput::new(
+        source_name,
+        McpServer {
+            name: BROWSEROS_MCP_SERVER_NAME.to_string(),
+            spec: spec_for(agent, target_mcp_url)?,
+        },
+        agent,
+    );
+    input.config_path = config_path;
     input.unmanaged_source_spec = unmanaged_source.map(|entry| entry.spec);
+    input.allow_destination_overwrite = allow_destination_overwrite;
     with_legacy_manifest_migration(workspace_dir, || manager.migrate_server(input.clone()))
         .map(|summary| summary.migrated)
+}
+
+fn allow_canonical_destination_overwrite(
+    manager: &McpManager,
+    agent: AgentId,
+    config_path: Option<&Path>,
+    destination_managed: bool,
+) -> Result<bool, ManagerError> {
+    if destination_managed {
+        return Ok(true);
+    }
+    let mut input = InspectEntryInput::new(BROWSEROS_MCP_SERVER_NAME, agent);
+    if let Some(config_path) = config_path {
+        input = input.at_path(config_path);
+    }
+    Ok(manager
+        .inspect_entry(input)?
+        .is_some_and(|entry| is_historical_browseros_spec(&entry.spec)))
 }
 
 fn is_historical_browseros_spec(spec: &McpServerSpec) -> bool {
@@ -1130,9 +1196,6 @@ impl From<std::io::Error> for AppError {
     }
 }
 
-/// Decides first-launch auto-connect targets (Option B). Returns `None` when any
-/// harness is already linked, marking this an existing install to seed without
-/// sweeping; otherwise the full detected-but-unlinked set to connect.
 fn first_run_connect_targets(connections: &[ConnectionState]) -> Option<Vec<Harness>> {
     if connections.iter().any(|state| state.installed) {
         return None;

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
@@ -774,22 +774,56 @@ fn migrate_browseros_agent(
     target_mcp_url: &str,
     managed_links: &[ListedLink],
 ) -> Result<bool, ManagerError> {
-    let mut migrated = false;
+    let mut destination_managed = managed_links
+        .iter()
+        .any(|link| link.agent == agent && link.server_name == BROWSEROS_MCP_SERVER_NAME);
+    let mut migrated = if destination_managed {
+        false
+    } else {
+        adopt_config_only_canonical(manager, workspace_dir, agent, target_mcp_url)?
+    };
+    destination_managed |= migrated;
     for source_name in BROWSEROS_LEGACY_MCP_SERVER_NAMES {
         let legacy_link = managed_links
             .iter()
             .find(|link| link.agent == agent && link.server_name == source_name);
-        migrated |= migrate_browseros_alias(
+        let alias_migrated = migrate_browseros_alias(
             manager,
             workspace_dir,
             agent,
             target_mcp_url,
             source_name,
             legacy_link,
-            managed_links,
+            destination_managed,
         )?;
+        migrated |= alias_migrated;
+        destination_managed |= alias_migrated;
     }
     Ok(migrated)
+}
+
+fn adopt_config_only_canonical(
+    manager: &McpManager,
+    workspace_dir: &Path,
+    agent: AgentId,
+    target_mcp_url: &str,
+) -> Result<bool, ManagerError> {
+    let entry =
+        match manager.inspect_entry(InspectEntryInput::new(BROWSEROS_MCP_SERVER_NAME, agent))? {
+            Some(entry) if is_historical_browseros_spec(&entry.spec) => entry,
+            _ => return Ok(false),
+        };
+    let mut input = LinkInput::new(
+        McpServer {
+            name: BROWSEROS_MCP_SERVER_NAME.to_string(),
+            spec: spec_for(agent, target_mcp_url)?,
+        },
+        agent,
+    );
+    input.config_path = Some(entry.config_path);
+    input.allow_overwrite = true;
+    with_legacy_manifest_migration(workspace_dir, || manager.link(input.clone()))
+        .map(|summary| summary.created)
 }
 
 fn migrate_browseros_alias(
@@ -799,7 +833,7 @@ fn migrate_browseros_alias(
     target_mcp_url: &str,
     source_name: &str,
     legacy_link: Option<&ListedLink>,
-    managed_links: &[ListedLink],
+    destination_managed: bool,
 ) -> Result<bool, ManagerError> {
     let unmanaged_source = if legacy_link.is_none() {
         match manager.inspect_entry(InspectEntryInput::new(source_name, agent))? {
@@ -820,9 +854,7 @@ fn migrate_browseros_alias(
         manager,
         agent,
         config_path.as_deref(),
-        managed_links
-            .iter()
-            .any(|link| link.agent == agent && link.server_name == BROWSEROS_MCP_SERVER_NAME),
+        destination_managed,
     )?;
     let mut input = MigrateServerInput::new(
         source_name,

--- a/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
@@ -9,7 +9,8 @@ use claw_server_rust::{
     build_router,
     config::Config,
     services::harness::{
-        BROWSEROS_LEGACY_MCP_SERVER_NAME, BROWSEROS_MCP_SERVER_NAME, Harness, HarnessService,
+        BROWSERCLAW_LEGACY_MCP_SERVER_NAME, BROWSEROS_MCP_SERVER_NAME,
+        BROWSEROS_NEO_LEGACY_MCP_SERVER_NAME, Harness, HarnessService,
     },
 };
 use harness_integrations::{
@@ -188,12 +189,17 @@ async fn run_connections_case() -> anyhow::Result<()> {
         json!({ "type": "http", "url": MCP_URL })
     );
     assert_eq!(
-        claude_json["mcpServers"][BROWSEROS_LEGACY_MCP_SERVER_NAME],
+        claude_json["mcpServers"][BROWSERCLAW_LEGACY_MCP_SERVER_NAME],
         json!({ "command": "unrelated" })
     );
+    assert_eq!(
+        claude_json["mcpServers"][BROWSEROS_NEO_LEGACY_MCP_SERVER_NAME],
+        json!({ "command": "foreign" })
+    );
 
-    let codex_toml: toml::Value =
-        toml::from_str(&fs::read_to_string(path_for(&paths, AgentId::Codex)?)?)?;
+    let codex_raw = fs::read_to_string(path_for(&paths, AgentId::Codex)?)?;
+    assert!(codex_raw.contains("[mcp_servers.browseros-neo]"));
+    let codex_toml: toml::Value = toml::from_str(&codex_raw)?;
     assert_eq!(
         codex_toml["mcp_servers"][BROWSEROS_MCP_SERVER_NAME]["url"].as_str(),
         Some(MCP_URL)
@@ -278,8 +284,6 @@ async fn run_connections_case() -> anyhow::Result<()> {
     let restored_skill = service.run_skill_reconciliation().await?;
     assert_eq!(restored_skill.updated, 2);
 
-    // Proxy port moved on this launch: migrating re-links every connected
-    // harness to the new URL and rewrites their config files + the manifest.
     const NEW_MCP_URL: &str = "http://127.0.0.1:9999/mcp";
     let migrated = service.migrate_connected_urls(NEW_MCP_URL).await?;
     assert_eq!(migrated.migrated, 3);
@@ -303,15 +307,12 @@ async fn run_connections_case() -> anyhow::Result<()> {
         NEW_MCP_URL
     );
 
-    // Regression: a crash mid-migration can leave the manifest already at the
-    // target while some agent configs are still stale. Re-running must repair
-    // the straggler, not short-circuit on the manifest URL. Simulate it by
-    // reverting one agent's config to a stale port with the manifest untouched.
+    // A crash can update the manifest before every agent config reaches the new URL.
     const STALE_MCP_URL: &str = "http://127.0.0.1:8888/mcp";
     fs::write(
         claude_path,
         format!(
-            r#"{{"mcpServers":{{"BrowserOS neo":{{"type":"http","url":"{STALE_MCP_URL}"}}}}}}"#
+            r#"{{"mcpServers":{{"{BROWSEROS_MCP_SERVER_NAME}":{{"type":"http","url":"{STALE_MCP_URL}"}}}}}}"#
         ),
     )?;
     let repaired = service.migrate_connected_urls(NEW_MCP_URL).await?;
@@ -323,7 +324,6 @@ async fn run_connections_case() -> anyhow::Result<()> {
         "a straggler left on a stale port is repaired, not skipped"
     );
 
-    // Restore the original URL so the rest of this scenario is unaffected.
     let restored = service.migrate_connected_urls(MCP_URL).await?;
     assert_eq!(restored.migrated, 3);
     assert_eq!(configured[0].message, "Configured in Claude Code.");
@@ -482,7 +482,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
         .as_object_mut()
         .ok_or_else(|| anyhow::anyhow!("missing Claude MCP object"))?
         .insert(
-            BROWSEROS_LEGACY_MCP_SERVER_NAME.to_string(),
+            BROWSERCLAW_LEGACY_MCP_SERVER_NAME.to_string(),
             json!({ "command": "unrelated" }),
         );
     fs::write(
@@ -496,7 +496,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
         assert!(!repeated.installed, "{}", repeated.message);
     }
     let claude_after_disconnect = fs::read_to_string(claude_path)?;
-    assert!(claude_after_disconnect.contains(BROWSEROS_LEGACY_MCP_SERVER_NAME));
+    assert!(claude_after_disconnect.contains(BROWSERCLAW_LEGACY_MCP_SERVER_NAME));
     assert!(!claude_after_disconnect.contains(BROWSEROS_MCP_SERVER_NAME));
     let captured = analytics.take();
     assert_eq!(captured.len(), Harness::ALL.len() * 2);
@@ -544,9 +544,17 @@ async fn assert_identity_migration(
             path_for(paths, agent)?.to_path_buf()
         };
         fs::create_dir_all(parent(&config_path)?)?;
+        let source_name = if matches!(
+            agent,
+            AgentId::ClaudeCode | AgentId::Codex | AgentId::Cursor | AgentId::OpenCode
+        ) {
+            BROWSEROS_NEO_LEGACY_MCP_SERVER_NAME
+        } else {
+            BROWSERCLAW_LEGACY_MCP_SERVER_NAME
+        };
         let mut input = LinkInput::new(
             McpServer {
-                name: BROWSEROS_LEGACY_MCP_SERVER_NAME.to_string(),
+                name: source_name.to_string(),
                 spec: source_spec.clone(),
             },
             agent,
@@ -559,9 +567,9 @@ async fn assert_identity_migration(
         }
         migration_paths.push((agent, config_path));
     }
-    let legacy = manager.list()?.remove(0);
-    let legacy_added_at = legacy.added_at;
-    let legacy_created_at = legacy.links[&AgentId::ClaudeCode].created_at.clone();
+    let source = manager.list()?.remove(0);
+    let source_added_at = source.added_at;
+    let source_created_at = source.links[&AgentId::ClaudeCode].created_at.clone();
 
     let vscode_path = path_for(&migration_paths, AgentId::VsCode)?;
     let mut collision = LinkInput::new(
@@ -596,15 +604,19 @@ async fn assert_identity_migration(
     assert!(!path_for(paths, AgentId::ClaudeCode)?.exists());
     assert!(analytics.take().is_empty());
     for (agent, config_path) in &migration_paths {
-        assert!(
-            manager
-                .inspect_entry(
-                    InspectEntryInput::new(BROWSEROS_LEGACY_MCP_SERVER_NAME, *agent)
-                        .at_path(config_path),
-                )?
-                .is_none(),
-            "{agent}"
-        );
+        for source_name in [
+            BROWSEROS_NEO_LEGACY_MCP_SERVER_NAME,
+            BROWSERCLAW_LEGACY_MCP_SERVER_NAME,
+        ] {
+            assert!(
+                manager
+                    .inspect_entry(
+                        InspectEntryInput::new(source_name, *agent).at_path(config_path)
+                    )?
+                    .is_none(),
+                "{agent}: {source_name}"
+            );
+        }
         assert_eq!(
             manager
                 .inspect_entry(
@@ -621,10 +633,10 @@ async fn assert_identity_migration(
     let canonical = manager.list()?.remove(0);
     assert_eq!(canonical.name, BROWSEROS_MCP_SERVER_NAME);
     assert_eq!(canonical.links.len(), 7);
-    assert_eq!(canonical.added_at, legacy_added_at);
+    assert_eq!(canonical.added_at, source_added_at);
     assert_eq!(
         canonical.links[&AgentId::ClaudeCode].created_at,
-        legacy_created_at
+        source_created_at
     );
     assert_eq!(
         canonical.links[&AgentId::ClaudeCode].config_path,
@@ -655,12 +667,52 @@ async fn assert_identity_migration(
     assert!(!foreign_workspace.join("manifest.json").exists());
     fs::remove_file(cursor_path)?;
 
+    let collision_workspace = home.join("claw/identity-collision-manager");
+    let collision_service = HarnessService::new(collision_workspace.clone(), home.to_path_buf());
+    let collision_raw = format!(
+        r#"{{"mcpServers":{{"{BROWSEROS_NEO_LEGACY_MCP_SERVER_NAME}":{{"type":"http","url":"{MCP_URL}"}},"{BROWSEROS_MCP_SERVER_NAME}":{{"command":"foreign"}}}},"keep":true}}"#
+    );
+    fs::write(cursor_path, &collision_raw)?;
+    let collision = collision_service
+        .migrate_browseros_identity(MCP_URL)
+        .await?;
+    assert_eq!(collision.migrated, 0);
+    assert_eq!(collision.failed, 1);
+    assert_eq!(collision.skipped, 6);
+    assert_eq!(fs::read_to_string(cursor_path)?, collision_raw);
+    assert!(!collision_workspace.join("manifest.json").exists());
+
+    let collision_disconnect = collision_service
+        .disconnect_browseros(Harness::Cursor)
+        .await?;
+    assert!(!collision_disconnect.installed);
+    assert!(
+        collision_disconnect
+            .message
+            .contains(BROWSEROS_MCP_SERVER_NAME)
+    );
+    assert_eq!(fs::read_to_string(cursor_path)?, collision_raw);
+    assert!(!collision_workspace.join("manifest.json").exists());
+
+    let collision_connect = collision_service
+        .connect_browseros(Harness::Cursor, MCP_URL)
+        .await?;
+    assert!(!collision_connect.installed);
+    assert!(
+        collision_connect
+            .message
+            .contains(BROWSEROS_MCP_SERVER_NAME)
+    );
+    assert_eq!(fs::read_to_string(cursor_path)?, collision_raw);
+    assert!(!collision_workspace.join("manifest.json").exists());
+    fs::remove_file(cursor_path)?;
+
     let failure_workspace = home.join("claw/identity-failure-manager");
     let failure_seed = McpManager::new(home.join("claw/identity-failure-seed"));
     let claude_path = path_for(paths, AgentId::ClaudeCode)?;
     let mut legacy = LinkInput::new(
         McpServer {
-            name: BROWSEROS_LEGACY_MCP_SERVER_NAME.to_string(),
+            name: BROWSERCLAW_LEGACY_MCP_SERVER_NAME.to_string(),
             spec: source_spec,
         },
         AgentId::ClaudeCode,
@@ -681,7 +733,7 @@ async fn assert_identity_migration(
     let compatibility_manager = McpManager::new(&compatibility_workspace);
     let mut legacy = LinkInput::new(
         McpServer {
-            name: BROWSEROS_LEGACY_MCP_SERVER_NAME.to_string(),
+            name: BROWSERCLAW_LEGACY_MCP_SERVER_NAME.to_string(),
             spec: McpServerSpec::Http {
                 url: STALE_URL.to_string(),
                 headers: Default::default(),
@@ -707,7 +759,7 @@ async fn assert_identity_migration(
     assert_eq!(url_outcome.migrated, 1);
     let updated = compatibility_manager
         .inspect_entry(
-            InspectEntryInput::new(BROWSEROS_LEGACY_MCP_SERVER_NAME, AgentId::Cursor)
+            InspectEntryInput::new(BROWSERCLAW_LEGACY_MCP_SERVER_NAME, AgentId::Cursor)
                 .at_path(cursor_path),
         )?
         .ok_or_else(|| anyhow::anyhow!("missing compatible legacy entry"))?;

--- a/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
@@ -655,9 +655,38 @@ async fn assert_identity_migration(
         fs::remove_dir_all(home.join(".gemini"))?;
     }
 
+    let canonical_workspace = home.join("claw/identity-canonical-manager");
+    let canonical_manager = McpManager::new(&canonical_workspace);
+    let canonical_service = HarnessService::new(canonical_workspace.clone(), home.to_path_buf());
+    let cursor_path = path_for(paths, AgentId::Cursor)?;
+    let canonical_raw = format!(
+        r#"{{"mcpServers":{{"{BROWSEROS_MCP_SERVER_NAME}":{{"type":"http","url":"{STALE_URL}"}}}},"keep":true}}"#
+    );
+    fs::write(cursor_path, canonical_raw)?;
+    let canonical = canonical_service
+        .migrate_browseros_identity(MCP_URL)
+        .await?;
+    assert_eq!(canonical.migrated, 1);
+    assert_eq!(canonical.failed, 0);
+    assert_eq!(canonical.skipped, 6);
+    let canonical_entry = canonical_manager
+        .inspect_entry(
+            InspectEntryInput::new(BROWSEROS_MCP_SERVER_NAME, AgentId::Cursor).at_path(cursor_path),
+        )?
+        .ok_or_else(|| anyhow::anyhow!("missing adopted canonical entry"))?;
+    assert_eq!(
+        canonical_entry.spec,
+        McpServerSpec::Http {
+            url: MCP_URL.to_string(),
+            headers: Default::default(),
+        }
+    );
+    assert!(fs::read_to_string(cursor_path)?.contains(r#""keep":true"#));
+    assert_eq!(canonical_manager.list()?.remove(0).links.len(), 1);
+    fs::remove_file(cursor_path)?;
+
     let foreign_workspace = home.join("claw/identity-foreign-manager");
     let foreign_service = HarnessService::new(foreign_workspace.clone(), home.to_path_buf());
-    let cursor_path = path_for(paths, AgentId::Cursor)?;
     let foreign_raw = r#"{"mcpServers":{"BrowserClaw":{"command":"foreign"},"BrowserOS neo":{"command":"standalone"}},"keep":true}"#;
     fs::write(cursor_path, foreign_raw)?;
     let foreign = foreign_service.migrate_browseros_identity(MCP_URL).await?;

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -175,7 +175,6 @@ struct McpSseStream {
 }
 
 impl McpSseStream {
-    /// Opens the session's standalone SSE channel for server-initiated MCP requests.
     async fn open(router: &Router, session_id: &str) -> anyhow::Result<Self> {
         let request = Request::builder()
             .method("GET")
@@ -372,8 +371,6 @@ async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
     )
     .await?;
     assert_eq!(status, StatusCode::OK);
-    // The complete catalog is advertised, including the run script tool and
-    // the locally implemented name_session tool.
     let listed: Vec<&str> = body["result"]["tools"]
         .as_array()
         .ok_or_else(|| anyhow::anyhow!("tools not array"))?
@@ -1511,7 +1508,7 @@ async fn initialize_mcp(app: &TestApp) -> anyhow::Result<String> {
     let (status, headers, body) =
         request_json_with_headers(&app.router, "POST", "/mcp", Some(initialize), &[]).await?;
     assert_eq!(status, StatusCode::OK, "initialize body: {body:?}");
-    assert_eq!(body["result"]["serverInfo"]["name"], "browserclaw");
+    assert_eq!(body["result"]["serverInfo"]["name"], "browseros-neo");
     assert_eq!(body["result"]["serverInfo"]["title"], "BrowserOS neo");
     assert!(
         body["result"]["instructions"].as_str().is_some_and(

--- a/packages/browseros-agent/crates/harness-integrations/src/mcp/planner.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/mcp/planner.rs
@@ -36,7 +36,6 @@ pub(crate) struct PlannedMigrationInstall {
     pub(crate) overwrote_foreign: bool,
 }
 
-/// Computes a link plan without touching the filesystem or mutating the state snapshot.
 pub(crate) fn plan_link(state: &State, input: &LinkInput, now: &str) -> Result<PlannedLink, Error> {
     let name = input.server.name.trim();
     if name.is_empty() {
@@ -139,7 +138,7 @@ pub(crate) fn plan_migration_install(
     let mut link_input = LinkInput::new(input.destination.clone(), input.agent);
     link_input.scope = input.scope;
     link_input.config_path = Some(agent_file.config_path.clone());
-    link_input.allow_overwrite = true;
+    link_input.allow_overwrite = input.allow_destination_overwrite;
     let mut planned = plan_link(state, &link_input, now)?;
     let destination_name = planned.summary.server_name.clone();
     let existing_destination = state.manifest.servers.get(&destination_name);
@@ -253,7 +252,6 @@ pub(crate) fn plan_migration_cleanup(
     Ok(Plan { ops, next_manifest })
 }
 
-/// Computes an unlink plan using the manifest-recorded config path.
 pub(crate) fn plan_unlink(state: &State, input: &UnlinkInput) -> Result<PlannedUnlink, Error> {
     let no_op = || PlannedUnlink {
         plan: Plan {
@@ -300,7 +298,6 @@ pub(crate) fn plan_unlink(state: &State, input: &UnlinkInput) -> Result<PlannedU
     })
 }
 
-/// Computes a single-agent disconnect without producing operations for any other agent.
 pub(crate) fn plan_disconnect(
     state: &State,
     input: &DisconnectInput,
@@ -373,7 +370,6 @@ pub(crate) fn plan_disconnect(
     })
 }
 
-/// Classifies manifest links against their recorded-path file snapshots without writing.
 pub(crate) fn plan_rescan(state: &State) -> Result<RescanReport, Error> {
     let mut report = RescanReport::default();
     for server in state.manifest.servers.values() {

--- a/packages/browseros-agent/crates/harness-integrations/src/mcp/types.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/mcp/types.rs
@@ -100,7 +100,6 @@ pub struct LinkInput {
 }
 
 impl LinkInput {
-    /// Creates a system-scope link request with overwrite protection enabled.
     pub fn new(server: McpServer, agent: AgentId) -> Self {
         Self {
             server,
@@ -121,7 +120,6 @@ pub struct InspectEntryInput {
 }
 
 impl InspectEntryInput {
-    /// Creates a system-scope entry inspection at the catalog path.
     pub fn new(server_name: impl Into<String>, agent: AgentId) -> Self {
         Self {
             server_name: server_name.into(),
@@ -151,6 +149,7 @@ pub struct InspectedEntry {
 pub struct MigrateServerInput {
     pub source_name: String,
     pub destination: McpServer,
+    pub allow_destination_overwrite: bool,
     pub agent: AgentId,
     pub scope: AgentScope,
     pub config_path: Option<PathBuf>,
@@ -158,11 +157,11 @@ pub struct MigrateServerInput {
 }
 
 impl MigrateServerInput {
-    /// Creates a system-scope server migration request.
     pub fn new(source_name: impl Into<String>, destination: McpServer, agent: AgentId) -> Self {
         Self {
             source_name: source_name.into(),
             destination,
+            allow_destination_overwrite: true,
             agent,
             scope: AgentScope::System,
             config_path: None,
@@ -190,7 +189,6 @@ pub struct UnlinkInput {
 }
 
 impl UnlinkInput {
-    /// Creates a system-scope unlink request that uses the manifest-recorded path.
     pub fn new(server_name: impl Into<String>, agent: AgentId) -> Self {
         Self {
             server_name: server_name.into(),
@@ -210,7 +208,6 @@ pub struct DisconnectInput {
 }
 
 impl DisconnectInput {
-    /// Creates a system-scope disconnect request that removes a last-link manifest entry.
     pub fn new(server_name: impl Into<String>, agent: AgentId) -> Self {
         Self {
             server_name: server_name.into(),

--- a/packages/browseros-agent/crates/harness-integrations/tests/api.rs
+++ b/packages/browseros-agent/crates/harness-integrations/tests/api.rs
@@ -332,6 +332,15 @@ fn migration_scopes_foreign_authority_and_preserves_timestamps_and_formatting()
         AgentId::Cursor,
     );
     migration.config_path = Some(config.clone());
+    migration.allow_destination_overwrite = false;
+    let before_rejected_migration = fs::read_to_string(&config)?;
+    assert!(matches!(
+        manager.migrate_server(migration.clone()),
+        Err(Error::ForeignEntry { .. })
+    ));
+    assert_eq!(fs::read_to_string(&config)?, before_rejected_migration);
+
+    migration.allow_destination_overwrite = true;
     let summary = manager.migrate_server(migration.clone())?;
     assert!(summary.migrated);
     assert!(summary.overwrote_foreign);

--- a/packages/browseros-agent/packages/shared/src/constants/browserclaw.test.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/browserclaw.test.ts
@@ -23,7 +23,7 @@ describe('BrowserClaw runtime constants', () => {
 
   test('preserves the canonical MCP identity and loopback URL', () => {
     expect(MCP_PATH).toBe('/mcp')
-    expect(BROWSEROS_MCP_SERVER_NAME).toBe('BrowserOS neo')
+    expect(BROWSEROS_MCP_SERVER_NAME).toBe('browseros-neo')
     expect(canonicalMcpUrlForPort()).toBe('http://127.0.0.1:9200/mcp')
     expect(canonicalMcpUrlForPort(9100)).toBe('http://127.0.0.1:9100/mcp')
   })

--- a/packages/browseros-agent/packages/shared/src/constants/urls.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/urls.ts
@@ -2,14 +2,12 @@
  * @license
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * Centralized URL configuration.
  */
 
 import { CLAW_API_PORT_DEFAULT } from './ports'
 
 export const MCP_PATH = '/mcp'
-export const BROWSEROS_MCP_SERVER_NAME = 'BrowserOS neo'
+export const BROWSEROS_MCP_SERVER_NAME = 'browseros-neo'
 
 export function canonicalMcpUrlForPort(port = CLAW_API_PORT_DEFAULT): string {
   return `http://127.0.0.1:${port}${MCP_PATH}`


### PR DESCRIPTION
## Summary
- use `browseros-neo` as the portable MCP machine identifier while keeping `BrowserOS neo` as the display title
- migrate both `BrowserOS neo` and `BrowserClaw` legacy entries, recover interrupted canonical registrations, and preserve unrelated foreign entries
- align generated CLI commands, shared constants, tests, and MCP documentation

## Design
MCP `Implementation.name` and client config keys now use the lowercase hyphenated identifier `browseros-neo`; the human-facing protocol title remains `BrowserOS neo`. Startup reconciliation treats both prior names as legacy aliases, adopts only recognizable BrowserOS loopback configurations, and refuses to overwrite an unrelated canonical destination.

## Test plan
- [x] `cargo test --workspace --locked`
- [x] `cargo +1.95.0 clippy --workspace --all-targets --locked -- -D warnings`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] Claw app, onboarding, and shared constant test suites
