### PR TITLE
fix(server): surface MCP route transport errors with their real status

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -7,6 +7,7 @@
 import type { BrowserSession } from '@browseros/browser-core/core/session'
 import { StreamableHTTPTransport } from '@hono/mcp'
 import { Hono } from 'hono'
+import { HTTPException } from 'hono/http-exception'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { Sentry } from '../../lib/sentry'
@@ -136,6 +137,12 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       })
       return response
     } catch (error) {
+      // @hono/mcp signals HTTP-level problems (unacceptable Accept/Content-Type,
+      // unsupported MCP-Protocol-Version, parse errors) by throwing HTTPException.
+      // Surface those with their real 4xx status instead of masking them as a 500.
+      if (error instanceof HTTPException) {
+        return error.getResponse()
+      }
       Sentry.withScope((scope) => {
         scope.setTag('route', 'mcp')
         scope.setTag('scopeId', scopeId)

--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { HTTPException } from 'hono/http-exception'
 import {
   createMcpRoutes,
   MANAGED_MCP_SERVERS_HEADER,
@@ -151,5 +152,35 @@ describe('createMcpRoutes', () => {
     expect(
       serverCreations.map((creation) => creation.includeStructuredContent),
     ).toEqual([false, true, false])
+  })
+
+  it('surfaces a transport HTTPException with its real status instead of masking it as 500', async () => {
+    const app = createTestMcpRoutes({
+      createMcpTransport: (() => ({
+        handleRequest: async () => {
+          throw new HTTPException(406, { message: 'Not Acceptable' })
+        },
+      })) as never,
+    })
+
+    const res = await postMcp(app)
+
+    expect(res.status).toBe(406)
+  })
+
+  it('returns 500 with a JSON-RPC internal error only for unexpected errors', async () => {
+    const app = createTestMcpRoutes({
+      createMcpTransport: (() => ({
+        handleRequest: async () => {
+          throw new Error('boom')
+        },
+      })) as never,
+    })
+
+    const res = await postMcp(app)
+    const body = (await res.json()) as { error: { code: number } }
+
+    expect(res.status).toBe(500)
+    expect(body.error.code).toBe(-32603)
   })
 })


### PR DESCRIPTION
## Problem

The `/mcp` route (`apps/server`) wraps `transport.handleRequest` in a `try/catch` that returns a blanket `HTTP 500` with JSON-RPC `-32603 "Internal server error"` for every error. But `@hono/mcp`'s `StreamableHTTPTransport` uses thrown `HTTPException`s for normal HTTP-level control flow: an unacceptable `Accept` header (406), wrong `Content-Type` (415), an unsupported `MCP-Protocol-Version` header (404), and body parse failures (400). Those client-side conditions were all swallowed and rewritten as a generic 500, discarding the real status and body, and logged to Sentry as server errors.

A visible symptom: a modern MCP client probing the endpoint (for example with `server/discover`) gets a confusing `500` instead of a clean, recognizable error, which also defeats the spec's error-based fallback to the legacy `initialize` handshake.

## Fix

Make the catch `HTTPException`-aware: pass `HTTPException`s through with their real status via `error.getResponse()`, and keep the `500 / -32603` path only for genuinely unexpected errors. This restores correct HTTP semantics and stops reporting client 4xx as server errors in Sentry.

## Tests

Extends the existing route tests (injected transport, asserting on status and JSON-RPC code as a client would):

- a transport `HTTPException` surfaces with its real status (406), not 500
- unexpected (non-`HTTPException`) errors still return `500 / -32603`

Scoped tests pass, server typecheck passes, Biome clean.

## Scope

No dependency changes and no protocol changes. Full 2026-07-28 (stateless) protocol support is a separate, larger effort. This PR only fixes the error-handling masking.

Refs #2168
