### PR TITLE
fix: reserve component versions from R2

### DIFF
--- a/.github/workflows/release-claw-onboard.yml
+++ b/.github/workflows/release-claw-onboard.yml
@@ -117,6 +117,10 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
           EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           REF_NAME: ${{ github.ref_name }}
           REQUESTED_VERSION: ${{ inputs.version || '' }}
         run: |
@@ -128,6 +132,7 @@ jobs:
             --ref-name "$REF_NAME" \
             --requested-version "$REQUESTED_VERSION" \
             --release-ref HEAD \
+            --r2-allocations \
             --repo "$GITHUB_REPOSITORY" \
             --github-output "$GITHUB_OUTPUT" \
             --github-summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -132,6 +132,10 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
           EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           REF_NAME: ${{ github.ref_name }}
           REQUESTED_VERSION: ${{ inputs.version || '' }}
         run: |
@@ -143,6 +147,7 @@ jobs:
             --ref-name "$REF_NAME" \
             --requested-version "$REQUESTED_VERSION" \
             --release-ref HEAD \
+            --r2-allocations \
             --repo "$GITHUB_REPOSITORY" \
             --github-output "$GITHUB_OUTPUT" \
             --github-summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -205,6 +205,10 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EXTENSION: ${{ inputs.extension }}
           GH_TOKEN: ${{ github.token }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           REQUESTED_VERSION: ${{ inputs.version || '' }}
         run: |
           set -euo pipefail
@@ -216,6 +220,7 @@ jobs:
               --default-branch "$DEFAULT_BRANCH"
               --requested-version "$REQUESTED_VERSION"
               --release-ref HEAD
+              --r2-allocations
               --repo "$GITHUB_REPOSITORY"
               --github-output "$GITHUB_OUTPUT"
               --github-summary "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -135,6 +135,10 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
           EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           REF_NAME: ${{ github.ref_name }}
           REQUESTED_VERSION: ${{ inputs.version || '' }}
         run: |
@@ -146,6 +150,7 @@ jobs:
             --ref-name "$REF_NAME" \
             --requested-version "$REQUESTED_VERSION" \
             --release-ref HEAD \
+            --r2-allocations \
             --repo "$GITHUB_REPOSITORY" \
             --github-output "$GITHUB_OUTPUT" \
             --github-summary "$GITHUB_STEP_SUMMARY"

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -1005,6 +1005,28 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
             1,
         )
 
