### PR TITLE
fix: inspect private release drafts

### DIFF
--- a/.github/workflows/release-claw-onboard.yml
+++ b/.github/workflows/release-claw-onboard.yml
@@ -188,10 +188,9 @@ jobs:
           title="BrowserOS neo Onboarding - v$VERSION"
           release_sha="${{ steps.release.outputs.release_sha }}"
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            tag_uri="$(jq -rn --arg value "$RELEASE_TAG" '$value | @uri')"
-            release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag_uri")"
-            is_draft="$(jq -r '.draft' <<< "$release")"
-            target="$(jq -r '.target_commitish' <<< "$release")"
+            release="$(gh release view "$RELEASE_TAG" --json isDraft,targetCommitish,assets)"
+            is_draft="$(jq -r '.isDraft' <<< "$release")"
+            target="$(jq -r '.targetCommitish' <<< "$release")"
             if [ "$is_draft" != "true" ] || [ "$target" != "$release_sha" ]; then
               echo "::error::$RELEASE_TAG is not a reusable draft for $release_sha"
               exit 1
@@ -289,16 +288,15 @@ jobs:
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
         run: |
           set -euo pipefail
-          tag_uri="$(jq -rn --arg value "$RELEASE_TAG" '$value | @uri')"
-          release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag_uri")"
+          release="$(gh release view "$RELEASE_TAG" --json isDraft,targetCommitish,assets)"
           asset_count="$(jq '[.assets[] | select(.name == "browseros-claw-onboard-resources.zip")] | length' <<< "$release")"
           if [ "$asset_count" -ne 1 ]; then
             echo "::error::Expected onboarding draft asset, found $asset_count"
             exit 1
           fi
           if [ "$RESERVATION" != "tag" ]; then
-            is_draft="$(jq -r '.draft' <<< "$release")"
-            target="$(jq -r '.target_commitish' <<< "$release")"
+            is_draft="$(jq -r '.isDraft' <<< "$release")"
+            target="$(jq -r '.targetCommitish' <<< "$release")"
             if [ "$is_draft" != "true" ] || [ "$target" != "$RELEASE_SHA" ]; then
               echo "::error::$RELEASE_TAG is not the prepared draft for $RELEASE_SHA"
               exit 1

--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -207,10 +207,9 @@ jobs:
           RELEASE_SHA="${{ steps.release.outputs.release_sha }}"
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            tag_uri="$(jq -rn --arg value "$RELEASE_TAG" '$value | @uri')"
-            release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag_uri")"
-            is_draft="$(jq -r '.draft' <<< "$release")"
-            target="$(jq -r '.target_commitish' <<< "$release")"
+            release="$(gh release view "$RELEASE_TAG" --json isDraft,targetCommitish,assets)"
+            is_draft="$(jq -r '.isDraft' <<< "$release")"
+            target="$(jq -r '.targetCommitish' <<< "$release")"
             if [ "$is_draft" != "true" ] || [ "$target" != "$RELEASE_SHA" ]; then
               echo "::error::$RELEASE_TAG is not a reusable draft for $RELEASE_SHA"
               exit 1
@@ -769,16 +768,15 @@ jobs:
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
         run: |
           set -euo pipefail
-          tag_uri="$(jq -rn --arg value "$RELEASE_TAG" '$value | @uri')"
-          release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag_uri")"
+          release="$(gh release view "$RELEASE_TAG" --json isDraft,targetCommitish,assets)"
           asset_count="$(jq '[.assets[] | select(.name | test("^browseros-claw-server-rust-resources-(darwin-arm64|darwin-x64|linux-arm64|linux-x64|windows-x64)\\.zip$"))] | length' <<< "$release")"
           if [ "$asset_count" -ne 5 ]; then
             echo "::error::Expected 5 draft assets, found $asset_count"
             exit 1
           fi
           if [ "$RESERVATION" != "tag" ]; then
-            is_draft="$(jq -r '.draft' <<< "$release")"
-            target="$(jq -r '.target_commitish' <<< "$release")"
+            is_draft="$(jq -r '.isDraft' <<< "$release")"
+            target="$(jq -r '.targetCommitish' <<< "$release")"
             if [ "$is_draft" != "true" ] || [ "$target" != "$RELEASE_SHA" ]; then
               echo "::error::$RELEASE_TAG is not the prepared draft for $RELEASE_SHA"
               exit 1

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -298,11 +298,10 @@ jobs:
             fi
 
             if gh release view "$TAG" >/dev/null 2>&1; then
