### PR TITLE
chore(claw-server): upgrade rmcp to 3.x with a legacy protocol version pin

### DIFF
--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -283,6 +283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,7 +333,7 @@ dependencies = [
 name = "browseros-core"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "browseros-cdp",
  "futures-util",
  "serde",
@@ -345,7 +351,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
- "base64",
+ "base64 0.22.1",
  "browseros-cdp",
  "browseros-core",
  "futures-util",
@@ -484,7 +490,7 @@ version = "0.0.35"
 dependencies = [
  "anyhow",
  "axum",
- "base64",
+ "base64 0.22.1",
  "browseros-cdp",
  "browseros-core",
  "browseros-mcp",
@@ -673,12 +679,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
 ]
 
 [[package]]
@@ -697,15 +703,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -721,13 +727,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.24.0",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1291,7 +1297,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2268,7 +2274,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -2306,7 +2312,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2355,12 +2361,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "futures",
@@ -2386,15 +2392,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2992,7 +2998,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -3081,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",

--- a/packages/browseros-agent/Cargo.toml
+++ b/packages/browseros-agent/Cargo.toml
@@ -26,7 +26,7 @@ pulldown-cmark = { version = "0.13", default-features = false }
 sha2 = "0.10"
 jsonc-parser = { version = "0.33", features = ["cst", "serde_json"] }
 toml_edit = "0.22"
-rmcp = { version = "2.1", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "3", features = ["server", "transport-io", "transport-streamable-http-server"] }
 schemars = "1.0"
 axum = "0.8"
 http = "1"

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -19,14 +19,15 @@ use rmcp::{
     ErrorData as McpError, RoleServer,
     handler::server::ServerHandler,
     model::{
-        CallToolRequestMethod, CallToolRequestParams, CallToolResult, Implementation,
-        InitializeRequestParams, InitializeResult, JsonObject, ListToolsResult,
-        PaginatedRequestParams, ServerCapabilities, Tool, ToolAnnotations,
+        CallToolRequestMethod, CallToolRequestParams, CallToolResponse, CallToolResult,
+        Implementation, InitializeRequestParams, InitializeResult, JsonObject, ListToolsResult,
+        PaginatedRequestParams, ProtocolVersion, ServerCapabilities, Tool, ToolAnnotations,
     },
     service::{NotificationContext, RequestContext},
 };
 use serde_json::{Value, json};
 use std::{
+    borrow::Cow,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -289,6 +290,18 @@ impl Drop for ClawMcpService {
     }
 }
 
+// Pin the claw-server to legacy protocol versions across the rmcp 3.x bump.
+// rmcp 3.x advertises 2026-07-28 by default, but the sessionless (modern) state
+// model is not in place yet: advertising it now would let modern clients
+// negotiate a stateless session this handler cannot track. Lifted once the
+// handle-based session model lands.
+const LEGACY_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
+    ProtocolVersion::V_2025_11_25,
+    ProtocolVersion::V_2025_06_18,
+    ProtocolVersion::V_2025_03_26,
+    ProtocolVersion::V_2024_11_05,
+];
+
 impl ServerHandler for ClawMcpService {
     fn get_info(&self) -> InitializeResult {
         let capabilities = ServerCapabilities::builder().enable_tools().build();
@@ -297,6 +310,10 @@ impl ServerHandler for ClawMcpService {
         InitializeResult::new(capabilities)
             .with_server_info(implementation)
             .with_instructions(BROWSERCLAW_MCP_INSTRUCTIONS)
+    }
+
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        Cow::Borrowed(LEGACY_PROTOCOL_VERSIONS)
     }
 
     async fn initialize(
@@ -338,7 +355,7 @@ impl ServerHandler for ClawMcpService {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         let is_name_session = request.name == NAME_SESSION_TOOL_NAME;
         let tool_index = self.find_tool_index(&request.name);
         if !is_name_session && tool_index.is_none() {
@@ -406,6 +423,7 @@ impl ServerHandler for ClawMcpService {
             result,
         )
         .await
+        .map(Into::into)
     }
 }
 
@@ -514,6 +532,16 @@ mod tests {
     use crate::identity::ConversationIdentity;
     use rmcp::handler::server::ServerHandler;
     use serde_json::json;
+
+    #[test]
+    fn legacy_protocol_pin_excludes_the_modern_revision() {
+        // Behavior-neutral bump: rmcp 3.x's default advertises 2026-07-28, but the
+        // sessionless state model is not in place yet, so the claw-server pins to
+        // legacy versions. Lifted with the handle-based session model.
+        assert!(ProtocolVersion::KNOWN_VERSIONS.contains(&ProtocolVersion::V_2026_07_28));
+        assert!(!LEGACY_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2026_07_28));
+        assert!(LEGACY_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2025_11_25));
+    }
 
     fn usage_session() -> Arc<Session> {
         Session::new(

--- a/packages/browseros-agent/crates/browseros-mcp/src/service.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/service.rs
@@ -13,8 +13,9 @@ use rmcp::{
     ErrorData as McpError, RoleServer,
     handler::server::ServerHandler,
     model::{
-        CallToolRequestMethod, CallToolRequestParams, CallToolResult, Implementation, JsonObject,
-        ListToolsResult, PaginatedRequestParams, ServerCapabilities, Tool,
+        CallToolRequestMethod, CallToolRequestParams, CallToolResponse, CallToolResult,
+        Implementation, JsonObject, ListToolsResult, PaginatedRequestParams, ServerCapabilities,
+        Tool,
     },
     service::RequestContext,
 };
@@ -295,7 +296,7 @@ impl ServerHandler for BrowserMcpService {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         let Some(def) = self.find_tool(&request.name) else {
             return Err(McpError::method_not_found::<CallToolRequestMethod>());
         };
@@ -305,6 +306,7 @@ impl ServerHandler for BrowserMcpService {
             .unwrap_or_else(|| Value::Object(JsonObject::new()));
         Ok(self
             .execute_registered_tool(def, args, context.ct.clone())
-            .await)
+            .await
+            .into())
     }
 }

--- a/packages/browseros-agent/crates/browseros-mcp/tests/rmcp_serving.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/tests/rmcp_serving.rs
@@ -5,7 +5,7 @@ use axum::{
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResult, ContentBlock, Implementation,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, Implementation,
         InitializeRequestParams, InitializeResult, ServerCapabilities,
     },
     serve_server,
@@ -138,7 +138,7 @@ impl ServerHandler for ProbeService {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         let session_id = session_id_from_request_context(&context);
         self.state
             .push(self.instance(), "call_tool", session_id.clone(), None)
@@ -147,7 +147,8 @@ impl ServerHandler for ProbeService {
             "{}:{}",
             request.name,
             session_id.unwrap_or_else(|| "missing".to_string())
-        ))]))
+        ))])
+        .into())
     }
 }
 

