### PR TITLE
fix(ci): isolate macOS Chromium builds in APFS workspaces

### DIFF
--- a/.github/scripts/macos-chromium-workspace.sh
+++ b/.github/scripts/macos-chromium-workspace.sh
@@ -323,8 +323,7 @@ setup_workspace() {
   [ "$(basename "$base_src")" = "src" ] || die "Persistent Chromium path must point to src: $base_src"
   base_root="$(resolve_existing_dir "$base_src/..")" \
     || die "Could not resolve Chromium gclient root from $base_src"
-  version_file="${version_file:-$(default_version_file)}"
-  verify_base "$version_file"
+  [ -f "$base_root/.gclient" ] || die "Chromium base root is missing .gclient: $base_root"
 
   base_parent="$(resolve_existing_dir "$base_root/..")"
   workspace_parent="$base_parent/$workspace_parent_name"
@@ -337,6 +336,8 @@ setup_workspace() {
 
   tag="$(run_tag)"
   reap_stale_workspaces "$workspace_parent" "$tag" "$base_root"
+  version_file="${version_file:-$(default_version_file)}"
+  verify_base "$version_file"
 
   workspace_root="$workspace_parent/$workspace_prefix$tag"
   workspace_src="$workspace_root/src"

--- a/.github/scripts/macos-chromium-workspace.sh
+++ b/.github/scripts/macos-chromium-workspace.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+state_path=""
+marker_name=".browseros-workspace-state.env"
+workspace_parent_name="browseros-ci-apfs-workspaces"
+workspace_prefix="browseros-ci-chromium-"
+setup_cleanup_active=0
+
+die() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+warn() {
+  echo "::warning::$*" >&2
+}
+
+append_env() {
+  local path="$1"
+  local name="$2"
+  local value="$3"
+  if [ -n "$path" ]; then
+    printf '%s=%s\n' "$name" "$value" >> "$path"
+  fi
+}
+
+run_tag() {
+  printf '%s-%s\n' "${GITHUB_RUN_ID:-local}" "${GITHUB_RUN_ATTEMPT:-1}"
+}
+
+default_state_path() {
+  [ -n "${RUNNER_TEMP:-}" ] || return 1
+  printf '%s/browseros-ci-chromium-workspace-%s.env\n' "$RUNNER_TEMP" "$(run_tag)"
+}
+
+resolve_state_path() {
+  if [ -n "${MACOS_CHROMIUM_WORKSPACE_STATE_PATH:-}" ]; then
+    state_path="$MACOS_CHROMIUM_WORKSPACE_STATE_PATH"
+    return 0
+  fi
+  state_path="$(default_state_path)"
+}
+
+owned_state_path() {
+  local expected
+  expected="$(default_state_path 2>/dev/null)" || return 1
+  [ "$1" = "$expected" ]
+}
+
+require_owned_state_path() {
+  if ! owned_state_path "$state_path"; then
+    die "Unexpected macOS Chromium workspace state path: $state_path"
+  fi
+}
+
+expand_home() {
+  local path="$1"
+  printf '%s\n' "${path/#\~/$HOME}"
+}
+
+resolve_existing_dir() {
+  local path
+  path="$(expand_home "$1")"
+  [ -d "$path" ] || return 1
+  (cd "$path" && pwd -P)
+}
+
+stat_device() {
+  stat -f '%d' "$1"
+}
+
+read_chromium_version() {
+  local version_file="$1"
+  awk -F= '
+    $1 == "MAJOR" { major=$2 }
+    $1 == "MINOR" { minor=$2 }
+    $1 == "BUILD" { build=$2 }
+    $1 == "PATCH" { patch=$2 }
+    END {
+      if (major == "" || minor == "" || build == "" || patch == "") {
+        exit 1
+      }
+      printf "%s.%s.%s.%s\n", major, minor, build, patch
+    }
+  ' "$version_file"
+}
+
+default_version_file() {
+  local script_dir repo_root
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+  repo_root="$(cd "$script_dir/../.." && pwd -P)"
+  printf '%s/packages/browseros/CHROMIUM_VERSION\n' "$repo_root"
+}
+
+write_workspace_state() {
+  local path="$1"
+  {
+    printf 'workspace_parent=%s\n' "$workspace_parent"
+    printf 'workspace_root=%s\n' "$workspace_root"
+    printf 'workspace_src=%s\n' "$workspace_src"
+    printf 'base_root=%s\n' "$base_root"
+    printf 'base_src=%s\n' "$base_src"
+    printf 'base_head=%s\n' "$base_head"
+    printf 'chromium_version=%s\n' "$chromium_version"
+    printf 'run_tag=%s\n' "$tag"
+  } > "$path"
+}
+
+read_state_file() {
+  workspace_parent=""
+  workspace_root=""
+  workspace_src=""
+  base_root=""
+  base_src=""
+  base_head=""
+  chromium_version=""
+  tag=""
+
+  local state_line
+  while IFS= read -r state_line; do
+    case "$state_line" in
+      workspace_parent=*) workspace_parent="${state_line#workspace_parent=}" ;;
+      workspace_root=*) workspace_root="${state_line#workspace_root=}" ;;
+      workspace_src=*) workspace_src="${state_line#workspace_src=}" ;;
+      base_root=*) base_root="${state_line#base_root=}" ;;
+      base_src=*) base_src="${state_line#base_src=}" ;;
+      base_head=*) base_head="${state_line#base_head=}" ;;
+      chromium_version=*) chromium_version="${state_line#chromium_version=}" ;;
+      run_tag=*) tag="${state_line#run_tag=}" ;;
+    esac
+  done < "$1"
+}
+
+owned_workspace_path() {
+  local path="$1"
+  local parent="$2"
+
+  [ -n "$path" ] || return 1
+  [ -n "$parent" ] || return 1
+  [ "$path" != "/" ] || return 1
+  [ "$path" != "${HOME:-}" ] || return 1
+  case "$path" in
+    "$parent"/"$workspace_prefix"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+marker_matches_workspace() {
+  local marker="$1"
+  local expected_workspace="$2"
+  local expected_base="${3:-}"
+  local marker_workspace=""
+  local marker_base=""
+  local line
+
+  [ -f "$marker" ] || return 1
+  while IFS= read -r line; do
+    case "$line" in
+      workspace_root=*) marker_workspace="${line#workspace_root=}" ;;
+      base_root=*) marker_base="${line#base_root=}" ;;
+    esac
+  done < "$marker"
+
+  [ "$marker_workspace" = "$expected_workspace" ] || return 1
+  [ -z "$expected_base" ] || [ "$marker_base" = "$expected_base" ]
+}
+
+cleanup_workspace_path() {
+  local target="$1"
+  local parent="$2"
+  local expected_base="${3:-}"
+  local resolved_target resolved_parent marker
+
+  [ -n "$target" ] || return 0
+  [ -e "$target" ] || return 0
+  [ -d "$target" ] || {
+    warn "Ignoring non-directory Chromium workspace target: $target"
+    return 0
+  }
+
+  resolved_target="$(resolve_existing_dir "$target")" || return 0
+  resolved_parent="$(resolve_existing_dir "$parent")" || {
+    warn "Ignoring Chromium workspace with missing parent: $parent"
+    return 0
+  }
+
+  if ! owned_workspace_path "$resolved_target" "$resolved_parent"; then
+    warn "Ignoring unexpected Chromium workspace path: $resolved_target"
+    return 0
+  fi
+
+  marker="$resolved_target/$marker_name"
+  if ! marker_matches_workspace "$marker" "$resolved_target" "$expected_base"; then
+    warn "Ignoring Chromium workspace without matching owned marker: $resolved_target"
+    return 0
+  fi
+
+  rm -rf "$resolved_target"
+}
+
+cleanup_workspace() {
+  resolve_state_path || return 0
+  if [ -z "$state_path" ] || [ ! -f "$state_path" ]; then
+    return 0
+  fi
+  if ! owned_state_path "$state_path"; then
+    warn "Ignoring unexpected macOS Chromium workspace state path: $state_path"
+    return 0
+  fi
+
+  read_state_file "$state_path"
+  cleanup_workspace_path "$workspace_root" "$workspace_parent" "$base_root"
+  rm -f "$state_path"
+}
+
+reap_stale_workspaces() {
+  local parent="$1"
+  local current_tag="$2"
+  local expected_base="$3"
+  local candidate resolved marker marker_tag line
+
+  [ -d "$parent" ] || return 0
+  for candidate in "$parent"/"$workspace_prefix"*; do
+    [ -e "$candidate" ] || continue
+    [ -d "$candidate" ] || continue
+    resolved="$(resolve_existing_dir "$candidate")" || continue
+    [ "$(basename "$resolved")" != "$workspace_prefix$current_tag" ] || continue
+    marker="$resolved/$marker_name"
+    [ -f "$marker" ] || continue
+    marker_tag=""
+    while IFS= read -r line; do
+      case "$line" in
+        run_tag=*) marker_tag="${line#run_tag=}" ;;
+      esac
+    done < "$marker"
+    [ "$marker_tag" != "$current_tag" ] || continue
+    cleanup_workspace_path "$resolved" "$parent" "$expected_base"
+  done
+}
+
+check_no_browseros_outputs() {
+  local out_dir="$1/out"
+  local found
+  [ -d "$out_dir" ] || return 0
+  found="$(
+    find "$out_dir" -maxdepth 1 -type d \
+      \( -name 'Default_browseros_*' -o -name 'Default_browserclaw_*' \) \
+      -print -quit
+  )"
+  [ -z "$found" ] || die "Persistent Chromium base contains BrowserOS output state: $found; remove BrowserOS out dirs from the base before rerunning"
+}
+
+verify_cow_clone_support() {
+  local parent="$1"
+  local probe_dir="$parent/.browseros-ci-apfs-probe-$(run_tag)-$$"
+  local source_file="$probe_dir/source"
+  local clone_file="$probe_dir/clone"
+
+  rm -rf "$probe_dir"
+  mkdir -p "$probe_dir"
+  printf 'browseros apfs clone probe\n' > "$source_file"
+  if ! cp -c "$source_file" "$clone_file"; then
+    rm -rf "$probe_dir"
+    die "APFS copy-on-write clone probe failed under $parent; place the workspace parent on APFS with clonefile support"
+  fi
+  if ! cmp -s "$source_file" "$clone_file"; then
+    rm -rf "$probe_dir"
+    die "APFS copy-on-write clone probe produced different bytes"
+  fi
+  rm -rf "$probe_dir"
+}
+
+verify_base() {
+  local version_file="$1"
+  local pin_head status
+
+  [ -f "$base_root/.gclient" ] || die "Chromium base root is missing .gclient: $base_root"
+  [ -e "$base_src/.git" ] || die "Chromium base src is missing .git: $base_src"
+  [ -f "$version_file" ] || die "Chromium version file not found: $version_file"
+
+  chromium_version="$(read_chromium_version "$version_file")" \
+    || die "Could not parse Chromium version file: $version_file"
+  base_head="$(git -C "$base_src" rev-parse HEAD)"
+  pin_head="$(git -C "$base_src" rev-parse "refs/tags/$chromium_version^{commit}")" \
+    || die "Chromium base is missing pinned tag $chromium_version; refresh the warm base checkout before rerunning"
+  [ "$base_head" = "$pin_head" ] \
+    || die "Chromium base HEAD $base_head does not match pinned $chromium_version ($pin_head); refresh the warm base checkout before rerunning"
+
+  status="$(git -C "$base_src" status --porcelain=v1 --untracked-files=no)"
+  [ -z "$status" ] || die "Persistent Chromium base has tracked changes; reset the warm base checkout before rerunning"
+  check_no_browseros_outputs "$base_src"
+}
+
+cleanup_after_setup_error() {
+  local status="$?"
+  [ "$setup_cleanup_active" = "1" ] || return 0
+  setup_cleanup_active=0
+  if [ -n "${workspace_root:-}" ] && [ -n "${workspace_parent:-}" ]; then
+    cleanup_workspace_path "$workspace_root" "$workspace_parent" "${base_root:-}" || true
+  fi
+  if owned_state_path "$state_path"; then
+    rm -f "$state_path"
+  fi
+  exit "$status"
+}
+
+setup_workspace() {
+  local requested_base_src="${1:-${CHROMIUM_SRC:-}}"
+  local version_file="${BROWSEROS_CHROMIUM_VERSION_FILE:-}"
+  local base_parent base_device parent_device
+
+  [ -n "$requested_base_src" ] || die "usage: $0 setup <persistent-chromium-src>"
+  [ "$(uname -s)" = "Darwin" ] || die "Disposable APFS Chromium workspaces require macOS"
+  [ -n "${RUNNER_TEMP:-}" ] || die "RUNNER_TEMP is required"
+  resolve_state_path
+  require_owned_state_path
+
+  cleanup_workspace
+
+  base_src="$(resolve_existing_dir "$requested_base_src")" \
+    || die "Persistent Chromium src does not exist: $requested_base_src"
+  [ "$(basename "$base_src")" = "src" ] || die "Persistent Chromium path must point to src: $base_src"
+  base_root="$(resolve_existing_dir "$base_src/..")" \
+    || die "Could not resolve Chromium gclient root from $base_src"
+  version_file="${version_file:-$(default_version_file)}"
+  verify_base "$version_file"
+
+  base_parent="$(resolve_existing_dir "$base_root/..")"
+  workspace_parent="$base_parent/$workspace_parent_name"
+  mkdir -p "$workspace_parent"
+  workspace_parent="$(resolve_existing_dir "$workspace_parent")"
+  base_device="$(stat_device "$base_root")"
+  parent_device="$(stat_device "$workspace_parent")"
+  [ "$base_device" = "$parent_device" ] \
+    || die "Chromium workspace parent is not on the base checkout volume: $workspace_parent; move the base or workspace parent onto one APFS volume"
+
+  tag="$(run_tag)"
+  reap_stale_workspaces "$workspace_parent" "$tag" "$base_root"
+
+  workspace_root="$workspace_parent/$workspace_prefix$tag"
+  workspace_src="$workspace_root/src"
+  if [ -e "$workspace_root" ]; then
+    cleanup_workspace_path "$workspace_root" "$workspace_parent" "$base_root"
+  fi
+  [ ! -e "$workspace_root" ] || die "Owned Chromium workspace already exists and could not be cleaned: $workspace_root"
+
+  mkdir "$workspace_root"
+  write_workspace_state "$workspace_root/$marker_name"
+  setup_cleanup_active=1
+  trap cleanup_after_setup_error EXIT
+
+  verify_cow_clone_support "$workspace_parent"
+  cp -cR "$base_root"/. "$workspace_root"
+  write_workspace_state "$workspace_root/$marker_name"
+  [ -d "$workspace_src" ] || die "APFS clone did not produce src: $workspace_src"
+  [ "$(git -C "$workspace_src" rev-parse HEAD)" = "$base_head" ] \
+    || die "APFS clone source HEAD does not match base HEAD"
+
+  write_workspace_state "$state_path"
+  append_env "${GITHUB_ENV:-}" CHROMIUM_SRC "$workspace_src"
+  append_env "${GITHUB_ENV:-}" MACOS_CHROMIUM_WORKSPACE_STATE_PATH "$state_path"
+  append_env "${GITHUB_OUTPUT:-}" chromium_src "$workspace_src"
+  append_env "${GITHUB_OUTPUT:-}" workspace_root "$workspace_root"
+  append_env "${GITHUB_OUTPUT:-}" base_src "$base_src"
+  append_env "${GITHUB_OUTPUT:-}" base_head "$base_head"
+  append_env "${GITHUB_OUTPUT:-}" state_path "$state_path"
+  setup_cleanup_active=0
+  trap - EXIT
+}
+
+case "${1:-}" in
+  setup)
+    shift
+    setup_workspace "$@"
+    ;;
+  cleanup)
+    cleanup_workspace
+    ;;
+  *)
+    echo "usage: $0 setup <persistent-chromium-src>|cleanup" >&2
+    exit 2
+    ;;
+esac

