### PR TITLE
fix: make nightly extension releases reliable

### DIFF
--- a/.github/workflows/release-claw-onboard.yml
+++ b/.github/workflows/release-claw-onboard.yml
@@ -429,15 +429,16 @@ jobs:
           fi
 
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            pr="$(gh pr list --state open --head "$branch" --json number --jq '.[0].number // ""')"
-            if [ -z "$pr" ]; then
-              gh pr create \
+            pr_url="$(gh pr list --state open --head "$branch" --json url --jq '.[0].url // ""')"
+            if [ -z "$pr_url" ]; then
+              pr_url="$(gh pr create \
                 --title "chore: bump claw onboarding version to ${VERSION}" \
                 --body "Reflects the published claw-onboard/v${VERSION} onboarding resources." \
                 --base "$DEFAULT_BRANCH" \
-                --head "$branch"
+                --head "$branch")"
             fi
-            gh pr merge "$branch" --squash --auto
+            head_sha="$(gh pr view "$pr_url" --json headRefOid --jq '.headRefOid')"
+            packages/browseros-agent/scripts/release/merge-release-pr.sh "$pr_url" "$head_sha"
             exit 0
           fi
 
@@ -446,10 +447,11 @@ jobs:
           git checkout -b "$branch"
           git add "$package_json" "$lock"
           git commit -m "chore: bump claw onboarding version to ${VERSION}"
+          head_sha="$(git rev-parse HEAD)"
           git push origin "$branch"
-          gh pr create \
+          pr_url="$(gh pr create \
             --title "chore: bump claw onboarding version to ${VERSION}" \
             --body "Reflects the published claw-onboard/v${VERSION} onboarding resources." \
             --base "$DEFAULT_BRANCH" \
-            --head "$branch"
-          gh pr merge "$branch" --squash --auto
+            --head "$branch")"
+          packages/browseros-agent/scripts/release/merge-release-pr.sh "$pr_url" "$head_sha"

--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -926,15 +926,16 @@ jobs:
           if git diff --quiet -- "$cargo_toml" "$lock"; then exit 0; fi
 
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            pr="$(gh pr list --state open --head "$branch" --json number --jq '.[0].number // ""')"
-            if [ -z "$pr" ]; then
-              gh pr create \
+            pr_url="$(gh pr list --state open --head "$branch" --json url --jq '.[0].url // ""')"
+            if [ -z "$pr_url" ]; then
+              pr_url="$(gh pr create \
                 --title "chore: bump Claw server version to ${VERSION}" \
                 --body "Reflects the published claw-server/v${VERSION} resources." \
                 --base "$DEFAULT_BRANCH" \
-                --head "$branch"
+                --head "$branch")"
             fi
-            gh pr merge "$branch" --squash --auto
+            head_sha="$(gh pr view "$pr_url" --json headRefOid --jq '.headRefOid')"
+            packages/browseros-agent/scripts/release/merge-release-pr.sh "$pr_url" "$head_sha"
             exit 0
           fi
 
@@ -943,10 +944,11 @@ jobs:
           git checkout -b "$branch"
           git add "$cargo_toml" "$lock"
           git commit -m "chore: bump Claw server version to ${VERSION}"
+          head_sha="$(git rev-parse HEAD)"
           git push origin "$branch"
-          gh pr create \
+          pr_url="$(gh pr create \
             --title "chore: bump Claw server version to ${VERSION}" \
             --body "Reflects the published claw-server/v${VERSION} resources." \
             --base "$DEFAULT_BRANCH" \
-            --head "$branch"
-          gh pr merge "$branch" --squash --auto
+            --head "$branch")"
+          packages/browseros-agent/scripts/release/merge-release-pr.sh "$pr_url" "$head_sha"

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -788,7 +788,7 @@ jobs:
               browserclaw) manifest="packages/browseros-agent/apps/claw-app/package.json" ;;
               *) continue ;;
             esac
-            current="$(jq -er '.version' "$GITHUB_WORKSPACE/$manifest")"
+            current="$(uv run browseros release component read --component "$name")"
             if [ "$current" != "$VERSION" ]; then
               newest="$(printf '%s\n%s\n' "$current" "$VERSION" | sort -V | tail -n 1)"
               if [ "$newest" = "$current" ]; then
@@ -808,15 +808,16 @@ jobs:
           scope="${{ inputs.extension }}"
           branch="chore-bump-${scope}-extension-v${VERSION}"
           if git -C "$GITHUB_WORKSPACE" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            pr="$(gh pr list --state open --head "$branch" --json number --jq '.[0].number // ""')"
-            if [ -z "$pr" ]; then
-              gh pr create \
+            pr_url="$(gh pr list --state open --head "$branch" --json url --jq '.[0].url // ""')"
+            if [ -z "$pr_url" ]; then
+              pr_url="$(gh pr create \
                 --title "chore: bump ${scope} extension version to ${VERSION}" \
                 --body "Reflects the published extension release at version ${VERSION}." \
                 --base "$DEFAULT_BRANCH" \
-                --head "$branch"
+                --head "$branch")"
             fi
-            gh pr merge "$branch" --squash --auto
+            head_sha="$(gh pr view "$pr_url" --json headRefOid --jq '.headRefOid')"
+            "$GITHUB_WORKSPACE/packages/browseros-agent/scripts/release/merge-release-pr.sh" "$pr_url" "$head_sha"
             exit 0
           fi
 
