### PR TITLE
fix: scope R2 collision probes

### DIFF
--- a/packages/browseros/bos_build/release/component_release.py
+++ b/packages/browseros/bos_build/release/component_release.py
@@ -16,7 +16,7 @@ from .components import (
     resolve_standalone_version,
 )
 from .github import list_github_releases, list_pull_requests
-from .r2_allocations import discover_r2_component_allocations
+from .r2_allocations import discover_r2_component_allocation
 
 
 @dataclass(frozen=True)
@@ -80,9 +80,11 @@ class ComponentReleaseOperations(Protocol):
 
     def is_default_branch_ancestor(self, sha: str, default_branch: str) -> bool: ...
 
-    def allocations(
-        self, component: str, source_sha: str = ""
-    ) -> Sequence[AllocationRecord]: ...
+    def allocations(self, component: str) -> Sequence[AllocationRecord]: ...
+
+    def resource_allocation(
+        self, component: str, version: str, source_sha: str
+    ) -> AllocationRecord | None: ...
 
 
 def _version_key(component: str, version: str) -> tuple[int, ...]:
@@ -136,17 +138,28 @@ def resolve_standalone_release(
             f"{operations.remote}/{request.default_branch}"
         )
 
-    allocations = (
-        *operations.allocations(request.component, release_sha),
+    allocations = [
+        *operations.allocations(request.component),
         *additional_allocations,
-    )
-    resolved = resolve_standalone_version(
-        component_id=request.component,
-        committed_version=version,
-        allocations=allocations,
-        requested_version=requested,
-        source_sha=release_sha,
-    )
+    ]
+    probed_versions = set()
+    while True:
+        resolved = resolve_standalone_version(
+            component_id=request.component,
+            committed_version=version,
+            allocations=allocations,
+            requested_version=requested,
+            source_sha=release_sha,
+        )
+        if resolved in probed_versions:
+            break
+        probed_versions.add(resolved)
+        resource = operations.resource_allocation(
+            request.component, resolved, release_sha
+        )
+        if resource is None:
+            break
+        allocations.append(resource)
     tag = f"{spec.tag_prefix}{resolved}"
     tag_state = operations.tag_state(tag)
     if tag_state is not None:
@@ -281,9 +294,7 @@ class GitComponentReleaseOperations:
         )
         return result.returncode == 0
 
-    def allocations(
-        self, component: str, source_sha: str = ""
-    ) -> Sequence[AllocationRecord]:
+    def allocations(self, component: str) -> Sequence[AllocationRecord]:
         spec = component_by_id(component)
         allocations = []
         prefixes = (spec.tag_prefix, *spec.legacy_tag_prefixes)
@@ -358,14 +369,17 @@ class GitComponentReleaseOperations:
                     reference=record.branch,
                 )
             )
-        if self.r2_client is not None:
-            allocations.extend(
-                discover_r2_component_allocations(
-                    self.r2_client,
-                    self.r2_bucket,
-                    component,
-                    source_sha,
-                    tuple(allocations),
-                )
-            )
         return tuple(allocations)
+
+    def resource_allocation(
+        self, component: str, version: str, source_sha: str
+    ) -> AllocationRecord | None:
+        if self.r2_client is None:
+            return None
+        return discover_r2_component_allocation(
+            self.r2_client,
+            self.r2_bucket,
+            component,
+            version,
+            source_sha,
+        )

--- a/packages/browseros/bos_build/release/component_release_test.py
+++ b/packages/browseros/bos_build/release/component_release_test.py
@@ -29,6 +29,8 @@ class FakeOperations:
         self.tags = {}
         self.ancestor = True
         self.synced = []
+        self.resource_records = {}
+        self.resource_probes = []
 
     def sync(self, default_branch: str) -> None:
         self.synced.append(default_branch)
@@ -45,8 +47,12 @@ class FakeOperations:
     def is_default_branch_ancestor(self, sha: str, default_branch: str) -> bool:
         return self.ancestor
 
-    def allocations(self, component: str, source_sha: str = ""):
+    def allocations(self, component: str):
         return self.records
+
+    def resource_allocation(self, component: str, version: str, source_sha: str):
+        self.resource_probes.append((component, version, source_sha))
+        return self.resource_records.get(version)
 
 
 def _request(**overrides) -> StandaloneReleaseRequest:
@@ -122,6 +128,98 @@ class StandaloneReleaseTest(unittest.TestCase):
 
         self.assertEqual(record.version, "0.0.128")
         self.assertEqual(record.reservation, "reuse")
