### PR TITLE
Fix macOS signing keychain setup for desktop CI

### DIFF
--- a/.github/scripts/macos-signing-keychain.sh
+++ b/.github/scripts/macos-signing-keychain.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_path="${MACOS_SIGNING_STATE_PATH:-${RUNNER_TEMP:-}/browseros-ci-signing-keychain-state.env}"
+
+owned_state_path() {
+  [ -n "${RUNNER_TEMP:-}" ] \
+    && [ "$1" = "$RUNNER_TEMP/browseros-ci-signing-keychain-state.env" ]
+}
+
+require_owned_state_path() {
+  if ! owned_state_path "$state_path"; then
+    echo "::error::Unexpected macOS signing state path: $state_path"
+    exit 1
+  fi
+}
+
+owned_keychain_path() {
+  case "$1" in
+    "$RUNNER_TEMP"/browseros-ci-signing-*.keychain-db) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+owned_cert_path() {
+  case "$1" in
+    "$RUNNER_TEMP"/browseros-signing-cert-*.p12) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+owned_keychains_file() {
+  case "$1" in
+    "$RUNNER_TEMP"/browseros-ci-original-keychains-*.txt) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+normalize_keychain_output() {
+  sed -e 's/^[[:space:]]*//' -e 's/^"//' -e 's/"$//'
+}
+
+require_env() {
+  local missing=()
+  local name
+  for name in "$@"; do
+    if [ -z "${!name:-}" ]; then
+      missing+=("$name")
+    fi
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "::error::Missing required secret(s): ${missing[*]}"
+    exit 1
+  fi
+}
+
+append_env() {
+  local path="$1"
+  local name="$2"
+  local value="$3"
+  if [ -n "$path" ]; then
+    printf '%s=%s\n' "$name" "$value" >> "$path"
+  fi
+}
+
+decode_certificate() {
+  local output="$1"
+  if printf '%s' "$MACOS_CERTIFICATE_P12" | base64 --decode > "$output" 2>/dev/null; then
+    return 0
+  fi
+  printf '%s' "$MACOS_CERTIFICATE_P12" | base64 -D > "$output"
+}
+
+cleanup_after_setup_error() {
+  local status="$?"
+  cleanup_keychain || true
+  exit "$status"
+}
+
+setup_keychain() {
+  if [ -z "${RUNNER_TEMP:-}" ]; then
+    echo "::error::RUNNER_TEMP is required"
+    exit 1
+  fi
+  require_owned_state_path
+  cleanup_keychain
+  require_env \
+    MACOS_CERTIFICATE_NAME \
+    MACOS_CERTIFICATE_P12 \
+    MACOS_CERTIFICATE_PWD \
+    MACOS_KEYCHAIN_PASSWORD
+
+  local run_tag="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
+  local cert_path="$RUNNER_TEMP/browseros-signing-cert-$run_tag.p12"
+  local keychain_path="$RUNNER_TEMP/browseros-ci-signing-$run_tag.keychain-db"
+  local original_keychains_file="$RUNNER_TEMP/browseros-ci-original-keychains-$run_tag.txt"
+  local listed_keychains_file="$RUNNER_TEMP/browseros-ci-listed-keychains-$run_tag.txt"
+  local original_default_keychain
+
+  security list-keychains -d user 2>/dev/null \
+    | normalize_keychain_output > "$listed_keychains_file" || : > "$listed_keychains_file"
+  : > "$original_keychains_file"
+  local listed_keychain
+  while IFS= read -r listed_keychain; do
+    if [ -z "$listed_keychain" ]; then
+      continue
+    fi
+    if owned_keychain_path "$listed_keychain"; then
+      security lock-keychain "$listed_keychain" >/dev/null 2>&1 || true
+      security delete-keychain "$listed_keychain" >/dev/null 2>&1 || rm -f "$listed_keychain"
+      continue
+    fi
+    printf '%s\n' "$listed_keychain" >> "$original_keychains_file"
+  done < "$listed_keychains_file"
+  rm -f "$listed_keychains_file"
+
+  original_default_keychain="$(
+    security default-keychain -d user 2>/dev/null \
+      | normalize_keychain_output || true
+  )"
+  if owned_keychain_path "$original_default_keychain"; then
+    security lock-keychain "$original_default_keychain" >/dev/null 2>&1 || true
+    security delete-keychain "$original_default_keychain" >/dev/null 2>&1 || rm -f "$original_default_keychain"
+    original_default_keychain=""
+  fi
+
+  {
+    printf 'cert_path=%s\n' "$cert_path"
+    printf 'keychain_path=%s\n' "$keychain_path"
+    printf 'original_default_keychain=%s\n' "$original_default_keychain"
+    printf 'original_keychains_file=%s\n' "$original_keychains_file"
+  } > "$state_path"
+
+  trap cleanup_after_setup_error ERR
+
+  rm -f "$cert_path"
+  security delete-keychain "$keychain_path" >/dev/null 2>&1 || true
+  rm -f "$keychain_path"
+
+  decode_certificate "$cert_path"
+  security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$keychain_path"
+  security set-keychain-settings -lut 21600 "$keychain_path"
+  security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$keychain_path"
+  security import "$cert_path" -P "$MACOS_CERTIFICATE_PWD" -A -t cert -f pkcs12 -k "$keychain_path"
+  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_KEYCHAIN_PASSWORD" "$keychain_path"
+
+  local search_keychains=("$keychain_path")
+  local original_keychain
+  while IFS= read -r original_keychain; do
+    if [ -n "$original_keychain" ]; then
+      search_keychains+=("$original_keychain")
+    fi
+  done < "$original_keychains_file"
+  security list-keychains -d user -s "${search_keychains[@]}"
+  security default-keychain -d user -s "$keychain_path"
+  security show-keychain-info "$keychain_path" >/dev/null
+
+  local identities
+  identities="$(security find-identity -v -p codesigning "$keychain_path")"
+  if ! grep -Fq "$MACOS_CERTIFICATE_NAME" <<< "$identities"; then
+    echo "::error::Imported keychain does not expose the configured macOS signing identity"
+    return 1
+  fi
+  rm -f "$cert_path"
+
+  append_env "${GITHUB_ENV:-}" MACOS_KEYCHAIN_PATH "$keychain_path"
+  append_env "${GITHUB_ENV:-}" MACOS_SIGNING_STATE_PATH "$state_path"
+  append_env "${GITHUB_OUTPUT:-}" keychain_path "$keychain_path"
+  append_env "${GITHUB_OUTPUT:-}" state_path "$state_path"
+  trap - ERR
+}
+
+cleanup_keychain() {
+  if [ -z "$state_path" ] || [ ! -f "$state_path" ]; then
+    return 0
+  fi
+  if ! owned_state_path "$state_path"; then
+    echo "::warning::Ignoring unexpected macOS signing state path: $state_path"
+    return 0
+  fi
+
+  local cert_path=""
+  local keychain_path=""
+  local original_default_keychain=""
+  local original_keychains_file=""
+  local state_line
+  while IFS= read -r state_line; do
+    case "$state_line" in
+      cert_path=*) cert_path="${state_line#cert_path=}" ;;
+      keychain_path=*) keychain_path="${state_line#keychain_path=}" ;;
+      original_default_keychain=*) original_default_keychain="${state_line#original_default_keychain=}" ;;
+      original_keychains_file=*) original_keychains_file="${state_line#original_keychains_file=}" ;;
+    esac
+  done < "$state_path"
+
+  local original_keychains=()
+  local original_keychain
+  if owned_keychains_file "$original_keychains_file" && [ -f "$original_keychains_file" ]; then
+    while IFS= read -r original_keychain; do
+      if [ -n "$original_keychain" ]; then
+        original_keychains+=("$original_keychain")
+      fi
+    done < "$original_keychains_file"
+  fi
+  if owned_keychains_file "$original_keychains_file" && [ -f "$original_keychains_file" ]; then
+    security list-keychains -d user -s "${original_keychains[@]}" || true
+  fi
+  if [ -n "$original_default_keychain" ]; then
+    security default-keychain -d user -s "$original_default_keychain" || true
+  elif [ "${#original_keychains[@]}" -gt 0 ]; then
+    security default-keychain -d user -s "${original_keychains[0]}" || true
+  fi
+
+  if owned_keychain_path "$keychain_path"; then
+    security lock-keychain "$keychain_path" >/dev/null 2>&1 || true
+    security delete-keychain "$keychain_path" >/dev/null 2>&1 || rm -f "$keychain_path"
+  fi
+  if owned_cert_path "$cert_path"; then
+    rm -f "$cert_path"
+  fi
+  if owned_keychains_file "$original_keychains_file"; then
+    rm -f "$original_keychains_file"
+  fi
+  rm -f "$state_path"
+}
+
+case "${1:-}" in
+  setup)
+    setup_keychain
+    ;;
+  cleanup)
+    cleanup_keychain
+    ;;
+  *)
+    echo "usage: $0 setup|cleanup" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/bos-build-tests.yml
+++ b/.github/workflows/bos-build-tests.yml
@@ -11,6 +11,7 @@ on:
       - "packages/browseros/pyproject.toml"
       - "packages/browseros/uv.lock"
       - "tools/release_secrets/**"
