### PR TITLE
fix(build): clean universal arch outputs

### DIFF
--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -1131,12 +1131,12 @@ class PublisherTestCase(unittest.TestCase):
         self.assertEqual((spec.kind, spec.channel), ("extensions", "alpha"))
         self.assertEqual(
             set(extract_manifest_versions(manifest).values()),
-            {"0.0.130.0", "54.0.0.0", "0.2.5.0"},
+            {"0.0.131.0", "54.0.0.0", "0.2.6.0"},
         )
         original = manifest.replace("</gupdate>", "  </app>\n</gupdate>")
         self.assertEqual(
             hashlib.sha256(original.encode()).hexdigest(),
-            "7e55c16285e602abb2dde22922679fd05bb7b9c8662a5b8cc68def343334002d",
+            "fc21e4747c904a7f74e9bfec17197e18349a596e2b8653356a1c8a9dfaaba219",
         )
 
     def test_browserclaw_snapshots_use_current_product_title(self):

--- a/packages/browseros/bos_build/steps/setup/clean.py
+++ b/packages/browseros/bos_build/steps/setup/clean.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """Clean module for BrowserOS build system"""
 
+from pathlib import Path
+
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
 from ...lib.utils import run_command, log_info, log_success, log_warning, safe_rmtree
 from ..storage.download import managed_binary_families
+
+UNIVERSAL_INPUT_ARCHITECTURES = ("arm64", "x64")
 
 
 @step("clean", phase="setup")
@@ -20,10 +24,13 @@ class CleanModule(Step):
     def execute(self, ctx: Context) -> None:
         log_info("🧹 Cleaning build artifacts...")
 
-        out_path = ctx.chromium_src / ctx.out_dir
-        if out_path.exists():
+        for out_path in self._output_dirs(ctx):
+            if not out_path.exists():
+                continue
             safe_rmtree(out_path)
-            log_success("Cleaned build directory")
+            log_success(
+                f"Cleaned build directory: {out_path.relative_to(ctx.chromium_src)}"
+            )
 
         log_info("\n🔀 Resetting git branch and removing tracked files...")
         self._git_reset(ctx)
@@ -33,6 +40,29 @@ class CleanModule(Step):
 
         log_info("\n🧹 Pruning orphaned resource binaries...")
         self._prune_orphan_binary_families(ctx)
+
+    def _output_dirs(self, ctx: Context) -> tuple[Path, ...]:
+        architectures = (
+            UNIVERSAL_INPUT_ARCHITECTURES
+            if "universal" in ctx.plan_architectures
+            else (ctx.architecture,)
+        )
+        dirs: list[Path] = []
+        seen: set[Path] = set()
+        for architecture in architectures:
+            out_ctx = Context(
+                root_dir=ctx.root_dir,
+                chromium_src=ctx.chromium_src,
+                architecture=architecture,
+                build_type=ctx.build_type,
+                product=ctx.product,
+            )
+            out_path = out_ctx.chromium_src / out_ctx.out_dir
+            if out_path in seen:
+                continue
+            dirs.append(out_path)
+            seen.add(out_path)
+        return tuple(dirs)
 
     def _prune_orphan_binary_families(self, ctx: Context) -> None:
         """Remove resources/binaries/<family> dirs the download config no longer lists.

--- a/packages/browseros/bos_build/steps/setup/clean_test.py
+++ b/packages/browseros/bos_build/steps/setup/clean_test.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 from . import clean
 from ...core.context import Context
+from ...core.products import get_product_descriptor
 from ...core.step import ValidationError
 from ...lib.testing import MockBrowserOSRoot, MockChromium, make_context
 
@@ -68,6 +69,62 @@ class CleanExecuteTest(unittest.TestCase):
 
             with mock.patch.object(clean, "run_command"):
                 clean.CleanModule().execute(ctx)
+
+    def test_single_arch_clean_keeps_other_arch_output(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            chromium = MockChromium(Path(chromium_tmp))
+            root = MockBrowserOSRoot(Path(root_tmp))
+            ctx = make_context(chromium, root, architecture="x64")
+            x64_out = chromium.with_out_dir("x64")
+            arm64_out = chromium.with_out_dir("arm64")
+
+            with mock.patch.object(clean, "run_command"):
+                clean.CleanModule().execute(ctx)
+
+            self.assertFalse(x64_out.exists())
+            self.assertTrue(arm64_out.exists())
+
+    def test_universal_clean_removes_same_product_arch_outputs_only(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            chromium = MockChromium(Path(chromium_tmp))
+            root = MockBrowserOSRoot(Path(root_tmp))
+
+            for product, other_product in (
+                ("browseros", "browserclaw"),
+                ("browserclaw", "browseros"),
+            ):
+                with self.subTest(product=product):
+                    arm64_out = chromium.with_out_dir("arm64", product=product)
+                    x64_out = chromium.with_out_dir("x64", product=product)
+                    other_arm64_out = chromium.with_out_dir(
+                        "arm64", product=other_product
+                    )
+                    other_x64_out = chromium.with_out_dir(
+                        "x64", product=other_product
+                    )
+
+                    ctx = Context(
+                        root_dir=root.root,
+                        chromium_src=chromium.src,
+                        architecture="arm64",
+                        plan_architectures=("universal",),
+                        build_type="release",
+                        product=get_product_descriptor(product),
+                    )
+
+                    with mock.patch.object(clean, "run_command"):
+                        clean.CleanModule().execute(ctx)
+
+                    self.assertFalse(arm64_out.exists())
+                    self.assertFalse(x64_out.exists())
+                    self.assertTrue(other_arm64_out.exists())
+                    self.assertTrue(other_x64_out.exists())
 
 
 class CleanPruneOrphanBinariesTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- make `clean` remove same-product arm64 and x64 output directories for universal invocations before any per-arch compile can reuse stale state
- keep single-arch cleanup scoped to the active output directory
- update regression coverage for BrowserOS and BrowserOS neo product-scoped universal cleanup
- refresh the feed publisher snapshot expectation to match current checked-in extension alpha manifest versions on origin/main

## Verification
- `uv run python -m unittest bos_build.steps.setup.clean_test bos_build.core.planner_test bos_build.steps.compile.universal_test bos_build.release.feeds.publisher_test.PublisherTestCase.test_repaired_snapshots_preserve_versions_and_original_payloads`
- `uv run python -m unittest discover -s bos_build -t . -p '*_test.py'`\n- `uv run ruff check bos_build`\n- `uv run pyright`\n- `git diff --check`\n\nNo release workflows triggered or rerun by this PR.