+    def test_component_resolvers_include_immutable_r2_allocations(self):
+        jobs = (
+            ("release-server.yml", "prepare", "Resolve release"),
+            ("release-claw-server.yml", "prepare", "Resolve release"),
+            ("release-claw-onboard.yml", "prepare", "Resolve release"),
+            ("release-extensions.yml", "prepare", "Resolve extension release"),
+        )
+        for workflow_name, job_name, step_name in jobs:
+            workflow = self.load_workflow(workflow_name)
+            step = self.named_step(workflow, job_name, step_name)
+            with self.subTest(workflow=workflow_name):
+                self.assertIn("--r2-allocations", step["run"])
+                for name in (
+                    "R2_ACCOUNT_ID",
+                    "R2_ACCESS_KEY_ID",
+                    "R2_SECRET_ACCESS_KEY",
+                    "R2_BUCKET",
+                ):
+                    self.assertEqual(
+                        step["env"][name], f"${{{{ secrets.{name} }}}}"
+                    )
+
     def test_feed_snapshot_writers_share_a_retained_queue(self):
         jobs = (
             ("publish-server-ota.yml", "publish"),

--- a/packages/browseros/bos_build/cli/release_component.py
+++ b/packages/browseros/bos_build/cli/release_component.py
@@ -10,7 +10,9 @@ from typing import List, Optional
 import requests
 import typer
 
+from ..lib.env import EnvConfig
 from ..lib.paths import get_package_root
+from ..lib.r2 import get_r2_client
 from ..lib.utils import log_error
 from ..release.component_release import (
     GitComponentReleaseOperations,
@@ -96,6 +98,7 @@ def resolve(
     repo_root: Optional[Path] = typer.Option(None, "--repo-root"),
     remote: str = typer.Option("origin", "--remote"),
     manifest: Optional[List[str]] = typer.Option(None, "--manifest"),
+    r2_allocations: bool = typer.Option(False, "--r2-allocations"),
     github_output: Optional[Path] = typer.Option(None, "--github-output"),
     github_summary: Optional[Path] = typer.Option(None, "--github-summary"),
 ) -> None:
@@ -104,6 +107,16 @@ def resolve(
         repository = repo or os.environ.get("GITHUB_REPOSITORY", "")
         if not repository:
             raise ValueError("--repo or GITHUB_REPOSITORY is required")
+        operation_options = {}
+        if r2_allocations:
+            env = EnvConfig()
+            client = get_r2_client(env)
+            if client is None:
+                raise RuntimeError("R2 client is required for immutable allocations")
+            operation_options = {
+                "r2_client": client,
+                "r2_bucket": env.r2_bucket,
+            }
         record = resolve_standalone_release(
             StandaloneReleaseRequest(
                 component=component,
@@ -113,7 +126,9 @@ def resolve(
                 requested_version=requested_version,
                 release_ref=release_ref,
             ),
-            GitComponentReleaseOperations(_repo_root(repo_root), repository, remote),
+            GitComponentReleaseOperations(
+                _repo_root(repo_root), repository, remote, **operation_options
+            ),
             _manifest_allocations(component, manifest or []),
         )
         values = {

--- a/packages/browseros/bos_build/cli/release_component_test.py
+++ b/packages/browseros/bos_build/cli/release_component_test.py
@@ -73,6 +73,59 @@ class ComponentReleaseCliTest(unittest.TestCase):
             self.assertEqual(values["names"], "server")
             self.assertIn("BrowserOS server release", summary.read_text())
 
+    def test_resolve_can_include_immutable_r2_allocations(self) -> None:
+        record = StandaloneReleaseRecord(
+            component="server",
+            version="0.0.130",
+            tag="agent-server/v0.0.130",
+            release_sha="1" * 40,
+            previous_tag="agent-server/v0.0.128",
+            reservation="create",
+        )
+        env = mock.Mock(r2_bucket="browseros")
+        client = object()
+        with (
+            mock.patch("bos_build.cli.release_component.EnvConfig", return_value=env),
+            mock.patch(
+                "bos_build.cli.release_component.get_r2_client", return_value=client
+            ),
+            mock.patch(
+                "bos_build.cli.release_component.GitComponentReleaseOperations"
+            ) as operations,
+            mock.patch(
+                "bos_build.cli.release_component.resolve_standalone_release",
+                return_value=record,
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "release",
+                    "component",
+                    "resolve",
+                    "--component",
+                    "server",
+                    "--event-name",
+                    "workflow_dispatch",
+                    "--default-branch",
+                    "main",
+                    "--release-ref",
+                    "HEAD",
+                    "--repo",
+                    "browseros-ai/BrowserOS",
+                    "--r2-allocations",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        operations.assert_called_once_with(
+            mock.ANY,
+            "browseros-ai/BrowserOS",
+            "origin",
+            r2_client=client,
+            r2_bucket="browseros",
+        )
+
     def test_manifest_versions_become_public_extension_allocations(self) -> None:
         content = render_update_manifest({"browserclaw": "0.1.9.0"})
         with mock.patch(

--- a/packages/browseros/bos_build/release/component_release.py
+++ b/packages/browseros/bos_build/release/component_release.py
@@ -16,6 +16,7 @@ from .components import (
     resolve_standalone_version,
 )
 from .github import list_github_releases, list_pull_requests
+from .r2_allocations import discover_r2_component_allocations
 
 
 @dataclass(frozen=True)
@@ -79,7 +80,9 @@ class ComponentReleaseOperations(Protocol):
 
     def is_default_branch_ancestor(self, sha: str, default_branch: str) -> bool: ...
 
-    def allocations(self, component: str) -> Sequence[AllocationRecord]: ...
+    def allocations(
+        self, component: str, source_sha: str = ""
+    ) -> Sequence[AllocationRecord]: ...
 
 
 def _version_key(component: str, version: str) -> tuple[int, ...]:
@@ -133,7 +136,10 @@ def resolve_standalone_release(
             f"{operations.remote}/{request.default_branch}"
         )
 
-    allocations = (*operations.allocations(request.component), *additional_allocations)
+    allocations = (
+        *operations.allocations(request.component, release_sha),
+        *additional_allocations,
+    )
     resolved = resolve_standalone_version(
         component_id=request.component,
         committed_version=version,
@@ -193,10 +199,15 @@ class GitComponentReleaseOperations:
         repo_root: Path,
         repo: str,
         remote: str = "origin",
+        *,
+        r2_client=None,
+        r2_bucket: str = "",
     ) -> None:
         self.repo_root = repo_root.resolve()
         self.repo = repo
         self.remote = remote
+        self.r2_client = r2_client
+        self.r2_bucket = r2_bucket
 
     def _git(self, *args: str, check: bool = True) -> str:
         result = subprocess.run(
@@ -270,7 +281,9 @@ class GitComponentReleaseOperations:
         )
         return result.returncode == 0
 
-    def allocations(self, component: str) -> Sequence[AllocationRecord]:
+    def allocations(
+        self, component: str, source_sha: str = ""
+    ) -> Sequence[AllocationRecord]:
         spec = component_by_id(component)
         allocations = []
         prefixes = (spec.tag_prefix, *spec.legacy_tag_prefixes)
@@ -308,7 +321,7 @@ class GitComponentReleaseOperations:
             except ValueError:
                 continue
             tag_identity = self.tag_state(tag)
-            source_sha = (
+            release_source_sha = (
                 tag_identity.target_sha
                 if tag_identity is not None
                 else str(release.get("targetCommitish", ""))
@@ -318,7 +331,7 @@ class GitComponentReleaseOperations:
                     component=component,
                     version=version,
                     kind="release",
-                    source_sha=source_sha,
+                    source_sha=release_source_sha,
                     reference=tag,
                     reusable=release.get("isDraft") is True,
                     public=release.get("isDraft") is False,
@@ -343,6 +356,16 @@ class GitComponentReleaseOperations:
                     source_sha=record.candidate_sha,
                     candidate_id=record.branch,
                     reference=record.branch,
+                )
+            )
+        if self.r2_client is not None:
+            allocations.extend(
+                discover_r2_component_allocations(
+                    self.r2_client,
+                    self.r2_bucket,
+                    component,
+                    source_sha,
+                    tuple(allocations),
                 )
             )
         return tuple(allocations)

--- a/packages/browseros/bos_build/release/component_release_test.py
+++ b/packages/browseros/bos_build/release/component_release_test.py
@@ -45,7 +45,7 @@ class FakeOperations:
     def is_default_branch_ancestor(self, sha: str, default_branch: str) -> bool:
         return self.ancestor
 
-    def allocations(self, component: str):
+    def allocations(self, component: str, source_sha: str = ""):
         return self.records
 
 
@@ -192,6 +192,65 @@ class StandaloneReleaseTest(unittest.TestCase):
 
 
 class ComponentAllocationDiscoveryTest(unittest.TestCase):
+    def test_r2_retry_uses_requested_source_with_older_release_history(self) -> None:
+        key = "artifacts/server/0.0.130/browseros-server-resources-linux-x64.zip"
+        client = mock.MagicMock()
+        client.list_objects_v2.return_value = {
+            "Contents": [{"Key": key}],
+            "IsTruncated": False,
+        }
+        client.head_object.return_value = {
+            "Metadata": {
+                "component": "artifacts/server",
+                "release-sha": SOURCE_SHA,
+                "sha256": "a" * 64,
+                "target": "linux-x64",
+                "version": "0.0.130",
+            }
+        }
+        releases = [
+            {
+                "tagName": "agent-server/v0.0.130",
+                "isDraft": True,
+                "targetCommitish": SOURCE_SHA,
+            },
+            {
+                "tagName": "agent-server/v0.0.129",
+                "isDraft": False,
+                "targetCommitish": "2" * 40,
+            },
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            operations = GitComponentReleaseOperations(
+                Path(tmp),
+                "browseros-ai/BrowserOS",
+                r2_client=client,
+                r2_bucket="browseros",
+            )
+            with (
+                mock.patch.object(operations, "_git", return_value=""),
+                mock.patch(
+                    "bos_build.release.component_release.subprocess.run",
+                    return_value=subprocess.CompletedProcess(
+                        args=[], returncode=1, stdout="", stderr=""
+                    ),
+                ),
+                mock.patch(
+                    "bos_build.release.component_release.list_pull_requests",
+                    return_value=[],
+                ),
+                mock.patch(
+                    "bos_build.release.component_release.list_github_releases",
+                    return_value=releases,
+                ),
+            ):
+                allocations = operations.allocations("server", SOURCE_SHA)
+
+        resource = next(record for record in allocations if record.kind == "resource")
+        self.assertTrue(resource.reusable)
+        self.assertEqual(resource.source_sha, SOURCE_SHA)
+        client.head_object.assert_called_once_with(Bucket="browseros", Key=key)
+
     def test_open_browser_candidate_is_discovered_as_a_reservation(self) -> None:
         candidate = CandidateRecord(
             product="browseros",

--- a/packages/browseros/bos_build/release/components.py
+++ b/packages/browseros/bos_build/release/components.py
@@ -9,7 +9,7 @@ from typing import Literal, Mapping, Sequence
 
 
 VersionScheme = Literal["semver", "chrome"]
-AllocationKind = Literal["tag", "release", "candidate"]
+AllocationKind = Literal["tag", "release", "candidate", "resource"]
 
 _SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 _CHROME_RE = re.compile(r"^\d+(?:\.\d+){0,3}$")
@@ -281,16 +281,28 @@ def resolve_standalone_version(
             return require_not_older(requested)
         raise ValueError(f"{component_id} version {requested} is already allocated")
 
-    reusable = [
-        record
+    reusable_versions = {
+        normalize_component_version(component_id, record.version)
         for record in records
         if record.reusable and source_sha and record.source_sha == source_sha
-    ]
-    if reusable:
-        return require_not_older(max(
-            (normalize_component_version(component_id, record.version) for record in reusable),
-            key=lambda version: _version_key(component_id, version),
-        ))
+    }
+    for reusable_version in sorted(
+        reusable_versions,
+        key=lambda version: _version_key(component_id, version),
+        reverse=True,
+    ):
+        resources = [
+            record
+            for record in records
+            if record.kind == "resource"
+            and normalize_component_version(component_id, record.version)
+            == reusable_version
+        ]
+        if resources and not all(
+            record.reusable and record.source_sha == source_sha for record in resources
+        ):
+            continue
+        return require_not_older(reusable_version)
 
     committed = normalize_component_version(component_id, committed_version)
     blocked = {

--- a/packages/browseros/bos_build/release/components_test.py
+++ b/packages/browseros/bos_build/release/components_test.py
@@ -164,6 +164,64 @@ class ComponentPlanningTest(unittest.TestCase):
             "0.0.127",
         )
 
+    def test_standalone_does_not_reuse_a_draft_with_conflicting_resources(self) -> None:
+        allocations = (
+            AllocationRecord(
+                component="server",
+                version="0.0.128",
+                kind="release",
+                source_sha="1" * 40,
+                reference="agent-server/v0.0.128",
+                reusable=True,
+            ),
+            AllocationRecord(
+                component="server",
+                version="0.0.128",
+                kind="resource",
+                reference="r2://browseros/artifacts/server/0.0.128",
+            ),
+        )
+
+        self.assertEqual(
+            resolve_standalone_version(
+                component_id="server",
+                committed_version="0.0.127",
+                allocations=allocations,
+                source_sha="1" * 40,
+            ),
+            "0.0.129",
+        )
+
+    def test_standalone_reuses_a_draft_with_matching_resources(self) -> None:
+        allocations = (
+            AllocationRecord(
+                component="server",
+                version="0.0.128",
+                kind="release",
+                source_sha="1" * 40,
+                reference="agent-server/v0.0.128",
+                reusable=True,
+            ),
+            AllocationRecord(
+                component="server",
+                version="0.0.128",
+                kind="resource",
+                source_sha="1" * 40,
+                reference="agent-server/v0.0.128",
+                reusable=True,
+            ),
+        )
+
+        self.assertEqual(
+            resolve_standalone_version(
+                component_id="server",
+                committed_version="0.0.127",
+                allocations=allocations,
+                source_sha="1" * 40,
+            ),
+            "0.0.128",
+        )
+
     def test_standalone_rejects_versions_older_than_public_history(self) -> None:
         allocations = (
             AllocationRecord(

--- a/packages/browseros/bos_build/release/r2_allocations.py
+++ b/packages/browseros/bos_build/release/r2_allocations.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Discover component versions occupied by immutable R2 objects."""
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+from .components import (
+    AllocationRecord,
+    component_by_id,
+    normalize_component_version,
+)
+from .resource_pins import RESOURCE_FAMILIES, ResourceFamily
+
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_RESOURCE_FAMILY_NAMES = {
+    "server": "browseros_server",
+    "claw-server-rust": "browserclaw_server",
+    "claw-onboard": "browserclaw_onboard",
+}
+_EXTENSION_COMPONENTS = frozenset({"agent", "browserclaw"})
+
+
+@dataclass(frozen=True)
+class _R2Object:
+    key: str
+    expected_metadata: Mapping[str, str]
+
+
+def _list_objects(client, bucket: str, prefix: str) -> Iterable[Mapping]:
+    token = ""
+    while True:
+        request = {"Bucket": bucket, "Prefix": prefix}
+        if token:
+            request["ContinuationToken"] = token
+        try:
+            response = client.list_objects_v2(**request)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to list immutable R2 objects at {prefix}: {exc}"
+            ) from exc
+        yield from response.get("Contents", [])
+        if not response.get("IsTruncated"):
+            return
+        token = str(response.get("NextContinuationToken", ""))
+        if not token:
+            raise RuntimeError(
+                f"R2 listing for {prefix} omitted its continuation token"
+            )
+
+
+def _family(component: str) -> ResourceFamily | None:
+    family_name = _RESOURCE_FAMILY_NAMES.get(component)
+    if family_name is None:
+        return None
+    return next(family for family in RESOURCE_FAMILIES if family.name == family_name)
+
+
+def _resource_objects(
+    client,
+    bucket: str,
+    component: str,
+    family: ResourceFamily,
+) -> dict[str, list[_R2Object]]:
+    prefix = f"{family.component}/"
+    targets = {family.filename(target): target for target in family.targets}
+    result: dict[str, list[_R2Object]] = {}
+    for item in _list_objects(client, bucket, prefix):
+        key = str(item.get("Key", ""))
+        relative = key.removeprefix(prefix)
+        parts = relative.split("/")
+        if len(parts) != 2 or parts[0] == "latest":
+            continue
+        raw_version, filename = parts
+        target = targets.get(filename)
+        if target is None:
+            continue
+        try:
+            version = normalize_component_version(component, raw_version)
+        except ValueError:
+            continue
+        result.setdefault(version, []).append(
+            _R2Object(
+                key,
+                {
+                    "component": family.component,
+                    "release-sha": "",
+                    "target": target,
+                    "version": version,
+                },
+            )
+        )
+    return result
+
+
+def _extension_objects(
+    client,
+    bucket: str,
+    component: str,
+) -> dict[str, list[_R2Object]]:
+    prefix = f"extensions/{component}-"
+    result: dict[str, list[_R2Object]] = {}
+    for item in _list_objects(client, bucket, prefix):
+        key = str(item.get("Key", ""))
+        if not key.startswith(prefix) or not key.endswith(".crx"):
+            continue
+        raw_version = key[len(prefix) : -len(".crx")]
+        try:
+            version = normalize_component_version(component, raw_version)
+        except ValueError:
+            continue
+        result.setdefault(version, []).append(
+            _R2Object(
+                key,
+                {
+                    "binding-schema": "browseros-extension-crx-v1",
+                    "extension": component,
+                    "source-sha": "",
+                    "version": version,
+                },
+            )
+        )
+    return result
+
+
+def _objects_by_version(
+    client,
+    bucket: str,
+    component: str,
+) -> dict[str, list[_R2Object]]:
+    family = _family(component)
+    if family is not None:
+        return _resource_objects(client, bucket, component, family)
+    if component in _EXTENSION_COMPONENTS:
+        return _extension_objects(client, bucket, component)
+    raise ValueError(f"Immutable R2 allocations are not defined for {component}")
+
+
+def _matches_source_binding(
+    client,
+    bucket: str,
+    obj: _R2Object,
+    source_sha: str,
+) -> bool:
+    try:
+        response = client.head_object(Bucket=bucket, Key=obj.key)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to inspect immutable R2 object {obj.key}: {exc}"
+        ) from exc
+    raw_metadata = response.get("Metadata", {})
+    if not isinstance(raw_metadata, Mapping):
+        return False
+    metadata = {str(name).lower(): str(value) for name, value in raw_metadata.items()}
+    expected = dict(obj.expected_metadata)
+    source_field = "source-sha" if "source-sha" in expected else "release-sha"
+    expected[source_field] = source_sha
+    return all(
+        metadata.get(name) == value for name, value in expected.items()
+    ) and bool(_SHA256_RE.fullmatch(metadata.get("sha256", "")))
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def discover_r2_component_allocations(
+    client,
+    bucket: str,
+    component: str,
+    source_sha: str,
+    existing_allocations: Sequence[AllocationRecord],
+) -> tuple[AllocationRecord, ...]:
+    """Return one blocking record per occupied immutable component version."""
+    if not bucket:
+        raise ValueError("R2 bucket is required for immutable allocation discovery")
+    objects_by_version = _objects_by_version(client, bucket, component)
+    retry_versions = {
+        normalize_component_version(component, record.version)
+        for record in existing_allocations
+        if record.component == component
+        and record.reusable
+        and source_sha
+        and record.source_sha == source_sha
+    }
+    canonical_prefix = component_by_id(component).tag_prefix
+    records = []
+    for version in sorted(objects_by_version, key=_version_key):
+        objects = objects_by_version[version]
+        reusable = version in retry_versions and all(
+            _matches_source_binding(client, bucket, obj, source_sha) for obj in objects
+        )
+        records.append(
+            AllocationRecord(
+                component=component,
+                version=version,
+                kind="resource",
+                source_sha=source_sha if reusable else "",
+                reference=(
+                    f"{canonical_prefix}{version}"
+                    if reusable
+                    else f"r2://{bucket}/{objects[0].key}"
+                ),
+                reusable=reusable,
+            )
+        )
+    return tuple(records)

--- a/packages/browseros/bos_build/release/r2_allocations_test.py
+++ b/packages/browseros/bos_build/release/r2_allocations_test.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Tests for immutable R2 component allocation discovery."""
+
+import unittest
+
+from bos_build.release.components import AllocationRecord
+from bos_build.release.r2_allocations import discover_r2_component_allocations
+
+
+SOURCE_SHA = "1" * 40
+SHA256 = "a" * 64
+
+
+class FakeR2Client:
+    def __init__(self, pages, metadata):
+        self.pages = pages
+        self.metadata = metadata
+        self.list_calls = []
+        self.head_calls = []
+
+    def list_objects_v2(self, **request):
+        self.list_calls.append(request)
+        token = request.get("ContinuationToken")
+        return self.pages[token]
+
+    def head_object(self, *, Bucket, Key):
+        self.head_calls.append((Bucket, Key))
+        return {"Metadata": self.metadata[Key]}
+
+
+def _draft(component: str, version: str, tag: str) -> AllocationRecord:
+    return AllocationRecord(
+        component=component,
+        version=version,
+        kind="release",
+        source_sha=SOURCE_SHA,
+        reference=tag,
+        reusable=True,
+    )
+
+
+class R2AllocationDiscoveryTest(unittest.TestCase):
+    def test_each_supported_component_lists_only_its_immutable_namespace(self) -> None:
+        cases = {
+            "server": "artifacts/server/",
+            "claw-server-rust": "claw-server-rust/prod-resources/",
+            "claw-onboard": "claw-onboard/prod-resources/",
+            "agent": "extensions/agent-",
+            "browserclaw": "extensions/browserclaw-",
+        }
+        for component, prefix in cases.items():
+            client = FakeR2Client(
+                {None: {"Contents": [], "IsTruncated": False}}, {}
+            )
+            with self.subTest(component=component):
+                allocations = discover_r2_component_allocations(
+                    client, "browseros", component, SOURCE_SHA, ()
+                )
+                self.assertEqual(allocations, ())
+                self.assertEqual(
+                    client.list_calls,
+                    [{"Bucket": "browseros", "Prefix": prefix}],
+                )
+
+    def test_server_objects_block_stale_versions_and_reuse_matching_retries(
+        self,
+    ) -> None:
+        stale_key = "artifacts/server/0.0.129/browseros-server-resources-linux-x64.zip"
+        retry_key = (
+            "artifacts/server/0.0.130/browseros-server-resources-darwin-arm64.zip"
+        )
+        client = FakeR2Client(
+            {
+                None: {
+                    "Contents": [{"Key": stale_key}, {"Key": retry_key}],
+                    "IsTruncated": False,
+                }
+            },
+            {
+                stale_key: {
+                    "component": "legacy/server",
+                    "release-sha": SOURCE_SHA,
+                    "sha256": SHA256,
+                    "target": "linux-x64",
+                    "version": "0.0.129",
+                },
+                retry_key: {
+                    "component": "artifacts/server",
+                    "release-sha": SOURCE_SHA,
+                    "sha256": SHA256,
+                    "target": "darwin-arm64",
+                    "version": "0.0.130",
+                },
+            },
+        )
+
+        allocations = discover_r2_component_allocations(
+            client,
+            "browseros",
+            "server",
+            SOURCE_SHA,
+            (
+                _draft("server", "0.0.129", "agent-server/v0.0.129"),
+                _draft("server", "0.0.130", "agent-server/v0.0.130"),
+            ),
+        )
+
+        self.assertEqual(
+            [record.version for record in allocations], ["0.0.129", "0.0.130"]
+        )
+        self.assertFalse(allocations[0].reusable)
+        self.assertEqual(allocations[0].kind, "resource")
+        self.assertTrue(allocations[1].reusable)
+        self.assertEqual(allocations[1].source_sha, SOURCE_SHA)
+        self.assertEqual(allocations[1].reference, "agent-server/v0.0.130")
+        self.assertEqual(
+            client.head_calls,
+            [("browseros", stale_key), ("browseros", retry_key)],
+        )
+
+    def test_occupied_versions_without_a_matching_draft_do_not_need_heads(self) -> None:
+        key = "artifacts/server/0.0.200/browseros-server-resources-linux-x64.zip"
+        client = FakeR2Client(
+            {None: {"Contents": [{"Key": key}], "IsTruncated": False}},
+            {},
+        )
+
+        allocations = discover_r2_component_allocations(
+            client, "browseros", "server", SOURCE_SHA, ()
+        )
+
+        self.assertEqual(len(allocations), 1)
+        self.assertFalse(allocations[0].reusable)
+        self.assertEqual(client.head_calls, [])
+
+    def test_extension_listing_paginates_and_validates_source_binding(self) -> None:
+        key = "extensions/agent-0.0.42.0.crx"
+        client = FakeR2Client(
+            {
+                None: {
+                    "Contents": [{"Key": key}],
+                    "IsTruncated": True,
+                    "NextContinuationToken": "next",
+                },
+                "next": {
+                    "Contents": [{"Key": "extensions/update-manifest.xml"}],
+                    "IsTruncated": False,
+                },
+            },
+            {
+                key: {
+                    "binding-schema": "browseros-extension-crx-v1",
+                    "extension": "agent",
+                    "source-sha": SOURCE_SHA,
+                    "sha256": SHA256,
+                    "version": "0.0.42.0",
+                }
+            },
+        )
+
+        allocations = discover_r2_component_allocations(
+            client,
+            "browseros",
+            "agent",
+            SOURCE_SHA,
+            (_draft("agent", "0.0.42.0", "ext-agent/v0.0.42.0"),),
+        )
+
+        self.assertEqual(len(allocations), 1)
+        self.assertTrue(allocations[0].reusable)
+        self.assertEqual(
+            client.list_calls,
+            [
+                {"Bucket": "browseros", "Prefix": "extensions/agent-"},
+                {
+                    "Bucket": "browseros",
+                    "Prefix": "extensions/agent-",
+                    "ContinuationToken": "next",
+                },
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- include immutable server ZIP and auto-versioned extension CRX keys in component allocation
- reuse partial releases only when every existing object is bound to the exact source
- pass scoped R2 credentials to server, onboarding, and extension resolvers

## Live failure reproduced

- BrowserOS server `0.0.129`: existing R2 object had a component binding mismatch
- BrowserOS neo server `0.0.29`: existing R2 targets had release-SHA mismatches

## Validation

- 1,073 `bos_build` tests (2 skipped)
- 54 release script tests
- 10 release-secret tests
- 47 vendor upload tests
- Ruff, Pyright, actionlint, product doctor
- BrowserOS and BrowserOS neo nightly plan smokes
- context-free adversarial review (one source-shadowing bug found, regression-added, fixed, clean re-review)