### PR TITLE
ci: run Biome via the repo lint script (fix CI/local version drift)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -24,13 +24,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Biome
-        uses: biomejs/setup-biome@v2
-        with:
-          version: 2.5.0
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
+      # Run Biome through the repo's own lint script (bunx @biomejs/biome) so CI
+      # uses the exact same Biome as local `bun run lint`, instead of a version
+      # pinned separately in a setup action that drifts from package.json.
       - name: Run Biome
-        run: biome ci .
+        run: bun run lint
 
   typecheck:
     name: runner / Typecheck


### PR DESCRIPTION
## What

Run Biome in CI via the repo's own `lint` script (`bunx @biomejs/biome`) instead of `biomejs/setup-biome@v2` with a separately-pinned version.

## Why

The `runner / Biome` job pinned Biome to **2.5.0** in the setup action, while local `bun run lint` uses `bunx @biomejs/biome` (which resolves a different version). That drift means code formatted locally can fail CI (and vice versa) purely over a Biome version difference, with no real issue. Running the same script in both places makes CI and local use an identical Biome.

## Change

`code-quality.yml` `runner / Biome`: replace `Setup Biome (setup-biome@v2, version 2.5.0)` + `biome ci .` with `Setup Bun` + `bun run lint`. Verified `bun run lint` passes clean on `main`, and actionlint is happy.

## Context / follow-ups (out of scope here)

While confirming this I found the Biome version story is messier than one action, worth a separate cleanup:

- `package.json` lists `@biomejs/biome: 2.5.5` as a devDependency, but it is **not installed** in `node_modules` (bunfig `linker = "isolated"`), so `bunx @biomejs/biome` floats to the latest release rather than the pinned version. Making bunx use the pinned version (fixing the install) would let a single `package.json` entry drive both CI and local, instead of floating.
- The `runner / Claw API generated code` job still uses `biomejs/setup-biome@v2` at **2.5.4** (it formats generated code via the codegen script). Aligning it needs a small change to how that script invokes Biome, so it is left for a follow-up.
- `biome.json`'s schema version is pinned to 2.5.0, which emits a harmless "schema version does not match CLI" warning under a floating CLI.

This PR does the targeted fix you asked for (CI uses the repo lint script); the pinning cleanup can follow.
