### PR TITLE
feat(skills): skill service, reconciler wiring, and REST endpoints

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
@@ -27,6 +27,7 @@ mod replay;
 mod screenshots;
 mod sessions;
 mod settings;
+mod skills;
 mod system;
 
 /// UTF-8 request-body ceiling enforced before recording ingest and advertised by
@@ -86,6 +87,12 @@ pub fn router(state: AppState) -> Router<AppState> {
             "/api/v1/connections/{harness}",
             put(connections::connect).delete(connections::disconnect),
         )
+        .route("/api/v1/skills", get(skills::list).post(skills::create))
+        .route(
+            "/api/v1/skills/{name}",
+            get(skills::get).put(skills::update).delete(skills::delete),
+        )
+        .route("/api/v1/skills/{name}/runs", get(skills::list_runs))
         .nest_service(
             "/mcp",
             Router::new()

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/skills.rs
@@ -1,0 +1,215 @@
+use super::{error, internal};
+use crate::{
+    AppState,
+    db::entities::skill_runs,
+    error::{AppError, CanonicalError, RequestId},
+    services::skills::{CreateSkill, SkillDetailView, SkillOrigin, SkillView, UpdateSkill},
+};
+use axum::{
+    Extension, Json,
+    extract::{Path, Query, State},
+    http::StatusCode,
+};
+use claw_api::models::{self, Skill, SkillCreate, SkillDetail, SkillList, SkillRun, SkillRunList};
+use harness_integrations::AgentId;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct RunsQuery {
+    cursor: Option<i64>,
+    limit: Option<u64>,
+}
+
+pub(super) async fn list(
+    Extension(request_id): Extension<RequestId>,
+    State(state): State<AppState>,
+) -> Result<Json<SkillList>, CanonicalError> {
+    let items = state
+        .skills
+        .list()
+        .await
+        .map_err(|source| map_error(&request_id, source))?
+        .into_iter()
+        .map(skill_to_dto)
+        .collect();
+    Ok(Json(SkillList::new(items)))
+}
+
+pub(super) async fn get(
+    Extension(request_id): Extension<RequestId>,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<SkillDetail>, CanonicalError> {
+    let detail = state
+        .skills
+        .get(&name)
+        .await
+        .map_err(|source| map_error(&request_id, source))?;
+    Ok(Json(detail_to_dto(detail)))
+}
+
+pub(super) async fn create(
+    Extension(request_id): Extension<RequestId>,
+    State(state): State<AppState>,
+    Json(body): Json<SkillCreate>,
+) -> Result<(StatusCode, Json<Skill>), CanonicalError> {
+    let view = state
+        .skills
+        .create(CreateSkill {
+            name: body.name,
+            description: body.description,
+            site: body.site,
+            steps: body.steps.unwrap_or_default(),
+            learned_notes: body.learned_notes.unwrap_or_default(),
+            origin: SkillOrigin::Manual,
+            source_session_id: None,
+        })
+        .await
+        .map_err(|source| map_error(&request_id, source))?;
+    Ok((StatusCode::CREATED, Json(skill_to_dto(view))))
+}
+
+pub(super) async fn update(
+    Extension(request_id): Extension<RequestId>,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(body): Json<models::SkillUpdate>,
+) -> Result<Json<SkillDetail>, CanonicalError> {
+    let detail = state
+        .skills
+        .update(
+            &name,
+            UpdateSkill {
+                description: body.description,
+                site: body.site,
+                body: body.body,
+            },
+        )
+        .await
+        .map_err(|source| map_error(&request_id, source))?;
+    Ok(Json(detail_to_dto(detail)))
+}
+
+pub(super) async fn delete(
+    Extension(request_id): Extension<RequestId>,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<StatusCode, CanonicalError> {
+    state
+        .skills
+        .delete(&name)
+        .await
+        .map_err(|source| map_error(&request_id, source))?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub(super) async fn list_runs(
+    Extension(request_id): Extension<RequestId>,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Query(query): Query<RunsQuery>,
+) -> Result<Json<SkillRunList>, CanonicalError> {
+    let (runs, next_cursor) = state
+        .skills
+        .list_runs(&name, query.cursor, query.limit)
+        .await
+        .map_err(|source| map_error(&request_id, source))?;
+    let mut list = SkillRunList::new(runs.into_iter().map(run_to_dto).collect());
+    list.next_cursor = next_cursor;
+    Ok(Json(list))
+}
+
+fn map_error(request_id: &RequestId, source: AppError) -> CanonicalError {
+    match source.status() {
+        StatusCode::NOT_FOUND => error(
+            request_id,
+            StatusCode::NOT_FOUND,
+            "skill_not_found",
+            &source.to_string(),
+        ),
+        StatusCode::CONFLICT => error(
+            request_id,
+            StatusCode::CONFLICT,
+            "skill_conflict",
+            &source.to_string(),
+        ),
+        StatusCode::BAD_REQUEST => error(
+            request_id,
+            StatusCode::BAD_REQUEST,
+            "invalid_skill",
+            &source.to_string(),
+        ),
+        _ => internal(request_id, source),
+    }
+}
+
+fn skill_to_dto(view: SkillView) -> Skill {
+    let SkillView {
+        model,
+        linked_agents,
+        stats,
+    } = view;
+    let mut skill = Skill::new(
+        model.name,
+        model.description,
+        origin_to_dto(&model.origin),
+        model.version,
+        linked_agents.into_iter().map(agent_to_harness).collect(),
+        stats.run_count,
+        stats.clean_run_count,
+        model.created_at,
+        model.updated_at,
+    );
+    skill.site = model.site;
+    skill.source_session_id = model.source_session_id;
+    skill.first_run_tokens = stats.first_run_tokens;
+    skill.latest_run_tokens = stats.latest_run_tokens;
+    skill.last_run_at = stats.last_run_at;
+    skill
+}
+
+fn detail_to_dto(detail: SkillDetailView) -> SkillDetail {
+    let SkillDetailView { view, body, runs } = detail;
+    SkillDetail::new(
+        skill_to_dto(view),
+        body,
+        runs.into_iter().map(run_to_dto).collect(),
+    )
+}
+
+fn run_to_dto(run: skill_runs::Model) -> SkillRun {
+    let mut dto = SkillRun::new(
+        run.id,
+        run.skill_name,
+        run.session_id,
+        run.run_number,
+        run.agent_id,
+        run.clean,
+        run.created_at,
+    );
+    dto.tokens = run.tokens;
+    dto.duration_ms = run.duration_ms;
+    dto.tool_count = run.tool_count;
+    dto.errored_tool = run.errored_tool;
+    dto
+}
+
+fn origin_to_dto(origin: &str) -> models::SkillOrigin {
+    match origin {
+        "manual" => models::SkillOrigin::Manual,
+        "directory" => models::SkillOrigin::Directory,
+        _ => models::SkillOrigin::Agent,
+    }
+}
+
+fn agent_to_harness(agent: AgentId) -> models::Harness {
+    match agent {
+        AgentId::ClaudeCode => models::Harness::ClaudeCode,
+        AgentId::Codex => models::Harness::Codex,
+        AgentId::Cursor => models::Harness::Cursor,
+        AgentId::OpenCode => models::Harness::OpenCode,
+        AgentId::Antigravity => models::Harness::Antigravity,
+        AgentId::VsCode => models::Harness::VsCode,
+        AgentId::Zed => models::Harness::Zed,
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/app.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/app.rs
@@ -2,7 +2,9 @@ use crate::{
     analytics::{AnalyticsService, AnalyticsSink},
     api::http,
     config::Config,
-    db::{AuditLog, DATABASE_FILENAME, Database, RecordingIndex, SessionTabLedger},
+    db::{
+        AuditLog, DATABASE_FILENAME, Database, RecordingIndex, SessionTabLedger, SkillsRepository,
+    },
     error::{AppError, AppResult},
     runtime::ShutdownHandle,
     services::{
@@ -17,6 +19,7 @@ use crate::{
         screenshots::ScreenshotService,
         session_efficiency::SessionEfficiencyService,
         sessions::Sessions,
+        skills::SkillService,
     },
     storage::JsonStore,
 };
@@ -38,6 +41,7 @@ pub struct AppState {
     pub tab_activity: Arc<TabActivityService>,
     pub tab_registry: Arc<TabRegistry>,
     pub harness: Arc<HarnessService>,
+    pub skills: Arc<SkillService>,
     pub analytics: Arc<AnalyticsService>,
     pub profiles: Arc<ProfileService>,
     pub sessions: Arc<Sessions>,
@@ -86,6 +90,11 @@ impl AppState {
             home_dir,
             skill,
             analytics_sink.clone(),
+        ));
+        let skills = Arc::new(SkillService::new(
+            SkillsRepository::new(database.clone()),
+            harness.clone(),
+            config.browserclaw_dir.join("skills"),
         ));
         let profiles = Arc::new(ProfileService::new(store.clone()));
         let session_efficiency = Arc::new(SessionEfficiencyService::new_with_analytics(
@@ -160,6 +169,7 @@ impl AppState {
             tab_activity,
             tab_registry,
             harness,
+            skills,
             analytics,
             profiles,
             sessions,

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
@@ -4,6 +4,7 @@ mod migration;
 pub mod recording_index;
 pub mod session_efficiency_stats;
 pub mod session_tabs;
+pub mod skills;
 
 pub use audit_log::AuditLog;
 pub use recording_index::{
@@ -12,6 +13,7 @@ pub use recording_index::{
 };
 pub use session_efficiency_stats::SessionEfficiencyStatsRepository;
 pub use session_tabs::SessionTabLedger;
+pub use skills::SkillsRepository;
 
 use crate::error::{AppError, AppResult, IoPath};
 use migration::Migrator;

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/skills.rs
@@ -1,0 +1,119 @@
+use crate::{
+    db::{
+        Database,
+        entities::{
+            prelude::{SkillRuns, Skills},
+            skill_runs, skills,
+        },
+    },
+    error::AppResult,
+};
+use sea_orm::{
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect,
+};
+
+/// Database boundary for user skills and their run history.
+#[derive(Clone)]
+pub struct SkillsRepository {
+    db: Database,
+}
+
+impl SkillsRepository {
+    #[must_use]
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    pub async fn all(&self) -> AppResult<Vec<skills::Model>> {
+        Ok(Skills::find()
+            .order_by_desc(skills::Column::UpdatedAt)
+            .all(self.db.connection())
+            .await?)
+    }
+
+    pub async fn get(&self, name: &str) -> AppResult<Option<skills::Model>> {
+        Ok(Skills::find_by_id(name.to_owned())
+            .one(self.db.connection())
+            .await?)
+    }
+
+    pub async fn exists(&self, name: &str) -> AppResult<bool> {
+        Ok(Skills::find_by_id(name.to_owned())
+            .one(self.db.connection())
+            .await?
+            .is_some())
+    }
+
+    pub async fn insert(&self, model: skills::Model) -> AppResult<()> {
+        Skills::insert(into_active(model))
+            .exec_without_returning(self.db.connection())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn update(&self, model: skills::Model) -> AppResult<()> {
+        into_active(model).update(self.db.connection()).await?;
+        Ok(())
+    }
+
+    pub async fn delete(&self, name: &str) -> AppResult<u64> {
+        let result = Skills::delete_by_id(name.to_owned())
+            .exec(self.db.connection())
+            .await?;
+        Ok(result.rows_affected)
+    }
+
+    /// A cursor-paginated page of a skill's runs, newest run first. `cursor` is
+    /// an exclusive upper bound on `run_number`; `next_cursor` is the last
+    /// returned run number when the page is full.
+    pub async fn list_runs(
+        &self,
+        name: &str,
+        cursor: Option<i64>,
+        limit: u64,
+    ) -> AppResult<(Vec<skill_runs::Model>, Option<i64>)> {
+        let mut query = SkillRuns::find()
+            .filter(skill_runs::Column::SkillName.eq(name))
+            .order_by_desc(skill_runs::Column::RunNumber);
+        if let Some(cursor) = cursor {
+            query = query.filter(skill_runs::Column::RunNumber.lt(cursor));
+        }
+        let rows = query.limit(limit).all(self.db.connection()).await?;
+        let next_cursor = (rows.len() as u64 == limit)
+            .then(|| rows.last().map(|row| row.run_number))
+            .flatten();
+        Ok((rows, next_cursor))
+    }
+
+    /// Every run across all skills, used to project per-skill list stats.
+    pub async fn all_runs(&self) -> AppResult<Vec<skill_runs::Model>> {
+        Ok(SkillRuns::find()
+            .order_by_asc(skill_runs::Column::RunNumber)
+            .all(self.db.connection())
+            .await?)
+    }
+
+    pub async fn runs_for(&self, name: &str) -> AppResult<Vec<skill_runs::Model>> {
+        Ok(SkillRuns::find()
+            .filter(skill_runs::Column::SkillName.eq(name))
+            .order_by_asc(skill_runs::Column::RunNumber)
+            .all(self.db.connection())
+            .await?)
+    }
+}
+
+fn into_active(model: skills::Model) -> skills::ActiveModel {
+    skills::ActiveModel {
+        name: Set(model.name),
+        description: Set(model.description),
+        site: Set(model.site),
+        origin: Set(model.origin),
+        source_session_id: Set(model.source_session_id),
+        version: Set(model.version),
+        body_path: Set(model.body_path),
+        linked_agents_json: Set(model.linked_agents_json),
+        created_at: Set(model.created_at),
+        updated_at: Set(model.updated_at),
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/error.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/error.rs
@@ -59,6 +59,14 @@ impl AppError {
     }
 
     #[must_use]
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::Http {
+            status: StatusCode::CONFLICT,
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
     pub fn gone(message: impl Into<String>) -> Self {
         Self::Http {
             status: StatusCode::GONE,

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
@@ -163,6 +163,7 @@ pub struct FirstRunConnectOutcome {
 pub struct HarnessService {
     manager: McpManager,
     workspace_dir: PathBuf,
+    skill_workspace_dir: PathBuf,
     home_dir: PathBuf,
     managed_skill: Option<ManagedSkill>,
     mutex: Arc<Mutex<()>>,
@@ -188,7 +189,14 @@ impl HarnessService {
         home_dir: PathBuf,
         analytics: Arc<dyn AnalyticsSink>,
     ) -> Self {
-        Self::build(workspace_dir, home_dir, analytics, None)
+        let skill_workspace_dir = default_skill_workspace_dir(&workspace_dir);
+        Self::build(
+            workspace_dir,
+            skill_workspace_dir,
+            home_dir,
+            analytics,
+            None,
+        )
     }
 
     #[must_use]
@@ -200,15 +208,22 @@ impl HarnessService {
         analytics: Arc<dyn AnalyticsSink>,
     ) -> Self {
         let managed_skill = ManagedSkill {
-            reconciler: SkillReconciler::new(skill_workspace_dir),
+            reconciler: SkillReconciler::new(skill_workspace_dir.clone()),
             spec,
             environment: SkillEnvironment::current(&home_dir),
         };
-        Self::build(workspace_dir, home_dir, analytics, Some(managed_skill))
+        Self::build(
+            workspace_dir,
+            skill_workspace_dir,
+            home_dir,
+            analytics,
+            Some(managed_skill),
+        )
     }
 
     fn build(
         workspace_dir: PathBuf,
+        skill_workspace_dir: PathBuf,
         home_dir: PathBuf,
         analytics: Arc<dyn AnalyticsSink>,
         managed_skill: Option<ManagedSkill>,
@@ -216,11 +231,65 @@ impl HarnessService {
         Self {
             manager: McpManager::new(&workspace_dir),
             workspace_dir,
+            skill_workspace_dir,
             home_dir,
             managed_skill,
             mutex: Arc::new(Mutex::new(())),
             analytics,
         }
+    }
+
+    /// Reconcile a user-authored skill into every connected agent, returning
+    /// the agents it was linked into. Serialized with all other skill and
+    /// MCP-link mutations through the shared lock so the shared skills.json
+    /// manifest stays consistent.
+    pub async fn install_skill(&self, spec: SkillSpec) -> AppResult<BTreeSet<AgentId>> {
+        let _guard = self.mutex.lock().await;
+        let manager = self.manager.clone();
+        let workspace_dir = self.workspace_dir.clone();
+        let reconciler = SkillReconciler::new(self.skill_workspace_dir.clone());
+        let environment = SkillEnvironment::current(&self.home_dir);
+        tokio::task::spawn_blocking(move || {
+            let consumers = recognized_browseros_links(&manager, &workspace_dir)
+                .map_err(manager_app_error)?
+                .into_iter()
+                .map(|link| link.agent)
+                .collect::<BTreeSet<_>>();
+            reconciler
+                .reconcile(&spec, &consumers, &environment)
+                .map_err(manager_app_error)?;
+            Ok(consumers)
+        })
+        .await?
+    }
+
+    /// Remove a skill from every agent directory it was linked into. Idempotent.
+    pub async fn uninstall_skill(&self, name: &str) -> AppResult<()> {
+        let _guard = self.mutex.lock().await;
+        let spec = SkillSpec::new(name, String::new()).map_err(manager_app_error)?;
+        let reconciler = SkillReconciler::new(self.skill_workspace_dir.clone());
+        let environment = SkillEnvironment::current(&self.home_dir);
+        tokio::task::spawn_blocking(move || {
+            reconciler
+                .reconcile(&spec, &BTreeSet::new(), &environment)
+                .map(|_| ())
+                .map_err(manager_app_error)
+        })
+        .await?
+    }
+
+    /// The agents currently linked to BrowserOS neo over MCP, i.e. the set a
+    /// newly authored skill links into by default.
+    pub async fn connected_agents(&self) -> AppResult<BTreeSet<AgentId>> {
+        let _guard = self.mutex.lock().await;
+        let manager = self.manager.clone();
+        let workspace_dir = self.workspace_dir.clone();
+        tokio::task::spawn_blocking(move || {
+            recognized_browseros_links(&manager, &workspace_dir)
+                .map(|links| links.into_iter().map(|link| link.agent).collect())
+                .map_err(manager_app_error)
+        })
+        .await?
     }
 
     pub async fn connect_browseros(
@@ -1205,6 +1274,16 @@ fn migrate_connected_urls(
 
 fn manager_app_error(error: ManagerError) -> AppError {
     AppError::Internal(error.to_string())
+}
+
+/// The reconciler workspace (holding `skills.json`) as a sibling of the MCP
+/// manager workspace, matching how `new_with_managed_skill` is wired in
+/// `AppState`. Keeps the two reconciler entry points pointed at one manifest.
+fn default_skill_workspace_dir(mcp_workspace_dir: &Path) -> PathBuf {
+    mcp_workspace_dir
+        .parent()
+        .map(|parent| parent.join("harness-integrations"))
+        .unwrap_or_else(|| mcp_workspace_dir.join("harness-integrations"))
 }
 
 #[derive(Debug)]

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/mod.rs
@@ -13,4 +13,5 @@ pub mod runtime_file;
 pub mod screenshots;
 pub mod session_efficiency;
 pub mod sessions;
+pub mod skills;
 pub mod tab_cleanup;

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -165,31 +165,46 @@ impl SkillService {
             return Err(AppError::conflict("a skill with this name already exists"));
         }
 
-        let content = render_skill_markdown(
-            &input.name,
-            &input.description,
-            &input.steps,
-            &input.learned_notes,
-        );
-        let body_path = self.write_body(&input.name, &content).await?;
-        let spec = SkillSpec::new(input.name.as_str(), content)
+        let CreateSkill {
+            name,
+            description,
+            site,
+            steps,
+            learned_notes,
+            origin,
+            source_session_id,
+        } = input;
+        let content = render_skill_markdown(&name, &description, &steps, &learned_notes);
+        // The agent install happens before the row lands, so a failure after it
+        // rolls the side effects back to avoid an install with no persisted row.
+        let body_path = self.write_body(&name, &content).await?;
+        let spec = SkillSpec::new(name.as_str(), content)
             .map_err(|error| AppError::bad_request(error.to_string()))?;
-        let linked = self.harness.install_skill(spec).await?;
+        let linked = match self.harness.install_skill(spec).await {
+            Ok(linked) => linked,
+            Err(error) => {
+                self.rollback_skill(&name).await;
+                return Err(error);
+            }
+        };
 
         let now = now_ms();
         let model = skills::Model {
-            name: input.name,
-            description: input.description,
-            site: input.site,
-            origin: input.origin.as_str().to_owned(),
-            source_session_id: input.source_session_id,
+            name: name.clone(),
+            description,
+            site,
+            origin: origin.as_str().to_owned(),
+            source_session_id,
             version: 1,
             body_path,
             linked_agents_json: linked_agents_json(&linked),
             created_at: now,
             updated_at: now,
         };
-        self.repo.insert(model.clone()).await?;
+        if let Err(error) = self.repo.insert(model.clone()).await {
+            self.rollback_skill(&name).await;
+            return Err(error);
+        }
         Ok(SkillView {
             model,
             linked_agents: linked.into_iter().collect(),
@@ -200,9 +215,12 @@ impl SkillService {
     pub async fn update(&self, name: &str, input: UpdateSkill) -> AppResult<SkillDetailView> {
         let mut model = self.require(name).await?;
         let mut relinked: Option<BTreeSet<AgentId>> = None;
+        let mut previous_body: Option<String> = None;
+        let body_path = model.body_path.clone();
 
         if let Some(body) = input.body {
-            self.write_body_at(&model.body_path, &body).await?;
+            previous_body = Some(self.read_body(&body_path).await);
+            self.write_body_at(&body_path, &body).await?;
             let spec = SkillSpec::new(name, body)
                 .map_err(|error| AppError::bad_request(error.to_string()))?;
             relinked = Some(self.harness.install_skill(spec).await?);
@@ -220,24 +238,35 @@ impl SkillService {
             model.linked_agents_json = linked_agents_json(linked);
         }
         model.updated_at = now_ms();
-        self.repo.update(model).await?;
+        if let Err(error) = self.repo.update(model).await {
+            // The durable row was not written, so restore the on-disk body and
+            // relink it, keeping the file and agents consistent with the row.
+            if let Some(previous) = previous_body {
+                let _ = self.write_body_at(&body_path, &previous).await;
+                if let Ok(spec) = SkillSpec::new(name, previous) {
+                    let _ = self.harness.install_skill(spec).await;
+                }
+            }
+            return Err(error);
+        }
         self.get(name).await
     }
 
     pub async fn delete(&self, name: &str) -> AppResult<()> {
         self.require(name).await?;
         self.harness.uninstall_skill(name).await?;
-        let skill_dir = self.skills_dir.join(name);
-        if let Err(error) = tokio::fs::remove_dir_all(&skill_dir).await
-            && error.kind() != std::io::ErrorKind::NotFound
-        {
-            return Err(AppError::Io {
-                path: Some(skill_dir),
-                source: error,
-            });
-        }
         self.repo.delete(name).await?;
+        // The canonical file is now orphaned; removing it is best-effort so a
+        // filesystem hiccup cannot resurrect an already-deleted skill.
+        let _ = tokio::fs::remove_dir_all(self.skills_dir.join(name)).await;
         Ok(())
+    }
+
+    /// Best-effort removal of a skill's side effects (agent installs and the
+    /// canonical file) after a failed create, so nothing is left without a row.
+    async fn rollback_skill(&self, name: &str) {
+        let _ = self.harness.uninstall_skill(name).await;
+        let _ = tokio::fs::remove_dir_all(self.skills_dir.join(name)).await;
     }
 
     async fn require(&self, name: &str) -> AppResult<skills::Model> {
@@ -316,6 +345,11 @@ fn render_skill_markdown(
     steps: &[String],
     learned_notes: &[String],
 ) -> String {
+    // JSON is a subset of YAML, so a JSON-encoded string is a valid, correctly
+    // escaped YAML scalar. This keeps descriptions with newlines, colons, or
+    // other YAML-sensitive characters from corrupting the frontmatter. The name
+    // is already constrained to `[a-z0-9-]`, so it stays a plain scalar.
+    let description = serde_json::to_string(description).unwrap_or_else(|_| "\"\"".to_string());
     let mut out =
         format!("---\nname: {name}\ndescription: {description}\ntools: {SKILL_TOOLS}\n---\n");
     if !steps.is_empty() {

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -1,0 +1,341 @@
+use crate::{
+    db::{
+        SkillsRepository,
+        entities::{skill_runs, skills},
+    },
+    error::{AppError, AppResult, IoPath},
+    services::harness::HarnessService,
+};
+use harness_integrations::{AgentId, SkillSpec};
+use std::{
+    collections::{BTreeSet, HashMap},
+    path::PathBuf,
+    str::FromStr,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+/// The embedded product skill owns this directory name; user skills may not
+/// reuse it or they would clobber the managed BrowserOS skill.
+const RESERVED_SKILL_NAMES: [&str; 1] = ["browserclaw"];
+const DEFAULT_RUN_LIMIT: u64 = 25;
+const MAX_RUN_LIMIT: u64 = 100;
+
+/// Where the agent gets told to drive the browser from a skill's frontmatter.
+const SKILL_TOOLS: &str = "browseros-neo";
+
+/// Skill creation surface, independent of transport. The MCP tool and the REST
+/// handler both build this.
+pub struct CreateSkill {
+    pub name: String,
+    pub description: String,
+    pub site: Option<String>,
+    pub steps: Vec<String>,
+    pub learned_notes: Vec<String>,
+    pub origin: SkillOrigin,
+    pub source_session_id: Option<String>,
+}
+
+pub struct UpdateSkill {
+    pub description: Option<String>,
+    pub site: Option<String>,
+    pub body: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+pub enum SkillOrigin {
+    Agent,
+    Manual,
+    Directory,
+}
+
+impl SkillOrigin {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Agent => "agent",
+            Self::Manual => "manual",
+            Self::Directory => "directory",
+        }
+    }
+}
+
+/// Aggregated run stats for the list and detail views.
+#[derive(Default)]
+pub struct RunStats {
+    pub run_count: i64,
+    pub clean_run_count: i64,
+    pub first_run_tokens: Option<i64>,
+    pub latest_run_tokens: Option<i64>,
+    pub last_run_at: Option<i64>,
+}
+
+pub struct SkillView {
+    pub model: skills::Model,
+    pub linked_agents: Vec<AgentId>,
+    pub stats: RunStats,
+}
+
+pub struct SkillDetailView {
+    pub view: SkillView,
+    pub body: String,
+    pub runs: Vec<skill_runs::Model>,
+}
+
+/// Owns user skills end to end: persists rows, keeps the canonical SKILL.md on
+/// disk, and links each skill into the connected agents through the harness.
+pub struct SkillService {
+    repo: SkillsRepository,
+    harness: Arc<HarnessService>,
+    skills_dir: PathBuf,
+}
+
+impl SkillService {
+    #[must_use]
+    pub fn new(repo: SkillsRepository, harness: Arc<HarnessService>, skills_dir: PathBuf) -> Self {
+        Self {
+            repo,
+            harness,
+            skills_dir,
+        }
+    }
+
+    pub async fn list(&self) -> AppResult<Vec<SkillView>> {
+        let models = self.repo.all().await?;
+        let runs = self.repo.all_runs().await?;
+        let mut by_skill: HashMap<String, Vec<skill_runs::Model>> = HashMap::new();
+        for run in runs {
+            by_skill
+                .entry(run.skill_name.clone())
+                .or_default()
+                .push(run);
+        }
+        Ok(models
+            .into_iter()
+            .map(|model| {
+                let skill_runs = by_skill.remove(&model.name).unwrap_or_default();
+                let stats = stats_from_runs(&skill_runs);
+                let linked_agents = parse_linked_agents(&model.linked_agents_json);
+                SkillView {
+                    model,
+                    linked_agents,
+                    stats,
+                }
+            })
+            .collect())
+    }
+
+    pub async fn get(&self, name: &str) -> AppResult<SkillDetailView> {
+        let model = self.require(name).await?;
+        let body = self.read_body(&model.body_path).await;
+        let runs = self.repo.runs_for(name).await?;
+        let stats = stats_from_runs(&runs);
+        let linked_agents = parse_linked_agents(&model.linked_agents_json);
+        Ok(SkillDetailView {
+            view: SkillView {
+                model,
+                linked_agents,
+                stats,
+            },
+            body,
+            runs,
+        })
+    }
+
+    pub async fn list_runs(
+        &self,
+        name: &str,
+        cursor: Option<i64>,
+        limit: Option<u64>,
+    ) -> AppResult<(Vec<skill_runs::Model>, Option<i64>)> {
+        self.require(name).await?;
+        let limit = limit.unwrap_or(DEFAULT_RUN_LIMIT).clamp(1, MAX_RUN_LIMIT);
+        self.repo.list_runs(name, cursor, limit).await
+    }
+
+    pub async fn create(&self, input: CreateSkill) -> AppResult<SkillView> {
+        if !is_valid_skill_name(&input.name) {
+            return Err(AppError::bad_request(
+                "skill name must contain only lowercase letters, digits, and hyphens",
+            ));
+        }
+        if RESERVED_SKILL_NAMES.contains(&input.name.as_str()) {
+            return Err(AppError::conflict("skill name is reserved"));
+        }
+        if self.repo.exists(&input.name).await? {
+            return Err(AppError::conflict("a skill with this name already exists"));
+        }
+
+        let content = render_skill_markdown(
+            &input.name,
+            &input.description,
+            &input.steps,
+            &input.learned_notes,
+        );
+        let body_path = self.write_body(&input.name, &content).await?;
+        let spec = SkillSpec::new(input.name.as_str(), content)
+            .map_err(|error| AppError::bad_request(error.to_string()))?;
+        let linked = self.harness.install_skill(spec).await?;
+
+        let now = now_ms();
+        let model = skills::Model {
+            name: input.name,
+            description: input.description,
+            site: input.site,
+            origin: input.origin.as_str().to_owned(),
+            source_session_id: input.source_session_id,
+            version: 1,
+            body_path,
+            linked_agents_json: linked_agents_json(&linked),
+            created_at: now,
+            updated_at: now,
+        };
+        self.repo.insert(model.clone()).await?;
+        Ok(SkillView {
+            model,
+            linked_agents: linked.into_iter().collect(),
+            stats: RunStats::default(),
+        })
+    }
+
+    pub async fn update(&self, name: &str, input: UpdateSkill) -> AppResult<SkillDetailView> {
+        let mut model = self.require(name).await?;
+        let mut relinked: Option<BTreeSet<AgentId>> = None;
+
+        if let Some(body) = input.body {
+            self.write_body_at(&model.body_path, &body).await?;
+            let spec = SkillSpec::new(name, body)
+                .map_err(|error| AppError::bad_request(error.to_string()))?;
+            relinked = Some(self.harness.install_skill(spec).await?);
+            model.version += 1;
+        }
+        if let Some(description) = input.description {
+            model.description = description;
+        }
+        // A nullable `site` cannot be explicitly cleared through the current
+        // contract; clearing is deferred to a later contract revision.
+        if let Some(site) = input.site {
+            model.site = Some(site);
+        }
+        if let Some(linked) = &relinked {
+            model.linked_agents_json = linked_agents_json(linked);
+        }
+        model.updated_at = now_ms();
+        self.repo.update(model).await?;
+        self.get(name).await
+    }
+
+    pub async fn delete(&self, name: &str) -> AppResult<()> {
+        self.require(name).await?;
+        self.harness.uninstall_skill(name).await?;
+        let skill_dir = self.skills_dir.join(name);
+        if let Err(error) = tokio::fs::remove_dir_all(&skill_dir).await
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(AppError::Io {
+                path: Some(skill_dir),
+                source: error,
+            });
+        }
+        self.repo.delete(name).await?;
+        Ok(())
+    }
+
+    async fn require(&self, name: &str) -> AppResult<skills::Model> {
+        self.repo
+            .get(name)
+            .await?
+            .ok_or_else(|| AppError::not_found("skill not found"))
+    }
+
+    async fn write_body(&self, name: &str, content: &str) -> AppResult<String> {
+        let dir = self.skills_dir.join(name);
+        tokio::fs::create_dir_all(&dir).await.with_path(&dir)?;
+        let path = dir.join("SKILL.md");
+        tokio::fs::write(&path, content).await.with_path(&path)?;
+        Ok(path.to_string_lossy().into_owned())
+    }
+
+    async fn write_body_at(&self, body_path: &str, content: &str) -> AppResult<()> {
+        let path = PathBuf::from(body_path);
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await.with_path(parent)?;
+        }
+        tokio::fs::write(&path, content).await.with_path(&path)?;
+        Ok(())
+    }
+
+    async fn read_body(&self, body_path: &str) -> String {
+        tokio::fs::read_to_string(body_path)
+            .await
+            .unwrap_or_default()
+    }
+}
+
+fn stats_from_runs(runs: &[skill_runs::Model]) -> RunStats {
+    RunStats {
+        run_count: runs.len() as i64,
+        clean_run_count: runs.iter().filter(|run| run.clean).count() as i64,
+        first_run_tokens: runs
+            .iter()
+            .min_by_key(|run| run.run_number)
+            .and_then(|run| run.tokens),
+        latest_run_tokens: runs
+            .iter()
+            .max_by_key(|run| run.run_number)
+            .and_then(|run| run.tokens),
+        last_run_at: runs.iter().map(|run| run.created_at).max(),
+    }
+}
+
+fn parse_linked_agents(json: &str) -> Vec<AgentId> {
+    serde_json::from_str::<Vec<String>>(json)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|value| AgentId::from_str(&value).ok())
+        .collect()
+}
+
+fn linked_agents_json(agents: &BTreeSet<AgentId>) -> String {
+    let ids = agents
+        .iter()
+        .map(|agent| agent.as_str())
+        .collect::<Vec<_>>();
+    serde_json::to_string(&ids).unwrap_or_else(|_| "[]".to_string())
+}
+
+fn is_valid_skill_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+fn render_skill_markdown(
+    name: &str,
+    description: &str,
+    steps: &[String],
+    learned_notes: &[String],
+) -> String {
+    let mut out =
+        format!("---\nname: {name}\ndescription: {description}\ntools: {SKILL_TOOLS}\n---\n");
+    if !steps.is_empty() {
+        out.push_str("\n## Steps\n");
+        for (index, step) in steps.iter().enumerate() {
+            out.push_str(&format!("{}. {}\n", index + 1, step));
+        }
+    }
+    if !learned_notes.is_empty() {
+        out.push_str("\n## Learned from past runs\n");
+        for note in learned_notes {
+            out.push_str(&format!("- {note}\n"));
+        }
+    }
+    out
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/packages/browseros-agent/apps/claw-server-rust/tests/dependency_boundaries.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/dependency_boundaries.rs
@@ -430,6 +430,7 @@ fn allowed_service_edge(source: &str, target: &str) -> bool {
             | ("recordings", "browser")
             | ("replay", "recordings")
             | ("tab_cleanup", "browser")
+            | ("skills", "harness")
     )
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -1,0 +1,198 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header},
+};
+use claw_server_rust::{AppState, build_router, config::Config};
+use serde_json::{Value, json};
+use std::{path::PathBuf, sync::Arc, time::Duration};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+struct TestApp {
+    router: Router,
+    _dir: TempDir,
+    root: PathBuf,
+}
+
+async fn test_app() -> anyhow::Result<TestApp> {
+    let dir = tempfile::tempdir()?;
+    let root = dir.path().join("browserclaw");
+    let config = Arc::new(Config {
+        server_port: 9200,
+        cdp_port: 49361,
+        proxy_port: None,
+        resources_dir: dir.path().join("resources"),
+        browserclaw_dir: root.clone(),
+        session_idle: Duration::from_secs(300),
+        session_retention: Duration::from_secs(7_200),
+        session_sweep_interval: Duration::from_secs(60),
+        replay_retention_days: 7,
+        dev_mode: false,
+        auth_token: None,
+    });
+    let state = AppState::new_with_home(config, dir.path().join("home")).await?;
+    Ok(TestApp {
+        router: build_router(state),
+        _dir: dir,
+        root,
+    })
+}
+
+async fn request(
+    router: &Router,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> anyhow::Result<(StatusCode, Value)> {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(header::HOST, "localhost");
+    let request_body = if let Some(body) = body {
+        builder = builder.header(header::CONTENT_TYPE, "application/json");
+        Body::from(body.to_string())
+    } else {
+        Body::empty()
+    };
+    let response = router.clone().oneshot(builder.body(request_body)?).await?;
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await?;
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes)?
+    };
+    Ok((status, value))
+}
+
+#[tokio::test]
+async fn skill_crud_round_trips_and_writes_the_canonical_file() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    let (status, list) = request(router, "GET", "/api/v1/skills", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(list["items"].as_array().map(Vec::len), Some(0));
+
+    let (status, created) = request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({
+            "name": "inbox-sweep",
+            "description": "Check the inbox and draft replies",
+            "site": "mail.google.com",
+            "steps": ["Open the inbox", "Draft replies", "Leave drafts unsent"],
+            "learnedNotes": ["Read the DOM snapshot, not screenshots"]
+        })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["name"], "inbox-sweep");
+    assert_eq!(created["origin"], "manual");
+    assert_eq!(created["version"].as_i64(), Some(1));
+    assert_eq!(created["runCount"].as_i64(), Some(0));
+    assert_eq!(created["site"], "mail.google.com");
+
+    let skill_md = app.root.join("skills").join("inbox-sweep").join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_md)?;
+    assert!(content.contains("name: inbox-sweep"));
+    assert!(content.contains("tools: browseros-neo"));
+    assert!(content.contains("## Steps"));
+    assert!(content.contains("Read the DOM snapshot, not screenshots"));
+
+    let (status, detail) = request(router, "GET", "/api/v1/skills/inbox-sweep", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["skill"]["name"], "inbox-sweep");
+    assert!(
+        detail["body"]
+            .as_str()
+            .is_some_and(|body| body.contains("name: inbox-sweep"))
+    );
+    assert_eq!(detail["runs"].as_array().map(Vec::len), Some(0));
+
+    let (_, list) = request(router, "GET", "/api/v1/skills", None).await?;
+    assert_eq!(list["items"].as_array().map(Vec::len), Some(1));
+
+    let (status, runs) = request(router, "GET", "/api/v1/skills/inbox-sweep/runs", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(runs["items"].as_array().map(Vec::len), Some(0));
+
+    let (status, updated) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/inbox-sweep",
+        Some(json!({
+            "description": "Updated description",
+            "body": "---\nname: inbox-sweep\ndescription: Updated\ntools: browseros-neo\n---\n\n## Steps\n1. A brand new step\n"
+        })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(updated["skill"]["version"].as_i64(), Some(2));
+    assert_eq!(updated["skill"]["description"], "Updated description");
+    assert!(
+        updated["body"]
+            .as_str()
+            .is_some_and(|body| body.contains("A brand new step"))
+    );
+    let content = std::fs::read_to_string(&skill_md)?;
+    assert!(content.contains("A brand new step"));
+
+    let (status, _) = request(router, "DELETE", "/api/v1/skills/inbox-sweep", None).await?;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (status, _) = request(router, "GET", "/api/v1/skills/inbox-sweep", None).await?;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(!app.root.join("skills").join("inbox-sweep").exists());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn skill_create_rejects_bad_names_and_duplicates() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    let (status, _) = request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({ "name": "Bad Name", "description": "invalid slug" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    let (status, _) = request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({ "name": "browserclaw", "description": "reserved name" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    let (status, _) = request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({ "name": "daily-brief", "description": "first" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, _) = request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({ "name": "daily-brief", "description": "duplicate" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CONFLICT);
+
+    let (status, _) = request(router, "GET", "/api/v1/skills/missing", None).await?;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    Ok(())
+}

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -196,3 +196,29 @@ async fn skill_create_rejects_bad_names_and_duplicates() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn skill_create_escapes_yaml_sensitive_descriptions() -> anyhow::Result<()> {
+    let app = test_app().await?;
+
+    let (status, _) = request(
+        &app.router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({
+            "name": "tricky-desc",
+            "description": "Reply within 24h: keep it brief\nthen stop"
+        })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let content =
+        std::fs::read_to_string(app.root.join("skills").join("tricky-desc").join("SKILL.md"))?;
+    // The description is emitted as a quoted scalar, so a raw newline or colon
+    // cannot break the frontmatter block.
+    assert!(content.contains(r#"description: "Reply within 24h: keep it brief\nthen stop""#));
+    assert_eq!(content.matches("---").count(), 2);
+
+    Ok(())
+}


### PR DESCRIPTION
## What

Builds the server side of Tasks on top of the Phase 1 data model and contract: skills are now created, read, edited, listed, and deleted through REST, and each one is written to disk as a `SKILL.md` and linked into the connected coding agents. No UI yet.

- **Skill service.** A new service owns skills end to end: it renders a `SKILL.md` from a create request (frontmatter + steps + learned notes), keeps a server-owned canonical copy so a skill's body is always retrievable even with no agent connected, persists the row, and links the skill into every connected agent through the harness. Update rewrites the body and re-links; delete unlinks and removes the row and files.
- **Reconciler reuse, not reinvention.** The existing `harness-integrations` reconciler is already multi-skill at the manifest level. The harness service gains `install_skill` / `uninstall_skill` / `connected_agents`, which drive it once per skill under the same lock that guards the shared skill manifest, so user skills and the embedded product skill never race. The embedded product skill's directory name is reserved from user skills.
- **REST endpoints.** `GET/POST /api/v1/skills`, `GET/PUT/DELETE /api/v1/skills/{name}`, and `GET /api/v1/skills/{name}/runs`, mapping the service to the generated DTOs with in-contract canonical errors (`skill_not_found` 404, `skill_conflict` 409, `invalid_skill` 400). `linkedAgents` is reported using the existing `Harness` vocabulary.
- **Runs** are read-only here and empty until run recording lands; the list and detail views already project run stats (count, clean count, first/latest tokens, last-run time) from run rows.

## Notes

- The directory endpoints from the contract are intentionally not implemented yet; they arrive with the remote catalog work.
- A nullable `site` still cannot be explicitly cleared through update; that was deferred earlier and is called out in the code where update applies changes.
- Skills link into the set of agents currently connected over MCP; per-skill agent subsets are future work.

## Tests

- New integration tests drive the full REST lifecycle against a real router over a temp state dir: create returns the skill and writes `SKILL.md` with the rendered frontmatter and sections, get/list/runs read back, update bumps the version and rewrites the on-disk body, delete removes the row and the files, and a follow-up read is a 404. A second test covers rejection of invalid slugs, the reserved name, duplicates, and unknown skills.
- Whole-workspace `cargo fmt` and `clippy` clean; server package tests green.
