### PR TITLE
feat(skills): add the save_skill agent MCP tool

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -12,7 +12,10 @@ use crate::{
     },
     identity::{ClientIdentity, ClientInfo, ProfileView},
     ids::{DispatchId, SessionId},
-    services::sessions::Session,
+    services::{
+        sessions::Session,
+        skills::{CreateSkill, SkillOrigin},
+    },
 };
 use browseros_mcp::{OutputFileAccess, ToolDef, ToolResult, catalog};
 use rmcp::{
@@ -43,6 +46,8 @@ const SERVER_TITLE: &str = "BrowserOS neo";
 const NAME_SESSION_TOOL_NAME: &str = "name_session";
 const NAME_SESSION_DESCRIPTION: &str = "Rename this browser session: a small lowercase 2-3 word label for what this session is doing, e.g. \"invoice processing\". Tabs are grouped as <client>/<name>. Call again to rename.";
 const NAME_SESSION_INPUT_MAX_LEN: usize = 64;
+const SAVE_SKILL_TOOL_NAME: &str = "save_skill";
+const SAVE_SKILL_DESCRIPTION: &str = "Save the current repeatable browser task as a BrowserOS neo skill so it can be re-run by name later. Give a lowercase-hyphen name, a one-line description, the ordered steps, and any shortcuts learned this run. Call again with the same name to update it in place.";
 
 /// Owns one MCP transport lifetime. Drop best-effort schedules removal of a started
 /// server session, which records its end and begins retained-group handling.
@@ -50,6 +55,7 @@ pub struct ClawMcpService {
     state: AppState,
     catalog: Arc<Vec<ToolDef>>,
     name_session_tool: Tool,
+    save_skill_tool: Tool,
     output_files: OutputFileAccess,
     lifecycle: Arc<Mutex<ServiceLifecycle>>,
     fallback_session_id: SessionId,
@@ -76,6 +82,7 @@ impl ClawMcpService {
             state,
             catalog: Arc::new(catalog()),
             name_session_tool: name_session_tool(),
+            save_skill_tool: save_skill_tool(),
             output_files: browseros_mcp::output_file::create_browser_output_file_access(),
             lifecycle: Arc::new(Mutex::new(ServiceLifecycle::default())),
             fallback_session_id: SessionId::new(format!("stdio-{}", Ulid::new())),
@@ -94,6 +101,7 @@ impl ClawMcpService {
             .map(ToolDef::to_mcp_tool)
             .collect::<Vec<_>>();
         tools.push(self.name_session_tool.clone());
+        tools.push(self.save_skill_tool.clone());
         tools
     }
 
@@ -142,6 +150,48 @@ impl ClawMcpService {
                 session: &started.session,
                 agent_label: &started.agent_label,
                 tool_name: NAME_SESSION_TOOL_NAME,
+                raw_args,
+                result: &result,
+                duration_ms: i64::try_from(started_at.elapsed().as_millis()).unwrap_or(i64::MAX),
+                dispatch_id: dispatch_id.clone(),
+            },
+        )
+        .await
+        {
+            warn!(error = %error, "local tool audit submission failed");
+        }
+        finish_local_dispatch(started.session.as_ref(), &dispatch_id, result)
+            .await
+            .into_call_tool_result()
+    }
+
+    async fn call_save_skill(&self, started: &StartedSession, raw_args: &Value) -> CallToolResult {
+        let dispatch_id = DispatchId::new();
+        let dispatch_cancel = CancellationToken::new();
+        if !started
+            .session
+            .try_register_dispatch(dispatch_id.clone(), dispatch_cancel)
+            .await
+        {
+            return CallToolResult::error(vec![rmcp::model::ContentBlock::text(
+                "BrowserOS neo session is no longer live",
+            )]);
+        }
+        let started_at = StdInstant::now();
+        let session_id = started.session.id().as_str().to_string();
+        let result = match parse_save_skill(raw_args, session_id) {
+            Ok(input) => match self.state.skills.upsert(input).await {
+                Ok(view) => ToolResult::text(format!("saved skill /{}", view.model.name), None),
+                Err(error) => ToolResult::error(error.to_string()),
+            },
+            Err(message) => ToolResult::error(message),
+        };
+        if let Err(error) = record_local_tool_dispatch(
+            &self.state,
+            LocalToolDispatch {
+                session: &started.session,
+                agent_label: &started.agent_label,
+                tool_name: SAVE_SKILL_TOOL_NAME,
                 raw_args,
                 result: &result,
                 duration_ms: i64::try_from(started_at.elapsed().as_millis()).unwrap_or(i64::MAX),
@@ -330,6 +380,9 @@ impl ServerHandler for ClawMcpService {
         if name == NAME_SESSION_TOOL_NAME {
             return Some(self.name_session_tool.clone());
         }
+        if name == SAVE_SKILL_TOOL_NAME {
+            return Some(self.save_skill_tool.clone());
+        }
         self.find_tool_index(name)
             .map(|index| self.catalog[index].to_mcp_tool())
     }
@@ -340,8 +393,9 @@ impl ServerHandler for ClawMcpService {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let is_name_session = request.name == NAME_SESSION_TOOL_NAME;
+        let is_save_skill = request.name == SAVE_SKILL_TOOL_NAME;
         let tool_index = self.find_tool_index(&request.name);
-        if !is_name_session && tool_index.is_none() {
+        if !is_name_session && !is_save_skill && tool_index.is_none() {
             return Err(McpError::method_not_found::<CallToolRequestMethod>());
         }
         let raw_args = request
@@ -357,6 +411,8 @@ impl ServerHandler for ClawMcpService {
 
         let result = if is_name_session {
             Ok(self.call_name_session(&started, &raw_args).await)
+        } else if is_save_skill {
+            Ok(self.call_save_skill(&started, &raw_args).await)
         } else {
             let Some(tool_index) = tool_index else {
                 unreachable!("catalog tool was validated before session resolution");
@@ -475,6 +531,77 @@ fn name_session_tool() -> Tool {
             .destructive(false)
             .idempotent(true),
     )
+}
+
+fn save_skill_tool() -> Tool {
+    let Value::Object(input_schema) = json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+            "description": { "type": "string" },
+            "steps": { "type": "array", "items": { "type": "string" } },
+            "learnedNotes": { "type": "array", "items": { "type": "string" } },
+            "site": { "type": "string" }
+        },
+        "required": ["name", "description"]
+    }) else {
+        unreachable!();
+    };
+    Tool::new(SAVE_SKILL_TOOL_NAME, SAVE_SKILL_DESCRIPTION, input_schema).with_annotations(
+        ToolAnnotations::with_title("Save skill")
+            .read_only(false)
+            .destructive(false)
+            .idempotent(true),
+    )
+}
+
+fn parse_save_skill(raw_args: &Value, session_id: String) -> Result<CreateSkill, String> {
+    let name = raw_args
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or("name must be a non-empty string")?
+        .to_string();
+    let description = raw_args
+        .get("description")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or("description must be a non-empty string")?
+        .to_string();
+    let steps = parse_string_array(raw_args.get("steps"), "steps")?;
+    let learned_notes = parse_string_array(raw_args.get("learnedNotes"), "learnedNotes")?;
+    let site = raw_args
+        .get("site")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    Ok(CreateSkill {
+        name,
+        description,
+        site,
+        steps,
+        learned_notes,
+        origin: SkillOrigin::Agent,
+        source_session_id: Some(session_id),
+    })
+}
+
+fn parse_string_array(value: Option<&Value>, field: &str) -> Result<Vec<String>, String> {
+    match value {
+        None | Some(Value::Null) => Ok(Vec::new()),
+        Some(Value::Array(items)) => items
+            .iter()
+            .map(|item| {
+                item.as_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| format!("{field} entries must be strings"))
+            })
+            .collect(),
+        Some(_) => Err(format!("{field} must be an array of strings")),
+    }
 }
 
 fn clean_client_field(value: &str, fallback: &str) -> String {
@@ -664,9 +791,11 @@ mod tests {
             .map(|tool| tool.name.to_string())
             .collect::<Vec<_>>();
         expected.push(NAME_SESSION_TOOL_NAME.to_string());
+        expected.push(SAVE_SKILL_TOOL_NAME.to_string());
         assert_eq!(names, expected);
         assert!(names.contains(&"run".to_string()));
         assert!(names.contains(&"name_session".to_string()));
+        assert!(names.contains(&"save_skill".to_string()));
         Ok(())
     }
 
@@ -707,6 +836,124 @@ mod tests {
                     .idempotent(true)
             )
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn save_skill_is_registered_locally_with_annotations() -> anyhow::Result<()> {
+        let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let service = ClawMcpService::new(call.state);
+        let listed = service
+            .listed_tools()
+            .into_iter()
+            .find(|tool| tool.name == SAVE_SKILL_TOOL_NAME)
+            .ok_or_else(|| anyhow::anyhow!("save_skill missing from list"))?;
+        let fetched = service
+            .get_tool(SAVE_SKILL_TOOL_NAME)
+            .ok_or_else(|| anyhow::anyhow!("save_skill missing from get_tool"))?;
+
+        assert_eq!(listed, fetched);
+        assert_eq!(listed.description.as_deref(), Some(SAVE_SKILL_DESCRIPTION));
+        assert_eq!(
+            listed.annotations,
+            Some(
+                ToolAnnotations::with_title("Save skill")
+                    .read_only(false)
+                    .destructive(false)
+                    .idempotent(true)
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parse_save_skill_reads_and_defaults_arguments() -> anyhow::Result<()> {
+        let input = parse_save_skill(
+            &json!({
+                "name": "  inbox-sweep  ",
+                "description": "  Check the inbox  ",
+                "steps": ["Open the inbox", "Draft replies"]
+            }),
+            "sess_123".to_string(),
+        )
+        .map_err(anyhow::Error::msg)?;
+        assert_eq!(input.name, "inbox-sweep");
+        assert_eq!(input.description, "Check the inbox");
+        assert_eq!(input.steps, vec!["Open the inbox", "Draft replies"]);
+        assert!(input.learned_notes.is_empty());
+        assert_eq!(input.site, None);
+        assert_eq!(input.source_session_id.as_deref(), Some("sess_123"));
+
+        assert!(parse_save_skill(&json!({ "description": "x" }), String::new()).is_err());
+        assert!(parse_save_skill(&json!({ "name": "x" }), String::new()).is_err());
+        assert!(
+            parse_save_skill(
+                &json!({ "name": "x", "description": "d", "steps": [1, 2] }),
+                String::new()
+            )
+            .is_err()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn save_skill_authors_then_updates_a_user_skill() -> anyhow::Result<()> {
+        let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let session = call
+            .identity
+            .as_ref()
+            .map(|identity| identity.session.clone())
+            .ok_or_else(|| anyhow::anyhow!("session missing"))?;
+        let service = ClawMcpService::new(call.state.clone());
+        let started = StartedSession {
+            session: session.clone(),
+            agent_label: "codex".to_string(),
+        };
+
+        service
+            .call_save_skill(
+                &started,
+                &json!({
+                    "name": "inbox-sweep",
+                    "description": "Check the inbox",
+                    "steps": ["Open the inbox", "Draft replies"],
+                    "learnedNotes": ["Read the DOM snapshot, not screenshots"],
+                    "site": "mail.google.com"
+                }),
+            )
+            .await;
+
+        let created = call.state.skills.get("inbox-sweep").await?;
+        assert_eq!(created.view.model.origin, "agent");
+        assert_eq!(
+            created.view.model.source_session_id.as_deref(),
+            Some(session.id().as_str())
+        );
+        assert_eq!(created.view.model.version, 1);
+        assert!(created.body.contains("Open the inbox"));
+        assert!(
+            created
+                .body
+                .contains("Read the DOM snapshot, not screenshots")
+        );
+        assert!(created.body.contains("tools: browseros-neo"));
+
+        // Same name again updates in place and bumps the version.
+        service
+            .call_save_skill(
+                &started,
+                &json!({
+                    "name": "inbox-sweep",
+                    "description": "Check the inbox and reply",
+                    "steps": ["Open the inbox", "Draft and send"]
+                }),
+            )
+            .await;
+        let updated = call.state.skills.get("inbox-sweep").await?;
+        assert_eq!(updated.view.model.version, 2);
+        assert_eq!(updated.view.model.description, "Check the inbox and reply");
+        assert!(updated.body.contains("Draft and send"));
+
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/skills.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use sea_orm::{
     ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter, QueryOrder,
-    QuerySelect,
+    QuerySelect, sea_query::OnConflict,
 };
 
 /// Database boundary for user skills and their run history.
@@ -38,18 +38,20 @@ impl SkillsRepository {
             .await?)
     }
 
-    pub async fn exists(&self, name: &str) -> AppResult<bool> {
-        Ok(Skills::find_by_id(name.to_owned())
-            .one(self.db.connection())
-            .await?
-            .is_some())
-    }
-
-    pub async fn insert(&self, model: skills::Model) -> AppResult<()> {
-        Skills::insert(into_active(model))
+    /// Insert a skill only if its name is free. Returns `true` when the row was
+    /// created and `false` when the name was already taken. The unique primary
+    /// key makes this an atomic reservation, including across processes sharing
+    /// the database.
+    pub async fn try_insert(&self, model: skills::Model) -> AppResult<bool> {
+        let inserted = Skills::insert(into_active(model))
+            .on_conflict(
+                OnConflict::column(skills::Column::Name)
+                    .do_nothing()
+                    .to_owned(),
+            )
             .exec_without_returning(self.db.connection())
             .await?;
-        Ok(())
+        Ok(inserted == 1)
     }
 
     pub async fn update(&self, model: skills::Model) -> AppResult<()> {

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -172,10 +172,6 @@ impl SkillService {
         if RESERVED_SKILL_NAMES.contains(&input.name.as_str()) {
             return Err(AppError::conflict("skill name is reserved"));
         }
-        if self.repo.exists(&input.name).await? {
-            return Err(AppError::conflict("a skill with this name already exists"));
-        }
-
         let CreateSkill {
             name,
             description,
@@ -186,41 +182,79 @@ impl SkillService {
             source_session_id,
         } = input;
         let content = render_skill_markdown(&name, &description, &steps, &learned_notes);
-        // The agent install happens before the row lands, so a failure after it
-        // rolls the side effects back to avoid an install with no persisted row.
-        let body_path = self.write_body(&name, &content).await?;
-        let spec = SkillSpec::new(name.as_str(), content)
-            .map_err(|error| AppError::bad_request(error.to_string()))?;
-        let linked = match self.harness.install_skill(spec).await {
+        let model = self.new_skill_model(&name, description, site, origin, source_session_id);
+        self.try_install_new(&name, &content, model)
+            .await?
+            .ok_or_else(|| AppError::conflict("a skill with this name already exists"))
+    }
+
+    /// Reserve the name with an atomic insert, then write the canonical file and
+    /// link it into the connected agents. The unique primary key arbitrates
+    /// across processes, so a concurrent create of the same new name loses the
+    /// insert and returns `Ok(None)` without touching any files or installs. A
+    /// failure after a won reservation rolls the row and side effects back.
+    async fn try_install_new(
+        &self,
+        name: &str,
+        content: &str,
+        mut model: skills::Model,
+    ) -> AppResult<Option<SkillView>> {
+        if !self.repo.try_insert(model.clone()).await? {
+            return Ok(None);
+        }
+        let linked = match self.write_and_install(name, content).await {
             Ok(linked) => linked,
             Err(error) => {
-                self.rollback_skill(&name).await;
+                let _ = self.repo.delete(name).await;
+                self.rollback_skill(name).await;
                 return Err(error);
             }
         };
+        model.linked_agents_json = linked_agents_json(&linked);
+        self.repo.update(model.clone()).await?;
+        Ok(Some(SkillView {
+            model,
+            linked_agents: linked.into_iter().collect(),
+            stats: RunStats::default(),
+        }))
+    }
 
+    async fn write_and_install(&self, name: &str, content: &str) -> AppResult<BTreeSet<AgentId>> {
+        self.write_body(name, content).await?;
+        let spec = SkillSpec::new(name, content.to_string())
+            .map_err(|error| AppError::bad_request(error.to_string()))?;
+        self.harness.install_skill(spec).await
+    }
+
+    fn new_skill_model(
+        &self,
+        name: &str,
+        description: String,
+        site: Option<String>,
+        origin: SkillOrigin,
+        source_session_id: Option<String>,
+    ) -> skills::Model {
         let now = now_ms();
-        let model = skills::Model {
-            name: name.clone(),
+        skills::Model {
+            name: name.to_string(),
             description,
             site,
             origin: origin.as_str().to_owned(),
             source_session_id,
             version: 1,
-            body_path,
-            linked_agents_json: linked_agents_json(&linked),
+            body_path: self.canonical_body_path(name),
+            linked_agents_json: "[]".to_string(),
             created_at: now,
             updated_at: now,
-        };
-        if let Err(error) = self.repo.insert(model.clone()).await {
-            self.rollback_skill(&name).await;
-            return Err(error);
         }
-        Ok(SkillView {
-            model,
-            linked_agents: linked.into_iter().collect(),
-            stats: RunStats::default(),
-        })
+    }
+
+    fn canonical_body_path(&self, name: &str) -> String {
+        self.skills_dir
+            .join(name)
+            .join("SKILL.md")
+            .to_string_lossy()
+            .into_owned()
     }
 
     pub async fn update(&self, name: &str, input: UpdateSkill) -> AppResult<SkillDetailView> {
@@ -281,29 +315,41 @@ impl SkillService {
         if RESERVED_SKILL_NAMES.contains(&input.name.as_str()) {
             return Err(AppError::conflict("skill name is reserved"));
         }
-        if self.repo.get(&input.name).await?.is_none() {
-            return self.create_locked(input).await;
-        }
         let CreateSkill {
             name,
             description,
             site,
             steps,
             learned_notes,
-            ..
+            origin,
+            source_session_id,
         } = input;
         let content = render_skill_markdown(&name, &description, &steps, &learned_notes);
-        let detail = self
-            .update_locked(
-                &name,
-                UpdateSkill {
-                    description: Some(description),
-                    site,
-                    body: Some(content),
-                },
-            )
-            .await?;
-        Ok(detail.view)
+        let model = self.new_skill_model(
+            &name,
+            description.clone(),
+            site.clone(),
+            origin,
+            source_session_id,
+        );
+        // Reserve atomically; if the name is already taken (this run lost the
+        // insert or the skill pre-existed), fall through to an in-place update.
+        match self.try_install_new(&name, &content, model).await? {
+            Some(view) => Ok(view),
+            None => {
+                let detail = self
+                    .update_locked(
+                        &name,
+                        UpdateSkill {
+                            description: Some(description),
+                            site,
+                            body: Some(content),
+                        },
+                    )
+                    .await?;
+                Ok(detail.view)
+            }
+        }
     }
 
     pub async fn delete(&self, name: &str) -> AppResult<()> {

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -14,6 +14,7 @@ use std::{
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
+use tokio::sync::Mutex;
 
 /// The embedded product skill owns this directory name; user skills may not
 /// reuse it or they would clobber the managed BrowserOS skill.
@@ -87,6 +88,10 @@ pub struct SkillService {
     repo: SkillsRepository,
     harness: Arc<HarnessService>,
     skills_dir: PathBuf,
+    /// Serializes mutations so the disk, the harness, and the row stay
+    /// consistent, and so a get-then-create decision cannot race a
+    /// concurrent create of the same new name.
+    mutate: Mutex<()>,
 }
 
 impl SkillService {
@@ -96,6 +101,7 @@ impl SkillService {
             repo,
             harness,
             skills_dir,
+            mutate: Mutex::new(()),
         }
     }
 
@@ -153,6 +159,11 @@ impl SkillService {
     }
 
     pub async fn create(&self, input: CreateSkill) -> AppResult<SkillView> {
+        let _guard = self.mutate.lock().await;
+        self.create_locked(input).await
+    }
+
+    async fn create_locked(&self, input: CreateSkill) -> AppResult<SkillView> {
         if !is_valid_skill_name(&input.name) {
             return Err(AppError::bad_request(
                 "skill name must contain only lowercase letters, digits, and hyphens",
@@ -213,6 +224,11 @@ impl SkillService {
     }
 
     pub async fn update(&self, name: &str, input: UpdateSkill) -> AppResult<SkillDetailView> {
+        let _guard = self.mutate.lock().await;
+        self.update_locked(name, input).await
+    }
+
+    async fn update_locked(&self, name: &str, input: UpdateSkill) -> AppResult<SkillDetailView> {
         let mut model = self.require(name).await?;
         let mut relinked: Option<BTreeSet<AgentId>> = None;
         let mut previous_body: Option<String> = None;
@@ -256,6 +272,7 @@ impl SkillService {
     /// skill's body from the same inputs. Idempotent on name; this is what the
     /// agent-facing MCP tool calls so re-authoring a task updates it in place.
     pub async fn upsert(&self, input: CreateSkill) -> AppResult<SkillView> {
+        let _guard = self.mutate.lock().await;
         if !is_valid_skill_name(&input.name) {
             return Err(AppError::bad_request(
                 "skill name must contain only lowercase letters, digits, and hyphens",
@@ -265,7 +282,7 @@ impl SkillService {
             return Err(AppError::conflict("skill name is reserved"));
         }
         if self.repo.get(&input.name).await?.is_none() {
-            return self.create(input).await;
+            return self.create_locked(input).await;
         }
         let CreateSkill {
             name,
@@ -277,7 +294,7 @@ impl SkillService {
         } = input;
         let content = render_skill_markdown(&name, &description, &steps, &learned_notes);
         let detail = self
-            .update(
+            .update_locked(
                 &name,
                 UpdateSkill {
                     description: Some(description),
@@ -290,6 +307,11 @@ impl SkillService {
     }
 
     pub async fn delete(&self, name: &str) -> AppResult<()> {
+        let _guard = self.mutate.lock().await;
+        self.delete_locked(name).await
+    }
+
+    async fn delete_locked(&self, name: &str) -> AppResult<()> {
         self.require(name).await?;
         self.harness.uninstall_skill(name).await?;
         self.repo.delete(name).await?;

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -252,6 +252,43 @@ impl SkillService {
         self.get(name).await
     }
 
+    /// Create the skill if its name is free, otherwise rewrite the existing
+    /// skill's body from the same inputs. Idempotent on name; this is what the
+    /// agent-facing MCP tool calls so re-authoring a task updates it in place.
+    pub async fn upsert(&self, input: CreateSkill) -> AppResult<SkillView> {
+        if !is_valid_skill_name(&input.name) {
+            return Err(AppError::bad_request(
+                "skill name must contain only lowercase letters, digits, and hyphens",
+            ));
+        }
+        if RESERVED_SKILL_NAMES.contains(&input.name.as_str()) {
+            return Err(AppError::conflict("skill name is reserved"));
+        }
+        if self.repo.get(&input.name).await?.is_none() {
+            return self.create(input).await;
+        }
+        let CreateSkill {
+            name,
+            description,
+            site,
+            steps,
+            learned_notes,
+            ..
+        } = input;
+        let content = render_skill_markdown(&name, &description, &steps, &learned_notes);
+        let detail = self
+            .update(
+                &name,
+                UpdateSkill {
+                    description: Some(description),
+                    site,
+                    body: Some(content),
+                },
+            )
+            .await?;
+        Ok(detail.view)
+    }
+
     pub async fn delete(&self, name: &str) -> AppResult<()> {
         self.require(name).await?;
         self.harness.uninstall_skill(name).await?;

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -398,6 +398,7 @@ async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
             "evaluate",
             "run",
             "name_session",
+            "save_skill",
         ]
     );
 

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -3,7 +3,11 @@ use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode, header},
 };
-use claw_server_rust::{AppState, build_router, config::Config};
+use claw_server_rust::{
+    AppState, build_router,
+    config::Config,
+    services::skills::{CreateSkill, SkillOrigin},
+};
 use serde_json::{Value, json};
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use tempfile::TempDir;
@@ -13,6 +17,7 @@ struct TestApp {
     router: Router,
     _dir: TempDir,
     root: PathBuf,
+    state: AppState,
 }
 
 async fn test_app() -> anyhow::Result<TestApp> {
@@ -33,9 +38,10 @@ async fn test_app() -> anyhow::Result<TestApp> {
     });
     let state = AppState::new_with_home(config, dir.path().join("home")).await?;
     Ok(TestApp {
-        router: build_router(state),
+        router: build_router(state.clone()),
         _dir: dir,
         root,
+        state,
     })
 }
 
@@ -219,6 +225,41 @@ async fn skill_create_escapes_yaml_sensitive_descriptions() -> anyhow::Result<()
     // cannot break the frontmatter block.
     assert!(content.contains(r#"description: "Reply within 24h: keep it brief\nthen stop""#));
     assert_eq!(content.matches("---").count(), 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn concurrent_upserts_of_a_new_name_keep_one_skill_intact() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let skills = app.state.skills.clone();
+    let input = |description: &str| CreateSkill {
+        name: "race-skill".to_string(),
+        description: description.to_string(),
+        site: None,
+        steps: vec!["Do the thing".to_string()],
+        learned_notes: vec![],
+        origin: SkillOrigin::Agent,
+        source_session_id: None,
+    };
+
+    let (first, second) = tokio::join!(skills.upsert(input("A")), skills.upsert(input("B")));
+    // Both calls settle without error: one creates, the other updates in place;
+    // neither call's rollback removes the other's installed skill.
+    first?;
+    second?;
+
+    let detail = skills.get("race-skill").await?;
+    assert!(
+        app.root
+            .join("skills")
+            .join("race-skill")
+            .join("SKILL.md")
+            .exists()
+    );
+    assert!(detail.body.contains("Do the thing"));
+    // A create followed by an update leaves the skill at version 2.
+    assert_eq!(detail.view.model.version, 2);
 
     Ok(())
 }

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-transport.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-transport.ts
@@ -19,6 +19,7 @@ const EXPECTED_TOOLS = [
   'pdf',
   'read',
   'run',
+  'save_skill',
   'screenshot',
   'snapshot',
   'tab_groups',


### PR DESCRIPTION
## What

Gives coding agents a way to author skills without leaving their session: a new `save_skill` MCP tool. When an agent notices it is repeating a browser task, it calls `save_skill` with a name, a one-line description, the ordered steps, and any shortcuts it learned, and BrowserOS neo writes the `SKILL.md`, links it into the connected agents, and records it as a skill. Calling it again with the same name updates the skill in place.

- **`save_skill` local MCP tool.** Registered alongside `name_session` in the MCP service, with the same dispatch, audit, and result plumbing. Inputs: `name` (lowercase-hyphen slug), `description`, `steps` (ordered), optional `learnedNotes`, optional `site`. The tool is annotated read-only=false, destructive=false, idempotent=true.
- **Idempotent authoring.** A new `SkillService::upsert` creates the skill when the name is free and otherwise rewrites the existing skill's body from the same inputs, reusing the existing create and update paths (including their rollback compensation). Skills authored this way are recorded with `origin: agent` and the current session as the source.

## Notes

- The tool records its own dispatch into the audit log, like `name_session`, since local tools sit outside the browser-tool observer pipeline.
- Service failures (invalid name, reserved name) surface as in-band tool errors, not protocol errors, matching the existing local-tool convention.
- This is the authoring half of the agent story. Run recording (marking a session as a run of a skill and projecting its stats) is the next change.

## Tests

- MCP unit tests: `save_skill` is registered locally with the right schema and annotations; the argument parser reads and trims inputs, defaults optional arrays, and rejects missing name/description and non-string array entries; and driving the tool authors a skill (with `origin: agent` and the source session) then, on a second call with the same name, updates it in place and bumps the version.
- The existing tool-surface test is updated to expect the new tool.
- Whole-workspace `cargo fmt` and `clippy` clean; server package tests green.
