### PR TITLE
feat(server): sqlite-backed conversation store and routes

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/conversations.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/conversations.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import {
+  type ConversationStore,
+  DbConversationStore,
+} from '../../lib/conversations/conversation-store'
+import type { Env } from '../types'
+import { ConversationIdParamSchema } from '../utils/validation'
+
+type ConversationRouteStore = Pick<ConversationStore, 'list' | 'get' | 'delete'>
+
+export function createConversationRoutes(
+  options: { store?: ConversationRouteStore } = {},
+) {
+  const store = options.store ?? new DbConversationStore()
+
+  return new Hono<Env>()
+    .get('/', async (c) => c.json({ conversations: await store.list() }))
+    .get(
+      '/:conversationId',
+      zValidator('param', ConversationIdParamSchema),
+      async (c) => {
+        const conversation = await store.get(
+          c.req.valid('param').conversationId,
+        )
+        if (!conversation) return c.json({ error: 'Unknown conversation' }, 404)
+        return c.json({ conversation })
+      },
+    )
+    .delete(
+      '/:conversationId',
+      zValidator('param', ConversationIdParamSchema),
+      async (c) => {
+        const deleted = await store.delete(c.req.valid('param').conversationId)
+        if (!deleted) return c.json({ error: 'Unknown conversation' }, 404)
+        return c.json({ success: true })
+      },
+    )
+}

--- a/packages/browseros-agent/apps/server/src/api/routes/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/index.ts
@@ -16,6 +16,7 @@ import { requireTrustedAppOrigin } from '../utils/request-auth'
 import { createAcpxProbeRoutes } from './acpx-probe'
 import { createAgentRoutes } from './agents'
 import { createChatRoutes } from './chat'
+import { createConversationRoutes } from './conversations'
 import { createCreditsRoutes } from './credits'
 import { createHealthRoute } from './health'
 import { createKlavisRoutes } from './klavis'
@@ -115,6 +116,7 @@ export function createApiRoutes(deps: CreateApiRoutesDeps) {
         }),
       )
       .route('/agents', protectedAppRoutes(resolvedAgentRoutes))
