### PR TITLE
feat(skills): record skill runs via mark_skill_run and completion projection

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -48,6 +48,8 @@ const NAME_SESSION_DESCRIPTION: &str = "Rename this browser session: a small low
 const NAME_SESSION_INPUT_MAX_LEN: usize = 64;
 const SAVE_SKILL_TOOL_NAME: &str = "save_skill";
 const SAVE_SKILL_DESCRIPTION: &str = "Save the current repeatable browser task as a BrowserOS neo skill so it can be re-run by name later. Give a lowercase-hyphen name, a one-line description, the ordered steps, and any shortcuts learned this run. Call again with the same name to update it in place.";
+const MARK_SKILL_RUN_TOOL_NAME: &str = "mark_skill_run";
+const MARK_SKILL_RUN_DESCRIPTION: &str = "Mark this browser session as a run of a saved skill so BrowserOS neo records the run and its cost once the session ends. Call this once, at the start, when you are running a skill, with the skill's name.";
 
 /// Owns one MCP transport lifetime. Drop best-effort schedules removal of a started
 /// server session, which records its end and begins retained-group handling.
@@ -56,6 +58,7 @@ pub struct ClawMcpService {
     catalog: Arc<Vec<ToolDef>>,
     name_session_tool: Tool,
     save_skill_tool: Tool,
+    mark_skill_run_tool: Tool,
     output_files: OutputFileAccess,
     lifecycle: Arc<Mutex<ServiceLifecycle>>,
     fallback_session_id: SessionId,
@@ -83,6 +86,7 @@ impl ClawMcpService {
             catalog: Arc::new(catalog()),
             name_session_tool: name_session_tool(),
             save_skill_tool: save_skill_tool(),
+            mark_skill_run_tool: mark_skill_run_tool(),
             output_files: browseros_mcp::output_file::create_browser_output_file_access(),
             lifecycle: Arc::new(Mutex::new(ServiceLifecycle::default())),
             fallback_session_id: SessionId::new(format!("stdio-{}", Ulid::new())),
@@ -102,6 +106,7 @@ impl ClawMcpService {
             .collect::<Vec<_>>();
         tools.push(self.name_session_tool.clone());
         tools.push(self.save_skill_tool.clone());
+        tools.push(self.mark_skill_run_tool.clone());
         tools
     }
 
@@ -192,6 +197,52 @@ impl ClawMcpService {
                 session: &started.session,
                 agent_label: &started.agent_label,
                 tool_name: SAVE_SKILL_TOOL_NAME,
+                raw_args,
+                result: &result,
+                duration_ms: i64::try_from(started_at.elapsed().as_millis()).unwrap_or(i64::MAX),
+                dispatch_id: dispatch_id.clone(),
+            },
+        )
+        .await
+        {
+            warn!(error = %error, "local tool audit submission failed");
+        }
+        finish_local_dispatch(started.session.as_ref(), &dispatch_id, result)
+            .await
+            .into_call_tool_result()
+    }
+
+    async fn call_mark_skill_run(
+        &self,
+        started: &StartedSession,
+        raw_args: &Value,
+    ) -> CallToolResult {
+        let dispatch_id = DispatchId::new();
+        let dispatch_cancel = CancellationToken::new();
+        if !started
+            .session
+            .try_register_dispatch(dispatch_id.clone(), dispatch_cancel)
+            .await
+        {
+            return CallToolResult::error(vec![rmcp::model::ContentBlock::text(
+                "BrowserOS neo session is no longer live",
+            )]);
+        }
+        let started_at = StdInstant::now();
+        let session_id = started.session.id().as_str().to_string();
+        let result = match parse_skill_name(raw_args) {
+            Ok(name) => match self.state.skill_runs.mark(&session_id, &name).await {
+                Ok(()) => ToolResult::text(format!("recording this run of /{name}"), None),
+                Err(error) => ToolResult::error(error.to_string()),
+            },
+            Err(message) => ToolResult::error(message),
+        };
+        if let Err(error) = record_local_tool_dispatch(
+            &self.state,
+            LocalToolDispatch {
+                session: &started.session,
+                agent_label: &started.agent_label,
+                tool_name: MARK_SKILL_RUN_TOOL_NAME,
                 raw_args,
                 result: &result,
                 duration_ms: i64::try_from(started_at.elapsed().as_millis()).unwrap_or(i64::MAX),
@@ -383,6 +434,9 @@ impl ServerHandler for ClawMcpService {
         if name == SAVE_SKILL_TOOL_NAME {
             return Some(self.save_skill_tool.clone());
         }
+        if name == MARK_SKILL_RUN_TOOL_NAME {
+            return Some(self.mark_skill_run_tool.clone());
+        }
         self.find_tool_index(name)
             .map(|index| self.catalog[index].to_mcp_tool())
     }
@@ -394,8 +448,9 @@ impl ServerHandler for ClawMcpService {
     ) -> Result<CallToolResult, McpError> {
         let is_name_session = request.name == NAME_SESSION_TOOL_NAME;
         let is_save_skill = request.name == SAVE_SKILL_TOOL_NAME;
+        let is_mark_skill_run = request.name == MARK_SKILL_RUN_TOOL_NAME;
         let tool_index = self.find_tool_index(&request.name);
-        if !is_name_session && !is_save_skill && tool_index.is_none() {
+        if !is_name_session && !is_save_skill && !is_mark_skill_run && tool_index.is_none() {
             return Err(McpError::method_not_found::<CallToolRequestMethod>());
         }
         let raw_args = request
@@ -413,6 +468,8 @@ impl ServerHandler for ClawMcpService {
             Ok(self.call_name_session(&started, &raw_args).await)
         } else if is_save_skill {
             Ok(self.call_save_skill(&started, &raw_args).await)
+        } else if is_mark_skill_run {
+            Ok(self.call_mark_skill_run(&started, &raw_args).await)
         } else {
             let Some(tool_index) = tool_index else {
                 unreachable!("catalog tool was validated before session resolution");
@@ -553,6 +610,39 @@ fn save_skill_tool() -> Tool {
             .destructive(false)
             .idempotent(true),
     )
+}
+
+fn mark_skill_run_tool() -> Tool {
+    let Value::Object(input_schema) = json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string", "pattern": "^[a-z0-9-]+$" }
+        },
+        "required": ["name"]
+    }) else {
+        unreachable!();
+    };
+    Tool::new(
+        MARK_SKILL_RUN_TOOL_NAME,
+        MARK_SKILL_RUN_DESCRIPTION,
+        input_schema,
+    )
+    .with_annotations(
+        ToolAnnotations::with_title("Mark skill run")
+            .read_only(false)
+            .destructive(false)
+            .idempotent(true),
+    )
+}
+
+fn parse_skill_name(raw_args: &Value) -> Result<String, String> {
+    raw_args
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| "name must be a non-empty string".to_string())
 }
 
 fn parse_save_skill(raw_args: &Value, session_id: String) -> Result<CreateSkill, String> {
@@ -792,10 +882,12 @@ mod tests {
             .collect::<Vec<_>>();
         expected.push(NAME_SESSION_TOOL_NAME.to_string());
         expected.push(SAVE_SKILL_TOOL_NAME.to_string());
+        expected.push(MARK_SKILL_RUN_TOOL_NAME.to_string());
         assert_eq!(names, expected);
         assert!(names.contains(&"run".to_string()));
         assert!(names.contains(&"name_session".to_string()));
         assert!(names.contains(&"save_skill".to_string()));
+        assert!(names.contains(&"mark_skill_run".to_string()));
         Ok(())
     }
 
@@ -858,6 +950,36 @@ mod tests {
             listed.annotations,
             Some(
                 ToolAnnotations::with_title("Save skill")
+                    .read_only(false)
+                    .destructive(false)
+                    .idempotent(true)
+            )
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mark_skill_run_is_registered_locally_with_annotations() -> anyhow::Result<()> {
+        let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let service = ClawMcpService::new(call.state);
+        let listed = service
+            .listed_tools()
+            .into_iter()
+            .find(|tool| tool.name == MARK_SKILL_RUN_TOOL_NAME)
+            .ok_or_else(|| anyhow::anyhow!("mark_skill_run missing from list"))?;
+        let fetched = service
+            .get_tool(MARK_SKILL_RUN_TOOL_NAME)
+            .ok_or_else(|| anyhow::anyhow!("mark_skill_run missing from get_tool"))?;
+
+        assert_eq!(listed, fetched);
+        assert_eq!(
+            listed.description.as_deref(),
+            Some(MARK_SKILL_RUN_DESCRIPTION)
+        );
+        assert_eq!(
+            listed.annotations,
+            Some(
+                ToolAnnotations::with_title("Mark skill run")
                     .read_only(false)
                     .destructive(false)
                     .idempotent(true)

--- a/packages/browseros-agent/apps/claw-server-rust/src/app.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/app.rs
@@ -19,6 +19,7 @@ use crate::{
         screenshots::ScreenshotService,
         session_efficiency::SessionEfficiencyService,
         sessions::Sessions,
+        skill_runs::SkillRunService,
         skills::SkillService,
     },
     storage::JsonStore,
@@ -42,6 +43,7 @@ pub struct AppState {
     pub tab_registry: Arc<TabRegistry>,
     pub harness: Arc<HarnessService>,
     pub skills: Arc<SkillService>,
+    pub skill_runs: Arc<SkillRunService>,
     pub analytics: Arc<AnalyticsService>,
     pub profiles: Arc<ProfileService>,
     pub sessions: Arc<Sessions>,
@@ -96,6 +98,10 @@ impl AppState {
             harness.clone(),
             config.browserclaw_dir.join("skills"),
         ));
+        let skill_runs = Arc::new(SkillRunService::new(
+            SkillsRepository::new(database.clone()),
+            audit_log.clone(),
+        ));
         let profiles = Arc::new(ProfileService::new(store.clone()));
         let session_efficiency = Arc::new(SessionEfficiencyService::new_with_analytics(
             database,
@@ -111,7 +117,9 @@ impl AppState {
         );
         sessions.set_completion_hook(Arc::new({
             let session_efficiency = session_efficiency.clone();
+            let skill_runs = skill_runs.clone();
             move |session_id| {
+                skill_runs.spawn_finalize(session_id.clone());
                 let _ = session_efficiency.queue_finalize(session_id);
             }
         }));
@@ -170,6 +178,7 @@ impl AppState {
             tab_registry,
             harness,
             skills,
+            skill_runs,
             analytics,
             profiles,
             sessions,

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/entities/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/entities/mod.rs
@@ -5,6 +5,7 @@ pub mod recording_payloads;
 pub mod recording_streams;
 pub mod session_efficiency_stats;
 pub mod session_tabs;
+pub mod skill_run_marks;
 pub mod skill_runs;
 pub mod skills;
 pub mod tab_claims;
@@ -20,6 +21,7 @@ pub mod prelude {
     pub use super::recording_streams::Entity as RecordingStreams;
     pub use super::session_efficiency_stats::Entity as SessionEfficiencyStats;
     pub use super::session_tabs::Entity as SessionTabs;
+    pub use super::skill_run_marks::Entity as SkillRunMarks;
     pub use super::skill_runs::Entity as SkillRuns;
     pub use super::skills::Entity as Skills;
     pub use super::tab_claims::Entity as TabClaims;

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/entities/skill_run_marks.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/entities/skill_run_marks.rs
@@ -1,0 +1,15 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "skill_run_marks")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub session_id: String,
+    pub skill_name: String,
+    pub created_at: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/migration.rs
@@ -21,7 +21,113 @@ impl MigratorTrait for Migrator {
             Box::new(m0012_recording_payload_files::Migration),
             Box::new(m0013_add_parent_dispatch_id::Migration),
             Box::new(m0014_add_skills_and_runs::Migration),
+            Box::new(m0015_add_skill_run_marks::Migration),
         ]
+    }
+}
+
+mod m0015_add_skill_run_marks {
+    use super::*;
+
+    pub struct Migration;
+
+    impl MigrationName for Migration {
+        fn name(&self) -> &str {
+            "m0015_add_skill_run_marks"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for Migration {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .create_table(
+                    Table::create()
+                        .table(SkillRunMarks::Table)
+                        .if_not_exists()
+                        .col(
+                            ColumnDef::new(SkillRunMarks::SessionId)
+                                .string()
+                                .not_null()
+                                .primary_key(),
+                        )
+                        .col(ColumnDef::new(SkillRunMarks::SkillName).string().not_null())
+                        .col(
+                            ColumnDef::new(SkillRunMarks::CreatedAt)
+                                .big_integer()
+                                .not_null(),
+                        )
+                        .to_owned(),
+                )
+                .await?;
+            // A session records at most one skill run, so make the session
+            // lookup unique. That lets run projection insert idempotently with
+            // ON CONFLICT, matching how session efficiency projects once.
+            manager
+                .drop_index(
+                    Index::drop()
+                        .name("skill_runs_session_idx")
+                        .table(SkillRuns::Table)
+                        .to_owned(),
+                )
+                .await?;
+            manager
+                .create_index(
+                    Index::create()
+                        .unique()
+                        .name("skill_runs_session_idx")
+                        .table(SkillRuns::Table)
+                        .col(SkillRuns::SessionId)
+                        .if_not_exists()
+                        .to_owned(),
+                )
+                .await?;
+            Ok(())
+        }
+
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .drop_index(
+                    Index::drop()
+                        .name("skill_runs_session_idx")
+                        .table(SkillRuns::Table)
+                        .to_owned(),
+                )
+                .await?;
+            manager
+                .create_index(
+                    Index::create()
+                        .name("skill_runs_session_idx")
+                        .table(SkillRuns::Table)
+                        .col(SkillRuns::SessionId)
+                        .if_not_exists()
+                        .to_owned(),
+                )
+                .await?;
+            manager
+                .drop_table(
+                    Table::drop()
+                        .table(SkillRunMarks::Table)
+                        .if_exists()
+                        .to_owned(),
+                )
+                .await?;
+            Ok(())
+        }
+    }
+
+    #[derive(DeriveIden)]
+    enum SkillRunMarks {
+        Table,
+        SessionId,
+        SkillName,
+        CreatedAt,
+    }
+
+    #[derive(DeriveIden)]
+    enum SkillRuns {
+        Table,
+        SessionId,
     }
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/mod.rs
@@ -225,6 +225,7 @@ mod tests {
             "session_efficiency_stats",
             "skills",
             "skill_runs",
+            "skill_run_marks",
             "seaql_migrations",
         ] {
             assert!(names.contains(table), "missing table {table}");
@@ -326,7 +327,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 14);
+        assert_eq!(migrations.len(), 15);
         assert_eq!(
             migrations[0].try_get::<String>("", "version")?,
             "m0001_baseline"
@@ -383,6 +384,10 @@ mod tests {
             migrations[13].try_get::<String>("", "version")?,
             "m0014_add_skills_and_runs"
         );
+        assert_eq!(
+            migrations[14].try_get::<String>("", "version")?,
+            "m0015_add_skill_run_marks"
+        );
         Ok(())
     }
 
@@ -422,7 +427,7 @@ mod tests {
         let migration_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM seaql_migrations")
             .fetch_one(&mut conn)
             .await?;
-        assert_eq!(migration_count, 14);
+        assert_eq!(migration_count, 15);
         conn.close().await?;
         Ok(())
     }
@@ -486,7 +491,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations ORDER BY version".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 14);
+        assert_eq!(migrations.len(), 15);
         assert_eq!(
             migrations
                 .iter()
@@ -509,7 +514,7 @@ mod tests {
             .await?
             .ok_or_else(|| anyhow::anyhow!("migration count missing"))?
             .try_get::<i64>("", "count")?;
-        assert_eq!(migration_count, 14);
+        assert_eq!(migration_count, 15);
         Ok(())
     }
 
@@ -645,7 +650,7 @@ mod tests {
                 "SELECT version FROM seaql_migrations".to_string(),
             ))
             .await?;
-        assert_eq!(migrations.len(), 14);
+        assert_eq!(migrations.len(), 15);
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/skills.rs
@@ -2,8 +2,8 @@ use crate::{
     db::{
         Database,
         entities::{
-            prelude::{SkillRuns, Skills},
-            skill_runs, skills,
+            prelude::{SkillRunMarks, SkillRuns, Skills, ToolDispatches},
+            skill_run_marks, skill_runs, skills, tool_dispatches,
         },
     },
     error::AppResult,
@@ -103,6 +103,97 @@ impl SkillsRepository {
             .all(self.db.connection())
             .await?)
     }
+
+    pub async fn max_run_number(&self, name: &str) -> AppResult<Option<i64>> {
+        Ok(SkillRuns::find()
+            .filter(skill_runs::Column::SkillName.eq(name))
+            .order_by_desc(skill_runs::Column::RunNumber)
+            .one(self.db.connection())
+            .await?
+            .map(|row| row.run_number))
+    }
+
+    /// Insert a run row unless the session already recorded one. The unique
+    /// session index makes this idempotent; returns whether this call inserted.
+    pub async fn insert_run_if_absent(&self, model: skill_runs::Model) -> AppResult<bool> {
+        let inserted = SkillRuns::insert(skill_runs::ActiveModel {
+            id: Set(model.id),
+            skill_name: Set(model.skill_name),
+            session_id: Set(model.session_id),
+            run_number: Set(model.run_number),
+            agent_id: Set(model.agent_id),
+            tokens: Set(model.tokens),
+            duration_ms: Set(model.duration_ms),
+            tool_count: Set(model.tool_count),
+            clean: Set(model.clean),
+            errored_tool: Set(model.errored_tool),
+            created_at: Set(model.created_at),
+        })
+        .on_conflict(
+            OnConflict::column(skill_runs::Column::SessionId)
+                .do_nothing()
+                .to_owned(),
+        )
+        .exec_without_returning(self.db.connection())
+        .await?;
+        Ok(inserted == 1)
+    }
+
+    /// The first tool in a session whose dispatch recorded an error (used for a
+    /// not-clean run's `errored_tool`).
+    pub async fn first_errored_tool(&self, session_id: &str) -> AppResult<Option<String>> {
+        let rows = ToolDispatches::find()
+            .filter(tool_dispatches::Column::SessionId.eq(session_id))
+            .order_by_asc(tool_dispatches::Column::Id)
+            .all(self.db.connection())
+            .await?;
+        Ok(rows
+            .into_iter()
+            .find(|row| dispatch_is_error(row.result_meta.as_deref()))
+            .map(|row| row.tool_name))
+    }
+
+    pub async fn upsert_mark(&self, session_id: &str, skill_name: &str, now: i64) -> AppResult<()> {
+        SkillRunMarks::insert(skill_run_marks::ActiveModel {
+            session_id: Set(session_id.to_owned()),
+            skill_name: Set(skill_name.to_owned()),
+            created_at: Set(now),
+        })
+        .on_conflict(
+            OnConflict::column(skill_run_marks::Column::SessionId)
+                .update_column(skill_run_marks::Column::SkillName)
+                .to_owned(),
+        )
+        .exec_without_returning(self.db.connection())
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_mark(&self, session_id: &str) -> AppResult<Option<skill_run_marks::Model>> {
+        Ok(SkillRunMarks::find_by_id(session_id.to_owned())
+            .one(self.db.connection())
+            .await?)
+    }
+
+    pub async fn all_marks(&self) -> AppResult<Vec<skill_run_marks::Model>> {
+        Ok(SkillRunMarks::find().all(self.db.connection()).await?)
+    }
+
+    pub async fn delete_mark(&self, session_id: &str) -> AppResult<()> {
+        SkillRunMarks::delete_by_id(session_id.to_owned())
+            .exec(self.db.connection())
+            .await?;
+        Ok(())
+    }
+}
+
+fn dispatch_is_error(result_meta: Option<&str>) -> bool {
+    result_meta
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .is_some_and(|value| {
+            value.get("isError").and_then(serde_json::Value::as_bool) == Some(true)
+                && value.get("cancelled").and_then(serde_json::Value::as_bool) != Some(true)
+        })
 }
 
 fn into_active(model: skills::Model) -> skills::ActiveModel {

--- a/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/runtime.rs
@@ -155,6 +155,23 @@ impl AppRuntime {
                     }
                 }),
             },
+            BackgroundTask {
+                name: "skill run reconciliation",
+                handle: tokio::spawn({
+                    let skill_runs = state.skill_runs.clone();
+                    async move {
+                        match skill_runs.reconcile().await {
+                            Ok(recorded) if recorded > 0 => {
+                                info!(recorded, "reconciled skill run projections");
+                            }
+                            Ok(_) => {}
+                            Err(error) => {
+                                warn!(error = %error, "skill run reconciliation failed");
+                            }
+                        }
+                    }
+                }),
+            },
         ];
         Self { state, tasks }
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/mod.rs
@@ -13,5 +13,6 @@ pub mod runtime_file;
 pub mod screenshots;
 pub mod session_efficiency;
 pub mod sessions;
+pub mod skill_runs;
 pub mod skills;
 pub mod tab_cleanup;

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skill_runs.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skill_runs.rs
@@ -1,0 +1,119 @@
+use crate::{
+    db::{
+        AuditLog, SkillsRepository,
+        audit_log::{TaskStatus, TaskSummary},
+        entities::skill_runs,
+    },
+    error::AppResult,
+};
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tracing::warn;
+use ulid::Ulid;
+
+/// Records a "skill run" when a session that was tagged as running a skill
+/// completes, by projecting the session's audit stats into a `skill_runs` row.
+/// The mark ties a session to a skill; the projection runs from the session
+/// completion hook, with a startup reconcile sweep as the durability backstop.
+pub struct SkillRunService {
+    repo: SkillsRepository,
+    audit_log: Arc<AuditLog>,
+}
+
+impl SkillRunService {
+    #[must_use]
+    pub fn new(repo: SkillsRepository, audit_log: Arc<AuditLog>) -> Self {
+        Self { repo, audit_log }
+    }
+
+    /// Tie the current session to a skill; completion turns this into a run row.
+    pub async fn mark(&self, session_id: &str, skill_name: &str) -> AppResult<()> {
+        self.repo
+            .upsert_mark(session_id, skill_name, now_ms())
+            .await
+    }
+
+    /// Fire-and-forget projection for a completed session, safe to call from the
+    /// session completion hook. Any miss is caught by `reconcile` at startup.
+    pub fn spawn_finalize(self: &Arc<Self>, session_id: String) {
+        let service = Arc::clone(self);
+        tokio::spawn(async move {
+            if let Err(error) = service.finalize(&session_id).await {
+                warn!(error = %error, "skill run projection failed");
+            }
+        });
+    }
+
+    /// Project one completed, marked session into a run row. Idempotent: a
+    /// session records at most one run. Returns whether a new run was recorded.
+    pub async fn finalize(&self, session_id: &str) -> AppResult<bool> {
+        let Some(mark) = self.repo.get_mark(session_id).await? else {
+            return Ok(false);
+        };
+        let Some(task) = self.audit_log.get_task_summary(session_id).await? else {
+            return Ok(false);
+        };
+        if matches!(task.status, TaskStatus::Live) {
+            // Not terminal yet; leave the mark for a later completion.
+            return Ok(false);
+        }
+        let recorded = self.record_run(&mark.skill_name, session_id, &task).await?;
+        // The run is durable now (this call inserted it or a prior one did), so
+        // the mark has served its purpose.
+        self.repo.delete_mark(session_id).await?;
+        Ok(recorded)
+    }
+
+    /// Sweep every outstanding mark on startup, projecting the terminal ones.
+    pub async fn reconcile(&self) -> AppResult<usize> {
+        let mut recorded = 0;
+        for mark in self.repo.all_marks().await? {
+            if self.finalize(&mark.session_id).await? {
+                recorded += 1;
+            }
+        }
+        Ok(recorded)
+    }
+
+    async fn record_run(
+        &self,
+        skill_name: &str,
+        session_id: &str,
+        task: &TaskSummary,
+    ) -> AppResult<bool> {
+        let run_number = self.repo.max_run_number(skill_name).await?.unwrap_or(0) + 1;
+        let tokens = task
+            .tokens_measured
+            .then(|| task.tool_input_token_estimate + task.tool_output_token_estimate);
+        let clean = task.error_count == 0
+            && !matches!(task.status, TaskStatus::Failed | TaskStatus::Cancelled);
+        let errored_tool = if clean {
+            None
+        } else {
+            self.repo.first_errored_tool(session_id).await?
+        };
+        let row = skill_runs::Model {
+            id: Ulid::new().to_string(),
+            skill_name: skill_name.to_owned(),
+            session_id: session_id.to_owned(),
+            run_number,
+            agent_id: task.agent_id.clone(),
+            tokens,
+            duration_ms: Some(task.duration_ms),
+            tool_count: Some(task.dispatch_count),
+            clean,
+            errored_tool,
+            created_at: now_ms(),
+        };
+        self.repo.insert_run_if_absent(row).await
+    }
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skill_runs.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skill_runs.rs
@@ -4,12 +4,13 @@ use crate::{
         audit_log::{TaskStatus, TaskSummary},
         entities::skill_runs,
     },
-    error::AppResult,
+    error::{AppError, AppResult},
 };
 use std::{
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
+use tokio::sync::Mutex;
 use tracing::warn;
 use ulid::Ulid;
 
@@ -20,16 +21,28 @@ use ulid::Ulid;
 pub struct SkillRunService {
     repo: SkillsRepository,
     audit_log: Arc<AuditLog>,
+    /// Serializes projection so concurrent finalizers of the same skill cannot
+    /// read the same max run number and assign duplicate run numbers.
+    finalize_lock: Mutex<()>,
 }
 
 impl SkillRunService {
     #[must_use]
     pub fn new(repo: SkillsRepository, audit_log: Arc<AuditLog>) -> Self {
-        Self { repo, audit_log }
+        Self {
+            repo,
+            audit_log,
+            finalize_lock: Mutex::new(()),
+        }
     }
 
     /// Tie the current session to a skill; completion turns this into a run row.
+    /// Rejects a name that does not resolve to a saved skill so a typo or stale
+    /// name never records a run for a skill that does not exist.
     pub async fn mark(&self, session_id: &str, skill_name: &str) -> AppResult<()> {
+        if self.repo.get(skill_name).await?.is_none() {
+            return Err(AppError::not_found("skill not found"));
+        }
         self.repo
             .upsert_mark(session_id, skill_name, now_ms())
             .await
@@ -49,9 +62,16 @@ impl SkillRunService {
     /// Project one completed, marked session into a run row. Idempotent: a
     /// session records at most one run. Returns whether a new run was recorded.
     pub async fn finalize(&self, session_id: &str) -> AppResult<bool> {
+        let _guard = self.finalize_lock.lock().await;
         let Some(mark) = self.repo.get_mark(session_id).await? else {
             return Ok(false);
         };
+        // The skill may have been deleted between the mark and completion; drop
+        // the mark rather than record a run for a skill that no longer exists.
+        if self.repo.get(&mark.skill_name).await?.is_none() {
+            self.repo.delete_mark(session_id).await?;
+            return Ok(false);
+        }
         let Some(task) = self.audit_log.get_task_summary(session_id).await? else {
             return Ok(false);
         };

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -455,13 +455,15 @@ fn render_skill_markdown(
     // other YAML-sensitive characters from corrupting the frontmatter. The name
     // is already constrained to `[a-z0-9-]`, so it stays a plain scalar.
     let description = serde_json::to_string(description).unwrap_or_else(|_| "\"\"".to_string());
-    let mut out =
-        format!("---\nname: {name}\ndescription: {description}\ntools: {SKILL_TOOLS}\n---\n");
-    if !steps.is_empty() {
-        out.push_str("\n## Steps\n");
-        for (index, step) in steps.iter().enumerate() {
-            out.push_str(&format!("{}. {}\n", index + 1, step));
-        }
+    let mut out = format!(
+        "---\nname: {name}\ndescription: {description}\ntools: {SKILL_TOOLS}\n---\n\n## Steps\n"
+    );
+    // Every run marks itself so BrowserOS neo records the run and its cost.
+    out.push_str(&format!(
+        "1. Call the mark_skill_run tool with name: {name} so this run is recorded.\n"
+    ));
+    for (index, step) in steps.iter().enumerate() {
+        out.push_str(&format!("{}. {}\n", index + 2, step));
     }
     if !learned_notes.is_empty() {
         out.push_str("\n## Learned from past runs\n");

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -399,6 +399,7 @@ async fn mcp_initialize_list_guard_audit_and_delete() -> anyhow::Result<()> {
             "run",
             "name_session",
             "save_skill",
+            "mark_skill_run",
         ]
     );
 

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -341,6 +341,59 @@ async fn skill_run_recorded_from_a_marked_session() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn mark_rejects_unknown_skill_and_finalize_skips_a_deleted_one() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let state = &app.state;
+
+    // A name that does not resolve to a saved skill is rejected at mark time.
+    assert!(
+        state
+            .skill_runs
+            .mark("some-session", "not-a-skill")
+            .await
+            .is_err()
+    );
+
+    // A skill deleted between the mark and completion records no run.
+    state
+        .skills
+        .create(CreateSkill {
+            name: "brief".to_string(),
+            description: "Daily brief".to_string(),
+            site: None,
+            steps: vec![],
+            learned_notes: vec![],
+            origin: SkillOrigin::Agent,
+            source_session_id: None,
+        })
+        .await?;
+    state
+        .audit_log
+        .record_session_start(
+            "gone-sess",
+            "convo-run",
+            "codex",
+            "codex/brief",
+            "codex",
+            "1",
+        )
+        .await?;
+    state
+        .audit_log
+        .record_tool_dispatch(dispatch("gone-sess", "read", false))
+        .await?;
+    state
+        .audit_log
+        .record_session_end("gone-sess", "closed", None)
+        .await?;
+    state.skill_runs.mark("gone-sess", "brief").await?;
+    state.skills.delete("brief").await?;
+    assert!(!state.skill_runs.finalize("gone-sess").await?);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn concurrent_upserts_of_a_new_name_keep_one_skill_intact() -> anyhow::Result<()> {
     let app = test_app().await?;
     let skills = app.state.skills.clone();

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -6,6 +6,8 @@ use axum::{
 use claw_server_rust::{
     AppState, build_router,
     config::Config,
+    db::audit_log::{RecordToolDispatchInput, bounded_args_json, result_meta},
+    ids::DispatchId,
     services::skills::{CreateSkill, SkillOrigin},
 };
 use serde_json::{Value, json};
@@ -225,6 +227,115 @@ async fn skill_create_escapes_yaml_sensitive_descriptions() -> anyhow::Result<()
     // cannot break the frontmatter block.
     assert!(content.contains(r#"description: "Reply within 24h: keep it brief\nthen stop""#));
     assert_eq!(content.matches("---").count(), 2);
+
+    Ok(())
+}
+
+fn dispatch(session_id: &str, tool: &str, is_error: bool) -> RecordToolDispatchInput {
+    RecordToolDispatchInput {
+        agent_id: "convo-run".to_string(),
+        slug: "codex".to_string(),
+        agent_label: "codex/inbox".to_string(),
+        session_id: session_id.to_string(),
+        tool_name: tool.to_string(),
+        page_id: None,
+        tab_id: None,
+        target_id: None,
+        url: None,
+        title: None,
+        args_json: bounded_args_json(&json!({})),
+        result_meta: result_meta(is_error, false, &json!({}), 0),
+        duration_ms: 100,
+        created_at: None,
+        dispatch_id: DispatchId::new(),
+        parent_dispatch_id: None,
+        tool_input_token_estimate: 10,
+        tool_output_token_estimate: 20,
+        token_estimator_version: 1,
+    }
+}
+
+#[tokio::test]
+async fn skill_run_recorded_from_a_marked_session() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let state = &app.state;
+
+    state
+        .skills
+        .create(CreateSkill {
+            name: "inbox-sweep".to_string(),
+            description: "Check the inbox".to_string(),
+            site: None,
+            steps: vec!["Read the inbox".to_string()],
+            learned_notes: vec![],
+            origin: SkillOrigin::Agent,
+            source_session_id: None,
+        })
+        .await?;
+
+    // A completed session with one clean dispatch and one that errored.
+    state
+        .audit_log
+        .record_session_start(
+            "run-sess",
+            "convo-run",
+            "codex",
+            "codex/inbox",
+            "codex",
+            "1",
+        )
+        .await?;
+    state
+        .audit_log
+        .record_tool_dispatch(dispatch("run-sess", "read", false))
+        .await?;
+    state
+        .audit_log
+        .record_tool_dispatch(dispatch("run-sess", "act", true))
+        .await?;
+    state
+        .audit_log
+        .record_session_end("run-sess", "closed", None)
+        .await?;
+
+    state.skill_runs.mark("run-sess", "inbox-sweep").await?;
+    assert!(state.skill_runs.finalize("run-sess").await?);
+    // Projecting again is a no-op.
+    assert!(!state.skill_runs.finalize("run-sess").await?);
+
+    let detail = state.skills.get("inbox-sweep").await?;
+    assert_eq!(detail.runs.len(), 1);
+    let run = &detail.runs[0];
+    assert_eq!(run.run_number, 1);
+    assert_eq!(run.tool_count, Some(2));
+    assert_eq!(run.tokens, Some(60));
+    assert!(!run.clean);
+    assert_eq!(run.errored_tool.as_deref(), Some("act"));
+    assert_eq!(detail.view.stats.run_count, 1);
+    assert_eq!(detail.view.stats.clean_run_count, 0);
+
+    // A completed but unmarked session records nothing.
+    state
+        .audit_log
+        .record_session_start(
+            "plain-sess",
+            "convo-run",
+            "codex",
+            "codex/plain",
+            "codex",
+            "1",
+        )
+        .await?;
+    state
+        .audit_log
+        .record_tool_dispatch(dispatch("plain-sess", "read", false))
+        .await?;
+    state
+        .audit_log
+        .record_session_end("plain-sess", "closed", None)
+        .await?;
+    assert!(!state.skill_runs.finalize("plain-sess").await?);
+    assert_eq!(state.skills.get("inbox-sweep").await?.runs.len(), 1);
 
     Ok(())
 }

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-transport.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-transport.ts
@@ -14,6 +14,7 @@ const EXPECTED_TOOLS = [
   'evaluate',
   'grep',
   'history',
+  'mark_skill_run',
   'name_session',
   'navigate',
   'pdf',


### PR DESCRIPTION
## What

Records a "run" every time an agent runs a saved skill, with its real cost, so the Tasks list and detail can show how often a skill runs and how it trends. This is the second half of the agent-facing skill loop (the first half added `save_skill`).

- **`mark_skill_run` MCP tool.** The agent calls it once, at the start of a run, with the skill's name; the server ties the current session to that skill (a durable mark). Every skill authored through `save_skill` now renders a first step that tells the agent to call it, so runs mark themselves.
- **Run projection on completion.** When a marked session ends, the server projects a `skill_runs` row from the session's already-materialized audit: tokens, duration, tool count, whether every tool succeeded (`clean`), and the first failing tool otherwise. This reuses the audit `tasks` projection (no re-summing of dispatches) and fires from the same session-completion hook that drives session-efficiency, so the audit is final when it runs.
- **Durable and idempotent.** The mark lives in a new `skill_run_marks` table; the `skill_runs.session_id` index is made unique so a run inserts at most once per session. A startup reconcile sweep is the backstop for any session that completed while the process was down. Run numbers are sequential per skill.

## Notes

- Projection is triggered live (fire-and-forget from the completion hook) with the reconcile sweep as durability; there is no heavier worker/drain because a missed projection is always caught by the next reconcile.
- `clean` means every tool dispatch in the run succeeded and the session was not failed/cancelled; the errored-tool name is read from the session's dispatches when a run is not clean.
- The list and detail run-stats (count, clean count, first/latest tokens, last run) were already wired in earlier work; this fills them with real data.

## Tests

- MCP: `mark_skill_run` is registered locally with the right schema and annotations; the tool-surface, `/mcp` protocol, and Bun conformance catalogs are updated for the new tool.
- Projection: a recorded session (start, a clean dispatch and an errored dispatch, end) that is marked for a skill projects exactly one `skill_runs` row with the expected tool count, duration, tokens, `clean=false`, and the failing tool; re-running the projection is a no-op (idempotent); an unmarked session records nothing.
- Migration tests updated for the new table and the now-unique session index.
- Whole-package `cargo fmt` and `clippy` clean; full server suite green.
