### PR TITLE
feat(server): stateless chat history with a local/cloud historyMode

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -32,6 +32,11 @@ import {
 import type { AcpAgentStore } from '../../lib/agents/storage/acp-agent-store'
 import { DbAcpAgentStore } from '../../lib/agents/storage/acp-agent-store'
 import { resolveLLMConfig } from '../../lib/clients/llm/config'
+import {
+  type ConversationStore,
+  DbConversationStore,
+  type SaveConversationInput,
+} from '../../lib/conversations/conversation-store'
 import { logger } from '../../lib/logger'
 import type { KlavisService } from '../services/klavis'
 import type { ServerActivity } from '../services/server-activity'
@@ -60,6 +65,7 @@ export interface ChatServiceDeps {
   activity?: ServerActivity
   acpAgentStore?: Pick<AcpAgentStore, 'get'>
   acpRuntime?: Pick<AcpAgentRuntime, 'stream' | 'close'>
+  conversationStore?: Pick<ConversationStore, 'get' | 'save'>
 }
 
 export class ChatService {
@@ -67,10 +73,12 @@ export class ChatService {
   private acpRuntime: Pick<AcpAgentRuntime, 'stream' | 'close'> | undefined
   private readonly acpMessages = new Map<string, UIMessage[]>()
   private readonly acpConversationAgents = new Map<string, string>()
+  private conversationStore: Pick<ConversationStore, 'get' | 'save'> | undefined
 
   constructor(private deps: ChatServiceDeps) {
     this.acpAgentStore = deps.acpAgentStore
     this.acpRuntime = deps.acpRuntime
+    this.conversationStore = deps.conversationStore
   }
 
   async processMessage(
@@ -261,19 +269,32 @@ export class ChatService {
       sessionStore.set(request.conversationId, session)
     }
 
-    if (isNewSession && request.previousConversation?.length) {
-      for (const msg of request.previousConversation) {
-        if (!msg.content.trim()) continue
-        session.agent.messages.push({
-          id: crypto.randomUUID(),
-          role: msg.role === 'assistant' ? 'assistant' : 'user',
-          parts: [{ type: 'text', text: msg.content }],
+    if (isNewSession) {
+      if (request.historyMode === 'local') {
+        const stored = await this.getConversationStore().get(
+          request.conversationId,
+        )
+        if (stored?.messages.length) {
+          session.agent.messages = stored.messages
+          logger.info('Hydrated conversation history from database', {
+            conversationId: request.conversationId,
+            messageCount: stored.messages.length,
+          })
+        }
+      } else if (request.previousConversation?.length) {
+        for (const msg of request.previousConversation) {
+          if (!msg.content.trim()) continue
+          session.agent.messages.push({
+            id: crypto.randomUUID(),
+            role: msg.role === 'assistant' ? 'assistant' : 'user',
+            parts: [{ type: 'text', text: msg.content }],
+          })
+        }
+        logger.info('Injected previous conversation history', {
+          conversationId: request.conversationId,
+          messageCount: request.previousConversation.length,
         })
       }
-      logger.info('Injected previous conversation history', {
-        conversationId: request.conversationId,
-        messageCount: request.previousConversation.length,
-      })
     }
 
     const messageContext = request.isScheduledTask
@@ -337,6 +358,15 @@ export class ChatService {
           conversationId: request.conversationId,
           totalMessages: session.agent.messages.length,
         })
+
+        if (request.historyMode === 'local') {
+          await this.persistConversation({
+            id: request.conversationId,
+            messages: session.agent.messages,
+            targetType: 'browseros',
+            origin: request.origin,
+          })
+        }
 
         if (session.scheduledPageId) {
           const pageId = session.scheduledPageId
@@ -409,11 +439,7 @@ export class ChatService {
     const historyKey = `${agent.id}:${request.conversationId}`
     const history: UIMessage[] =
       this.acpMessages.get(historyKey) ??
-      (request.previousConversation ?? []).map((message) => ({
-        id: crypto.randomUUID(),
-        role: message.role,
-        parts: [{ type: 'text' as const, text: message.content }],
-      }))
+      (await this.loadAcpDisplayHistory(request))
     const priorHistoryLength = history.length
     const messageId = crypto.randomUUID()
     const files = (request.attachments ?? []).map((attachment) => ({
@@ -453,11 +479,18 @@ export class ChatService {
       messages: promptMessages,
       browserContext,
       abortSignal,
-      onFinish: ({ messages }) => {
+      onFinish: async ({ messages }) => {
         const existingIds = new Set(history.map((message) => message.id))
         history.push(
           ...messages.filter((message) => !existingIds.has(message.id)),
         )
+        await this.persistConversation({
+          id: request.conversationId,
+          messages: history,
+          targetType: agent.type,
+          origin: request.origin,
+          agentId: agent.id,
+        })
       },
     }
     let stream: ReadableStream<UIMessageChunk>
@@ -498,6 +531,49 @@ export class ChatService {
       resourcesDir: this.deps.resourcesDir,
     })
     return this.acpRuntime
+  }
+
+  private getConversationStore(): Pick<ConversationStore, 'get' | 'save'> {
+    this.conversationStore ??= new DbConversationStore()
+    return this.conversationStore
+  }
+
+  // Best-effort: a persistence failure must not fail an already-streamed turn.
+  private async persistConversation(
+    input: SaveConversationInput,
+  ): Promise<void> {
+    try {
+      await this.getConversationStore().save(input)
+    } catch (error) {
+      logger.warn('Failed to persist conversation history', {
+        conversationId: input.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  // ACP continuity lives in acpx; SQLite holds a display copy. On a cold turn
+  // (e.g. after a restart) re-seed from that copy before falling back to the
+  // client-supplied history.
+  private async loadAcpDisplayHistory(
+    request: AcpChatRequest,
+  ): Promise<UIMessage[]> {
+    try {
+      const stored = await this.getConversationStore().get(
+        request.conversationId,
+      )
+      if (stored?.messages.length) return stored.messages
+    } catch (error) {
+      logger.warn('Failed to load ACP display history', {
+        conversationId: request.conversationId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+    return (request.previousConversation ?? []).map((message) => ({
+      id: crypto.randomUUID(),
+      role: message.role,
+      parts: [{ type: 'text' as const, text: message.content }],
+    }))
   }
 
   private closeScheduledPage(pageId: number, conversationId: string): void {

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -274,7 +274,9 @@ export class ChatService {
         const stored = await this.getConversationStore().get(
           request.conversationId,
         )
-        if (stored?.messages.length) {
+        // Only reuse a record this target owns; a conversationId shared with an
+        // ACP agent must not bleed its history into the BrowserOS agent.
+        if (stored?.messages.length && stored.targetType === 'browseros') {
           session.agent.messages = stored.messages
           logger.info('Hydrated conversation history from database', {
             conversationId: request.conversationId,
@@ -439,7 +441,7 @@ export class ChatService {
     const historyKey = `${agent.id}:${request.conversationId}`
     const history: UIMessage[] =
       this.acpMessages.get(historyKey) ??
-      (await this.loadAcpDisplayHistory(request))
+      (await this.loadAcpDisplayHistory(agent.id, request))
     const priorHistoryLength = history.length
     const messageId = crypto.randomUUID()
     const files = (request.attachments ?? []).map((attachment) => ({
@@ -556,13 +558,18 @@ export class ChatService {
   // (e.g. after a restart) re-seed from that copy before falling back to the
   // client-supplied history.
   private async loadAcpDisplayHistory(
+    agentId: string,
     request: AcpChatRequest,
   ): Promise<UIMessage[]> {
     try {
       const stored = await this.getConversationStore().get(
         request.conversationId,
       )
-      if (stored?.messages.length) return stored.messages
+      // Only reuse the display copy when it belongs to this agent; the in-memory
+      // key is agent-scoped, so a shared conversationId must not cross agents.
+      if (stored?.messages.length && stored.agentId === agentId) {
+        return stored.messages
+      }
     } catch (error) {
       logger.warn('Failed to load ACP display history', {
         conversationId: request.conversationId,

--- a/packages/browseros-agent/apps/server/src/api/types.ts
+++ b/packages/browseros-agent/apps/server/src/api/types.ts
@@ -62,6 +62,11 @@ const ChatInputSchema = z.object({
     })
     .optional(),
   previousConversation: PreviousConversationSchema,
+  // 'local': the server owns history in SQLite (load + persist). 'cloud': the
+  // client owns history (logged-in cloud sync or incognito); the server stays
+  // stateless and persists nothing. Defaults to 'cloud' so existing clients are
+  // unchanged until they opt into server-owned history.
+  historyMode: z.enum(['local', 'cloud']).optional().default('cloud'),
   attachments: z
     .array(
       z.object({

--- a/packages/browseros-agent/apps/server/src/lib/conversations/conversation-store.ts
+++ b/packages/browseros-agent/apps/server/src/lib/conversations/conversation-store.ts
@@ -40,7 +40,6 @@ export interface ConversationStore {
   list(): Promise<ConversationSummary[]>
   get(id: string): Promise<ConversationDetail | null>
   save(input: SaveConversationInput): Promise<ConversationSummary>
-  appendAcpDisplay(input: SaveConversationInput): Promise<ConversationSummary>
   delete(id: string): Promise<boolean>
 }
 
@@ -92,24 +91,6 @@ export class DbConversationStore implements ConversationStore {
 
   async save(input: SaveConversationInput): Promise<ConversationSummary> {
     return this.withWriteLock(async () => this.upsert(input, input.messages))
-  }
-
-  /**
-   * Display-only copy for ACP conversations: acpx owns real continuity, so the
-   * blob is a merge of prior and incoming messages keyed by id.
-   */
-  async appendAcpDisplay(
-    input: SaveConversationInput,
-  ): Promise<ConversationSummary> {
-    return this.withWriteLock(async () => {
-      const existing = this.db
-        .select({ messages: conversations.messages })
-        .from(conversations)
-        .where(eq(conversations.id, input.id))
-        .get()
-      const merged = mergeById(existing?.messages ?? [], input.messages)
-      return this.upsert(input, merged)
-    })
   }
 
   async delete(id: string): Promise<boolean> {
@@ -193,17 +174,6 @@ function toSummary(row: SummaryFields): ConversationSummary {
 
 function toDetail(row: ConversationRow): ConversationDetail {
   return { ...toSummary(row), messages: row.messages }
-}
-
-function mergeById(prior: UIMessage[], incoming: UIMessage[]): UIMessage[] {
-  const seen = new Set(prior.map((message) => message.id))
-  const merged = [...prior]
-  for (const message of incoming) {
-    if (seen.has(message.id)) continue
-    merged.push(message)
-    seen.add(message.id)
-  }
-  return merged
 }
 
 function extractLastUserText(messages: UIMessage[]): string | undefined {

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service-acp.test.ts
@@ -168,6 +168,42 @@ describe('ChatService ACP dispatch', () => {
     ).toBe(true)
   })
 
+  it('ignores a stored display copy that belongs to a different agent', async () => {
+    const fixture = deps()
+    fixture.conversationStore.get.mockImplementation(async () => ({
+      id: 'shared',
+      messages: [
+        {
+          id: 'foreign',
+          role: 'user',
+          parts: [{ type: 'text', text: 'other agent secret' }],
+        },
+      ],
+      targetType: 'claude',
+      agentId: 'a-different-agent',
+      lastMessagedAt: 1,
+      createdAt: 1,
+      updatedAt: 1,
+    }))
+
+    await fixture.service.processMessage(
+      {
+        target: { type: 'claude', agentId: AGENT_ID },
+        conversationId: crypto.randomUUID(),
+        message: 'my message',
+        isScheduledTask: false,
+        mode: 'agent',
+        origin: 'sidepanel',
+      },
+      new AbortController().signal,
+    )
+
+    // The foreign history must not reach the runtime; only the current turn.
+    const sent = fixture.calls[0]?.messages ?? []
+    expect(sent).toHaveLength(1)
+    expect(JSON.stringify(sent)).not.toContain('other agent secret')
+  })
+
   it('rejects a target whose stored agent has a different adapter type', async () => {
     const fixture = deps({ agent: acpAgent('codex') })
     const response = await fixture.service.processMessage(

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service-acp.test.ts
@@ -66,6 +66,16 @@ function deps(
     },
     close,
   }
+  const conversationStore = {
+    get: mock(async () => null),
+    save: mock(async () => ({
+      id: '',
+      targetType: 'claude' as const,
+      lastMessagedAt: 1,
+      createdAt: 1,
+      updatedAt: 1,
+    })),
+  }
   const service = new ChatService({
     sessionStore: {
       get: () => undefined,
@@ -85,8 +95,9 @@ function deps(
       ),
     },
     acpRuntime: acpRuntime as never,
+    conversationStore: conversationStore as never,
   })
-  return { calls, close, service }
+  return { calls, close, service, conversationStore }
 }
 
 describe('ChatService ACP dispatch', () => {
@@ -121,6 +132,40 @@ describe('ChatService ACP dispatch', () => {
       type: 'text',
       text: '<USER_QUERY>\ninspect the page\n</USER_QUERY>',
     })
+  })
+
+  it('persists an ACP display copy on finish', async () => {
+    const fixture = deps()
+    const conversationId = crypto.randomUUID()
+    await fixture.service.processMessage(
+      {
+        target: { type: 'claude', agentId: AGENT_ID },
+        conversationId,
+        message: 'inspect the page',
+        isScheduledTask: false,
+        mode: 'agent',
+        origin: 'sidepanel',
+      },
+      new AbortController().signal,
+    )
+
+    expect(fixture.conversationStore.save).toHaveBeenCalledTimes(1)
+    const saved = fixture.conversationStore.save.mock.calls.at(-1)?.[0] as
+      | {
+          id: string
+          targetType: string
+          agentId?: string
+          messages: unknown[]
+        }
+      | undefined
+    expect(saved?.id).toBe(conversationId)
+    expect(saved?.targetType).toBe('claude')
+    expect(saved?.agentId).toBe(AGENT_ID)
+    expect(
+      (saved?.messages as Array<{ role: string }> | undefined)?.some(
+        (message) => message.role === 'assistant',
+      ),
+    ).toBe(true)
   })
 
   it('rejects a target whose stored agent has a different adapter type', async () => {

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -1050,4 +1050,52 @@ describe('ChatService history persistence', () => {
       true,
     )
   })
+
+  it('ignores a stored record whose target is not browseros in local mode', async () => {
+    const agent = createFakeAgent()
+    agentToReturn = agent
+    streamResponseHandler = async ({ onFinish }) => {
+      await onFinish({ messages: agent.messages })
+      return new Response('ok')
+    }
+    const conversationStore = {
+      get: mock(async () => ({
+        id: 'stored',
+        messages: [
+          {
+            id: 'foreign',
+            role: 'user',
+            parts: [{ type: 'text', text: 'acp history' }],
+          },
+        ],
+        targetType: 'claude',
+        agentId: 'some-agent',
+        lastMessagedAt: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      })),
+      save: mock(async () => ({
+        id: 'stored',
+        targetType: 'browseros',
+        lastMessagedAt: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      })),
+    }
+    const service = new ChatService({
+      sessionStore: createSessionStore() as never,
+      klavis: createKlavisStub() as never,
+      browser: persistenceBrowser() as never,
+      conversationStore: conversationStore as never,
+    })
+
+    await service.processMessage(
+      browserOsRequest(crypto.randomUUID(), 'local'),
+      new AbortController().signal,
+    )
+
+    expect(
+      agent.messages.every((m) => m.parts[0]?.text !== 'acp history'),
+    ).toBe(true)
+  })
 })

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -924,3 +924,130 @@ describe('ChatService single-rebuild reconciliation', () => {
     )
   })
 })
+
+describe('ChatService history persistence', () => {
+  beforeEach(() => {
+    resolveLLMConfigSpy.mockImplementation(async () => ({
+      provider: 'openai',
+      model: 'gpt-5',
+      apiKey: 'test-key',
+    }))
+  })
+
+  function persistenceBrowser() {
+    return {
+      resolveTabIds: mock(async () => new Map<number, number>()),
+      closePage: mock(async () => {}),
+    }
+  }
+
+  function browserOsRequest(
+    conversationId: string,
+    historyMode: 'local' | 'cloud',
+  ) {
+    return {
+      target: BROWSEROS_TARGET,
+      conversationId,
+      message: 'hello',
+      isScheduledTask: false,
+      mode: 'agent',
+      origin: 'sidepanel',
+      historyMode,
+      browserContext: {
+        activeTab: { id: 3, url: 'https://example.com', title: 'Example' },
+      },
+    } as never
+  }
+
+  it('hydrates from and persists to the store in local mode', async () => {
+    const agent = createFakeAgent()
+    agentToReturn = agent
+    streamResponseHandler = async ({ onFinish }) => {
+      await onFinish({ messages: agent.messages })
+      return new Response('ok')
+    }
+    const conversationStore = {
+      get: mock(async () => ({
+        id: 'stored',
+        messages: [
+          {
+            id: 'old',
+            role: 'user',
+            parts: [{ type: 'text', text: 'earlier' }],
+          },
+        ],
+        targetType: 'browseros',
+        lastMessagedAt: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      })),
+      save: mock(async () => ({
+        id: 'stored',
+        targetType: 'browseros',
+        lastMessagedAt: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      })),
+    }
+    const service = new ChatService({
+      sessionStore: createSessionStore() as never,
+      klavis: createKlavisStub() as never,
+      browser: persistenceBrowser() as never,
+      conversationStore: conversationStore as never,
+    })
+    const conversationId = crypto.randomUUID()
+
+    await service.processMessage(
+      browserOsRequest(conversationId, 'local'),
+      new AbortController().signal,
+    )
+
+    expect(conversationStore.get).toHaveBeenCalledWith(conversationId)
+    expect(agent.messages[0]?.parts[0]?.text).toBe('earlier')
+    expect(conversationStore.save).toHaveBeenCalledTimes(1)
+    const saved = conversationStore.save.mock.calls.at(-1)?.[0] as
+      | { id: string; targetType: string }
+      | undefined
+    expect(saved?.id).toBe(conversationId)
+    expect(saved?.targetType).toBe('browseros')
+  })
+
+  it('never touches the store and seeds from previousConversation in cloud mode', async () => {
+    const agent = createFakeAgent()
+    agentToReturn = agent
+    streamResponseHandler = async ({ onFinish }) => {
+      await onFinish({ messages: agent.messages })
+      return new Response('ok')
+    }
+    const conversationStore = {
+      get: mock(async () => null),
+      save: mock(async () => ({
+        id: 'stored',
+        targetType: 'browseros',
+        lastMessagedAt: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      })),
+    }
+    const service = new ChatService({
+      sessionStore: createSessionStore() as never,
+      klavis: createKlavisStub() as never,
+      browser: persistenceBrowser() as never,
+      conversationStore: conversationStore as never,
+    })
+
+    await service.processMessage(
+      {
+        ...browserOsRequest(crypto.randomUUID(), 'cloud'),
+        previousConversation: [{ role: 'user', content: 'from client' }],
+      } as never,
+      new AbortController().signal,
+    )
+
+    expect(conversationStore.get).not.toHaveBeenCalled()
+    expect(conversationStore.save).not.toHaveBeenCalled()
+    expect(agent.messages.some((m) => m.parts[0]?.text === 'from client')).toBe(
+      true,
+    )
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/conversations/conversation-store.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/conversations/conversation-store.test.ts
@@ -86,23 +86,29 @@ describe('DbConversationStore', () => {
     expect(summaries[0].lastUserMessage).toBe('q2')
   })
 
-  test('appendAcpDisplay merges new messages and skips duplicate ids', async () => {
+  test('save persists agent metadata for acp display copies', async () => {
     const store = createStore()
-    await store.appendAcpDisplay({
+    await store.save({
       id: CONVERSATION_ID,
       messages: [userMessage('u1', 'run this'), assistantMessage('a1', 'ok')],
       targetType: 'claude',
       agentId: 'agent-1',
     })
-    await store.appendAcpDisplay({
+    // A later ACP turn overwrites with the full in-memory thread.
+    await store.save({
       id: CONVERSATION_ID,
-      messages: [assistantMessage('a1', 'ok'), userMessage('u2', 'next')],
+      messages: [
+        userMessage('u1', 'run this'),
+        assistantMessage('a1', 'ok'),
+        userMessage('u2', 'next'),
+      ],
       targetType: 'claude',
       agentId: 'agent-1',
     })
 
     const detail = await store.get(CONVERSATION_ID)
     expect(detail?.messages.map((m) => m.id)).toEqual(['u1', 'a1', 'u2'])
+    expect(detail?.targetType).toBe('claude')
     expect(detail?.agentId).toBe('agent-1')
   })
 


### PR DESCRIPTION
## What

Wires the conversation store into the chat flow and makes the agent server stateless with respect to message history, behind a per-request `historyMode`.

- **`historyMode: 'local' | 'cloud'`** (default `cloud`) added to the chat request. `cloud` is the current behavior unchanged: the client supplies `previousConversation` and the server persists nothing. `local` is server-owned: on a cold session the BrowserOS agent path hydrates history from SQLite (not the request), and persists the full thread on finish.
- **ACP** always persists a display-only copy of the thread to SQLite and re-seeds from it on a cold turn (e.g. after a restart), while acpx keeps owning real continuity. This fixes ACP history previously living only in process memory.
- Persistence is **best-effort**: a database write failure logs a warning and never fails an already-streamed turn.
- Removes the now-redundant `appendAcpDisplay` store method. Both paths hold the full thread in memory, so the durable write is always a full-array `save`.

## Rollout safety

Default `cloud` means existing clients are unchanged until they opt into server-owned history (a later PR on this branch). The only immediately-active new behavior is the ACP display copy, which is additive and not yet read by any UI.

## Tests

- BrowserOS: hydrates from and persists to the store in `local` mode; never touches the store and seeds from `previousConversation` in `cloud` mode.
- ACP: persists a display copy on finish (agent id + target type + assistant message present).
- Store: `save` covers the ACP-metadata case (agent id, non-browseros target, full-thread overwrite).
- All existing chat-service, ACP, route, and DB tests remain green.
