### PR TITLE
ci(turbo): affected-only CI with GitHub Actions cache

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -53,7 +53,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Start Turbo remote cache (GitHub Actions cache)
-        uses: rharkor/caching-for-turbo@v2
+        uses: rharkor/caching-for-turbo@v2.5.1
 
       - name: Install dependencies
         run: bun ci

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -45,9 +45,15 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+          # Full history so Turbo's --affected can compute the merge base;
+          # a shallow checkout silently makes it treat every package as changed.
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+
+      - name: Start Turbo remote cache (GitHub Actions cache)
+        uses: rharkor/caching-for-turbo@v2
 
       - name: Install dependencies
         run: bun ci
@@ -55,14 +61,15 @@ jobs:
       - name: Check env examples
         run: bun run env:examples:check
 
-      - name: Prepare wxt
-        run: VITE_PUBLIC_BROWSEROS_API=http://localhost:3000 bun run --cwd apps/app wxt prepare
+      - name: Create dev env file
+        run: cp .env.development.example .env.development
 
-      - name: Run codegen
-        run: bun run --cwd apps/app codegen
-
-      - name: Run Typecheck
-        run: bun run typecheck
+      # Turbo runs each affected package's typecheck (its script self-contains
+      # wxt prepare) after its `codegen` task dep, so unchanged packages are
+      # cache hits. Replaces the manual wxt-prepare + codegen + `bun run
+      # typecheck` steps.
+      - name: Run Typecheck (affected)
+        run: bunx turbo run typecheck --affected
 
   claw-api-codegen:
     name: runner / Claw API generated code

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -53,7 +53,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Start Turbo remote cache (GitHub Actions cache)
-        uses: rharkor/caching-for-turbo@v2.5.1
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
 
       - name: Install dependencies
         run: bun ci

--- a/.github/workflows/test-affected.yml
+++ b/.github/workflows/test-affected.yml
@@ -36,6 +36,7 @@ jobs:
     outputs:
       matrix: ${{ steps.affected.outputs.matrix }}
       has_any: ${{ steps.affected.outputs.has_any }}
