### PR TITLE
feat(claw-server): serve the modern MCP revision with a session handle

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -250,17 +250,28 @@ impl ClawMcpService {
         Ok(started)
     }
 
-    /// Modern stateless path. Resolves the handle-carried session without touching
-    /// `self.lifecycle`, so the per-request service `Drop` never reaps it; idle
-    /// sweeping owns cleanup instead. A client-supplied handle with no live session
-    /// is minted under that id so continuity survives idle reaps and restarts.
-    async fn ensure_modern_session(&self, handle: SessionId) -> Result<StartedSession, McpError> {
+    /// Modern stateless path. Reuses a live server-minted handle; any absent or
+    /// unrecognized handle mints a fresh server-generated handle rather than being
+    /// honored, so a caller cannot choose or seed a session id and concurrent calls
+    /// never mint the same id. Does not touch `self.lifecycle`, so the per-request
+    /// service `Drop` never reaps it; idle sweeping owns cleanup.
+    async fn resolve_modern_session(
+        &self,
+        provided: Option<SessionId>,
+    ) -> Result<(StartedSession, SessionId), McpError> {
         let client = ClientInfo {
             name: "agent".to_string(),
             version: "unknown".to_string(),
             title: None,
         };
-        self.start_session_in_store(handle, client).await
+        if let Some(handle) = provided
+            && let Some(session) = self.state.sessions.lookup(&handle).await
+        {
+            return Ok((started_session_from(session, &client), handle));
+        }
+        let handle = SessionId::new(Uuid::new_v4().to_string());
+        let started = self.start_session_in_store(handle.clone(), client).await?;
+        Ok((started, handle))
     }
 
     async fn learn_session_from_request(
@@ -400,9 +411,7 @@ impl ServerHandler for ClawMcpService {
             .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28)
             && session_id_from_extensions(&context.extensions).is_none();
         let (started, session_handle) = if modern {
-            let handle =
-                provided_handle.unwrap_or_else(|| SessionId::new(Uuid::new_v4().to_string()));
-            let started = self.ensure_modern_session(handle.clone()).await?;
+            let (started, handle) = self.resolve_modern_session(provided_handle).await?;
             (started, Some(handle))
         } else {
             (self.learn_session_from_request(&context).await?, None)
@@ -684,31 +693,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn modern_session_handle_is_reused_across_calls() -> anyhow::Result<()> {
+    async fn modern_session_reuses_returned_handles_and_never_honors_client_ids()
+    -> anyhow::Result<()> {
         let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
         let service = ClawMcpService::new(call.state);
 
-        let handle = SessionId::new("modern-handle-1");
-        let first = service
-            .ensure_modern_session(handle.clone())
+        let (first, minted) = service
+            .resolve_modern_session(None)
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
-        let second = service
-            .ensure_modern_session(handle.clone())
+
+        let (again, reused) = service
+            .resolve_modern_session(Some(minted.clone()))
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+        assert_eq!(reused.to_string(), minted.to_string());
         assert_eq!(
-            first.session.id().to_string(),
-            second.session.id().to_string()
+            again.session.id().to_string(),
+            first.session.id().to_string()
         );
 
-        let other = service
-            .ensure_modern_session(SessionId::new("modern-handle-2"))
+        let client_chosen = SessionId::new("client-picked-id");
+        let (other, other_handle) = service
+            .resolve_modern_session(Some(client_chosen.clone()))
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+        assert_ne!(other_handle.to_string(), client_chosen.to_string());
         assert_ne!(
-            first.session.id().to_string(),
-            other.session.id().to_string()
+            other.session.id().to_string(),
+            first.session.id().to_string()
         );
         Ok(())
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -38,12 +38,14 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 use ulid::Ulid;
+use uuid::Uuid;
 
 const SERVER_NAME: &str = "browseros-neo";
 const SERVER_TITLE: &str = "BrowserOS neo";
 const NAME_SESSION_TOOL_NAME: &str = "name_session";
 const NAME_SESSION_DESCRIPTION: &str = "Rename this browser session: a small lowercase 2-3 word label for what this session is doing, e.g. \"invoice processing\". Tabs are grouped as <client>/<name>. Call again to rename.";
 const NAME_SESSION_INPUT_MAX_LEN: usize = 64;
+const SESSION_ARG_DESCRIPTION: &str = "Opaque session handle returned by the server. Pass it back on every call to keep working in the same browser session; omit it to start a new session.";
 
 /// Owns one MCP transport lifetime. Drop best-effort schedules removal of a started
 /// server session, which records its end and begins retained-group handling.
@@ -93,8 +95,9 @@ impl ClawMcpService {
             .catalog
             .iter()
             .map(ToolDef::to_mcp_tool)
+            .map(with_session_arg)
             .collect::<Vec<_>>();
-        tools.push(self.name_session_tool.clone());
+        tools.push(with_session_arg(self.name_session_tool.clone()));
         tools
     }
 
@@ -173,6 +176,42 @@ impl ClawMcpService {
         });
     }
 
+    /// Looks up an existing store session for `session_id` or mints one under it.
+    /// Does not touch `self.lifecycle`, so a caller that must stay out of the
+    /// transport-close cleanup can start a session without arming that teardown.
+    async fn start_session_in_store(
+        &self,
+        session_id: SessionId,
+        client: ClientInfo,
+    ) -> Result<StartedSession, McpError> {
+        let session = if let Some(session) = self.state.sessions.lookup(&session_id).await {
+            session
+        } else {
+            let profiles = self.state.profiles.list_profiles().await.map_err(|error| {
+                McpError::internal_error(format!("agent profile lookup failed: {error}"), None)
+            })?;
+            let profiles = profiles.iter().map(ProfileView::from).collect::<Vec<_>>();
+            let agent = ClientIdentity::resolve(&client, &profiles);
+            let session = self
+                .state
+                .sessions
+                .mint_with_id(session_id.clone(), agent, client.clone())
+                .await
+                .map_err(|error| {
+                    McpError::internal_error(format!("mcp session start failed: {error}"), None)
+                })?;
+            tracing::info!(
+                session_id = %session.id(),
+                agent = %session.convo_id(),
+                "mcp session initialized"
+            );
+            session
+        };
+        Ok(started_session_from(session, &client))
+    }
+
+    /// Legacy and stdio path. Caches the session id and start flag in
+    /// `self.lifecycle`, which the transport-close `Drop` uses to reap the session.
     async fn ensure_session_started(
         &self,
         session_id: SessionId,
@@ -191,8 +230,9 @@ impl ClawMcpService {
             title: None,
         });
 
-        let session = if lifecycle.started {
-            self.state
+        if lifecycle.started {
+            let session = self
+                .state
                 .sessions
                 .lookup(&session_id)
                 .await
@@ -201,43 +241,26 @@ impl ClawMcpService {
                         format!("BrowserOS neo session {session_id} is no longer live"),
                         None,
                     )
-                })?
-        } else if let Some(session) = self.state.sessions.lookup(&session_id).await {
-            lifecycle.started = true;
-            session
-        } else {
-            let profiles = self.state.profiles.list_profiles().await.map_err(|error| {
-                McpError::internal_error(format!("agent profile lookup failed: {error}"), None)
-            })?;
-            let profiles = profiles.iter().map(ProfileView::from).collect::<Vec<_>>();
-            let agent = ClientIdentity::resolve(&client, &profiles);
-            let session = self
-                .state
-                .sessions
-                .mint_with_id(session_id.clone(), agent, client.clone())
-                .await
-                .map_err(|error| {
-                    McpError::internal_error(format!("mcp session start failed: {error}"), None)
                 })?;
-            lifecycle.started = true;
-            tracing::info!(
-                session_id = %session.id(),
-                agent = %session.convo_id(),
-                "mcp session initialized"
-            );
-            session
+            return Ok(started_session_from(session, &client));
+        }
+
+        let started = self.start_session_in_store(session_id, client).await?;
+        lifecycle.started = true;
+        Ok(started)
+    }
+
+    /// Modern stateless path. Resolves the handle-carried session without touching
+    /// `self.lifecycle`, so the per-request service `Drop` never reaps it; idle
+    /// sweeping owns cleanup instead. A client-supplied handle with no live session
+    /// is minted under that id so continuity survives idle reaps and restarts.
+    async fn ensure_modern_session(&self, handle: SessionId) -> Result<StartedSession, McpError> {
+        let client = ClientInfo {
+            name: "agent".to_string(),
+            version: "unknown".to_string(),
+            title: None,
         };
-        let agent_label = client
-            .title
-            .as_deref()
-            .filter(|value| !value.is_empty())
-            .or_else(|| (!client.name.is_empty()).then_some(client.name.as_str()))
-            .unwrap_or_else(|| session.agent().slug())
-            .to_string();
-        Ok(StartedSession {
-            session,
-            agent_label,
-        })
+        self.start_session_in_store(handle, client).await
     }
 
     async fn learn_session_from_request(
@@ -290,12 +313,11 @@ impl Drop for ClawMcpService {
     }
 }
 
-// Pin the claw-server to legacy protocol versions across the rmcp 3.x bump.
-// rmcp 3.x advertises 2026-07-28 by default, but the sessionless (modern) state
-// model is not in place yet: advertising it now would let modern clients
-// negotiate a stateless session this handler cannot track. Lifted once the
-// handle-based session model lands.
-const LEGACY_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
+// The server serves the modern stateless revision alongside the legacy revisions,
+// so 2026-07-28 clients get the sessionless model while older clients keep the
+// session model. rmcp picks per request from what a client negotiates.
+const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
+    ProtocolVersion::V_2026_07_28,
     ProtocolVersion::V_2025_11_25,
     ProtocolVersion::V_2025_06_18,
     ProtocolVersion::V_2025_03_26,
@@ -313,7 +335,7 @@ impl ServerHandler for ClawMcpService {
     }
 
     fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
-        Cow::Borrowed(LEGACY_PROTOCOL_VERSIONS)
+        Cow::Borrowed(SUPPORTED_PROTOCOL_VERSIONS)
     }
 
     async fn initialize(
@@ -345,10 +367,10 @@ impl ServerHandler for ClawMcpService {
 
     fn get_tool(&self, name: &str) -> Option<Tool> {
         if name == NAME_SESSION_TOOL_NAME {
-            return Some(self.name_session_tool.clone());
+            return Some(with_session_arg(self.name_session_tool.clone()));
         }
         self.find_tool_index(name)
-            .map(|index| self.catalog[index].to_mcp_tool())
+            .map(|index| with_session_arg(self.catalog[index].to_mcp_tool()))
     }
 
     async fn call_tool(
@@ -361,11 +383,30 @@ impl ServerHandler for ClawMcpService {
         if !is_name_session && tool_index.is_none() {
             return Err(McpError::method_not_found::<CallToolRequestMethod>());
         }
-        let raw_args = request
+        let mut raw_args = request
             .arguments
             .map(Value::Object)
             .unwrap_or_else(|| Value::Object(JsonObject::new()));
-        let started = self.learn_session_from_request(&context).await?;
+        let provided_handle = raw_args
+            .get("session")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(SessionId::new);
+        if let Value::Object(map) = &mut raw_args {
+            map.remove("session");
+        }
+        let modern = protocol_version_from_extensions(&context.extensions)
+            .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28)
+            && session_id_from_extensions(&context.extensions).is_none();
+        let (started, session_handle) = if modern {
+            let handle =
+                provided_handle.unwrap_or_else(|| SessionId::new(Uuid::new_v4().to_string()));
+            let started = self.ensure_modern_session(handle.clone()).await?;
+            (started, Some(handle))
+        } else {
+            (self.learn_session_from_request(&context).await?, None)
+        };
         started.session.touch(tokio::time::Instant::now()).await;
         started.session.mark_used();
         let concurrent_used_sessions = self.state.sessions.used_count().await.max(1);
@@ -415,15 +456,15 @@ impl ServerHandler for ClawMcpService {
             dispatch_tool_call(call).await
         };
 
-        finish_tool_call(
+        let finished = finish_tool_call(
             started.session.as_ref(),
             &tool_name,
             tool_started_at,
             concurrent_used_sessions,
             result,
         )
-        .await
-        .map(Into::into)
+        .await;
+        attach_session_handle(finished, session_handle).map(Into::into)
     }
 }
 
@@ -516,6 +557,56 @@ async fn finish_local_dispatch(
     }
 }
 
+fn started_session_from(session: Arc<Session>, client: &ClientInfo) -> StartedSession {
+    let agent_label = client
+        .title
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .or_else(|| (!client.name.is_empty()).then_some(client.name.as_str()))
+        .unwrap_or_else(|| session.agent().slug())
+        .to_string();
+    StartedSession {
+        session,
+        agent_label,
+    }
+}
+
+fn with_session_arg(mut tool: Tool) -> Tool {
+    let mut schema = tool.input_schema.as_ref().clone();
+    let properties = schema
+        .entry("properties")
+        .or_insert_with(|| Value::Object(JsonObject::new()));
+    if let Value::Object(properties) = properties {
+        properties.insert(
+            "session".to_string(),
+            json!({ "type": "string", "description": SESSION_ARG_DESCRIPTION }),
+        );
+    }
+    tool.input_schema = Arc::new(schema);
+    tool
+}
+
+fn attach_session_handle(
+    result: Result<CallToolResult, McpError>,
+    handle: Option<SessionId>,
+) -> Result<CallToolResult, McpError> {
+    let Some(handle) = handle else {
+        return result;
+    };
+    result.map(|mut call_result| {
+        let handle = handle.to_string();
+        match &mut call_result.structured_content {
+            Some(Value::Object(map)) => {
+                map.insert("session".to_string(), Value::String(handle));
+            }
+            _ => {
+                call_result.structured_content = Some(json!({ "session": handle }));
+            }
+        }
+        call_result
+    })
+}
+
 fn session_id_from_extensions(extensions: &rmcp::model::Extensions) -> Option<SessionId> {
     extensions
         .get::<axum::http::request::Parts>()
@@ -526,6 +617,29 @@ fn session_id_from_extensions(extensions: &rmcp::model::Extensions) -> Option<Se
         .map(SessionId::new)
 }
 
+fn protocol_version_from_extensions(
+    extensions: &rmcp::model::Extensions,
+) -> Option<ProtocolVersion> {
+    extensions
+        .get::<axum::http::request::Parts>()
+        .and_then(|parts| parts.headers.get("mcp-protocol-version"))
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(protocol_version_from_str)
+}
+
+fn protocol_version_from_str(value: &str) -> Option<ProtocolVersion> {
+    match value {
+        "2026-07-28" => Some(ProtocolVersion::V_2026_07_28),
+        "2025-11-25" => Some(ProtocolVersion::V_2025_11_25),
+        "2025-06-18" => Some(ProtocolVersion::V_2025_06_18),
+        "2025-03-26" => Some(ProtocolVersion::V_2025_03_26),
+        "2024-11-05" => Some(ProtocolVersion::V_2024_11_05),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -534,13 +648,94 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn legacy_protocol_pin_excludes_the_modern_revision() {
-        // Behavior-neutral bump: rmcp 3.x's default advertises 2026-07-28, but the
-        // sessionless state model is not in place yet, so the claw-server pins to
-        // legacy versions. Lifted with the handle-based session model.
-        assert!(ProtocolVersion::KNOWN_VERSIONS.contains(&ProtocolVersion::V_2026_07_28));
-        assert!(!LEGACY_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2026_07_28));
-        assert!(LEGACY_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2025_11_25));
+    fn supported_protocol_versions_includes_modern_and_legacy() {
+        assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2026_07_28));
+        assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2025_11_25));
+    }
+
+    #[tokio::test]
+    async fn with_session_arg_adds_an_optional_session_property_to_every_tool() -> anyhow::Result<()>
+    {
+        let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let service = ClawMcpService::new(call.state);
+
+        let injected = with_session_arg(service.name_session_tool.clone());
+        let schema = Value::Object(injected.input_schema.as_ref().clone());
+        assert_eq!(
+            schema["properties"]["session"],
+            json!({ "type": "string", "description": SESSION_ARG_DESCRIPTION })
+        );
+        assert!(
+            !schema["required"]
+                .as_array()
+                .is_some_and(|required| required.contains(&json!("session")))
+        );
+
+        for tool in service.listed_tools() {
+            let schema = Value::Object(tool.input_schema.as_ref().clone());
+            assert_eq!(
+                schema["properties"]["session"]["type"],
+                json!("string"),
+                "tool {} is missing the session property",
+                tool.name
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn modern_session_handle_is_reused_across_calls() -> anyhow::Result<()> {
+        let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let service = ClawMcpService::new(call.state);
+
+        let handle = SessionId::new("modern-handle-1");
+        let first = service
+            .ensure_modern_session(handle.clone())
+            .await
+            .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+        let second = service
+            .ensure_modern_session(handle.clone())
+            .await
+            .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+        assert_eq!(
+            first.session.id().to_string(),
+            second.session.id().to_string()
+        );
+
+        let other = service
+            .ensure_modern_session(SessionId::new("modern-handle-2"))
+            .await
+            .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+        assert_ne!(
+            first.session.id().to_string(),
+            other.session.id().to_string()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn attach_session_handle_adds_the_handle_only_for_modern_calls() -> anyhow::Result<()> {
+        let modern = attach_session_handle(
+            Ok(CallToolResult::success(vec![
+                rmcp::model::ContentBlock::text("ok"),
+            ])),
+            Some(SessionId::new("handle-xyz")),
+        )
+        .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+        let structured = modern
+            .structured_content
+            .ok_or_else(|| anyhow::anyhow!("modern result carries the session handle"))?;
+        assert_eq!(structured["session"], json!("handle-xyz"));
+
+        let legacy = attach_session_handle(
+            Ok(CallToolResult::success(vec![
+                rmcp::model::ContentBlock::text("ok"),
+            ])),
+            None,
+        )
+        .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+        assert!(legacy.structured_content.is_none());
+        Ok(())
     }
 
     fn usage_session() -> Arc<Session> {
@@ -721,7 +916,8 @@ mod tests {
             json!({
                 "type": "object",
                 "properties": {
-                    "name": { "type": "string", "maxLength": 64 }
+                    "name": { "type": "string", "maxLength": 64 },
+                    "session": { "type": "string", "description": SESSION_ARG_DESCRIPTION }
                 },
                 "required": ["name"]
             })

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -491,7 +491,13 @@ async fn mcp_name_session_lists_and_renames_while_disconnected() -> anyhow::Resu
         tool["inputSchema"],
         json!({
             "type": "object",
-            "properties": { "name": { "type": "string", "maxLength": 64 } },
+            "properties": {
+                "name": { "type": "string", "maxLength": 64 },
+                "session": {
+                    "type": "string",
+                    "description": "Opaque session handle returned by the server. Pass it back on every call to keep working in the same browser session; omit it to start a new session."
+                }
+            },
             "required": ["name"]
         })
     );


### PR DESCRIPTION
## What

The claw-server MCP HTTP endpoint now serves the modern `2026-07-28` revision alongside the legacy revisions. rmcp negotiates per request: `2026-07-28` clients are served statelessly, older clients keep the session model.

The stateless revision removes the `Mcp-Session-Id` header the claw-server used to key each agent's tab-group session. That session is now carried the way the spec recommends for cross-call state: a server-minted handle passed as an ordinary `session` tool argument.

- Every tool gains an optional `session` string argument.
- On a call with no `session`, the server mints a UUID handle, starts the session, and returns it in `structuredContent.session`. The agent passes it back on later calls.
- On a call with a `session`, the server looks up that session and scopes the tool to its tab group, exactly as before.
- The handle is stripped from the arguments before the tool runs, so tool schemas and argument validation are unaffected.

## Behavior preserved

- Legacy clients and stdio are untouched: they keep the `Mcp-Session-Id` / fallback session model, the per-connection lifecycle, and transport-close cleanup.
- Modern handle sessions are reaped by the existing idle sweeper, so they do not depend on transport close and do not leak.
- No change to browser or tab-group behavior: each agent still gets its own tab group.

## Tests

- The advertised protocol versions now include `2026-07-28` plus the legacy revisions.
- The optional `session` argument is injected into every listed tool without becoming required.
- A modern handle resolves the same session across calls; a fresh handle mints a distinct session.
- The minted handle is merged into `structuredContent` for modern calls and omitted otherwise.

`cargo check`, `cargo clippy --all-targets -D warnings`, and the `api::mcp` test suite pass.
