### PR TITLE
fix: authenticate nightly reservation PRs

### DIFF
--- a/.github/workflows/reserve-nightly-browser-version.yml
+++ b/.github/workflows/reserve-nightly-browser-version.yml
@@ -46,6 +46,7 @@ jobs:
         id: reserve
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
           TRIGGER_SHA: ${{ inputs.trigger_sha }}
         run: |
           set -euo pipefail

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -1296,6 +1296,7 @@ class NightlyWorkflowTest(unittest.TestCase):
             for step in reserve_workflow["jobs"]["reserve"]["steps"]
             if step.get("name") == "Reserve the next version on main"
         )
+        self.assertEqual(reserve_step["env"]["GH_TOKEN"], "${{ github.token }}")
         for token in (
             'git merge-base --is-ancestor "$TRIGGER_SHA" origin/main',
             "bump_version.py --mode offset+build",


### PR DESCRIPTION
## Summary
- expose the job-scoped GitHub token to GitHub CLI in nightly version reservation
- assert the token mapping in the workflow regression suite

## Design
Keep the protected-main reservation PR and retry flow intact. The checkout credential remains responsible for Git pushes; GitHub CLI now receives the same job-scoped token explicitly through GH_TOKEN.

## Test plan
- [x] Regression test failed with missing GH_TOKEN, then passed after the fix
- [x] 1,064 bos_build tests passed (2 skipped)
- [x] Ruff, changed-file formatting, actionlint, shellcheck, product doctor
- [x] BrowserOS and BrowserOS neo nightly plan smoke checks
- [ ] Re-dispatch both live nightlies after merge
