### PR TITLE
feat(claw-app): restyle the MCP page and calm the audit page's live signals

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { TaskSummary } from '@/modules/api/audit.hooks'
+import { AuditHoverPreview } from './AuditHoverPreview'
+
+const task: TaskSummary = {
+  sessionId: 'sess-1',
+  slug: 'claude-code',
+  label: 'Claude Code',
+  name: 'Browsed example.com',
+  site: 'example.com',
+  startedAt: Date.now() - 12_000,
+  endedAt: Date.now(),
+  durationMs: 12_000,
+  dispatchCount: 4,
+  toolSequence: ['tabs', 'read'],
+  status: 'done',
+  errorCount: 0,
+  latestScreenshotId: undefined,
+  tokenUsage: undefined,
+}
+
+function render(t: TaskSummary | null): string {
+  return renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <AuditHoverPreview task={t} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('AuditHoverPreview', () => {
+  // AgentDot paints its per-agent colour through an inline `background`
+  // style, so its absence is the thing to assert — a class check would
+  // pass even if the dot came back.
+  it('renders the agent label without a per-agent colour dot', () => {
+    const html = render(task)
+    expect(html).toContain('Claude Code')
+    expect(html).not.toContain('style="background:')
+  })
+
+  it('marks a live session with a static pill and no pulse', () => {
+    const html = render({ ...task, status: 'live' })
+    expect(html).toContain('Live')
+    expect(html).not.toContain('pulse-dot')
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.tsx
@@ -1,4 +1,3 @@
-import { AgentDot } from '@/components/audit/AgentDot'
 import { activityCardCaptionTones } from '@/components/cockpit/activityCardTone'
 import { cn } from '@/lib/utils'
 import {
@@ -58,9 +57,8 @@ export function AuditHoverPreview({ task }: AuditHoverPreviewProps) {
           data-caption-tone="blue"
         >
           <div className="flex items-center gap-2 font-mono text-[10px] text-white/75 uppercase tracking-[0.08em]">
-            <AgentDot slug={task.slug} />
             <span className="truncate text-white/95">{task.label}</span>
-            {task.status === 'live' && <LiveDot />}
+            {task.status === 'live' && <LiveChip />}
           </div>
           <p className="truncate font-semibold text-[13px] text-white leading-tight">
             {task.name}
@@ -97,14 +95,11 @@ function NoShotComposition({ task }: { task: TaskSummary }) {
   )
 }
 
-function LiveDot() {
+/** Matches the audit table's static Live pill so both surfaces read the same. */
+function LiveChip() {
   return (
-    <span className="inline-flex items-center gap-1 text-[#8fb4ff]">
-      <span
-        aria-hidden
-        className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-[#8fb4ff]"
-      />
-      LIVE
+    <span className="inline-flex shrink-0 items-center rounded-full bg-cyanotype-live px-2.5 py-[3px] font-sans font-semibold text-[11px] text-cyanotype-live-ink normal-case leading-[14px] tracking-normal">
+      Live
     </span>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
@@ -84,7 +84,10 @@ export function FilterBar({
           )}
           <ChevronDown className="size-3 text-ink-3" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="ph-no-capture min-w-52">
+        <DropdownMenuContent
+          align="start"
+          className="ph-no-capture min-w-52 bg-popover before:hidden"
+        >
           <DropdownMenuItem onClick={() => onAgentChange(null)}>
             <span className="flex-1">All</span>
             {selectedAgentSlug === null && <Check className="size-3.5" />}
@@ -118,7 +121,10 @@ export function FilterBar({
           {selectedStatus ? <StatusPill status={selectedStatus} /> : 'Status'}
           <ChevronDown className="size-3 text-ink-3" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="ph-no-capture min-w-44">
+        <DropdownMenuContent
+          align="start"
+          className="ph-no-capture min-w-44 bg-popover before:hidden"
+        >
           <DropdownMenuItem onClick={() => onStatusChange(null)}>
             <span className="flex-1">All</span>
             {selectedStatus === null && <Check className="size-3.5" />}
@@ -154,7 +160,7 @@ export function FilterBar({
           </DropdownMenuTrigger>
           <DropdownMenuContent
             align="start"
-            className="ph-no-capture max-h-64 min-w-52 overflow-y-auto"
+            className="ph-no-capture max-h-64 min-w-52 overflow-y-auto bg-popover before:hidden"
           >
             <DropdownMenuItem onClick={() => onSiteChange(null)}>
               <span className="flex-1">All</span>
@@ -210,25 +216,13 @@ export function FilterBar({
 function StatusPill({ status }: { status: TaskStatus }) {
   if (status === 'live') {
     return (
-      <span className="inline-flex items-center gap-1 text-accent">
-        <span
-          aria-hidden
-          className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-accent"
-        />
+      <span className="inline-flex items-center rounded-full bg-cyanotype-live px-2 py-px font-semibold text-[11px] text-cyanotype-live-ink">
         Live
       </span>
     )
   }
   if (status === 'failed') {
-    return (
-      <span className="inline-flex items-center gap-1 text-red-500">
-        <span
-          aria-hidden
-          className="inline-block size-1.5 rounded-full bg-red-500"
-        />
-        Failed
-      </span>
-    )
+    return <span className="text-red-500">Failed</span>
   }
   if (status === 'cancelled') return <span>Stopped</span>
   return <span>Done</span>

--- a/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
@@ -216,7 +216,7 @@ export function FilterBar({
 function StatusPill({ status }: { status: TaskStatus }) {
   if (status === 'live') {
     return (
-      <span className="inline-flex items-center rounded-full bg-cyanotype-live px-2 py-px font-semibold text-[11px] text-cyanotype-live-ink">
+      <span className="inline-flex items-center rounded-full bg-cyanotype-live px-2.5 py-[3px] font-semibold text-[11px] text-cyanotype-live-ink leading-[14px]">
         Live
       </span>
     )

--- a/packages/browseros-agent/apps/claw-app/components/audit/StatusBadge.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/StatusBadge.test.tsx
@@ -8,4 +8,10 @@ describe('StatusBadge', () => {
       'Stopped',
     )
   })
+
+  it('renders a static live badge with no animation', () => {
+    const html = renderToStaticMarkup(<StatusBadge status="live" />)
+    expect(html).toContain('Live')
+    expect(html).not.toContain('animate-pulse')
+  })
 })

--- a/packages/browseros-agent/apps/claw-app/components/audit/StatusBadge.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/StatusBadge.tsx
@@ -7,7 +7,7 @@ interface StatusBadgeProps {
 }
 
 const STYLES: Record<TaskStatus, string> = {
-  live: 'bg-accent-tint text-accent',
+  live: 'bg-cyanotype-live text-cyanotype-live-ink',
   done: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
   failed: 'bg-red-500/15 text-red-700 dark:text-red-300',
   cancelled: 'bg-bg-sunken text-ink-3',
@@ -24,15 +24,11 @@ export function StatusBadge({ status, className }: StatusBadgeProps) {
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-md px-2 py-0.5 font-semibold text-[11px] uppercase tracking-wide',
+        'inline-flex items-center rounded-full px-2.5 py-[3px] font-semibold text-[11px] leading-[14px]',
         STYLES[status],
-        status === 'live' && 'animate-pulse',
         className,
       )}
     >
-      {status === 'live' && (
-        <span className="mr-1 inline-block size-1.5 rounded-full bg-current" />
-      )}
       {LABELS[status]}
     </span>
   )

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
@@ -148,6 +148,17 @@ describe('Audit screen', () => {
     expect(html).toContain('Load older tasks')
   })
 
+  it('renders a live row as a static Live pill with no animation', () => {
+    dataOverride = {
+      ...baseData,
+      tasks: [{ ...sampleTask, status: 'live' }],
+      statusOptions: [{ status: 'live', count: 1 }],
+    }
+    const html = renderApp()
+    expect(html).toContain('Live')
+    expect(html).not.toMatch(/animate-\[pulse-dot/)
+  })
+
   it('labels cancelled rows as stopped', () => {
     dataOverride = {
       ...baseData,

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
@@ -156,7 +156,7 @@ describe('Audit screen', () => {
     }
     const html = renderApp()
     expect(html).toContain('Live')
-    expect(html).not.toMatch(/animate-\[pulse-dot/)
+    expect(html).not.toContain('pulse-dot')
   })
 
   it('labels cancelled rows as stopped', () => {

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
@@ -243,7 +243,7 @@ function LedgerHeader({ table }: LedgerTableProps) {
               key={h.id}
               className={cn(
                 CELL_PADDING,
-                'h-auto font-medium text-[11px] text-ledger-head-ink',
+                'h-auto font-medium text-[12px] text-ledger-head-ink',
                 COLUMN_WIDTHS[h.column.id],
                 NUMERIC_COLUMN_IDS.has(h.column.id) && 'text-right',
               )}

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
@@ -29,7 +29,7 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
     accessorKey: 'agentLabel',
     cell: ({ row }) => (
       <div className="flex items-center gap-2">
-        <span className="min-w-0 truncate text-[11px] text-ledger-link">
+        <span className="min-w-0 truncate text-[12px] text-ledger-link">
           {row.original.label}
         </span>
         {row.original.status === 'live' && <LiveInlineChip />}
@@ -62,7 +62,7 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
     // rendering bug next to the explicit trailing ellipsis. The wider
     // cockpit tiles keep the default.
     cell: ({ row }) => (
-      <span className="block truncate text-[11px] text-ledger-ink-3">
+      <span className="block truncate text-[12px] text-ledger-ink-3">
         {abbreviateSequence(row.original.toolSequence, 4)}
       </span>
     ),
@@ -80,7 +80,7 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
     header: 'Duration',
     accessorFn: (t) => t.durationMs,
     cell: ({ getValue }) => (
-      <span className="text-[11px] text-ledger-ink-2 tabular-nums">
+      <span className="text-[12px] text-ledger-ink-2 tabular-nums">
         {formatDuration(getValue<number>())}
       </span>
     ),
@@ -91,7 +91,7 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
     header: 'When',
     accessorKey: 'startedAt',
     cell: ({ getValue }) => (
-      <span className="text-[11px] text-ledger-ink-3 tabular-nums">
+      <span className="text-[12px] text-ledger-ink-3 tabular-nums">
         {formatRelative(getValue<number>(), Date.now())}
       </span>
     ),
@@ -121,7 +121,7 @@ export const NUMERIC_COLUMN_IDS = new Set(['tokens', 'duration', 'when'])
  */
 export const COLUMN_WIDTHS: Record<string, string> = {
   agent: 'w-[260px]',
-  sequence: 'w-[256px]',
+  sequence: 'w-[288px]',
   tokens: 'w-[88px]',
   duration: 'w-[88px]',
   when: 'w-[88px]',
@@ -137,7 +137,7 @@ function TokensCell({ task }: { task: TaskSummary }) {
   if (!usage) {
     return (
       <span
-        className="text-[11px] text-ledger-ink-3 tabular-nums"
+        className="text-[12px] text-ledger-ink-3 tabular-nums"
         title="Token usage not measured for this session"
       >
         —
@@ -146,7 +146,7 @@ function TokensCell({ task }: { task: TaskSummary }) {
   }
   return (
     <span
-      className="text-[11px] text-ledger-ink-2 tabular-nums"
+      className="text-[12px] text-ledger-ink-2 tabular-nums"
       title={`${formatTokensFull(usage.totalTokenEstimate)} tokens`}
     >
       {formatTokensCompact(usage.totalTokenEstimate)}
@@ -160,7 +160,7 @@ function TokensCell({ task }: { task: TaskSummary }) {
  * a run being live is a state to notice, not an alarm to chase.
  */
 const STATE_CHIP =
-  'inline-flex shrink-0 items-center rounded-full px-2.5 py-[3px] font-semibold text-[11px] leading-[14px]'
+  '-my-[3px] inline-flex shrink-0 items-center rounded-full px-2.5 py-[3px] font-semibold text-[11px] leading-[14px]'
 
 function LiveInlineChip() {
   return (

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
@@ -1,4 +1,5 @@
 import type { ColumnDef } from '@tanstack/react-table'
+import { cn } from '@/lib/utils'
 import type { TaskSummary } from '@/modules/api/audit.hooks'
 import {
   abbreviateSequence,
@@ -153,30 +154,30 @@ function TokensCell({ task }: { task: TaskSummary }) {
   )
 }
 
+/**
+ * Exceptional-state pills. One geometry for all three so they read as a
+ * family; only Live carries a saturated fill. No dot and no animation —
+ * a run being live is a state to notice, not an alarm to chase.
+ */
+const STATE_CHIP =
+  'inline-flex shrink-0 items-center rounded-full px-2.5 py-[3px] font-semibold text-[11px] leading-[14px]'
+
 function LiveInlineChip() {
   return (
-    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-green-tint px-1.5 py-px font-semibold text-[9.5px] text-green uppercase tracking-[0.06em]">
-      <span
-        aria-hidden
-        className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-green"
-      />
+    <span
+      className={cn(STATE_CHIP, 'bg-cyanotype-live text-cyanotype-live-ink')}
+    >
       Live
     </span>
   )
 }
 
 function FailedInlineChip() {
-  return (
-    <span className="inline-flex shrink-0 items-center rounded-full bg-red-tint px-1.5 py-px font-semibold text-[9.5px] text-red uppercase tracking-[0.06em]">
-      Failed
-    </span>
-  )
+  return <span className={cn(STATE_CHIP, 'bg-red-tint text-red')}>Failed</span>
 }
 
 function StoppedInlineChip() {
   return (
-    <span className="inline-flex shrink-0 items-center rounded-full bg-card-tint px-1.5 py-px font-semibold text-[9.5px] text-ink-3 uppercase tracking-[0.06em]">
-      Stopped
-    </span>
+    <span className={cn(STATE_CHIP, 'bg-card-tint text-ink-3')}>Stopped</span>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/ClaudeDesktopCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/ClaudeDesktopCard.tsx
@@ -15,30 +15,30 @@ export function ClaudeDesktopCard() {
   return (
     <section className="space-y-2">
       <header className="flex items-baseline justify-between gap-3">
-        <h2 className="font-semibold text-ink text-lg">Claude Desktop</h2>
-        <span className="font-mono text-[10.5px] text-ink-3 uppercase tracking-[0.08em]">
-          extension
-        </span>
+        <h2 className="font-semibold text-cyanotype-ink text-lg">
+          Claude Desktop
+        </h2>
+        <span className="text-[12px] text-cyanotype-muted">Extension</span>
       </header>
       <button
         type="button"
         onClick={() => setGuideOpen(true)}
-        className="group block w-full rounded-xl border border-border-2 bg-card-tint px-4 py-4 text-left transition-colors hover:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        className="group block w-full rounded-9 border border-cyanotype-border bg-card p-4 text-left transition-colors hover:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
       >
         <div className="flex items-start gap-3">
           <ClaudeMark className="size-7 shrink-0" />
           <div className="min-w-0 flex-1 space-y-1">
-            <p className="font-semibold text-[15px] text-ink leading-snug">
+            <p className="font-semibold text-[15px] text-cyanotype-ink leading-snug">
               Give Claude Desktop a real browser.
             </p>
-            <p className="text-[13px] text-ink-2 leading-snug">
+            <p className="text-[13px] text-cyanotype-muted leading-snug">
               {COWORK_REQUIREMENT_LINE}
             </p>
           </div>
         </div>
         <div className="mt-3 flex justify-end">
-          <span className="inline-flex items-center gap-1 font-mono text-[11px] text-accent uppercase tracking-[0.08em] transition-colors group-hover:text-accent-2">
-            show me how
+          <span className="inline-flex items-center gap-1 text-[12px] text-cyanotype-blue transition-colors group-hover:text-accent-2">
+            Show me how
             <ArrowRight
               aria-hidden
               className="size-3.5 transition-transform group-hover:translate-x-0.5"

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/ClaudeDesktopCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/ClaudeDesktopCard.tsx
@@ -37,7 +37,7 @@ export function ClaudeDesktopCard() {
           </div>
         </div>
         <div className="mt-3 flex justify-end">
-          <span className="inline-flex items-center gap-1 text-[12px] text-cyanotype-blue transition-colors group-hover:text-accent-2">
+          <span className="inline-flex items-center gap-1 text-[12px] text-cyanotype-blue transition-colors group-hover:text-cyanotype-blue-hover">
             Show me how
             <ArrowRight
               aria-hidden

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/ConnectionRow.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/ConnectionRow.tsx
@@ -17,10 +17,11 @@ interface ConnectionRowProps {
  * icon square. The whole row is a single click target: clicking
  * anywhere on the row fires the currently visible action.
  *
- *   Not connected   click row -> connect. Row shows `connect →` as
- *                    the visual label (mono uppercase accent green).
+ *   Not connected   click row -> connect. Row shows `Connect →` as
+ *                    the visual label, in cobalt.
  *   Connected       click row -> disconnect. Row shows
- *                    `● connected · disconnect →` as the label.
+ *                    `Connected · Disconnect →` as the label. The green
+ *                    word carries the state, so there is no status dot.
  *
  * The row highlights on hover / focus / active with `bg-card-tint`
  * so the affordance is unambiguous. Errors render as a red hairline
@@ -45,7 +46,7 @@ export function ConnectionRow({
           : `Connect ${state.harness}`
       }
       className={cn(
-        'group block w-full border-border-2 border-t text-left transition-colors',
+        'group block w-full border-cyanotype-border border-t text-left transition-colors',
         'hover:bg-card-tint focus-visible:bg-card-tint focus-visible:outline-none',
         'disabled:cursor-not-allowed disabled:opacity-70',
       )}
@@ -53,11 +54,11 @@ export function ConnectionRow({
       <div className="flex items-center gap-3 px-2 py-3">
         <HarnessIcon harness={state.harness} className="size-5 shrink-0" />
         <div className="min-w-0 flex-1">
-          <div className="font-semibold text-[14px] text-ink">
+          <div className="font-semibold text-[14px] text-cyanotype-ink">
             {state.harness}
           </div>
           {state.installed && state.configPath && (
-            <div className="truncate font-mono text-[11px] text-ink-3">
+            <div className="truncate font-mono text-[11px] text-cyanotype-muted">
               {state.configPath}
             </div>
           )}
@@ -86,24 +87,15 @@ function RowAction({
   if (state.installed) {
     return (
       <div className="flex shrink-0 items-center gap-3">
-        <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-2 uppercase tracking-[0.08em]">
-          <span
-            aria-hidden
-            className="inline-block size-1.5 rounded-full bg-green"
-          />
-          connected
+        <span className="font-semibold text-[12px] text-cyanotype-live-text">
+          Connected
         </span>
-        <span aria-hidden className="text-ink-4">
+        <span aria-hidden className="text-[16px] text-cyanotype-border">
           ·
         </span>
-        <span className="inline-flex items-center gap-1 font-mono text-[11px] text-ink-3 uppercase tracking-[0.08em] transition-colors group-hover:text-ink">
-          disconnect
-          <span
-            aria-hidden
-            className="transition-transform group-hover:translate-x-0.5"
-          >
-            →
-          </span>
+        <span className="inline-flex items-center gap-1 text-[12px] text-cyanotype-muted transition-colors group-hover:text-cyanotype-ink">
+          Disconnect
+          <ActionArrow />
         </span>
       </div>
     )
@@ -111,17 +103,23 @@ function RowAction({
   return (
     <span
       className={cn(
-        'inline-flex shrink-0 items-center gap-1.5 font-mono text-[11px] text-accent uppercase tracking-[0.08em]',
+        'inline-flex shrink-0 items-center gap-1.5 text-[12px] text-cyanotype-blue',
         'transition-colors group-hover:text-accent-2',
       )}
     >
-      connect
-      <span
-        aria-hidden
-        className="transition-transform group-hover:translate-x-0.5"
-      >
-        →
-      </span>
+      Connect
+      <ActionArrow />
+    </span>
+  )
+}
+
+function ActionArrow() {
+  return (
+    <span
+      aria-hidden
+      className="font-mono text-[11px] tracking-[0.08em] transition-transform group-hover:translate-x-0.5"
+    >
+      →
     </span>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/ConnectionRow.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/ConnectionRow.tsx
@@ -58,7 +58,7 @@ export function ConnectionRow({
             {state.harness}
           </div>
           {state.installed && state.configPath && (
-            <div className="truncate font-mono text-[11px] text-cyanotype-muted">
+            <div className="truncate font-mono text-[12px] text-cyanotype-muted">
               {state.configPath}
             </div>
           )}
@@ -104,7 +104,7 @@ function RowAction({
     <span
       className={cn(
         'inline-flex shrink-0 items-center gap-1.5 text-[12px] text-cyanotype-blue',
-        'transition-colors group-hover:text-accent-2',
+        'transition-colors group-hover:text-cyanotype-blue-hover',
       )}
     >
       Connect

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
@@ -22,21 +22,19 @@ export function EndpointStrip({ label, value }: EndpointStripProps) {
   return (
     <div className="space-y-2">
       <div className="flex items-baseline justify-between gap-3">
-        <span className="font-mono text-[10.5px] text-ink-3 uppercase tracking-[0.08em]">
-          {label}
-        </span>
+        <span className="text-[12px] text-cyanotype-muted">{label}</span>
         {hasValue && (
           <button
             type="button"
             onClick={copy}
             aria-label={`Copy ${label}`}
-            className="group inline-flex items-center gap-1 font-mono text-[10.5px] text-ink-3 uppercase tracking-[0.08em] transition-colors hover:text-accent"
+            className="group inline-flex items-center gap-1 text-[12px] text-cyanotype-blue transition-colors hover:text-accent-2"
           >
-            {copied ? 'copied ✓' : 'copy'}
+            {copied ? 'Copied ✓' : 'Copy'}
             {!copied && (
               <span
                 aria-hidden
-                className="transition-transform group-hover:translate-x-0.5"
+                className="font-mono text-[10.5px] text-ink-3 tracking-[0.08em] transition-transform group-hover:translate-x-0.5"
               >
                 →
               </span>
@@ -44,7 +42,7 @@ export function EndpointStrip({ label, value }: EndpointStripProps) {
           </button>
         )}
       </div>
-      <div className="overflow-hidden rounded-xl bg-ink-deep px-4 py-3">
+      <div className="overflow-hidden rounded-9 bg-cyanotype-blue px-4 py-3">
         {hasValue ? (
           <code
             className="block truncate font-mono text-[12.5px] text-white/95"

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
@@ -28,7 +28,7 @@ export function EndpointStrip({ label, value }: EndpointStripProps) {
             type="button"
             onClick={copy}
             aria-label={`Copy ${label}`}
-            className="group inline-flex items-center gap-1 text-[12px] text-cyanotype-blue transition-colors hover:text-accent-2"
+            className="group inline-flex items-center gap-1 text-[12px] text-cyanotype-blue transition-colors hover:text-cyanotype-blue-hover"
           >
             {copied ? 'Copied ✓' : 'Copy'}
             {!copied && (

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/HeroCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/HeroCard.tsx
@@ -9,15 +9,11 @@ export function HeroCard({ url }: HeroCardProps) {
   return (
     <header className="space-y-6">
       <div className="space-y-1">
-        <h1 className="font-extrabold text-3xl leading-tight tracking-tight md:text-4xl">
+        <h1 className="font-extrabold text-3xl text-cyanotype-ink leading-tight tracking-tight md:text-4xl">
           MCP
         </h1>
-        <p className="text-[15px] text-ink-2 leading-snug">
-          One endpoint,{' '}
-          <span className="font-medium font-serif text-accent italic">
-            every
-          </span>{' '}
-          harness.
+        <p className="text-[15px] text-cyanotype-muted leading-snug">
+          One endpoint, every harness.
         </p>
       </div>
       <EndpointStrip label="Endpoint URL" value={url} />

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
@@ -137,7 +137,7 @@ describe('Mcp (editorial)', () => {
     expect(html).toContain('every')
     expect(html).toContain('harness.')
     expect(html).not.toContain('http://127.0.0.1:9200/mcp')
-    expect(html).not.toContain('copy')
+    expect(html).not.toContain('Copy')
   })
 
   it('renders the endpoint copy strip once the resolved URL is available', () => {
@@ -148,7 +148,7 @@ describe('Mcp (editorial)', () => {
     expect(html).toContain('http://127.0.0.1:9512/mcp')
     expect(html).not.toContain('/mcp/claude-code')
     expect(html).not.toContain('/cockpit')
-    expect(html).toContain('copy')
+    expect(html).toContain('Copy')
   })
 
   it('does NOT render the removed CLI snippet block', () => {
@@ -185,7 +185,7 @@ describe('Mcp (editorial)', () => {
     const html = renderApp()
     expect(html).toContain('Claude Desktop')
     expect(html).toContain('Give Claude Desktop a real browser.')
-    expect(html).toContain('show me how')
+    expect(html).toContain('Show me how')
     expect(html).toContain(COWORK_REQUIREMENT_LINE)
     // The walkthrough replaced the link-out; nothing here should leave the app.
     expect(html).not.toContain(
@@ -200,11 +200,13 @@ describe('Mcp (editorial)', () => {
     expect(html).not.toContain(EXTENSION_DOWNLOAD_URL)
   })
 
-  it('renders editorial state voices (silent success, mono uppercase action text)', () => {
+  it('renders the row action voices in title case with no status dot', () => {
     const html = renderApp()
-    expect(html).toMatch(/>\s*connect\s*/)
-    expect(html).toMatch(/>\s*connected\s*/)
-    expect(html).toMatch(/>\s*disconnect\s*/)
+    expect(html).toMatch(/>\s*Connect\s*/)
+    expect(html).toMatch(/>\s*Connected\s*/)
+    expect(html).toMatch(/>\s*Disconnect\s*/)
+    // The green word carries the state; the mock has no dot.
+    expect(html).not.toContain('rounded-full bg-green')
   })
 
   it('does NOT render the removed floating footer paragraph', () => {

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
@@ -134,8 +134,8 @@ describe('Mcp (editorial)', () => {
   it('renders the editorial hero without exposing the fallback endpoint before pref resolution', () => {
     const html = renderApp()
     expect(html).toContain('MCP')
-    expect(html).toContain('every')
-    expect(html).toContain('harness.')
+    expect(html).toContain('One endpoint, every harness.')
+    expect(html).not.toContain('font-serif')
     expect(html).not.toContain('http://127.0.0.1:9200/mcp')
     expect(html).not.toContain('Copy')
   })
@@ -202,9 +202,9 @@ describe('Mcp (editorial)', () => {
 
   it('renders the row action voices in title case with no status dot', () => {
     const html = renderApp()
-    expect(html).toMatch(/>\s*Connect\s*/)
-    expect(html).toMatch(/>\s*Connected\s*/)
-    expect(html).toMatch(/>\s*Disconnect\s*/)
+    expect(html).toMatch(/>Connect</)
+    expect(html).toMatch(/>Connected</)
+    expect(html).toMatch(/>Disconnect</)
     // The green word carries the state; the mock has no dot.
     expect(html).not.toContain('rounded-full bg-green')
   })

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.tsx
@@ -88,9 +88,11 @@ export function Mcp() {
       <HeroCard url={url} />
       <section className="space-y-2">
         <header className="flex items-baseline justify-between gap-3">
-          <h2 className="font-semibold text-ink text-lg">Connected agents</h2>
+          <h2 className="font-semibold text-cyanotype-ink text-lg">
+            Connected agents
+          </h2>
           {!isLoading && !connections.isError && (
-            <span className="font-mono text-[10.5px] text-ink-3 uppercase tabular-nums tracking-[0.08em]">
+            <span className="text-[12px] text-cyanotype-muted tabular-nums">
               {connectedCount} of {totalCount} connected
             </span>
           )}
@@ -132,8 +134,8 @@ function SkeletonList() {
   return (
     <div>
       {['s1', 's2', 's3', 's4', 's5', 's6'].map((id) => (
-        <div key={id} className="border-border-2 border-t">
-          <div className="flex items-center gap-3 py-3">
+        <div key={id} className="border-cyanotype-border border-t">
+          <div className="flex items-center gap-3 px-2 py-3">
             <div className="size-5 shrink-0 animate-pulse rounded bg-card-tint" />
             <div className="flex-1">
               <div className="h-3 w-32 animate-pulse rounded bg-card-tint" />


### PR DESCRIPTION
## Summary
- **MCP page** restyled to the supplied design: cobalt endpoint block at radius 9, title-case 12px sans labels replacing mono-uppercase, hairline agent rows with no status dot, white Claude Desktop callout.
- **Audit page** live signals calmed: the pulsing Live chip becomes a static `#2FE08C` pill, the per-agent colour dot comes off the hover card, and the filter dropdowns are opaque white instead of translucent-over-blur (they were reading as a gradient).
- **Ledger body text 11px → 12px**, with the tool-chain track widened 256 → 288px so the four-link chain still fits without mid-word clipping.

## Design
No new design tokens. Every colour in the mock already existed as a `--cyanotype-*` var from the recent-activity redesign, so this consumes that vocabulary rather than minting a third one. The state pills share one geometry across the table, the filter bar, the hover card, and `StatusBadge`; only Live carries a saturated fill.

Behaviour is untouched — connect/disconnect, the pending spinner, the error strip, and the install dialog all work as before. Cockpit live indicators deliberately keep pulsing.

## Test plan
- [x] `bun run test` — full suite, 136 files, 0 failures
- [x] `bun run lint` and claw-app typecheck clean
- [x] Both screens rendered and screenshotted against the mock
- [x] New coverage: static Live pill emits no `pulse-dot`; hover card renders no per-agent dot