### PR TITLE
feat(app): promote logged-out server history to the cloud on sign-in

### DIFF
--- a/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.helpers.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.helpers.ts
@@ -111,3 +111,23 @@ export async function promoteServerConversations({
     allUploaded: uploadedIds.length === conversations.length,
   }
 }
+
+/**
+ * Returns a runner that executes tasks one at a time. The promote must not
+ * overlap across an account switch: a serialized second promotion waits for the
+ * first to upload and drain, so it never re-uploads the same unowned server rows
+ * into a different account.
+ */
+export function createSerialRunner(): <T>(
+  task: () => Promise<T>,
+) => Promise<T> {
+  let chain: Promise<unknown> = Promise.resolve()
+  return <T>(task: () => Promise<T>): Promise<T> => {
+    const result = chain.then(task, task)
+    chain = result.then(
+      () => undefined,
+      () => undefined,
+    )
+    return result
+  }
+}

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.helpers.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.helpers.ts
@@ -75,3 +75,39 @@ export async function collectServerConversations({
     (conversation): conversation is Conversation => conversation !== null,
   )
 }
+
+export interface PromoteServerConversationsOptions {
+  userId: string
+  collect: () => Promise<Conversation[]>
+  upload: (conversations: Conversation[], userId: string) => Promise<string[]>
+  drain: (id: string) => Promise<void>
+}
+
+export interface PromoteResult {
+  uploadedIds: string[]
+  allUploaded: boolean
+}
+
+/**
+ * Promotes the local server's (logged-out) history to the cloud, then drains
+ * only the conversations the cloud confirmed. Draining is what keeps a later
+ * sign-in under a different account from re-uploading someone else's retained
+ * history, and it leaves any failed conversation on the server for a retry.
+ */
+export async function promoteServerConversations({
+  userId,
+  collect,
+  upload,
+  drain,
+}: PromoteServerConversationsOptions): Promise<PromoteResult> {
+  const conversations = await collect()
+  if (conversations.length === 0) return { uploadedIds: [], allUploaded: true }
+
+  const uploadedIds = await upload(conversations, userId)
+  await Promise.all(uploadedIds.map((id) => drain(id)))
+
+  return {
+    uploadedIds,
+    allUploaded: uploadedIds.length === conversations.length,
+  }
+}

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.helpers.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.helpers.ts
@@ -1,3 +1,4 @@
+import type { UIMessage } from 'ai'
 import type { Conversation } from '@/lib/conversations/conversationStorage'
 
 export interface MigrateLegacyConversationsOptions {
@@ -40,4 +41,37 @@ export async function migrateLegacyConversations({
     }
   }
   return migrated
+}
+
+export interface CollectServerConversationsOptions {
+  listSummaries: () => Promise<Array<{ id: string; lastMessagedAt: number }>>
+  loadDetail: (
+    id: string,
+  ) => Promise<{ id: string; messages: UIMessage[] } | null>
+}
+
+/**
+ * Reads every server conversation with its messages, shaped for a cloud upload.
+ * Drops any conversation deleted between the list and its detail fetch.
+ */
+export async function collectServerConversations({
+  listSummaries,
+  loadDetail,
+}: CollectServerConversationsOptions): Promise<Conversation[]> {
+  const summaries = await listSummaries()
+  const details = await Promise.all(
+    summaries.map(async (summary) => {
+      const detail = await loadDetail(summary.id)
+      return detail
+        ? {
+            id: detail.id,
+            messages: detail.messages,
+            lastMessagedAt: summary.lastMessagedAt,
+          }
+        : null
+    }),
+  )
+  return details.filter(
+    (conversation): conversation is Conversation => conversation !== null,
+  )
 }

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.test.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.test.ts
@@ -4,6 +4,7 @@ import type { Conversation } from '@/lib/conversations/conversationStorage'
 import {
   collectServerConversations,
   migrateLegacyConversations,
+  promoteServerConversations,
 } from './conversations-migration.helpers'
 
 function conversation(id: string): Conversation {
@@ -147,5 +148,52 @@ describe('collectServerConversations', () => {
     })
 
     expect(result.map((conversation) => conversation.id)).toEqual(['a'])
+  })
+})
+
+describe('promoteServerConversations', () => {
+  it('does nothing when the server has no conversations', async () => {
+    const upload = mock(async () => [])
+    const drain = mock(async () => {})
+
+    const result = await promoteServerConversations({
+      userId: 'u1',
+      collect: mock(async () => []),
+      upload,
+      drain,
+    })
+
+    expect(result).toEqual({ uploadedIds: [], allUploaded: true })
+    expect(upload).not.toHaveBeenCalled()
+    expect(drain).not.toHaveBeenCalled()
+  })
+
+  it('drains every conversation the cloud confirms', async () => {
+    const drain = mock((_id: string) => Promise.resolve())
+
+    const result = await promoteServerConversations({
+      userId: 'u1',
+      collect: mock(async () => [conversation('a'), conversation('b')]),
+      upload: mock(async () => ['a', 'b']),
+      drain,
+    })
+
+    expect(result).toEqual({ uploadedIds: ['a', 'b'], allUploaded: true })
+    expect(drain.mock.calls.map((call) => call[0]).sort()).toEqual(['a', 'b'])
+  })
+
+  it('keeps a failed conversation on the server and reports incomplete', async () => {
+    const drain = mock(async () => {})
+
+    const result = await promoteServerConversations({
+      userId: 'u1',
+      collect: mock(async () => [conversation('a'), conversation('b')]),
+      upload: mock(async () => ['a']),
+      drain,
+    })
+
+    expect(result).toEqual({ uploadedIds: ['a'], allUploaded: false })
+    expect(drain).toHaveBeenCalledTimes(1)
+    expect(drain).toHaveBeenCalledWith('a')
   })
 })

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.test.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, mock } from 'bun:test'
 import type { UIMessage } from 'ai'
 import type { Conversation } from '@/lib/conversations/conversationStorage'