--- a/.github/scripts/macos-chromium-workspace.sh
+++ b/.github/scripts/macos-chromium-workspace.sh
@@ -251,6 +251,28 @@ check_no_browseros_outputs() {
   [ -z "$found" ] || die "Persistent Chromium base contains BrowserOS output state: $found; remove BrowserOS out dirs from the base before rerunning"
 }
 
+check_git_repo_clean() {
+  local repo="$1"
+  local status
+
+  status="$(git -C "$repo" status --porcelain=v1 --untracked-files=all)"
+  [ -z "$status" ] || die "Persistent Chromium base has tracked or untracked changes in $repo; reset the warm base checkout before rerunning"
+}
+
+check_nested_git_repos_clean() {
+  local git_meta repo
+
+  while IFS= read -r git_meta; do
+    repo="$(resolve_existing_dir "$(dirname "$git_meta")")" || continue
+    [ "$repo" != "$base_src" ] || continue
+    check_git_repo_clean "$repo"
+  done < <(
+    find "$base_root" \
+      \( -path "$base_src/out" -o -path "$base_src/out/*" \) -prune -o \
+      -name .git -print -prune
+  )
+}
+
 verify_cow_clone_support() {
   local parent="$1"
   local probe_dir="$parent/.browseros-ci-apfs-probe-$(run_tag)-$$"
@@ -273,7 +295,7 @@ verify_cow_clone_support() {
 
 verify_base() {
   local version_file="$1"
-  local pin_head status
+  local pin_head
 
   [ -f "$base_root/.gclient" ] || die "Chromium base root is missing .gclient: $base_root"
   [ -e "$base_src/.git" ] || die "Chromium base src is missing .git: $base_src"
@@ -287,8 +309,8 @@ verify_base() {
   [ "$base_head" = "$pin_head" ] \
     || die "Chromium base HEAD $base_head does not match pinned $chromium_version ($pin_head); refresh the warm base checkout before rerunning"
 
-  status="$(git -C "$base_src" status --porcelain=v1 --untracked-files=no)"
-  [ -z "$status" ] || die "Persistent Chromium base has tracked changes; reset the warm base checkout before rerunning"
+  check_git_repo_clean "$base_src"
+  check_nested_git_repos_clean
   check_no_browseros_outputs "$base_src"
 }
 

--- a/.github/workflows/bos-build-tests.yml
+++ b/.github/workflows/bos-build-tests.yml
@@ -11,6 +11,7 @@ on:
       - "packages/browseros/pyproject.toml"
       - "packages/browseros/uv.lock"
       - "tools/release_secrets/**"
+      - ".github/scripts/macos-chromium-workspace.sh"
       - ".github/scripts/macos-signing-keychain.sh"
       - ".github/workflows/bos-build-tests.yml"
       - ".github/workflows/build-browseros.yml"

--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -197,6 +197,12 @@ jobs:
 
       - uses: astral-sh/setup-uv@v8.3.2
 
+      - name: Setup disposable Chromium workspace
+        id: chromium_workspace
+        working-directory: ${{ steps.build_inputs.outputs.browseros_repo }}
+        shell: bash
+        run: bash .github/scripts/macos-chromium-workspace.sh setup "${{ steps.build_inputs.outputs.chromium_src }}"
+
       - name: Verify reserved browser version
         id: version
         env:
@@ -242,7 +248,7 @@ jobs:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
           BUNDLED_EXTENSIONS_MANIFEST_URL: ${{ steps.build_inputs.outputs.browseros_repo }}/updates/extensions/bundled-manifest.xml
           BUNDLED_PRODUCT_EXTENSION_VERSION: ${{ needs.extension.outputs.version }}
-          CHROMIUM_SRC: ${{ steps.build_inputs.outputs.chromium_src }}
+          CHROMIUM_SRC: ${{ steps.chromium_workspace.outputs.chromium_src }}
           CLAW_POSTHOG_KEY: ${{ secrets.CLAW_POSTHOG_KEY }}
           MACOS_CERTIFICATE_NAME: ${{ steps.macos_signing.outputs.codesign_identity }}
           MACOS_KEYCHAIN_PATH: ${{ steps.macos_signing.outputs.keychain_path }}
@@ -271,6 +277,18 @@ jobs:
             flags+=(--no-upload)
           fi
           uv run browseros build "${flags[@]}" --chromium-src "$CHROMIUM_SRC"
+
+      - name: Clean up disposable Chromium workspace
+        if: always()
+        env:
+          MACOS_CHROMIUM_WORKSPACE_STATE_PATH: ${{ steps.chromium_workspace.outputs.state_path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          script="${{ steps.build_inputs.outputs.browseros_repo }}/.github/scripts/macos-chromium-workspace.sh"
+          if [ -f "$script" ]; then
+            bash "$script" cleanup
+          fi
 
       - name: Clean up macOS signing keychain
         if: always()

--- a/.github/workflows/nightly-browseros.yml
+++ b/.github/workflows/nightly-browseros.yml
@@ -197,6 +197,12 @@ jobs:
 
       - uses: astral-sh/setup-uv@v8.3.2
 
+      - name: Setup disposable Chromium workspace
+        id: chromium_workspace
+        working-directory: ${{ steps.build_inputs.outputs.browseros_repo }}
+        shell: bash
+        run: bash .github/scripts/macos-chromium-workspace.sh setup "${{ steps.build_inputs.outputs.chromium_src }}"
+
       - name: Verify reserved browser version
         id: version
         env:
@@ -242,7 +248,7 @@ jobs:
           BROWSERCLAW_ONBOARD_RESOURCE_VERSION: ${{ needs.reserve.outputs.onboarding_version }}
           BUNDLED_EXTENSIONS_MANIFEST_URL: ${{ steps.build_inputs.outputs.browseros_repo }}/updates/extensions/bundled-manifest.xml
           BUNDLED_PRODUCT_EXTENSION_VERSION: ${{ needs.extension.outputs.version }}
-          CHROMIUM_SRC: ${{ steps.build_inputs.outputs.chromium_src }}
+          CHROMIUM_SRC: ${{ steps.chromium_workspace.outputs.chromium_src }}
           MACOS_CERTIFICATE_NAME: ${{ steps.macos_signing.outputs.codesign_identity }}
           MACOS_KEYCHAIN_PATH: ${{ steps.macos_signing.outputs.keychain_path }}
           MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
@@ -270,6 +276,18 @@ jobs:
             flags+=(--no-upload)
           fi
           uv run browseros build "${flags[@]}" --chromium-src "$CHROMIUM_SRC"
+
+      - name: Clean up disposable Chromium workspace
+        if: always()
+        env:
+          MACOS_CHROMIUM_WORKSPACE_STATE_PATH: ${{ steps.chromium_workspace.outputs.state_path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          script="${{ steps.build_inputs.outputs.browseros_repo }}/.github/scripts/macos-chromium-workspace.sh"
+          if [ -f "$script" ]; then
+            bash "$script" cleanup
+          fi
 
       - name: Clean up macOS signing keychain
         if: always()

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -258,6 +258,12 @@ jobs:
 
       - uses: astral-sh/setup-uv@v8.3.2
 
+      - name: Setup disposable Chromium workspace
+        id: chromium_workspace
+        working-directory: ${{ steps.inputs.outputs.browseros_repo }}
+        shell: bash
+        run: bash .github/scripts/macos-chromium-workspace.sh setup "${{ steps.inputs.outputs.chromium_src }}"
+
       - name: Setup Bun
         if: steps.inputs.outputs.resource_mode == 'source' && steps.inputs.outputs.products == 'browseros'
         uses: oven-sh/setup-bun@v2
@@ -359,7 +365,7 @@ jobs:
               --product "$product"
               --arch "${{ steps.inputs.outputs.arch }}"
               --resource-mode "${{ steps.inputs.outputs.resource_mode }}"
-              --chromium-src "${{ steps.inputs.outputs.chromium_src }}"
+              --chromium-src "${{ steps.chromium_workspace.outputs.chromium_src }}"
             )
             if [ "${{ steps.inputs.outputs.upload_to_r2 }}" != "true" ]; then
               args+=(--no-upload)
@@ -374,6 +380,18 @@ jobs:
             fi
             uv run browseros build "${args[@]}"
           done
+
+      - name: Clean up disposable Chromium workspace
+        if: always()
+        env:
+          MACOS_CHROMIUM_WORKSPACE_STATE_PATH: ${{ steps.chromium_workspace.outputs.state_path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          script="${{ steps.inputs.outputs.browseros_repo }}/.github/scripts/macos-chromium-workspace.sh"
+          if [ -f "$script" ]; then
+            bash "$script" cleanup
+          fi
 
       - name: Clean up macOS signing keychain
         if: always()

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -17,6 +17,9 @@ from bos_build.steps.source import provision
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 MACOS_SIGNING_HELPER = REPO_ROOT / ".github" / "scripts" / "macos-signing-keychain.sh"
+MACOS_CHROMIUM_WORKSPACE_HELPER = (
+    REPO_ROOT / ".github" / "scripts" / "macos-chromium-workspace.sh"
+)
 GIT_BOOTSTRAP_STEP = "Configure Git for depot_tools"
 EXPECTED_GIT_CONFIG = {
     "core.autocrlf": "false",
@@ -809,6 +812,16 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
             pull_request_paths,
         )
 
+    def test_macos_chromium_workspace_helper_changes_trigger_build_system_tests(self):
+        test_workflow = self.load_workflow("bos-build-tests.yml")
+        triggers = test_workflow.get("on", test_workflow.get(True))
+        pull_request_paths = triggers["pull_request"]["paths"]
+
+        self.assertIn(
+            ".github/scripts/macos-chromium-workspace.sh",
+            pull_request_paths,
+        )
+
     def test_build_system_tests_cross_git_bash_to_native_git_on_windows(self):
         test_workflow = self.load_workflow("bos-build-tests.yml")
         windows_job = test_workflow["jobs"]["windows-git-bootstrap"]
@@ -1178,6 +1191,56 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
             },
         )
 
+    def test_macos_release_builds_inside_disposable_chromium_workspace(self):
+        workflow = self.load_workflow("release-macos.yml")
+        steps = workflow["jobs"]["build"]["steps"]
+        indexes = {
+            step.get("name"): index
+            for index, step in enumerate(steps)
+            if "name" in step
+        }
+        setup = steps[indexes["Setup disposable Chromium workspace"]]
+        build = steps[indexes["Build selected products"]]
+        workspace_cleanup = steps[indexes["Clean up disposable Chromium workspace"]]
+        keychain_cleanup = steps[indexes["Clean up macOS signing keychain"]]
+
+        self.assertLess(
+            indexes["Setup disposable Chromium workspace"],
+            indexes["Build selected products"],
+        )
+        self.assertLess(
+            indexes["Build selected products"],
+            indexes["Clean up disposable Chromium workspace"],
+        )
+        self.assertLess(
+            indexes["Clean up disposable Chromium workspace"],
+            indexes["Clean up macOS signing keychain"],
+        )
+        self.assertEqual(setup["id"], "chromium_workspace")
+        self.assertEqual(setup["shell"], "bash")
+        self.assertEqual(
+            setup["working-directory"],
+            "${{ steps.inputs.outputs.browseros_repo }}",
+        )
+        self.assertIn("macos-chromium-workspace.sh setup", setup["run"])
+        self.assertIn("${{ steps.inputs.outputs.chromium_src }}", setup["run"])
+        self.assertIn(
+            '--chromium-src "${{ steps.chromium_workspace.outputs.chromium_src }}"',
+            build["run"],
+        )
+        self.assertNotIn(
+            '--chromium-src "${{ steps.inputs.outputs.chromium_src }}"',
+            build["run"],
+        )
+        self.assertEqual(workspace_cleanup["if"], "always()")
+        self.assertEqual(
+            workspace_cleanup["env"]["MACOS_CHROMIUM_WORKSPACE_STATE_PATH"],
+            "${{ steps.chromium_workspace.outputs.state_path }}",
+        )
+        self.assertIn("macos-chromium-workspace.sh", workspace_cleanup["run"])
+        self.assertIn(" cleanup", workspace_cleanup["run"])
+        self.assertEqual(keychain_cleanup["if"], "always()")
+
 
 class NightlyWorkflowTest(unittest.TestCase):
     NIGHTLIES = {
@@ -1391,6 +1454,59 @@ class NightlyWorkflowTest(unittest.TestCase):
                 self.assertIn("macos-signing-keychain.sh", cleanup["run"])
                 self.assertIn(" cleanup", cleanup["run"])
 
+    def test_nightlies_build_inside_disposable_chromium_workspace(self):
+        for workflow_name, config in self.NIGHTLIES.items():
+            workflow = self.load_workflow(workflow_name)
+            steps = workflow["jobs"]["build"]["steps"]
+            indexes = {
+                step.get("name"): index
+                for index, step in enumerate(steps)
+                if "name" in step
+            }
+            setup = steps[indexes["Setup disposable Chromium workspace"]]
+            build = steps[indexes[config["build_step"]]]
+            workspace_cleanup = steps[
+                indexes["Clean up disposable Chromium workspace"]
+            ]
+            keychain_cleanup = steps[indexes["Clean up macOS signing keychain"]]
+
+            with self.subTest(workflow=workflow_name):
+                self.assertLess(
+                    indexes["Setup disposable Chromium workspace"],
+                    indexes[config["build_step"]],
+                )
+                self.assertLess(
+                    indexes[config["build_step"]],
+                    indexes["Clean up disposable Chromium workspace"],
+                )
+                self.assertLess(
+                    indexes["Clean up disposable Chromium workspace"],
+                    indexes["Clean up macOS signing keychain"],
+                )
+                self.assertEqual(setup["id"], "chromium_workspace")
+                self.assertEqual(setup["shell"], "bash")
+                self.assertEqual(
+                    setup["working-directory"],
+                    "${{ steps.build_inputs.outputs.browseros_repo }}",
+                )
+                self.assertIn("macos-chromium-workspace.sh setup", setup["run"])
+                self.assertIn(
+                    "${{ steps.build_inputs.outputs.chromium_src }}",
+                    setup["run"],
+                )
+                self.assertEqual(
+                    build["env"]["CHROMIUM_SRC"],
+                    "${{ steps.chromium_workspace.outputs.chromium_src }}",
+                )
+                self.assertEqual(workspace_cleanup["if"], "always()")
+                self.assertEqual(
+                    workspace_cleanup["env"]["MACOS_CHROMIUM_WORKSPACE_STATE_PATH"],
+                    "${{ steps.chromium_workspace.outputs.state_path }}",
+                )
+                self.assertIn("macos-chromium-workspace.sh", workspace_cleanup["run"])
+                self.assertIn(" cleanup", workspace_cleanup["run"])
+                self.assertEqual(keychain_cleanup["if"], "always()")
+
     def test_nightlies_publish_rolling_release_after_the_build(self):
         for workflow_name, config in self.NIGHTLIES.items():
             workflow = self.load_workflow(workflow_name)
@@ -1513,6 +1629,340 @@ class NightlyWorkflowTest(unittest.TestCase):
         self.assertIn(".github/workflows/nightly-browseros.yml", paths)
         self.assertIn(".github/workflows/nightly-browserclaw.yml", paths)
         self.assertIn(".github/workflows/reserve-nightly-browser-version.yml", paths)
+
+
+@unittest.skipIf(os.name == "nt", "macOS signing helper shell tests run on POSIX")
+class MacOSChromiumWorkspaceHelperTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runner_temp = self.root / "runner"
+        self.runner_temp.mkdir()
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.github_env = self.root / "github_env"
+        self.github_output = self.root / "github_output"
+        self.git_log = self.root / "git.log"
+        self.cp_log = self.root / "cp.log"
+        self.version_file = self.root / "CHROMIUM_VERSION"
+        self.version_file.write_text(
+            "MAJOR=1\nMINOR=2\nBUILD=3\nPATCH=4\n",
+            encoding="utf-8",
+        )
+        self.base_root = self.root / "chromium-base"
+        self.base_src = self.base_root / "src"
+        self.base_src.mkdir(parents=True)
+        (self.base_root / ".gclient").write_text("solutions = []\n")
+        (self.base_src / ".git").mkdir()
+        self.base_root_resolved = self.base_root.resolve()
+        self.base_src_resolved = self.base_src.resolve()
+        self.head = "a" * 40
+        self._write_fake_uname()
+        self._write_fake_stat()
+        self._write_fake_git()
+        self._write_fake_cp()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write_fake_uname(self):
+        uname = self.bin_dir / "uname"
+        uname.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "${UNAME_VALUE:-Darwin}"
+"""
+        )
+        uname.chmod(0o755)
+
+    def _write_fake_stat(self):
+        stat = self.bin_dir / "stat"
+        stat.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+path="${@: -1}"
+if [ "${STAT_SPLIT_WORKSPACE_PARENT:-}" = "1" ] && [[ "$path" == *"browseros-ci-apfs-workspaces"* ]]; then
+  printf '222\\n'
+else
+  printf '111\\n'
+fi
+"""
+        )
+        stat.chmod(0o755)
+
+    def _write_fake_git(self):
+        git = self.bin_dir / "git"
+        git.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$GIT_LOG"
+if [ "${1:-}" = "-C" ]; then
+  shift 2
+fi
+cmd="${1:-}"
+shift || true
+case "$cmd" in
+  rev-parse)
+    target="${1:-}"
+    case "$target" in
+      HEAD)
+        printf '%s\\n' "${GIT_HEAD:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+        ;;
+      refs/tags/*)
+        printf '%s\\n' "${GIT_PIN_HEAD:-${GIT_HEAD:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}}"
+        ;;
+      *)
+        printf '%s\\n' "${GIT_HEAD:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+        ;;
+    esac
+    ;;
+  status)
+    printf '%b' "${GIT_STATUS:-}"
+    ;;
+esac
+"""
+        )
+        git.chmod(0o755)
+
+    def _write_fake_cp(self):
+        cp = self.bin_dir / "cp"
+        cp.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$CP_LOG"
+case "${1:-}" in
+  -c)
+    [ "${CP_FAIL_PROBE:-}" != "1" ] || exit 65
+    /bin/cp "$2" "$3"
+    ;;
+  -cR)
+    [ "${CP_FAIL_CLONE:-}" != "1" ] || exit 66
+    /bin/cp -R "$2" "$3"
+    ;;
+  *)
+    printf 'unexpected cp invocation: %s\\n' "$*" >&2
+    exit 64
+    ;;
+esac
+"""
+        )
+        cp.chmod(0o755)
+
+    def _env(self, **overrides):
+        env = os.environ.copy()
+        env.update(
+            {
+                "BROWSEROS_CHROMIUM_VERSION_FILE": str(self.version_file),
+                "CP_LOG": str(self.cp_log),
+                "GIT_HEAD": self.head,
+                "GIT_LOG": str(self.git_log),
+                "GITHUB_ENV": str(self.github_env),
+                "GITHUB_OUTPUT": str(self.github_output),
+                "GITHUB_RUN_ATTEMPT": "4",
+                "GITHUB_RUN_ID": "123",
+                "PATH": f"{self.bin_dir}{os.pathsep}{env['PATH']}",
+                "RUNNER_TEMP": str(self.runner_temp),
+            }
+        )
+        env.update(overrides)
+        return env
+
+    def _run_helper(self, command, *args, **env_overrides):
+        return subprocess.run(
+            ["bash", str(MACOS_CHROMIUM_WORKSPACE_HELPER), command, *map(str, args)],
+            capture_output=True,
+            env=self._env(**env_overrides),
+            text=True,
+        )
+
+    def _outputs(self):
+        values = {}
+        if not self.github_output.exists():
+            return values
+        for line in self.github_output.read_text(encoding="utf-8").splitlines():
+            name, value = line.split("=", 1)
+            values[name] = value
+        return values
+
+    def _workspace_parent(self):
+        return self.base_root_resolved.parent / "browseros-ci-apfs-workspaces"
+
+    def _workspace_root(self, tag="123-4"):
+        return self._workspace_parent() / f"browseros-ci-chromium-{tag}"
+
+    def _state_path(self, tag="123-4"):
+        return self.runner_temp / f"browseros-ci-chromium-workspace-{tag}.env"
+
+    def _write_workspace_marker(self, workspace_root, tag="old-1"):
+        marker = workspace_root / ".browseros-workspace-state.env"
+        marker.write_text(
+            "\n".join(
+                (
+                    f"workspace_parent={self._workspace_parent()}",
+                    f"workspace_root={workspace_root}",
+                    f"workspace_src={workspace_root / 'src'}",
+                    f"base_root={self.base_root_resolved}",
+                    f"base_src={self.base_src_resolved}",
+                    f"base_head={self.head}",
+                    "chromium_version=1.2.3.4",
+                    f"run_tag={tag}",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    def test_setup_clones_gclient_root_and_cleanup_removes_workspace_only(self):
+        result = self._run_helper("setup", self.base_src)
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+
+        outputs = self._outputs()
+        workspace_root = Path(outputs["workspace_root"])
+        workspace_src = Path(outputs["chromium_src"])
+        state_path = Path(outputs["state_path"])
+
+        self.assertEqual(workspace_src, workspace_root / "src")
+        self.assertEqual(outputs["base_src"], str(self.base_src_resolved))
+        self.assertEqual(outputs["base_head"], self.head)
+        self.assertTrue((workspace_root / ".gclient").is_file())
+        self.assertTrue((workspace_src / ".git").is_dir())
+        self.assertTrue((workspace_root / ".browseros-workspace-state.env").is_file())
+        self.assertTrue(state_path.is_file())
+        self.assertTrue(self.base_src.is_dir())
+
+        env_lines = self.github_env.read_text(encoding="utf-8").splitlines()
+        self.assertIn(f"CHROMIUM_SRC={workspace_src}", env_lines)
+        self.assertIn(
+            f"MACOS_CHROMIUM_WORKSPACE_STATE_PATH={state_path}",
+            env_lines,
+        )
+        cp_lines = self.cp_log.read_text(encoding="utf-8").splitlines()
+        self.assertTrue(any(line.startswith("-c ") for line in cp_lines))
+        self.assertTrue(any(line.startswith("-cR ") for line in cp_lines))
+        self.assertFalse(any(line.startswith("-R ") for line in cp_lines))
+
+        cleanup = self._run_helper(
+            "cleanup",
+            MACOS_CHROMIUM_WORKSPACE_STATE_PATH=str(state_path),
+        )
+        self.assertEqual(cleanup.returncode, 0, cleanup.stderr + cleanup.stdout)
+        self.assertFalse(workspace_root.exists())
+        self.assertFalse(state_path.exists())
+        self.assertTrue(self.base_src.is_dir())
+
+    def test_setup_reaps_only_marked_stale_owned_workspaces(self):
+        parent = self._workspace_parent()
+        parent.mkdir()
+        stale = self._workspace_root("old-1")
+        stale.mkdir()
+        (stale / "src").mkdir()
+        self._write_workspace_marker(stale, tag="old-1")
+        unmarked = self._workspace_root("unmarked")
+        unmarked.mkdir()
+
+        result = self._run_helper("setup", self.base_src)
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertFalse(stale.exists())
+        self.assertTrue(unmarked.exists())
+        self.assertTrue(Path(self._outputs()["workspace_root"]).exists())
+        self.assertTrue(self.base_root.exists())
+
+    def test_cleanup_ignores_unsafe_state_target(self):
+        state_path = self._state_path()
+        state_path.write_text(
+            "\n".join(
+                (
+                    f"workspace_parent={self.root}",
+                    "workspace_root=/",
+                    "workspace_src=/src",
+                    f"base_root={self.base_root}",
+                    f"base_src={self.base_src}",
+                    f"base_head={self.head}",
+                    "chromium_version=1.2.3.4",
+                    "run_tag=old-1",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = self._run_helper("cleanup")
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("Ignoring unexpected Chromium workspace path", result.stderr)
+        self.assertFalse(state_path.exists())
+        self.assertTrue(self.base_root.exists())
+
+    def test_setup_rejects_unowned_state_path(self):
+        outside_state = self.root / "outside.env"
+
+        result = self._run_helper(
+            "setup",
+            self.base_src,
+            MACOS_CHROMIUM_WORKSPACE_STATE_PATH=str(outside_state),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Unexpected macOS Chromium workspace state path",
+            result.stderr + result.stdout,
+        )
+        self.assertFalse(outside_state.exists())
+
+    def test_setup_fails_when_workspace_parent_is_not_on_base_volume(self):
+        result = self._run_helper(
+            "setup",
+            self.base_src,
+            STAT_SPLIT_WORKSPACE_PARENT="1",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "workspace parent is not on the base checkout volume",
+            result.stderr + result.stdout,
+        )
+        self.assertFalse(self._workspace_root().exists())
+
+    def test_setup_fails_without_full_copy_fallback_when_apfs_clone_fails(self):
+        result = self._run_helper("setup", self.base_src, CP_FAIL_CLONE="1")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self._workspace_root().exists())
+        self.assertFalse(
+            self._state_path().exists()
+        )
+        cp_lines = self.cp_log.read_text(encoding="utf-8").splitlines()
+        self.assertTrue(any(line.startswith("-cR ") for line in cp_lines))
+        self.assertFalse(any(line.startswith("-R ") for line in cp_lines))
+
+    def test_setup_fails_when_base_is_not_at_pinned_chromium_tag(self):
+        result = self._run_helper("setup", self.base_src, GIT_PIN_HEAD="b" * 40)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not match pinned", result.stderr + result.stdout)
+        self.assertFalse(self._workspace_root().exists())
+
+    def test_setup_fails_when_base_has_tracked_changes(self):
+        result = self._run_helper(
+            "setup",
+            self.base_src,
+            GIT_STATUS=" M chrome/app/generated_resources.grd\n",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("tracked changes", result.stderr + result.stdout)
+        self.assertFalse(self._workspace_root().exists())
+
+    def test_setup_fails_when_base_has_browseros_output_dirs(self):
+        out_dir = self.base_src / "out" / "Default_browseros_arm64"
+        out_dir.mkdir(parents=True)
+
+        result = self._run_helper("setup", self.base_src)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("BrowserOS output state", result.stderr + result.stdout)
+        self.assertFalse(self._workspace_root().exists())
 
 
 @unittest.skipIf(os.name == "nt", "macOS signing helper shell tests run on POSIX")

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -1868,6 +1868,26 @@ esac
         self.assertTrue(Path(self._outputs()["workspace_root"]).exists())
         self.assertTrue(self.base_root.exists())
 
+    def test_setup_reaps_stale_workspaces_before_dirty_base_failure(self):
+        parent = self._workspace_parent()
+        parent.mkdir()
+        stale = self._workspace_root("old-1")
+        stale.mkdir()
+        (stale / "src").mkdir()
+        self._write_workspace_marker(stale, tag="old-1")
+
+        result = self._run_helper(
+            "setup",
+            self.base_src,
+            GIT_STATUS=" M chrome/app/generated_resources.grd\n",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("tracked changes", result.stderr + result.stdout)
+        self.assertFalse(stale.exists())
+        self.assertFalse(self._workspace_root().exists())
+        self.assertTrue(self.base_root.exists())
+
     def test_cleanup_ignores_unsafe_state_target(self):
         state_path = self._state_path()
         state_path.write_text(

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -1696,7 +1696,9 @@ fi
             """#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$*" >> "$GIT_LOG"
+repo=""
 if [ "${1:-}" = "-C" ]; then
+  repo="$2"
   shift 2
 fi
 cmd="${1:-}"
@@ -1717,7 +1719,13 @@ case "$cmd" in
     esac
     ;;
   status)
-    printf '%b' "${GIT_STATUS:-}"
+    if [ -n "${GIT_DIRTY_REPO:-}" ]; then
+      if [ "$repo" = "$GIT_DIRTY_REPO" ]; then
+        printf '%b' "${GIT_DIRTY_STATUS:- M nested-change\\n}"
+      fi
+    else
+      printf '%b' "${GIT_STATUS:-}"
+    fi
     ;;
 esac
 """
@@ -1883,7 +1891,7 @@ esac
         )
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("tracked changes", result.stderr + result.stdout)
+        self.assertIn("tracked or untracked changes", result.stderr + result.stdout)
         self.assertFalse(stale.exists())
         self.assertFalse(self._workspace_root().exists())
         self.assertTrue(self.base_root.exists())
@@ -1971,7 +1979,35 @@ esac
         )
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("tracked changes", result.stderr + result.stdout)
+        self.assertIn("tracked or untracked changes", result.stderr + result.stdout)
+        self.assertFalse(self._workspace_root().exists())
+
+    def test_setup_fails_when_base_has_untracked_changes(self):
+        result = self._run_helper(
+            "setup",
+            self.base_src,
+            GIT_STATUS="?? chrome/browser/browseros/generated_resources.grd\n",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("tracked or untracked changes", result.stderr + result.stdout)
+        self.assertFalse(self._workspace_root().exists())
+
+    def test_setup_fails_when_nested_gclient_repo_has_changes(self):
+        nested_repo = self.base_src / "third_party" / "v8"
+        nested_repo.mkdir(parents=True)
+        (nested_repo / ".git").mkdir()
+
+        result = self._run_helper(
+            "setup",
+            self.base_src,
+            GIT_DIRTY_REPO=str(nested_repo.resolve()),
+            GIT_DIRTY_STATUS=" M src/builtins/generated.cc\n",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(str(nested_repo.resolve()), result.stderr + result.stdout)
+        self.assertIn("tracked or untracked changes", result.stderr + result.stdout)
         self.assertFalse(self._workspace_root().exists())
 
     def test_setup_fails_when_base_has_browseros_output_dirs(self):

--- a/packages/browseros/bos_build/docs/nightly-macos-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-macos-ci.md
@@ -131,7 +131,7 @@ Only the final browser job joins the shared `macos-build` concurrency group.
 `queue: max` retains up to 100 pending browser jobs in FIFO order instead of
 letting a newer run replace an older pending one. Server and extension jobs run
 before the Mac lock is requested. Full releases and both nightlies share this
-lock, so they cannot mutate the persistent checkout simultaneously.
+lock.
 
 Run the Mac runner in the logged-in GUI user's session. Codesign and
 `xcrun notarytool` need that user's keychain; daemon or SSH-only sessions
@@ -140,7 +140,8 @@ commonly fail with `User interaction not allowed`.
 The machine needs:
 
 - A persistent BrowserOS checkout.
-- A persistent Chromium `src` checkout at the repository pin.
+- A persistent pristine Chromium `src` checkout at the repository pin, used
+  only as the APFS clone base.
 - `uv`, `gh`, depot_tools, Xcode tools, and Chrome.
 - The macOS signing identity and notarization credentials.
 - Enough disk for Chromium outputs and DMGs.
@@ -150,11 +151,19 @@ Set these repository variables:
 | Variable | Meaning |
 | --- | --- |
 | `BROWSEROS_REPO_PATH` | Absolute path to the persistent BrowserOS checkout |
-| `BROWSEROS_CHROMIUM_SRC` | Absolute path to Chromium `src` |
+| `BROWSEROS_CHROMIUM_SRC` | Absolute path to the warm pristine Chromium base `src` |
 
 Component, R2, signing, and notarization credentials come from GitHub Actions
 secrets. `SLACK_WEBHOOK_URL` is optional and receives failures after the Mac job
 has started.
+
+Before each signed browser build, `.github/scripts/macos-chromium-workspace.sh`
+validates the base checkout and creates a run/attempt-specific APFS
+copy-on-write clone of the whole gclient root under
+`../browseros-ci-apfs-workspaces/`. `bos_build` receives the clone's `src`, so
+cleaning, patching, compiling, signing, packaging, and universal merge outputs
+stay inside the disposable workspace. Cleanup runs with `if: always()`, and the
+next setup reaps abandoned owned workspaces from killed jobs.
 
 ## Troubleshooting
 
@@ -170,6 +179,11 @@ extension manifest were published.
 
 `User interaction not allowed`: run the runner as the logged-in GUI user and
 verify `MACOS_KEYCHAIN_PASSWORD` and the signing identity.
+
+APFS workspace setup fails: confirm the base checkout is on APFS, the helper can
+create a same-volume `browseros-ci-apfs-workspaces` sibling directory, the base
+`src` is at `packages/browseros/CHROMIUM_VERSION`, and the base has no
+BrowserOS output directories or tracked patch/resource changes.
 
 No browser version commit: inspect the hosted `Reserve new browser version on
 main` job. It requires `contents: write` and `pull-requests: write`, plus branch

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -185,6 +185,9 @@ matching signing key and build-time secrets.
 
 Windows signing needs the eSigner secrets and `SPARKLE_PRIVATE_KEY`. macOS uses
 repository variables `BROWSEROS_REPO_PATH` and `BROWSEROS_CHROMIUM_SRC` plus
-the signing and notarization secrets on the persistent builder. Runner labels,
-cache behavior, and queue recovery are documented in `warpbuild-ci.md`;
-persistent macOS setup is in `nightly-macos-ci.md`.
+the signing and notarization secrets on the persistent builder.
+`BROWSEROS_CHROMIUM_SRC` is the pristine APFS clone base; the release build
+runs against a disposable copy-on-write workspace and cleans it under
+`if: always()`. Runner labels, cache behavior, and queue recovery are
+documented in `warpbuild-ci.md`; persistent macOS setup is in
+`nightly-macos-ci.md`.

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -1131,12 +1131,12 @@ class PublisherTestCase(unittest.TestCase):
         self.assertEqual((spec.kind, spec.channel), ("extensions", "alpha"))
         self.assertEqual(
             set(extract_manifest_versions(manifest).values()),
-            {"0.0.131.0", "54.0.0.0", "0.2.6.0"},
+            {"0.0.132.0", "54.0.0.0", "0.2.7.0"},
         )
         original = manifest.replace("</gupdate>", "  </app>\n</gupdate>")
         self.assertEqual(
             hashlib.sha256(original.encode()).hexdigest(),
-            "fc21e4747c904a7f74e9bfec17197e18349a596e2b8653356a1c8a9dfaaba219",
+            "9ba4ec047af45f6e54551f5100096de09d9ba5229a3ecd2853f0e4ddc94ee262",
         )
 
     def test_browserclaw_snapshots_use_current_product_title(self):


### PR DESCRIPTION
## Summary
- add an owned macOS Chromium APFS workspace helper that validates a pristine base, proves COW clone support, clones the full gclient root, records base identity, and safely cleans owned workspaces
- wire signed macOS release and both signed nightly workflows to build against the disposable clone src and clean it under `if: always()`
- add workflow and mocked shell tests plus runbook notes for the new lifecycle

## Verification
- `cd packages/browseros && uv run python -m unittest discover -s bos_build -t . -p "*_test.py"`
- `cd packages/browseros && uv run ruff check bos_build`
- `python3 -m unittest discover -s tools/release_secrets -t . -p "*_test.py"`
- `bash -n .github/scripts/macos-chromium-workspace.sh .github/scripts/macos-signing-keychain.sh`
- `git diff --check`

## Note
- `actionlint` still flags the repo-existing `queue: max` concurrency key in these workflows; this PR leaves that scoped behavior unchanged because existing tests assert it.