+
+    def test_probes_only_resolved_versions_until_one_is_unoccupied(self) -> None:
+        operations = FakeOperations()
+        operations.records = [
+            AllocationRecord(
+                component="server",
+                version="0.0.128",
+                kind="release",
+                source_sha=SOURCE_SHA,
+                reference="agent-server/v0.0.128",
+                reusable=True,
+            )
+        ]
+        operations.resource_records = {
+            "0.0.128": AllocationRecord(
+                component="server",
+                version="0.0.128",
+                kind="resource",
+                reference="r2://browseros/artifacts/server/0.0.128",
+            ),
+            "0.0.129": AllocationRecord(
+                component="server",
+                version="0.0.129",
+                kind="resource",
+                reference="r2://browseros/artifacts/server/0.0.129",
+            ),
+        }
+
+        record = resolve_standalone_release(_request(), operations)
+
+        self.assertEqual(record.version, "0.0.130")
+        self.assertEqual(
+            operations.resource_probes,
+            [
+                ("server", "0.0.128", SOURCE_SHA),
+                ("server", "0.0.129", SOURCE_SHA),
+                ("server", "0.0.130", SOURCE_SHA),
+            ],
+        )
+
+    def test_matching_resource_binding_preserves_source_bound_retry(self) -> None:
+        operations = FakeOperations()
+        operations.records = [
+            AllocationRecord(
+                component="server",
+                version="0.0.128",
+                kind="release",
+                source_sha=SOURCE_SHA,
+                reference="agent-server/v0.0.128",
+                reusable=True,
+            )
+        ]
+        operations.resource_records = {
+            "0.0.128": AllocationRecord(
+                component="server",
+                version="0.0.128",
+                kind="resource",
+                source_sha=SOURCE_SHA,
+                reference="agent-server/v0.0.128",
+                reusable=True,
+            )
+        }
+
+        record = resolve_standalone_release(_request(), operations)
+
+        self.assertEqual(record.version, "0.0.128")
+        self.assertEqual(record.reservation, "reuse")
+        self.assertEqual(
+            operations.resource_probes,
+            [("server", "0.0.128", SOURCE_SHA)],
+        )
+
+    def test_explicit_version_rejects_conflicting_resource_binding(self) -> None:
+        operations = FakeOperations()
+        operations.resource_records = {
+            "0.0.129": AllocationRecord(
+                component="server",
+                version="0.0.129",
+                kind="resource",
+                reference="r2://browseros/artifacts/server/0.0.129",
+            )
+        }
+
+        with self.assertRaisesRegex(ValueError, "already allocated"):
+            resolve_standalone_release(
+                _request(requested_version="0.0.129"), operations
+            )
+
+        self.assertEqual(
+            operations.resource_probes,
+            [("server", "0.0.129", SOURCE_SHA)],
+        )
 
     def test_tag_push_requires_annotated_source_bound_tag(self) -> None:
         operations = FakeOperations()
@@ -244,9 +342,13 @@ class ComponentAllocationDiscoveryTest(unittest.TestCase):
                     return_value=releases,
                 ),
             ):
-                allocations = operations.allocations("server", SOURCE_SHA)
+                operations.allocations("server")
+                resource = operations.resource_allocation(
+                    "server", "0.0.130", SOURCE_SHA
+                )
 
-        resource = next(record for record in allocations if record.kind == "resource")
+        self.assertIsNotNone(resource)
+        assert resource is not None
         self.assertTrue(resource.reusable)
         self.assertEqual(resource.source_sha, SOURCE_SHA)
         client.head_object.assert_called_once_with(Bucket="browseros", Key=key)