-              tag_uri="$(jq -rn --arg value "$TAG" '$value | @uri')"
-              release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag_uri")"
-              is_draft="$(jq -r '.draft' <<< "$release")"
+              release="$(gh release view "$TAG" --json isDraft,targetCommitish,assets)"
+              is_draft="$(jq -r '.isDraft' <<< "$release")"
               if [ "$is_draft" = "true" ]; then
-                target="$(jq -r '.target_commitish' <<< "$release")"
+                target="$(jq -r '.targetCommitish' <<< "$release")"
                 tag_matches=false
                 if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
                   if [ "$(git cat-file -t "refs/tags/$TAG")" != "tag" ] || \
@@ -592,8 +591,7 @@ jobs:
           for NAME in $NAMES; do
             TAG="ext-${NAME}/v${VERSION}"
             asset="${NAME}-${VERSION}.crx"
-            tag_uri="$(jq -rn --arg value "$TAG" '$value | @uri')"
-            release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag_uri")"
+            release="$(gh release view "$TAG" --json isDraft,targetCommitish,assets)"
             if ! jq -e --arg asset "$asset" \
               '([.assets[].name] | sort) == [$asset]' <<< "$release" >/dev/null; then
               echo "::error::$TAG must contain exactly the prepared asset $asset"
@@ -606,7 +604,7 @@ jobs:
               echo "::error::GitHub release asset does not match canonical R2 object: $TAG/$asset"
               exit 1
             fi
-            is_draft="$(jq -r '.draft' <<< "$release")"
+            is_draft="$(jq -r '.isDraft' <<< "$release")"
             tag_exists=false
             if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
               if [ "$(git cat-file -t "refs/tags/$TAG")" != "tag" ] || \
@@ -617,7 +615,7 @@ jobs:
               tag_exists=true
             fi
             if [ "$is_draft" = "true" ]; then
-              target="$(jq -r '.target_commitish' <<< "$release")"
+              target="$(jq -r '.targetCommitish' <<< "$release")"
               if [ "$target" != "$RELEASE_SHA" ] && [ "$tag_exists" != "true" ]; then
                 echo "::error::Draft $TAG is not prepared for $RELEASE_SHA"
                 exit 1

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -207,10 +207,9 @@ jobs:
           set -euo pipefail
           title="BrowserOS Server - v$VERSION"
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            tag_uri="$(jq -rn --arg value "$RELEASE_TAG" '$value | @uri')"
-            release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag_uri")"
-            is_draft="$(jq -r '.draft' <<< "$release")"
-            target="$(jq -r '.target_commitish' <<< "$release")"
+            release="$(gh release view "$RELEASE_TAG" --json isDraft,targetCommitish,assets)"
+            is_draft="$(jq -r '.isDraft' <<< "$release")"
+            target="$(jq -r '.targetCommitish' <<< "$release")"
             if [ "$is_draft" != "true" ] || [ "$target" != "$RELEASE_SHA" ]; then
               echo "::error::$RELEASE_TAG is not a reusable draft for $RELEASE_SHA"
               exit 1
@@ -343,16 +342,15 @@ jobs:
           R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
         run: |
           set -euo pipefail
-          tag_uri="$(jq -rn --arg value "$RELEASE_TAG" '$value | @uri')"
-          release="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag_uri")"
+          release="$(gh release view "$RELEASE_TAG" --json isDraft,targetCommitish,assets)"
           asset_count="$(jq '[.assets[] | select(.name | test("^browseros-server-resources-(darwin-arm64|darwin-x64|linux-arm64|linux-x64|windows-x64)\\.zip$"))] | length' <<< "$release")"
           if [ "$asset_count" -ne 5 ]; then
             echo "::error::Expected 5 draft assets, found $asset_count"
             exit 1
           fi
           if [ "$RESERVATION" != "tag" ]; then
-            is_draft="$(jq -r '.draft' <<< "$release")"
-            target="$(jq -r '.target_commitish' <<< "$release")"
+            is_draft="$(jq -r '.isDraft' <<< "$release")"
+            target="$(jq -r '.targetCommitish' <<< "$release")"
             if [ "$is_draft" != "true" ] || [ "$target" != "$RELEASE_SHA" ]; then
               echo "::error::$RELEASE_TAG is not the prepared draft for $RELEASE_SHA"
               exit 1

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -958,6 +958,21 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
                     "max",
                 )
 
