### PR TITLE
fix(build): verify resume checkpoints

### DIFF
--- a/packages/browseros/bos_build/cli/build.py
+++ b/packages/browseros/bos_build/cli/build.py
@@ -26,6 +26,11 @@ from ..core.planner import (
     required_env,
     slice_runs_from,
 )
+from ..core.resume import (
+    ResumeValidationError,
+    attach_resume_state,
+    validate_resume_before_execution,
+)
 from ..core.resolver import resolve_config, resolve_pipeline
 from ..lib.notify import slack_subscriber
 from ..release.lane import write_lane_manifest
@@ -458,9 +463,10 @@ def _execute_runs(
     # per-step static checks) for EVERY arch before any run starts — a
     # misconfigured second arch must not surface after hours of arch one.
     try:
+        validate_resume_before_execution(runs)
         for run_ctx, run_steps in runs:
             preflight(run_steps, ctx=run_ctx)
-    except ValueError as e:
+    except (ResumeValidationError, ValueError) as e:
         log_error(str(e))
         raise typer.Exit(1)
 
@@ -632,7 +638,8 @@ def _resolve_preset(
 
         # Runs execute sequentially (universal is three runs on one tree),
         # so --from resumes the run timeline, not each run.
-        arch_plans = plan_runs(switches)
+        full_arch_plans = plan_runs(switches)
+        arch_plans = full_arch_plans
         if from_ is not None:
             arch_plans = slice_runs_from(arch_plans, from_)
 
@@ -703,7 +710,7 @@ def _resolve_preset(
                         )
                 else:
                     resolved_source_sha = ""
-                return [
+                runs = [
                     (
                         Context(
                             chromium_src=src,
@@ -721,6 +728,13 @@ def _resolve_preset(
                     )
                     for run_arch, steps in arch_plans
                 ]
+                attach_resume_state(
+                    runs,
+                    full_arch_plans,
+                    resume_from=from_,
+                    strict=from_ is not None,
+                )
+                return runs
             except ValueError as e:
                 log_error(str(e))
                 raise typer.Exit(1)

--- a/packages/browseros/bos_build/cli/build_test.py
+++ b/packages/browseros/bos_build/cli/build_test.py
@@ -15,17 +15,20 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
+import typer
 from typer.testing import CliRunner
 
 from bos_build.browseros import app
 from bos_build.cli.build import (
     _PlanProjection,
+    _execute_runs,
     _parse_toolchain_ids,
     _resolve_preset,
     _resolve_source_sha,
 )
 from bos_build.core.checkout_lock import ChromiumCheckoutLock
 from bos_build.core.planner import Switches, plan
+from bos_build.core.resume import ResumeState
 from bos_build.lib.testing import MockChromium
 from bos_build.lib.utils import get_platform, get_platform_arch
 
@@ -348,6 +351,80 @@ class CheckoutLockCliTest(unittest.TestCase):
                     proc.kill()
                     proc.join(5)
             self.assertEqual(proc.exitcode, 0)
+
+
+class ResumeValidationCliTest(unittest.TestCase):
+    def _ctx(self, tmp: Path, resume_state=None):
+        return SimpleNamespace(
+            chromium_src=tmp,
+            product=SimpleNamespace(id="browseros"),
+            architecture="x64",
+            build_type="release",
+            extra_gn_args=(),
+            semantic_version="0.31.0",
+            chromium_version="137.0.7151.69",
+            browseros_build_offset="80",
+            resume_state=resume_state,
+        )
+
+    def _resume_state(self, strict: bool) -> ResumeState:
+        return ResumeState(
+            full_arch_plans=(("x64", ("compile", "sign_macos")),),
+            resume_from="sign_macos",
+            candidate={"schema": "test"},
+            candidate_digest="digest",
+            strict=strict,
+        )
+
+    def test_strict_resume_missing_checkpoint_stops_before_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = self._ctx(Path(tmp), self._resume_state(strict=True))
+            with (
+                mock.patch("bos_build.cli.build.run_pipeline") as run_pipeline,
+                self.assertRaises(typer.Exit),
+            ):
+                _execute_runs(
+                    [(ctx, ["sign_macos"])],
+                    has_flags=False,
+                    prep=False,
+                    root_dir=Path(tmp),
+                )
+
+        run_pipeline.assert_not_called()
+
+    def test_nonstrict_resume_state_does_not_require_checkpoints(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = self._ctx(Path(tmp), self._resume_state(strict=False))
+            with (
+                mock.patch("bos_build.cli.build.preflight"),
+                mock.patch("bos_build.cli.build.slack_subscriber", return_value=lambda event: None),
+                mock.patch("bos_build.cli.build.run_pipeline") as run_pipeline,
+            ):
+                _execute_runs(
+                    [(ctx, ["compile"])],
+                    has_flags=False,
+                    prep=False,
+                    root_dir=Path(tmp),
+                )
+
+        run_pipeline.assert_called_once()
+
+    def test_context_without_resume_state_keeps_direct_execution(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = self._ctx(Path(tmp), resume_state=None)
+            with (
+                mock.patch("bos_build.cli.build.preflight"),
+                mock.patch("bos_build.cli.build.slack_subscriber", return_value=lambda event: None),
+                mock.patch("bos_build.cli.build.run_pipeline") as run_pipeline,
+            ):
+                _execute_runs(
+                    [(ctx, ["compile"])],
+                    has_flags=False,
+                    prep=False,
+                    root_dir=Path(tmp),
+                )
+
+        run_pipeline.assert_called_once()
 
 
 class ModulesProfileCliTest(_ProfileMixin):

--- a/packages/browseros/bos_build/core/context.py
+++ b/packages/browseros/bos_build/core/context.py
@@ -90,6 +90,7 @@ class Context:
     prepared_resources: Optional[Path] = None
     prepared_resources_supplied: bool = False
     source_sha: str = ""
+    resume_state: Any = None
 
     # Third party pins
     SPARKLE_VERSION: str = "2.7.0"

--- a/packages/browseros/bos_build/core/resume.py
+++ b/packages/browseros/bos_build/core/resume.py
@@ -25,6 +25,14 @@ CONTRACT_SCHEMA = "browseros-build-resume-contract-v1"
 CHECKPOINT_ROOT = ".browseros_resume"
 _HASH_CHUNK_SIZE = 1024 * 1024
 _CHROMIUM_MUTATION_EXCLUDES = ("out", "chrome/VERSION")
+_CHROMIUM_MUTATION_STEPS = frozenset(
+    {
+        "chromium_replace",
+        "string_replaces",
+        "series_patches",
+        "patches",
+    }
+)
 
 
 class ResumeValidationError(ValueError):
@@ -108,8 +116,15 @@ def validate_resume_before_execution(
         state.full_arch_plans, state.resume_from
     ):
         ctx = contexts.get(arch) or _context_for_arch(base_ctx, arch)
+        latest_mutation = _latest_mutation_step(completed_steps)
         for step_name in completed_steps:
-            checkpoint = _validated_checkpoint(ctx, step_name, state)
+            checkpoint = _validated_checkpoint(
+                ctx,
+                step_name,
+                state,
+                validate_chromium_mutation=step_name == latest_mutation
+                or step_name not in _CHROMIUM_MUTATION_STEPS,
+            )
             if arch in contexts:
                 _restore_registry(contexts[arch], checkpoint)
 
@@ -175,6 +190,9 @@ def write_step_checkpoint(
     if state is None or not state.enabled:
         return
     step_name = step.name or step.__class__.__name__
+    recorded_steps = _steps_for_arch(state.full_arch_plans, ctx.architecture)
+    if not recorded_steps:
+        recorded_steps = tuple(run_steps)
     document = {
         "schema": CHECKPOINT_SCHEMA,
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -186,7 +204,7 @@ def write_step_checkpoint(
         "platform": get_platform(),
         "out_dir": ctx.out_dir,
         "step": step_name,
-        "run_steps": list(run_steps),
+        "run_steps": list(recorded_steps),
         "chromium_checkout": _chromium_checkout_identity(ctx),
         "registry": _registry_entries(ctx, step),
         "snapshots": _step_snapshots(ctx, step_name),
@@ -416,12 +434,7 @@ def _step_snapshots(ctx: Context, step_name: str) -> list[dict[str, Any]]:
             "bundled_extensions",
             ctx.chromium_src / "chrome/browser/browseros/bundled_extensions",
         )
-    elif step_name in {
-        "chromium_replace",
-        "string_replaces",
-        "series_patches",
-        "patches",
-    }:
+    elif step_name in _CHROMIUM_MUTATION_STEPS:
         digest = _chromium_mutation_digest(ctx)
         if digest:
             snapshots.append({"kind": "chromium_mutation", **digest})
@@ -448,6 +461,8 @@ def _validated_checkpoint(
     ctx: Context,
     step_name: str,
     state: ResumeState,
+    *,
+    validate_chromium_mutation: bool = True,
 ) -> Mapping[str, Any]:
     path = checkpoint_path(ctx, step_name)
     try:
@@ -473,7 +488,12 @@ def _validated_checkpoint(
     for entry in document.get("registry", []):
         _validate_registry_entry(ctx.architecture, step_name, entry)
     for snapshot in document.get("snapshots", []):
-        _validate_snapshot(ctx.architecture, step_name, snapshot)
+        _validate_snapshot(
+            ctx.architecture,
+            step_name,
+            snapshot,
+            validate_chromium_mutation=validate_chromium_mutation,
+        )
     return document
 
 
@@ -540,7 +560,13 @@ def _validate_registry_entry(arch: str, step_name: str, entry: Any) -> None:
         raise _mismatch(arch, step_name, "registry entry kind is unsupported")
 
 
-def _validate_snapshot(arch: str, step_name: str, snapshot: Any) -> None:
+def _validate_snapshot(
+    arch: str,
+    step_name: str,
+    snapshot: Any,
+    *,
+    validate_chromium_mutation: bool,
+) -> None:
     if not isinstance(snapshot, dict):
         raise _mismatch(arch, step_name, "snapshot is invalid")
     if snapshot.get("kind") == "path":
@@ -553,6 +579,8 @@ def _validate_snapshot(arch: str, step_name: str, snapshot: Any) -> None:
         )
         return
     if snapshot.get("kind") == "chromium_mutation":
+        if not validate_chromium_mutation:
+            return
         current = _chromium_mutation_digest_for_root(
             Path(str(snapshot.get("root", "")))
         )
@@ -631,6 +659,13 @@ def _completed_steps_before(
             return completed
         completed.append((arch, tuple(steps)))
     return completed
+
+
+def _latest_mutation_step(completed_steps: Sequence[str]) -> str:
+    for step_name in reversed(completed_steps):
+        if step_name in _CHROMIUM_MUTATION_STEPS:
+            return step_name
+    return ""
 
 
 def _steps_for_arch(

--- a/packages/browseros/bos_build/core/resume.py
+++ b/packages/browseros/bos_build/core/resume.py
@@ -1,0 +1,1008 @@
+#!/usr/bin/env python3
+"""Versioned resume checkpoint validation."""
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+from .context import Context
+from .step import Step
+from ..lib.utils import get_platform
+from ..products.resource_sources import source_resources_for_product
+
+CHECKPOINT_SCHEMA = "browseros-build-resume-checkpoint-v1"
+CONTRACT_SCHEMA = "browseros-build-resume-contract-v1"
+CHECKPOINT_ROOT = ".browseros_resume"
+_HASH_CHUNK_SIZE = 1024 * 1024
+_CHROMIUM_MUTATION_EXCLUDES = ("out", "chrome/VERSION")
+
+
+class ResumeValidationError(ValueError):
+    """Raised when a resume checkpoint cannot prove the requested state."""
+
+
+@dataclass(frozen=True)
+class ResumeState:
+    full_arch_plans: tuple[tuple[str, tuple[str, ...]], ...]
+    resume_from: str | None
+    candidate: Mapping[str, Any]
+    candidate_digest: str
+    strict: bool = False
+    unresumable_reason: str = ""
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.candidate_digest) and not self.unresumable_reason
+
+
+def make_resume_state(
+    ctx: Context,
+    full_arch_plans: Sequence[tuple[str, Sequence[str]]],
+    *,
+    resume_from: str | None,
+    strict: bool,
+) -> ResumeState:
+    plans = tuple((arch, tuple(steps)) for arch, steps in full_arch_plans)
+    try:
+        candidate = _candidate_contract(ctx, plans)
+    except _Unresumable as exc:
+        return ResumeState(plans, resume_from, {}, "", strict, str(exc))
+    return ResumeState(
+        plans,
+        resume_from,
+        candidate,
+        _json_digest(candidate),
+        strict,
+    )
+
+
+def attach_resume_state(
+    runs: Sequence[tuple[Context, Sequence[str]]],
+    full_arch_plans: Sequence[tuple[str, Sequence[str]]],
+    *,
+    resume_from: str | None,
+    strict: bool,
+) -> None:
+    if not runs:
+        return
+    base_state = make_resume_state(
+        runs[0][0],
+        full_arch_plans,
+        resume_from=resume_from,
+        strict=strict,
+    )
+    for ctx, _steps in runs:
+        ctx.resume_state = base_state
+
+
+def validate_resume_before_execution(
+    runs: Sequence[tuple[Context, Sequence[str]]],
+) -> None:
+    states = [state for ctx, _steps in runs if (state := _state(ctx)) is not None]
+    if not states or not states[0].strict:
+        return
+    state = states[0]
+    if state.unresumable_reason:
+        raise ResumeValidationError(
+            _restart_message(
+                "Resume state cannot be proven: " + state.unresumable_reason,
+                state.resume_from or "the requested step",
+            )
+        )
+    if not state.resume_from:
+        return
+
+    contexts = {ctx.architecture: ctx for ctx, _steps in runs}
+    base_ctx = runs[0][0]
+    for arch, completed_steps in _completed_steps_before(
+        state.full_arch_plans, state.resume_from
+    ):
+        ctx = contexts.get(arch) or _context_for_arch(base_ctx, arch)
+        for step_name in completed_steps:
+            checkpoint = _validated_checkpoint(ctx, step_name, state)
+            if arch in contexts:
+                _restore_registry(contexts[arch], checkpoint)
+
+
+def validate_universal_inputs(ctx: Context, architectures: Sequence[str]) -> None:
+    state = _state(ctx)
+    if state is None:
+        return
+    if state.unresumable_reason:
+        raise ResumeValidationError(
+            _restart_message(
+                "Universal input provenance cannot be proven: "
+                + state.unresumable_reason,
+                "clean",
+            )
+        )
+    expected = tuple(architectures)
+    seen = []
+    for arch in expected:
+        arch_ctx = _context_for_arch(ctx, arch)
+        checkpoint = _validated_checkpoint(arch_ctx, "sign_macos", state)
+        if checkpoint.get("architecture") != arch:
+            raise _mismatch(
+                arch,
+                "sign_macos",
+                f"architecture mismatch: expected {arch}, got "
+                f"{checkpoint.get('architecture')!r}",
+            )
+        _require_attested_path(checkpoint, "signed_app", arch, "sign_macos")
+        seen.append(checkpoint.get("architecture"))
+    if tuple(seen) != expected:
+        raise ResumeValidationError(
+            _restart_message(
+                f"Universal input architecture set mismatch: expected "
+                f"{', '.join(expected)}, got {', '.join(str(item) for item in seen)}",
+                "merge_universal",
+            )
+        )
+
+
+def invalidate_checkpoints_from(
+    ctx: Context,
+    run_steps: Sequence[str],
+    step_name: str,
+) -> None:
+    state = _state(ctx)
+    if state is None:
+        return
+    try:
+        start = list(run_steps).index(step_name)
+    except ValueError:
+        return
+    for name in run_steps[start:]:
+        checkpoint_path(ctx, name).unlink(missing_ok=True)
+
+
+def write_step_checkpoint(
+    ctx: Context,
+    step: Step,
+    run_steps: Sequence[str],
+) -> None:
+    state = _state(ctx)
+    if state is None or not state.enabled:
+        return
+    step_name = step.name or step.__class__.__name__
+    document = {
+        "schema": CHECKPOINT_SCHEMA,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "candidate_digest": state.candidate_digest,
+        "candidate": state.candidate,
+        "product": ctx.product.id,
+        "architecture": ctx.architecture,
+        "build_type": ctx.build_type,
+        "platform": get_platform(),
+        "out_dir": ctx.out_dir,
+        "step": step_name,
+        "run_steps": list(run_steps),
+        "chromium_checkout": _chromium_checkout_identity(ctx),
+        "registry": _registry_entries(ctx, step),
+        "snapshots": _step_snapshots(ctx, step_name),
+    }
+    _atomic_write_json(checkpoint_path(ctx, step_name), document)
+
+
+def remove_checkpoint_dirs(ctx: Context, architectures: Sequence[str]) -> None:
+    for architecture in architectures:
+        shutil.rmtree(checkpoint_dir(ctx, architecture), ignore_errors=True)
+
+
+def checkpoint_dir(ctx: Context, architecture: str | None = None) -> Path:
+    return (
+        ctx.chromium_src
+        / "out"
+        / CHECKPOINT_ROOT
+        / ctx.product.id
+        / ctx.build_type
+        / (architecture or ctx.architecture)
+    )
+
+
+def checkpoint_path(
+    ctx: Context,
+    step_name: str,
+    architecture: str | None = None,
+) -> Path:
+    return checkpoint_dir(ctx, architecture) / f"{step_name}.json"
+
+
+class _Unresumable(RuntimeError):
+    pass
+
+
+def _state(ctx: Context) -> ResumeState | None:
+    state = getattr(ctx, "resume_state", None)
+    return state if isinstance(state, ResumeState) else None
+
+
+def _candidate_contract(
+    ctx: Context,
+    full_arch_plans: tuple[tuple[str, tuple[str, ...]], ...],
+) -> dict[str, Any]:
+    return {
+        "schema": CONTRACT_SCHEMA,
+        "product": ctx.product.id,
+        "build_type": ctx.build_type,
+        "platform": get_platform(),
+        "plan_architectures": list(ctx.plan_architectures),
+        "full_arch_plans": [
+            {"architecture": arch, "steps": list(steps)}
+            for arch, steps in full_arch_plans
+        ],
+        "versions": {
+            "chromium": ctx.chromium_version,
+            "browseros_chromium": ctx.browseros_chromium_version,
+            "semantic": ctx.semantic_version,
+            "build_offset": ctx.browseros_build_offset,
+        },
+        "browseros_source": _browseros_source_identity(ctx),
+        "chromium_pin": {"version": ctx.chromium_version},
+        "configuration": _configuration_identity(ctx),
+        "resources": _resource_identity(ctx),
+    }
+
+
+def _browseros_source_identity(ctx: Context) -> dict[str, Any]:
+    repo_root = ctx.root_dir.parent.parent.resolve()
+    head = _git_text(["rev-parse", "HEAD"], repo_root)
+    if not _is_full_sha(head):
+        raise _Unresumable("BrowserOS source checkout HEAD is not a full SHA")
+    top = _git_text(["rev-parse", "--show-toplevel"], repo_root)
+    paths = _git_changed_paths(repo_root)
+    identity: dict[str, Any] = {
+        "kind": "git-clean" if not paths else "git-dirty",
+        "root": top,
+        "head": head,
+    }
+    if paths:
+        identity["dirty_digest"] = _changed_paths_digest(repo_root, paths)
+        identity["dirty_paths"] = paths
+    if ctx.source_sha and ctx.source_sha != head:
+        raise _Unresumable("Context source SHA does not match BrowserOS HEAD")
+    return identity
+
+
+def _configuration_identity(ctx: Context) -> dict[str, Any]:
+    paths = {
+        "gn_flags": ctx.gn_flags_file,
+        "copy_resources": ctx.get_copy_resources_config(),
+        "download_resources": ctx.get_download_resources_config(),
+    }
+    return {
+        "extra_gn_args": list(ctx.extra_gn_args),
+        "files": {
+            name: _file_identity(path) if path else {"missing": True}
+            for name, path in paths.items()
+        },
+    }
+
+
+def _resource_identity(ctx: Context) -> dict[str, Any]:
+    if ctx.resource_mode == "source":
+        identity: dict[str, Any] = {
+            "mode": "source",
+            "source_sha": ctx.source_sha,
+            "prepared_resources": str(ctx.prepared_resources or ""),
+        }
+        if ctx.prepared_resources and ctx.prepared_resources.exists():
+            from ..release.prepared_resources import load_prepared_resources
+
+            manifest = load_prepared_resources(ctx.prepared_resources)
+            identity.update(
+                {
+                    "prepared_digest": manifest.digest(),
+                    "component_versions": dict(manifest.component_versions),
+                }
+            )
+        return identity
+
+    source = source_resources_for_product(ctx.product.id)
+    server_version = (
+        ctx.env.browseros_server_resource_version
+        if ctx.product.id == "browseros"
+        else ctx.env.browserclaw_server_resource_version
+    )
+    components = {
+        source.server_component: server_version,
+        source.extension_component: ctx.env.bundled_product_extension_version,
+        source.onboarding_component: ctx.env.browserclaw_onboard_resource_version,
+    }
+    missing = [name for name, value in components.items() if not value]
+    if missing:
+        raise _Unresumable(
+            "published resources require exact component pins: "
+            + ", ".join(sorted(missing))
+        )
+    return {
+        "mode": "published",
+        "component_versions": components,
+        "bundled_manifest_url": ctx.get_extensions_manifest_url(),
+    }
+
+
+def _registry_entries(ctx: Context, step: Step) -> list[dict[str, Any]]:
+    names = set(step.produces)
+    step_name = step.name or step.__class__.__name__
+    if step_name == "package_windows":
+        names.add("built_app")
+    if step_name == "bundled_extensions":
+        names.add("common_manifest_digest")
+
+    entries = []
+    registry = ctx.artifact_registry
+    for name in sorted(names):
+        if not registry.has(name):
+            continue
+        value = registry.get(name)
+        entry = _registry_entry(name, value)
+        if entry is not None:
+            entries.append(entry)
+    return entries
+
+
+def _registry_entry(name: str, value: Any) -> dict[str, Any] | None:
+    if isinstance(value, Path):
+        return {
+            "name": name,
+            "kind": "path",
+            "path": str(value),
+            "attestation": _path_attestation(value),
+        }
+    if name == "sparkle_signatures" and isinstance(value, dict):
+        return {
+            "name": name,
+            "kind": "sparkle_signatures",
+            "value": {
+                str(filename): [str(signature), int(length)]
+                for filename, (signature, length) in value.items()
+            },
+        }
+    if name == "server_resources" and isinstance(value, dict):
+        return {
+            "name": name,
+            "kind": "server_resources",
+            "value": {
+                str(target): {
+                    "product": str(result.product),
+                    "target": str(result.target),
+                    "version": str(result.version),
+                    "source_sha": str(result.source_sha),
+                    "destination": str(result.destination),
+                    "manifest_sha256": str(result.manifest_sha256),
+                }
+                for target, result in value.items()
+            },
+        }
+    if _json_safe(value):
+        return {"name": name, "kind": "json", "value": value}
+    return None
+
+
+def _step_snapshots(ctx: Context, step_name: str) -> list[dict[str, Any]]:
+    snapshots: list[dict[str, Any]] = []
+    if step_name == "configure":
+        _append_existing_snapshot(snapshots, "args_gn", ctx.get_gn_args_file())
+    elif step_name == "download_resources":
+        for path in _download_resource_paths(ctx):
+            _append_existing_snapshot(snapshots, "download_resource", path)
+    elif step_name == "prepare_common_resources":
+        if ctx.prepared_resources:
+            _append_existing_snapshot(
+                snapshots, "prepared_resources", ctx.prepared_resources
+            )
+    elif step_name == "prepare_server_resources":
+        for value in ctx.artifact_registry.get("server_resources", {}).values():
+            destination = getattr(value, "destination", None)
+            if isinstance(destination, Path):
+                _append_existing_snapshot(snapshots, "server_resource", destination)
+    elif step_name == "resources":
+        for path in _managed_copy_destinations(ctx):
+            _append_existing_snapshot(snapshots, "managed_resource", path)
+    elif step_name == "bundled_extensions":
+        _append_existing_snapshot(
+            snapshots,
+            "bundled_extensions",
+            ctx.chromium_src / "chrome/browser/browseros/bundled_extensions",
+        )
+    elif step_name in {
+        "chromium_replace",
+        "string_replaces",
+        "series_patches",
+        "patches",
+    }:
+        digest = _chromium_mutation_digest(ctx)
+        if digest:
+            snapshots.append({"kind": "chromium_mutation", **digest})
+    return snapshots
+
+
+def _append_existing_snapshot(
+    snapshots: list[dict[str, Any]],
+    role: str,
+    path: Path,
+) -> None:
+    if path.exists() or path.is_symlink():
+        snapshots.append(
+            {
+                "kind": "path",
+                "role": role,
+                "path": str(path),
+                "attestation": _path_attestation(path),
+            }
+        )
+
+
+def _validated_checkpoint(
+    ctx: Context,
+    step_name: str,
+    state: ResumeState,
+) -> Mapping[str, Any]:
+    path = checkpoint_path(ctx, step_name)
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ResumeValidationError(
+            _restart_message(
+                f"Resume checkpoint missing for {ctx.architecture}/{step_name}: {path}",
+                step_name,
+            )
+        ) from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ResumeValidationError(
+            _restart_message(
+                f"Resume checkpoint corrupt for {ctx.architecture}/{step_name}: {path}",
+                step_name,
+            )
+        ) from exc
+    if not isinstance(document, dict) or document.get("schema") != CHECKPOINT_SCHEMA:
+        raise _mismatch(ctx.architecture, step_name, "unsupported checkpoint schema")
+    _validate_checkpoint_identity(ctx, step_name, state, document)
+    _validate_chromium_checkout(ctx, step_name, document)
+    for entry in document.get("registry", []):
+        _validate_registry_entry(ctx.architecture, step_name, entry)
+    for snapshot in document.get("snapshots", []):
+        _validate_snapshot(ctx.architecture, step_name, snapshot)
+    return document
+
+
+def _validate_checkpoint_identity(
+    ctx: Context,
+    step_name: str,
+    state: ResumeState,
+    document: Mapping[str, Any],
+) -> None:
+    if document.get("candidate_digest") != state.candidate_digest:
+        detail = _candidate_mismatch_detail(document.get("candidate"), state.candidate)
+        raise _mismatch(ctx.architecture, step_name, detail)
+    expected = {
+        "product": ctx.product.id,
+        "architecture": ctx.architecture,
+        "build_type": ctx.build_type,
+        "platform": get_platform(),
+        "step": step_name,
+    }
+    for field, value in expected.items():
+        if document.get(field) != value:
+            raise _mismatch(
+                ctx.architecture,
+                step_name,
+                f"{field} mismatch: expected {value!r}, got {document.get(field)!r}",
+            )
+    expected_steps = list(_steps_for_arch(state.full_arch_plans, ctx.architecture))
+    if document.get("run_steps") != expected_steps:
+        raise _mismatch(ctx.architecture, step_name, "run step list mismatch")
+
+
+def _validate_chromium_checkout(
+    ctx: Context,
+    step_name: str,
+    document: Mapping[str, Any],
+) -> None:
+    recorded = document.get("chromium_checkout")
+    if not isinstance(recorded, dict) or "head" not in recorded:
+        return
+    current = _chromium_checkout_identity(ctx)
+    if current.get("head") != recorded.get("head"):
+        raise _mismatch(
+            ctx.architecture,
+            step_name,
+            f"Chromium checkout mismatch: expected {recorded.get('head')}, "
+            f"got {current.get('head') or 'unavailable'}",
+        )
+
+
+def _validate_registry_entry(arch: str, step_name: str, entry: Any) -> None:
+    if not isinstance(entry, dict):
+        raise _mismatch(arch, step_name, "registry entry is invalid")
+    if entry.get("kind") == "path":
+        _validate_attestation(
+            entry.get("attestation"),
+            Path(str(entry.get("path", ""))),
+            arch,
+            step_name,
+            str(entry.get("name", "artifact")),
+        )
+    elif entry.get("kind") in {"json", "sparkle_signatures", "server_resources"}:
+        return
+    else:
+        raise _mismatch(arch, step_name, "registry entry kind is unsupported")
+
+
+def _validate_snapshot(arch: str, step_name: str, snapshot: Any) -> None:
+    if not isinstance(snapshot, dict):
+        raise _mismatch(arch, step_name, "snapshot is invalid")
+    if snapshot.get("kind") == "path":
+        _validate_attestation(
+            snapshot.get("attestation"),
+            Path(str(snapshot.get("path", ""))),
+            arch,
+            step_name,
+            str(snapshot.get("role", "snapshot")),
+        )
+        return
+    if snapshot.get("kind") == "chromium_mutation":
+        current = _chromium_mutation_digest_for_root(
+            Path(str(snapshot.get("root", "")))
+        )
+        if not current or current.get("digest") != snapshot.get("digest"):
+            raise _mismatch(arch, step_name, "Chromium mutation digest mismatch")
+        return
+    raise _mismatch(arch, step_name, "snapshot kind is unsupported")
+
+
+def _restore_registry(ctx: Context, document: Mapping[str, Any]) -> None:
+    for entry in document.get("registry", []):
+        if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+            continue
+        name = entry["name"]
+        kind = entry.get("kind")
+        if kind == "path":
+            ctx.artifact_registry.add(name, Path(str(entry.get("path", ""))))
+        elif kind == "json":
+            ctx.artifact_registry.add(name, entry.get("value"))
+        elif kind == "sparkle_signatures":
+            value = entry.get("value", {})
+            if isinstance(value, dict):
+                ctx.artifact_registry.add(
+                    name,
+                    {
+                        str(filename): (str(pair[0]), int(pair[1]))
+                        for filename, pair in value.items()
+                        if isinstance(pair, list) and len(pair) == 2
+                    },
+                )
+        elif kind == "server_resources":
+            value = entry.get("value", {})
+            if isinstance(value, dict):
+                ctx.artifact_registry.add(
+                    name,
+                    {
+                        str(target): SimpleNamespace(
+                            product=str(item["product"]),
+                            target=str(item["target"]),
+                            version=str(item["version"]),
+                            source_sha=str(item["source_sha"]),
+                            destination=Path(str(item["destination"])),
+                            manifest_sha256=str(item["manifest_sha256"]),
+                        )
+                        for target, item in value.items()
+                        if isinstance(item, dict)
+                    },
+                )
+
+
+def _require_attested_path(
+    checkpoint: Mapping[str, Any],
+    artifact_name: str,
+    arch: str,
+    step_name: str,
+) -> None:
+    for entry in checkpoint.get("registry", []):
+        if (
+            isinstance(entry, dict)
+            and entry.get("name") == artifact_name
+            and entry.get("kind") == "path"
+        ):
+            _validate_registry_entry(arch, step_name, entry)
+            return
+    raise _mismatch(arch, step_name, f"missing attested {artifact_name}")
+
+
+def _completed_steps_before(
+    full_arch_plans: Sequence[tuple[str, Sequence[str]]],
+    resume_from: str,
+) -> list[tuple[str, tuple[str, ...]]]:
+    completed = []
+    for arch, steps in full_arch_plans:
+        if resume_from in steps:
+            completed.append((arch, tuple(steps[: list(steps).index(resume_from)])))
+            return completed
+        completed.append((arch, tuple(steps)))
+    return completed
+
+
+def _steps_for_arch(
+    full_arch_plans: Sequence[tuple[str, Sequence[str]]],
+    architecture: str,
+) -> tuple[str, ...]:
+    for arch, steps in full_arch_plans:
+        if arch == architecture:
+            return tuple(steps)
+    return ()
+
+
+def _context_for_arch(ctx: Context, architecture: str) -> Context:
+    sibling = Context(
+        root_dir=ctx.root_dir,
+        chromium_src=ctx.chromium_src,
+        architecture=architecture,
+        plan_architectures=ctx.plan_architectures,
+        build_type=ctx.build_type,
+        product=ctx.product,
+        gn_flags_file=ctx.gn_flags_file,
+        extra_gn_args=ctx.extra_gn_args,
+        resource_mode=ctx.resource_mode,
+        prepared_resources=ctx.prepared_resources,
+        prepared_resources_supplied=ctx.prepared_resources_supplied,
+        source_sha=ctx.source_sha,
+    )
+    sibling.resume_state = ctx.resume_state
+    return sibling
+
+
+def _candidate_mismatch_detail(
+    actual: Any,
+    expected: Mapping[str, Any],
+) -> str:
+    if not isinstance(actual, dict):
+        return "candidate contract is missing"
+    labels = {
+        "product": "product",
+        "build_type": "build type",
+        "platform": "platform",
+        "plan_architectures": "plan architecture",
+        "full_arch_plans": "resolved build plan",
+        "versions": "version",
+        "browseros_source": "BrowserOS source",
+        "chromium_pin": "Chromium pin",
+        "configuration": "build configuration",
+        "resources": "resource identity",
+    }
+    for key, label in labels.items():
+        if actual.get(key) != expected.get(key):
+            return f"{label} mismatch"
+    return "candidate contract digest mismatch"
+
+
+def _mismatch(arch: str, step_name: str, detail: str) -> ResumeValidationError:
+    return ResumeValidationError(
+        _restart_message(
+            f"Resume checkpoint mismatch for {arch}/{step_name}: {detail}",
+            step_name,
+        )
+    )
+
+
+def _restart_message(detail: str, step_name: str) -> str:
+    return (
+        f"{detail}. Safe restart: rerun with --from {step_name} after rebuilding "
+        "that boundary, or rerun without --from to rebuild verified checkpoints."
+    )
+
+
+def _path_attestation(path: Path) -> dict[str, Any]:
+    path = Path(path)
+    if path.is_symlink():
+        return {
+            "type": "symlink",
+            "target": os.readlink(path),
+        }
+    if path.is_file():
+        return {
+            "type": "file",
+            "size": path.stat().st_size,
+            "mode": path.stat().st_mode & 0o777,
+            "sha256": _sha256(path),
+        }
+    if path.is_dir():
+        return {
+            "type": "directory",
+            "digest": _directory_digest(path),
+        }
+    raise FileNotFoundError(path)
+
+
+def _validate_attestation(
+    attestation: Any,
+    path: Path,
+    arch: str,
+    step_name: str,
+    label: str,
+) -> None:
+    if not isinstance(attestation, dict):
+        raise _mismatch(arch, step_name, f"{label} attestation is invalid")
+    try:
+        current = _path_attestation(path)
+    except OSError as exc:
+        raise _mismatch(arch, step_name, f"{label} is missing: {path}") from exc
+    if current != attestation:
+        raise _mismatch(arch, step_name, f"{label} checksum mismatch: {path}")
+
+
+def _directory_digest(root: Path) -> str:
+    entries = []
+    for path in sorted(
+        root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()
+    ):
+        rel = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            entries.append(
+                {"type": "symlink", "path": rel, "target": os.readlink(path)}
+            )
+        elif path.is_file():
+            entries.append(
+                {
+                    "type": "file",
+                    "path": rel,
+                    "size": path.stat().st_size,
+                    "mode": path.stat().st_mode & 0o777,
+                    "sha256": _sha256(path),
+                }
+            )
+        elif path.is_dir():
+            entries.append(
+                {
+                    "type": "dir",
+                    "path": rel,
+                    "mode": path.stat().st_mode & 0o777,
+                }
+            )
+    return _json_digest(entries)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        while chunk := stream.read(_HASH_CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _file_identity(path: Path) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "exists": path.exists(),
+        "sha256": _sha256(path) if path.is_file() else "",
+    }
+
+
+def _download_resource_paths(ctx: Context) -> list[Path]:
+    config = _load_yaml_mapping(ctx.get_download_resources_config())
+    operations = config.get("download_operations")
+    if not isinstance(operations, list):
+        return []
+    target_archs = [ctx.architecture]
+    if ctx.architecture == "universal" or "universal" in ctx.plan_architectures:
+        target_archs = ["arm64", "x64", "universal"]
+    paths = []
+    for op in operations:
+        if isinstance(op, dict) and _operation_applies(op, ctx, target_archs):
+            destination = op.get("destination")
+            if isinstance(destination, str):
+                paths.append(ctx.root_dir / destination)
+    return sorted(set(paths))
+
+
+def _managed_copy_destinations(ctx: Context) -> list[Path]:
+    config = _load_yaml_mapping(ctx.get_copy_resources_config())
+    operations = config.get("copy_operations")
+    if not isinstance(operations, list):
+        return []
+    paths = []
+    for op in operations:
+        if not isinstance(op, dict) or not _operation_applies(
+            op, ctx, [ctx.architecture]
+        ):
+            continue
+        destination = op.get("destination")
+        if isinstance(destination, str):
+            paths.append(ctx.chromium_src / destination)
+    return sorted(set(paths))
+
+
+def _operation_applies(
+    op: Mapping[str, Any],
+    ctx: Context,
+    target_archs: Sequence[str],
+) -> bool:
+    os_condition = op.get("os")
+    if os_condition and get_platform() not in os_condition:
+        return False
+    arch_condition = op.get("arch")
+    if arch_condition and not any(arch in arch_condition for arch in target_archs):
+        return False
+    build_type_condition = op.get("build_type")
+    if build_type_condition and build_type_condition != ctx.build_type:
+        return False
+    product_condition = op.get("product")
+    if product_condition is None or ctx.build_type == "debug":
+        return True
+    products = (
+        [product_condition]
+        if isinstance(product_condition, str)
+        else product_condition
+    )
+    return isinstance(products, list) and ctx.product.id in products
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    try:
+        with open(path, "r") as stream:
+            data = yaml.safe_load(stream)
+    except (OSError, yaml.YAMLError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _chromium_mutation_digest(ctx: Context) -> dict[str, Any] | None:
+    return _chromium_mutation_digest_for_root(ctx.chromium_src)
+
+
+def _chromium_mutation_digest_for_root(root: Path) -> dict[str, Any] | None:
+    if not (root / ".git").exists():
+        return None
+    paths = _git_changed_paths(root, excludes=_CHROMIUM_MUTATION_EXCLUDES)
+    return {
+        "kind": "chromium_mutation",
+        "root": str(root),
+        "paths": paths,
+        "digest": _changed_paths_digest(root, paths),
+    }
+
+
+def _chromium_checkout_identity(ctx: Context) -> dict[str, str]:
+    try:
+        head = _git_text(["rev-parse", "HEAD"], ctx.chromium_src)
+    except _Unresumable:
+        return {}
+    return {"head": head} if _is_full_sha(head) else {}
+
+
+def _git_changed_paths(
+    root: Path,
+    excludes: Sequence[str] = (),
+) -> list[str]:
+    pathspec = ["."]
+    pathspec.extend(f":(exclude){item}" for item in excludes)
+    changed = set(
+        _git_paths(["diff", "--name-only", "-z", "HEAD", "--", *pathspec], root)
+    )
+    changed.update(
+        _git_paths(
+            ["diff", "--cached", "--name-only", "-z", "HEAD", "--", *pathspec],
+            root,
+        )
+    )
+    changed.update(
+        _git_paths(
+            ["ls-files", "--others", "--exclude-standard", "-z", "--", *pathspec],
+            root,
+        )
+    )
+    return sorted(path for path in changed if path)
+
+
+def _changed_paths_digest(root: Path, paths: Sequence[str]) -> str:
+    entries = []
+    for rel in sorted(paths):
+        path = root / rel
+        if path.is_symlink():
+            entries.append(
+                {"type": "symlink", "path": rel, "target": os.readlink(path)}
+            )
+        elif path.is_file():
+            entries.append(
+                {
+                    "type": "file",
+                    "path": rel,
+                    "size": path.stat().st_size,
+                    "mode": path.stat().st_mode & 0o777,
+                    "sha256": _sha256(path),
+                }
+            )
+        elif path.exists():
+            entries.append({"type": "other", "path": rel})
+        else:
+            entries.append({"type": "deleted", "path": rel})
+    return _json_digest(entries)
+
+
+def _git_text(args: Sequence[str], cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise _Unresumable(
+            f"git {' '.join(args)} failed in {cwd}: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def _git_paths(args: Sequence[str], cwd: Path) -> list[str]:
+    result = subprocess.run(["git", *args], cwd=cwd, capture_output=True)
+    if result.returncode != 0:
+        raise _Unresumable(
+            f"git {' '.join(args)} failed in {cwd}: "
+            f"{result.stderr.decode(errors='replace').strip()}"
+        )
+    return [
+        item.decode("utf-8", errors="surrogateescape")
+        for item in result.stdout.split(b"\0")
+        if item
+    ]
+
+
+def _is_full_sha(value: str) -> bool:
+    return len(value) == 40 and all(ch in "0123456789abcdefABCDEF" for ch in value)
+
+
+def _atomic_write_json(path: Path, document: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as stream:
+            temp_name = stream.name
+            json.dump(document, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        Path(temp_name).replace(path)
+        _fsync_dir(path.parent)
+    finally:
+        if temp_name:
+            Path(temp_name).unlink(missing_ok=True)
+
+
+def _fsync_dir(path: Path) -> None:
+    if os.name == "nt":
+        return
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _json_digest(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _json_safe(value: Any) -> bool:
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return False
+    return True

--- a/packages/browseros/bos_build/core/resume_test.py
+++ b/packages/browseros/bos_build/core/resume_test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Tests for strict resume checkpoints."""
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from .context import Context
+from .resume import (
+    ResumeValidationError,
+    checkpoint_path,
+    make_resume_state,
+    validate_resume_before_execution,
+    write_step_checkpoint,
+)
+from .step import Step
+from ..lib.testing import MockBrowserOSRoot, MockChromium
+
+
+class _CompileStep(Step):
+    name = "compile"
+    produces = ["built_app"]
+
+
+class ResumeCheckpointTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.base = Path(self.temp.name)
+        self.repo_root = self.base / "repo"
+        self.browseros = MockBrowserOSRoot(self.repo_root / "packages/browseros")
+        self._init_repo(self.repo_root)
+        self.chromium = MockChromium(self.base / "chromium").with_git()
+        self.env = mock.patch.dict(
+            os.environ,
+            {
+                "BROWSEROS_SERVER_RESOURCE_VERSION": "0.0.138",
+                "BUNDLED_PRODUCT_EXTENSION_VERSION": "0.0.132.0",
+                "BROWSERCLAW_ONBOARD_RESOURCE_VERSION": "0.0.36",
+            },
+        )
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.plan = (("x64", ("compile", "sign_macos")),)
+
+    def _init_repo(self, root: Path) -> None:
+        subprocess.run(
+            ["git", "init", "--initial-branch=main"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(["git", "config", "user.name", "Resume test"], cwd=root, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "resume@example.invalid"],
+            cwd=root,
+            check=True,
+        )
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+        )
+
+    def _context(self, resume_from: str = "sign_macos") -> Context:
+        ctx = Context(
+            root_dir=self.browseros.root,
+            chromium_src=self.chromium.src,
+            architecture="x64",
+            plan_architectures=("x64",),
+            build_type="release",
+        )
+        ctx.resume_state = make_resume_state(
+            ctx,
+            self.plan,
+            resume_from=resume_from,
+            strict=True,
+        )
+        return ctx
+
+    def _write_compile_checkpoint(self) -> tuple[Context, Path]:
+        ctx = self._context()
+        app = ctx.get_app_path()
+        app.parent.mkdir(parents=True)
+        app.write_bytes(b"browser")
+        ctx.artifact_registry.add("built_app", app)
+        write_step_checkpoint(ctx, _CompileStep(), self.plan[0][1])
+        return ctx, app
+
+    def test_valid_checkpoint_restores_required_artifact(self):
+        _ctx, app = self._write_compile_checkpoint()
+        resumed = self._context()
+
+        validate_resume_before_execution([(resumed, ("sign_macos",))])
+
+        self.assertEqual(resumed.artifact_registry.get("built_app"), app)
+
+    def test_modified_artifact_fails_before_resume(self):
+        _ctx, app = self._write_compile_checkpoint()
+        app.write_bytes(b"stale")
+        resumed = self._context()
+
+        with self.assertRaisesRegex(ResumeValidationError, "checksum mismatch"):
+            validate_resume_before_execution([(resumed, ("sign_macos",))])
+
+    def test_cross_architecture_checkpoint_fails(self):
+        ctx, _app = self._write_compile_checkpoint()
+        path = checkpoint_path(ctx, "compile")
+        document = json.loads(path.read_text(encoding="utf-8"))
+        document["architecture"] = "arm64"
+        path.write_text(json.dumps(document), encoding="utf-8")
+        resumed = self._context()
+
+        with self.assertRaisesRegex(ResumeValidationError, "architecture mismatch"):
+            validate_resume_before_execution([(resumed, ("sign_macos",))])
+
+    def test_corrupt_checkpoint_fails(self):
+        ctx, _app = self._write_compile_checkpoint()
+        checkpoint_path(ctx, "compile").write_text("{", encoding="utf-8")
+        resumed = self._context()
+
+        with self.assertRaisesRegex(ResumeValidationError, "corrupt"):
+            validate_resume_before_execution([(resumed, ("sign_macos",))])
+
+    def test_source_identity_mismatch_fails(self):
+        _ctx, _app = self._write_compile_checkpoint()
+        version = self.browseros.root / "resources" / "BROWSEROS_VERSION"
+        version.write_text(version.read_text() + "\n")
+        resumed = self._context()
+
+        with self.assertRaisesRegex(ResumeValidationError, "BrowserOS source"):
+            validate_resume_before_execution([(resumed, ("sign_macos",))])
+
+    def test_unpinned_published_resources_make_strict_resume_unprovable(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            resumed = self._context()
+
+        with self.assertRaisesRegex(ResumeValidationError, "exact component pins"):
+            validate_resume_before_execution([(resumed, ("sign_macos",))])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/core/resume_test.py
+++ b/packages/browseros/bos_build/core/resume_test.py
@@ -26,6 +26,19 @@ class _CompileStep(Step):
     produces = ["built_app"]
 
 
+class _SignStep(Step):
+    name = "sign_macos"
+    produces = ["signed_app"]
+
+
+class _ChromiumReplaceStep(Step):
+    name = "chromium_replace"
+
+
+class _StringReplacesStep(Step):
+    name = "string_replaces"
+
+
 class ResumeCheckpointTest(unittest.TestCase):
     def setUp(self):
         self.temp = tempfile.TemporaryDirectory()
@@ -68,7 +81,11 @@ class ResumeCheckpointTest(unittest.TestCase):
             capture_output=True,
         )
 
-    def _context(self, resume_from: str = "sign_macos") -> Context:
+    def _context(
+        self,
+        resume_from: str = "sign_macos",
+        plan: tuple[tuple[str, tuple[str, ...]], ...] | None = None,
+    ) -> Context:
         ctx = Context(
             root_dir=self.browseros.root,
             chromium_src=self.chromium.src,
@@ -78,7 +95,7 @@ class ResumeCheckpointTest(unittest.TestCase):
         )
         ctx.resume_state = make_resume_state(
             ctx,
-            self.plan,
+            plan or self.plan,
             resume_from=resume_from,
             strict=True,
         )
@@ -143,6 +160,55 @@ class ResumeCheckpointTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ResumeValidationError, "exact component pins"):
             validate_resume_before_execution([(resumed, ("sign_macos",))])
+
+    def test_sliced_resume_checkpoint_records_full_plan(self):
+        plan = (("x64", ("compile", "sign_macos", "package")),)
+        ctx = self._context(resume_from="sign_macos", plan=plan)
+        app = ctx.get_app_path()
+        app.parent.mkdir(parents=True)
+        app.write_bytes(b"browser")
+        ctx.artifact_registry.add("built_app", app)
+        write_step_checkpoint(ctx, _CompileStep(), plan[0][1])
+        ctx.artifact_registry.add("signed_app", app)
+        write_step_checkpoint(ctx, _SignStep(), ("sign_macos", "package"))
+
+        document = json.loads(
+            checkpoint_path(ctx, "sign_macos").read_text(encoding="utf-8")
+        )
+        self.assertEqual(document["run_steps"], list(plan[0][1]))
+        resumed = self._context(resume_from="package", plan=plan)
+
+        validate_resume_before_execution([(resumed, ("package",))])
+
+    def test_later_chromium_mutation_checkpoint_supersedes_earlier_digest(self):
+        plan = (("x64", ("chromium_replace", "string_replaces", "configure")),)
+        ctx = self._context(resume_from="configure", plan=plan)
+        target = self.chromium.src / "chrome" / "browser" / "browseros" / "patched.cc"
+        target.parent.mkdir(parents=True)
+        target.write_text("first")
+        write_step_checkpoint(ctx, _ChromiumReplaceStep(), plan[0][1])
+        target.write_text("second")
+        write_step_checkpoint(ctx, _StringReplacesStep(), plan[0][1])
+        resumed = self._context(resume_from="configure", plan=plan)
+
+        validate_resume_before_execution([(resumed, ("configure",))])
+
+    def test_latest_chromium_mutation_checkpoint_still_detects_stale_tree(self):
+        plan = (("x64", ("chromium_replace", "string_replaces", "configure")),)
+        ctx = self._context(resume_from="configure", plan=plan)
+        target = self.chromium.src / "chrome" / "browser" / "browseros" / "patched.cc"
+        target.parent.mkdir(parents=True)
+        target.write_text("first")
+        write_step_checkpoint(ctx, _ChromiumReplaceStep(), plan[0][1])
+        target.write_text("second")
+        write_step_checkpoint(ctx, _StringReplacesStep(), plan[0][1])
+        target.write_text("stale")
+        resumed = self._context(resume_from="configure", plan=plan)
+
+        with self.assertRaisesRegex(
+            ResumeValidationError, "Chromium mutation digest mismatch"
+        ):
+            validate_resume_before_execution([(resumed, ("configure",))])
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/core/runner.py
+++ b/packages/browseros/bos_build/core/runner.py
@@ -26,6 +26,7 @@ from .events import (
     StepStarted,
     Subscriber,
 )
+from .resume import invalidate_checkpoints_from, write_step_checkpoint
 from .step import Step, ValidationError, all_steps
 from ..lib.utils import log_error, log_info, log_success, log_warning
 
@@ -88,6 +89,7 @@ def run(
             _emit(subscribers, StepStarted(run=name, step=step_name, phase=step.phase))
             step_start = time.time()
             _warn_missing_requires(ctx, step, step_name)
+            invalidate_checkpoints_from(ctx, step_names, step_name)
 
             try:
                 step.validate(ctx)
@@ -98,6 +100,7 @@ def run(
 
             try:
                 step.execute(ctx)
+                write_step_checkpoint(ctx, step, step_names)
             except Exception as e:
                 _finish_step(subscribers, results, name, step, step_start, error=str(e))
                 log_error(f"Step {step_name} failed: {e}")

--- a/packages/browseros/bos_build/core/runner_test.py
+++ b/packages/browseros/bos_build/core/runner_test.py
@@ -3,6 +3,7 @@
 
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 from bos_build.core.events import RunFinished, RunStarted, StepFinished, StepStarted
 from bos_build.core.runner import RunResult, StepExecutionError, run
@@ -130,6 +131,24 @@ class RunnerEventTest(unittest.TestCase):
         finished = [e for e in rec.events if isinstance(e, StepFinished)]
         self.assertEqual(started[0].phase, "build")
         self.assertEqual(finished[0].phase, "build")
+
+    def test_checkpoint_lifecycle_invalidates_before_step_and_writes_after_success(self):
+        ctx = _ctx()
+        with (
+            mock.patch(
+                "bos_build.core.runner.invalidate_checkpoints_from"
+            ) as invalidate,
+            mock.patch("bos_build.core.runner.write_step_checkpoint") as write,
+        ):
+            with self.assertRaises(StepExecutionError):
+                run(ctx, [_OkStep(), _BoomStep()], name="r")
+
+        self.assertEqual(
+            [call.args[2] for call in invalidate.call_args_list],
+            ["ok_step", "boom_step"],
+        )
+        self.assertEqual(write.call_count, 1)
+        self.assertEqual(write.call_args.args[1].name, "ok_step")
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -1131,12 +1131,12 @@ class PublisherTestCase(unittest.TestCase):
         self.assertEqual((spec.kind, spec.channel), ("extensions", "alpha"))
         self.assertEqual(
             set(extract_manifest_versions(manifest).values()),
-            {"0.0.131.0", "54.0.0.0", "0.2.6.0"},
+            {"0.0.132.0", "54.0.0.0", "0.2.7.0"},
         )
         original = manifest.replace("</gupdate>", "  </app>\n</gupdate>")
         self.assertEqual(
             hashlib.sha256(original.encode()).hexdigest(),
-            "fc21e4747c904a7f74e9bfec17197e18349a596e2b8653356a1c8a9dfaaba219",
+            "9ba4ec047af45f6e54551f5100096de09d9ba5229a3ecd2853f0e4ddc94ee262",
         )
 
     def test_browserclaw_snapshots_use_current_product_title(self):

--- a/packages/browseros/bos_build/steps/compile/universal.py
+++ b/packages/browseros/bos_build/steps/compile/universal.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Optional
 
 from ...core.context import Context
+from ...core.resume import ResumeValidationError, validate_universal_inputs
 from ...core.step import Step, ValidationError, step
 from ...products.server_binaries import server_bundles_for_product
 from ..package.merge import merge_architectures
@@ -104,6 +105,10 @@ class MergeUniversalModule(Step):
             raise ValidationError(
                 f"merge_universal needs a universal context, got '{ctx.architecture}'"
             )
+        try:
+            validate_universal_inputs(ctx, UNIVERSAL_ARCHITECTURES)
+        except ResumeValidationError as exc:
+            raise ValidationError(str(exc)) from exc
         for arch in UNIVERSAL_ARCHITECTURES:
             app = _arch_app_path(ctx, arch)
             if not app.exists():

--- a/packages/browseros/bos_build/steps/compile/universal_test.py
+++ b/packages/browseros/bos_build/steps/compile/universal_test.py
@@ -10,7 +10,20 @@ from unittest import mock
 from . import universal
 from .universal import UNIVERSAL_ARCHITECTURES, MergeUniversalModule
 from ...core.context import Context
-from ...core.step import ValidationError, all_steps
+from ...core.resume import ResumeState, checkpoint_path, write_step_checkpoint
+from ...core.step import Step, ValidationError, all_steps
+
+
+UNIVERSAL_FULL_PLAN = (
+    ("arm64", ("compile", "sign_macos", "package_macos")),
+    ("x64", ("compile", "sign_macos", "package_macos")),
+    ("universal", ("merge_universal", "sign_macos")),
+)
+
+
+class _SignStep(Step):
+    name = "sign_macos"
+    produces = ["signed_app"]
 
 
 def _universal_ctx(chromium_src: Path) -> Context:
@@ -65,6 +78,68 @@ class ValidateTest(MergeUniversalTestBase):
     def test_passes_when_both_arch_apps_exist(self):
         self._create_arch_apps()
         MergeUniversalModule().validate(self.ctx)
+
+
+class ProvenanceTest(MergeUniversalTestBase):
+    def _state(self, digest: str = "candidate") -> ResumeState:
+        return ResumeState(
+            full_arch_plans=UNIVERSAL_FULL_PLAN,
+            resume_from=None,
+            candidate={"schema": "test"},
+            candidate_digest=digest,
+        )
+
+    def _arch_ctx(self, arch: str, state: ResumeState) -> Context:
+        ctx = Context(
+            root_dir=self.ctx.root_dir,
+            chromium_src=self.ctx.chromium_src,
+            architecture=arch,
+            build_type=self.ctx.build_type,
+            product=self.ctx.product,
+        )
+        ctx.resume_state = state
+        return ctx
+
+    def _write_arch_checkpoints(self, state: ResumeState) -> None:
+        self.ctx.resume_state = state
+        for arch, steps in UNIVERSAL_FULL_PLAN[:2]:
+            arch_ctx = self._arch_ctx(arch, state)
+            app = _arch_app(self.ctx, arch)
+            app.mkdir(parents=True, exist_ok=True)
+            arch_ctx.artifact_registry.add("signed_app", app)
+            write_step_checkpoint(arch_ctx, _SignStep(), steps)
+
+    def test_valid_arch_provenance_passes(self):
+        self._write_arch_checkpoints(self._state())
+
+        MergeUniversalModule().validate(self.ctx)
+
+    def test_candidate_mismatch_fails(self):
+        self._write_arch_checkpoints(self._state("old"))
+        self.ctx.resume_state = self._state("new")
+
+        with self.assertRaisesRegex(ValidationError, "candidate"):
+            MergeUniversalModule().validate(self.ctx)
+
+    def test_architecture_mismatch_fails(self):
+        state = self._state()
+        self._write_arch_checkpoints(state)
+        path = checkpoint_path(self.ctx, "sign_macos", "x64")
+        document = json.loads(path.read_text(encoding="utf-8"))
+        document["architecture"] = "arm64"
+        path.write_text(json.dumps(document), encoding="utf-8")
+
+        with self.assertRaisesRegex(ValidationError, "architecture mismatch"):
+            MergeUniversalModule().validate(self.ctx)
+
+    def test_modified_arch_app_fails(self):
+        self._write_arch_checkpoints(self._state())
+        changed = _arch_app(self.ctx, "x64") / "Contents" / "stale"
+        changed.parent.mkdir(parents=True, exist_ok=True)
+        changed.write_text("old")
+
+        with self.assertRaisesRegex(ValidationError, "checksum mismatch"):
+            MergeUniversalModule().validate(self.ctx)
 
 
 class ExecuteTest(MergeUniversalTestBase):

--- a/packages/browseros/bos_build/steps/setup/clean.py
+++ b/packages/browseros/bos_build/steps/setup/clean.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 
+from ...core.resume import remove_checkpoint_dirs
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
 from ...lib.utils import run_command, log_info, log_success, log_warning, safe_rmtree
@@ -31,6 +32,7 @@ class CleanModule(Step):
             log_success(
                 f"Cleaned build directory: {out_path.relative_to(ctx.chromium_src)}"
             )
+        remove_checkpoint_dirs(ctx, self._checkpoint_architectures(ctx))
 
         log_info("\n🔀 Resetting git branch and removing tracked files...")
         self._git_reset(ctx)
@@ -42,14 +44,9 @@ class CleanModule(Step):
         self._prune_orphan_binary_families(ctx)
 
     def _output_dirs(self, ctx: Context) -> tuple[Path, ...]:
-        architectures = (
-            UNIVERSAL_INPUT_ARCHITECTURES
-            if "universal" in ctx.plan_architectures
-            else (ctx.architecture,)
-        )
         dirs: list[Path] = []
         seen: set[Path] = set()
-        for architecture in architectures:
+        for architecture in self._output_architectures(ctx):
             out_ctx = Context(
                 root_dir=ctx.root_dir,
                 chromium_src=ctx.chromium_src,
@@ -63,6 +60,16 @@ class CleanModule(Step):
             dirs.append(out_path)
             seen.add(out_path)
         return tuple(dirs)
+
+    def _output_architectures(self, ctx: Context) -> tuple[str, ...]:
+        if "universal" in ctx.plan_architectures:
+            return UNIVERSAL_INPUT_ARCHITECTURES
+        return (ctx.architecture,)
+
+    def _checkpoint_architectures(self, ctx: Context) -> tuple[str, ...]:
+        if "universal" in ctx.plan_architectures:
+            return (*UNIVERSAL_INPUT_ARCHITECTURES, "universal")
+        return (ctx.architecture,)
 
     def _prune_orphan_binary_families(self, ctx: Context) -> None:
         """Remove resources/binaries/<family> dirs the download config no longer lists.

--- a/packages/browseros/bos_build/steps/setup/clean_test.py
+++ b/packages/browseros/bos_build/steps/setup/clean_test.py
@@ -9,6 +9,7 @@ from unittest import mock
 from . import clean
 from ...core.context import Context
 from ...core.products import get_product_descriptor
+from ...core.resume import checkpoint_dir
 from ...core.step import ValidationError
 from ...lib.testing import MockBrowserOSRoot, MockChromium, make_context
 
@@ -87,6 +88,26 @@ class CleanExecuteTest(unittest.TestCase):
             self.assertFalse(x64_out.exists())
             self.assertTrue(arm64_out.exists())
 
+    def test_single_arch_clean_removes_matching_checkpoint_dir_only(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            chromium = MockChromium(Path(chromium_tmp))
+            root = MockBrowserOSRoot(Path(root_tmp))
+            ctx = make_context(chromium, root, architecture="x64")
+            chromium.with_out_dir("x64")
+            x64_checkpoint = checkpoint_dir(ctx, "x64")
+            arm64_checkpoint = checkpoint_dir(ctx, "arm64")
+            x64_checkpoint.mkdir(parents=True)
+            arm64_checkpoint.mkdir(parents=True)
+
+            with mock.patch.object(clean, "run_command"):
+                clean.CleanModule().execute(ctx)
+
+            self.assertFalse(x64_checkpoint.exists())
+            self.assertTrue(arm64_checkpoint.exists())
+
     def test_universal_clean_removes_same_product_arch_outputs_only(self):
         with (
             tempfile.TemporaryDirectory() as chromium_tmp,
@@ -125,6 +146,29 @@ class CleanExecuteTest(unittest.TestCase):
                     self.assertFalse(x64_out.exists())
                     self.assertTrue(other_arm64_out.exists())
                     self.assertTrue(other_x64_out.exists())
+
+    def test_universal_clean_removes_arch_and_universal_checkpoint_dirs(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            chromium = MockChromium(Path(chromium_tmp))
+            root = MockBrowserOSRoot(Path(root_tmp))
+            ctx = Context(
+                root_dir=root.root,
+                chromium_src=chromium.src,
+                architecture="arm64",
+                plan_architectures=("universal",),
+                build_type="release",
+            )
+            for arch in ("arm64", "x64", "universal"):
+                checkpoint_dir(ctx, arch).mkdir(parents=True)
+
+            with mock.patch.object(clean, "run_command"):
+                clean.CleanModule().execute(ctx)
+
+            for arch in ("arm64", "x64", "universal"):
+                self.assertFalse(checkpoint_dir(ctx, arch).exists())
 
 
 class CleanPruneOrphanBinariesTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add versioned resume checkpoints bound to source, Chromium pin, build plan/config, resource identity, run architecture, and concrete artifact hashes
- validate preset --from resumes before sliced execution and restore proven registry artifacts after validation
- require checkpointed arm64/x64 provenance for preset universal merge and invalidate checkpoint dirs from clean

## Verification
- cd packages/browseros && uv run python -m unittest discover -s bos_build -t . -p "*_test.py"
- cd packages/browseros && uv run ruff check bos_build