--- a/packages/browseros/bos_build/release/r2_allocations.py
+++ b/packages/browseros/bos_build/release/r2_allocations.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Discover component versions occupied by immutable R2 objects."""
+"""Probe component versions for immutable R2 objects."""
 
 import re
 from dataclasses import dataclass
-from typing import Iterable, Mapping, Sequence
+from typing import Iterable, Mapping
 
 from .components import (
     AllocationRecord,
@@ -60,27 +60,18 @@ def _family(component: str) -> ResourceFamily | None:
 def _resource_objects(
     client,
     bucket: str,
-    component: str,
     family: ResourceFamily,
-) -> dict[str, list[_R2Object]]:
-    prefix = f"{family.component}/"
-    targets = {family.filename(target): target for target in family.targets}
-    result: dict[str, list[_R2Object]] = {}
+    version: str,
+) -> list[_R2Object]:
+    prefix = f"{family.component}/{version}/"
+    targets = {family.version_key(version, target): target for target in family.targets}
+    result = []
     for item in _list_objects(client, bucket, prefix):
         key = str(item.get("Key", ""))
-        relative = key.removeprefix(prefix)
-        parts = relative.split("/")
-        if len(parts) != 2 or parts[0] == "latest":
-            continue
-        raw_version, filename = parts
-        target = targets.get(filename)
+        target = targets.get(key)
         if target is None:
             continue
-        try:
-            version = normalize_component_version(component, raw_version)
-        except ValueError:
-            continue
-        result.setdefault(version, []).append(
+        result.append(
             _R2Object(
                 key,
                 {
@@ -98,19 +89,15 @@ def _extension_objects(
     client,
     bucket: str,
     component: str,
-) -> dict[str, list[_R2Object]]:
-    prefix = f"extensions/{component}-"
-    result: dict[str, list[_R2Object]] = {}
+    version: str,
+) -> list[_R2Object]:
+    prefix = f"extensions/{component}-{version}.crx"
+    result = []
     for item in _list_objects(client, bucket, prefix):
         key = str(item.get("Key", ""))
-        if not key.startswith(prefix) or not key.endswith(".crx"):
+        if key != prefix:
             continue
-        raw_version = key[len(prefix) : -len(".crx")]
-        try:
-            version = normalize_component_version(component, raw_version)
-        except ValueError:
-            continue
-        result.setdefault(version, []).append(
+        result.append(
             _R2Object(
                 key,
                 {
@@ -124,16 +111,17 @@ def _extension_objects(
     return result
 
 
-def _objects_by_version(
+def _version_objects(
     client,
     bucket: str,
     component: str,
-) -> dict[str, list[_R2Object]]:
+    version: str,
+) -> list[_R2Object]:
     family = _family(component)
     if family is not None:
-        return _resource_objects(client, bucket, component, family)
+        return _resource_objects(client, bucket, family, version)
     if component in _EXTENSION_COMPONENTS:
-        return _extension_objects(client, bucket, component)
+        return _extension_objects(client, bucket, component, version)
     raise ValueError(f"Immutable R2 allocations are not defined for {component}")
 
 
@@ -161,48 +149,33 @@ def _matches_source_binding(
     ) and bool(_SHA256_RE.fullmatch(metadata.get("sha256", "")))
 
 
-def _version_key(version: str) -> tuple[int, ...]:
-    return tuple(int(part) for part in version.split("."))
-
-
-def discover_r2_component_allocations(
+def discover_r2_component_allocation(
     client,
     bucket: str,
     component: str,
+    version: str,
     source_sha: str,
-    existing_allocations: Sequence[AllocationRecord],
-) -> tuple[AllocationRecord, ...]:
-    """Return one blocking record per occupied immutable component version."""
+) -> AllocationRecord | None:
+    """Probe one component version for an immutable R2 allocation."""
     if not bucket:
         raise ValueError("R2 bucket is required for immutable allocation discovery")
-    objects_by_version = _objects_by_version(client, bucket, component)
-    retry_versions = {
-        normalize_component_version(component, record.version)
-        for record in existing_allocations
-        if record.component == component
-        and record.reusable
-        and source_sha
-        and record.source_sha == source_sha
-    }
+    normalized = normalize_component_version(component, version)
+    objects = _version_objects(client, bucket, component, normalized)
+    if not objects:
+        return None
     canonical_prefix = component_by_id(component).tag_prefix
-    records = []
-    for version in sorted(objects_by_version, key=_version_key):
-        objects = objects_by_version[version]
-        reusable = version in retry_versions and all(
-            _matches_source_binding(client, bucket, obj, source_sha) for obj in objects
-        )
-        records.append(
-            AllocationRecord(
-                component=component,
-                version=version,
-                kind="resource",
-                source_sha=source_sha if reusable else "",
-                reference=(
-                    f"{canonical_prefix}{version}"
-                    if reusable
-                    else f"r2://{bucket}/{objects[0].key}"
-                ),
-                reusable=reusable,
-            )
-        )
-    return tuple(records)
+    reusable = bool(source_sha) and all(
+        _matches_source_binding(client, bucket, obj, source_sha) for obj in objects
+    )
+    return AllocationRecord(
+        component=component,
+        version=normalized,
+        kind="resource",
+        source_sha=source_sha if reusable else "",
+        reference=(
+            f"{canonical_prefix}{normalized}"
+            if reusable
+            else f"r2://{bucket}/{objects[0].key}"
+        ),
+        reusable=reusable,
+    )

--- a/packages/browseros/bos_build/release/r2_allocations_test.py
+++ b/packages/browseros/bos_build/release/r2_allocations_test.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Tests for immutable R2 component allocation discovery."""
+"""Tests for immutable R2 component allocation probes."""
 
 import unittest
 