+      all_suites: ${{ steps.affected.outputs.all_suites }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -230,3 +231,134 @@ jobs:
         run: |
           echo 'needs = ${{ toJSON(needs) }}'
           jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")' <<< '${{ toJSON(needs) }}'
+
+  comment:
+    name: Tests (affected) / summary
+    needs: [discover, test]
+    if: >-
+      always()
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Download JUnit artifacts
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          path: junit
+          pattern: junit-affected-*
+
+      - name: Build comment body
+        env:
+          ALL_SUITES: ${{ needs.discover.outputs.all_suites }}
+        run: |
+          python3 <<'PY'
+          import glob, json, os, xml.etree.ElementTree as ET
+
+          run_url = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+          marker = "<!-- browseros-agent-affected-tests-summary -->"
+          all_suites = json.loads(os.environ.get("ALL_SUITES") or "[]")
+
+          ran = {}
+          failed_cases = []
+          for xml_path in sorted(glob.glob("junit/junit-affected-*/*.xml")):
+              suite_name = os.path.basename(os.path.dirname(xml_path)).removeprefix("junit-affected-")
+              try:
+                  root = ET.parse(xml_path).getroot()
+              except ET.ParseError:
+                  ran[suite_name] = (0, 1, 0, 1)
+                  failed_cases.append((suite_name, "(could not parse junit XML)"))
+                  continue
+              testsuites = root.findall("testsuite") if root.tag == "testsuites" else [root]
+              s_tests = s_fail = s_err = s_skip = 0
+              for ts in testsuites:
+                  s_tests += int(ts.get("tests") or 0)
+                  s_fail += int(ts.get("failures") or 0)
+                  s_err += int(ts.get("errors") or 0)
+                  s_skip += int(ts.get("skipped") or 0)
+                  for tc in ts.iter("testcase"):
+                      if tc.find("failure") is not None or tc.find("error") is not None:
+                          cls = tc.get("classname") or ""
+                          name = tc.get("name") or "(unnamed)"
+                          failed_cases.append((suite_name, f"{cls} > {name}" if cls else name))
+              s_failed = s_fail + s_err
+              s_passed = max(s_tests - s_failed - s_skip, 0)
+              ran[suite_name] = (s_passed, s_failed, s_skip, s_tests)
+
+          total_passed = sum(v[0] for v in ran.values())
+          total_failed = sum(v[1] for v in ran.values())
+          total_tests = sum(v[3] for v in ran.values())
+          order = all_suites or sorted(ran)
+          n_total = len(order)
+          n_ran = len(ran)
+          n_skipped = max(n_total - n_ran, 0)
+
+          if total_failed:
+              header = f"## :x: Tests failed: {total_failed}/{total_tests} failed"
+          elif n_ran == 0:
+              header = "## :white_check_mark: No suites affected by this change"
+          else:
+              header = f"## :white_check_mark: Tests passed: {total_passed}/{total_tests}"
+
+          lines = [marker, header, "",
+                   f"Ran {n_ran} of {n_total} suites ({n_skipped} not affected by this change).", ""]
+          lines.append("| Suite | Passed | Failed | Skipped |")
+          lines.append("|-------|--------|--------|---------|")
+          gate_suites = []
+          for name in order:
+              if name in ran:
+                  passed, failed, skipped, total = ran[name]
+                  if failed > 0:
+                      icon, passed_cell = ":x:", f"{passed}/{total}"
+                  elif total == 0:
+                      icon, passed_cell = ":white_check_mark:", "passed"
+                      gate_suites.append(name)
+                  else:
+                      icon, passed_cell = ":white_check_mark:", f"{passed}/{total}"
+                  lines.append(f"| {icon} `{name}` | {passed_cell} | {failed} | {skipped} |")
+              else:
+                  lines.append(f"| :fast_forward: `{name}` | n/a | n/a | not affected |")
+          if gate_suites:
+              lines += ["", "> `passed` = ran successfully but emits no JUnit counts (a lint/format gate)."]
+          if failed_cases:
+              lines += ["", "<details open>", "<summary><b>Failed tests</b></summary>", ""]
+              for suite_name, label in failed_cases[:50]:
+                  lines.append(f"- **{suite_name}** `{label}`")
+              if len(failed_cases) > 50:
+                  lines.append(f"- ...and {len(failed_cases) - 50} more")
+              lines += ["", "</details>"]
+          lines += ["", f"[View workflow run]({run_url})"]
+
+          with open("comment.md", "w") as fp:
+              fp.write("\n".join(lines) + "\n")
+          PY
+
+      - name: Upsert sticky PR comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('comment.md', 'utf8');
+            const marker = '<!-- browseros-agent-affected-tests-summary -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const triggerSha = context.payload.pull_request.head.sha;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
+            if (pr.head.sha !== triggerSha) {
+              core.info(`PR head has moved (${pr.head.sha} vs ${triggerSha}), skipping stale comment.`);
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/test-affected.yml
+++ b/.github/workflows/test-affected.yml
@@ -1,0 +1,232 @@
+name: Tests (affected)
+
+# Affected-only variant of test.yml: a discover job computes which suites a
+# change touches (via Turbo), and only those run. Runs alongside test.yml
+# during probation so the always-run matrix still gates while this is proven
+# out; once trusted, test.yml is retired and this becomes the test workflow.
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - .github/workflows/test-affected.yml
+      - packages/browseros-agent/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BROWSEROS_APPIMAGE_URL: https://files.browseros.com/download/BrowserOS.AppImage
+
+concurrency:
+  group: tests-affected-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  discover:
+    name: Tests (affected) / discover
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/browseros-agent
+    outputs:
+      matrix: ${{ steps.affected.outputs.matrix }}
+      has_any: ${{ steps.affected.outputs.has_any }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          # Full history so Turbo's --affected has the merge base; a shallow
+          # checkout would silently mark every package changed.
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun ci
+
+      - name: Compute affected suites
+        id: affected
+        env:
+          BROWSEROS_AFFECTED_BASE: ${{ github.event.pull_request.base.sha }}
+          TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+        run: bun run ci/affected-suites.ts
+
+  test:
+    name: Tests (affected) / ${{ matrix.suite }}
+    needs: discover
+    if: needs.discover.outputs.has_any == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.needs_rust && 45 || 20 }}
+    defaults:
+      run:
+        working-directory: packages/browseros-agent
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Rust
+        if: matrix.needs_rust == true
+        # Pinned so the clippy lint set is deterministic and matches local dev;
+        # a floating `stable` silently changes which lints fire across runs.
+        uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          components: clippy,rustfmt
+
+      - name: Cache Rust build
+        if: matrix.needs_rust == true
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/browseros-agent
+
+      - name: Install dependencies
+        run: bun ci
+
+      - name: Resolve BrowserOS cache key
+        if: matrix.needs_browser == true
+        id: browseros-cache-key
+        run: |
+          set -euo pipefail
+          headers="$(curl -fsSI "$BROWSEROS_APPIMAGE_URL")"
+          etag="$(printf '%s\n' "$headers" | awk 'BEGIN{IGNORECASE=1} /^etag:/ {sub(/\r$/, "", $2); gsub(/"/, "", $2); print $2; exit}')"
+          last_modified="$(printf '%s\n' "$headers" | awk 'BEGIN{IGNORECASE=1} /^last-modified:/ {$1=""; sub(/^ /, ""); sub(/\r$/, ""); print; exit}')"
+          raw_key="${etag:-$last_modified}"
+          if [ -z "$raw_key" ]; then
+            raw_key="$BROWSEROS_APPIMAGE_URL"
+          fi
+          cache_key="$(printf '%s' "$raw_key" | shasum -a 256 | awk '{print $1}')"
+          echo "key=browseros-appimage-${{ runner.os }}-$cache_key" >> "$GITHUB_OUTPUT"
+
+      - name: Restore BrowserOS cache
+        if: matrix.needs_browser == true
+        id: browseros-cache
+        uses: actions/cache@v6.1.0
+        with:
+          path: packages/browseros-agent/.ci/bin/BrowserOS.AppImage
+          key: ${{ steps.browseros-cache-key.outputs.key }}
+
+      - name: Download BrowserOS
+        if: matrix.needs_browser == true && steps.browseros-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p .ci/bin
+          curl -fsSL "$BROWSEROS_APPIMAGE_URL" -o .ci/bin/BrowserOS.AppImage
+          chmod +x .ci/bin/BrowserOS.AppImage
+
+      - name: Prepare BrowserOS wrapper
+        if: matrix.needs_browser == true
+        run: |
+          mkdir -p .ci/bin
+          cat > .ci/bin/browseros <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          export APPIMAGE_EXTRACT_AND_RUN=1
+          # Chromium's hidden-window APIs require a real X11 platform.
+          if [ "${BROWSEROS_TEST_HEADLESS:-true}" = "false" ]; then
+            export XDG_SESSION_TYPE=x11
+            exec xvfb-run --auto-servernum "$(dirname "$0")/BrowserOS.AppImage" "$@"
+          fi
+          exec "$(dirname "$0")/BrowserOS.AppImage" "$@"
+          EOF
+          chmod +x .ci/bin/browseros
+
+      - name: Create dev env file
+        working-directory: packages/browseros-agent
+        run: cp .env.development.example .env.development
+
+      - name: Run ${{ matrix.suite }} tests
+        id: test
+        env:
+          BROWSEROS_BINARY: ${{ github.workspace }}/packages/browseros-agent/.ci/bin/browseros
+          BROWSEROS_TEST_HEADLESS: ${{ matrix.suite == 'claw-mcp' && 'false' || 'true' }}
+          BROWSEROS_TEST_EXTRA_ARGS: --no-sandbox --disable-dev-shm-usage
+          BROWSEROS_JUNIT_PATH: ${{ github.workspace }}/packages/browseros-agent/${{ matrix.junit_path }}
+        run: |
+          set +e
+          mkdir -p test-results
+          # Bun's TS-file parser has occasional races on Linux when many test
+          # workers parse the same source concurrently, surfacing as
+          # `SyntaxError: Export named 'X' not found in module ...` on files
+          # whose source clearly exports X. It is not reproducible locally
+          # and clears on rerun. Retry once on failure so a single flake does
+          # not block PRs; a second consecutive failure still fails the job.
+          attempt=0
+          max_attempts=2
+          exit_code=1
+          while [ "$attempt" -lt "$max_attempts" ]; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -gt 1 ]; then
+              echo "::warning::${{ matrix.suite }} attempt $attempt (previous exit $exit_code)"
+              # Fresh junit slot per attempt so stale output does not mask the retry.
+              rm -f "${{ matrix.junit_path }}"
+            fi
+            ${{ matrix.command }}
+            exit_code=$?
+            if [ "$exit_code" = "0" ]; then break; fi
+          done
+          if [ ! -f "${{ matrix.junit_path }}" ]; then
+            if [ "$exit_code" = "0" ]; then
+              cat > "${{ matrix.junit_path }}" <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <testsuites tests="0" failures="0">
+            <testsuite name="${{ matrix.suite }}" tests="0" failures="0">
+            </testsuite>
+          </testsuites>
+          EOF
+            else
+              cat > "${{ matrix.junit_path }}" <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <testsuites tests="1" failures="1">
+            <testsuite name="${{ matrix.suite }}" tests="1" failures="1">
+              <testcase classname="workflow" name="${{ matrix.suite }} setup">
+                <failure message="Test run failed before JUnit output was written">See workflow logs for details.</failure>
+              </testcase>
+            </testsuite>
+          </testsuites>
+          EOF
+            fi
+          fi
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+
+      - name: Upload JUnit XML
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit-affected-${{ matrix.suite }}
+          path: packages/browseros-agent/${{ matrix.junit_path }}
+
+      - name: Summarize suite result
+        if: always()
+        run: |
+          if [ "${{ steps.test.outputs.exit_code }}" = "0" ]; then
+            echo "### :white_check_mark: ${{ matrix.suite }} suite passed" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### :x: ${{ matrix.suite }} suite failed (exit code ${{ steps.test.outputs.exit_code }})"
+              echo ""
+              echo "See the uploaded \`junit-affected-${{ matrix.suite }}\` artifact for details."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+  gate:
+    name: Tests (affected) / gate
+    needs: [discover, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every suite to pass or be skipped
+        run: |
+          echo 'needs = ${{ toJSON(needs) }}'
+          jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")' <<< '${{ toJSON(needs) }}'

--- a/.github/workflows/turbo-cache-warm.yml
+++ b/.github/workflows/turbo-cache-warm.yml
@@ -44,7 +44,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Start Turbo remote cache (GitHub Actions cache)
-        uses: rharkor/caching-for-turbo@v2
+        uses: rharkor/caching-for-turbo@v2.5.1
 
       - name: Install dependencies
         run: bun ci

--- a/.github/workflows/turbo-cache-warm.yml
+++ b/.github/workflows/turbo-cache-warm.yml
@@ -44,7 +44,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Start Turbo remote cache (GitHub Actions cache)
-        uses: rharkor/caching-for-turbo@v2.5.1
+        uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
 
       - name: Install dependencies
         run: bun ci

--- a/.github/workflows/turbo-cache-warm.yml
+++ b/.github/workflows/turbo-cache-warm.yml
@@ -1,0 +1,63 @@
+name: Turbo Cache Warm
+
+# Populates the Turbo cache on `main` so PR branches inherit warm cache.
+# GitHub Actions caches restore only from the same branch or the base/default
+# branch, so without a run on `main` every PR would start cold. Neither the
+# Tests nor Code Quality workflows run on `main`, so this is that run.
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/turbo-cache-warm.yml
+      - packages/browseros-agent/**
+  schedule:
+    # Weekly full warm to backstop GitHub's 7-day unused-cache eviction for
+    # packages that rarely change (a cache read counts as access, so frequently
+    # depended-on packages stay warm on their own).
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: turbo-cache-warm-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: packages/browseros-agent
+
+jobs:
+  warm:
+    name: Warm Turbo cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          # Full history so Turbo's `--affected` can compute the merge base.
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Start Turbo remote cache (GitHub Actions cache)
+        uses: rharkor/caching-for-turbo@v2
+
+      - name: Install dependencies
+        run: bun ci
+
+      - name: Create dev env file
+        run: cp .env.development.example .env.development
+
+      - name: Warm cache
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            # Full run: refresh every package's cached artifacts + access time.
+            bunx turbo run typecheck
+          else
+            # Per-merge: warm only what this merge changed.
+            bunx turbo run typecheck --affected
+          fi

--- a/packages/browseros-agent/.gitignore
+++ b/packages/browseros-agent/.gitignore
@@ -204,3 +204,6 @@ test-results/
 .agent/
 .llm/
 .grove/
+
+# Turborepo
+.turbo

--- a/packages/browseros-agent/apps/claw-server-rust/package.json
+++ b/packages/browseros-agent/apps/claw-server-rust/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@browseros/claw-server-rust",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "lint:rust": "cargo fmt --package claw-server-rust -- --check && cargo clippy --package claw-server-rust --all-targets --locked -- -D warnings",
+    "test:rust": "cargo test --package claw-server-rust --locked"
+  }
+}

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -17,6 +17,7 @@
         "lefthook": "^2.1.10",
         "openapi-typescript": "7.13.0",
         "picocolors": "^1.1.1",
+        "turbo": "^2.9.6",
         "typedoc": "^0.28.20",
         "typescript": "^7.0.2",
         "yaml": "2.9.0",
@@ -208,6 +209,10 @@
         "vite": "^7.3.6",
       },
     },
+    "apps/claw-server-rust": {
+      "name": "@browseros/claw-server-rust",
+      "version": "0.0.0",
+    },
     "apps/server": {
       "name": "@browseros/server",
       "version": "0.0.129",
@@ -257,6 +262,26 @@
         "pino-pretty": "^13.1.3",
         "puppeteer": "^25.3.0",
       },
+    },
+    "crates/browseros-cdp": {
+      "name": "@browseros/browseros-cdp-rust",
+      "version": "0.0.0",
+    },
+    "crates/browseros-core": {
+      "name": "@browseros/browseros-core-rust",
+      "version": "0.0.0",
+    },
+    "crates/browseros-mcp": {
+      "name": "@browseros/browseros-mcp-rust",
+      "version": "0.0.0",
+    },
+    "crates/claw-api": {
+      "name": "@browseros/claw-api-rust",
+      "version": "0.0.0",
+    },
+    "crates/harness-integrations": {
+      "name": "@browseros/harness-integrations-rust",
+      "version": "0.0.0",
     },
     "packages/acpx-ai-provider": {
       "name": "@browseros/acpx-ai-provider",
@@ -569,6 +594,12 @@
 
     "@browseros/browser-mcp": ["@browseros/browser-mcp@workspace:packages/browser-mcp"],
 
+    "@browseros/browseros-cdp-rust": ["@browseros/browseros-cdp-rust@workspace:crates/browseros-cdp"],
+
+    "@browseros/browseros-core-rust": ["@browseros/browseros-core-rust@workspace:crates/browseros-core"],
+
+    "@browseros/browseros-mcp-rust": ["@browseros/browseros-mcp-rust@workspace:crates/browseros-mcp"],
+
     "@browseros/build-server-tools": ["@browseros/build-server-tools@workspace:packages/build-server-tools"],
 
     "@browseros/cdp-protocol": ["@browseros/cdp-protocol@workspace:packages/cdp-protocol"],
@@ -577,9 +608,15 @@
 
     "@browseros/claw-api-client": ["@browseros/claw-api-client@workspace:packages/claw-api-client"],
 
+    "@browseros/claw-api-rust": ["@browseros/claw-api-rust@workspace:crates/claw-api"],
+
     "@browseros/claw-app": ["@browseros/claw-app@workspace:apps/claw-app"],
 
     "@browseros/claw-onboard": ["@browseros/claw-onboard@workspace:apps/claw-onboard"],
+
+    "@browseros/claw-server-rust": ["@browseros/claw-server-rust@workspace:apps/claw-server-rust"],
+
+    "@browseros/harness-integrations-rust": ["@browseros/harness-integrations-rust@workspace:crates/harness-integrations"],
 
     "@browseros/onboarding-video": ["@browseros/onboarding-video@workspace:packages/onboarding-video"],
 
@@ -1660,6 +1697,18 @@
     "@tokenlens/models": ["@tokenlens/models@1.3.0", "", { "dependencies": { "@tokenlens/core": "1.3.0" } }, "sha512-9mx7ZGeewW4ndXAiD7AT1bbCk4OpJeortbjHHyNkgap+pMPPn1chY6R5zqe1ggXIUzZ2l8VOAKfPqOvpcrisJw=="],
 
     "@tsconfig/svelte": ["@tsconfig/svelte@1.0.13", "", {}, "sha512-5lYJP45Xllo4yE/RUBccBT32eBlRDbqN8r1/MIvQbKxW3aFqaYPCNgm8D5V20X4ShHcwvYWNlKg3liDh1MlBoA=="],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-po+7rfJfUnFXjWlcoN2RwhErgzCdRtBc1T26vYPcywHlggmCQiQe1uWaE4j+BibI2uY9/2pDoFzMN0rmSaPFOw=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+zB2btDJ00lnPRuqOvpVvgl4x34k/djZQGZTTCfjn7JgNCl8QFY5Njo5+dqkY1g/+9gbbsnAvWm9CmJg9ebcXA=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.8", "", { "os": [ "linux", "android", ], "cpu": "x64" }, "sha512-K1dxqiVisyN7cViVsfQLs6xscQbYuI8aO2nbUhFURDACgEDfZRdP/b4CCxeosBJpcMfhYyiibWqJorCnvz9kKg=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.8", "", { "os": [ "linux", "android", ], "cpu": "arm64" }, "sha512-Gi77ibVnrE1fEmvr+/wBD/yvRqhwp/RQuCp2+//lv1U1wNFFyVg0V7Wj8FG9FXPFAw5QHReo8rxc9+wBSDZjzA=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.8", "", { "os": "win32", "cpu": "x64" }, "sha512-znnLO1haJPYTHoKMKwlAvlkjRiYbbhBzME6wIGaMd+fwir23U6jVd1ecaTWWi1fbnRVqxMfgDBKseQ/hLKb83g=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-VN30vh3b3Czh2WzYHNTfF1FE0YMZ5aHsLO8dBMGHJewA6792wX6iJR8ZxlzFW6WdOu0gEAKIvlYhfyT81Wkm4Q=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
@@ -3928,6 +3977,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
+
+    "turbo": ["turbo@2.10.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.8", "@turbo/darwin-arm64": "2.10.8", "@turbo/linux-64": "2.10.8", "@turbo/linux-arm64": "2.10.8", "@turbo/windows-64": "2.10.8", "@turbo/windows-arm64": "2.10.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-9+8YX5QOkGXzZxcIykTHgaooRHGMWO+jfdyRK0o+rN0U7hBIig2MrJ8r/aNzIPDPhdA73SGb0O+tIztaModTMg=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 

--- a/packages/browseros-agent/ci/affected-suites.test.ts
+++ b/packages/browseros-agent/ci/affected-suites.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  type AffectedPackage,
+  computeAffectedSuites,
+  SUITES,
+} from './affected-suites'
+
+function pkg(name: string, path: string): AffectedPackage {
+  return { name, path }
+}
+
+function suiteNames(
+  packages: AffectedPackage[],
+  changedFiles: string[] = [],
+): string[] {
+  return computeAffectedSuites(packages, changedFiles).map((s) => s.suite)
+}
+
+describe('computeAffectedSuites', () => {
+  it('returns nothing when nothing is affected', () => {
+    expect(suiteNames([], [])).toEqual([])
+  })
+
+  it('maps a claw-app change to only the claw-app suite', () => {
+    expect(suiteNames([pkg('@browseros/claw-app', 'apps/claw-app')])).toEqual([
+      'claw-app',
+    ])
+  })
+
+  it('maps the server package to all seven server suites', () => {
+    expect(suiteNames([pkg('@browseros/server', 'apps/server')])).toEqual([
+      'server-agent',
+      'server-api',
+      'server-tools',
+      'server-browser',
+      'server-integration',
+      'server-lib',
+      'server-root',
+    ])
+  })
+
+  it('maps the app package to the agent suite', () => {
+    expect(suiteNames([pkg('@browseros/app', 'apps/app')])).toEqual(['agent'])
+  })
+
+  it('maps any affected Rust crate to all three Rust suites', () => {
+    expect(
+      suiteNames([
+        pkg('@browseros/browseros-core-rust', 'crates/browseros-core'),
+      ]),
+    ).toEqual(['claw-server-rust', 'claw-server-rust-quality', 'claw-mcp'])
+  })
+
+  it('treats the Rust server app path as a Rust package', () => {
+    expect(
+      suiteNames([pkg('@browseros/claw-server-rust', 'apps/claw-server-rust')]),
+    ).toEqual(['claw-server-rust', 'claw-server-rust-quality', 'claw-mcp'])
+  })
+
+  it('adds the build suite when scripts change', () => {
+    expect(suiteNames([], ['scripts/build/server.ts'])).toEqual(['build'])
+  })
+
+  it('adds the build suite when build-server-tools is affected', () => {
+    expect(
+      suiteNames([
+        pkg('@browseros/build-server-tools', 'packages/build-server-tools'),
+      ]),
+    ).toEqual(['build'])
+  })
+
+  it('adds claw-mcp when the claw-api or claw-mcp contract changes', () => {
+    expect(suiteNames([], ['contracts/claw-api/openapi.yaml'])).toEqual([
+      'claw-mcp',
+    ])
+    expect(suiteNames([], ['contracts/claw-mcp/tools.json'])).toEqual([
+      'claw-mcp',
+    ])
+  })
+
+  it('ignores unrelated non-package files', () => {
+    expect(suiteNames([], ['README.md', 'docs/whatever.md'])).toEqual([])
+  })
+
+  it('unions and de-duplicates across packages and paths, in declared order', () => {
+    const result = suiteNames(
+      [
+        pkg('@browseros/claw-app', 'apps/claw-app'),
+        pkg('@browseros/app', 'apps/app'),
+        pkg('@browseros/browseros-mcp-rust', 'crates/browseros-mcp'),
+      ],
+      ['contracts/claw-api/openapi.yaml'],
+    )
+    // claw-mcp appears once even though both the rust crate and the contract
+    // path request it, and the order follows the SUITES declaration.
+    expect(result).toEqual([
+      'agent',
+      'claw-app',
+      'claw-server-rust',
+      'claw-server-rust-quality',
+      'claw-mcp',
+    ])
+  })
+
+  it('surfaces every affected suite when a universal dependency changes', () => {
+    // A change to @browseros/shared marks all packages affected (Turbo global
+    // hash); the mapping should then request every suite.
+    const allPackages: AffectedPackage[] = [
+      pkg('@browseros/server', 'apps/server'),
+      pkg('@browseros/app', 'apps/app'),
+      pkg('@browseros/claw-app', 'apps/claw-app'),
+      pkg('@browseros/claw-onboard', 'apps/claw-onboard'),
+      pkg('@browseros/build-server-tools', 'packages/build-server-tools'),
+      pkg('@browseros/claw-server-rust', 'apps/claw-server-rust'),
+    ]
+    expect(new Set(suiteNames(allPackages))).toEqual(
+      new Set(Object.keys(SUITES)),
+    )
+  })
+
+  it('emits full suite config, not just names', () => {
+    const [claw] = computeAffectedSuites(
+      [pkg('@browseros/claw-app', 'apps/claw-app')],
+      [],
+    )
+    expect(claw).toEqual({
+      suite: 'claw-app',
+      command: '(cd apps/claw-app && bun run test)',
+      junit_path: 'test-results/claw-app.xml',
+      needs_browser: false,
+      needs_rust: false,
+    })
+  })
+})

--- a/packages/browseros-agent/ci/affected-suites.ts
+++ b/packages/browseros-agent/ci/affected-suites.ts
@@ -1,0 +1,242 @@
+/**
+ * Computes which CI test suites are affected by a change, for the dynamic
+ * matrix in `.github/workflows/test-affected.yml`.
+ *
+ * Turbo detects affected JS + Rust workspace packages (dependents included);
+ * this maps those packages, plus a couple of path signals for things that are
+ * not workspace packages (root `scripts/`, `contracts/`), to the suite list
+ * from `test.yml`. The suite config here is the single source of truth for
+ * each suite's command, JUnit path, and browser/rust setup needs.
+ *
+ * The mapping (`computeAffectedSuites`) is pure and unit-tested; only `main`
+ * shells out to turbo/git and writes the GitHub Actions outputs.
+ */
+import { execFileSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
+
+export interface SuiteConfig {
+  suite: string
+  command: string
+  junit_path: string
+  needs_browser: boolean
+  needs_rust: boolean
+}
+
+/** Every suite, in the order `test.yml` declares them (stable CI ordering). */
+export const SUITES: Record<string, SuiteConfig> = {
+  'server-agent': {
+    suite: 'server-agent',
+    command: '(cd apps/server && bun run test:agent)',
+    junit_path: 'test-results/server-agent.xml',
+    needs_browser: false,
+    needs_rust: false,
+  },
+  'server-api': {
+    suite: 'server-api',
+    command: '(cd apps/server && bun run test:api)',
+    junit_path: 'test-results/server-api.xml',
+    needs_browser: true,
+    needs_rust: false,
+  },
+  'server-tools': {
+    suite: 'server-tools',
+    command: '(cd apps/server && bun run test:tools)',
+    junit_path: 'test-results/server-tools.xml',
+    needs_browser: true,
+    needs_rust: false,
+  },
+  'server-browser': {
+    suite: 'server-browser',
+    command: '(cd apps/server && bun run test:browser)',
+    junit_path: 'test-results/server-browser.xml',
+    needs_browser: false,
+    needs_rust: false,
+  },
+  'server-integration': {
+    suite: 'server-integration',
+    command: '(cd apps/server && bun run test:integration)',
+    junit_path: 'test-results/server-integration.xml',
+    needs_browser: true,
+    needs_rust: false,
+  },
+  'server-lib': {
+    suite: 'server-lib',
+    command: '(cd apps/server && bun run test:lib)',
+    junit_path: 'test-results/server-lib.xml',
+    needs_browser: false,
+    needs_rust: false,
+  },
+  'server-root': {
+    suite: 'server-root',
+    command: '(cd apps/server && bun run test:root)',
+    junit_path: 'test-results/server-root.xml',
+    needs_browser: false,
+    needs_rust: false,
+  },
+  agent: {
+    suite: 'agent',
+    command: '(cd apps/app && bun run test)',
+    junit_path: 'test-results/agent.xml',
+    needs_browser: false,
+    needs_rust: false,
+  },
+  'claw-app': {
+    suite: 'claw-app',
+    command: '(cd apps/claw-app && bun run test)',
+    junit_path: 'test-results/claw-app.xml',
+    needs_browser: false,
+    needs_rust: false,
+  },
+  'claw-onboard': {
+    suite: 'claw-onboard',
+    command: '(cd apps/claw-onboard && bun run test)',
+    junit_path: 'test-results/claw-onboard.xml',
+    needs_browser: false,
+    needs_rust: false,
+  },
+  build: {
+    suite: 'build',
+    command: 'bun run ./scripts/run-bun-test.ts ./scripts/build',
+    junit_path: 'test-results/build.xml',
+    needs_browser: false,
+    needs_rust: false,
+  },
+  'claw-server-rust': {
+    suite: 'claw-server-rust',
+    command: 'bun run ./scripts/run-cargo-test.ts test --workspace --locked',
+    junit_path: 'test-results/claw-server-rust.xml',
+    needs_browser: false,
+    needs_rust: true,
+  },
+  'claw-server-rust-quality': {
+    suite: 'claw-server-rust-quality',
+    command:
+      'cargo fmt --all -- --check && cargo clippy --workspace --all-targets --locked -- -D warnings',
+    junit_path: 'test-results/claw-server-rust-quality.xml',
+    needs_browser: false,
+    needs_rust: true,
+  },
+  'claw-mcp': {
+    suite: 'claw-mcp',
+    command: 'bun run test:claw-mcp-contract',
+    junit_path: 'test-results/claw-mcp.xml',
+    needs_browser: true,
+    needs_rust: true,
+  },
+}
+
+/** Workspace package name -> the suites that cover it. */
+const PACKAGE_SUITES: Record<string, string[]> = {
+  '@browseros/server': [
+    'server-agent',
+    'server-api',
+    'server-tools',
+    'server-browser',
+    'server-integration',
+    'server-lib',
+    'server-root',
+  ],
+  '@browseros/app': ['agent'],
+  '@browseros/claw-app': ['claw-app'],
+  '@browseros/claw-onboard': ['claw-onboard'],
+  // The build suite exercises scripts/build, which uses build-server-tools, so
+  // an affected build-server-tools (or a scripts/ change, handled below) runs it.
+  '@browseros/build-server-tools': ['build'],
+}
+
+/**
+ * The Rust CI suites run workspace-wide cargo, so any affected Rust crate
+ * triggers all of them.
+ */
+const RUST_SUITES = ['claw-server-rust', 'claw-server-rust-quality', 'claw-mcp']
+
+export interface AffectedPackage {
+  name: string
+  path: string
+}
+
+function isRustPackage(path: string): boolean {
+  return path.startsWith('crates/') || path === 'apps/claw-server-rust'
+}
+
+/**
+ * Pure mapping from affected workspace packages + changed file paths (relative
+ * to `packages/browseros-agent`) to the suite matrix. Over-inclusive by design:
+ * bias toward running a suite when uncertain, never toward skipping one.
+ */
+export function computeAffectedSuites(
+  packages: AffectedPackage[],
+  changedFiles: string[],
+): SuiteConfig[] {
+  const keys = new Set<string>()
+
+  for (const pkg of packages) {
+    for (const suite of PACKAGE_SUITES[pkg.name] ?? []) keys.add(suite)
+    if (isRustPackage(pkg.path)) {
+      for (const suite of RUST_SUITES) keys.add(suite)
+    }
+  }
+
+  // Path signals for things that are not workspace packages.
+  if (changedFiles.some((f) => f.startsWith('scripts/'))) keys.add('build')
+  if (
+    changedFiles.some(
+      (f) =>
+        f.startsWith('contracts/claw-mcp/') ||
+        f.startsWith('contracts/claw-api/'),
+    )
+  ) {
+    keys.add('claw-mcp')
+  }
+
+  return Object.keys(SUITES)
+    .filter((key) => keys.has(key))
+    .map((key) => SUITES[key] as SuiteConfig)
+}
+
+function readAffectedPackages(): AffectedPackage[] {
+  const raw = execFileSync(
+    'bunx',
+    ['turbo', 'ls', '--affected', '--output=json'],
+    { encoding: 'utf8' },
+  )
+  const parsed = JSON.parse(raw) as {
+    packages?: { items?: Array<{ name: string; path: string }> }
+  }
+  return (parsed.packages?.items ?? []).map((item) => ({
+    name: item.name,
+    path: item.path,
+  }))
+}
+
+function readChangedFiles(base: string): string[] {
+  const range = base ? `${base}...HEAD` : 'HEAD'
+  const raw = execFileSync(
+    'git',
+    ['diff', '--name-only', '--relative', range],
+    { encoding: 'utf8' },
+  )
+  return raw.split('\n').filter(Boolean)
+}
+
+function main(): void {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: CI-only base ref passed by the workflow.
+  const base = process.env.BROWSEROS_AFFECTED_BASE ?? ''
+  const packages = readAffectedPackages()
+  const changed = readChangedFiles(base)
+  const suites = computeAffectedSuites(packages, changed)
+  const matrix = { include: suites }
+  const hasAny = suites.length > 0
+
+  const summary = `packages=[${packages.map((p) => p.name).join(', ') || '-'}] suites=[${suites.map((s) => s.suite).join(', ') || '-'}]`
+  console.error(`[affected-suites] ${summary}`)
+
+  const githubOutput = process.env.GITHUB_OUTPUT
+  if (githubOutput) {
+    appendFileSync(githubOutput, `matrix=${JSON.stringify(matrix)}\n`)
+    appendFileSync(githubOutput, `has_any=${hasAny}\n`)
+  }
+  console.log(JSON.stringify(matrix))
+}
+
+if (import.meta.main) main()

--- a/packages/browseros-agent/ci/affected-suites.ts
+++ b/packages/browseros-agent/ci/affected-suites.ts
@@ -222,13 +222,24 @@ function readChangedFiles(base: string): string[] {
 function main(): void {
   // biome-ignore lint/suspicious/noUndeclaredEnvVars: CI-only base ref passed by the workflow.
   const base = process.env.BROWSEROS_AFFECTED_BASE ?? ''
-  const packages = readAffectedPackages()
-  const changed = readChangedFiles(base)
-  const suites = computeAffectedSuites(packages, changed)
+
+  let suites: SuiteConfig[]
+  let summary: string
+  if (base) {
+    const packages = readAffectedPackages()
+    const changed = readChangedFiles(base)
+    suites = computeAffectedSuites(packages, changed)
+    summary = `packages=[${packages.map((p) => p.name).join(', ') || '-'}] suites=[${suites.map((s) => s.suite).join(', ') || '-'}]`
+  } else {
+    // No base ref (e.g. a workflow_dispatch run, which has no PR base): fail
+    // safe to the full matrix so a manual run never reports green with zero
+    // coverage.
+    suites = Object.values(SUITES)
+    summary = `no base ref, running the full matrix (${suites.length} suites)`
+  }
+
   const matrix = { include: suites }
   const hasAny = suites.length > 0
-
-  const summary = `packages=[${packages.map((p) => p.name).join(', ') || '-'}] suites=[${suites.map((s) => s.suite).join(', ') || '-'}]`
   console.error(`[affected-suites] ${summary}`)
 
   const githubOutput = process.env.GITHUB_OUTPUT

--- a/packages/browseros-agent/ci/affected-suites.ts
+++ b/packages/browseros-agent/ci/affected-suites.ts
@@ -246,6 +246,11 @@ function main(): void {
   if (githubOutput) {
     appendFileSync(githubOutput, `matrix=${JSON.stringify(matrix)}\n`)
     appendFileSync(githubOutput, `has_any=${hasAny}\n`)
+    // Full suite universe so the summary comment can mark the non-affected ones.
+    appendFileSync(
+      githubOutput,
+      `all_suites=${JSON.stringify(Object.keys(SUITES))}\n`,
+    )
   }
   console.log(JSON.stringify(matrix))
 }

--- a/packages/browseros-agent/crates/browseros-cdp/package.json
+++ b/packages/browseros-agent/crates/browseros-cdp/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@browseros/browseros-cdp-rust",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "lint:rust": "cargo fmt --package browseros-cdp -- --check && cargo clippy --package browseros-cdp --all-targets --locked -- -D warnings",
+    "test:rust": "cargo test --package browseros-cdp --locked"
+  }
+}

--- a/packages/browseros-agent/crates/browseros-core/package.json
+++ b/packages/browseros-agent/crates/browseros-core/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@browseros/browseros-core-rust",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "lint:rust": "cargo fmt --package browseros-core -- --check && cargo clippy --package browseros-core --all-targets --locked -- -D warnings",
+    "test:rust": "cargo test --package browseros-core --locked"
+  }
+}

