### PR TITLE
feat(claw-app): swipeable session carousel for the audit screenshot lightbox

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
@@ -1,13 +1,92 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { parseHTML } from 'linkedom'
-import { act, type ComponentProps, type ReactNode, useState } from 'react'
+import { act, type ComponentProps, type ReactNode } from 'react'
 import type { Root } from 'react-dom/client'
 import * as _dialog from '@/components/ui/dialog'
 import * as _auditHooks from '@/modules/api/audit.hooks'
+import type { ScreenshotLightboxItem } from './ScreenshotLightbox'
 
 mock.module('@/modules/api/audit.hooks', () => ({
   ..._auditHooks,
   useTaskScreenshotBaseUrl: () => 'http://127.0.0.1:9200',
+}))
+
+// embla measures the DOM, which linkedom has no layout for. Mock it at the
+// boundary with an index-based fake so the toolbar/counter wiring is exercised
+// the way a real swipe would drive it (select events, clamped scrolls).
+type Listener = () => void
+interface EmblaFake {
+  index: number
+  count: number
+  initialized: boolean
+  listeners: Map<string, Listener[]>
+  api: Record<string, unknown>
+  ref: (node: Element | null) => void
+}
+
+function makeEmbla(): EmblaFake {
+  const listeners = new Map<string, Listener[]>()
+  const emit = (name: string) => {
+    for (const cb of listeners.get(name) ?? []) cb()
+  }
+  const state: EmblaFake = {
+    index: 0,
+    count: 0,
+    initialized: false,
+    listeners,
+    api: {},
+    ref: () => undefined,
+  }
+  state.api = {
+    scrollNext: () => {
+      if (state.index < state.count - 1) {
+        state.index += 1
+        emit('select')
+      }
+    },
+    scrollPrev: () => {
+      if (state.index > 0) {
+        state.index -= 1
+        emit('select')
+      }
+    },
+    scrollTo: (i: number) => {
+      state.index = Math.max(0, Math.min(i, Math.max(0, state.count - 1)))
+      emit('select')
+    },
+    canScrollNext: () => state.index < state.count - 1,
+    canScrollPrev: () => state.index > 0,
+    selectedScrollSnap: () => state.index,
+    on: (name: string, cb: Listener) => {
+      const arr = listeners.get(name) ?? []
+      arr.push(cb)
+      listeners.set(name, arr)
+    },
+    off: (name: string, cb: Listener) => {
+      listeners.set(
+        name,
+        (listeners.get(name) ?? []).filter((entry) => entry !== cb),
+      )
+    },
+  }
+  state.ref = (node) => {
+    if (node) {
+      state.count = node.querySelectorAll('[data-slot="carousel-item"]').length
+    }
+  }
+  return state
+}
+
+let embla = makeEmbla()
+
+mock.module('embla-carousel-react', () => ({
+  default: (options?: { startIndex?: number }) => {
+    if (!embla.initialized) {
+      embla.initialized = true
+      if (options?.startIndex != null) embla.index = options.startIndex
+    }
+    return [embla.ref, embla.api]
+  },
 }))
 
 let dialogOnOpenChange: ((open: boolean) => void) | undefined
