### PR TITLE
fix: update Product Hunt banner copy

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.test.tsx
@@ -66,7 +66,10 @@ describe('ProductHuntBanner', () => {
     )
 
     expect(html).toContain('live on Product Hunt')
-    expect(html).toContain('Check out our launch')
+    expect(html).toContain(
+      'An upvote or comment would mean a lot — it helps us keep BrowserOS free and supported.',
+    )
+    expect(html).toContain('Support us →')
     expect(html).toContain('Product Hunt')
   })
 

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.test.tsx
@@ -65,7 +65,7 @@ describe('ProductHuntBanner', () => {
       }),
     )
 
-    expect(html).toContain('live on Product Hunt')
+    expect(html).toContain('We&#x27;re live on Product Hunt today 🎉')
     expect(html).toContain(
       'An upvote or comment would mean a lot — it helps us keep BrowserOS free and supported.',
     )

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.tsx
@@ -46,16 +46,17 @@ export function ProductHuntBannerCard({
           We&apos;re live on Product Hunt 🎉
         </p>
         <p className="text-muted-foreground text-xs">
-          BrowserOS neo just launched. Take a look and share your feedback.
+          An upvote or comment would mean a lot &mdash; it helps us keep
+          BrowserOS free and supported.
         </p>
       </div>
       <Button
         size="sm"
         onClick={onOpen}
-        aria-label="Check out our Product Hunt launch"
+        aria-label="Support BrowserOS on Product Hunt"
         className="shrink-0 bg-[#ff6154] text-[#18181b] hover:bg-[#e5563f]"
       >
-        Check out our launch
+        Support us →
       </Button>
       <button
         type="button"

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/ProductHuntBanner.tsx
@@ -43,7 +43,7 @@ export function ProductHuntBannerCard({
       <ProductHuntIcon className="size-9 shrink-0" />
       <div className="min-w-0 flex-1">
         <p className="font-semibold text-foreground text-sm">
-          We&apos;re live on Product Hunt 🎉
+          We&apos;re live on Product Hunt today 🎉
         </p>
         <p className="text-muted-foreground text-xs">
           An upvote or comment would mean a lot &mdash; it helps us keep


### PR DESCRIPTION
## Summary
- Update the Product Hunt banner headline to say BrowserOS is live today.
- Ask users for an upvote or comment and explain that support helps keep BrowserOS free.
- Replace the CTA with "Support us →" and align its accessible label and regression coverage.

## Design
Preserves the existing banner structure, dismiss behavior, analytics, and Product Hunt brand styling. The change is limited to visible copy, the CTA label, and its accessible name.

## Test plan
- [x] `bun run --cwd apps/claw-app test`
- [x] `bun run --cwd apps/claw-app lint`
- [x] `bun run --cwd apps/claw-app typecheck`