+      - ".github/scripts/macos-signing-keychain.sh"
       - ".github/workflows/bos-build-tests.yml"
       - ".github/workflows/build-browseros.yml"
       - ".github/workflows/nightly-browserclaw.yml"

--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -222,6 +222,17 @@ jobs:
               -name 'BrowserOS_neo_*.dmg' -delete
           fi
 
+      - name: Import macOS signing certificate
+        id: macos_signing
+        working-directory: ${{ steps.build_inputs.outputs.browseros_repo }}
+        env:
+          MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        shell: bash
+        run: bash .github/scripts/macos-signing-keychain.sh setup
+
       - name: Build BrowserOS neo (macOS arm64)
         env:
           BROWSERCLAW_SERVER_RESOURCE_VERSION: ${{ needs.server.outputs.version }}
@@ -234,6 +245,7 @@ jobs:
           CHROMIUM_SRC: ${{ steps.build_inputs.outputs.chromium_src }}
           CLAW_POSTHOG_KEY: ${{ secrets.CLAW_POSTHOG_KEY }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+          MACOS_KEYCHAIN_PATH: ${{ steps.macos_signing.outputs.keychain_path }}
           MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
@@ -259,6 +271,18 @@ jobs:
             flags+=(--no-upload)
           fi
           uv run browseros build "${flags[@]}" --chromium-src "$CHROMIUM_SRC"
+
+      - name: Clean up macOS signing keychain
+        if: always()
+        env:
+          MACOS_SIGNING_STATE_PATH: ${{ steps.macos_signing.outputs.state_path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          script="${{ steps.build_inputs.outputs.browseros_repo }}/.github/scripts/macos-signing-keychain.sh"
+          if [ -f "$script" ]; then
+            bash "$script" cleanup
+          fi
 
       - name: Upload DMG artifact
         if: ${{ always() && steps.version.outputs.version != '' }}

--- a/.github/workflows/nightly-browseros.yml
+++ b/.github/workflows/nightly-browseros.yml
@@ -222,6 +222,17 @@ jobs:
               -name 'BrowserOS_*.dmg' ! -name 'BrowserOS_neo_*.dmg' -delete
           fi
 
+      - name: Import macOS signing certificate
+        id: macos_signing
+        working-directory: ${{ steps.build_inputs.outputs.browseros_repo }}
+        env:
+          MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        shell: bash
+        run: bash .github/scripts/macos-signing-keychain.sh setup
+
       - name: Build BrowserOS (macOS arm64)
         env:
           BROWSEROS_BUILD_SOURCE_SHA: ${{ steps.build_inputs.outputs.source_sha }}
@@ -233,6 +244,7 @@ jobs:
           BUNDLED_PRODUCT_EXTENSION_VERSION: ${{ needs.extension.outputs.version }}
           CHROMIUM_SRC: ${{ steps.build_inputs.outputs.chromium_src }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+          MACOS_KEYCHAIN_PATH: ${{ steps.macos_signing.outputs.keychain_path }}
           MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
@@ -258,6 +270,18 @@ jobs:
             flags+=(--no-upload)
           fi
           uv run browseros build "${flags[@]}" --chromium-src "$CHROMIUM_SRC"
+
+      - name: Clean up macOS signing keychain
+        if: always()
+        env:
+          MACOS_SIGNING_STATE_PATH: ${{ steps.macos_signing.outputs.state_path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          script="${{ steps.build_inputs.outputs.browseros_repo }}/.github/scripts/macos-signing-keychain.sh"
+          if [ -f "$script" ]; then
+            bash "$script" cleanup
+          fi
 
       - name: Upload DMG artifact
         if: ${{ always() && steps.version.outputs.version != '' }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -97,6 +97,10 @@ on:
         required: false
       MACOS_CERTIFICATE_NAME:
         required: false
+      MACOS_CERTIFICATE_P12:
+        required: false
+      MACOS_CERTIFICATE_PWD:
+        required: false
       MACOS_KEYCHAIN_PASSWORD:
         required: false
       PROD_MACOS_NOTARIZATION_APPLE_ID:
@@ -312,6 +316,17 @@ jobs:
             esac
           done
 
+      - name: Import macOS signing certificate
+        id: macos_signing
+        working-directory: ${{ steps.inputs.outputs.browseros_repo }}
+        env:
+          MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        shell: bash
+        run: bash .github/scripts/macos-signing-keychain.sh setup
+
       - name: Build selected products
         working-directory: ${{ steps.inputs.outputs.browseros_repo }}/packages/browseros
         env:
@@ -324,6 +339,7 @@ jobs:
           BUNDLED_PRODUCT_EXTENSION_VERSION: ${{ inputs.extension_version }}
           CLAW_POSTHOG_KEY: ${{ secrets.CLAW_POSTHOG_KEY }}
           MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+          MACOS_KEYCHAIN_PATH: ${{ steps.macos_signing.outputs.keychain_path }}
           MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
@@ -358,6 +374,18 @@ jobs:
             fi
             uv run browseros build "${args[@]}"
           done
+
+      - name: Clean up macOS signing keychain
+        if: always()
+        env:
+          MACOS_SIGNING_STATE_PATH: ${{ steps.macos_signing.outputs.state_path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          script="${{ steps.inputs.outputs.browseros_repo }}/.github/scripts/macos-signing-keychain.sh"
+          if [ -f "$script" ]; then
+            bash "$script" cleanup
+          fi
 
       - name: Upload lane manifest
         if: steps.inputs.outputs.resource_mode == 'source'

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -16,6 +16,7 @@ from bos_build.steps.source import provision
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+MACOS_SIGNING_HELPER = REPO_ROOT / ".github" / "scripts" / "macos-signing-keychain.sh"
 GIT_BOOTSTRAP_STEP = "Configure Git for depot_tools"
 EXPECTED_GIT_CONFIG = {
     "core.autocrlf": "false",
@@ -229,6 +230,61 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
         ):
             self.assertIn(value, build_step["run"])
         self.assertEqual(upload["with"]["if-no-files-found"], "error")
+
+    def test_macos_release_sets_up_ci_keychain_before_build_and_cleans_up(self):
+        workflow = self.load_workflow("release-macos.yml")
+        triggers = workflow.get("on", workflow.get(True))
+        secrets = triggers["workflow_call"]["secrets"]
+        steps = workflow["jobs"]["build"]["steps"]
+        setup_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Import macOS signing certificate"
+        )
+        build_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Build selected products"
+        )
+        cleanup_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Clean up macOS signing keychain"
+        )
+        upload_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Upload BrowserOS DMG artifact"
+        )
+        setup = steps[setup_index]
+        build = steps[build_index]
+        cleanup = steps[cleanup_index]
+
+        self.assertIn("MACOS_CERTIFICATE_P12", secrets)
+        self.assertIn("MACOS_CERTIFICATE_PWD", secrets)
+        self.assertLess(setup_index, build_index)
+        self.assertLess(build_index, cleanup_index)
+        self.assertLess(cleanup_index, upload_index)
+        self.assertEqual(setup["id"], "macos_signing")
+        self.assertIn("macos-signing-keychain.sh setup", setup["run"])
+        for name in (
+            "MACOS_CERTIFICATE_NAME",
+            "MACOS_CERTIFICATE_P12",
+            "MACOS_CERTIFICATE_PWD",
+            "MACOS_KEYCHAIN_PASSWORD",
+        ):
+            self.assertEqual(setup["env"][name], f"${{{{ secrets.{name} }}}}")
+        self.assertEqual(
+            build["env"]["MACOS_KEYCHAIN_PATH"],
+            "${{ steps.macos_signing.outputs.keychain_path }}",
+        )
+        self.assertEqual(cleanup["if"], "always()")
+        self.assertEqual(
+            cleanup["env"]["MACOS_SIGNING_STATE_PATH"],
+            "${{ steps.macos_signing.outputs.state_path }}",
+        )
+        self.assertIn("macos-signing-keychain.sh", cleanup["run"])
+        self.assertIn(" cleanup", cleanup["run"])
 
     def test_reusable_browser_build_records_the_checked_out_source(self):
         workflow = self.load_workflow("build-browseros.yml")
@@ -736,6 +792,16 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
 
         self.assertIn(
             ".github/workflows/build-browseros.yml",
+            pull_request_paths,
+        )
+
+    def test_macos_signing_helper_changes_trigger_build_system_tests(self):
+        test_workflow = self.load_workflow("bos-build-tests.yml")
+        triggers = test_workflow.get("on", test_workflow.get(True))
+        pull_request_paths = triggers["pull_request"]["paths"]
+
+        self.assertIn(
+            ".github/scripts/macos-signing-keychain.sh",
             pull_request_paths,
         )
 
@@ -1264,6 +1330,59 @@ class NightlyWorkflowTest(unittest.TestCase):
                     "${{ needs.reserve.outputs.onboarding_version }}",
                 )
 
+    def test_nightlies_setup_ci_keychain_before_build_and_cleanup_always(self):
+        for workflow_name, config in self.NIGHTLIES.items():
+            workflow = self.load_workflow(workflow_name)
+            steps = workflow["jobs"]["build"]["steps"]
+            setup_index = next(
+                index
+                for index, step in enumerate(steps)
+                if step.get("name") == "Import macOS signing certificate"
+            )
+            build_index = next(
+                index
+                for index, step in enumerate(steps)
+                if step.get("name") == config["build_step"]
+            )
+            cleanup_index = next(
+                index
+                for index, step in enumerate(steps)
+                if step.get("name") == "Clean up macOS signing keychain"
+            )
+            upload_index = next(
+                index
+                for index, step in enumerate(steps)
+                if step.get("name") == "Upload DMG artifact"
+            )
+            setup = steps[setup_index]
+            build = steps[build_index]
+            cleanup = steps[cleanup_index]
+
+            with self.subTest(workflow=workflow_name):
+                self.assertLess(setup_index, build_index)
+                self.assertLess(build_index, cleanup_index)
+                self.assertLess(cleanup_index, upload_index)
+                self.assertEqual(setup["id"], "macos_signing")
+                self.assertIn("macos-signing-keychain.sh setup", setup["run"])
+                for name in (
+                    "MACOS_CERTIFICATE_NAME",
+                    "MACOS_CERTIFICATE_P12",
+                    "MACOS_CERTIFICATE_PWD",
+                    "MACOS_KEYCHAIN_PASSWORD",
+                ):
+                    self.assertEqual(setup["env"][name], f"${{{{ secrets.{name} }}}}")
+                self.assertEqual(
+                    build["env"]["MACOS_KEYCHAIN_PATH"],
+                    "${{ steps.macos_signing.outputs.keychain_path }}",
+                )
+                self.assertEqual(cleanup["if"], "always()")
+                self.assertEqual(
+                    cleanup["env"]["MACOS_SIGNING_STATE_PATH"],
+                    "${{ steps.macos_signing.outputs.state_path }}",
+                )
+                self.assertIn("macos-signing-keychain.sh", cleanup["run"])
+                self.assertIn(" cleanup", cleanup["run"])
+
     def test_nightlies_publish_rolling_release_after_the_build(self):
         for workflow_name, config in self.NIGHTLIES.items():
             workflow = self.load_workflow(workflow_name)
@@ -1386,6 +1505,235 @@ class NightlyWorkflowTest(unittest.TestCase):
         self.assertIn(".github/workflows/nightly-browseros.yml", paths)
         self.assertIn(".github/workflows/nightly-browserclaw.yml", paths)
         self.assertIn(".github/workflows/reserve-nightly-browser-version.yml", paths)
+
+
+@unittest.skipIf(os.name == "nt", "macOS signing helper shell tests run on POSIX")
+class MacOSSigningKeychainHelperTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runner_temp = self.root / "runner"
+        self.runner_temp.mkdir()
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.security_log = self.root / "security.log"
+        self.github_env = self.root / "github_env"
+        self.github_output = self.root / "github_output"
+        self.original_keychain = self.root / "login.keychain-db"
+        self.original_default = self.original_keychain
+        self._write_fake_security()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write_fake_security(self):
+        security = self.bin_dir / "security"
+        security.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$SECURITY_LOG"
+cmd="$1"
+shift || true
+last="${@: -1}"
+case "$cmd" in
+  list-keychains)
+    if [[ " $* " == *" -s "* ]]; then
+      exit 0
+    fi
+    printf '"%s"\\n' "$ORIGINAL_KEYCHAIN"
+    if [ -n "${EXTRA_KEYCHAIN:-}" ]; then
+      printf '"%s"\\n' "$EXTRA_KEYCHAIN"
+    fi
+    ;;
+  default-keychain)
+    if [[ " $* " == *" -s "* ]]; then
+      exit 0
+    fi
+    printf '"%s"\\n' "$ORIGINAL_DEFAULT_KEYCHAIN"
+    ;;
+  create-keychain)
+    touch "$last"
+    ;;
+  delete-keychain)
+    rm -f "$last"
+    ;;
+  import)
+    if [ "${SECURITY_FAIL_IMPORT:-}" = "1" ]; then
+      exit 42
+    fi
+    ;;
+  find-identity)
+    printf '  1) ABC "%s"\\n' "$MACOS_CERTIFICATE_NAME"
+    ;;
+  unlock-keychain|set-keychain-settings|set-key-partition-list|show-keychain-info|lock-keychain)
+    ;;
+esac
+"""
+        )
+        security.chmod(0o755)
+
+    def _env(self, **overrides):
+        env = os.environ.copy()
+        env.update(
+            {
+                "GITHUB_ENV": str(self.github_env),
+                "GITHUB_OUTPUT": str(self.github_output),
+                "GITHUB_RUN_ATTEMPT": "4",
+                "GITHUB_RUN_ID": "123",
+                "MACOS_CERTIFICATE_NAME": "Developer ID Application",
+                "MACOS_CERTIFICATE_P12": "ZmFrZS1wMTI=",
+                "MACOS_CERTIFICATE_PWD": "p12-password",
+                "MACOS_KEYCHAIN_PASSWORD": "keychain-password",
+                "ORIGINAL_DEFAULT_KEYCHAIN": str(self.original_default),
+                "ORIGINAL_KEYCHAIN": str(self.original_keychain),
+                "PATH": f"{self.bin_dir}{os.pathsep}{env['PATH']}",
+                "RUNNER_TEMP": str(self.runner_temp),
+                "SECURITY_LOG": str(self.security_log),
+            }
+        )
+        env.update(overrides)
+        return env
+
+    def _run_helper(self, command, **env_overrides):
+        return subprocess.run(
+            ["bash", str(MACOS_SIGNING_HELPER), command],
+            capture_output=True,
+            env=self._env(**env_overrides),
+            text=True,
+        )
+
+    def _outputs(self):
+        values = {}
+        for line in self.github_output.read_text(encoding="utf-8").splitlines():
+            name, value = line.split("=", 1)
+            values[name] = value
+        return values
+
+    def test_setup_imports_p12_and_cleanup_restores_keychain_state(self):
+        result = self._run_helper("setup")
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        outputs = self._outputs()
+        keychain_path = Path(outputs["keychain_path"])
+        state_path = Path(outputs["state_path"])
+        cert_path = self.runner_temp / "browseros-signing-cert-123-4.p12"
+
+        self.assertTrue(keychain_path.exists())
+        self.assertTrue(state_path.exists())
+        self.assertFalse(cert_path.exists())
+        self.assertIn(
+            f"MACOS_KEYCHAIN_PATH={keychain_path}",
+            self.github_env.read_text(encoding="utf-8"),
+        )
+
+        cleanup = self._run_helper(
+            "cleanup",
+            MACOS_SIGNING_STATE_PATH=str(state_path),
+        )
+        self.assertEqual(cleanup.returncode, 0, cleanup.stderr + cleanup.stdout)
+
+        log = self.security_log.read_text(encoding="utf-8")
+        self.assertIn(f"import {self.runner_temp}", log)
+        self.assertIn("set-key-partition-list", log)
+        self.assertIn(f"find-identity -v -p codesigning {keychain_path}", log)
+        self.assertIn(
+            f"list-keychains -d user -s {keychain_path} {self.original_keychain}",
+            log,
+        )
+        self.assertIn(
+            f"default-keychain -d user -s {self.original_keychain}",
+            log,
+        )
+        self.assertFalse(keychain_path.exists())
+        self.assertFalse(state_path.exists())
+
+    def test_setup_failure_cleans_partial_keychain_and_certificate(self):
+        result = self._run_helper("setup", SECURITY_FAIL_IMPORT="1")
+
+        self.assertNotEqual(result.returncode, 0)
+        keychain_path = self.runner_temp / "browseros-ci-signing-123-4.keychain-db"
+        cert_path = self.runner_temp / "browseros-signing-cert-123-4.p12"
+        state_path = self.runner_temp / "browseros-ci-signing-keychain-state.env"
+        log = self.security_log.read_text(encoding="utf-8")
+
+        self.assertIn(f"lock-keychain {keychain_path}", log)
+        self.assertIn(f"delete-keychain {keychain_path}", log)
+        self.assertFalse(keychain_path.exists())
+        self.assertFalse(cert_path.exists())
+        self.assertFalse(state_path.exists())
+
+    def test_setup_rejects_unowned_state_path(self):
+        unowned_state_path = self.root / "outside-state.env"
+
+        result = self._run_helper(
+            "setup",
+            MACOS_SIGNING_STATE_PATH=str(unowned_state_path),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Unexpected macOS signing state path",
+            result.stdout + result.stderr,
+        )
+        self.assertFalse(unowned_state_path.exists())
+
+    def test_setup_first_cleans_previous_recorded_state(self):
+        old_keychain_path = self.runner_temp / "browseros-ci-signing-old-1.keychain-db"
+        old_cert_path = self.runner_temp / "browseros-signing-cert-old-1.p12"
+        old_originals_path = self.runner_temp / "browseros-ci-original-keychains-old-1.txt"
+        old_state_path = self.runner_temp / "browseros-ci-signing-keychain-state.env"
+        old_original = self.root / "old-login.keychain-db"
+        old_keychain_path.write_text("old-keychain")
+        old_cert_path.write_text("old-cert")
+        old_originals_path.write_text(f"{old_original}\n", encoding="utf-8")
+        old_state_path.write_text(
+            "\n".join(
+                (
+                    f"cert_path={old_cert_path}",
+                    f"keychain_path={old_keychain_path}",
+                    f"original_default_keychain={old_original}",
+                    f"original_keychains_file={old_originals_path}",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = self._run_helper("setup")
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        log = self.security_log.read_text(encoding="utf-8")
+        self.assertIn(f"lock-keychain {old_keychain_path}", log)
+        self.assertIn(f"delete-keychain {old_keychain_path}", log)
+        self.assertIn(f"default-keychain -d user -s {old_original}", log)
+        self.assertFalse(old_keychain_path.exists())
+        self.assertFalse(old_cert_path.exists())
+        self.assertFalse(old_originals_path.exists())
+        self.assertTrue(old_state_path.exists())
+
+    def test_setup_filters_stale_ci_keychains_from_restored_search_list(self):
+        stale_keychain = self.runner_temp / "browseros-ci-signing-stale-1.keychain-db"
+        stale_keychain.write_text("stale")
+
+        result = self._run_helper("setup", EXTRA_KEYCHAIN=str(stale_keychain))
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        outputs = self._outputs()
+        cleanup = self._run_helper(
+            "cleanup",
+            MACOS_SIGNING_STATE_PATH=outputs["state_path"],
+        )
+
+        self.assertEqual(cleanup.returncode, 0, cleanup.stderr + cleanup.stdout)
+        log = self.security_log.read_text(encoding="utf-8")
+        self.assertIn(f"delete-keychain {stale_keychain}", log)
+        self.assertNotIn(
+            f"list-keychains -d user -s {outputs['keychain_path']} {self.original_keychain} {stale_keychain}",
+            log,
+        )
+        self.assertNotIn(
+            f"list-keychains -d user -s {self.original_keychain} {stale_keychain}",
+            log,
+        )
+        self.assertFalse(stale_keychain.exists())
 
 
 class ReleaseDocumentationTest(unittest.TestCase):

--- a/packages/browseros/bos_build/lib/env.py
+++ b/packages/browseros/bos_build/lib/env.py
@@ -20,6 +20,8 @@ SENSITIVE_ENV_VARS: frozenset[str] = frozenset(
         "ESIGNER_TOTP_SECRET",
         "GITHUB_TOKEN",
         "GH_TOKEN",
+        "MACOS_CERTIFICATE_P12",
+        "MACOS_CERTIFICATE_PWD",
         "MACOS_KEYCHAIN_PASSWORD",
         "POSTHOG_API_KEY",
         "PROD_MACOS_NOTARIZATION_PWD",
@@ -123,6 +125,11 @@ class EnvConfig:
     def macos_keychain_password(self) -> Optional[str]:
         """macOS login keychain password (used to unlock keychain on build servers)"""
         return os.environ.get("MACOS_KEYCHAIN_PASSWORD")
+
+    @property
+    def macos_keychain_path(self) -> Optional[str]:
+        """Explicit macOS signing keychain path."""
+        return os.environ.get("MACOS_KEYCHAIN_PATH")
 
     @property
     def code_sign_tool_path(self) -> Optional[str]:

--- a/packages/browseros/bos_build/steps/package/macos.py
+++ b/packages/browseros/bos_build/steps/package/macos.py
@@ -3,10 +3,17 @@
 
 import shutil
 from pathlib import Path
-from typing import Optional, List
+from typing import Optional, List, Dict
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
-from ...lib.utils import run_command, log_info, log_error, log_success, IS_MACOS
+from ...lib.utils import (
+    run_command,
+    log_info,
+    log_error,
+    log_success,
+    log_warning,
+    IS_MACOS,
+)
 
 
 @step("package_macos", phase="package", platforms=("macos",))
@@ -53,12 +60,15 @@ class MacOSPackageModule(Step):
     ) -> None:
         from ..sign.macos import check_environment
 
-        env_ok, env_vars = check_environment()
+        env_ok, env_vars = check_environment(ctx.env)
         if not env_ok:
             raise ValidationError("Signing environment not configured")
 
         certificate_name = env_vars["certificate_name"]
         keychain_profile = env_vars.get("keychain_profile", "notarytool-profile")
+        keychain_path = (
+            Path(env_vars["keychain_path"]) if env_vars.get("keychain_path") else None
+        )
 
         if not create_signed_notarized_dmg(
             app_path,
@@ -67,8 +77,12 @@ class MacOSPackageModule(Step):
             ctx.product.mac.dmg_volume_name,
             pkg_dmg_path,
             keychain_profile,
+            keychain_path,
+            env_vars,
         ):
             raise RuntimeError("Failed to create signed and notarized DMG")
+
+
 def create_dmg(
     app_path: Path,
     dmg_path: Path,
@@ -135,7 +149,11 @@ def create_dmg(
         return False
 
 
-def sign_dmg(dmg_path: Path, certificate_name: str) -> bool:
+def sign_dmg(
+    dmg_path: Path,
+    certificate_name: str,
+    keychain_path: Optional[Path] = None,
+) -> bool:
     """Sign a DMG file"""
     log_info(f"\n🔏 Signing DMG: {dmg_path.name}")
 
@@ -144,16 +162,17 @@ def sign_dmg(dmg_path: Path, certificate_name: str) -> bool:
         return False
 
     try:
-        run_command(
-            [
-                "codesign",
-                "--sign",
-                certificate_name,
-                "--force",
-                "--timestamp",
-                str(dmg_path),
-            ]
-        )
+        cmd = [
+            "codesign",
+            "--sign",
+            certificate_name,
+            "--force",
+            "--timestamp",
+        ]
+        if keychain_path:
+            cmd.extend(["--keychain", str(keychain_path)])
+        cmd.append(str(dmg_path))
+        run_command(cmd)
 
         # Verify signature
         log_info("🔍 Verifying DMG signature...")
@@ -166,7 +185,12 @@ def sign_dmg(dmg_path: Path, certificate_name: str) -> bool:
         return False
 
 
-def notarize_dmg(dmg_path: Path, keychain_profile: str = "notarytool-profile") -> bool:
+def notarize_dmg(
+    dmg_path: Path,
+    keychain_profile: str = "notarytool-profile",
+    keychain_path: Optional[Path] = None,
+    notarization_env: Optional[Dict[str, str]] = None,
+) -> bool:
     """Notarize a DMG file"""
     log_info(f"\n📤 Notarizing DMG: {dmg_path.name}")
 
@@ -177,18 +201,41 @@ def notarize_dmg(dmg_path: Path, keychain_profile: str = "notarytool-profile") -
     try:
         # Submit for notarization
         log_info("📤 Submitting DMG for notarization (this may take a while)...")
-        result = run_command(
-            [
-                "xcrun",
-                "notarytool",
-                "submit",
-                str(dmg_path),
-                "--keychain-profile",
-                keychain_profile,
-                "--wait",
-            ],
-            check=False,
-        )
+        submit_cmd = [
+            "xcrun",
+            "notarytool",
+            "submit",
+            str(dmg_path),
+            "--keychain-profile",
+            keychain_profile,
+            "--wait",
+        ]
+        if keychain_path:
+            submit_cmd.extend(["--keychain", str(keychain_path)])
+        result = run_command(submit_cmd, check=False)
+
+        if (
+            result.returncode != 0
+            and not keychain_path
+            and notarization_env is not None
+        ):
+            log_warning("Keychain profile unavailable — passing credentials directly")
+            result = run_command(
+                [
+                    "xcrun",
+                    "notarytool",
+                    "submit",
+                    str(dmg_path),
+                    "--apple-id",
+                    notarization_env["apple_id"],
+                    "--team-id",
+                    notarization_env["team_id"],
+                    "--password",
+                    notarization_env["notarization_pwd"],
+                    "--wait",
+                ],
+                check=False,
+            )
 
         log_info(result.stdout)
         if result.stderr:
@@ -270,6 +317,8 @@ def create_signed_notarized_dmg(
     volume_name: str = "BrowserOS",
     pkg_dmg_path: Optional[Path] = None,
     keychain_profile: str = "notarytool-profile",
+    keychain_path: Optional[Path] = None,
+    notarization_env: Optional[Dict[str, str]] = None,
 ) -> bool:
     """Create, sign, and notarize a DMG in one go"""
     log_info("=" * 70)
@@ -281,11 +330,11 @@ def create_signed_notarized_dmg(
         return False
 
     # Sign DMG
-    if not sign_dmg(dmg_path, certificate_name):
+    if not sign_dmg(dmg_path, certificate_name, keychain_path):
         return False
 
     # Notarize DMG
-    if not notarize_dmg(dmg_path, keychain_profile):
+    if not notarize_dmg(dmg_path, keychain_profile, keychain_path, notarization_env):
         return False
 
     log_info("=" * 70)

--- a/packages/browseros/bos_build/steps/package/macos_test.py
+++ b/packages/browseros/bos_build/steps/package/macos_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Tests for macOS DMG packaging."""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from . import macos as macos_module
+from .macos import notarize_dmg, sign_dmg
+
+
+def _completed(cmd, returncode=0, stdout=""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
+
+
+class MacOSPackageKeychainTest(unittest.TestCase):
+    def test_sign_dmg_passes_configured_keychain_to_codesign(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dmg_path = Path(tmp) / "BrowserOS.dmg"
+            dmg_path.write_text("dmg")
+            keychain = Path(tmp) / "ci.keychain-db"
+            calls = []
+
+            def run(cmd, cwd=None, check=True):
+                calls.append(cmd)
+                return _completed(cmd)
+
+            with mock.patch.object(macos_module, "run_command", run):
+                self.assertTrue(sign_dmg(dmg_path, "Cert", keychain))
+
+            sign_cmd = calls[0]
+            self.assertEqual(sign_cmd[0], "codesign")
+            self.assertIn("--keychain", sign_cmd)
+            self.assertEqual(
+                sign_cmd[sign_cmd.index("--keychain") + 1],
+                str(keychain),
+            )
+
+    def test_notarize_dmg_passes_configured_keychain_to_notarytool(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dmg_path = Path(tmp) / "BrowserOS.dmg"
+            dmg_path.write_text("dmg")
+            keychain = Path(tmp) / "ci.keychain-db"
+            calls = []
+
+            def run(cmd, cwd=None, check=True):
+                calls.append(cmd)
+                if cmd[:3] == ["xcrun", "notarytool", "submit"]:
+                    return _completed(cmd, stdout="status: Accepted\n")
+                return _completed(cmd)
+
+            with mock.patch.object(macos_module, "run_command", run):
+                self.assertTrue(
+                    notarize_dmg(
+                        dmg_path,
+                        "notarytool-profile",
+                        keychain,
+                    )
+                )
+
+            submit = calls[0]
+            self.assertEqual(submit[:3], ["xcrun", "notarytool", "submit"])
+            self.assertIn("--keychain", submit)
+            self.assertEqual(
+                submit[submit.index("--keychain") + 1],
+                str(keychain),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/packages/browseros/bos_build/steps/sign/macos.py
+++ b/packages/browseros/bos_build/steps/sign/macos.py
@@ -128,33 +128,58 @@ def run_command(
     return utils_run_command(cmd, cwd=cwd, check=check)
 
 
-def unlock_keychain(env: Optional[EnvConfig] = None) -> None:
-    """Unlock the login keychain for non-interactive sessions (SSH, launchd).
+def get_macos_keychain_path(env: Optional[EnvConfig] = None) -> Optional[Path]:
+    """Return the explicitly configured macOS signing keychain."""
+    value = env.macos_keychain_path if env else os.environ.get("MACOS_KEYCHAIN_PATH")
+    if not value:
+        return None
+    return Path(value).expanduser()
 
-    Without this, codesign and notarytool fail with errSecInternalComponent
-    or 'User interaction is not allowed' when running over SSH.
-    """
-    keychain_path = Path.home() / "Library" / "Keychains" / "login.keychain-db"
-    password = env.macos_keychain_password if env else os.environ.get("MACOS_KEYCHAIN_PASSWORD")
+
+def unlock_keychain(env: Optional[EnvConfig] = None) -> None:
+    """Unlock the configured signing keychain."""
+    configured_keychain = get_macos_keychain_path(env)
+    keychain_path = (
+        configured_keychain
+        if configured_keychain
+        else Path.home() / "Library" / "Keychains" / "login.keychain-db"
+    )
+    password = (
+        env.macos_keychain_password
+        if env
+        else os.environ.get("MACOS_KEYCHAIN_PASSWORD")
+    )
 
     if not password:
+        if configured_keychain:
+            raise RuntimeError(
+                "MACOS_KEYCHAIN_PASSWORD is required when MACOS_KEYCHAIN_PATH is set"
+            )
         log_warning("MACOS_KEYCHAIN_PASSWORD not set — keychain may be locked (will fail over SSH)")
         return
 
     if not keychain_path.exists():
+        if configured_keychain:
+            raise RuntimeError(f"Configured keychain not found at {keychain_path}")
         log_warning(f"Keychain not found at {keychain_path}")
         return
 
-    log_info("🔓 Unlocking login keychain...")
-    run_command(
+    log_info(f"🔓 Unlocking macOS signing keychain: {keychain_path}")
+    unlock_result = run_command(
         ["security", "unlock-keychain", "-p", password, str(keychain_path)],
         check=False,
     )
     # Prevent auto-lock during long signing + notarization runs
-    run_command(
+    settings_result = run_command(
         ["security", "set-keychain-settings", "-t", "3600", str(keychain_path)],
         check=False,
     )
+    if configured_keychain and unlock_result.returncode != 0:
+        raise RuntimeError(f"Failed to unlock configured keychain: {keychain_path}")
+    if configured_keychain and settings_result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to update configured keychain settings: {keychain_path}"
+        )
 
 
 @step(
@@ -185,15 +210,21 @@ class MacOSSignModule(Step):
         log_info(f"🚀 Starting signing process for {ctx.product.display_name}...")
         log_info("=" * 70)
 
-        unlock_keychain(ctx.env)
-
         app_path = ctx.get_app_path()
         env_ok, env_vars = check_environment(ctx.env)
+        if not env_ok:
+            raise RuntimeError("Signing environment not configured")
+        unlock_keychain(ctx.env)
 
         self._verify_server_resources(app_path, ctx)
         self._stamp_update_versions(app_path, ctx)
         self._clear_extended_attributes(app_path)
-        self._sign_all_components(app_path, env_vars["certificate_name"], ctx)
+        self._sign_all_components(
+            app_path,
+            env_vars["certificate_name"],
+            ctx,
+            env_vars["keychain_path"],
+        )
         self._verify_signature(app_path, ctx)
         self._notarize(app_path, env_vars, ctx)
 
@@ -242,8 +273,20 @@ class MacOSSignModule(Step):
         log_info("🧹 Clearing extended attributes...")
         run_command(["xattr", "-cs", str(app_path)])
 
-    def _sign_all_components(self, app_path: Path, certificate_name: str, ctx: Context) -> None:
-        if not sign_all_components(app_path, certificate_name, ctx.root_dir, ctx):
+    def _sign_all_components(
+        self,
+        app_path: Path,
+        certificate_name: str,
+        ctx: Context,
+        keychain_path: str = "",
+    ) -> None:
+        if not sign_all_components(
+            app_path,
+            certificate_name,
+            ctx.root_dir,
+            ctx,
+            Path(keychain_path) if keychain_path else None,
+        ):
             raise RuntimeError("Failed to sign all components")
 
     def _verify_signature(self, app_path: Path, ctx: Optional[Context] = None) -> None:
@@ -251,8 +294,17 @@ class MacOSSignModule(Step):
             raise RuntimeError("Signature verification failed")
 
     def _notarize(self, app_path: Path, env_vars: Dict[str, str], ctx: Context) -> None:
-        if not notarize_app(app_path, ctx.root_dir, env_vars, ctx):
+        keychain_path = env_vars.get("keychain_path", "")
+        if not notarize_app(
+            app_path,
+            ctx.root_dir,
+            env_vars,
+            ctx,
+            Path(keychain_path) if keychain_path else None,
+        ):
             raise RuntimeError("Notarization failed")
+
+
 def check_signing_environment(env: Optional[EnvConfig] = None) -> bool:
     """Check if all required environment variables are set for signing (early check)
 
@@ -300,10 +352,14 @@ def check_environment(env: Optional[EnvConfig] = None) -> Tuple[bool, Dict[str, 
         "apple_id": env.macos_notarization_apple_id or "",
         "team_id": env.macos_notarization_team_id or "",
         "notarization_pwd": env.macos_notarization_password or "",
+        "keychain_path": str(get_macos_keychain_path(env) or ""),
+        "keychain_profile": "notarytool-profile",
     }
 
     missing = []
     for key, value in env_vars.items():
+        if key in {"keychain_path", "keychain_profile"}:
+            continue
         if not value:
             env_name = {
                 "certificate_name": "MACOS_CERTIFICATE_NAME",
@@ -562,8 +618,12 @@ def _codesign_cmd(
     identifier: Optional[str] = None,
     options: Optional[str] = None,
     entitlements: Optional[Path] = None,
+    keychain_path: Optional[Path] = None,
 ) -> List[str]:
     cmd = ["codesign", "--sign", certificate_name, "--force", "--timestamp"]
+
+    if keychain_path:
+        cmd.extend(["--keychain", str(keychain_path)])
 
     if identifier:
         cmd.extend(["--identifier", identifier])
@@ -585,6 +645,7 @@ def sign_fat_component_per_slice(
     identifier: Optional[str] = None,
     options: Optional[str] = None,
     entitlements: Optional[Path] = None,
+    keychain_path: Optional[Path] = None,
 ) -> bool:
     """Sign each slice as a thin file and lipo them back together."""
     try:
@@ -598,7 +659,12 @@ def sign_fat_component_per_slice(
                 )
                 run_command(
                     _codesign_cmd(
-                        thin, certificate_name, identifier, options, entitlements
+                        thin,
+                        certificate_name,
+                        identifier,
+                        options,
+                        entitlements,
+                        keychain_path,
                     )
                 )
                 thin_paths.append(thin)
@@ -621,6 +687,7 @@ def sign_component(
     identifier: Optional[str] = None,
     options: Optional[str] = None,
     entitlements: Optional[Path] = None,
+    keychain_path: Optional[Path] = None,
 ) -> bool:
     """Sign a single component"""
     asymmetric_archs = find_asymmetric_info_plist_archs(component_path)
@@ -636,12 +703,18 @@ def sign_component(
             identifier,
             options,
             entitlements,
+            keychain_path,
         )
 
     try:
         run_command(
             _codesign_cmd(
-                component_path, certificate_name, identifier, options, entitlements
+                component_path,
+                certificate_name,
+                identifier,
+                options,
+                entitlements,
+                keychain_path,
             )
         )
         return True
@@ -655,6 +728,7 @@ def sign_all_components(
     certificate_name: str,
     root_dir: Path,
     ctx: Optional[Context] = None,
+    keychain_path: Optional[Path] = None,
 ) -> bool:
     """Sign all components in the correct order (bottom-up)"""
     log_info("🔍 Discovering components to sign...")
@@ -681,7 +755,9 @@ def sign_all_components(
     for xpc in components["xpc_services"]:
         identifier = get_identifier_for_component(xpc, base_identifier)
         options = get_signing_options(xpc)
-        if not sign_component(xpc, certificate_name, identifier, options):
+        if not sign_component(
+            xpc, certificate_name, identifier, options, keychain_path=keychain_path
+        ):
             return False
 
     # 2. Sign nested apps (like Sparkle's Updater.app)
@@ -690,7 +766,13 @@ def sign_all_components(
         for nested_app in components["apps"]:
             identifier = get_identifier_for_component(nested_app, base_identifier)
             options = get_signing_options(nested_app)
-            if not sign_component(nested_app, certificate_name, identifier, options):
+            if not sign_component(
+                nested_app,
+                certificate_name,
+                identifier,
+                options,
+                keychain_path=keychain_path,
+            ):
                 return False
 
     # 3. Sign executables
@@ -717,7 +799,14 @@ def sign_all_components(
                             entitlements = ent_path
                             break
 
-            if not sign_component(exe, certificate_name, identifier, options, entitlements):
+            if not sign_component(
+                exe,
+                certificate_name,
+                identifier,
+                options,
+                entitlements,
+                keychain_path,
+            ):
                 return False
 
     # 4. Sign dylibs
@@ -725,7 +814,9 @@ def sign_all_components(
         log_info("\n🔏 Signing dynamic libraries...")
         for dylib in components["dylibs"]:
             identifier = get_identifier_for_component(dylib, base_identifier)
-            if not sign_component(dylib, certificate_name, identifier):
+            if not sign_component(
+                dylib, certificate_name, identifier, keychain_path=keychain_path
+            ):
                 return False
 
     # 5. Sign helper apps
@@ -759,7 +850,12 @@ def sign_all_components(
                         break
 
             if not sign_component(
-                helper, certificate_name, identifier, options, entitlements
+                helper,
+                certificate_name,
+                identifier,
+                options,
+                entitlements,
+                keychain_path,
             ):
                 return False
 
@@ -772,7 +868,9 @@ def sign_all_components(
         )
         for framework in frameworks_sorted:
             identifier = get_identifier_for_component(framework, base_identifier)
-            if not sign_component(framework, certificate_name, identifier):
+            if not sign_component(
+                framework, certificate_name, identifier, keychain_path=keychain_path
+            ):
                 return False
 
     # 7. Sign main executable
@@ -796,7 +894,9 @@ def sign_all_components(
         )
         return False
 
-    if not sign_component(main_exe, certificate_name, main_identifier):
+    if not sign_component(
+        main_exe, certificate_name, main_identifier, keychain_path=keychain_path
+    ):
         return False
 
     # 8. Finally sign the app bundle
@@ -848,6 +948,9 @@ def sign_all_components(
         "--requirements",
         requirements,
     ]
+
+    if keychain_path:
+        cmd.extend(["--keychain", str(keychain_path)])
 
     if entitlements:
         cmd.extend(["--entitlements", str(entitlements)])
@@ -902,6 +1005,7 @@ def notarize_app(
     root_dir: Path,
     env_vars: Dict[str, str],
     ctx: Optional[Context] = None,
+    keychain_path: Optional[Path] = None,
 ) -> bool:
     """Notarize the application"""
     log_info("\n📤 Preparing for notarization...")
@@ -918,21 +1022,27 @@ def notarize_app(
 
     # Store credentials
     log_info("🔑 Storing notarization credentials...")
-    store_result = run_command(
-        [
-            "xcrun",
-            "notarytool",
-            "store-credentials",
-            "notarytool-profile",
-            "--apple-id",
-            env_vars["apple_id"],
-            "--team-id",
-            env_vars["team_id"],
-            "--password",
-            env_vars["notarization_pwd"],
-        ],
-        check=False,
-    )
+    profile = env_vars.get("keychain_profile", "notarytool-profile")
+    store_cmd = [
+        "xcrun",
+        "notarytool",
+        "store-credentials",
+        profile,
+        "--apple-id",
+        env_vars["apple_id"],
+        "--team-id",
+        env_vars["team_id"],
+        "--password",
+        env_vars["notarization_pwd"],
+    ]
+    if keychain_path:
+        store_cmd.extend(["--keychain", str(keychain_path)])
+    store_result = run_command(store_cmd, check=False)
+
+    if keychain_path and store_result.returncode != 0:
+        log_error("Failed to store notarization credentials in configured keychain")
+        notarize_zip.unlink(missing_ok=True)
+        return False
 
     # Submit for notarization — if store-credentials failed, pass creds
     # directly to avoid depending on the keychain profile.
@@ -945,9 +1055,11 @@ def notarize_app(
             "submit",
             str(notarize_zip),
             "--keychain-profile",
-            "notarytool-profile",
+            profile,
             "--wait",
         ]
+        if keychain_path:
+            submit_cmd.extend(["--keychain", str(keychain_path)])
     else:
         log_warning("Keychain profile unavailable — passing credentials directly")
         submit_cmd = [
@@ -981,7 +1093,7 @@ def notarize_app(
             if "id:" in line:
                 submission_id = line.split("id:")[1].strip().split()[0]
                 log_info(
-                    f'Get detailed logs with: xcrun notarytool log {submission_id} --keychain-profile "notarytool-profile"'
+                    f'Get detailed logs with: xcrun notarytool log {submission_id} --keychain-profile "{profile}"'
                 )
                 break
         return False
@@ -1028,8 +1140,6 @@ def sign_app(ctx: Context, create_dmg: bool = True) -> bool:
     log_info(f"🚀 Starting signing process for {ctx.product.display_name}...")
     log_info("=" * 70)
 
-    unlock_keychain(ctx.env if ctx else None)
-
     # Error tracking similar to bash script
     error_count = 0
     error_messages = []
@@ -1041,9 +1151,13 @@ def sign_app(ctx: Context, create_dmg: bool = True) -> bool:
         log_error(msg)
 
     # Check environment
-    env_ok, env_vars = check_environment()
+    env_ok, env_vars = check_environment(ctx.env if ctx else None)
     if not env_ok:
         return False
+    unlock_keychain(ctx.env if ctx else None)
+    keychain_path = (
+        Path(env_vars["keychain_path"]) if env_vars["keychain_path"] else None
+    )
 
     # Setup app path
     app_path = ctx.get_app_path()
@@ -1077,7 +1191,11 @@ def sign_app(ctx: Context, create_dmg: bool = True) -> bool:
 
         # Sign all components
         if not sign_all_components(
-            app_path, env_vars["certificate_name"], ctx.root_dir, ctx
+            app_path,
+            env_vars["certificate_name"],
+            ctx.root_dir,
+            ctx,
+            keychain_path,
         ):
             return False
 
@@ -1086,7 +1204,7 @@ def sign_app(ctx: Context, create_dmg: bool = True) -> bool:
             return False
 
         # Notarize app
-        if not notarize_app(app_path, ctx.root_dir, env_vars, ctx):
+        if not notarize_app(app_path, ctx.root_dir, env_vars, ctx, keychain_path):
             return False
 
         # Create and notarize DMG if requested
@@ -1107,7 +1225,9 @@ def sign_app(ctx: Context, create_dmg: bool = True) -> bool:
                 certificate_name=env_vars["certificate_name"],
                 volume_name=ctx.product.mac.dmg_volume_name,
                 pkg_dmg_path=pkg_dmg_path,
-                keychain_profile="notarytool-profile",
+                keychain_profile=env_vars["keychain_profile"],
+                keychain_path=keychain_path,
+                notarization_env=env_vars,
             ):
                 log_error("DMG creation/notarization failed")
                 return False

--- a/packages/browseros/bos_build/steps/sign/macos_test.py
+++ b/packages/browseros/bos_build/steps/sign/macos_test.py
@@ -15,8 +15,11 @@ from . import macos as macos_module
 from .macos import (
     SERVER_RESOURCES_SOURCE_REL,
     MacOSSignModule,
+    check_environment,
     find_components_to_sign,
+    notarize_app,
     sign_component,
+    unlock_keychain,
     verify_server_resources_bundle,
     verify_signature,
 )
@@ -31,6 +34,13 @@ def _write_exec(path: Path) -> None:
 def _write_file(path: Path, content: str = "data\n") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
+
+
+def _env(**values):
+    env = type("Env", (), {})()
+    for name, value in values.items():
+        setattr(env, name, value)
+    return env
 
 
 class MacOSSignDiscoveryTest(unittest.TestCase):
@@ -285,6 +295,139 @@ class SignModuleGuardWiringTest(unittest.TestCase):
             )
 
             MacOSSignModule()._verify_server_resources(app_path, ctx)
+
+
+class MacOSKeychainSelectionTest(unittest.TestCase):
+    def test_unlock_keychain_uses_configured_keychain(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            keychain = Path(tmp) / "ci.keychain-db"
+            keychain.write_text("keychain")
+            calls = []
+            env = _env(
+                macos_keychain_path=str(keychain),
+                macos_keychain_password="password",
+            )
+
+            with mock.patch.object(
+                macos_module, "run_command", _fake_run_command(calls)
+            ):
+                unlock_keychain(env)
+
+            self.assertEqual(
+                calls[0],
+                ["security", "unlock-keychain", "-p", "password", str(keychain)],
+            )
+            self.assertEqual(calls[1][-1], str(keychain))
+
+    def test_unlock_keychain_requires_existing_configured_keychain(self):
+        env = _env(
+            macos_keychain_path="/tmp/missing-browseros-ci.keychain-db",
+            macos_keychain_password="password",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "Configured keychain not found"):
+            unlock_keychain(env)
+
+    def test_check_environment_exposes_configured_keychain(self):
+        env = _env(
+            macos_certificate_name="Developer ID Application",
+            macos_notarization_apple_id="dev@example.com",
+            macos_notarization_team_id="TEAMID1234",
+            macos_notarization_password="notary-password",
+            macos_keychain_path="/tmp/browseros-ci.keychain-db",
+        )
+
+        ok, values = check_environment(env)
+
+        self.assertTrue(ok)
+        self.assertEqual(values["keychain_path"], "/tmp/browseros-ci.keychain-db")
+        self.assertEqual(values["keychain_profile"], "notarytool-profile")
+
+    def test_sign_component_passes_configured_keychain_to_codesign(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            component = Path(tmp) / "tool"
+            component.write_bytes(b"not-macho")
+            keychain = Path(tmp) / "ci.keychain-db"
+            calls = []
+
+            with (
+                mock.patch.object(
+                    macos_module, "_run_probe", _fake_probe([], set(), macho=False)
+                ),
+                mock.patch.object(
+                    macos_module, "run_command", _fake_run_command(calls)
+                ),
+            ):
+                ok = sign_component(component, "Cert", keychain_path=keychain)
+
+            self.assertTrue(ok)
+            self.assertIn("--keychain", calls[0])
+            self.assertEqual(calls[0][calls[0].index("--keychain") + 1], str(keychain))
+
+    def test_notarize_app_uses_configured_keychain_for_profile(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app_path = Path(tmp) / "BrowserOS.app"
+            app_path.mkdir()
+            keychain = Path(tmp) / "ci.keychain-db"
+            calls = []
+
+            def run(cmd, cwd=None, check=True):
+                calls.append(cmd)
+                if cmd[0] == "ditto":
+                    Path(cmd[-1]).write_text("zip")
+                if cmd[:3] == ["xcrun", "notarytool", "submit"]:
+                    return _completed(cmd, stdout="status: Accepted\n")
+                return _completed(cmd)
+
+            env_vars = {
+                "apple_id": "dev@example.com",
+                "team_id": "TEAMID1234",
+                "notarization_pwd": "notary-password",
+                "keychain_profile": "notarytool-profile",
+            }
+
+            with mock.patch.object(macos_module, "run_command", run):
+                self.assertTrue(
+                    notarize_app(app_path, Path(tmp), env_vars, keychain_path=keychain)
+                )
+
+            store = next(c for c in calls if c[:3] == ["xcrun", "notarytool", "store-credentials"])
+            submit = next(c for c in calls if c[:3] == ["xcrun", "notarytool", "submit"])
+            for cmd in (store, submit):
+                self.assertIn("--keychain", cmd)
+                self.assertEqual(cmd[cmd.index("--keychain") + 1], str(keychain))
+
+    def test_notarize_app_requires_profile_storage_for_configured_keychain(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app_path = Path(tmp) / "BrowserOS.app"
+            app_path.mkdir()
+            keychain = Path(tmp) / "ci.keychain-db"
+            calls = []
+
+            def run(cmd, cwd=None, check=True):
+                calls.append(cmd)
+                if cmd[0] == "ditto":
+                    Path(cmd[-1]).write_text("zip")
+                    return _completed(cmd)
+                if cmd[:3] == ["xcrun", "notarytool", "store-credentials"]:
+                    return _completed(cmd, returncode=1)
+                raise AssertionError(f"unexpected command: {cmd}")
+
+            env_vars = {
+                "apple_id": "dev@example.com",
+                "team_id": "TEAMID1234",
+                "notarization_pwd": "notary-password",
+                "keychain_profile": "notarytool-profile",
+            }
+
+            with mock.patch.object(macos_module, "run_command", run):
+                self.assertFalse(
+                    notarize_app(app_path, Path(tmp), env_vars, keychain_path=keychain)
+                )
+
+            self.assertFalse(
+                any(c[:3] == ["xcrun", "notarytool", "submit"] for c in calls)
+            )
 
 
 def _completed(cmd, returncode=0, stdout=""):


### PR DESCRIPTION
## Summary
- Add a shared macOS signing keychain helper that imports the repository P12 into an owned `$RUNNER_TEMP` keychain, validates identity access before the Chromium build, restores the prior search/default keychain state, and cleans partial or interrupted setup state.
- Wire the helper into `release-macos.yml`, `nightly-browseros.yml`, and `nightly-browserclaw.yml` before the desktop build steps, then clean up immediately after build and before uploads/publishing.
- Propagate `MACOS_KEYCHAIN_PATH` through app signing, DMG signing, and notarytool profile usage while preserving the existing local login-keychain fallback when no explicit path is configured.

## Verification
- `uv run python -m unittest bos_build.steps.sign.macos_test bos_build.steps.package.macos_test bos_build.ci_workflow_test -q`
- `uv run ruff check bos_build`
- `shellcheck .github/scripts/macos-signing-keychain.sh`
- `bash -n .github/scripts/macos-signing-keychain.sh`
- `git diff --check`
- workflow YAML parse over `.github/workflows/*.yml`
- `python3 -m unittest discover -s tools/release_secrets -t . -p "*_test.py" -q`
- `uv run python -m unittest discover -s bos_build -t . -p "*_test.py" -v` runs 1097 tests with one known unrelated baseline failure: `bos_build.release.feeds.publisher_test.PublisherTestCase.test_repaired_snapshots_preserve_versions_and_original_payloads` expects old snapshot versions `0.0.124.0` / `0.2.0.3`, while current main has `0.0.129.0` / `0.2.3.0`.

No release workflows were triggered, rerun, or cancelled by this change.
