### PR TITLE
fix(agent): support Chromium 137 side panel APIs

### DIFF
--- a/packages/browseros-agent/apps/app/lib/browseros/toggleSidePanel.no-on-closed.test.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/toggleSidePanel.no-on-closed.test.ts
@@ -1,0 +1,32 @@
+import { expect, it, mock } from 'bun:test'
+
+mock.module('./sidePanelOpenStateStorage', () => ({
+  sidePanelPerWindowStorage: {
+    getValue: async () => false,
+    setValue: async () => {},
+  },
+  openWindowSidePanelIdsStorage: {
+    getValue: async () => [],
+    setValue: async () => {},
+  },
+}))
+
+it('registers onOpened when Chromium does not expose onClosed', async () => {
+  let openListenerRegistrations = 0
+  globalThis.chrome = {
+    sidePanel: {
+      onOpened: {
+        addListener: () => {
+          openListenerRegistrations += 1
+        },
+      },
+    },
+  } as unknown as typeof chrome
+
+  const { registerSidePanelOpenStateListeners } = await import(
+    './toggleSidePanel'
+  )
+
+  expect(() => registerSidePanelOpenStateListeners()).not.toThrow()
+  expect(openListenerRegistrations).toBe(1)
+})

--- a/packages/browseros-agent/apps/app/lib/browseros/toggleSidePanel.no-on-opened.test.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/toggleSidePanel.no-on-opened.test.ts
@@ -1,0 +1,32 @@
+import { expect, it, mock } from 'bun:test'
+
+mock.module('./sidePanelOpenStateStorage', () => ({
+  sidePanelPerWindowStorage: {
+    getValue: async () => false,
+    setValue: async () => {},
+  },
+  openWindowSidePanelIdsStorage: {
+    getValue: async () => [],
+    setValue: async () => {},
+  },
+}))
+
+it('registers onClosed when Chromium does not expose onOpened', async () => {
+  let closeListenerRegistrations = 0
+  globalThis.chrome = {
+    sidePanel: {
+      onClosed: {
+        addListener: () => {
+          closeListenerRegistrations += 1
+        },
+      },
+    },
+  } as unknown as typeof chrome
+
+  const { registerSidePanelOpenStateListeners } = await import(
+    './toggleSidePanel'
+  )
+
+  expect(() => registerSidePanelOpenStateListeners()).not.toThrow()
+  expect(closeListenerRegistrations).toBe(1)
+})

--- a/packages/browseros-agent/apps/app/lib/browseros/toggleSidePanel.test.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/toggleSidePanel.test.ts
@@ -204,6 +204,37 @@ describe('side panel scope routing', () => {
     expect(closeCalls).toEqual([])
   })
 
+  it('falls back to the standard open API when BrowserOS tab open APIs are unavailable', async () => {
+    Reflect.deleteProperty(chrome.sidePanel, 'browserosIsOpen')
+
+    const result = await openSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(result).toEqual({ opened: true })
+    expect(openCalls).toEqual([{ tabId: 7 }])
+    expect(browserosToggleCalls).toEqual([])
+  })
+
+  it('falls back to the standard open API when BrowserOS tab toggle is unavailable', async () => {
+    Reflect.deleteProperty(chrome.sidePanel, 'browserosToggle')
+
+    const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(result).toEqual({ opened: true })
+    expect(openCalls).toEqual([{ tabId: 7 }])
+  })
+
+  it('keeps an open window panel open when Chromium cannot close it', async () => {
+    storedSidePanelPerWindow = true
+    storedOpenWindowIds = [3]
+    await refreshSidePanelRuntimeState()
+    Reflect.deleteProperty(chrome.sidePanel, 'close')
+
+    const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(result).toEqual({ opened: true })
+    expect(closeCalls).toEqual([])
+  })
+
   it('refreshes the cached scope from extension storage outside the click path', async () => {
     storedSidePanelPerWindow = true
 

--- a/packages/browseros-agent/apps/app/lib/browseros/toggleSidePanel.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/toggleSidePanel.ts
@@ -126,6 +126,13 @@ export async function ensureSidePanelRuntimeStateLoaded(): Promise<void> {
 async function openTabSidePanel({
   tabId,
 }: SidePanelTarget): Promise<SidePanelToggleResult> {
+  if (
+    typeof chrome.sidePanel.browserosIsOpen !== 'function' ||
+    typeof chrome.sidePanel.browserosToggle !== 'function'
+  ) {
+    await chrome.sidePanel.open({ tabId })
+    return { opened: true }
+  }
   const isAlreadyOpen = await chrome.sidePanel.browserosIsOpen({ tabId })
   if (isAlreadyOpen) {
     return { opened: true }
@@ -136,6 +143,10 @@ async function openTabSidePanel({
 async function toggleTabSidePanel({
   tabId,
 }: SidePanelTarget): Promise<SidePanelToggleResult> {
+  if (typeof chrome.sidePanel.browserosToggle !== 'function') {
+    await chrome.sidePanel.open({ tabId })
+    return { opened: true }
+  }
   return await chrome.sidePanel.browserosToggle({ tabId })
 }
 
@@ -153,6 +164,9 @@ async function toggleWindowSidePanel(
   target: SidePanelTarget,
 ): Promise<SidePanelToggleResult> {
   if (openWindowSidePanelIds.has(target.windowId)) {
+    if (typeof chrome.sidePanel.close !== 'function') {
+      return { opened: true }
+    }
     await chrome.sidePanel.close({ windowId: target.windowId })
     rememberWindowSidePanelClosed(target.windowId)
     return { opened: false }
@@ -165,13 +179,13 @@ export function registerSidePanelOpenStateListeners(): void {
   if (sidePanelOpenStateListenersRegistered) return
   sidePanelOpenStateListenersRegistered = true
 
-  chrome.sidePanel.onOpened.addListener((info) => {
+  chrome.sidePanel.onOpened?.addListener((info) => {
     if (info.tabId === undefined) {
       rememberWindowSidePanelOpen(info.windowId)
     }
   })
 
-  chrome.sidePanel.onClosed.addListener((info) => {
+  chrome.sidePanel.onClosed?.addListener((info) => {
     if (info.tabId === undefined) {
       rememberWindowSidePanelClosed(info.windowId)
     }


### PR DESCRIPTION
## Summary

- feature-detect BrowserOS-only side panel lifecycle and action APIs absent from Chromium 137
- fall back to standard `chrome.sidePanel.open` for tab open/toggle behavior
- preserve known-open window state when Chromium lacks `sidePanel.close`
- add mutation-killing tests for each partial API shape

## Design

The compatibility boundary remains in `toggleSidePanel.ts`. Newer BrowserOS builds retain the richer `browserosIsOpen`, `browserosToggle`, `close`, `onOpened`, and `onClosed` paths. Chromium 137 uses only its standard supported API surface.

## Test plan

- [x] 18 focused side-panel tests
- [x] root lint
- [x] root typecheck
- [x] full test suite
- [x] WXT development extension build
- [x] audited all 32 direct extension API calls against Chromium 137 schemas
- [x] live headed Chrome 137.0.7187.69 service worker remains alive with all five guarded side-panel members undefined
- [x] `app.html#/home` mounts with no JavaScript exceptions
- [x] headless Chromium 137 camera capture of the same bundle: `/Users/felarof01/Workspaces/build/CHROME/nightwork/shots/ext-on-137.png`

Root Fallow remains baseline-red on 320 pre-existing repository findings; none references the changed files.