### PR TITLE
feat(app): serve logged-out conversation history from the local server

### DIFF
--- a/packages/browseros-agent/apps/app/lib/messaging/server/buildChatRequestBody.ts
+++ b/packages/browseros-agent/apps/app/lib/messaging/server/buildChatRequestBody.ts
@@ -35,6 +35,7 @@ export interface ChatRequestBodyParams {
   userWorkingDir?: string
   supportsImages?: boolean
   previousConversation?: ChatHistoryEntry[] | string
+  historyMode?: 'local' | 'cloud'
   declinedApps?: string[]
   selectedText?: string
   selectedTextSource?: {
@@ -54,6 +55,7 @@ export const buildChatRequestBody = ({
   userWorkingDir,
   supportsImages,
   previousConversation,
+  historyMode,
   declinedApps,
   selectedText,
   selectedTextSource,
@@ -84,6 +86,7 @@ export const buildChatRequestBody = ({
   userWorkingDir,
   supportsImages: supportsImages ?? provider.supportsImages,
   previousConversation,
+  historyMode,
   declinedApps: declinedApps?.length ? declinedApps : undefined,
   selectedText,
   selectedTextSource,

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session-restore.test.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session-restore.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, mock } from 'bun:test'
+import { restoreServerConversation } from './chat-session-restore'
+
+describe('restoreServerConversation', () => {
+  it('applies the restored conversation and settles', async () => {
+    const onRestore = mock(() => {})
+    const onError = mock(() => {})
+    const onSettled = mock(() => {})
+
+    await restoreServerConversation({
+      conversationId: 'c1',
+      fetchConversation: async () => ({ id: 'c1', messages: [] }),
+      isCancelled: () => false,
+      onRestore,
+      onError,
+      onSettled,
+    })
+
+    expect(onRestore).toHaveBeenCalledWith({ id: 'c1', messages: [] })
+    expect(onError).not.toHaveBeenCalled()
+    expect(onSettled).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles without restoring when the conversation is missing', async () => {
+    const onRestore = mock(() => {})
+    const onSettled = mock(() => {})
+
+    await restoreServerConversation({
+      conversationId: 'c1',
+      fetchConversation: async () => null,
+      isCancelled: () => false,
+      onRestore,
+      onError: mock(() => {}),
+      onSettled,
+    })
+
+    expect(onRestore).not.toHaveBeenCalled()
+    expect(onSettled).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a stale response when cancelled mid-flight', async () => {
+    const onRestore = mock(() => {})
+    const onError = mock(() => {})
+    const onSettled = mock(() => {})
+
+    await restoreServerConversation({
+      conversationId: 'c1',
+      fetchConversation: async () => ({ id: 'c1', messages: [] }),
+      isCancelled: () => true,
+      onRestore,
+      onError,
+      onSettled,
+    })
+
+    expect(onRestore).not.toHaveBeenCalled()
+    expect(onError).not.toHaveBeenCalled()
+    expect(onSettled).not.toHaveBeenCalled()
+  })
+
+  it('reports the error but still settles on failure', async () => {
+    const onError = mock(() => {})
+    const onSettled = mock(() => {})
+    const failure = new Error('network down')
+
+    await restoreServerConversation({
+      conversationId: 'c1',
+      fetchConversation: async () => {
+        throw failure
+      },
+      isCancelled: () => false,
+      onRestore: mock(() => {}),
+      onError,
+      onSettled,
+    })
+
+    expect(onError).toHaveBeenCalledWith(failure)
+    expect(onSettled).toHaveBeenCalledTimes(1)
+  })
+
+  it('neither reports nor settles when cancelled during a failure', async () => {
+    const onError = mock(() => {})
+    const onSettled = mock(() => {})
+
+    await restoreServerConversation({
+      conversationId: 'c1',
+      fetchConversation: async () => {
+        throw new Error('boom')
+      },
+      isCancelled: () => true,
+      onRestore: mock(() => {}),
+      onError,
+      onSettled,
+    })
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onSettled).not.toHaveBeenCalled()
+  })
+})

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session-restore.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session-restore.ts
@@ -1,0 +1,44 @@
+import type { UIMessage } from 'ai'
+
+export interface RestoredServerConversation {
+  id: string
+  messages: UIMessage[]
+}
+
+interface RestoreServerConversationOptions {
+  conversationId: string
+  fetchConversation: (
+    conversationId: string,
+  ) => Promise<RestoredServerConversation | null>
+  isCancelled: () => boolean
+  onRestore: (conversation: RestoredServerConversation) => void
+  onError: (error: unknown) => void
+  onSettled: () => void
+}
+
+/**
+ * Restore a logged-out conversation from the local server. Unlike the old
+ * extension-storage read this hits the network, so it guards two failure modes:
+ * a conversation switch mid-flight must not apply a stale response
+ * (`isCancelled`), and any failure must still settle the UI (`finally`) so it
+ * never strands in the restoring state with the query param unresolved.
+ */
+export async function restoreServerConversation({
+  conversationId,
+  fetchConversation,
+  isCancelled,
+  onRestore,
+  onError,
+  onSettled,
+}: RestoreServerConversationOptions): Promise<void> {
+  try {
+    const conversation = await fetchConversation(conversationId)
+    if (isCancelled()) return
+    if (conversation) onRestore(conversation)
+  } catch (error) {
+    if (isCancelled()) return
+    onError(error)
+  } finally {
+    if (!isCancelled()) onSettled()
+  }
+}

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -831,6 +831,10 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     setLiked({})
     setDisliked({})
     setRestoredConversationId(null)
+    // Clearing the restore param also cancels any in-flight logged-out restore
+    // (via the restore effect's cleanup), so a stale response can't revive the
+    // old conversation over this new blank session.
+    setSearchParams({}, { replace: true })
     resetRemoteConversation()
   }
 

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -24,10 +24,8 @@ import {
   bufferActiveConversation,
   flushActiveConversationBuffer,
 } from '@/lib/conversations/active-conversation-buffer'
-import { conversationStorage } from '@/lib/conversations/conversationStorage'
 import { formatConversationHistory } from '@/lib/conversations/formatConversationHistory'
 import { uploadConversations } from '@/lib/conversations/uploadConversationsToGraphql'
-import { useConversations } from '@/lib/conversations/useConversations'
 import { declinedAppsStorage } from '@/lib/declined-apps/storage'
 import { resolveChatProvider } from '@/lib/llm-providers/provider-runtime'
 import { createDefaultBrowserOSProvider } from '@/lib/llm-providers/storage'
@@ -40,6 +38,7 @@ import { stopAgentStorage } from '@/lib/stop-agent/stop-agent-storage'
 import { selectedWorkspaceStorage } from '@/lib/workspace/workspace-storage'
 import { resolveAgentServerUrlWithRetry } from '@/modules/browseros/agent-server-url.helpers'
 import { useAgentServerUrl } from '@/modules/browseros/agent-server-url.hooks'
+import { fetchServerConversation } from '@/modules/conversations/conversations.hooks'
 import { useInvalidateCredits } from '@/modules/credits/credits.hooks'
 import { useGraphqlQuery } from '@/modules/graphql/graphql-query.hooks'
 import { useChatRefs } from './chat-refs.hooks'
@@ -212,7 +211,6 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     error: agentUrlError,
   } = useAgentServerUrl()
 
-  const { saveConversation: saveLocalConversation } = useConversations()
   const {
     isLoggedIn,
     userId,
@@ -222,6 +220,14 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   } = useRemoteConversationSave()
   const [searchParams, setSearchParams] = useSearchParams()
   const conversationIdParam = searchParams.get('conversationId')
+
+  // 'local': the local server owns history (persisted during /chat, loaded from
+  // SQLite); 'cloud': the client owns it (logged-in cloud sync, or incognito).
+  // Read via a ref because the transport closure below is created only once.
+  const historyModeRef = useRef<'local' | 'cloud'>('cloud')
+  useEffect(() => {
+    historyModeRef.current = !isLoggedIn && persistHistory ? 'local' : 'cloud'
+  }, [isLoggedIn, persistHistory])
 
   const agentUrlRef = useRef(agentServerUrl)
 
@@ -375,9 +381,12 @@ export const useChatSession = (options?: ChatSessionOptions) => {
         })
 
         const declinedApps = await declinedAppsStorage.getValue()
+        const historyMode = historyModeRef.current
         const previousMessages = messagesRef.current
+        // In local mode the server owns history and loads it from SQLite, so
+        // the client stops replaying it. Cloud mode still ships the projection.
         const history =
-          previousMessages.length > 0
+          historyMode === 'cloud' && previousMessages.length > 0
             ? formatConversationHistory(previousMessages)
             : undefined
         const previousConversation = history?.length ? history : undefined
@@ -393,6 +402,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
           userSystemPrompt,
           userWorkingDir: workingDirRef.current,
           previousConversation,
+          historyMode,
           declinedApps,
           attachments: getLastUserMessageFiles(messages).map((file) => ({
             mediaType: file.mediaType,
@@ -516,12 +526,8 @@ export const useChatSession = (options?: ChatSessionOptions) => {
       setRestoredConversationId(conversationIdParam)
       setSearchParams({}, { replace: true })
     } else {
-      const restoreLocal = async () => {
-        const conversations = await conversationStorage.getValue()
-        const conversation = conversations?.find(
-          (c) => c.id === conversationIdParam,
-        )
-
+      const restoreFromServer = async () => {
+        const conversation = await fetchServerConversation(conversationIdParam)
         if (conversation) {
           setConversationId(
             conversation.id as ReturnType<typeof crypto.randomUUID>,
@@ -531,7 +537,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
         setRestoredConversationId(conversationIdParam)
         setSearchParams({}, { replace: true })
       }
-      restoreLocal()
+      restoreFromServer()
     }
   }, [conversationIdParam, remoteConversationData, isLoggedIn])
 
@@ -610,23 +616,21 @@ export const useChatSession = (options?: ChatSessionOptions) => {
 
     // Skip all history writes in incognito so the chat never becomes durable
     // (neither local nor cloud) and can't surface in a normal window (#1189).
-    if (persistHistory) {
-      if (isLoggedIn) {
-        // Buffer the settled turn durably before the fire-and-forget cloud
-        // write, so an interrupted navigation still lets the next mount sync it
-        // (#559).
-        if (userId) {
-          void bufferActiveConversation({
-            id: conversationIdRef.current,
-            messages: messagesToSave,
-            lastMessagedAt: Date.now(),
-            userId,
-          })
-        }
-        saveRemoteConversation(conversationIdRef.current, messagesToSave)
-      } else {
-        saveLocalConversation(conversationIdRef.current, messagesToSave)
+    // Logged-out history is owned by the local server (persisted during /chat
+    // in local mode), so only the cloud lane writes from the client now.
+    if (persistHistory && isLoggedIn) {
+      // Buffer the settled turn durably before the fire-and-forget cloud
+      // write, so an interrupted navigation still lets the next mount sync it
+      // (#559).
+      if (userId) {
+        void bufferActiveConversation({
+          id: conversationIdRef.current,
+          messages: messagesToSave,
+          lastMessagedAt: Date.now(),
+          userId,
+        })
       }
+      saveRemoteConversation(conversationIdRef.current, messagesToSave)
     }
 
     invalidateCredits()

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -52,6 +52,7 @@ import {
   prepareSidepanelSendMessagesRequest,
   toProviderOption,
 } from './chat-session-request'
+import { restoreServerConversation } from './chat-session-restore'
 import type { ChatMode } from './chat-types'
 import { addContentFilterNotice } from './content-filter-notice'
 import { useExecutionHistoryTracker } from './execution-history-tracker.hooks'
@@ -525,19 +526,31 @@ export const useChatSession = (options?: ChatSessionOptions) => {
       }
       setRestoredConversationId(conversationIdParam)
       setSearchParams({}, { replace: true })
-    } else {
-      const restoreFromServer = async () => {
-        const conversation = await fetchServerConversation(conversationIdParam)
-        if (conversation) {
-          setConversationId(
-            conversation.id as ReturnType<typeof crypto.randomUUID>,
-          )
-          setMessages(conversation.messages)
-        }
+      return
+    }
+
+    let cancelled = false
+    void restoreServerConversation({
+      conversationId: conversationIdParam,
+      fetchConversation: fetchServerConversation,
+      isCancelled: () => cancelled,
+      onRestore: (conversation) => {
+        setConversationId(
+          conversation.id as ReturnType<typeof crypto.randomUUID>,
+        )
+        setMessages(conversation.messages)
+      },
+      onError: (error) =>
+        sentry.captureException(error, {
+          extra: { conversationId: conversationIdParam },
+        }),
+      onSettled: () => {
         setRestoredConversationId(conversationIdParam)
         setSearchParams({}, { replace: true })
-      }
-      restoreFromServer()
+      },
+    })
+    return () => {
+      cancelled = true
     }
   }, [conversationIdParam, remoteConversationData, isLoggedIn])
 

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations.hooks.test.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations.hooks.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+mock.module('@/modules/browseros/agent-server-url.helpers', () => ({
+  resolveAgentServerUrlWithRetry: mock(async () => 'http://127.0.0.1:9999'),
+}))
+
+const removeExecutionHistory = mock(async () => {})
+mock.module('@/lib/execution-history/storage', () => ({
+  removeConversationExecutionHistory: removeExecutionHistory,
+}))
+
+const {
+  fetchServerConversations,
+  fetchServerConversation,
+  deleteServerConversation,
+} = await import('./conversations.hooks')
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const originalFetch = globalThis.fetch
+
+describe('server conversations api', () => {
+  beforeEach(() => {
+    removeExecutionHistory.mockClear()
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('lists conversations, defaulting a missing snippet to empty', async () => {
+    const fetchMock = mock((_input: RequestInfo | URL) =>
+      Promise.resolve(
+        jsonResponse({
+          conversations: [
+            { id: 'a', lastMessagedAt: 2, lastUserMessage: 'hi' },
+            { id: 'b', lastMessagedAt: 1 },
+          ],
+        }),
+      ),
+    )
+    globalThis.fetch = fetchMock as never
+
+    expect(await fetchServerConversations()).toEqual([
+      { id: 'a', lastMessagedAt: 2, lastUserMessage: 'hi' },
+      { id: 'b', lastMessagedAt: 1, lastUserMessage: '' },
+    ])
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'http://127.0.0.1:9999/conversations',
+    )
+  })
+
+  it('loads a conversation and returns null on 404', async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({
+        conversation: {
+          id: 'a',
+          messages: [{ id: 'm', role: 'user', parts: [] }],
+        },
+      }),
+    ) as never
+    expect((await fetchServerConversation('a'))?.messages).toHaveLength(1)
+
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ error: 'Unknown conversation' }, 404),
+    ) as never
+    expect(await fetchServerConversation('missing')).toBeNull()
+  })
+
+  it('deletes then clears execution history, tolerating a 404', async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ success: true }),
+    ) as never
+    await deleteServerConversation('a')
+    expect(removeExecutionHistory).toHaveBeenCalledWith('a')
+
+    removeExecutionHistory.mockClear()
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ error: 'Unknown conversation' }, 404),
+    ) as never
+    await deleteServerConversation('missing')
+    expect(removeExecutionHistory).toHaveBeenCalledWith('missing')
+  })
+
+  it('throws when the list request fails', async () => {
+    globalThis.fetch = mock(async () =>
+      jsonResponse({ error: 'boom' }, 500),
+    ) as never
+    await expect(fetchServerConversations()).rejects.toThrow(
+      'Failed to load conversations (500)',
+    )
+  })
+})

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations.hooks.ts
@@ -1,0 +1,92 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { UIMessage } from 'ai'
+import { removeConversationExecutionHistory } from '@/lib/execution-history/storage'
+import { resolveAgentServerUrlWithRetry } from '@/modules/browseros/agent-server-url.helpers'
+import { useAgentServerUrl } from '@/modules/browseros/agent-server-url.hooks'
+
+const SERVER_CONVERSATIONS_QUERY_KEY = 'server-conversations'
+
+export interface ServerConversationSummary {
+  id: string
+  lastMessagedAt: number
+  lastUserMessage: string
+}
+
+interface ConversationListResponse {
+  conversations: Array<{
+    id: string
+    lastMessagedAt: number
+    lastUserMessage?: string
+  }>
+}
+
+interface ConversationDetailResponse {
+  conversation: { id: string; messages: UIMessage[] }
+}
+
+async function conversationsUrl(path: string): Promise<string> {
+  const baseUrl = await resolveAgentServerUrlWithRetry()
+  return `${baseUrl}/conversations${path}`
+}
+
+export async function fetchServerConversations(): Promise<
+  ServerConversationSummary[]
+> {
+  const response = await fetch(await conversationsUrl(''))
+  if (!response.ok) {
+    throw new Error(`Failed to load conversations (${response.status})`)
+  }
+  const { conversations } = (await response.json()) as ConversationListResponse
+  return conversations.map((conversation) => ({
+    id: conversation.id,
+    lastMessagedAt: conversation.lastMessagedAt,
+    lastUserMessage: conversation.lastUserMessage ?? '',
+  }))
+}
+
+export async function fetchServerConversation(
+  conversationId: string,
+): Promise<{ id: string; messages: UIMessage[] } | null> {
+  const response = await fetch(
+    await conversationsUrl(`/${encodeURIComponent(conversationId)}`),
+  )
+  if (response.status === 404) return null
+  if (!response.ok) {
+    throw new Error(`Failed to load conversation (${response.status})`)
+  }
+  const { conversation } = (await response.json()) as ConversationDetailResponse
+  return { id: conversation.id, messages: conversation.messages }
+}
+
+export async function deleteServerConversation(
+  conversationId: string,
+): Promise<void> {
+  const response = await fetch(
+    await conversationsUrl(`/${encodeURIComponent(conversationId)}`),
+    { method: 'DELETE' },
+  )
+  if (!response.ok && response.status !== 404) {
+    throw new Error(`Failed to delete conversation (${response.status})`)
+  }
+  await removeConversationExecutionHistory(conversationId)
+}
+
+export function useServerConversations(enabled = true) {
+  const { baseUrl, isLoading } = useAgentServerUrl()
+  return useQuery({
+    queryKey: [SERVER_CONVERSATIONS_QUERY_KEY, baseUrl],
+    queryFn: fetchServerConversations,
+    enabled: Boolean(baseUrl) && !isLoading && enabled,
+  })
+}
+
+export function useDeleteServerConversation() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: deleteServerConversation,
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: [SERVER_CONVERSATIONS_QUERY_KEY],
+      }),
+  })
+}