+      .route('/conversations', protectedAppRoutes(createConversationRoutes()))
   )
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/conversations/conversation-store.ts
+++ b/packages/browseros-agent/apps/server/src/lib/conversations/conversation-store.ts
@@ -58,11 +58,17 @@ const SUMMARY_COLUMNS = {
 const MAX_SNIPPET_CHARS = 200
 
 export class DbConversationStore implements ConversationStore {
-  private readonly db: BrowserOsDatabase
+  private readonly injectedDb?: BrowserOsDatabase
   private writeQueue: Promise<unknown> = Promise.resolve()
 
   constructor(options: { db?: BrowserOsDatabase } = {}) {
-    this.db = options.db ?? getDb()
+    this.injectedDb = options.db
+  }
+
+  // Resolve the shared handle lazily: routes (and this store) are constructed at
+  // registration time, which can precede initializeDb().
+  private get db(): BrowserOsDatabase {
+    return this.injectedDb ?? getDb()
   }
 
   async list(): Promise<ConversationSummary[]> {

--- a/packages/browseros-agent/apps/server/src/lib/conversations/conversation-store.ts
+++ b/packages/browseros-agent/apps/server/src/lib/conversations/conversation-store.ts
@@ -1,0 +1,214 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { UIMessage } from 'ai'
+import { desc, eq } from 'drizzle-orm'
+import { type BrowserOsDatabase, getDb } from '../db'
+import { type ConversationRow, conversations } from '../db/schema'
+import { logger } from '../logger'
+
+export type ConversationTargetType = 'browseros' | 'claude' | 'codex'
+
+/** Row metadata without the message blob, for cheap history listing. */
+export interface ConversationSummary {
+  id: string
+  lastUserMessage?: string
+  origin?: string
+  targetType: ConversationTargetType
+  agentId?: string
+  lastMessagedAt: number
+  createdAt: number
+  updatedAt: number
+}
+
+export interface ConversationDetail extends ConversationSummary {
+  messages: UIMessage[]
+}
+
+export interface SaveConversationInput {
+  id: string
+  messages: UIMessage[]
+  targetType: ConversationTargetType
+  origin?: string
+  agentId?: string
+}
+
+export interface ConversationStore {
+  list(): Promise<ConversationSummary[]>
+  get(id: string): Promise<ConversationDetail | null>
+  save(input: SaveConversationInput): Promise<ConversationSummary>
+  appendAcpDisplay(input: SaveConversationInput): Promise<ConversationSummary>
+  delete(id: string): Promise<boolean>
+}
+
+const SUMMARY_COLUMNS = {
+  id: conversations.id,
+  lastUserMessage: conversations.lastUserMessage,
+  origin: conversations.origin,
+  targetType: conversations.targetType,
+  agentId: conversations.agentId,
+  lastMessagedAt: conversations.lastMessagedAt,
+  createdAt: conversations.createdAt,
+  updatedAt: conversations.updatedAt,
+} as const
+
+const MAX_SNIPPET_CHARS = 200
+
+export class DbConversationStore implements ConversationStore {
+  private readonly db: BrowserOsDatabase
+  private writeQueue: Promise<unknown> = Promise.resolve()
+
+  constructor(options: { db?: BrowserOsDatabase } = {}) {
+    this.db = options.db ?? getDb()
+  }
+
+  async list(): Promise<ConversationSummary[]> {
+    return this.db
+      .select(SUMMARY_COLUMNS)
+      .from(conversations)
+      .orderBy(desc(conversations.lastMessagedAt))
+      .all()
+      .map(toSummary)
+  }
+
+  async get(id: string): Promise<ConversationDetail | null> {
+    const row =
+      this.db
+        .select()
+        .from(conversations)
+        .where(eq(conversations.id, id))
+        .get() ?? null
+    return row ? toDetail(row) : null
+  }
+
+  async save(input: SaveConversationInput): Promise<ConversationSummary> {
+    return this.withWriteLock(async () => this.upsert(input, input.messages))
+  }
+
+  /**
+   * Display-only copy for ACP conversations: acpx owns real continuity, so the
+   * blob is a merge of prior and incoming messages keyed by id.
+   */
+  async appendAcpDisplay(
+    input: SaveConversationInput,
+  ): Promise<ConversationSummary> {
+    return this.withWriteLock(async () => {
+      const existing = this.db
+        .select({ messages: conversations.messages })
+        .from(conversations)
+        .where(eq(conversations.id, input.id))
+        .get()
+      const merged = mergeById(existing?.messages ?? [], input.messages)
+      return this.upsert(input, merged)
+    })
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.withWriteLock(async () => {
+      const existing = this.db
+        .select({ id: conversations.id })
+        .from(conversations)
+        .where(eq(conversations.id, id))
+        .get()
+      if (!existing) return false
+      this.db.delete(conversations).where(eq(conversations.id, id)).run()
+      logger.info('Conversation deleted', { conversationId: id })
+      return true
+    })
+  }
+
+  private upsert(
+    input: SaveConversationInput,
+    messages: UIMessage[],
+  ): ConversationSummary {
+    const now = Date.now()
+    const existing = this.db
+      .select({ createdAt: conversations.createdAt })
+      .from(conversations)
+      .where(eq(conversations.id, input.id))
+      .get()
+    const row: ConversationRow = {
+      id: input.id,
+      messages,
+      lastUserMessage: extractLastUserText(messages) ?? null,
+      origin: input.origin ?? null,
+      targetType: input.targetType,
+      agentId: input.agentId ?? null,
+      lastMessagedAt: now,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    }
+    this.db
+      .insert(conversations)
+      .values(row)
+      .onConflictDoUpdate({
+        target: conversations.id,
+        set: {
+          messages: row.messages,
+          lastUserMessage: row.lastUserMessage,
+          origin: row.origin,
+          targetType: row.targetType,
+          agentId: row.agentId,
+          lastMessagedAt: row.lastMessagedAt,
+          updatedAt: row.updatedAt,
+        },
+      })
+      .run()
+    return toSummary(row)
+  }
+
+  private withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+    const result = this.writeQueue.then(fn, fn)
+    this.writeQueue = result.then(
+      () => undefined,
+      () => undefined,
+    )
+    return result
+  }
+}
+
+type SummaryFields = Omit<ConversationRow, 'messages'>
+
+function toSummary(row: SummaryFields): ConversationSummary {
+  return {
+    id: row.id,
+    lastUserMessage: row.lastUserMessage ?? undefined,
+    origin: row.origin ?? undefined,
+    targetType: row.targetType,
+    agentId: row.agentId ?? undefined,
+    lastMessagedAt: row.lastMessagedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+function toDetail(row: ConversationRow): ConversationDetail {
+  return { ...toSummary(row), messages: row.messages }
+}
+
+function mergeById(prior: UIMessage[], incoming: UIMessage[]): UIMessage[] {
+  const seen = new Set(prior.map((message) => message.id))
+  const merged = [...prior]
+  for (const message of incoming) {
+    if (seen.has(message.id)) continue
+    merged.push(message)
+    seen.add(message.id)
+  }
+  return merged
+}
+
+function extractLastUserText(messages: UIMessage[]): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    if (message.role !== 'user') continue
+    const text = message.parts
+      .map((part) => (part.type === 'text' ? part.text : ''))
+      .join(' ')
+      .trim()
+    if (text) return text.slice(0, MAX_SNIPPET_CHARS)
+  }
+  return undefined
+}

--- a/packages/browseros-agent/apps/server/src/lib/db/client.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/client.ts
@@ -206,6 +206,11 @@ const currentMigrationHistory = [
     hash: '44a8d4afc62cc58f0f958f633e5262331370d1e1538981b69c1ec2cb807a3154',
     createdAt: 1785900211901,
   },
+  {
+    tag: '0006_add_conversations',
+    hash: 'e9a01f94d41f7718c66039a8483302f6db7c7de946f99987a6dd2e78613bce90',
+    createdAt: 1786538823114,
+  },
 ]
 
 // TODO(nikhil): Remove this fallback once Windows/Linux packaging always includes Drizzle migrations.
@@ -246,6 +251,23 @@ const currentSchemaStatements = [
   `
     CREATE INDEX IF NOT EXISTS oauth_tokens_browseros_id_idx
     ON oauth_tokens (browseros_id)
+  `,
+  `
+    CREATE TABLE IF NOT EXISTS conversations (
+      id text PRIMARY KEY NOT NULL,
+      messages text NOT NULL,
+      last_user_message text,
+      origin text,
+      target_type text NOT NULL,
+      agent_id text,
+      last_messaged_at integer NOT NULL,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    )
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS conversations_last_messaged_at_idx
+    ON conversations (last_messaged_at)
   `,
   `
     CREATE TABLE IF NOT EXISTS __drizzle_migrations (

--- a/packages/browseros-agent/apps/server/src/lib/db/migrations/0006_add_conversations.sql
+++ b/packages/browseros-agent/apps/server/src/lib/db/migrations/0006_add_conversations.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `conversations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`messages` text NOT NULL,
+	`last_user_message` text,
+	`origin` text,
+	`target_type` text NOT NULL,
+	`agent_id` text,
+	`last_messaged_at` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `conversations_last_messaged_at_idx` ON `conversations` (`last_messaged_at`);

--- a/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/0006_snapshot.json
+++ b/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,263 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8e56d542-cbc1-4d18-90d5-89a6259e064d",
+  "prevId": "58ce7d99-5338-4994-bc70-198228767258",
+  "tables": {
+    "acp_agents": {
+      "name": "acp_agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "working_directory": {
+          "name": "working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "acp_agents_updated_at_idx": {
+          "name": "acp_agents_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "acp_agents_type_updated_at_idx": {
+          "name": "acp_agents_type_updated_at_idx",
+          "columns": [
+            "type",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_user_message": {
+          "name": "last_user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_messaged_at": {
+          "name": "last_messaged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversations_last_messaged_at_idx": {
+          "name": "conversations_last_messaged_at_idx",
+          "columns": [
+            "last_messaged_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_tokens": {
+      "name": "oauth_tokens",
+      "columns": {
+        "browseros_id": {
+          "name": "browseros_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_tokens_browseros_id_idx": {
+          "name": "oauth_tokens_browseros_id_idx",
+          "columns": [
+            "browseros_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauth_tokens_browseros_id_provider_pk": {
+          "columns": [
+            "browseros_id",
+            "provider"
+          ],
+          "name": "oauth_tokens_browseros_id_provider_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/_journal.json
+++ b/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785900211901,
       "tag": "0005_yellow_riptide",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1786538823114,
+      "tag": "0006_add_conversations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/browseros-agent/apps/server/src/lib/db/schema/conversations.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/schema/conversations.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { UIMessage } from 'ai'
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+export const conversations = sqliteTable(
+  'conversations',
+  {
+    id: text('id').primaryKey(),
+    messages: text('messages', { mode: 'json' }).$type<UIMessage[]>().notNull(),
+    lastUserMessage: text('last_user_message'),
+    origin: text('origin'),
+    targetType: text('target_type', {
+      enum: ['browseros', 'claude', 'codex'],
+    }).notNull(),
+    agentId: text('agent_id'),
+    lastMessagedAt: integer('last_messaged_at').notNull(),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    index('conversations_last_messaged_at_idx').on(table.lastMessagedAt),
+  ],
+)
+
+export type ConversationRow = InferSelectModel<typeof conversations>
+export type NewConversationRow = InferInsertModel<typeof conversations>

--- a/packages/browseros-agent/apps/server/src/lib/db/schema/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/schema/index.ts
@@ -5,4 +5,5 @@
  */
 
 export * from './agents'
+export * from './conversations'
 export * from './oauth'

--- a/packages/browseros-agent/apps/server/tests/api/routes/conversations.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/conversations.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'bun:test'
+import type { UIMessage } from 'ai'
+import { createConversationRoutes } from '../../../src/api/routes/conversations'
+import type {
+  ConversationDetail,
+  ConversationStore,
+  ConversationSummary,
+} from '../../../src/lib/conversations/conversation-store'
+
+const CONVERSATION_ID = '00000000-0000-4000-8000-000000000001'
+
+describe('conversation routes', () => {
+  it('lists conversation summaries', async () => {
+    const store = new MemoryConversationStore([
+      detail(CONVERSATION_ID, 'latest question'),
+    ])
+    const routes = createConversationRoutes({ store })
+
+    const response = await routes.request('/')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      conversations: [
+        { id: CONVERSATION_ID, lastUserMessage: 'latest question' },
+      ],
+    })
+  })
+
+  it('loads a conversation with its full message blob', async () => {
+    const store = new MemoryConversationStore([detail(CONVERSATION_ID, 'hi')])
+    const routes = createConversationRoutes({ store })
+
+    const response = await routes.request(`/${CONVERSATION_ID}`)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      conversation: { id: CONVERSATION_ID, messages: [{ id: 'u1' }] },
+    })
+  })
+
+  it('returns 404 for an unknown conversation', async () => {
+    const routes = createConversationRoutes({
+      store: new MemoryConversationStore([]),
+    })
+    expect((await routes.request(`/${CONVERSATION_ID}`)).status).toBe(404)
+  })
+
+  it('rejects a non-uuid conversation id', async () => {
+    const routes = createConversationRoutes({
+      store: new MemoryConversationStore([]),
+    })
+    expect((await routes.request('/not-a-uuid')).status).toBe(400)
+  })
+
+  it('deletes a conversation', async () => {
+    const store = new MemoryConversationStore([detail(CONVERSATION_ID, 'hi')])
+    const routes = createConversationRoutes({ store })
+
+    expect(
+      (await routes.request(`/${CONVERSATION_ID}`, { method: 'DELETE' }))
+        .status,
+    ).toBe(200)
+    expect(
+      (await routes.request(`/${CONVERSATION_ID}`, { method: 'DELETE' }))
+        .status,
+    ).toBe(404)
+  })
+})
+
+function detail(id: string, lastUserMessage: string): ConversationDetail {
+  const messages: UIMessage[] = [
+    {
+      id: 'u1',
+      role: 'user',
+      parts: [{ type: 'text', text: lastUserMessage }],
+    },
+  ]
+  return {
+    id,
+    lastUserMessage,
+    targetType: 'browseros',
+    lastMessagedAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    messages,
+  }
+}
+
+class MemoryConversationStore
+  implements Pick<ConversationStore, 'list' | 'get' | 'delete'>
+{
+  private readonly byId = new Map<string, ConversationDetail>()
+
+  constructor(seed: ConversationDetail[]) {
+    for (const conversation of seed)
+      this.byId.set(conversation.id, conversation)
+  }
+
+  async list(): Promise<ConversationSummary[]> {
+    return [...this.byId.values()]
+  }
+
+  async get(id: string): Promise<ConversationDetail | null> {
+    return this.byId.get(id) ?? null
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.byId.delete(id)
+  }
+}

--- a/packages/browseros-agent/apps/server/tests/lib/conversations/conversation-store.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/conversations/conversation-store.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { UIMessage } from 'ai'
+import { DbConversationStore } from '../../../src/lib/conversations/conversation-store'
+import { closeDb, initializeDb } from '../../../src/lib/db'
+
+describe('DbConversationStore', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    closeDb()
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    )
+    tempDirs.length = 0
+  })
+
+  test('round-trips the full message blob through get', async () => {
+    const store = createStore()
+    const messages = [userMessage('u1', 'hello'), assistantMessage('a1', 'hi')]
+    await store.save({ id: CONVERSATION_ID, messages, targetType: 'browseros' })
+
+    const detail = await store.get(CONVERSATION_ID)
+    expect(detail?.messages).toEqual(messages)
+    expect(detail?.targetType).toBe('browseros')
+    expect(await store.get('00000000-0000-4000-8000-0000000000ff')).toBeNull()
+  })
+
+  test('list returns summaries without the message blob, newest first', async () => {
+    const store = createStore()
+    await store.save({
+      id: idFor(1),
+      messages: [userMessage('u1', 'first')],
+      targetType: 'browseros',
+    })
+    await sleep(5)
+    await store.save({
+      id: idFor(2),
+      messages: [userMessage('u2', 'second')],
+      targetType: 'browseros',
+    })
+
+    const summaries = await store.list()
+    expect(summaries.map((s) => s.id)).toEqual([idFor(2), idFor(1)])
+    expect('messages' in summaries[0]).toBe(false)
+    expect(summaries[0].lastUserMessage).toBe('second')
+  })
+
+  test('save upserts messages while preserving createdAt', async () => {
+    const store = createStore()
+    const first = await store.save({
+      id: CONVERSATION_ID,
+      messages: [userMessage('u1', 'one')],
+      targetType: 'browseros',
+    })
+    await sleep(5)
+    const second = await store.save({
+      id: CONVERSATION_ID,
+      messages: [userMessage('u1', 'one'), assistantMessage('a1', 'two')],
+      targetType: 'browseros',
+    })
+
+    expect(second.createdAt).toBe(first.createdAt)
+    expect(second.updatedAt).toBeGreaterThan(first.updatedAt)
+    expect(second.lastMessagedAt).toBeGreaterThan(first.lastMessagedAt)
+    expect((await store.get(CONVERSATION_ID))?.messages).toHaveLength(2)
+  })
+
+  test('lastUserMessage reflects the most recent user turn', async () => {
+    const store = createStore()
+    await store.save({
+      id: CONVERSATION_ID,
+      messages: [
+        userMessage('u1', 'q1'),
+        assistantMessage('a1', 'ans1'),
+        userMessage('u2', 'q2'),
+        assistantMessage('a2', 'ans2'),
+      ],
+      targetType: 'browseros',
+    })
+
+    const summaries = await store.list()
+    expect(summaries[0].lastUserMessage).toBe('q2')
+  })
+
+  test('appendAcpDisplay merges new messages and skips duplicate ids', async () => {
+    const store = createStore()
+    await store.appendAcpDisplay({
+      id: CONVERSATION_ID,
+      messages: [userMessage('u1', 'run this'), assistantMessage('a1', 'ok')],
+      targetType: 'claude',
+      agentId: 'agent-1',
+    })
+    await store.appendAcpDisplay({
+      id: CONVERSATION_ID,
+      messages: [assistantMessage('a1', 'ok'), userMessage('u2', 'next')],
+      targetType: 'claude',
+      agentId: 'agent-1',
+    })
+
+    const detail = await store.get(CONVERSATION_ID)
+    expect(detail?.messages.map((m) => m.id)).toEqual(['u1', 'a1', 'u2'])
+    expect(detail?.agentId).toBe('agent-1')
+  })
+
+  test('delete removes the record', async () => {
+    const store = createStore()
+    await store.save({
+      id: CONVERSATION_ID,
+      messages: [userMessage('u1', 'hello')],
+      targetType: 'browseros',
+    })
+
+    expect(await store.delete(CONVERSATION_ID)).toBe(true)
+    expect(await store.delete(CONVERSATION_ID)).toBe(false)
+    expect(await store.get(CONVERSATION_ID)).toBeNull()
+  })
+
+  test('history survives closing and reopening the database', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'browseros-conversations-durable-'))
+    tempDirs.push(dir)
+    const dbPath = join(dir, 'db', 'browseros.sqlite')
+    const messages = [userMessage('u1', 'persist me')]
+
+    const first = initializeDb({ dbPath })
+    await new DbConversationStore({ db: first.db }).save({
+      id: CONVERSATION_ID,
+      messages,
+      targetType: 'browseros',
+    })
+    closeDb()
+
+    const reopened = initializeDb({ dbPath })
+    const detail = await new DbConversationStore({ db: reopened.db }).get(
+      CONVERSATION_ID,
+    )
+    expect(detail?.messages).toEqual(messages)
+  })
+
+  function createStore(): DbConversationStore {
+    const dir = mkdtempSync(join(tmpdir(), 'browseros-conversations-test-'))
+    tempDirs.push(dir)
+    const handle = initializeDb({ dbPath: join(dir, 'db', 'browseros.sqlite') })
+    return new DbConversationStore({ db: handle.db })
+  }
+})
+
+const CONVERSATION_ID = '00000000-0000-4000-8000-000000000001'
+
+function idFor(n: number): string {
+  return `00000000-0000-4000-8000-00000000000${n}`
+}
+
+function userMessage(id: string, text: string): UIMessage {
+  return { id, role: 'user', parts: [{ type: 'text', text }] }
+}
+
+function assistantMessage(id: string, text: string): UIMessage {
+  return { id, role: 'assistant', parts: [{ type: 'text', text }] }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/packages/browseros-agent/apps/server/tests/lib/db/index.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/db/index.test.ts
@@ -241,4 +241,8 @@ const expectedMigrationHistory = [
     hash: '44a8d4afc62cc58f0f958f633e5262331370d1e1538981b69c1ec2cb807a3154',
     createdAt: 1785900211901,
   },
+  {
+    hash: 'e9a01f94d41f7718c66039a8483302f6db7c7de946f99987a6dd2e78613bce90',
+    createdAt: 1786538823114,
+  },
 ]


### PR DESCRIPTION
## What

Adds a server-owned conversation store so message history can live in the local SQLite DB instead of being replayed from the extension on every turn.

- New `conversations` table (drizzle + `bun:sqlite`) storing each thread's messages as a JSON blob, ordered by `last_messaged_at`, plus a display snippet, origin, target type, and optional acp agent id.
- `DbConversationStore` with `list` / `get` / `save` / `appendAcpDisplay` / `delete`, a serialized write queue, and a dedup-by-id merge for the acp display copy.
- A trusted-origin-gated `/conversations` route (`GET` list, `GET /:id` load, `DELETE /:id`), mounted like `/agents`. Extends the typed `AppType` contract with no codegen.
- Named migration `0006_add_conversations`, with the packaged-build schema fallback and migration history kept in sync.

## Scope

Additive only: nothing in the chat flow consumes the store yet. Server statelessness and the extension rewire land in follow-up PRs on this branch.

## Tests

- Store: full-blob round-trip, summary-without-blob listing and ordering, upsert preserving `created_at`, acp dedup merge, delete, and survival across a database close and reopen.
- Route: list, load, 404 on unknown id, non-uuid rejection, delete.
- Existing DB migration-history test updated for the new migration.
