### PR TITLE
docs: add the featured on Product Hunt badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br></br>
 
 <a href="https://www.producthunt.com/products/browseros_ai?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-browseros-neo" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1031913&amp;theme=dark&amp;t=1786088428884" /><img alt="BrowserOS neo - The Missing Browser for Claude, Cowork &amp; Codex | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1031913&amp;theme=light&amp;t=1786088428884" /></picture></a>
-<a href="https://trendshift.io/repositories/16468?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-16468" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/16468/daily?language=TypeScript" alt="browseros-ai%2FBrowserOS | Trendshift" width="250" height="55" /></a>
+<a href="https://trendshift.io/repositories/16468?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-16468" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/16468" alt="browseros-ai%2FBrowserOS | Trendshift" width="250" height="55" /></a>
 <br></br>
 
 <h3>Two browsers: one for your agents, one for you.</h3>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <br></br>
 
 <a href="https://www.producthunt.com/products/browseros_ai?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-browseros-neo" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1031913&amp;theme=dark&amp;t=1786088428884" /><img alt="BrowserOS neo - The Missing Browser for Claude, Cowork &amp; Codex | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1031913&amp;theme=light&amp;t=1786088428884" /></picture></a>
+<a href="https://trendshift.io/repositories/16468?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-16468" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/16468/daily?language=TypeScript" alt="browseros-ai%2FBrowserOS | Trendshift" width="250" height="55" /></a>
 <br></br>
 
 <h3>Two browsers: one for your agents, one for you.</h3>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 <a href="https://github.com/browseros-ai/BrowserOS"><img src="https://img.shields.io/github/stars/browseros-ai/BrowserOS?style=flat&logo=github&label=stars&color=4c71f2" alt="GitHub stars" /></a>
 <br></br>
 
+<a href="https://www.producthunt.com/products/browseros_ai?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-browseros-neo" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1031913&amp;theme=dark&amp;t=1786088428884" /><img alt="BrowserOS neo - The Missing Browser for Claude, Cowork &amp; Codex | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1031913&amp;theme=light&amp;t=1786088428884" /></picture></a>
+<br></br>
+
 <h3>Two browsers: one for your agents, one for you.</h3>
 
 Free · Open source · Everything runs on your machine


### PR DESCRIPTION
## What

Adds the official "Featured on Product Hunt" badge for the BrowserOS neo launch to the README hero, right below the existing social/stars badges.

## Details

- Uses Product Hunt's official featured embed (unaltered) for the live launch, linking to the launch page with the standard badge UTM parameters.
- Wrapped in a `<picture>` with a `prefers-color-scheme: dark` source so the badge adapts to GitHub's light and dark themes (light badge in light mode, dark badge in dark mode). Both variants were verified to return valid SVGs.
- Placed in the centered hero for launch-day visibility.