@@ -825,10 +826,11 @@ jobs:
           git -C "$GITHUB_WORKSPACE" checkout -b "$branch"
           git -C "$GITHUB_WORKSPACE" add -- "${paths[@]}"
           git -C "$GITHUB_WORKSPACE" commit -m "chore: bump ${scope} extension version to ${VERSION}"
+          head_sha="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
           git -C "$GITHUB_WORKSPACE" push origin "$branch"
-          gh pr create \
+          pr_url="$(gh pr create \
             --title "chore: bump ${scope} extension version to ${VERSION}" \
             --body "Reflects the published extension release at version ${VERSION}." \
             --base "$DEFAULT_BRANCH" \
-            --head "$branch"
-          gh pr merge "$branch" --squash --auto
+            --head "$branch")"
+          "$GITHUB_WORKSPACE/packages/browseros-agent/scripts/release/merge-release-pr.sh" "$pr_url" "$head_sha"

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -508,11 +508,12 @@ jobs:
             --version "$VERSION"
           if git diff --quiet -- "$package_json" "$lock"; then exit 0; fi
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            pr="$(gh pr list --state open --head "$branch" --json number --jq '.[0].number // ""')"
-            if [ -z "$pr" ]; then
-              gh pr create --title "chore: bump server version to ${VERSION}" --body "Reflects the published agent-server/v${VERSION} resources." --base "$DEFAULT_BRANCH" --head "$branch"
+            pr_url="$(gh pr list --state open --head "$branch" --json url --jq '.[0].url // ""')"
+            if [ -z "$pr_url" ]; then
+              pr_url="$(gh pr create --title "chore: bump server version to ${VERSION}" --body "Reflects the published agent-server/v${VERSION} resources." --base "$DEFAULT_BRANCH" --head "$branch")"
             fi
-            gh pr merge "$branch" --squash --auto
+            head_sha="$(gh pr view "$pr_url" --json headRefOid --jq '.headRefOid')"
+            packages/browseros-agent/scripts/release/merge-release-pr.sh "$pr_url" "$head_sha"
             exit 0
           fi
           git config user.name "github-actions[bot]"
@@ -520,6 +521,7 @@ jobs:
           git checkout -b "$branch"
           git add "$package_json" "$lock"
           git commit -m "chore: bump server version to ${VERSION}"
+          head_sha="$(git rev-parse HEAD)"
           git push origin "$branch"
-          gh pr create --title "chore: bump server version to ${VERSION}" --body "Reflects the published agent-server/v${VERSION} resources." --base "$DEFAULT_BRANCH" --head "$branch"
-          gh pr merge "$branch" --squash --auto
+          pr_url="$(gh pr create --title "chore: bump server version to ${VERSION}" --body "Reflects the published agent-server/v${VERSION} resources." --base "$DEFAULT_BRANCH" --head "$branch")"
+          packages/browseros-agent/scripts/release/merge-release-pr.sh "$pr_url" "$head_sha"

--- a/.github/workflows/reserve-nightly-browser-version.yml
+++ b/.github/workflows/reserve-nightly-browser-version.yml
@@ -89,29 +89,16 @@ jobs:
               continue
             fi
             source_sha=""