-import { migrateLegacyConversations } from './conversations-migration.helpers'
+import {
+  collectServerConversations,
+  migrateLegacyConversations,
+} from './conversations-migration.helpers'
 
 function conversation(id: string): Conversation {
   const messages: UIMessage[] = [
@@ -96,5 +99,53 @@ describe('migrateLegacyConversations', () => {
     ).toEqual([])
     expect(importToServer).not.toHaveBeenCalled()
     expect(uploadToCloud).not.toHaveBeenCalled()
+  })
+})
+
+describe('collectServerConversations', () => {
+  it('pairs each summary with its detail and carries lastMessagedAt', async () => {
+    const listSummaries = mock(async () => [
+      { id: 'a', lastMessagedAt: 10 },
+      { id: 'b', lastMessagedAt: 20 },
+    ])
+    const loadDetail = mock(async (id: string) => ({
+      id,
+      messages: [{ id: `${id}-m`, role: 'user', parts: [] }] as UIMessage[],
+    }))
+
+    const result = await collectServerConversations({
+      listSummaries,
+      loadDetail,
+    })
+
+    expect(result).toEqual([
+      {
+        id: 'a',
+        lastMessagedAt: 10,
+        messages: [{ id: 'a-m', role: 'user', parts: [] }],
+      },
+      {
+        id: 'b',
+        lastMessagedAt: 20,
+        messages: [{ id: 'b-m', role: 'user', parts: [] }],
+      },
+    ])
+  })
+
+  it('drops a conversation deleted before its detail loaded', async () => {
+    const listSummaries = mock(async () => [
+      { id: 'a', lastMessagedAt: 10 },
+      { id: 'gone', lastMessagedAt: 5 },
+    ])
+    const loadDetail = mock(async (id: string) =>
+      id === 'gone' ? null : { id, messages: [] as UIMessage[] },
+    )
+
+    const result = await collectServerConversations({
+      listSummaries,
+      loadDetail,
+    })
+
+    expect(result.map((conversation) => conversation.id)).toEqual(['a'])
   })
 })

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.test.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.test.ts
@@ -3,6 +3,7 @@ import type { UIMessage } from 'ai'
 import type { Conversation } from '@/lib/conversations/conversationStorage'
 import {
   collectServerConversations,
+  createSerialRunner,
   migrateLegacyConversations,
   promoteServerConversations,
 } from './conversations-migration.helpers'