--- a/packages/browseros-agent/crates/browseros-mcp/package.json
+++ b/packages/browseros-agent/crates/browseros-mcp/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@browseros/browseros-mcp-rust",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "lint:rust": "cargo fmt --package browseros-mcp -- --check && cargo clippy --package browseros-mcp --all-targets --locked -- -D warnings",
+    "test:rust": "cargo test --package browseros-mcp --locked"
+  }
+}

--- a/packages/browseros-agent/crates/claw-api/package.json
+++ b/packages/browseros-agent/crates/claw-api/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@browseros/claw-api-rust",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "lint:rust": "cargo fmt --package claw-api -- --check && cargo clippy --package claw-api --all-targets --locked -- -D warnings",
+    "test:rust": "cargo test --package claw-api --locked"
+  }
+}

--- a/packages/browseros-agent/crates/harness-integrations/package.json
+++ b/packages/browseros-agent/crates/harness-integrations/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@browseros/harness-integrations-rust",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "lint:rust": "cargo fmt --package harness-integrations -- --check && cargo clippy --package harness-integrations --all-targets --locked -- -D warnings",
+    "test:rust": "cargo test --package harness-integrations --locked"
+  }
+}

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "crates/*"
   ],
   "scripts": {
     "postinstall": "lefthook install || true",
@@ -92,6 +93,7 @@
     "lefthook": "^2.1.10",
     "openapi-typescript": "7.13.0",
     "picocolors": "^1.1.1",
+    "turbo": "^2.9.6",
     "typedoc": "^0.28.20",
     "typescript": "^7.0.2",
     "yaml": "2.9.0"

--- a/packages/browseros-agent/turbo.json
+++ b/packages/browseros-agent/turbo.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "globalDependencies": [
+    "bun.lock",
+    "bunfig.toml",
+    "tsconfig.json",
+    "biome.json",
+    "Cargo.toml",
+    "Cargo.lock",
+    "turbo.json"
+  ],
+  "globalEnv": ["CI"],
+  "globalPassThroughEnv": ["VITE_PUBLIC_BROWSEROS_API", "BROWSEROS_*", "NODE_ENV"],
+  "tasks": {
+    "codegen": {
+      "outputs": ["generated/**", "src/**/*.gen.ts"]
+    },
+    "build": {
+      "dependsOn": ["^build", "codegen"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": ["dist/**", ".output/**", ".wxt/**", "build/**"]
+    },
+    "typecheck": {
+      "dependsOn": ["codegen"],
+      "inputs": ["$TURBO_DEFAULT$", "tsconfig*.json"]
+    },
+    "test": {
+      "dependsOn": ["codegen"],
+      "outputs": ["test-results/**", "coverage/**"]
+    },
+    "lint:rust": {
+      "cache": false
+    },
+    "test:rust": {
+      "cache": false
+    }
+  }
+}

--- a/packages/browseros-agent/turbo.json
+++ b/packages/browseros-agent/turbo.json
@@ -10,7 +10,11 @@
     "turbo.json"
   ],
   "globalEnv": ["CI"],
-  "globalPassThroughEnv": ["VITE_PUBLIC_BROWSEROS_API", "BROWSEROS_*", "NODE_ENV"],
+  "globalPassThroughEnv": [
+    "VITE_PUBLIC_BROWSEROS_API",
+    "BROWSEROS_*",
+    "NODE_ENV"
+  ],
   "tasks": {
     "codegen": {
       "outputs": ["generated/**", "src/**/*.gen.ts"]


### PR DESCRIPTION
## What

Introduces Turborepo as the affected-detection + caching engine for `packages/browseros-agent`, so CI runs only the checks a change actually touches instead of the full 14-suite test matrix and all 5 code-quality jobs on every PR. Unchanged/unaffected packages are skipped (matrix) or served from cache, backed by the GitHub Actions cache.

## Why `--affected` *and* caching (they're complementary)

Turbo's cache makes unchanged work free *when warm*, but caching alone doesn't skip: a cold/evicted cache re-runs everything; and for a 14-job matrix, caching can't remove per-job checkout+install+browser-download+toolchain overhead. The Turbo docs are explicit that `--affected` is the tool for that ("skip lengthy container preparation steps like dependency installation that will end up resulting in a cache hit, anyway"). So `--affected` prunes the *jobs*; caching makes the surviving *work* free.

## How

- **Turbo config** (`turbo.json`): `typecheck`/`test`/`build`/`codegen` tasks with `inputs`, `outputs`, and `globalDependencies` (lockfiles, tsconfig, biome.json, Cargo.*). Adds the `turbo` devDependency and a `.turbo` ignore.
- **Rust made affected-aware** via thin `package.json` wrappers on each Cargo crate + the Rust app, registered as `crates/*` workspace members. Turbo detects them in the package graph; the Rust CI suites stay workspace-wide `cargo` (Turbo decides *whether* to run, `Swatinem/rust-cache` owns the artifacts).
- **Code Quality — Typecheck** now runs `turbo run typecheck --affected` with the GHA cache. Only changed packages (and dependents) typecheck; unchanged ones are cache hits. Biome and Fallow stay whole-repo/always-on.
- **Tests (affected)** — a new workflow that runs **alongside** the existing `test.yml`: a `discover` job maps affected packages → suites (`ci/affected-suites.ts`, pure + unit-tested), and a dynamic matrix runs only those, reusing `test.yml`'s exact per-suite setup (browser AppImage, Rust toolchain, retry-on-flake, JUnit). A `gate` job rolls up pass/skip.
- **Cache warming on `main`** (`turbo-cache-warm.yml`): GHA caches restore only from the same or base/default branch, so PRs inherit `main`'s cache — but neither workflow ran on `main` before. This adds a `push:main` run (incremental `--affected`) plus a weekly full run to backstop 7-day cache eviction.

## Rollout is deliberately safe (probation, not cutover)

There are **no required status checks** in branch protection today (confirmed), so skipping unaffected suites can't block merges. `test.yml` is left **untouched and still gating** while `Tests (affected)` runs beside it, so the always-run matrix and the affected matrix can be compared on real PRs. Once the affected matrix is trusted, retire `test.yml` (and, if CI ever becomes required, require the `gate` job — never the per-suite jobs, per GitHub's "avoid requiring workflows that can be skipped").

## Validated locally

- `turbo ls`/`turbo run` see all 20 packages incl. the 6 Rust wrappers; Rust wrappers are cleanly *skipped* by `turbo run typecheck` (no script → no-op, no error).
- Affected scoping is correct: a claw-app edit → only `@browseros/claw-app`; a Rust crate edit → only that crate; a `@browseros/shared` edit → everything (it's a root devDependency, so it's in Turbo's global hash — over-run, never under-run).
- `turbo run typecheck --affected` runs the real chain end-to-end (graphql codegen → wxt prepare → tsc) for the app and claw-app.
- `ci/affected-suites.ts` unit tests: 13/13 pass. actionlint + biome clean.

## Not in this PR (deferred, infra ready)

Per-suite test-*result* caching (routing suite commands through Turbo with JUnit as a cached output) is intentionally deferred: a mis-declared input/output could serve a stale green, which can't be validated before this runs in real CI. The `turbo.json` `outputs` are already in place to enable it after the probation period proves the affected matrix out.

## Follow-ups

- Benchmark the affected matrix on throwaway branches and record the cold-vs-warm cache + suites-pruned numbers.
- After probation: retire `test.yml`, and expand the cache-warm task set as more tasks become cache-consumed.