@@ -59,6 +138,7 @@ let root: Root
 let container: HTMLElement
 
 beforeEach(async () => {
+  embla = makeEmbla()
   const dom = parseHTML(
     '<!doctype html><html><body><div id="root"></div></body></html>',
   )
@@ -98,46 +178,15 @@ afterEach(async () => {
   Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
 })
 
-const ORDERED_IDS = [11, 22, 33] as const
-const META = {
-  11: { sourceUrl: 'https://first.example/start', offsetMs: 400 },
-  22: { sourceUrl: 'https://second.example/middle', offsetMs: 4300 },
-  33: { sourceUrl: 'https://third.example/end', offsetMs: 11700 },
-} as const
-
-interface ControlledLightboxProps {
-  initialId?: number
-  screenshotIds?: readonly number[]
-  onNavigate?: (screenshotId: number) => void
-  onClose?: () => void
-}
-
-function ControlledLightbox({
-  initialId = 22,
-  screenshotIds = ORDERED_IDS,
-  onNavigate = () => undefined,
-  onClose = () => undefined,
-}: ControlledLightboxProps) {
-  const [screenshotId, setScreenshotId] = useState(initialId)
-  const meta = META[screenshotId as keyof typeof META] ?? {
-    sourceUrl: 'https://unlisted.example/current',
-    offsetMs: 9900,
-  }
-  return (
-    <ScreenshotLightbox
-      sessionId="session-navigation"
-      screenshotId={screenshotId}
-      screenshotIds={screenshotIds}
-      sourceUrl={meta.sourceUrl}
-      offsetMs={meta.offsetMs}
-      onNavigate={(nextId) => {
-        onNavigate(nextId)
-        setScreenshotId(nextId)
-      }}
-      onClose={onClose}
-    />
-  )
-}
+const ITEMS: ScreenshotLightboxItem[] = [
+  { screenshotId: 11, sourceUrl: 'https://first.example/start', offsetMs: 400 },
+  {
+    screenshotId: 22,
+    sourceUrl: 'https://second.example/middle',
+    offsetMs: 4300,
+  },
+  { screenshotId: 33, sourceUrl: 'https://third.example/end', offsetMs: 11700 },
+]
 
 async function render(node: ReactNode) {
   await act(async () => root.render(node))
@@ -152,12 +201,25 @@ function getDialog(): HTMLElement {
   return dialog
 }
 
+function counter(): string {
+  const span = Array.from(getDialog().querySelectorAll('span')).find((node) =>
+    /^\d+ \/ \d+$/.test(node.textContent?.trim() ?? ''),
+  )
+  return span?.textContent?.trim() ?? ''
+}
+
 function getButton(label: string): HTMLButtonElement {
   const button = container.querySelector<HTMLButtonElement>(
     `button[aria-label="${label}"]`,
   )
   if (!button) throw new Error(`button missing: ${label}`)
   return button
+}
+
+function imgSrcs(): string[] {
+  return Array.from(getDialog().querySelectorAll('img')).map(
+    (img) => img.getAttribute('src') ?? '',
+  )
 }
 
 async function click(element: Element) {
@@ -200,11 +262,14 @@ describe('ScreenshotLightbox', () => {
     await render(
       <ScreenshotLightbox
         sessionId="session-private"
-        screenshotId={42}
-        screenshotIds={[42]}
-        sourceUrl="https://private.example/secret"
-        offsetMs={1200}
-        onNavigate={() => undefined}
+        items={[
+          {
+            screenshotId: 42,
+            sourceUrl: 'https://private.example/secret',
+            offsetMs: 1200,
+          },
+        ]}
+        startId={42}
         onClose={() => undefined}
       />,
     )
@@ -213,16 +278,16 @@ describe('ScreenshotLightbox', () => {
     expect(dialog.getAttribute('class') ?? '').toContain('ph-no-capture')
     expect(dialog.getAttribute('class') ?? '').toContain('sm:max-w-[94vw]')
     expect(dialog.textContent).toContain('private.example')
-    expect(dialog.textContent).toContain('1 / 1')
+    expect(counter()).toBe('1 / 1')
+
     const image = dialog.querySelector('img')
     expect(image?.getAttribute('src')).toContain(
       '/sessions/session-private/screenshots/42',
     )
     const imageClass = image?.getAttribute('class') ?? ''
     expect(imageClass).toContain('max-h-[calc(92vh-3.5rem)]')
-    expect(imageClass).toContain('w-auto')
-    expect(imageClass).toContain('max-w-[94vw]')
     expect(imageClass).toContain('object-contain')
+
     const previous = getButton('Previous screenshot')
     expect(previous.getAttribute('type')).toBe('button')
     expect(previous.getAttribute('class') ?? '').toContain('focus-visible')
@@ -231,70 +296,96 @@ describe('ScreenshotLightbox', () => {
     )
     expect(position?.getAttribute('class') ?? '').toContain('tabular-nums')
     expect(position?.getAttribute('class') ?? '').toContain('min-w-[7ch]')
+
+    // The carousel region follows the toolbar (never overlays the image).
     const toolbar = previous.parentElement?.parentElement
-    expect(toolbar?.nextElementSibling).toBe(image)
+    expect(toolbar?.nextElementSibling?.getAttribute('data-slot')).toBe(
+      'carousel',
+    )
     expect(previous.disabled).toBe(true)
     expect(getButton('Next screenshot').disabled).toBe(true)
   })
 
-  it('moves to adjacent ids and updates the image, caption, alt, and position together', async () => {
-    const onNavigate = mock((_screenshotId: number) => undefined)
-    await render(<ControlledLightbox onNavigate={onNavigate} />)
+  it('renders every screenshot as a slide and opens on the clicked one', async () => {
+    await render(
+      <ScreenshotLightbox
+        sessionId="session-navigation"
+        items={ITEMS}
+        startId={22}
+        onClose={() => undefined}
+      />,
+    )
+
+    const srcs = imgSrcs()
+    expect(srcs).toHaveLength(3)
+    expect(srcs.some((src) => src.includes('screenshots/11'))).toBe(true)
+    expect(srcs.some((src) => src.includes('screenshots/22'))).toBe(true)
+    expect(srcs.some((src) => src.includes('screenshots/33'))).toBe(true)
 
     expect(getDialog().textContent).toContain('second.example · T+4.3s')
-    expect(getDialog().textContent).toContain('2 / 3')
-    expect(getDialog().querySelector('img')?.getAttribute('alt')).toBe(
-      'Screenshot of second.example',
+    expect(counter()).toBe('2 / 3')
+  })
+
+  it('moves forward and back through the carousel, keeping caption and position in sync', async () => {
+    await render(
+      <ScreenshotLightbox
+        sessionId="session-navigation"
+        items={ITEMS}
+        startId={22}
+        onClose={() => undefined}
+      />,
     )
 
     await click(getButton('Next screenshot'))
-    expect(onNavigate.mock.calls[0]?.[0]).toBe(33)
+    expect(counter()).toBe('3 / 3')
     expect(getDialog().textContent).toContain('third.example · T+11.7s')
-    expect(getDialog().textContent).toContain('3 / 3')
-    expect(getDialog().querySelector('img')?.getAttribute('src')).toContain(
-      '/sessions/session-navigation/screenshots/33',
-    )
-    expect(getDialog().querySelector('img')?.getAttribute('alt')).toBe(
-      'Screenshot of third.example',
-    )
 
     await click(getButton('Previous screenshot'))
     await click(getButton('Previous screenshot'))
-    expect(onNavigate.mock.calls.map((call) => call[0])).toEqual([33, 22, 11])
+    expect(counter()).toBe('1 / 3')
     expect(getDialog().textContent).toContain('first.example · T+400ms')
-    expect(getDialog().textContent).toContain('1 / 3')
   })
 
-  it('disables both boundaries without wrapping or firing navigation', async () => {
-    const onNavigate = mock((_screenshotId: number) => undefined)
-    await render(<ControlledLightbox initialId={11} onNavigate={onNavigate} />)
+  it('disables both boundaries without wrapping', async () => {
+    await render(
+      <ScreenshotLightbox
+        sessionId="session-navigation"
+        items={ITEMS}
+        startId={11}
+        onClose={() => undefined}
+      />,
+    )
 
     const previous = getButton('Previous screenshot')
     expect(previous.disabled).toBe(true)
     await click(previous)
-    expect(onNavigate).toHaveBeenCalledTimes(0)
+    expect(counter()).toBe('1 / 3')
 
     await click(getButton('Next screenshot'))
     await click(getButton('Next screenshot'))
     const next = getButton('Next screenshot')
     expect(next.disabled).toBe(true)
-    expect(onNavigate).toHaveBeenCalledTimes(2)
     await click(next)
-    expect(onNavigate).toHaveBeenCalledTimes(2)
-    expect(getDialog().textContent).toContain('3 / 3')
+    expect(counter()).toBe('3 / 3')
   })
 
   it('navigates on bare arrow keys and leaves modified, composing, and Escape keys alone', async () => {
-    const onNavigate = mock((_screenshotId: number) => undefined)
-    await render(<ControlledLightbox onNavigate={onNavigate} />)
+    await render(
+      <ScreenshotLightbox
+        sessionId="session-navigation"
+        items={ITEMS}
+        startId={22}
+        onClose={() => undefined}
+      />,
+    )
 
     const right = await pressKey(getDialog(), 'ArrowRight')
     expect(right.defaultPrevented).toBe(true)
-    expect(onNavigate.mock.calls[0]?.[0]).toBe(33)
+    expect(counter()).toBe('3 / 3')
 
     const left = await pressKey(getDialog(), 'ArrowLeft')
     expect(left.defaultPrevented).toBe(true)
-    expect(onNavigate.mock.calls[1]?.[0]).toBe(22)
+    expect(counter()).toBe('2 / 3')
 
     const modifiedEvents: Event[] = []
     for (const options of [
@@ -309,17 +400,23 @@ describe('ScreenshotLightbox', () => {
       isComposing: true,
     })
     const escapeEvent = await pressKey(getDialog(), 'Escape')
-    expect(onNavigate).toHaveBeenCalledTimes(2)
     for (const event of modifiedEvents) {
       expect(event.defaultPrevented).toBe(false)
     }
     expect(composing.defaultPrevented).toBe(false)
     expect(escapeEvent.defaultPrevented).toBe(false)
+    expect(counter()).toBe('2 / 3')
   })
 
   it('does not hijack arrow keys from editable or arrow-driven controls', async () => {
-    const onNavigate = mock((_screenshotId: number) => undefined)
-    await render(<ControlledLightbox onNavigate={onNavigate} />)
+    await render(
+      <ScreenshotLightbox
+        sessionId="session-navigation"
+        items={ITEMS}
+        startId={22}
+        onClose={() => undefined}
+      />,
+    )
     const dialog = getDialog()
 
     const input = document.createElement('input')
@@ -349,32 +446,56 @@ describe('ScreenshotLightbox', () => {
       const event = await pressKey(target, 'ArrowRight')
       expect(event.defaultPrevented).toBe(false)
     }
-    expect(onNavigate).toHaveBeenCalledTimes(0)
+    expect(counter()).toBe('2 / 3')
   })
 
-  it('keeps an active id missing from the polled list previewable as 1 / 1', async () => {
-    const onNavigate = mock((_screenshotId: number) => undefined)
+  it('opens on the first slide when the clicked id is absent from the list', async () => {
     await render(
-      <ControlledLightbox
-        initialId={99}
-        screenshotIds={[11, 22]}
-        onNavigate={onNavigate}
+      <ScreenshotLightbox
+        sessionId="session-navigation"
+        items={ITEMS.slice(0, 2)}
+        startId={99}
+        onClose={() => undefined}
       />,
     )
 
-    expect(getDialog().textContent).toContain('unlisted.example · T+9.9s')
-    expect(getDialog().textContent).toContain('1 / 1')
-    expect(getDialog().querySelector('img')?.getAttribute('src')).toContain(
-      '/sessions/session-navigation/screenshots/99',
-    )
+    expect(counter()).toBe('1 / 2')
+    expect(getDialog().textContent).toContain('first.example · T+400ms')
     expect(getButton('Previous screenshot').disabled).toBe(true)
-    expect(getButton('Next screenshot').disabled).toBe(true)
-    expect(onNavigate).toHaveBeenCalledTimes(0)
+    expect(getButton('Next screenshot').disabled).toBe(false)
+  })
+
+  it('eager-loads the active slide and its neighbors, lazy-loads the rest', async () => {
+    const many: ScreenshotLightboxItem[] = [1, 2, 3, 4, 5].map((id) => ({
+      screenshotId: id,
+      sourceUrl: `https://site-${id}.example/page`,
+      offsetMs: id * 1000,
+    }))
+    await render(
+      <ScreenshotLightbox
+        sessionId="session-lazy"
+        items={many}
+        startId={3}
+        onClose={() => undefined}
+      />,
+    )
+
+    const loading = Array.from(getDialog().querySelectorAll('img')).map((img) =>
+      img.getAttribute('loading'),
+    )
+    expect(loading).toEqual(['lazy', 'eager', 'eager', 'eager', 'lazy'])
   })
 
   it('preserves the close callback contract through dialog open changes', async () => {
     const onClose = mock(() => undefined)
-    await render(<ControlledLightbox onClose={onClose} />)
+    await render(
+      <ScreenshotLightbox
+        sessionId="session-navigation"
+        items={ITEMS}
+        startId={22}
+        onClose={onClose}
+      />,
+    )
 
     await act(async () => dialogOnOpenChange?.(true))
     expect(onClose).toHaveBeenCalledTimes(0)

--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.test.tsx
@@ -449,7 +449,7 @@ describe('ScreenshotLightbox', () => {
     expect(counter()).toBe('2 / 3')
   })
 
-  it('opens on the first slide when the clicked id is absent from the list', async () => {
+  it('keeps the clicked screenshot visible solo when it is absent from the list', async () => {
     await render(
       <ScreenshotLightbox
         sessionId="session-navigation"
@@ -459,10 +459,14 @@ describe('ScreenshotLightbox', () => {
       />,
     )
 
-    expect(counter()).toBe('1 / 2')
-    expect(getDialog().textContent).toContain('first.example · T+400ms')
+    // The selection dropped out of the polled list (e.g. pruned mid-view): show
+    // it alone rather than jumping to an unrelated screenshot.
+    expect(counter()).toBe('1 / 1')
+    expect(imgSrcs()).toEqual([
+      expect.stringContaining('/sessions/session-navigation/screenshots/99'),
+    ])
     expect(getButton('Previous screenshot').disabled).toBe(true)
-    expect(getButton('Next screenshot').disabled).toBe(false)
+    expect(getButton('Next screenshot').disabled).toBe(true)
   })
 
   it('eager-loads the active slide and its neighbors, lazy-loads the rest', async () => {

--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
@@ -52,12 +52,18 @@ export function ScreenshotLightbox({
 }: ScreenshotLightboxProps) {
   const screenshotBaseUrl = useTaskScreenshotBaseUrl()
   const open = startId !== null
+  // If the clicked screenshot has dropped out of the polled list (e.g. pruned
+  // mid-view), keep showing it solo rather than silently jumping to another one.
+  const slides =
+    startId !== null && !items.some((item) => item.screenshotId === startId)
+      ? [{ screenshotId: startId, sourceUrl: null, offsetMs: null }]
+      : items
   const startIndex =
     startId === null
       ? 0
       : Math.max(
           0,
-          items.findIndex((item) => item.screenshotId === startId),
+          slides.findIndex((item) => item.screenshotId === startId),
         )
 
   const [api, setApi] = useState<CarouselApi>()
@@ -86,8 +92,8 @@ export function ScreenshotLightbox({
   }, [api])
 
   const canPrev = current > 0
-  const canNext = current < items.length - 1
-  const active = items[current] ?? null
+  const canNext = current < slides.length - 1
+  const active = slides[current] ?? null
   const host = hostOf(active?.sourceUrl ?? null)
   const caption =
     [
@@ -156,7 +162,7 @@ export function ScreenshotLightbox({
                   <IconChevronLeft aria-hidden />
                 </Button>
                 <span className="min-w-[7ch] text-center font-mono text-[11.5px] text-ink-3 tabular-nums">
-                  {items.length ? current + 1 : 0} / {items.length}
+                  {slides.length ? current + 1 : 0} / {slides.length}
                 </span>
                 <Button
                   type="button"
@@ -188,7 +194,7 @@ export function ScreenshotLightbox({
                 className="w-full"
               >
                 <CarouselContent className="ml-0">
-                  {items.map((item, index) => {
+                  {slides.map((item, index) => {
                     const itemHost = hostOf(item.sourceUrl)
                     return (
                       <CarouselItem

--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
@@ -1,6 +1,12 @@
 import { IconChevronLeft, IconChevronRight, IconX } from '@tabler/icons-react'
-import type { KeyboardEventHandler } from 'react'
+import { type KeyboardEventHandler, useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import {
+  Carousel,
+  type CarouselApi,
+  CarouselContent,
+  CarouselItem,
+} from '@/components/ui/carousel'
 import {
   Dialog,
   DialogClose,
@@ -13,53 +19,83 @@ import {
 } from '@/modules/api/audit.hooks'
 import { formatOffset, hostOf } from './screenshot.helpers'
 
+export interface ScreenshotLightboxItem {
+  screenshotId: number
+  sourceUrl: string | null
+  offsetMs: number | null
+}
+
 interface ScreenshotLightboxProps {
   sessionId: string
-  screenshotId: number | null
-  screenshotIds: readonly number[]
-  sourceUrl?: string | null
-  offsetMs?: number | null
-  onNavigate: (screenshotId: number) => void
+  items: readonly ScreenshotLightboxItem[]
+  startId: number | null
   onClose: () => void
 }
 
 /**
- * Full-size screenshot inspector. A caption + close toolbar sits above
- * the image (never over it), and the image is bounded to the viewport
- * with object-contain so it renders as large as possible without
- * overflow or distortion.
+ * Full-size screenshot inspector. Every screenshot in the session is a
+ * slide in a swipeable carousel, opened on the clicked one, so the user
+ * moves through them all without closing and reopening. A caption + close
+ * toolbar sits above the image (never over it), and each image is bounded
+ * to the viewport with object-contain so it renders as large as possible
+ * without overflow or distortion.
  *
  * DialogContent's default width clamp is `sm:max-w-md` (448px); the
- * `sm:max-w-[94vw]` override is load-bearing — a base-only `max-w` is
+ * `sm:max-w-[94vw]` override is load-bearing, a base-only `max-w` is
  * silently ignored at every width ≥640px.
  */
 export function ScreenshotLightbox({
   sessionId,
-  screenshotId,
-  screenshotIds,
-  sourceUrl = null,
-  offsetMs = null,
-  onNavigate,
+  items,
+  startId,
   onClose,
 }: ScreenshotLightboxProps) {
   const screenshotBaseUrl = useTaskScreenshotBaseUrl()
-  const host = hostOf(sourceUrl)
+  const open = startId !== null
+  const startIndex =
+    startId === null
+      ? 0
+      : Math.max(
+          0,
+          items.findIndex((item) => item.screenshotId === startId),
+        )
+
+  const [api, setApi] = useState<CarouselApi>()
+  const [current, setCurrent] = useState(startIndex)
+  // Reset the active slide to the clicked one when the lightbox reopens on a
+  // different screenshot (state persists across opens); derived in render, not
+  // an effect. The Carousel's `key` remounts embla to the same start index.
+  const [seenStartId, setSeenStartId] = useState(startId)
+  if (startId !== seenStartId) {
+    setSeenStartId(startId)
+    setCurrent(startIndex)
+  }
+
+  // embla is an external system: subscribe so swipes/drags feed back into the
+  // caption + counter. Kept in sync on select and on layout re-init.
+  useEffect(() => {
+    if (!api) return
+    const sync = () => setCurrent(api.selectedScrollSnap())
+    sync()
+    api.on('select', sync)
+    api.on('reInit', sync)
+    return () => {
+      api.off('select', sync)
+      api.off('reInit', sync)
+    }
+  }, [api])
+
+  const canPrev = current > 0
+  const canNext = current < items.length - 1
+  const active = items[current] ?? null
+  const host = hostOf(active?.sourceUrl ?? null)
   const caption =
-    [host, offsetMs != null ? `T+${formatOffset(offsetMs)}` : null]
+    [
+      host,
+      active?.offsetMs != null ? `T+${formatOffset(active.offsetMs)}` : null,
+    ]
       .filter(Boolean)
       .join(' · ') || 'Screenshot'
-  const orderedScreenshotIds =
-    screenshotId !== null && !screenshotIds.includes(screenshotId)
-      ? [screenshotId]
-      : screenshotIds
-  const activeIndex =
-    screenshotId === null ? -1 : orderedScreenshotIds.indexOf(screenshotId)
-  const previousId =
-    activeIndex > 0 ? (orderedScreenshotIds[activeIndex - 1] ?? null) : null
-  const nextId =
-    activeIndex >= 0 && activeIndex < orderedScreenshotIds.length - 1
-      ? (orderedScreenshotIds[activeIndex + 1] ?? null)
-      : null
 
   const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
     if (
@@ -76,33 +112,32 @@ export function ScreenshotLightbox({
     if (
       target instanceof Element &&
       target.closest(
-        'input, textarea, select, [contenteditable]:not([contenteditable="false"]), [role="textbox"], [role="combobox"], [role="slider"], [role="spinbutton"]',
+        'input, textarea, select, [contenteditable]:not([contenteditable="false"]), [role="textbox"], [role="combobox"], [role="slider"], [role="spinbutton"], [data-slot="carousel"]',
       )
     ) {
       return
     }
 
-    const destinationId =
-      event.key === 'ArrowLeft'
-        ? previousId
-        : event.key === 'ArrowRight'
-          ? nextId
-          : null
-    if (destinationId === null) return
-
-    event.preventDefault()
-    onNavigate(destinationId)
+    if (event.key === 'ArrowLeft') {
+      if (!canPrev) return
+      event.preventDefault()
+      api?.scrollPrev()
+    } else if (event.key === 'ArrowRight') {
+      if (!canNext) return
+      event.preventDefault()
+      api?.scrollNext()
+    }
   }
 
   return (
-    <Dialog open={screenshotId !== null} onOpenChange={(o) => !o && onClose()}>
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent
         showCloseButton={false}
-        className="ph-no-capture flex max-h-[92vh] w-auto max-w-[94vw] flex-col gap-2 bg-transparent p-0 shadow-none ring-0 sm:max-w-[94vw]"
+        className="ph-no-capture flex max-h-[92vh] w-[92vw] max-w-[94vw] flex-col gap-2 bg-transparent p-0 shadow-none ring-0 sm:max-w-[94vw]"
         onKeyDown={handleKeyDown}
       >
         <DialogTitle className="sr-only">Screenshot preview</DialogTitle>
-        {screenshotId !== null && (
+        {open && (
           <>
             <div className="flex items-center gap-3 rounded-lg bg-popover/95 px-3 py-2 ring-1 ring-foreground/10 supports-backdrop-filter:backdrop-blur">
               <span className="min-w-0 flex-1 truncate font-mono text-[12.5px] text-ink-2">
@@ -114,23 +149,23 @@ export function ScreenshotLightbox({
                   variant="ghost"
                   size="icon-sm"
                   aria-label="Previous screenshot"
-                  disabled={previousId === null}
+                  disabled={!canPrev}
                   className="text-ink-2 hover:bg-card-tint hover:text-ink"
-                  onClick={() => previousId !== null && onNavigate(previousId)}
+                  onClick={() => api?.scrollPrev()}
                 >
                   <IconChevronLeft aria-hidden />
                 </Button>
                 <span className="min-w-[7ch] text-center font-mono text-[11.5px] text-ink-3 tabular-nums">
-                  {activeIndex + 1} / {orderedScreenshotIds.length}
+                  {items.length ? current + 1 : 0} / {items.length}
                 </span>
                 <Button
                   type="button"
                   variant="ghost"
                   size="icon-sm"
                   aria-label="Next screenshot"
-                  disabled={nextId === null}
+                  disabled={!canNext}
                   className="text-ink-2 hover:bg-card-tint hover:text-ink"
-                  onClick={() => nextId !== null && onNavigate(nextId)}
+                  onClick={() => api?.scrollNext()}
                 >
                   <IconChevronRight aria-hidden />
                 </Button>
@@ -146,17 +181,43 @@ export function ScreenshotLightbox({
               </div>
             </div>
             {screenshotBaseUrl !== null ? (
-              <img
-                src={taskScreenshotUrl(
-                  sessionId,
-                  screenshotId,
-                  screenshotBaseUrl,
-                )}
-                alt={host ? `Screenshot of ${host}` : 'Screenshot'}
-                className="max-h-[calc(92vh-3.5rem)] w-auto max-w-[94vw] rounded-xl object-contain shadow-2xl ring-1 ring-foreground/10"
-              />
+              <Carousel
+                key={startId ?? 'closed'}
+                setApi={setApi}
+                opts={{ startIndex }}
+                className="w-full"
+              >
+                <CarouselContent className="ml-0">
+                  {items.map((item, index) => {
+                    const itemHost = hostOf(item.sourceUrl)
+                    return (
+                      <CarouselItem
+                        key={item.screenshotId}
+                        className="flex items-center justify-center pl-0"
+                      >
+                        <img
+                          src={taskScreenshotUrl(
+                            sessionId,
+                            item.screenshotId,
+                            screenshotBaseUrl,
+                          )}
+                          alt={
+                            itemHost
+                              ? `Screenshot of ${itemHost}`
+                              : 'Screenshot'
+                          }
+                          loading={
+                            Math.abs(index - current) <= 1 ? 'eager' : 'lazy'
+                          }
+                          className="max-h-[calc(92vh-3.5rem)] w-auto max-w-full rounded-xl object-contain shadow-2xl ring-1 ring-foreground/10"
+                        />
+                      </CarouselItem>
+                    )
+                  })}
+                </CarouselContent>
+              </Carousel>
             ) : (
-              <div className="aspect-[16/10] max-h-[calc(92vh-3.5rem)] w-[70vw] max-w-[94vw] animate-pulse rounded-xl bg-card-tint ring-1 ring-foreground/10" />
+              <div className="aspect-[16/10] max-h-[calc(92vh-3.5rem)] w-full max-w-[94vw] animate-pulse rounded-xl bg-card-tint ring-1 ring-foreground/10" />
             )}
           </>
         )}

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.navigation.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.navigation.test.tsx
@@ -12,6 +12,84 @@ mock.module('@/modules/api/audit.hooks', () => ({
   useTaskScreenshotBaseUrl: () => 'http://127.0.0.1:9200',
 }))
 
+// embla measures the DOM, which linkedom has no layout for. Mock it at the
+// boundary with an index-based fake so button/keyboard navigation drives the
+// carousel the way a real swipe would.
+type Listener = () => void
+interface EmblaFake {
+  index: number
+  count: number
+  initialized: boolean
+  listeners: Map<string, Listener[]>
+  api: Record<string, unknown>
+  ref: (node: Element | null) => void
+}
+
+function makeEmbla(): EmblaFake {
+  const listeners = new Map<string, Listener[]>()
+  const emit = (name: string) => {
+    for (const cb of listeners.get(name) ?? []) cb()
+  }
+  const state: EmblaFake = {
+    index: 0,
+    count: 0,
+    initialized: false,
+    listeners,
+    api: {},
+    ref: () => undefined,
+  }
+  state.api = {
+    scrollNext: () => {
+      if (state.index < state.count - 1) {
+        state.index += 1
+        emit('select')
+      }
+    },
+    scrollPrev: () => {
+      if (state.index > 0) {
+        state.index -= 1
+        emit('select')
+      }
+    },
+    scrollTo: (i: number) => {
+      state.index = Math.max(0, Math.min(i, Math.max(0, state.count - 1)))
+      emit('select')
+    },
+    canScrollNext: () => state.index < state.count - 1,
+    canScrollPrev: () => state.index > 0,
+    selectedScrollSnap: () => state.index,
+    on: (name: string, cb: Listener) => {
+      const arr = listeners.get(name) ?? []
+      arr.push(cb)
+      listeners.set(name, arr)
+    },
+    off: (name: string, cb: Listener) => {
+      listeners.set(
+        name,
+        (listeners.get(name) ?? []).filter((entry) => entry !== cb),
+      )
+    },
+  }
+  state.ref = (node) => {
+    if (node) {
+      state.count = node.querySelectorAll('[data-slot="carousel-item"]').length
+    }
+  }
+  return state
+}
+
+let embla = makeEmbla()
+
+mock.module('embla-carousel-react', () => ({
+  default: (options?: { startIndex?: number }) => {
+    if (!embla.initialized) {
+      embla.initialized = true
+      if (options?.startIndex != null) embla.index = options.startIndex
+    }
+    return [embla.ref, embla.api]
+  },
+}))
+
 mock.module('@/components/ui/dialog', () => ({
   ..._dialog,
   Dialog: ({ children }: { children?: ReactNode }) => <>{children}</>,
@@ -154,6 +232,7 @@ let root: Root
 let container: HTMLElement
 
 beforeEach(async () => {
+  embla = makeEmbla()
   dataOverride = screenData()
   const dom = parseHTML(
     '<!doctype html><html><body><div id="root"></div></body></html>',
@@ -229,6 +308,13 @@ function getDialog(): HTMLElement {
   return dialog
 }
 
+function counter(): string {
+  const span = Array.from(getDialog().querySelectorAll('span')).find((node) =>
+    /^\d+ \/ \d+$/.test(node.textContent?.trim() ?? ''),
+  )
+  return span?.textContent?.trim() ?? ''
+}
+
 function getNavigationButton(label: string): HTMLButtonElement {
   const button = getDialog().querySelector<HTMLButtonElement>(
     `button[aria-label="${label}"]`,
@@ -238,37 +324,39 @@ function getNavigationButton(label: string): HTMLButtonElement {
 }
 
 describe('TaskDetailPage screenshot navigation', () => {
-  it('keeps navigation scoped to the clicked group across navigation and polling', async () => {
+  it('opens on the clicked screenshot and lets the user swipe the whole session across groups', async () => {
+    await renderPage()
+
+    // Open a screenshot that lives in the "page-1" group.
+    await click(getByTestId('open-page-1-30'))
+    expect(getDialog().textContent).toContain('30.example · T+300ms')
+    expect(counter()).toBe('3 / 5')
+    expect(getDialog().querySelectorAll('img')).toHaveLength(5)
+
+    // Next crosses into a screenshot owned by the other group (40 is page-2).
+    await click(getNavigationButton('Next screenshot'))
+    expect(getDialog().textContent).toContain('40.example · T+400ms')
+    expect(counter()).toBe('4 / 5')
+
+    await click(getNavigationButton('Next screenshot'))
+    expect(counter()).toBe('5 / 5')
+    expect(getNavigationButton('Next screenshot').disabled).toBe(true)
+  })
+
+  it('keeps the carousel position through a background poll re-render', async () => {
     await renderPage()
 
     await click(getByTestId('open-page-1-30'))
-
-    expect(getDialog().textContent).toContain('30.example · T+300ms')
-    expect(getDialog().textContent).toContain('2 / 3')
-    expect(getDialog().querySelector('img')?.getAttribute('src')).toContain(
-      '/sessions/session-navigation/screenshots/30',
-    )
-
     await click(getNavigationButton('Next screenshot'))
+    expect(counter()).toBe('4 / 5')
 
-    expect(getDialog().textContent).toContain('50.example · T+500ms')
-    expect(getDialog().textContent).toContain('3 / 3')
-    expect(getDialog().querySelector('img')?.getAttribute('src')).toContain(
-      '/sessions/session-navigation/screenshots/50',
-    )
-    expect(getDialog().querySelector('img')?.getAttribute('alt')).toBe(
-      'Screenshot of 50.example',
-    )
-
+    // A poll moves the last screenshot to another tab group; the flat session
+    // carousel is unaffected and the current position is preserved.
     dataOverride = screenData(true)
     await renderPage()
 
-    expect(getDialog().textContent).toContain('50.example · T+500ms')
-    expect(getDialog().textContent).toContain('1 / 1')
-    expect(getDialog().querySelector('img')?.getAttribute('src')).toContain(
-      '/sessions/session-navigation/screenshots/50',
-    )
-    expect(getNavigationButton('Previous screenshot').disabled).toBe(true)
-    expect(getNavigationButton('Next screenshot').disabled).toBe(true)
+    expect(counter()).toBe('4 / 5')
+    expect(getDialog().textContent).toContain('40.example · T+400ms')
+    expect(getDialog().querySelectorAll('img')).toHaveLength(5)
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
@@ -1,6 +1,9 @@
 import { useMemo, useState } from 'react'
 import { useParams } from 'react-router'
-import { ScreenshotLightbox } from '@/components/audit/ScreenshotLightbox'
+import {
+  ScreenshotLightbox,
+  type ScreenshotLightboxItem,
+} from '@/components/audit/ScreenshotLightbox'
 import { TaskHeader } from '@/components/audit/TaskHeader'
 import { EmptyState } from '@/components/cockpit/EmptyState'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -28,15 +31,29 @@ export function TaskDetailPage() {
   const { sessionId = '' } = useParams()
   const { detail, screenshots, isPending, isError, error } =
     useTaskDetailScreenData(sessionId)
-  const [lightbox, setLightbox] = useState<{
-    groupId: string
-    screenshotId: number
-  } | null>(null)
+  const [openScreenshotId, setOpenScreenshotId] = useState<number | null>(null)
 
   const groups = useMemo(
     () => (detail ? groupDispatchesByTab(detail.dispatches, screenshots) : []),
     [detail, screenshots],
   )
+
+  const lightboxItems = useMemo<ScreenshotLightboxItem[]>(() => {
+    if (!detail) return []
+    const urlByScreenshot = new Map<number, string | null>()
+    for (const dispatch of detail.dispatches) {
+      if (dispatch.screenshotId != null) {
+        urlByScreenshot.set(dispatch.screenshotId, dispatch.url ?? null)
+      }
+    }
+    return [...screenshots]
+      .sort((a, b) => a.capturedAt - b.capturedAt)
+      .map((screenshot) => ({
+        screenshotId: screenshot.screenshotId,
+        sourceUrl: urlByScreenshot.get(screenshot.screenshotId) ?? null,
+        offsetMs: Math.max(0, screenshot.capturedAt - detail.session.startedAt),
+      }))
+  }, [detail, screenshots])
 
   if (isPending) {
     return (
@@ -61,23 +78,6 @@ export function TaskDetailPage() {
       </div>
     )
   }
-
-  const lightboxId = lightbox?.screenshotId ?? null
-  const lightboxGroup =
-    lightbox !== null
-      ? (groups.find((group) => group.id === lightbox.groupId) ?? null)
-      : null
-  const lightboxScreenshotIds =
-    lightboxGroup?.screenshots.map((screenshot) => screenshot.screenshotId) ??
-    []
-  const selectedDispatch =
-    lightboxId !== null
-      ? (detail.dispatches.find((d) => d.screenshotId === lightboxId) ?? null)
-      : null
-  const selectedScreenshot =
-    lightboxId !== null
-      ? (screenshots.find((s) => s.screenshotId === lightboxId) ?? null)
-      : null
 
   const { session } = detail
   const endEvent = session.endedAt
@@ -109,9 +109,7 @@ export function TaskDetailPage() {
         group={g}
         startedAt={session.startedAt}
         endEvent={endEvent}
-        onScreenshotClick={(screenshotId) =>
-          setLightbox({ groupId: g.id, screenshotId })
-        }
+        onScreenshotClick={(screenshotId) => setOpenScreenshotId(screenshotId)}
       />
     ),
   }))
@@ -126,20 +124,9 @@ export function TaskDetailPage() {
       />
       <ScreenshotLightbox
         sessionId={sessionId}
-        screenshotId={lightboxId}
-        screenshotIds={lightboxScreenshotIds}
-        sourceUrl={selectedDispatch?.url ?? null}
-        offsetMs={
-          selectedScreenshot
-            ? Math.max(0, selectedScreenshot.capturedAt - session.startedAt)
-            : null
-        }
-        onNavigate={(screenshotId) =>
-          setLightbox((current) =>
-            current === null ? null : { ...current, screenshotId },
-          )
-        }
-        onClose={() => setLightbox(null)}
+        items={lightboxItems}
+        startId={openScreenshotId}
+        onClose={() => setOpenScreenshotId(null)}
       />
     </div>
   )


### PR DESCRIPTION
## What

Screenshots in the task audit view now open in a **carousel** instead of a single-image lightbox. Clicking a screenshot opens the one you clicked and lets you move through **every screenshot in the session** by swipe/drag, the prev/next controls, or the arrow keys, all without closing and reopening one image at a time.

Previously the lightbox navigated only within the clicked tab group and advanced by swapping a single `<img>` via buttons, so users had to close and re-open to reach other screenshots.

## How

- Reuses the existing `Carousel` primitive (`components/ui/carousel.tsx`, built on `embla-carousel-react`), so **no new dependency** is added.
- `ScreenshotLightbox` now takes a flat, chronological list of the session's screenshots plus the id to open on; the caption, `X / N` counter, and boundary (first/last) controls stay in sync with the active slide.
- Off-screen slides `loading="lazy"`; the active slide and its immediate neighbors load eagerly so swiping stays instant on long sessions.
- Keyboard: Left/Right arrows drive the carousel; editable/arrow-driven controls and modified/composing keys are left alone as before.

## Tests

- `ScreenshotLightbox.test.tsx` rewritten for the new API: renders every screenshot as a slide, opens on the clicked one, forward/back navigation keeps caption + counter in sync, boundary disabling, arrow-key handling, lazy/eager loading, and the close contract.
- `TaskDetailPage.navigation.test.tsx` updated: opening a screenshot in one tab group now lets the user swipe across the whole session (including screenshots owned by other groups), and the carousel position survives a background poll re-render.
- `embla-carousel-react` is mocked at the boundary in these tests (linkedom has no layout for embla to measure).

Typecheck and Biome pass on the changed files.

## Note

Real-browser QA of the swipe/drag feel and image sizing across varied screenshot aspect ratios is worth a look before merge.