@@ -195,5 +196,41 @@ describe('promoteServerConversations', () => {
     expect(result).toEqual({ uploadedIds: ['a'], allUploaded: false })
     expect(drain).toHaveBeenCalledTimes(1)
     expect(drain).toHaveBeenCalledWith('a')
+  })
+})
+
+describe('createSerialRunner', () => {
+  it('runs tasks one at a time', async () => {
+    const run = createSerialRunner()
+    const order: string[] = []
+
+    const first = run(async () => {
+      order.push('1-start')
+      await Promise.resolve()
+      order.push('1-end')
+    })
+    const second = run(async () => {
+      order.push('2-start')
+      order.push('2-end')
+    })
+    await Promise.all([first, second])
+
+    expect(order).toEqual(['1-start', '1-end', '2-start', '2-end'])
+  })
+
+  it('runs the next task even when the previous one rejects', async () => {
+    const run = createSerialRunner()
+    const ran: string[] = []
+
+    const first = run(async () => {
+      throw new Error('boom')
+    })
+    const second = run(async () => {
+      ran.push('second')
+    })
+
+    await expect(first).rejects.toThrow('boom')
+    await second
+    expect(ran).toEqual(['second'])
   })
 })

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.ts
@@ -5,6 +5,7 @@ import { conversationStorage } from '@/lib/conversations/conversationStorage'
 import { uploadConversations } from '@/lib/conversations/uploadConversationsToGraphql'
 import { sentry } from '@/lib/sentry/sentry'
 import {
+  deleteServerConversationRow,
   fetchServerConversation,
   fetchServerConversations,
   importServerConversation,
@@ -13,6 +14,7 @@ import {
 import {
   collectServerConversations,
   migrateLegacyConversations,
+  promoteServerConversations,
 } from './conversations-migration.helpers'
 
 /**
@@ -61,32 +63,16 @@ export function useLegacyConversationMigration(): void {
   }, [userId, queryClient])
 }
 
-/**
- * Uploads the local server's (logged-out) conversations to the cloud so they
- * follow the user into their account. The server copy is kept (Decision 4);
- * `uploadConversations` is idempotent, so re-running only syncs the delta.
- * Returns how many conversations were considered.
- */
-export async function promoteServerConversationsToCloud(
-  userId: string,
-): Promise<number> {
-  const conversations = await collectServerConversations({
-    listSummaries: fetchServerConversations,
-    loadDetail: fetchServerConversation,
-  })
-  if (conversations.length === 0) return 0
-  await uploadConversations(conversations, userId)
-  return conversations.length
-}
-
 // Module-scoped so the promote survives history remounts (once per sign-in, not
-// once per history open); reset when the user is absent so a re-sign-in
-// promotes again.
+// once per history open); reset when the user is absent, or when a promote does
+// not fully complete, so leftovers retry.
 let lastPromotedUserId: string | undefined
 
 /**
- * On sign-in, promote server-held (logged-out) history to the cloud, then run
- * `onPromoted` (e.g. to refresh the cloud history list) when anything landed.
+ * On sign-in, promote server-held (logged-out) history to the cloud (draining
+ * each conversation the cloud confirms, so it cannot leak to a later sign-in),
+ * then run `onPromoted` (e.g. to refresh the cloud history list) when anything
+ * landed.
  */
 export function useSignInConversationPromote(onPromoted?: () => void): void {
   const { sessionInfo } = useSessionInfo()
@@ -101,9 +87,21 @@ export function useSignInConversationPromote(onPromoted?: () => void): void {
     lastPromotedUserId = userId
 
     let cancelled = false
-    promoteServerConversationsToCloud(userId)
-      .then((count) => {
-        if (!cancelled && count > 0) onPromoted?.()
+    promoteServerConversations({
+      userId,
+      collect: () =>
+        collectServerConversations({
+          listSummaries: fetchServerConversations,
+          loadDetail: fetchServerConversation,
+        }),
+      upload: uploadConversations,
+      drain: deleteServerConversationRow,
+    })
+      .then((result) => {
+        if (cancelled) return
+        // Leftovers stay on the server; let the next mount retry them.
+        if (!result.allUploaded) lastPromotedUserId = undefined
+        if (result.uploadedIds.length > 0) onPromoted?.()
       })
       .catch((error) => {
         lastPromotedUserId = undefined

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.ts
@@ -5,10 +5,15 @@ import { conversationStorage } from '@/lib/conversations/conversationStorage'
 import { uploadConversations } from '@/lib/conversations/uploadConversationsToGraphql'
 import { sentry } from '@/lib/sentry/sentry'
 import {
+  fetchServerConversation,
+  fetchServerConversations,
   importServerConversation,
   SERVER_CONVERSATIONS_QUERY_KEY,
 } from './conversations.hooks'
-import { migrateLegacyConversations } from './conversations-migration.helpers'
+import {
+  collectServerConversations,
+  migrateLegacyConversations,
+} from './conversations-migration.helpers'
 
 /**
  * Drains any pre-upgrade `local:conversations` to their new home (cloud when
@@ -54,4 +59,60 @@ export function useLegacyConversationMigration(): void {
       cancelled = true
     }
   }, [userId, queryClient])
+}
+
+/**
+ * Uploads the local server's (logged-out) conversations to the cloud so they
+ * follow the user into their account. The server copy is kept (Decision 4);
+ * `uploadConversations` is idempotent, so re-running only syncs the delta.
+ * Returns how many conversations were considered.
+ */
+export async function promoteServerConversationsToCloud(
+  userId: string,
+): Promise<number> {
+  const conversations = await collectServerConversations({
+    listSummaries: fetchServerConversations,
+    loadDetail: fetchServerConversation,
+  })
+  if (conversations.length === 0) return 0
+  await uploadConversations(conversations, userId)
+  return conversations.length
+}
+
+// Module-scoped so the promote survives history remounts (once per sign-in, not
+// once per history open); reset when the user is absent so a re-sign-in
+// promotes again.
+let lastPromotedUserId: string | undefined
+
+/**
+ * On sign-in, promote server-held (logged-out) history to the cloud, then run
+ * `onPromoted` (e.g. to refresh the cloud history list) when anything landed.
+ */
+export function useSignInConversationPromote(onPromoted?: () => void): void {
+  const { sessionInfo } = useSessionInfo()
+  const userId = sessionInfo.user?.id
+
+  useEffect(() => {
+    if (!userId) {
+      lastPromotedUserId = undefined
+      return
+    }
+    if (lastPromotedUserId === userId) return
+    lastPromotedUserId = userId
+
+    let cancelled = false
+    promoteServerConversationsToCloud(userId)
+      .then((count) => {
+        if (!cancelled && count > 0) onPromoted?.()
+      })
+      .catch((error) => {
+        lastPromotedUserId = undefined
+        sentry.captureException(error, {
+          extra: { message: 'Sign-in conversation promote failed' },
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [userId, onPromoted])
 }

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations-migration.ts
@@ -13,6 +13,7 @@ import {
 } from './conversations.hooks'
 import {
   collectServerConversations,
+  createSerialRunner,
   migrateLegacyConversations,
   promoteServerConversations,
 } from './conversations-migration.helpers'
@@ -67,6 +68,9 @@ export function useLegacyConversationMigration(): void {
 // once per history open); reset when the user is absent, or when a promote does
 // not fully complete, so leftovers retry.
 let lastPromotedUserId: string | undefined
+// Serialize so an account switch cannot run two promotions over the same
+// undrained server rows concurrently (which could upload them into two accounts).
+const runPromoteExclusive = createSerialRunner()
 
 /**
  * On sign-in, promote server-held (logged-out) history to the cloud (draining
@@ -87,21 +91,24 @@ export function useSignInConversationPromote(onPromoted?: () => void): void {
     lastPromotedUserId = userId
 
     let cancelled = false
-    promoteServerConversations({
-      userId,
-      collect: () =>
-        collectServerConversations({
-          listSummaries: fetchServerConversations,
-          loadDetail: fetchServerConversation,
-        }),
-      upload: uploadConversations,
-      drain: deleteServerConversationRow,
-    })
+    runPromoteExclusive(() =>
+      promoteServerConversations({
+        userId,
+        collect: () =>
+          collectServerConversations({
+            listSummaries: fetchServerConversations,
+            loadDetail: fetchServerConversation,
+          }),
+        upload: uploadConversations,
+        drain: deleteServerConversationRow,
+      }),
+    )
       .then((result) => {
-        if (cancelled) return
-        // Leftovers stay on the server; let the next mount retry them.
+        // Reset the guard whenever the promote did not fully complete, even if
+        // this effect was cancelled, so leftovers are retried and never linger
+        // leak-eligible. Only the UI refresh is gated on cancellation.
         if (!result.allUploaded) lastPromotedUserId = undefined
-        if (result.uploadedIds.length > 0) onPromoted?.()
+        if (!cancelled && result.uploadedIds.length > 0) onPromoted?.()
       })
       .catch((error) => {
         lastPromotedUserId = undefined

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations.hooks.ts
@@ -79,7 +79,8 @@ export async function importServerConversation(conversation: {
   }
 }
 
-export async function deleteServerConversation(
+/** Deletes only the server row (tolerating 404); leaves execution history. */
+export async function deleteServerConversationRow(
   conversationId: string,
 ): Promise<void> {
   const response = await fetch(
@@ -89,6 +90,12 @@ export async function deleteServerConversation(
   if (!response.ok && response.status !== 404) {
     throw new Error(`Failed to delete conversation (${response.status})`)
   }
+}
+
+export async function deleteServerConversation(
+  conversationId: string,
+): Promise<void> {
+  await deleteServerConversationRow(conversationId)
   await removeConversationExecutionHistory(conversationId)
 }
 

--- a/packages/browseros-agent/apps/app/screens/sidepanel/history/ChatHistory.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/history/ChatHistory.tsx
@@ -2,12 +2,15 @@ import { keepPreviousData, useQueryClient } from '@tanstack/react-query'
 import type { UIMessage } from 'ai'
 import { Loader2 } from 'lucide-react'
 import type { FC } from 'react'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useSessionInfo } from '@/lib/auth/sessionStorage'
 import { GetProfileIdByUserIdDocument } from '@/lib/conversations/graphql/uploadConversationDocument'
 import { getQueryKeyFromDocument } from '@/lib/graphql/getQueryKeyFromDocument'
 import { useChatSessionContext } from '@/modules/chat/chat-session-context'
-import { useLegacyConversationMigration } from '@/modules/conversations/conversations-migration'
+import {
+  useLegacyConversationMigration,
+  useSignInConversationPromote,
+} from '@/modules/conversations/conversations-migration'
 import { useGraphqlInfiniteQuery } from '@/modules/graphql/graphql-infinite-query.hooks'
 import { useGraphqlMutation } from '@/modules/graphql/graphql-mutation.hooks'
 import { useGraphqlQuery } from '@/modules/graphql/graphql-query.hooks'
@@ -121,8 +124,18 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
 export const ChatHistory: FC = () => {
   const { sessionInfo } = useSessionInfo()
   const userId = sessionInfo.user?.id
+  const queryClient = useQueryClient()
   // Drain any pre-upgrade local:conversations to their new home.
   useLegacyConversationMigration()
+  // On sign-in, promote logged-out (server) history to the cloud, then refresh
+  // the cloud list so it appears. Stable callback keeps the promote effect from
+  // re-running on every render.
+  const refreshCloudHistory = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: [getQueryKeyFromDocument(GetConversationsForHistoryDocument)],
+    })
+  }, [queryClient])
+  useSignInConversationPromote(refreshCloudHistory)
 
   if (userId) {
     return <RemoteChatHistory userId={userId} />


### PR DESCRIPTION
## What

Closes the ongoing half of Decision 4 that the migration PR deferred: when a user signs in, promote their local server (logged-out) history to the cloud so it follows them into their account cross-device.

- On sign-in, read every server conversation with its messages and upload them via the existing idempotent `uploadConversations`, then refresh the cloud history list so they appear.
- **Drain on success:** each conversation the cloud confirms is deleted from the device-local server (a server-row-only delete; execution history untouched). The `conversations` table has no owner column, so retaining copies would let a later sign-in re-upload another user's logged-out history. Only the ids `uploadConversations` returns are drained, so a failed upload stays on the server for a retry.
- **Serialized:** promotes run one at a time, so an account switch cannot run two promotions over the same undrained rows concurrently.
- Once-per-sign-in guard, reset whenever a promote does not fully complete (regardless of cancellation) so leftovers retry. No server change (reuses the existing list, detail, and delete endpoints).

## Shape

```mermaid
sequenceDiagram
  participant Ext as Extension (on sign-in)
  participant Srv as Local server
  participant Cloud as Cloud (GraphQL)
  Ext->>Srv: GET /conversations (summaries)
  loop each id
    Ext->>Srv: GET /conversations/:id (messages)
  end
  Ext->>Cloud: uploadConversations(convs, userId)
  loop each cloud-confirmed id
    Ext->>Srv: DELETE /conversations/:id (drain)
  end
```

Mounted in `ChatHistory` (which observes sign-in and sign-out), invalidating the cloud history query on success.

## Known limitation (accepted)

Server-held logged-out history is device-local and is not partitioned by account (it is account-less by nature). If a promote leaves a conversation undrained (a rare per-conversation upload or delete failure), a later sign-in on the same browser profile can pick it up and upload it under that account. This is an accepted tradeoff: the history lives only on the user's own machine, and the device-local model assumes a single user per browser profile, so the cross-device convenience is worth the narrow residual. Fully eliminating it would require partitioning account-less history or dropping the promote. The persistent-retention and concurrent-double-upload amplifications of this residual are closed (drain + serialize); this is the irreducible core.

## Tests

- Pure `collectServerConversations`: pairs each summary with its detail; drops a conversation deleted between the list and its detail fetch.
- Pure `promoteServerConversations`: no-op on empty; drains every cloud-confirmed conversation; keeps a failed conversation on the server and reports incomplete.
- Pure `createSerialRunner`: runs tasks one at a time; continues after a rejecting task.
- Existing migration tests remain green. App typecheck + Biome clean.