+    def test_component_workflows_inspect_private_drafts_with_release_cli(self):
+        for workflow_name in (
+            "release-server.yml",
+            "release-claw-server.yml",
+            "release-claw-onboard.yml",
+            "release-extensions.yml",
+        ):
+            text = (WORKFLOW_DIR / workflow_name).read_text(encoding="utf-8")
+            with self.subTest(workflow=workflow_name):
+                self.assertNotIn("releases/tags/", text)
+                self.assertGreaterEqual(
+                    text.count("--json isDraft,targetCommitish,assets"),
+                    2,
+                )
+
     def test_release_critical_concurrency_groups_retain_pending_runs(self):
         for workflow_name in (
             "release-browseros.yml",

--- a/packages/browseros/bos_build/release/github.py
+++ b/packages/browseros/bos_build/release/github.py
@@ -282,10 +282,18 @@ def github_release_tag(version: str, product_id: str) -> str:
 
 def inspect_github_release(tag: str, repo: str) -> Dict:
     """Read a release or raise; callers must never treat API failure as absence."""
-    tag_uri = quote(tag, safe="")
     document = json.loads(
         _run_gh(
-            ["gh", "api", f"repos/{repo}/releases/tags/{tag_uri}"],
+            [
+                "gh",
+                "release",
+                "view",
+                tag,
+                "--repo",
+                repo,
+                "--json",
+                "isDraft,targetCommitish,assets",
+            ],
             subprocess.run,
         )
     )
@@ -304,8 +312,8 @@ def inspect_github_release(tag: str, repo: str) -> Dict:
             "size": asset.get("size"),
         }
     return {
-        "isDraft": document.get("draft"),
-        "targetCommitish": document.get("target_commitish"),
+        "isDraft": document.get("isDraft"),
+        "targetCommitish": document.get("targetCommitish"),
         "assets": list(assets),
         "asset_metadata": assets,
     }

--- a/packages/browseros/bos_build/release/github_test.py
+++ b/packages/browseros/bos_build/release/github_test.py
@@ -131,10 +131,10 @@ class ReleaseAdapterTest(unittest.TestCase):
             command[-1], "repos/browseros-ai/BrowserOS/releases?per_page=100"
         )
 
-    def test_inspects_release_through_rest_with_encoded_tag(self) -> None:
+    def test_inspects_draft_release_through_release_cli(self) -> None:
         response = {
-            "draft": True,
-            "target_commitish": "1" * 40,
+            "isDraft": True,
+            "targetCommitish": "1" * 40,
             "assets": [
                 {
                     "name": "BrowserOS.dmg",
@@ -158,11 +158,9 @@ class ReleaseAdapterTest(unittest.TestCase):
         self.assertEqual(release["assets"], ["BrowserOS.dmg"])
         self.assertEqual(release["asset_metadata"]["BrowserOS.dmg"]["sha256"], "a" * 64)
         command = runner.call_args.args[0]
-        self.assertEqual(command[:2], ["gh", "api"])
-        self.assertEqual(
-            command[-1],
-            "repos/browseros-ai/BrowserOS/releases/tags/ext-agent%2Fv0.0.124.0",
-        )
+        self.assertEqual(command[:3], ["gh", "release", "view"])
+        self.assertEqual(command[3], "ext-agent/v0.0.124.0")
+        self.assertEqual(command[-2:], ["--json", "isDraft,targetCommitish,assets"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- inspect private component release drafts through `gh release view`, which supports drafts
- replace the REST get-by-tag route in server, BrowserClaw server/onboarding, extension, and shared browser release finalization
- normalize the GraphQL-style release fields and add a workflow-wide regression banning the draft-incompatible route

## Live finding
BrowserOS nightly run 31655971412 built and uploaded all five immutable `agent-server/v0.0.130` artifacts, then finalization failed because GitHub REST `GET /releases/tags/{tag}` returned 404 for the private draft. Downstream OTA, extension, and signed browser jobs correctly remained gated. The parallel BrowserClaw run was canceled before immutable publication because it shared the same finalization defect.

The replacement was exercised directly against the real `agent-server/v0.0.130` and `claw-server/v0.0.30` private drafts, including slash-containing names, target SHA, draft state, and asset enumeration.

## Validation
- 1,077 Python tests passed, 2 skipped
- 54 release script tests passed
- 10 release secret tests passed
- 47 vendor tests passed
- Ruff passed
- Pyright passed
- product doctor passed
- BrowserOS, BrowserOS neo, and source-release show-plan smokes passed
- context-free adversarial review found no Critical, Important, or Minor findings