### PR TITLE
chore: ignore the Turborepo cache repo-wide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 **/releases/
 **/.wrangler/
 **/node_modules/
+**/.turbo/
 
 
 

--- a/packages/browseros-agent/.gitignore
+++ b/packages/browseros-agent/.gitignore
@@ -204,6 +204,3 @@ test-results/
 .agent/
 .llm/
 .grove/
-
-# Turborepo
-.turbo


### PR DESCRIPTION
Turbo resolves its local cache to a `.turbo/` directory at the **git root**, but the ignore rule added with the Turbo CI setup (#2169) went into `packages/browseros-agent/.gitignore` — one level too deep. So after any local `turbo` run, the root `.turbo/` cache showed up as untracked junk.

This adds `**/.turbo/` to the **root** `.gitignore` (matching the repo's existing `**/` convention, so it covers the git root and every package), and removes the now-redundant package-level rule.

Verified `.turbo/cache` is ignored by the new rule. No code or CI behavior changes.