### PR TITLE
fix: retry release pr inspections

### DIFF
--- a/packages/browseros-agent/scripts/release/merge-release-pr.sh
+++ b/packages/browseros-agent/scripts/release/merge-release-pr.sh
@@ -37,10 +37,42 @@ inspect_pr() {
     --json state,mergeStateStatus,headRefOid,isDraft,statusCheckRollup
 }
 
-verify_head() {
-  local details="$1"
+details=""
+state=""
+is_draft=""
+merge_state=""
+failed_checks=""
+
+read_inspection() {
+  local phase="$1"
   local actual_head
-  actual_head="$(jq -er '.headRefOid' <<<"$details")"
+  local parsed
+  if ! details="$(inspect_pr)"; then
+    echo "Release PR inspection failed $phase: $pr" >&2
+    return 1
+  fi
+  if ! parsed="$(jq -er '
+    if ((.state | type) == "string")
+      and ((.headRefOid | type) == "string")
+      and ((.isDraft | type) == "boolean")
+      and ((.mergeStateStatus | type) == "string")
+    then [
+      .state,
+      .headRefOid,
+      (.isDraft | tostring),
+      .mergeStateStatus,
+      ([.statusCheckRollup[]? | select(
+        (.__typename == "CheckRun" and ((.conclusion // "") | test("^(FAILURE|CANCELLED|TIMED_OUT|ACTION_REQUIRED)$"))) or
+        (.__typename == "StatusContext" and ((.state // "") | test("^(FAILURE|ERROR)$")))
+      )] | length | tostring)
+    ] | @tsv
+    else error("missing pull request fields")
+    end
+  ' <<<"$details")"; then
+    echo "Release PR inspection was not parseable $phase: $pr" >&2
+    return 1
+  fi
+  IFS=$'\t' read -r state actual_head is_draft merge_state failed_checks <<<"$parsed"
   if [ "$actual_head" != "$expected_head" ]; then
     echo "Release PR head changed: expected $expected_head, found $actual_head" >&2
     exit 1
@@ -62,9 +94,14 @@ if [ -n "$body" ]; then
 fi
 
 for ((attempt = 1; attempt <= attempts; attempt++)); do
-  details="$(inspect_pr)"
-  state="$(jq -er '.state' <<<"$details")"
-  verify_head "$details"
+  if ! read_inspection "before merge"; then
+    if [ "$attempt" -lt "$attempts" ]; then
+      echo "Release PR is not ready yet ($attempt/$attempts)"
+      sleep "$poll_seconds"
+      continue
+    fi
+    break
+  fi
   if [ "$state" = "MERGED" ]; then
     echo "Release PR merged: $pr"
     exit 0
@@ -74,16 +111,11 @@ for ((attempt = 1; attempt <= attempts; attempt++)); do
     exit 1
   fi
 
-  if [ "$(jq -r '.isDraft' <<<"$details")" = "true" ]; then
+  if [ "$is_draft" = "true" ]; then
     echo "Release PR is still a draft: $pr" >&2
     exit 1
   fi
 
-  merge_state="$(jq -er '.mergeStateStatus' <<<"$details")"
-  failed_checks="$(jq '[.statusCheckRollup[]? | select(
-    (.__typename == "CheckRun" and ((.conclusion // "") | test("^(FAILURE|CANCELLED|TIMED_OUT|ACTION_REQUIRED)$"))) or
-    (.__typename == "StatusContext" and ((.state // "") | test("^(FAILURE|ERROR)$")))
-  )] | length' <<<"$details")"
   if [ "$merge_state" = "DIRTY" ] || [ "$failed_checks" -gt 0 ]; then
     echo "Release PR cannot merge: state=$merge_state, failed_checks=$failed_checks" >&2
     exit 1
@@ -93,9 +125,14 @@ for ((attempt = 1; attempt <= attempts; attempt++)); do
     gh "${merge_args[@]}" --auto || true
   fi
 
-  details="$(inspect_pr)"
-  state="$(jq -er '.state' <<<"$details")"
-  verify_head "$details"
+  if ! read_inspection "after merge"; then
+    if [ "$attempt" -lt "$attempts" ]; then
+      echo "Release PR is not ready yet ($attempt/$attempts)"
+      sleep "$poll_seconds"
+      continue
+    fi
+    break
+  fi
   if [ "$state" = "MERGED" ]; then
     echo "Release PR merged: $pr"
     exit 0

--- a/packages/browseros-agent/scripts/release/merge-release-pr.test.ts
+++ b/packages/browseros-agent/scripts/release/merge-release-pr.test.ts
@@ -18,16 +18,33 @@ function fixture() {
   const bin = join(root, 'gh')
   const state = join(root, 'state')
   const calls = join(root, 'calls')
+  const viewCalls = join(root, 'view-calls')
   writeFileSync(state, 'OPEN')
   writeFileSync(calls, '')
+  writeFileSync(viewCalls, '')
   writeFileSync(
     bin,
     `#!/bin/sh
 set -eu
 case "$1:$2" in
   pr:view)
-    printf '{"state":"%s","mergeStateStatus":"%s","headRefOid":"%s","isDraft":false,"statusCheckRollup":[]}\n' \
-      "$(cat "$MERGE_TEST_STATE")" "${'$'}{MERGE_TEST_MERGE_STATE:-CLEAN}" "${'$'}{MERGE_TEST_HEAD}"
+    printf '%s\n' "$*" >> "$MERGE_TEST_VIEW_CALLS"
+    count="$(wc -l < "$MERGE_TEST_VIEW_CALLS" | tr -d ' ')"
+    case ",${'$'}{MERGE_TEST_FAIL_VIEW_CALLS:-}," in
+      *,"$count",*)
+        echo "transient gh pr view failure" >&2
+        exit 1
+        ;;
+    esac
+    case ",${'$'}{MERGE_TEST_BAD_JSON_VIEW_CALLS:-}," in
+      *,"$count",*)
+        printf '{not-json'
+        exit 0
+        ;;
+    esac
+    printf '{"state":"%s","mergeStateStatus":"%s","headRefOid":"%s","isDraft":%s,"statusCheckRollup":%s}\n' \
+      "$(cat "$MERGE_TEST_STATE")" "${'$'}{MERGE_TEST_MERGE_STATE:-CLEAN}" "${'$'}{MERGE_TEST_HEAD}" \
+      "${'$'}{MERGE_TEST_DRAFT:-false}" "${'$'}{MERGE_TEST_STATUS_CHECK_ROLLUP:-[]}"
     ;;
   pr:merge)
     printf '%s\n' "$*" >> "$MERGE_TEST_CALLS"
@@ -42,7 +59,7 @@ esac
 `,
   )
   chmodSync(bin, 0o755)
-  return { root, state, calls }
+  return { root, state, calls, viewCalls }
 }
 
 function run(
@@ -57,6 +74,7 @@ function run(
       MERGE_TEST_CALLS: test.calls,
       MERGE_TEST_HEAD: head,
       MERGE_TEST_STATE: test.state,
+      MERGE_TEST_VIEW_CALLS: test.viewCalls,
       PATH: `${test.root}:${process.env.PATH}`,
       RELEASE_PR_MERGE_POLL_SECONDS: '0',
       ...env,
@@ -96,6 +114,74 @@ describe('merge-release-pr', () => {
     }
   })
 
+  it('retries a transient pre-merge pull request inspection failure', () => {
+    const test = fixture()
+    try {
+      const result = run(test, {
+        MERGE_TEST_FAIL_VIEW_CALLS: '1',
+        RELEASE_PR_MERGE_ATTEMPTS: '2',
+      })
+      expect(result.status, result.stderr || result.stdout).toBe(0)
+      expect(result.stdout).toContain('not ready yet (1/2)')
+      expect(readFileSync(test.calls, 'utf8').trim().split('\n')).toHaveLength(
+        1,
+      )
+    } finally {
+      rmSync(test.root, { recursive: true, force: true })
+    }
+  })
+
+  it('retries malformed pre-merge pull request inspection JSON', () => {
+    const test = fixture()
+    try {
+      const result = run(test, {
+        MERGE_TEST_BAD_JSON_VIEW_CALLS: '1',
+        RELEASE_PR_MERGE_ATTEMPTS: '2',
+      })
+      expect(result.status, result.stderr || result.stdout).toBe(0)
+      expect(result.stdout).toContain('not ready yet (1/2)')
+      expect(readFileSync(test.calls, 'utf8').trim().split('\n')).toHaveLength(
+        1,
+      )
+    } finally {
+      rmSync(test.root, { recursive: true, force: true })
+    }
+  })
+
+  it('retries a transient post-merge pull request inspection failure', () => {
+    const test = fixture()
+    try {
+      const result = run(test, {
+        MERGE_TEST_FAIL_VIEW_CALLS: '2',
+        RELEASE_PR_MERGE_ATTEMPTS: '2',
+      })
+      expect(result.status, result.stderr || result.stdout).toBe(0)
+      expect(result.stdout).toContain('not ready yet (1/2)')
+      expect(readFileSync(test.calls, 'utf8').trim().split('\n')).toHaveLength(
+        1,
+      )
+    } finally {
+      rmSync(test.root, { recursive: true, force: true })
+    }
+  })
+
+  it('retries malformed post-merge pull request inspection JSON', () => {
+    const test = fixture()
+    try {
+      const result = run(test, {
+        MERGE_TEST_BAD_JSON_VIEW_CALLS: '2',
+        RELEASE_PR_MERGE_ATTEMPTS: '2',
+      })
+      expect(result.status, result.stderr || result.stdout).toBe(0)
+      expect(result.stdout).toContain('not ready yet (1/2)')
+      expect(readFileSync(test.calls, 'utf8').trim().split('\n')).toHaveLength(
+        1,
+      )
+    } finally {
+      rmSync(test.root, { recursive: true, force: true })
+    }
+  })
+
   it('refuses a changed pull request head', () => {
     const test = fixture()
     try {
@@ -105,6 +191,61 @@ describe('merge-release-pr', () => {
       expect(result.status).not.toBe(0)
       expect(result.stderr).toContain('Release PR head changed')
       expect(readFileSync(test.calls, 'utf8')).toBe('')
+    } finally {
+      rmSync(test.root, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses drafts without retrying merge attempts', () => {
+    const test = fixture()
+    try {
+      const result = run(test, {
+        MERGE_TEST_DRAFT: 'true',
+        RELEASE_PR_MERGE_ATTEMPTS: '2',
+      })
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain('Release PR is still a draft')
+      expect(readFileSync(test.calls, 'utf8')).toBe('')
+      expect(
+        readFileSync(test.viewCalls, 'utf8').trim().split('\n'),
+      ).toHaveLength(1)
+    } finally {
+      rmSync(test.root, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses dirty pull requests without retrying merge attempts', () => {
+    const test = fixture()
+    try {
+      const result = run(test, {
+        MERGE_TEST_MERGE_STATE: 'DIRTY',
+        RELEASE_PR_MERGE_ATTEMPTS: '2',
+      })
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain('Release PR cannot merge')
+      expect(readFileSync(test.calls, 'utf8')).toBe('')
+      expect(
+        readFileSync(test.viewCalls, 'utf8').trim().split('\n'),
+      ).toHaveLength(1)
+    } finally {
+      rmSync(test.root, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses failed checks without retrying merge attempts', () => {
+    const test = fixture()
+    try {
+      const result = run(test, {
+        MERGE_TEST_STATUS_CHECK_ROLLUP:
+          '[{"__typename":"CheckRun","conclusion":"FAILURE"}]',
+        RELEASE_PR_MERGE_ATTEMPTS: '2',
+      })
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain('failed_checks=1')
+      expect(readFileSync(test.calls, 'utf8')).toBe('')
+      expect(
+        readFileSync(test.viewCalls, 'utf8').trim().split('\n'),
+      ).toHaveLength(1)
     } finally {
       rmSync(test.root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- Retry transient `gh pr view` failures and malformed inspection JSON inside `merge-release-pr.sh`'s bounded merge loop.
- Apply the retry behavior to both pre-merge and post-merge inspections.
- Preserve fail-fast handling for changed PR heads, draft PRs, DIRTY merge state, and failed checks.

## Validation
- `git diff --name-only origin/main...HEAD` contains only `packages/browseros-agent/scripts/release/merge-release-pr.sh` and `packages/browseros-agent/scripts/release/merge-release-pr.test.ts`.
- `git diff --check origin/main...HEAD`
- `bash -n scripts/release/merge-release-pr.sh`
- `bunx @biomejs/biome check scripts/release/merge-release-pr.test.ts`
- `bun run ./scripts/run-bun-test.ts ./scripts/release`

No release workflows were triggered.