--- a/packages/browseros-agent/apps/app/screens/sidepanel/history/local/LocalChatHistory.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/history/local/LocalChatHistory.tsx
@@ -1,23 +1,26 @@
 import type { FC } from 'react'
 import { useMemo } from 'react'
-import { useConversations } from '@/lib/conversations/useConversations'
 import { useChatSessionContext } from '@/modules/chat/chat-session-context'
+import {
+  useDeleteServerConversation,
+  useServerConversations,
+} from '@/modules/conversations/conversations.hooks'
 import { ConversationList } from '../components/ConversationList'
 import type { HistoryConversation } from '../components/types'
-import { extractLastUserMessage, groupConversations } from '../components/utils'
+import { groupConversations } from '../components/utils'
 
 export const LocalChatHistory: FC = () => {
-  const { conversations: localConversations, removeConversation } =
-    useConversations()
+  const { data: serverConversations = [] } = useServerConversations()
+  const deleteConversation = useDeleteServerConversation()
   const { conversationId: activeConversationId } = useChatSessionContext()
 
   const conversations = useMemo<HistoryConversation[]>(() => {
-    return localConversations.map((conv) => ({
-      id: conv.id,
-      lastMessagedAt: conv.lastMessagedAt,
-      lastUserMessage: extractLastUserMessage(conv.messages),
+    return serverConversations.map((conversation) => ({
+      id: conversation.id,
+      lastMessagedAt: conversation.lastMessagedAt,
+      lastUserMessage: conversation.lastUserMessage,
     }))
-  }, [localConversations])
+  }, [serverConversations])
 
   const groupedConversations = useMemo(
     () => groupConversations(conversations),
@@ -28,7 +31,7 @@ export const LocalChatHistory: FC = () => {
     <ConversationList
       groupedConversations={groupedConversations}
       activeConversationId={activeConversationId}
-      onDelete={removeConversation}
+      onDelete={(id) => deleteConversation.mutate(id)}
     />
   )
 }


### PR DESCRIPTION
## What

Moves the extension's logged-out conversation lane off `local:conversations` (extension storage) and onto the local server's SQLite, activating the server-owned history added earlier on this branch. The logged-in cloud lane is left exactly as it was.

- **`historyMode` on the wire.** Chat requests now carry `historyMode` (`'local' | 'cloud'`): logged-out and not incognito is `'local'`, everything else is `'cloud'`. In `local` mode the client stops replaying `previousConversation` (the server loads history from SQLite); `cloud` mode still ships the current last-10 projection unchanged.
- **Open / list / delete via the server.** Restoring a logged-out conversation, listing history, and deleting a row now call the local server's `/conversations` endpoints. `LocalChatHistory` is backed by a `useServerConversations` query + a `useDeleteServerConversation` mutation.
- **Turn-end write dropped for logged-out.** The client no longer writes logged-out history to extension storage; the server persists it during `/chat`. The cloud lane (GraphQL save + the in-flight active-conversation buffer) is untouched.

## Notes

- Uses untyped `fetch` against the local server, matching the existing agents lane. The typed `hc<AppType>` client cannot resolve routes mounted behind `protectedAppRoutes`: that wrapper's parameter is a bare `Hono<Env>`, which widens the mounted routes and strips their sub-route types (this also affects `/agents` and `/acpx/probe`). Making the wrapper generic to unlock the typed client is a follow-up.
- `previousConversation` is still sent in `cloud` mode by design; the client-side helpers for the WXT lane are retired in the cleanup phase, along with the first-run import and the login-migration re-point.

## Tests

- New unit tests for the server-conversations fetchers: list mapping (missing snippet defaults to empty), load returning null on 404, delete clearing execution history and tolerating a 404, and a failed-list throw.
- Existing chat request-builder and persistence tests remain green with the added `historyMode` field.
- App typecheck clean; Biome clean.