-from bos_build.release.components import AllocationRecord
-from bos_build.release.r2_allocations import discover_r2_component_allocations
+from bos_build.release.r2_allocations import discover_r2_component_allocation
 
 
 SOURCE_SHA = "1" * 40
@@ -28,51 +27,47 @@ class FakeR2Client:
         return {"Metadata": self.metadata[Key]}
 
 
-def _draft(component: str, version: str, tag: str) -> AllocationRecord:
-    return AllocationRecord(
-        component=component,
-        version=version,
-        kind="release",
-        source_sha=SOURCE_SHA,
-        reference=tag,
-        reusable=True,
-    )
-
-
 class R2AllocationDiscoveryTest(unittest.TestCase):
-    def test_each_supported_component_lists_only_its_immutable_namespace(self) -> None:
+    def test_each_supported_component_probes_only_the_requested_version(self) -> None:
         cases = {
-            "server": "artifacts/server/",
-            "claw-server-rust": "claw-server-rust/prod-resources/",
-            "claw-onboard": "claw-onboard/prod-resources/",
-            "agent": "extensions/agent-",
-            "browserclaw": "extensions/browserclaw-",
+            "server": ("0.0.130", "artifacts/server/0.0.130/"),
+            "claw-server-rust": (
+                "0.0.30",
+                "claw-server-rust/prod-resources/0.0.30/",
+            ),
+            "claw-onboard": (
+                "0.0.20",
+                "claw-onboard/prod-resources/0.0.20/",
+            ),
+            "agent": ("0.0.42.0", "extensions/agent-0.0.42.0.crx"),
+            "browserclaw": (
+                "0.0.9.0",
+                "extensions/browserclaw-0.0.9.0.crx",
+            ),
         }
-        for component, prefix in cases.items():
-            client = FakeR2Client(
-                {None: {"Contents": [], "IsTruncated": False}}, {}
-            )
+        for component, (version, prefix) in cases.items():
+            client = FakeR2Client({None: {"Contents": [], "IsTruncated": False}}, {})
             with self.subTest(component=component):