--- a/packages/browseros-agent/crates/browseros-mcp/tests/rmcp_serving.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/tests/rmcp_serving.rs
@@ -6,7 +6,7 @@ use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     model::{
         CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, Implementation,
-        InitializeRequestParams, InitializeResult, ServerCapabilities,
+        InitializeRequestParams, InitializeResult, ProtocolVersion, ServerCapabilities,
     },
     serve_server,
     service::{NotificationContext, RequestContext},
@@ -17,6 +17,7 @@ use rmcp::{
 };
 use serde_json::{Value, json};
 use std::{
+    borrow::Cow,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -100,10 +101,23 @@ impl Drop for ProbeService {
     }
 }
 
+// Mirrors the claw-server's production legacy pin so the serving proof below
+// exercises the same override.
+const LEGACY_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
+    ProtocolVersion::V_2025_11_25,
+    ProtocolVersion::V_2025_06_18,
+    ProtocolVersion::V_2025_03_26,
+    ProtocolVersion::V_2024_11_05,
+];
+
 impl ServerHandler for ProbeService {
     fn get_info(&self) -> InitializeResult {
         InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("probe", "0.0.0"))
+    }
+
+    fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+        Cow::Borrowed(LEGACY_PROTOCOL_VERSIONS)
     }
 
     async fn initialize(
@@ -261,6 +275,48 @@ fn initialize_request(id: i64, client_name: &str) -> Value {
             }
         }
     })
+}
+
+#[tokio::test]
+async fn legacy_pin_does_not_agree_to_the_modern_revision() -> anyhow::Result<()> {
+    // Proof that rmcp consults supported_protocol_versions(): an initialize that
+    // requests 2026-07-28 is not agreed to. The pinned server negotiates down to a
+    // legacy revision instead of echoing the modern one, so a client never ends up
+    // on the stateless modern lifecycle this handler cannot track.
+    let state = ProbeState::new();
+    let service = streamable_service(state);
+
+    let (status, _headers, response) = post_json(
+        &service,
+        None,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2026-07-28",
+                "capabilities": {},
+                "clientInfo": { "name": "modern", "version": "1" }
+            }
+        }),
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::OK);
+    let negotiated = response["result"]["protocolVersion"]
+        .as_str()
+        .unwrap_or_default();
+    assert_ne!(
+        negotiated, "2026-07-28",
+        "server must not agree to the modern revision: {response:?}"
+    );
+    assert!(
+        LEGACY_PROTOCOL_VERSIONS
+            .iter()
+            .any(|v| v.as_str() == negotiated),
+        "expected a pinned legacy version, got {negotiated:?}: {response:?}"
+    );
+    Ok(())
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Upgrade the Rust claw-server to `rmcp` 3.x, in isolation and behavior-neutral. Targets the `feat/mcp-2026-07-28` epic branch. Context: #2168.

## Changes

- Bump `rmcp` 2.1 to 3.1.2 (workspace `Cargo.toml` + lockfile). MSRV is already satisfied (the workspace is at 1.94; rmcp 3.x needs 1.88), and the enabled feature names are unchanged.
- rmcp 3.0 changed `ServerHandler::call_tool` to return the MRTR-aware `CallToolResponse`. Wrap the existing `CallToolResult` with `.into()` in the production handler (`ClawMcpService`), the reference handler (`BrowserMcpService`), and the serving test.
- **Legacy protocol pin**: rmcp 3.x advertises `2026-07-28` by default, but the claw-server's sessionless state model for that revision is not in place yet. Overriding `supported_protocol_versions()` on the production handler pins it to legacy versions (`2025-11-25` and earlier) so this upgrade is behavior-neutral: modern clients are not served a stateless session the handler cannot track. A unit test locks the pin. It is lifted together with the handle-based session model in a follow-up.

## Testing

- All crates compile. `cargo test` passes: `browseros-mcp` (including the streamable-HTTP and stdio serving tests) and `claw-server-rust` (300+ tests). `cargo clippy` and `cargo fmt --check` clean.

Refs #2168
