### PR TITLE
chore: ignore non-bun lock files (repo standardizes on bun)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@
 **/node_modules/
 **/.turbo/
 
+# Non-bun lock files (the repo standardizes on bun; only bun.lock is tracked)
+**/package-lock.json
+**/yarn.lock
+**/pnpm-lock.yaml
+
 
 
 nxtscape-cli-access.json


### PR DESCRIPTION
The repo standardizes on bun: only `packages/browseros-agent/bun.lock` is tracked, and `packageManager` is `bun@1.3.6`. Ignore stray `package-lock.json` / `yarn.lock` / `pnpm-lock.yaml` at the root `.gitignore` so an accidental `npm`/`yarn`/`pnpm install` can't commit a conflicting lock file.

Safe by construction: no non-bun lock files are tracked anywhere today, and `.gitignore` never affects already-tracked files, so `bun.lock` is untouched (verified). Docs/config only, no code or CI change.