-            for merge_try in 1 2 3 4 5 6; do
-              gh pr merge "$pr_url" \
+            if packages/browseros-agent/scripts/release/merge-release-pr.sh \
+                "$pr_url" \
+                "$head_sha" \
+                "chore(release): reserve nightly v${version} [skip ci]" \
+                "Automated nightly browser version reservation."; then
+              source_sha="$(gh pr view "$pr_url" \
                 --repo "$GITHUB_REPOSITORY" \
-                --squash \
-                --auto \
-                --delete-branch \
-                --match-head-commit "$head_sha" \
-                --subject "chore(release): reserve nightly v${version} [skip ci]" \
-                --body "Automated nightly browser version reservation." || true
-              state="$(gh pr view "$pr_url" \
-                --repo "$GITHUB_REPOSITORY" \
-                --json state \
-                --jq '.state' 2>/dev/null || true)"
-              if [ "$state" = "MERGED" ]; then
-                source_sha="$(gh pr view "$pr_url" \
-                  --repo "$GITHUB_REPOSITORY" \
-                  --json mergeCommit \
-                  --jq '.mergeCommit.oid // ""')"
-                break
-              fi
-              echo "Reservation PR merge attempt $merge_try is not ready"
-              sleep 5
-            done
+                --json mergeCommit \
+                --jq '.mergeCommit.oid // ""')"
+            fi
             if [[ "$source_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
               git fetch origin --no-tags --force \
                 '+refs/heads/main:refs/remotes/origin/main'

--- a/packages/browseros-agent/scripts/release/commit-update-snapshot.sh
+++ b/packages/browseros-agent/scripts/release/commit-update-snapshot.sh
@@ -22,6 +22,7 @@ if ! git check-ref-format --branch "$branch" >/dev/null; then
 fi
 
 repo_root="$(git rev-parse --show-toplevel)"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 for snapshot_path in "${snapshot_paths[@]}"; do
   case "$snapshot_path" in
     updates/*) ;;
@@ -104,29 +105,17 @@ for attempt in 1 2 3 4 5; do
   fi
 
   merge_sha=""
-  for merge_try in 1 2 3 4 5 6; do
-    gh pr merge "$pr_url" \
+  if RELEASE_PR_MERGE_POLL_SECONDS="${SNAPSHOT_MERGE_POLL_SECONDS:-5}" \
+    "$script_dir/merge-release-pr.sh" \
+      "$pr_url" \
+      "$head_sha" \
+      "$commit_message" \
+      "Automated release snapshot update."; then
+    merge_sha="$(gh pr view "$pr_url" \
       --repo "$GITHUB_REPOSITORY" \
-      --squash \
-      --auto \
-      --delete-branch \
-      --match-head-commit "$head_sha" \
-      --subject "$commit_message" \
-      --body "Automated release snapshot update." || true
-    state="$(gh pr view "$pr_url" \
-      --repo "$GITHUB_REPOSITORY" \
-      --json state \
-      --jq '.state' 2>/dev/null || true)"
-    if [ "$state" = "MERGED" ]; then
-      merge_sha="$(gh pr view "$pr_url" \
-        --repo "$GITHUB_REPOSITORY" \
-        --json mergeCommit \
-        --jq '.mergeCommit.oid // ""')"
-      break
-    fi
-    echo "Snapshot PR is not merged yet ($merge_try/6)"
-    sleep "${SNAPSHOT_MERGE_POLL_SECONDS:-5}"
-  done
+      --json mergeCommit \
+      --jq '.mergeCommit.oid // ""')"
+  fi
 
   if [[ "$merge_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
     git -C "$worktree" fetch origin \

--- a/packages/browseros-agent/scripts/release/commit-update-snapshot.test.ts
+++ b/packages/browseros-agent/scripts/release/commit-update-snapshot.test.ts
@@ -44,6 +44,7 @@ function initFixture() {
   const competitor = join(root, 'competitor')
   const wrapperDir = join(root, 'bin')
   const prHead = join(root, 'pr-head')
+  const prHeadSha = join(root, 'pr-head-sha')
 
   mkdirSync(source)
   mkdirSync(wrapperDir)
@@ -86,6 +87,7 @@ function initFixture() {
       '      esac',
       '    done',
       '    printf "%s\\n" "$head" > "$SNAPSHOT_PR_HEAD_FILE"',
+      '    "$SNAPSHOT_REAL_GIT" -C "$SNAPSHOT_MERGE_REPO" ls-remote --heads origin "$head" | cut -f1 > "$SNAPSHOT_PR_HEAD_SHA_FILE"',
       '    echo "https://example.test/pull/1"',
       '    ;;',
       '  pr:merge)',
@@ -118,6 +120,17 @@ function initFixture() {
       '      esac',
       '    done',
       '    case "$json" in',
+      '      state,mergeStateStatus,headRefOid,isDraft,statusCheckRollup)',
+      '        head="$(cat "$SNAPSHOT_PR_HEAD_FILE")"',
+      '        if "$SNAPSHOT_REAL_GIT" -C "$SNAPSHOT_MERGE_REPO" ls-remote --exit-code --heads origin "$head" >/dev/null 2>&1; then',
+      '          state="OPEN"',
+      '          head_sha="$("$SNAPSHOT_REAL_GIT" -C "$SNAPSHOT_MERGE_REPO" ls-remote --heads origin "$head" | cut -f1)"',
+      '        else',
+      '          state="MERGED"',
+      '          head_sha="$(cat "$SNAPSHOT_PR_HEAD_SHA_FILE")"',
+      '        fi',
+      '        printf \'{"state":"%s","mergeStateStatus":"CLEAN","headRefOid":"%s","isDraft":false,"statusCheckRollup":[]}\\n\' "$state" "$head_sha"',
+      '        ;;',
       '      state)',
       '        head="$(cat "$SNAPSHOT_PR_HEAD_FILE")"',
       '        if "$SNAPSHOT_REAL_GIT" -C "$SNAPSHOT_MERGE_REPO" ls-remote --exit-code --heads origin "$head" >/dev/null 2>&1; then',
@@ -141,7 +154,16 @@ function initFixture() {
   )
   chmodSync(gh, 0o755)
 
-  return { root, remote, source, competitor, wrapperDir, prHead, realGit }
+  return {
+    root,
+    remote,
+    source,
+    competitor,
+    wrapperDir,
+    prHead,
+    prHeadSha,
+    realGit,
+  }
 }
 
 function scriptEnv(fixture: ReturnType<typeof initFixture>) {
@@ -153,6 +175,7 @@ function scriptEnv(fixture: ReturnType<typeof initFixture>) {
     PATH: `${fixture.wrapperDir}:${process.env.PATH}`,
     SNAPSHOT_MERGE_REPO: fixture.competitor,
     SNAPSHOT_PR_HEAD_FILE: fixture.prHead,
+    SNAPSHOT_PR_HEAD_SHA_FILE: fixture.prHeadSha,
     SNAPSHOT_REAL_GIT: fixture.realGit,
   }
 }
@@ -286,7 +309,6 @@ exec "$SNAPSHOT_REAL_GIT" "$@"
       )
 
       expect(result.code, result.stderr || result.stdout).toBe(0)
-      expect(result.stdout).toContain('Snapshot PR is not merged yet (1/6)')
       expect(result.stdout).toContain('Snapshot PR merged')
       expect(
         mustRun(fixture.root, [

--- a/packages/browseros-agent/scripts/release/merge-release-pr.sh
+++ b/packages/browseros-agent/scripts/release/merge-release-pr.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 4 ]; then
+  echo "Usage: $0 <pr-url-or-number> <expected-head-sha> [subject] [body]" >&2
+  exit 2
+fi
+
+pr="$1"
+expected_head="$2"
+subject="${3:-}"
+body="${4:-}"
+attempts="${RELEASE_PR_MERGE_ATTEMPTS:-36}"
+poll_seconds="${RELEASE_PR_MERGE_POLL_SECONDS:-5}"
+
+if [ -z "${GITHUB_REPOSITORY:-}" ] || [ -z "${GH_TOKEN:-}" ]; then
+  echo "GITHUB_REPOSITORY and GH_TOKEN are required" >&2
+  exit 2
+fi
+if [[ ! "$expected_head" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "Expected head must be a full commit SHA: $expected_head" >&2
+  exit 2
+fi
+if [[ ! "$attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "RELEASE_PR_MERGE_ATTEMPTS must be a positive integer" >&2
+  exit 2
+fi
+if [[ ! "$poll_seconds" =~ ^[0-9]+$ ]]; then
+  echo "RELEASE_PR_MERGE_POLL_SECONDS must be a non-negative integer" >&2
+  exit 2
+fi
+
+inspect_pr() {
+  gh pr view "$pr" \
+    --repo "$GITHUB_REPOSITORY" \
+    --json state,mergeStateStatus,headRefOid,isDraft,statusCheckRollup
+}
+
+verify_head() {
+  local details="$1"
+  local actual_head
+  actual_head="$(jq -er '.headRefOid' <<<"$details")"
+  if [ "$actual_head" != "$expected_head" ]; then
+    echo "Release PR head changed: expected $expected_head, found $actual_head" >&2
+    exit 1
+  fi
+}
+
+merge_args=(
+  pr merge "$pr"
+  --repo "$GITHUB_REPOSITORY"
+  --squash
+  --delete-branch
+  --match-head-commit "$expected_head"
+)
+if [ -n "$subject" ]; then
+  merge_args+=(--subject "$subject")
+fi
+if [ -n "$body" ]; then
+  merge_args+=(--body "$body")
+fi
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  details="$(inspect_pr)"
+  state="$(jq -er '.state' <<<"$details")"
+  verify_head "$details"
+  if [ "$state" = "MERGED" ]; then
+    echo "Release PR merged: $pr"
+    exit 0
+  fi
+  if [ "$state" != "OPEN" ]; then
+    echo "Release PR is not open: $pr ($state)" >&2
+    exit 1
+  fi
+
+  if [ "$(jq -r '.isDraft' <<<"$details")" = "true" ]; then
+    echo "Release PR is still a draft: $pr" >&2
+    exit 1
+  fi
+
+  merge_state="$(jq -er '.mergeStateStatus' <<<"$details")"
+  failed_checks="$(jq '[.statusCheckRollup[]? | select(
+    (.__typename == "CheckRun" and ((.conclusion // "") | test("^(FAILURE|CANCELLED|TIMED_OUT|ACTION_REQUIRED)$"))) or
+    (.__typename == "StatusContext" and ((.state // "") | test("^(FAILURE|ERROR)$")))
+  )] | length' <<<"$details")"
+  if [ "$merge_state" = "DIRTY" ] || [ "$failed_checks" -gt 0 ]; then
+    echo "Release PR cannot merge: state=$merge_state, failed_checks=$failed_checks" >&2
+    exit 1
+  fi
+
+  if ! gh "${merge_args[@]}"; then
+    gh "${merge_args[@]}" --auto || true
+  fi
+
+  details="$(inspect_pr)"
+  state="$(jq -er '.state' <<<"$details")"
+  verify_head "$details"
+  if [ "$state" = "MERGED" ]; then
+    echo "Release PR merged: $pr"
+    exit 0
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "Release PR is not merged yet ($attempt/$attempts)"
+    sleep "$poll_seconds"
+  fi
+done
+
+echo "Release PR did not merge after $attempts attempts: $pr" >&2
+exit 1

--- a/packages/browseros-agent/scripts/release/merge-release-pr.test.ts
+++ b/packages/browseros-agent/scripts/release/merge-release-pr.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'bun:test'
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const script = resolve(import.meta.dir, 'merge-release-pr.sh')
+const head = '0123456789abcdef0123456789abcdef01234567'
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'merge-release-pr-'))
+  const bin = join(root, 'gh')
+  const state = join(root, 'state')
+  const calls = join(root, 'calls')
+  writeFileSync(state, 'OPEN')
+  writeFileSync(calls, '')
+  writeFileSync(
+    bin,
+    `#!/bin/sh
+set -eu
+case "$1:$2" in
+  pr:view)
+    printf '{"state":"%s","mergeStateStatus":"%s","headRefOid":"%s","isDraft":false,"statusCheckRollup":[]}\n' \
+      "$(cat "$MERGE_TEST_STATE")" "${'$'}{MERGE_TEST_MERGE_STATE:-CLEAN}" "${'$'}{MERGE_TEST_HEAD}"
+    ;;
+  pr:merge)
+    printf '%s\n' "$*" >> "$MERGE_TEST_CALLS"
+    count="$(wc -l < "$MERGE_TEST_CALLS" | tr -d ' ')"
+    if [ "$count" -lt "${'$'}{MERGE_TEST_SUCCEED_ON_CALL:-1}" ]; then
+      exit 1
+    fi
+    printf 'MERGED' > "$MERGE_TEST_STATE"
+    ;;
+  *) exit 2 ;;
+esac
+`,
+  )
+  chmodSync(bin, 0o755)
+  return { root, state, calls }
+}
+
+function run(
+  test: ReturnType<typeof fixture>,
+  env: Record<string, string> = {},
+) {
+  return spawnSync(script, ['https://example.test/pull/1', head], {
+    env: {
+      ...process.env,
+      GH_TOKEN: 'token',
+      GITHUB_REPOSITORY: 'example/repo',
+      MERGE_TEST_CALLS: test.calls,
+      MERGE_TEST_HEAD: head,
+      MERGE_TEST_STATE: test.state,
+      PATH: `${test.root}:${process.env.PATH}`,
+      RELEASE_PR_MERGE_POLL_SECONDS: '0',
+      ...env,
+    },
+    encoding: 'utf8',
+  })
+}
+
+describe('merge-release-pr', () => {
+  it('merges a clean pull request immediately with head protection', () => {
+    const test = fixture()
+    try {
+      const result = run(test)
+      expect(result.status, result.stderr || result.stdout).toBe(0)
+      expect(result.stdout).toContain('Release PR merged')
+      const calls = readFileSync(test.calls, 'utf8')
+      expect(calls).toContain('--squash')
+      expect(calls).toContain(`--match-head-commit ${head}`)
+      expect(calls).not.toContain('--auto')
+    } finally {
+      rmSync(test.root, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to auto-merge and retries transient failures', () => {
+    const test = fixture()
+    try {
+      const result = run(test, {
+        MERGE_TEST_SUCCEED_ON_CALL: '3',
+        RELEASE_PR_MERGE_ATTEMPTS: '2',
+      })
+      expect(result.status, result.stderr || result.stdout).toBe(0)
+      expect(result.stdout).toContain('not merged yet (1/2)')
+      expect(readFileSync(test.calls, 'utf8')).toContain('--auto')
+    } finally {
+      rmSync(test.root, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses a changed pull request head', () => {
+    const test = fixture()
+    try {
+      const result = run(test, {
+        MERGE_TEST_HEAD: 'fedcba9876543210fedcba9876543210fedcba98',
+      })
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain('Release PR head changed')
+      expect(readFileSync(test.calls, 'utf8')).toBe('')
+    } finally {
+      rmSync(test.root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/browseros-agent/scripts/release/release-claw-onboard-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-onboard-workflow.test.ts
@@ -101,5 +101,8 @@ describe('release-claw-onboard workflow', () => {
     expect(reflection).toContain('apps/claw-onboard/package.json')
     expect(reflection).toContain('git config user.name "github-actions[bot]"')
     expect(reflection).toContain('gh pr create')
+    expect(reflection).toContain('merge-release-pr.sh')
+    expect(reflection).toContain('headRefOid')
+    expect(reflection).not.toContain('--squash --auto')
   })
 })

--- a/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-workflow.test.ts
@@ -189,5 +189,8 @@ describe('release-claw-server workflow', () => {
     expect(reflection).toContain('Cargo.lock')
     expect(reflection).toContain('git config user.name "github-actions[bot]"')
     expect(reflection).toContain('gh pr create')
+    expect(reflection).toContain('merge-release-pr.sh')
+    expect(reflection).toContain('headRefOid')
+    expect(reflection).not.toContain('--squash --auto')
   })
 })

--- a/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
@@ -89,6 +89,13 @@ describe('release-extensions workflow', () => {
     const publish = section('- name: Publish private drafts')
     expect(publish).toContain("--json isDraft --jq '.isDraft'")
     expect(publish).toContain('Release $TAG is already published')
+
+    const reflection = section('  reflect-version:')
+    expect(reflection).toContain('browseros release component read')
+    expect(reflection).toContain('browseros release component stamp')
+    expect(reflection).toContain('merge-release-pr.sh')
+    expect(reflection).toContain('headRefOid')
+    expect(reflection).not.toContain('--squash --auto')
   })
 
   it('builds and attaches the immutable CRX before optional finalization', () => {

--- a/packages/browseros-agent/scripts/release/release-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-server-workflow.test.ts
@@ -117,6 +117,13 @@ describe('release-server workflow', () => {
     expect(section('  reflect-version:')).toContain('- finalize')
   })
 
+  it('merges reflection PRs through the verified release helper', () => {
+    const reflection = section('  reflect-version:')
+    expect(reflection).toContain('merge-release-pr.sh')
+    expect(reflection).toContain('headRefOid')
+    expect(reflection).not.toContain('--squash --auto')
+  })
+
   it('publishes and persists standalone alpha releases by default', () => {
     const dispatch = section('  workflow_dispatch:', '  workflow_call:')
     const ota = section('  publish-ota:', '  reflect-version:')

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -1338,8 +1338,7 @@ class NightlyWorkflowTest(unittest.TestCase):
             'git merge-base --is-ancestor "$TRIGGER_SHA" origin/main',
             "bump_version.py --mode offset+build",
             "gh pr create",
-            "gh pr merge",
-            "--match-head-commit",
+            "merge-release-pr.sh",
             "'.mergeCommit.oid // \"\"'",
             'test "$merged_version" = "$version"',
             "onboarding_version=\"$(jq -er '.version' packages/browseros-agent/apps/claw-onboard/package.json)\"",
@@ -1356,6 +1355,14 @@ class NightlyWorkflowTest(unittest.TestCase):
         self.assertEqual(
             reserve_workflow["permissions"],
             {"contents": "write", "pull-requests": "write"},
+        )
+        merge_helper = (
+            REPO_ROOT / "packages/browseros-agent/scripts/release/merge-release-pr.sh"
+        ).read_text(encoding="utf-8")
+        self.assertIn('--match-head-commit "$expected_head"', merge_helper)
+        self.assertLess(
+            merge_helper.index('gh "${merge_args[@]}"'),
+            merge_helper.index('gh "${merge_args[@]}" --auto'),
         )
 
     def test_nightly_profile_downloads_published_resources_once(self):

--- a/packages/browseros/bos_build/cli/release_component.py
+++ b/packages/browseros/bos_build/cli/release_component.py
@@ -19,7 +19,11 @@ from ..release.component_release import (
     StandaloneReleaseRequest,
     resolve_standalone_release,
 )
-from ..release.components import AllocationRecord, stamp_component
+from ..release.components import (
+    AllocationRecord,
+    read_component_version,
+    stamp_component,
+)
 from ..release.extensions.specs import spec_by_name
 from ..release.feeds.render import extract_manifest_versions
 
@@ -171,6 +175,19 @@ def stamp(
                 {"changed": [str(path) for path in changed]}, sort_keys=True
             )
         )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        log_error(str(exc))
+        raise typer.Exit(1)
+
+
+@app.command("read")
+def read(
+    component: str = typer.Option(..., "--component"),
+    repo_root: Optional[Path] = typer.Option(None, "--repo-root"),
+) -> None:
+    """Read the normalized release identity from source."""
+    try:
+        typer.echo(read_component_version(_repo_root(repo_root), component))
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         log_error(str(exc))
         raise typer.Exit(1)

--- a/packages/browseros/bos_build/cli/release_component_test.py
+++ b/packages/browseros/bos_build/cli/release_component_test.py
@@ -179,6 +179,29 @@ class ComponentReleaseCliTest(unittest.TestCase):
             self.assertEqual(json.loads(manifest.read_text())["version"], "0.0.128")
             self.assertIn('"version": "0.0.128"', lockfile.read_text())
 
+    def test_read_decodes_semver_safe_chrome_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = root / "packages/browseros-agent/apps/app/package.json"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(json.dumps({"version": "0.0.126+7"}))
+
+            result = runner.invoke(
+                app,
+                [
+                    "release",
+                    "component",
+                    "read",
+                    "--component",
+                    "agent",
+                    "--repo-root",
+                    str(root),
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(result.output.strip(), "0.0.126.7")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/browseros/bos_build/release/candidate.py
+++ b/packages/browseros/bos_build/release/candidate.py
@@ -13,6 +13,7 @@ from ..lib.versions import load_semantic_version
 from .components import (
     AllocationRecord,
     component_by_id,
+    component_version_from_package,
     components_for_candidate,
     read_component_version,
     resolve_candidate_versions,
@@ -783,7 +784,10 @@ class GitHubCandidateBackend:
         if ancestor.returncode != 0:
             return False
         return all(
-            self._version_at_ref(spec.id, merge_sha)
+            component_version_from_package(
+                spec.id,
+                self._version_at_ref(spec.id, merge_sha),
+            )
             == record.component_versions.get(spec.id)
             for spec in components_for_candidate(record.product)
         )

--- a/packages/browseros/bos_build/release/candidate_test.py
+++ b/packages/browseros/bos_build/release/candidate_test.py
@@ -368,6 +368,44 @@ class CandidateBackendVersionGuardTest(unittest.TestCase):
 
         self.assertNotIn("claw-onboard", observed)
 
+    def test_merged_candidate_retry_decodes_chrome_package_version(self) -> None:
+        for package_version, release_version in (
+            ("0.0.101", "0.0.101.0"),
+            ("0.0.101+7", "0.0.101.7"),
+        ):
+            with self.subTest(package_version=package_version):
+                record = replace(
+                    self.record,
+                    component_versions={
+                        **self.record.component_versions,
+                        "agent": release_version,
+                    },
+                )
+
+                def version_at_ref(component: str, ref: str) -> str:
+                    if component == "agent":
+                        return package_version
+                    return record.component_versions[component]
+
+                with (
+                    patch.object(self.backend, "_git"),
+                    patch.object(
+                        self.backend,
+                        "_version_at_ref",
+                        side_effect=version_at_ref,
+                    ),
+                    patch(
+                        "bos_build.release.candidate.subprocess.run",
+                        return_value=subprocess.CompletedProcess([], 0),
+                    ),
+                ):
+                    self.assertTrue(
+                        self.backend.merge_commit_matches_candidate(
+                            record,
+                            "3" * 40,
+                        )
+                    )
+
 
 class CandidateMergeTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/packages/browseros/bos_build/release/component_release.py
+++ b/packages/browseros/bos_build/release/component_release.py
@@ -12,6 +12,7 @@ from .candidate import GitHubCandidateBackend, candidate_record_from_pull_reques
 from .components import (
     AllocationRecord,
     component_by_id,
+    component_version_from_package,
     normalize_component_version,
     resolve_standalone_version,
 )
@@ -267,7 +268,7 @@ class GitComponentReleaseOperations:
             value = match.group(1) if match else None
         if not isinstance(value, str):
             raise ValueError(f"Missing version in {spec.manifest_path} at {ref}")
-        return normalize_component_version(component, value)
+        return component_version_from_package(component, value)
 
     def tag_state(self, tag: str) -> TagState | None:
         result = subprocess.run(

--- a/packages/browseros/bos_build/release/component_release_test.py
+++ b/packages/browseros/bos_build/release/component_release_test.py
@@ -290,6 +290,18 @@ class StandaloneReleaseTest(unittest.TestCase):
 
 
 class ComponentAllocationDiscoveryTest(unittest.TestCase):
+    def test_read_version_decodes_semver_safe_chrome_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            operations = GitComponentReleaseOperations(
+                Path(tmp), "browseros-ai/BrowserOS"
+            )
+            with mock.patch.object(
+                operations, "_git", return_value='{"version":"0.0.126+7"}'
+            ):
+                version = operations.read_version("agent", "origin/main")
+
+        self.assertEqual(version, "0.0.126.7")
+
     def test_r2_retry_uses_requested_source_with_older_release_history(self) -> None:
         key = "artifacts/server/0.0.130/browseros-server-resources-linux-x64.zip"
         client = mock.MagicMock()

--- a/packages/browseros/bos_build/release/components.py
+++ b/packages/browseros/bos_build/release/components.py
@@ -13,6 +13,9 @@ AllocationKind = Literal["tag", "release", "candidate", "resource"]
 
 _SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 _CHROME_RE = re.compile(r"^\d+(?:\.\d+){0,3}$")
+_CHROME_PACKAGE_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\+(0|[1-9]\d*))?$"
+)
 
 
 @dataclass(frozen=True)
@@ -158,6 +161,30 @@ def increment_component_version(component_id: str, version: str) -> str:
     if len(parts) == 4:
         parts[3] = 0
     return ".".join(str(part) for part in parts)
+
+
+def component_package_version(component_id: str, version: str) -> str:
+    """Encode a release version for its source package manifest."""
+    normalized = normalize_component_version(component_id, version)
+    if component_by_id(component_id).version_scheme == "semver":
+        return normalized
+    major, minor, patch, build = normalized.split(".")
+    base = f"{major}.{minor}.{patch}"
+    return base if build == "0" else f"{base}+{build}"
+
+
+def component_version_from_package(component_id: str, version: str) -> str:
+    """Decode a source package version into its release identity."""
+    if component_by_id(component_id).version_scheme == "semver":
+        return normalize_component_version(component_id, version)
+    match = _CHROME_PACKAGE_RE.fullmatch(version)
+    if match is not None:
+        major, minor, patch, build = match.groups()
+        return normalize_component_version(
+            component_id,
+            f"{major}.{minor}.{patch}.{build or '0'}",
+        )
+    return normalize_component_version(component_id, version)
 
 
 def _version_key(component_id: str, version: str) -> tuple[int, ...]:
@@ -336,7 +363,7 @@ def read_component_version(repo_root: Path, component_id: str) -> str:
         version = match.group(1) if match else None
     if not isinstance(version, str):
         raise ValueError(f"Missing version in {path}")
-    return normalize_component_version(component_id, version)
+    return component_version_from_package(component_id, version)
 
 
 def _stamp_json_manifest(path: Path, version: str) -> None:
@@ -411,8 +438,9 @@ def stamp_component(repo_root: Path, component_id: str, version: str) -> tuple[P
     manifest = repo_root / spec.manifest_path
     lockfile = repo_root / spec.lockfile_path
     if manifest.suffix == ".json":
-        _stamp_json_manifest(manifest, normalized)
-        _stamp_bun_lock(lockfile, spec.workspace_path, normalized)
+        package_version = component_package_version(component_id, normalized)
+        _stamp_json_manifest(manifest, package_version)
+        _stamp_bun_lock(lockfile, spec.workspace_path, package_version)
     else:
         manifest.write_text(
             _replace_package_version(

--- a/packages/browseros/bos_build/release/components_test.py
+++ b/packages/browseros/bos_build/release/components_test.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from bos_build.release.components import (
     AllocationRecord,
+    read_component_version,
     components_for_candidate,
     resolve_candidate_versions,
     resolve_standalone_version,
@@ -276,9 +277,34 @@ class ComponentStampingTest(unittest.TestCase):
             changed = stamp_component(root, "agent", "0.0.101.0")
 
             self.assertEqual(changed, (app, lock))
-            self.assertEqual(json.loads(app.read_text())["version"], "0.0.101.0")
-            self.assertIn('"version": "0.0.101.0"', lock.read_text())
+            self.assertEqual(json.loads(app.read_text())["version"], "0.0.101")
+            self.assertIn('"version": "0.0.101"', lock.read_text())
             self.assertIn(before_server, lock.read_text())
+            self.assertEqual(read_component_version(root, "agent"), "0.0.101.0")
+
+    def test_chrome_build_component_uses_semver_build_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            app = root / "packages/browseros-agent/apps/app/package.json"
+            lock = root / "packages/browseros-agent/bun.lock"
+            app.parent.mkdir(parents=True)
+            app.write_text(json.dumps({"version": "0.0.100"}))
+            lock.parent.mkdir(parents=True, exist_ok=True)
+            lock.write_text(
+                "{\n"
+                '  "workspaces": {\n'
+                '    "apps/app": {\n'
+                '      "version": "0.0.100",\n'
+                "    },\n"
+                "  },\n"
+                "}\n"
+            )
+
+            stamp_component(root, "agent", "0.0.101.7")
+
+            self.assertEqual(json.loads(app.read_text())["version"], "0.0.101+7")
+            self.assertIn('"version": "0.0.101+7"', lock.read_text())
+            self.assertEqual(read_component_version(root, "agent"), "0.0.101.7")
 
     def test_cargo_component_updates_only_matching_package_entries(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/packages/browseros/bos_build/release/extensions/build.py
+++ b/packages/browseros/bos_build/release/extensions/build.py
@@ -6,8 +6,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Optional
 
+from ..components import component_version_from_package, normalize_component_version
 from .crx import pack_crx
-from .specs import ExtensionSpec
+from .specs import ExtensionSpec, InRepoSource
 from .workspace import (
     require_env,
     resolve_source,
@@ -80,12 +81,23 @@ def build_extension_crx(
         branch_override=branch_override,
     )
     manifest_path = source_root / spec.manifest_path
-    if stamp_version:
+    in_repo = isinstance(spec.source, InRepoSource)
+    if stamp_version and not in_repo:
         update_manifest_version(manifest_path, version)
-    elif _manifest_version(manifest_path) != version:
-        raise ValueError(
-            f"Extension '{spec.name}' source version does not match requested version {version}"
+    elif not stamp_version:
+        source_version = _manifest_version(manifest_path)
+        expected = (
+            normalize_component_version(spec.name, version) if in_repo else version
         )
+        actual = (
+            component_version_from_package(spec.name, source_version)
+            if in_repo
+            else source_version
+        )
+        if actual != expected:
+            raise ValueError(
+                f"Extension '{spec.name}' source version does not match requested version {version}"
+            )
     if spec.env:
         env_dir = source_root / spec.env_dir if spec.env_dir else source_root
         write_env_file(env_dir, spec.env, required_names=spec.required_env)
@@ -94,7 +106,10 @@ def build_extension_crx(
     run_command(spec.build, source_root)
 
     dist_path = source_root / spec.dist_path
-    manifest = json.loads((dist_path / "manifest.json").read_text(encoding="utf-8"))
+    built_manifest_path = dist_path / "manifest.json"
+    if in_repo:
+        update_manifest_version(built_manifest_path, version)
+    manifest = json.loads(built_manifest_path.read_text(encoding="utf-8"))
     if not isinstance(manifest, dict):
         raise RuntimeError(f"Extension output manifest must be an object: {dist_path}")
     _validate_built_manifest(spec, manifest, dist_path, version)

--- a/packages/browseros/bos_build/release/extensions/build_test.py
+++ b/packages/browseros/bos_build/release/extensions/build_test.py
@@ -23,12 +23,12 @@ class ExtensionBuildTest(unittest.TestCase):
             manifest = source / spec.manifest_path
             dist = source / spec.dist_path
             manifest.parent.mkdir(parents=True)
-            manifest.write_text(json.dumps({"version": "0.0.101.0"}))
+            manifest.write_text(json.dumps({"version": "0.0.101"}))
             dist.mkdir(parents=True)
             (dist / "manifest.json").write_text(
                 json.dumps(
                     {
-                        "version": "0.0.101.0",
+                        "version": "0.0.101",
                         "update_url": "https://cdn.browseros.com/extensions/update-manifest.xml",
                     }
                 )
@@ -55,13 +55,17 @@ class ExtensionBuildTest(unittest.TestCase):
                     stamp_version=False,
                 )
 
-            self.assertEqual(json.loads(manifest.read_text())["version"], "0.0.101.0")
+            self.assertEqual(json.loads(manifest.read_text())["version"], "0.0.101")
+            self.assertEqual(
+                json.loads((dist / "manifest.json").read_text())["version"],
+                "0.0.101.0",
+            )
             self.assertEqual(built.path, output)
             self.assertEqual(built.version, "0.0.101.0")
             self.assertEqual(run.call_count, 2)
             pack.assert_called_once()
 
-    def test_standalone_build_can_stamp_the_shared_source(self) -> None:
+    def test_standalone_build_stamps_only_the_built_manifest(self) -> None:
         spec = spec_by_name("browserclaw")
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -69,12 +73,12 @@ class ExtensionBuildTest(unittest.TestCase):
             manifest = source / spec.manifest_path
             dist = source / spec.dist_path
             manifest.parent.mkdir(parents=True)
-            manifest.write_text(json.dumps({"version": "0.1.7.0"}))
+            manifest.write_text(json.dumps({"version": "0.1.7"}))
             dist.mkdir(parents=True)
             (dist / "manifest.json").write_text(
                 json.dumps(
                     {
-                        "version": "0.1.8.0",
+                        "version": "0.1.7",
                         "update_url": "https://cdn.browseros.com/extensions/update-manifest.xml",
                     }
                 )
@@ -100,7 +104,11 @@ class ExtensionBuildTest(unittest.TestCase):
                     stamp_version=True,
                 )
 
-            self.assertEqual(json.loads(manifest.read_text())["version"], "0.1.8.0")
+            self.assertEqual(json.loads(manifest.read_text())["version"], "0.1.7")
+            self.assertEqual(
+                json.loads((dist / "manifest.json").read_text())["version"],
+                "0.1.8.0",
+            )
 
     def test_refuses_version_drift_before_build(self) -> None:
         spec = spec_by_name("agent")

--- a/packages/browseros/bos_build/release/extensions/release.py
+++ b/packages/browseros/bos_build/release/extensions/release.py
@@ -432,13 +432,10 @@ class ExtensionReleaseModule(Step):
                 chrome_binary=chrome,
                 stamp_version=True,
             )
-            if isinstance(spec.source, InRepoSource):
-                touched = spec.manifest_path
-                if spec.env:
-                    touched += f" and {spec.env_dir or '.'}/.env"
+            if isinstance(spec.source, InRepoSource) and spec.env:
                 log_warning(
-                    f"stamped {touched} in the working tree — "
-                    "revert them if this was a local test run"
+                    f"wrote {spec.env_dir or '.'}/.env in the working tree — "
+                    "remove it if this was a local test run"
                 )
             upload_bound_extension_crx(
                 client,


### PR DESCRIPTION
Fixes the live nightly failures found during end-to-end testing: keeps Bun workspace versions SemVer-safe while stamping exact Chrome versions into built CRXs, and makes automated release PR merges direct-first, head-verified, and retryable. Validation includes the full build-system and release suites plus a real Bun 1.3.6 agent build and Chrome CRX pack.