-                allocations = discover_r2_component_allocations(
-                    client, "browseros", component, SOURCE_SHA, ()
+                allocation = discover_r2_component_allocation(
+                    client, "browseros", component, version, SOURCE_SHA
                 )
-                self.assertEqual(allocations, ())
+                self.assertIsNone(allocation)
                 self.assertEqual(
                     client.list_calls,
                     [{"Bucket": "browseros", "Prefix": prefix}],
                 )
 
-    def test_server_objects_block_stale_versions_and_reuse_matching_retries(
+    def test_server_probe_ignores_out_of_band_versions_and_blocks_mismatch(
         self,
     ) -> None:
         stale_key = "artifacts/server/0.0.129/browseros-server-resources-linux-x64.zip"
-        retry_key = (
-            "artifacts/server/0.0.130/browseros-server-resources-darwin-arm64.zip"
+        out_of_band_key = (
+            "artifacts/server/99.0.0/browseros-server-resources-linux-x64.zip"
         )
         client = FakeR2Client(
             {
                 None: {
-                    "Contents": [{"Key": stale_key}, {"Key": retry_key}],
+                    "Contents": [{"Key": stale_key}, {"Key": out_of_band_key}],
                     "IsTruncated": False,
                 }
             },
@@ -84,56 +79,50 @@ class R2AllocationDiscoveryTest(unittest.TestCase):
                     "target": "linux-x64",
                     "version": "0.0.129",
                 },
-                retry_key: {
+            },
+        )
+
+        allocation = discover_r2_component_allocation(
+            client, "browseros", "server", "0.0.129", SOURCE_SHA
+        )
+
+        self.assertIsNotNone(allocation)
+        assert allocation is not None
+        self.assertEqual(allocation.version, "0.0.129")
+        self.assertFalse(allocation.reusable)
+        self.assertEqual(allocation.kind, "resource")
+        self.assertEqual(client.head_calls, [("browseros", stale_key)])
+        self.assertEqual(
+            client.list_calls,
+            [{"Bucket": "browseros", "Prefix": "artifacts/server/0.0.129/"}],
+        )
+
+    def test_partial_server_retry_reuses_exact_source_binding(self) -> None:
+        key = "artifacts/server/0.0.130/browseros-server-resources-darwin-arm64.zip"
+        client = FakeR2Client(
+            {None: {"Contents": [{"Key": key}], "IsTruncated": False}},
+            {
+                key: {
                     "component": "artifacts/server",
                     "release-sha": SOURCE_SHA,
                     "sha256": SHA256,
                     "target": "darwin-arm64",
                     "version": "0.0.130",
-                },
+                }
             },
         )
 
-        allocations = discover_r2_component_allocations(
-            client,
-            "browseros",
-            "server",
-            SOURCE_SHA,
-            (
-                _draft("server", "0.0.129", "agent-server/v0.0.129"),
-                _draft("server", "0.0.130", "agent-server/v0.0.130"),
-            ),
+        allocation = discover_r2_component_allocation(
+            client, "browseros", "server", "0.0.130", SOURCE_SHA
         )
 
-        self.assertEqual(
-            [record.version for record in allocations], ["0.0.129", "0.0.130"]
-        )
-        self.assertFalse(allocations[0].reusable)
-        self.assertEqual(allocations[0].kind, "resource")
-        self.assertTrue(allocations[1].reusable)
-        self.assertEqual(allocations[1].source_sha, SOURCE_SHA)
-        self.assertEqual(allocations[1].reference, "agent-server/v0.0.130")
-        self.assertEqual(
-            client.head_calls,
-            [("browseros", stale_key), ("browseros", retry_key)],
-        )
+        self.assertIsNotNone(allocation)
+        assert allocation is not None
+        self.assertTrue(allocation.reusable)
+        self.assertEqual(allocation.source_sha, SOURCE_SHA)
+        self.assertEqual(allocation.reference, "agent-server/v0.0.130")
 
-    def test_occupied_versions_without_a_matching_draft_do_not_need_heads(self) -> None:
-        key = "artifacts/server/0.0.200/browseros-server-resources-linux-x64.zip"
-        client = FakeR2Client(
-            {None: {"Contents": [{"Key": key}], "IsTruncated": False}},
-            {},
-        )
-
-        allocations = discover_r2_component_allocations(
-            client, "browseros", "server", SOURCE_SHA, ()
-        )
-
-        self.assertEqual(len(allocations), 1)
-        self.assertFalse(allocations[0].reusable)
-        self.assertEqual(client.head_calls, [])
-
-    def test_extension_listing_paginates_and_validates_source_binding(self) -> None:
+    def test_extension_probe_paginates_and_validates_source_binding(self) -> None:
         key = "extensions/agent-0.0.42.0.crx"
         client = FakeR2Client(
             {
@@ -158,23 +147,20 @@ class R2AllocationDiscoveryTest(unittest.TestCase):
             },
         )
 
-        allocations = discover_r2_component_allocations(
-            client,
-            "browseros",
-            "agent",
-            SOURCE_SHA,
-            (_draft("agent", "0.0.42.0", "ext-agent/v0.0.42.0"),),
+        allocation = discover_r2_component_allocation(
+            client, "browseros", "agent", "0.0.42.0", SOURCE_SHA
         )
 
-        self.assertEqual(len(allocations), 1)
-        self.assertTrue(allocations[0].reusable)
+        self.assertIsNotNone(allocation)
+        assert allocation is not None
+        self.assertTrue(allocation.reusable)
         self.assertEqual(
             client.list_calls,
             [
-                {"Bucket": "browseros", "Prefix": "extensions/agent-"},
+                {"Bucket": "browseros", "Prefix": key},
                 {
                     "Bucket": "browseros",
-                    "Prefix": "extensions/agent-",
+                    "Prefix": key,
                     "ContinuationToken": "next",
                 },
             ],


### PR DESCRIPTION
## Summary
- probe R2 only for the component version proposed by Git/GitHub/feed history
- advance one version at a time when that exact namespace is occupied incompatibly
- preserve same-source retry reuse without allowing unrelated high-version R2 objects to jump the release line
- cover prior releases, partial retries, pagination, and repeated-candidate termination

## Live finding
The first R2-aware implementation correctly prevented immutable-object overwrites, but its global bucket scan let unrelated objects such as 99.0.0 dictate the next version. Both validation nightlies were canceled before publication, and their empty private drafts were removed. This follow-up narrows discovery to candidate versions.

## Validation
- 1076 Python tests passed, 2 skipped
- 54 release script tests passed
- 10 secret tests passed
- 47 vendor tests passed
- Ruff passed
- Pyright passed
- product doctor passed
- full release and both nightly show-plan smoke tests passed
- context-free adversarial review found no Critical, Important, or Minor issues