### PR TITLE
feat(claw-app): add Tasks page for repeatable skills

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarNavigation.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarNavigation.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, PlugZap, ScrollText } from 'lucide-react'
+import { LayoutDashboard, PlugZap, Repeat, ScrollText } from 'lucide-react'
 import type { ComponentType, SVGProps } from 'react'
 import { NavLink, useLocation } from 'react-router'
 import {
@@ -21,6 +21,7 @@ interface NavItem {
 const navItems: NavItem[] = [
   { name: 'Cockpit', to: '/', icon: LayoutDashboard },
   { name: 'MCP', to: '/mcp', icon: PlugZap },
+  { name: 'Tasks', to: '/skills', icon: Repeat },
   { name: 'Audit', to: '/audit', icon: ScrollText },
 ]
 

--- a/packages/browseros-agent/apps/claw-app/components/skills/DeleteSkillDialog.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/skills/DeleteSkillDialog.tsx
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { useQueryClient } from '@tanstack/react-query'
+import type { ReactElement } from 'react'
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { useDeleteSkill, useSkills } from '@/modules/api/skills.hooks'
+
+interface DeleteSkillDialogProps {
+  name: string
+  onDeleted: () => void
+  trigger?: ReactElement
+}
+
+export function DeleteSkillDialog({
+  name,
+  onDeleted,
+  trigger,
+}: DeleteSkillDialogProps) {
+  const queryClient = useQueryClient()
+  const remove = useDeleteSkill()
+
+  const onConfirm = () => {
+    void toast.promise(
+      remove.mutateAsync({ name }).then(() => {
+        void queryClient.invalidateQueries({ queryKey: useSkills.getKey() })
+        onDeleted()
+      }),
+      {
+        loading: `Deleting ${name}…`,
+        success: `Deleted ${name}`,
+        error: 'Could not delete the task',
+      },
+    )
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger
+        render={
+          trigger ?? (
+            <Button variant="outline" size="sm" className="rounded-9 text-red">
+              Delete
+            </Button>
+          )
+        }
+      />
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this task?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This removes {name} and unlinks its skill from your coding agents.
+            Its run history is discarded.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Delete task</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/skills/RunSkillButton.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/skills/RunSkillButton.tsx
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Copy } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { skillCommand } from '@/screens/skills/skills.helpers'
+
+interface RunSkillButtonProps {
+  name: string
+  size?: 'sm' | 'default'
+}
+
+/** Copies the `/name` command a user pastes into a coding agent to run a skill. */
+export function RunSkillButton({ name, size = 'sm' }: RunSkillButtonProps) {
+  const onRun = () => {
+    if (typeof window === 'undefined' || !navigator?.clipboard?.writeText) {
+      return
+    }
+    void navigator.clipboard.writeText(skillCommand(name)).then(() => {
+      toast.success(`Copied ${skillCommand(name)}`, {
+        description: 'Paste it into your coding agent to run this task.',
+      })
+    })
+  }
+  return (
+    <Button size={size} variant="outline" className="rounded-9" onClick={onRun}>
+      <Copy />
+      Run
+    </Button>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/skills/SkillFormDialog.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/skills/SkillFormDialog.tsx
@@ -1,0 +1,343 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useQueryClient } from '@tanstack/react-query'
+import { type ReactElement, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import { z } from 'zod'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  useCreateSkill,
+  useSkill,
+  useSkills,
+  useUpdateSkill,
+} from '@/modules/api/skills.hooks'
+
+const createSchema = z.object({
+  name: z
+    .string()
+    .regex(/^[a-z0-9-]+$/, 'Lowercase letters, digits, and hyphens only'),
+  description: z.string().min(1, 'A one-line description is required'),
+  site: z.string().optional(),
+  steps: z.string().optional(),
+  learnedNotes: z.string().optional(),
+})
+
+const editSchema = z.object({
+  description: z.string().min(1, 'A one-line description is required'),
+  site: z.string().optional(),
+  body: z.string().min(1, 'The SKILL.md body cannot be empty'),
+})
+
+function toLines(value: string | undefined): string[] {
+  return (value ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function trimmedOrUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+interface CreateProps {
+  mode: 'create'
+  trigger: ReactElement
+}
+
+interface EditProps {
+  mode: 'edit'
+  name: string
+  description: string
+  site?: string
+  body: string
+  trigger: ReactElement
+}
+
+type SkillFormDialogProps = CreateProps | EditProps
+
+export function SkillFormDialog(props: SkillFormDialogProps) {
+  const [open, setOpen] = useState(false)
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={props.trigger} />
+      <DialogContent className="max-w-lg">
+        {props.mode === 'create' ? (
+          <CreateForm onClose={() => setOpen(false)} />
+        ) : (
+          <EditForm {...props} onClose={() => setOpen(false)} />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CreateForm({ onClose }: { onClose: () => void }) {
+  const queryClient = useQueryClient()
+  const create = useCreateSkill()
+  const form = useForm<z.infer<typeof createSchema>>({
+    resolver: zodResolver(createSchema),
+    defaultValues: {
+      name: '',
+      description: '',
+      site: '',
+      steps: '',
+      learnedNotes: '',
+    },
+  })
+
+  const onSubmit = form.handleSubmit((values) => {
+    void toast.promise(
+      create
+        .mutateAsync({
+          name: values.name,
+          description: values.description,
+          site: trimmedOrUndefined(values.site),
+          steps: toLines(values.steps),
+          learnedNotes: toLines(values.learnedNotes),
+        })
+        .then(() => {
+          void queryClient.invalidateQueries({ queryKey: useSkills.getKey() })
+          onClose()
+        }),
+      {
+        loading: 'Saving the task…',
+        success: `Saved /${values.name}`,
+        error: 'Could not save the task',
+      },
+    )
+  })
+
+  return (
+    <Form {...form}>
+      <form onSubmit={onSubmit} className="flex flex-col gap-4">
+        <DialogHeader>
+          <DialogTitle>New task</DialogTitle>
+          <DialogDescription>
+            A task is a skill BrowserOS neo links into your agents and you
+            re-run by name.
+          </DialogDescription>
+        </DialogHeader>
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="inbox-sweep"
+                  className="font-mono"
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                Lowercase letters, digits, and hyphens. Used as the /command.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="Check the inbox and draft what is owed"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="site"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Site (optional)</FormLabel>
+              <FormControl>
+                <Input placeholder="mail.google.com" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="steps"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Steps</FormLabel>
+              <FormControl>
+                <Textarea rows={4} placeholder="One step per line" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="learnedNotes"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Learned notes (optional)</FormLabel>
+              <FormControl>
+                <Textarea rows={3} placeholder="One note per line" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <DialogFooter>
+          <DialogClose
+            render={
+              <Button variant="outline" type="button">
+                Cancel
+              </Button>
+            }
+          />
+          <Button type="submit" disabled={create.isPending}>
+            Save task
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  )
+}
+
+function EditForm({
+  name,
+  description,
+  site,
+  body,
+  onClose,
+}: EditProps & { onClose: () => void }) {
+  const queryClient = useQueryClient()
+  const update = useUpdateSkill()
+  const form = useForm<z.infer<typeof editSchema>>({
+    resolver: zodResolver(editSchema),
+    defaultValues: { description, site: site ?? '', body },
+  })
+
+  const onSubmit = form.handleSubmit((values) => {
+    void toast.promise(
+      update
+        .mutateAsync({
+          name,
+          body: {
+            description: values.description,
+            site: trimmedOrUndefined(values.site),
+            body: values.body,
+          },
+        })
+        .then(() => {
+          void queryClient.invalidateQueries({
+            queryKey: useSkill.getKey({ name }),
+          })
+          void queryClient.invalidateQueries({ queryKey: useSkills.getKey() })
+          onClose()
+        }),
+      {
+        loading: 'Saving…',
+        success: `Saved /${name}`,
+        error: 'Could not save the task',
+      },
+    )
+  })
+
+  return (
+    <Form {...form}>
+      <form onSubmit={onSubmit} className="flex flex-col gap-4">
+        <DialogHeader>
+          <DialogTitle>Edit {name}</DialogTitle>
+          <DialogDescription>
+            Editing the SKILL.md re-links it into your agents.
+          </DialogDescription>
+        </DialogHeader>
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="site"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Site</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="body"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>SKILL.md</FormLabel>
+              <FormControl>
+                <Textarea rows={12} className="font-mono text-xs" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <DialogFooter>
+          <DialogClose
+            render={
+              <Button variant="outline" type="button">
+                Cancel
+              </Button>
+            }
+          />
+          <Button type="submit" disabled={update.isPending}>
+            Save
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/skills/SkillFormDialog.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/skills/SkillFormDialog.tsx
@@ -38,6 +38,7 @@ import {
   useSkills,
   useUpdateSkill,
 } from '@/modules/api/skills.hooks'
+import { parseSkillBody } from '@/screens/skills/skills.helpers'
 
 const createSchema = z.object({
   name: z
@@ -52,7 +53,8 @@ const createSchema = z.object({
 const editSchema = z.object({
   description: z.string().min(1, 'A one-line description is required'),
   site: z.string().optional(),
-  body: z.string().min(1, 'The SKILL.md body cannot be empty'),
+  steps: z.string().optional(),
+  learnedNotes: z.string().optional(),
 })
 
 function toLines(value: string | undefined): string[] {
@@ -246,9 +248,15 @@ function EditForm({
 }: EditProps & { onClose: () => void }) {
   const queryClient = useQueryClient()
   const update = useUpdateSkill()
+  const parsed = parseSkillBody(body)
   const form = useForm<z.infer<typeof editSchema>>({
     resolver: zodResolver(editSchema),
-    defaultValues: { description, site: site ?? '', body },
+    defaultValues: {
+      description,
+      site: site ?? '',
+      steps: parsed.steps.join('\n'),
+      learnedNotes: parsed.learnedNotes.join('\n'),
+    },
   })
 
   const onSubmit = form.handleSubmit((values) => {
@@ -258,8 +266,10 @@ function EditForm({
           name,
           body: {
             description: values.description,
-            site: trimmedOrUndefined(values.site),
-            body: values.body,
+            // An empty string clears the site; the field is always sent.
+            site: values.site?.trim() ?? '',
+            steps: toLines(values.steps),
+            learnedNotes: toLines(values.learnedNotes),
           },
         })
         .then(() => {
@@ -283,7 +293,7 @@ function EditForm({
         <DialogHeader>
           <DialogTitle>Edit {name}</DialogTitle>
           <DialogDescription>
-            Editing the SKILL.md re-links it into your agents.
+            Saving re-renders the SKILL.md and re-links it into your agents.
           </DialogDescription>
         </DialogHeader>
         <FormField
@@ -306,7 +316,7 @@ function EditForm({
             <FormItem>
               <FormLabel>Site</FormLabel>
               <FormControl>
-                <Input {...field} />
+                <Input placeholder="Leave empty to clear" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -314,12 +324,25 @@ function EditForm({
         />
         <FormField
           control={form.control}
-          name="body"
+          name="steps"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>SKILL.md</FormLabel>
+              <FormLabel>Steps</FormLabel>
               <FormControl>
-                <Textarea rows={12} className="font-mono text-xs" {...field} />
+                <Textarea rows={5} placeholder="One step per line" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="learnedNotes"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Learned notes</FormLabel>
+              <FormControl>
+                <Textarea rows={3} placeholder="One note per line" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/App.tsx
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/App.tsx
@@ -6,6 +6,8 @@ import { Audit } from '@/screens/audit/Audit'
 import { Cockpit } from '@/screens/cockpit/Cockpit'
 import { Mcp } from '@/screens/mcp/Mcp'
 import { Replay } from '@/screens/replay/Replay'
+import { SkillDetail } from '@/screens/skills/SkillDetail'
+import { Skills } from '@/screens/skills/Skills'
 import { TaskDetailPage } from '@/screens/task-detail/TaskDetailPage'
 
 /** Mounts the v2 cockpit route tree. */
@@ -17,6 +19,8 @@ export function App() {
         <Route element={<CockpitShell />}>
           <Route path="/" element={<Cockpit />} />
           <Route path="/mcp" element={<Mcp />} />
+          <Route path="/skills" element={<Skills />} />
+          <Route path="/skills/:name" element={<SkillDetail />} />
           <Route
             path="/audit"
             element={

--- a/packages/browseros-agent/apps/claw-app/modules/api/skills.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/skills.hooks.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Tasks (skills) surface: the list, one skill's detail, its run history, and
+ * create / edit / delete. Mutations invalidate at the call site via
+ * `Hook.getKey()`, so the cache surface stays grep-able.
+ */
+
+import type {
+  Skill,
+  SkillCreate,
+  SkillDetail,
+  SkillList,
+  SkillRunList,
+} from '@browseros/claw-api'
+import type {
+  SkillNameRequest,
+  UpdateSkillRequest,
+} from '@browseros/claw-api-client'
+import { createMutation, createQuery } from 'react-query-kit'
+import { apiClient } from './client'
+
+export const useSkills = createQuery<SkillList>({
+  queryKey: ['api', 'skills'],
+  fetcher: async () => (await apiClient()).listSkills(),
+})
+
+export const useSkill = createQuery<SkillDetail, { name: string }, Error>({
+  queryKey: ['api', 'skill'],
+  fetcher: async ({ name }) => (await apiClient()).getSkill({ name }),
+})
+
+export const useSkillRuns = createQuery<SkillRunList, { name: string }, Error>({
+  queryKey: ['api', 'skill-runs'],
+  fetcher: async ({ name }) => (await apiClient()).listSkillRuns({ name }),
+})
+
+export const useCreateSkill = createMutation<Skill, SkillCreate>({
+  mutationFn: async (body) => (await apiClient()).createSkill(body),
+})
+
+export const useUpdateSkill = createMutation<SkillDetail, UpdateSkillRequest>({
+  mutationFn: async (request) => (await apiClient()).updateSkill(request),
+})
+
+export const useDeleteSkill = createMutation<void, SkillNameRequest>({
+  mutationFn: async (request) => (await apiClient()).deleteSkill(request),
+})

--- a/packages/browseros-agent/apps/claw-app/screens/skills/SkillDetail.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/SkillDetail.tsx
@@ -1,0 +1,423 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Skill, SkillRun } from '@browseros/claw-api'
+import { ArrowLeft, Check } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useNavigate } from 'react-router'
+import { DeleteSkillDialog } from '@/components/skills/DeleteSkillDialog'
+import { RunSkillButton } from '@/components/skills/RunSkillButton'
+import { SkillFormDialog } from '@/components/skills/SkillFormDialog'
+import { Button } from '@/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { cn } from '@/lib/utils'
+import { useSkillDetailData } from './skill-detail.data'
+import {
+  formatRelativeTime,
+  formatTokens,
+  skillCommand,
+  tokenDeltaPercent,
+} from './skills.helpers'
+
+const AGENT_LABELS: Record<string, string> = {
+  claude_code: 'Claude Code',
+  codex: 'Codex',
+  cursor: 'Cursor',
+  gemini: 'Gemini',
+}
+
+function agentLabel(id: string): string {
+  return AGENT_LABELS[id] ?? id
+}
+
+/** Task detail: the SKILL.md, whether it is getting cheaper and safe to leave
+ *  alone, which agents it is linked into, and its run history. */
+export function SkillDetail() {
+  const { detail, isLoading, isError } = useSkillDetailData()
+  const navigate = useNavigate()
+
+  return (
+    <div className="relative mx-auto flex w-full max-w-5xl flex-col gap-6 px-8 pt-8 pb-16">
+      <button
+        type="button"
+        onClick={() => navigate('/skills')}
+        className="inline-flex w-fit items-center gap-1.5 font-medium text-[13px] text-ink-2 transition-colors hover:text-ink"
+      >
+        <ArrowLeft className="size-3.5" />
+        Tasks
+      </button>
+
+      {isError ? (
+        <Notice>
+          Could not load this task. Check that BrowserOS neo is running and try
+          again.
+        </Notice>
+      ) : isLoading || !detail ? (
+        <DetailSkeleton />
+      ) : (
+        <DetailBody
+          skill={detail.skill}
+          body={detail.body}
+          runs={detail.runs}
+          onDeleted={() => navigate('/skills')}
+        />
+      )}
+    </div>
+  )
+}
+
+function DetailBody({
+  skill,
+  body,
+  runs,
+  onDeleted,
+}: {
+  skill: Skill
+  body: string
+  runs: SkillRun[]
+  onDeleted: () => void
+}) {
+  return (
+    <>
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-extrabold font-mono text-2xl text-primary leading-tight tracking-tight md:text-3xl">
+            {skillCommand(skill.name)}
+          </h1>
+          <p className="max-w-2xl text-ink-2 text-sm">{skill.description}</p>
+          {skill.site && (
+            <p className="text-ink-3 text-xs">operates on {skill.site}</p>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <RunSkillButton name={skill.name} />
+          <SkillFormDialog
+            mode="edit"
+            name={skill.name}
+            description={skill.description}
+            site={skill.site}
+            body={body}
+            trigger={
+              <Button variant="outline" size="sm" className="rounded-9">
+                Edit
+              </Button>
+            }
+          />
+          <DeleteSkillDialog name={skill.name} onDeleted={onDeleted} />
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <GettingCheaperCard skill={skill} />
+        <SafeToLeaveCard skill={skill} />
+        <LinkedIntoCard skill={skill} />
+      </div>
+
+      <section className="flex flex-col gap-2">
+        <h2 className="font-semibold text-ink text-sm">SKILL.md</h2>
+        <pre className="overflow-x-auto rounded-9 border border-ledger-border bg-card p-4 font-mono text-[12px] text-ledger-ink leading-relaxed">
+          {body}
+        </pre>
+      </section>
+
+      <RunHistory runs={runs} />
+    </>
+  )
+}
+
+function StatCard({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-3 rounded-9 border border-ledger-border bg-card p-4">
+      <h3 className="font-medium text-[12px] text-ledger-ink-2 uppercase tracking-wide">
+        {title}
+      </h3>
+      {children}
+    </div>
+  )
+}
+
+/** Two bars comparing the first run's token cost to the latest run's. */
+function GettingCheaperCard({ skill }: { skill: Skill }) {
+  const { firstRunTokens, latestRunTokens } = skill
+  const delta = tokenDeltaPercent(firstRunTokens, latestRunTokens)
+  const max = Math.max(firstRunTokens ?? 0, latestRunTokens ?? 0, 1)
+
+  if (firstRunTokens === undefined || latestRunTokens === undefined) {
+    return (
+      <StatCard title="Getting cheaper">
+        <p className="text-ink-3 text-sm">
+          Not enough runs to compare cost yet.
+        </p>
+      </StatCard>
+    )
+  }
+
+  return (
+    <StatCard title="Getting cheaper">
+      <div className="flex flex-col gap-2">
+        <CostBar label="Run 1" tokens={firstRunTokens} max={max} muted />
+        <CostBar label="Latest" tokens={latestRunTokens} max={max} />
+      </div>
+      {delta !== null && (
+        <p
+          className={cn(
+            'font-medium text-sm',
+            delta < 0 ? 'text-green' : delta > 0 ? 'text-red' : 'text-ink-2',
+          )}
+        >
+          {delta < 0
+            ? `${Math.abs(delta)}% cheaper than the first run`
+            : delta > 0
+              ? `${delta}% pricier than the first run`
+              : 'Same cost as the first run'}
+        </p>
+      )}
+    </StatCard>
+  )
+}
+
+function CostBar({
+  label,
+  tokens,
+  max,
+  muted = false,
+}: {
+  label: string
+  tokens: number
+  max: number
+  muted?: boolean
+}) {
+  const width = `${Math.max(4, Math.round((tokens / max) * 100))}%`
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-12 shrink-0 text-[11px] text-ink-3">{label}</span>
+      <div className="h-4 flex-1 overflow-hidden rounded bg-card-tint">
+        <div
+          className={cn('h-full rounded', muted ? 'bg-ink-4' : 'bg-primary')}
+          style={{ width }}
+        />
+      </div>
+      <span className="w-12 shrink-0 text-right text-[11px] text-ink-2">
+        {formatTokens(tokens)}
+      </span>
+    </div>
+  )
+}
+
+/** Clean-run ratio: how often the skill ran end to end without a tool error. */
+function SafeToLeaveCard({ skill }: { skill: Skill }) {
+  const ratio =
+    skill.runCount > 0
+      ? Math.round((skill.cleanRunCount / skill.runCount) * 100)
+      : 0
+  return (
+    <StatCard title="Safe to leave alone">
+      <div className="flex items-baseline gap-1">
+        <span className="font-extrabold text-3xl text-ink">
+          {skill.runCount > 0 ? `${ratio}%` : 'not run'}
+        </span>
+        {skill.runCount > 0 && (
+          <span className="text-ink-2 text-sm">clean</span>
+        )}
+      </div>
+      <p className="text-ink-2 text-sm">
+        {skill.cleanRunCount} of {skill.runCount} runs finished without a tool
+        error.
+      </p>
+      {skill.lastRunAt !== undefined && (
+        <p className="text-ink-3 text-xs">
+          last run {formatRelativeTime(skill.lastRunAt)}
+        </p>
+      )}
+    </StatCard>
+  )
+}
+
+/** The coding agents the skill is currently linked into. */
+function LinkedIntoCard({ skill }: { skill: Skill }) {
+  return (
+    <StatCard title="Linked into">
+      {skill.linkedAgents.length === 0 ? (
+        <p className="text-ink-3 text-sm">Not linked into any agent.</p>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {skill.linkedAgents.map((agent) => (
+            <span
+              key={agent}
+              className="rounded-9 bg-card-tint px-2 py-1 font-medium text-[12px] text-ledger-ink-2"
+            >
+              {agentLabel(agent)}
+            </span>
+          ))}
+        </div>
+      )}
+    </StatCard>
+  )
+}
+
+const CELL_PADDING = 'px-2 py-2.5 first:pl-4 last:pr-4'
+
+function RunHistory({ runs }: { runs: SkillRun[] }) {
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="font-semibold text-ink text-sm">Run history</h2>
+      {runs.length === 0 ? (
+        <div className="rounded-9 border border-ledger-border bg-card px-6 py-8 text-center text-ink-2 text-sm">
+          This task has not run yet.
+        </div>
+      ) : (
+        <div className="overflow-clip rounded-9 border border-ledger-border bg-card">
+          <Table className="table-fixed">
+            <TableHeader>
+              <TableRow className="border-none bg-ledger-head hover:bg-ledger-head">
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto w-16 font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  Run
+                </TableHead>
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  Agent
+                </TableHead>
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto w-24 text-right font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  Tokens
+                </TableHead>
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto w-20 text-right font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  Tools
+                </TableHead>
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto w-40 font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  Result
+                </TableHead>
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto w-24 text-right font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  When
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {runs.map((run) => (
+                <TableRow
+                  key={run.id}
+                  className="border-ledger-divider border-b hover:bg-card-tint"
+                >
+                  <TableCell
+                    className={cn(CELL_PADDING, 'text-[13px] text-ink')}
+                  >
+                    #{run.runNumber}
+                  </TableCell>
+                  <TableCell
+                    className={cn(
+                      CELL_PADDING,
+                      'truncate text-[13px] text-ledger-ink-2',
+                    )}
+                  >
+                    {agentLabel(run.agentId)}
+                  </TableCell>
+                  <TableCell
+                    className={cn(
+                      CELL_PADDING,
+                      'text-right text-[13px] text-ink',
+                    )}
+                  >
+                    {run.tokens === undefined
+                      ? 'not run'
+                      : formatTokens(run.tokens)}
+                  </TableCell>
+                  <TableCell
+                    className={cn(
+                      CELL_PADDING,
+                      'text-right text-[13px] text-ledger-ink-2',
+                    )}
+                  >
+                    {run.toolCount ?? 0}
+                  </TableCell>
+                  <TableCell className={cn(CELL_PADDING, 'text-[13px]')}>
+                    {run.clean ? (
+                      <span className="inline-flex items-center gap-1 text-green">
+                        <Check className="size-3.5" />
+                        clean
+                      </span>
+                    ) : (
+                      <span className="truncate text-red">
+                        {run.erroredTool ?? 'error'}
+                      </span>
+                    )}
+                  </TableCell>
+                  <TableCell
+                    className={cn(
+                      CELL_PADDING,
+                      'text-right text-[13px] text-ink-3',
+                    )}
+                  >
+                    {formatRelativeTime(run.createdAt)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function Notice({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-9 border border-ledger-border bg-card px-6 py-10 text-center text-ink-2 text-sm">
+      {children}
+    </div>
+  )
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="h-9 w-48 animate-pulse rounded bg-card-tint" />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {['c1', 'c2', 'c3'].map((id) => (
+          <div
+            key={id}
+            className="h-32 animate-pulse rounded-9 border border-ledger-border bg-card-tint"
+          />
+        ))}
+      </div>
+      <div className="h-64 animate-pulse rounded-9 border border-ledger-border bg-card-tint" />
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/screens/skills/Skills.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/Skills.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Static-markup checks for the Tasks list screen. Stubs the data hook so the
+ * test does not need a running backend.
+ */
+
+import { describe, expect, it, mock } from 'bun:test'
+import type { Skill } from '@browseros/claw-api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+import type { SkillsScreenData } from './skills.data'
+
+const baseData: SkillsScreenData = {
+  skills: [],
+  isLoading: false,
+  isError: false,
+}
+
+let dataOverride: SkillsScreenData = baseData
+
+mock.module('./skills.data', () => ({
+  useSkillsScreenData: () => dataOverride,
+}))
+
+const { Skills } = await import('./Skills')
+
+function renderApp(): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <Skills />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const sampleSkill: Skill = {
+  name: 'inbox-sweep',
+  description: 'Check the inbox and draft what is owed',
+  origin: 'agent',
+  version: 3,
+  linkedAgents: ['Claude Code', 'Codex'],
+  runCount: 5,
+  cleanRunCount: 4,
+  firstRunTokens: 23000,
+  latestRunTokens: 14600,
+  lastRunAt: 1_000_000_000_000,
+  createdAt: 900_000_000_000,
+  updatedAt: 1_000_000_000_000,
+}
+
+describe('Tasks list screen', () => {
+  it('renders the header', () => {
+    dataOverride = { ...baseData }
+    expect(renderApp()).toContain('Tasks')
+  })
+
+  it('shows the empty state when there are no tasks', () => {
+    dataOverride = { ...baseData }
+    expect(renderApp()).toContain('No tasks yet')
+  })
+
+  it('shows skeleton loading rows while the first page is pending', () => {
+    dataOverride = { ...baseData, isLoading: true }
+    expect(renderApp()).toMatch(/animate-pulse/)
+  })
+
+  it('shows the error notice when the query fails', () => {
+    dataOverride = { ...baseData, isError: true }
+    expect(renderApp()).toContain('Could not load')
+  })
+
+  it('renders a row per skill with the command, description, and clean ratio', () => {
+    dataOverride = { ...baseData, skills: [sampleSkill] }
+    const html = renderApp()
+    expect(html).toContain('/inbox-sweep')
+    expect(html).toContain('Check the inbox and draft what is owed')
+    expect(html).toContain('4/5')
+    expect(html).toContain('14.6k')
+  })
+
+  it('renders the getting-cheaper delta on the cost column', () => {
+    dataOverride = { ...baseData, skills: [sampleSkill] }
+    // 23000 -> 14600 is roughly a 37% reduction.
+    expect(renderApp()).toContain('37%')
+  })
+
+  it('renders "not run" for a skill with no measured runs', () => {
+    dataOverride = {
+      ...baseData,
+      skills: [
+        {
+          ...sampleSkill,
+          runCount: 0,
+          cleanRunCount: 0,
+          firstRunTokens: undefined,
+          latestRunTokens: undefined,
+          lastRunAt: undefined,
+        },
+      ],
+    }
+    expect(renderApp()).toContain('not run')
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/skills/Skills.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/Skills.tsx
@@ -1,0 +1,270 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { Skill } from '@browseros/claw-api'
+import { Plus } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useLocation, useNavigate } from 'react-router'
+import { DeleteSkillDialog } from '@/components/skills/DeleteSkillDialog'
+import { RunSkillButton } from '@/components/skills/RunSkillButton'
+import { SkillFormDialog } from '@/components/skills/SkillFormDialog'
+import { Button } from '@/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { cn } from '@/lib/utils'
+import { useSkillsScreenData } from './skills.data'
+import { formatTokens, skillCommand, tokenDeltaPercent } from './skills.helpers'
+
+const CELL_PADDING = 'px-2 py-3 first:pl-4 last:pr-4'
+
+/**
+ * Tasks list. A task is a skill BrowserOS neo linked into the connected coding
+ * agents; each row shows how often it has run, how clean those runs were, and
+ * whether it is getting cheaper. Row click opens the SKILL.md and run history.
+ */
+export function Skills() {
+  const { skills, isLoading, isError } = useSkillsScreenData()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const openSkill = (name: string) =>
+    navigate(`/skills/${encodeURIComponent(name)}`, {
+      state: { from: location.pathname },
+    })
+
+  return (
+    <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-6 px-8 pt-8 pb-16">
+      <header className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <h1 className="font-extrabold text-3xl leading-tight tracking-tight md:text-4xl">
+            Tasks
+          </h1>
+          <p className="text-ink-2 text-sm">
+            Skills BrowserOS neo linked into your coding agents. Re-run one by
+            name.
+          </p>
+        </div>
+        <SkillFormDialog
+          mode="create"
+          trigger={
+            <Button size="sm" className="rounded-9">
+              <Plus />
+              New task
+            </Button>
+          }
+        />
+      </header>
+
+      {isError ? (
+        <SkillsNotice>
+          Could not load your tasks. Check that BrowserOS neo is running and try
+          again.
+        </SkillsNotice>
+      ) : isLoading ? (
+        <SkillsSkeleton />
+      ) : skills.length === 0 ? (
+        <SkillsEmpty />
+      ) : (
+        <LedgerCard>
+          <Table className="table-fixed">
+            <TableHeader>
+              <TableRow className="border-none bg-ledger-head hover:bg-ledger-head">
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  Task
+                </TableHead>
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto w-24 text-right font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  Runs
+                </TableHead>
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto w-40 text-right font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  Cost / run
+                </TableHead>
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto w-24 text-right font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  Clean
+                </TableHead>
+                <TableHead
+                  className={cn(
+                    CELL_PADDING,
+                    'h-auto w-44 font-medium text-[12px] text-ledger-head-ink',
+                  )}
+                >
+                  <span className="sr-only">Actions</span>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {skills.map((skill) => (
+                <SkillRow
+                  key={skill.name}
+                  skill={skill}
+                  onOpen={() => openSkill(skill.name)}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </LedgerCard>
+      )}
+    </div>
+  )
+}
+
+function SkillRow({ skill, onOpen }: { skill: Skill; onOpen: () => void }) {
+  const delta = tokenDeltaPercent(skill.firstRunTokens, skill.latestRunTokens)
+  return (
+    <TableRow
+      data-testid={`skill-row-${skill.name}`}
+      onClick={onOpen}
+      className="cursor-pointer border-ledger-divider border-b hover:bg-card-tint"
+    >
+      <TableCell className={cn(CELL_PADDING, 'align-top')}>
+        <div className="flex flex-col gap-0.5">
+          <span className="font-medium font-mono text-[13px] text-primary">
+            {skillCommand(skill.name)}
+          </span>
+          <span className="truncate text-[13px] text-ledger-ink-2">
+            {skill.description}
+          </span>
+        </div>
+      </TableCell>
+      <TableCell
+        className={cn(
+          CELL_PADDING,
+          'text-right align-top text-[13px] text-ink',
+        )}
+      >
+        {skill.runCount}
+      </TableCell>
+      <TableCell className={cn(CELL_PADDING, 'text-right align-top')}>
+        {skill.latestRunTokens === undefined ? (
+          <span className="text-[13px] text-ink-3">not run</span>
+        ) : (
+          <div className="flex flex-col items-end gap-0.5">
+            <span className="text-[13px] text-ink">
+              {formatTokens(skill.latestRunTokens)}
+            </span>
+            {delta !== null && delta !== 0 && (
+              <span
+                className={cn(
+                  'text-[11px]',
+                  delta < 0 ? 'text-green' : 'text-red',
+                )}
+              >
+                {delta < 0 ? '↓' : '↑'} {Math.abs(delta)}%
+              </span>
+            )}
+          </div>
+        )}
+      </TableCell>
+      <TableCell
+        className={cn(
+          CELL_PADDING,
+          'text-right align-top text-[13px] text-ledger-ink-2',
+        )}
+      >
+        {skill.cleanRunCount}/{skill.runCount}
+      </TableCell>
+      <TableCell
+        className={cn(CELL_PADDING, 'align-top')}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-end gap-1.5">
+          <RunSkillButton name={skill.name} />
+          <DeleteSkillDialog
+            name={skill.name}
+            onDeleted={() => {}}
+            trigger={
+              <Button
+                variant="ghost"
+                size="sm"
+                className="rounded-9 text-red hover:text-red"
+              >
+                Delete
+              </Button>
+            }
+          />
+        </div>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function LedgerCard({ children }: { children: ReactNode }) {
+  return (
+    <div className="overflow-clip rounded-9 border border-ledger-border bg-card">
+      {children}
+    </div>
+  )
+}
+
+function SkillsNotice({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-9 border border-ledger-border bg-card px-6 py-10 text-center text-ink-2 text-sm">
+      {children}
+    </div>
+  )
+}
+
+function SkillsEmpty() {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-9 border border-ledger-border border-dashed bg-card px-6 py-16 text-center">
+      <div className="flex flex-col gap-1">
+        <p className="font-semibold text-base text-ink">No tasks yet</p>
+        <p className="mx-auto max-w-md text-ink-2 text-sm">
+          When BrowserOS neo turns a session into a repeatable skill it shows up
+          here, linked into your coding agents. You can also write one yourself.
+        </p>
+      </div>
+      <SkillFormDialog
+        mode="create"
+        trigger={
+          <Button size="sm" className="rounded-9">
+            <Plus />
+            New task
+          </Button>
+        }
+      />
+    </div>
+  )
+}
+
+function SkillsSkeleton() {
+  return (
+    <LedgerCard>
+      <div className="divide-y divide-ledger-divider">
+        {['s1', 's2', 's3', 's4'].map((id) => (
+          <div key={id} className="px-4 py-4">
+            <div className="h-4 w-full animate-pulse rounded bg-card-tint" />
+          </div>
+        ))}
+      </div>
+    </LedgerCard>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/screens/skills/skill-detail.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/skill-detail.data.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Single data-aggregation hook for the task detail screen. Resolves the skill
+ * name from the route and returns the SKILL.md, its stats, and its run history.
+ */
+
+import type { SkillDetail } from '@browseros/claw-api'
+import { useParams } from 'react-router'
+import { useSkill } from '@/modules/api/skills.hooks'
+
+export interface SkillDetailScreenData {
+  name: string
+  detail: SkillDetail | undefined
+  isLoading: boolean
+  isError: boolean
+}
+
+export function useSkillDetailData(): SkillDetailScreenData {
+  const { name = '' } = useParams()
+  const query = useSkill({
+    variables: { name },
+    enabled: name.length > 0,
+  })
+  return {
+    name,
+    detail: query.data,
+    isLoading: query.isPending,
+    isError: query.isError,
+  }
+}

--- a/packages/browseros-agent/apps/claw-app/screens/skills/skills.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/skills.data.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Single data-aggregation hook for the Tasks list screen. The screen calls only
+ * this hook and renders what it returns.
+ */
+
+import type { Skill } from '@browseros/claw-api'
+import { useSkills } from '@/modules/api/skills.hooks'
+
+export interface SkillsScreenData {
+  skills: Skill[]
+  isLoading: boolean
+  isError: boolean
+}
+
+export function useSkillsScreenData(): SkillsScreenData {
+  const query = useSkills()
+  return {
+    skills: query.data?.items ?? [],
+    isLoading: query.isPending,
+    isError: query.isError,
+  }
+}

--- a/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   formatRelativeTime,
   formatTokens,
+  parseSkillBody,
   skillCommand,
   tokenDeltaPercent,
 } from './skills.helpers'
@@ -42,6 +43,46 @@ describe('tokenDeltaPercent', () => {
 
   it('is positive when the skill got pricier', () => {
     expect(tokenDeltaPercent(100, 150)).toBe(50)
+  })
+})
+
+describe('parseSkillBody', () => {
+  const body = [
+    '---',
+    'name: inbox-sweep',
+    'description: "Check the inbox"',
+    'tools: browseros-neo',
+    '---',
+    '',
+    '## Steps',
+    '1. Call the mark_skill_run tool with name: inbox-sweep so this run is recorded.',
+    '2. Open the inbox',
+    '3. Draft replies',
+    '',
+    '## Learned from past runs',
+    '- Read the DOM snapshot, not screenshots',
+    '- Leave drafts unsent',
+  ].join('\n')
+
+  it('extracts the user steps and drops the auto run-marking step', () => {
+    expect(parseSkillBody(body).steps).toEqual([
+      'Open the inbox',
+      'Draft replies',
+    ])
+  })
+
+  it('extracts the learned notes', () => {
+    expect(parseSkillBody(body).learnedNotes).toEqual([
+      'Read the DOM snapshot, not screenshots',
+      'Leave drafts unsent',
+    ])
+  })
+
+  it('returns empty arrays for a body with no sections', () => {
+    expect(parseSkillBody('just prose')).toEqual({
+      steps: [],
+      learnedNotes: [],
+    })
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  formatRelativeTime,
+  formatTokens,
+  skillCommand,
+  tokenDeltaPercent,
+} from './skills.helpers'
+
+describe('skillCommand', () => {
+  it('prefixes the name with a slash', () => {
+    expect(skillCommand('inbox-sweep')).toBe('/inbox-sweep')
+  })
+})
+
+describe('formatTokens', () => {
+  it('leaves values under 1000 as-is', () => {
+    expect(formatTokens(840)).toBe('840')
+  })
+
+  it('compacts thousands to one decimal', () => {
+    expect(formatTokens(14600)).toBe('14.6k')
+  })
+
+  it('keeps the trailing decimal on a round thousand', () => {
+    expect(formatTokens(23000)).toBe('23.0k')
+  })
+})
+
+describe('tokenDeltaPercent', () => {
+  it('is null when either side is missing', () => {
+    expect(tokenDeltaPercent(undefined, 100)).toBeNull()
+    expect(tokenDeltaPercent(100, undefined)).toBeNull()
+  })
+
+  it('is null when the first run measured zero tokens', () => {
+    expect(tokenDeltaPercent(0, 100)).toBeNull()
+  })
+
+  it('is negative when the skill got cheaper', () => {
+    expect(tokenDeltaPercent(23000, 14600)).toBe(-37)
+  })
+
+  it('is positive when the skill got pricier', () => {
+    expect(tokenDeltaPercent(100, 150)).toBe(50)
+  })
+})
+
+describe('formatRelativeTime', () => {
+  const now = 1_000_000_000_000
+
+  it('reads "just now" under a minute', () => {
+    expect(formatRelativeTime(now - 30_000, now)).toBe('just now')
+  })
+
+  it('reads minutes', () => {
+    expect(formatRelativeTime(now - 5 * 60_000, now)).toBe('5m ago')
+  })
+
+  it('reads hours', () => {
+    expect(formatRelativeTime(now - 3 * 3_600_000, now)).toBe('3h ago')
+  })
+
+  it('reads days', () => {
+    expect(formatRelativeTime(now - 2 * 86_400_000, now)).toBe('2d ago')
+  })
+
+  it('never goes negative for a future timestamp', () => {
+    expect(formatRelativeTime(now + 60_000, now)).toBe('just now')
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Pure formatters for the Tasks list and detail. No React, no side effects.
+ */
+
+/** The command a user pastes into a coding agent to run a skill. */
+export function skillCommand(name: string): string {
+  return `/${name}`
+}
+
+/** Compact token count, e.g. 14600 -> "14.6k". */
+export function formatTokens(tokens: number): string {
+  if (tokens < 1000) {
+    return String(tokens)
+  }
+  return `${(tokens / 1000).toFixed(1)}k`
+}
+
+/**
+ * Percent change from the first run's tokens to the latest run's, so a negative
+ * value means the skill got cheaper. `null` when there is nothing to compare.
+ */
+export function tokenDeltaPercent(
+  first: number | undefined,
+  latest: number | undefined,
+): number | null {
+  if (first === undefined || latest === undefined || first === 0) {
+    return null
+  }
+  return Math.round(((latest - first) / first) * 100)
+}
+
+/** A short "time ago" label from an epoch-ms timestamp. */
+export function formatRelativeTime(
+  epochMs: number,
+  now: number = Date.now(),
+): string {
+  const minutes = Math.floor(Math.max(0, now - epochMs) / 60_000)
+  if (minutes < 1) {
+    return 'just now'
+  }
+  if (minutes < 60) {
+    return `${minutes}m ago`
+  }
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return `${hours}h ago`
+  }
+  return `${Math.floor(hours / 24)}d ago`
+}

--- a/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.ts
@@ -33,6 +33,47 @@ export function tokenDeltaPercent(
   return Math.round(((latest - first) / first) * 100)
 }
 
+/**
+ * Split a rendered SKILL.md into its editable structured fields so the edit
+ * form can pre-fill them. Reads the numbered `## Steps` and the bulleted
+ * `## Learned from past runs` sections. The auto-generated first step that
+ * records the run is dropped, since the server re-adds it on save.
+ */
+export function parseSkillBody(body: string): {
+  steps: string[]
+  learnedNotes: string[]
+} {
+  const steps: string[] = []
+  const learnedNotes: string[] = []
+  let section: 'steps' | 'learned' | null = null
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('## ')) {
+      const title = trimmed.slice(3).toLowerCase()
+      section = title.startsWith('steps')
+        ? 'steps'
+        : title.startsWith('learned')
+          ? 'learned'
+          : null
+      continue
+    }
+    if (section === 'steps') {
+      const match = line.match(/^\s*\d+\.\s+(.*)$/)
+      const step = match?.[1]?.trim()
+      if (step && !step.includes('mark_skill_run')) {
+        steps.push(step)
+      }
+    } else if (section === 'learned') {
+      const match = line.match(/^\s*-\s+(.*)$/)
+      const note = match?.[1]?.trim()
+      if (note) {
+        learnedNotes.push(note)
+      }
+    }
+  }
+  return { steps, learnedNotes }
+}
+
 /** A short "time ago" label from an epoch-ms timestamp. */
 export function formatRelativeTime(
   epochMs: number,

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/skills.rs
@@ -82,6 +82,8 @@ pub(super) async fn update(
             UpdateSkill {
                 description: body.description,
                 site: body.site,
+                steps: body.steps,
+                learned_notes: body.learned_notes,
                 body: body.body,
             },
         )

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -40,6 +40,8 @@ pub struct CreateSkill {
 pub struct UpdateSkill {
     pub description: Option<String>,
     pub site: Option<String>,
+    pub steps: Option<Vec<String>>,
+    pub learned_notes: Option<Vec<String>>,
     pub body: Option<String>,
 }
 
@@ -268,21 +270,60 @@ impl SkillService {
         let mut previous_body: Option<String> = None;
         let body_path = model.body_path.clone();
 
-        if let Some(body) = input.body {
+        let UpdateSkill {
+            description,
+            site,
+            steps,
+            learned_notes,
+            body,
+        } = input;
+
+        // The description that the rendered/patched frontmatter must carry: the
+        // incoming value if present, otherwise the one already stored.
+        let effective_description = description
+            .clone()
+            .unwrap_or_else(|| model.description.clone());
+
+        // Decide what, if anything, to write to disk. A structured edit renders
+        // the whole SKILL.md so its frontmatter description can never drift from
+        // the stored column. A raw `body` is written verbatim (agent authoring
+        // or a manual override). A metadata-only description change patches just
+        // the frontmatter line so the file matches the new column without
+        // disturbing the rest of the body.
+        let rewrite: Option<String> = if steps.is_some() || learned_notes.is_some() {
+            Some(render_skill_markdown(
+                name,
+                &effective_description,
+                &steps.unwrap_or_default(),
+                &learned_notes.unwrap_or_default(),
+            ))
+        } else if let Some(raw) = body {
+            Some(raw)
+        } else if description.is_some() {
+            let current = self.read_body(&body_path).await;
+            Some(sync_frontmatter_description(
+                &current,
+                &effective_description,
+            ))
+        } else {
+            None
+        };
+
+        if let Some(content) = rewrite {
             previous_body = Some(self.read_body(&body_path).await);
-            self.write_body_at(&body_path, &body).await?;
-            let spec = SkillSpec::new(name, body)
+            self.write_body_at(&body_path, &content).await?;
+            let spec = SkillSpec::new(name, content)
                 .map_err(|error| AppError::bad_request(error.to_string()))?;
             relinked = Some(self.harness.install_skill(spec).await?);
             model.version += 1;
         }
-        if let Some(description) = input.description {
+        if let Some(description) = description {
             model.description = description;
         }
-        // A nullable `site` cannot be explicitly cleared through the current
-        // contract; clearing is deferred to a later contract revision.
-        if let Some(site) = input.site {
-            model.site = Some(site);
+        // An empty string clears the site; a non-empty value sets it; an absent
+        // value leaves it unchanged.
+        if let Some(site) = site {
+            model.site = (!site.is_empty()).then_some(site);
         }
         if let Some(linked) = &relinked {
             model.linked_agents_json = linked_agents_json(linked);
@@ -343,6 +384,8 @@ impl SkillService {
                         UpdateSkill {
                             description: Some(description),
                             site,
+                            steps: None,
+                            learned_notes: None,
                             body: Some(content),
                         },
                     )
@@ -470,6 +513,42 @@ fn render_skill_markdown(
         for note in learned_notes {
             out.push_str(&format!("- {note}\n"));
         }
+    }
+    out
+}
+
+/// Rewrite the `description:` line inside a SKILL.md frontmatter block so the
+/// on-disk file matches the stored description, leaving the rest of the body
+/// untouched. The description is JSON-encoded to stay a valid YAML scalar, the
+/// same way `render_skill_markdown` emits it. A body without a leading `---`
+/// frontmatter fence is returned unchanged.
+fn sync_frontmatter_description(body: &str, description: &str) -> String {
+    let encoded = serde_json::to_string(description).unwrap_or_else(|_| "\"\"".to_string());
+    let mut lines: Vec<String> = body.lines().map(str::to_string).collect();
+    if lines.first().map(|line| line.trim_end()) != Some("---") {
+        return body.to_string();
+    }
+    let Some(closing) = lines
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, line)| line.trim_end() == "---")
+        .map(|(index, _)| index)
+    else {
+        return body.to_string();
+    };
+    let description_line = lines
+        .iter_mut()
+        .take(closing)
+        .skip(1)
+        .find(|line| line.trim_start().starts_with("description:"));
+    match description_line {
+        Some(line) => *line = format!("description: {encoded}"),
+        None => lines.insert(1, format!("description: {encoded}")),
+    }
+    let mut out = lines.join("\n");
+    if body.ends_with('\n') {
+        out.push('\n');
     }
     out
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -278,6 +278,22 @@ impl SkillService {
             body,
         } = input;
 
+        // A raw body and structured fields are two representations of the same
+        // file; accepting both would silently persist one and discard the other.
+        if body.is_some() && (steps.is_some() || learned_notes.is_some()) {
+            return Err(AppError::bad_request(
+                "provide either a raw body or structured steps/learnedNotes, not both",
+            ));
+        }
+        // A structured edit replaces both sections at once, so both must be sent
+        // together; otherwise the omitted section would be silently erased. An
+        // explicit empty array clears a section.
+        if steps.is_some() != learned_notes.is_some() {
+            return Err(AppError::bad_request(
+                "steps and learnedNotes must be provided together",
+            ));
+        }
+
         // The description that the rendered/patched frontmatter must carry: the
         // incoming value if present, otherwise the one already stored.
         let effective_description = description
@@ -302,6 +318,7 @@ impl SkillService {
         } else if description.is_some() {
             let current = self.read_body(&body_path).await;
             Some(sync_frontmatter_description(
+                name,
                 &current,
                 &effective_description,
             ))
@@ -520,22 +537,28 @@ fn render_skill_markdown(
 /// Rewrite the `description:` line inside a SKILL.md frontmatter block so the
 /// on-disk file matches the stored description, leaving the rest of the body
 /// untouched. The description is JSON-encoded to stay a valid YAML scalar, the
-/// same way `render_skill_markdown` emits it. A body without a leading `---`
-/// frontmatter fence is returned unchanged.
-fn sync_frontmatter_description(body: &str, description: &str) -> String {
+/// same way `render_skill_markdown` emits it. A body with no `---` frontmatter
+/// fence (a raw body written without one) gets a fresh frontmatter block
+/// prepended so the description is always present in the file.
+fn sync_frontmatter_description(name: &str, body: &str, description: &str) -> String {
     let encoded = serde_json::to_string(description).unwrap_or_else(|_| "\"\"".to_string());
     let mut lines: Vec<String> = body.lines().map(str::to_string).collect();
-    if lines.first().map(|line| line.trim_end()) != Some("---") {
-        return body.to_string();
-    }
-    let Some(closing) = lines
-        .iter()
-        .enumerate()
-        .skip(1)
-        .find(|(_, line)| line.trim_end() == "---")
-        .map(|(index, _)| index)
-    else {
-        return body.to_string();
+    let closing = lines
+        .first()
+        .map(|line| line.trim_end())
+        .filter(|first| *first == "---")
+        .and_then(|_| {
+            lines
+                .iter()
+                .enumerate()
+                .skip(1)
+                .find(|(_, line)| line.trim_end() == "---")
+                .map(|(index, _)| index)
+        });
+    let Some(closing) = closing else {
+        let front =
+            format!("---\nname: {name}\ndescription: {encoded}\ntools: {SKILL_TOOLS}\n---\n\n");
+        return format!("{front}{body}");
     };
     let description_line = lines
         .iter_mut()

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -159,6 +159,92 @@ async fn skill_crud_round_trips_and_writes_the_canonical_file() -> anyhow::Resul
 }
 
 #[tokio::test]
+async fn skill_structured_edit_re_renders_frontmatter_and_clears_site() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({
+            "name": "inbox-sweep",
+            "description": "First description",
+            "site": "mail.google.com",
+            "steps": ["Old step"]
+        })),
+    )
+    .await?;
+
+    let (status, updated) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/inbox-sweep",
+        Some(json!({
+            "description": "Second description",
+            "site": "",
+            "steps": ["New step"],
+            "learnedNotes": ["Prefer the DOM snapshot"]
+        })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(updated["skill"]["description"], "Second description");
+    assert_eq!(updated["skill"]["version"].as_i64(), Some(2));
+    // An empty site string clears the column, so it is omitted from the DTO.
+    assert!(updated["skill"]["site"].is_null());
+
+    // The on-disk frontmatter description tracks the column: agents reading the
+    // file see the new description, never the stale one.
+    let skill_md = app.root.join("skills").join("inbox-sweep").join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_md)?;
+    assert!(content.contains(r#"description: "Second description""#));
+    assert!(!content.contains("First description"));
+    assert!(content.contains("New step"));
+    assert!(content.contains("Prefer the DOM snapshot"));
+    assert!(!content.contains("Old step"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn skill_metadata_only_description_edit_patches_frontmatter() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({
+            "name": "daily-brief",
+            "description": "Old description",
+            "steps": ["Keep this step"]
+        })),
+    )
+    .await?;
+
+    let (status, updated) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/daily-brief",
+        Some(json!({ "description": "Fresh description" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(updated["skill"]["description"], "Fresh description");
+
+    // Only the frontmatter description line changes; the body is preserved.
+    let skill_md = app.root.join("skills").join("daily-brief").join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_md)?;
+    assert!(content.contains(r#"description: "Fresh description""#));
+    assert!(!content.contains("Old description"));
+    assert!(content.contains("Keep this step"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn skill_create_rejects_bad_names_and_duplicates() -> anyhow::Result<()> {
     let app = test_app().await?;
     let router = &app.router;

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -245,6 +245,98 @@ async fn skill_metadata_only_description_edit_patches_frontmatter() -> anyhow::R
 }
 
 #[tokio::test]
+async fn skill_update_rejects_ambiguous_field_combinations() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({ "name": "inbox-sweep", "description": "First", "steps": ["Old step"] })),
+    )
+    .await?;
+
+    // A raw body plus structured fields is ambiguous: reject it rather than
+    // silently discard one representation.
+    let (status, _) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/inbox-sweep",
+        Some(json!({
+            "body": "---\nname: inbox-sweep\ndescription: X\ntools: browseros-neo\n---\n",
+            "steps": ["New step"],
+            "learnedNotes": []
+        })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // Only one of the two structured sections would silently erase the other.
+    let (status, _) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/inbox-sweep",
+        Some(json!({ "steps": ["New step"] })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // The original steps survive both rejected updates.
+    let (_, detail) = request(router, "GET", "/api/v1/skills/inbox-sweep", None).await?;
+    assert!(
+        detail["body"]
+            .as_str()
+            .is_some_and(|body| body.contains("Old step"))
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn skill_description_edit_adds_frontmatter_to_a_raw_body() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({ "name": "raw-note", "description": "First" })),
+    )
+    .await?;
+
+    // Store a raw body that has no frontmatter fence.
+    let (status, _) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/raw-note",
+        Some(json!({ "body": "Just prose, no frontmatter\n" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+
+    // A description-only edit must still land in the file: a frontmatter block
+    // is prepended so linked agents read the new description.
+    let (status, _) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/raw-note",
+        Some(json!({ "description": "Now described" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+
+    let skill_md = app.root.join("skills").join("raw-note").join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_md)?;
+    assert!(content.starts_with("---\nname: raw-note\n"));
+    assert!(content.contains(r#"description: "Now described""#));
+    assert!(content.contains("Just prose, no frontmatter"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn skill_create_rejects_bad_names_and_duplicates() -> anyhow::Result<()> {
     let app = test_app().await?;
     let router = &app.router;

--- a/packages/browseros-agent/contracts/claw-api/schemas/skills.yaml
+++ b/packages/browseros-agent/contracts/claw-api/schemas/skills.yaml
@@ -186,9 +186,20 @@ SkillUpdate:
       type: string
     site:
       type: string
+      description: Primary site the skill operates on. An empty string clears it.
+    steps:
+      type: array
+      items:
+        type: string
+      description: Replacement steps. Re-renders the SKILL.md from structured fields.
+    learnedNotes:
+      type: array
+      items:
+        type: string
+      description: Replacement learned notes. Re-renders the SKILL.md from structured fields.
     body:
       type: string
-      description: Replacement SKILL.md contents for a manual edit.
+      description: Replacement SKILL.md contents for a raw manual edit or agent authoring.
 DirectorySkill:
   type: object
   additionalProperties: false

--- a/packages/browseros-agent/crates/claw-api/src/generated/skills.rs
+++ b/packages/browseros-agent/crates/claw-api/src/generated/skills.rs
@@ -323,9 +323,16 @@ impl SkillRunList {
 pub struct SkillUpdate {
     #[serde(rename = "description", skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Primary site the skill operates on. An empty string clears it.
     #[serde(rename = "site", skip_serializing_if = "Option::is_none")]
     pub site: Option<String>,
-    /// Replacement SKILL.md contents for a manual edit.
+    /// Replacement steps. Re-renders the SKILL.md from structured fields.
+    #[serde(rename = "steps", skip_serializing_if = "Option::is_none")]
+    pub steps: Option<Vec<String>>,
+    /// Replacement learned notes. Re-renders the SKILL.md from structured fields.
+    #[serde(rename = "learnedNotes", skip_serializing_if = "Option::is_none")]
+    pub learned_notes: Option<Vec<String>>,
+    /// Replacement SKILL.md contents for a raw manual edit or agent authoring.
     #[serde(rename = "body", skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
 }
@@ -335,6 +342,8 @@ impl SkillUpdate {
         SkillUpdate {
             description: None,
             site: None,
+            steps: None,
+            learned_notes: None,
             body: None,
         }
     }

--- a/packages/browseros-agent/packages/claw-api-client/src/client.ts
+++ b/packages/browseros-agent/packages/claw-api-client/src/client.ts
@@ -14,6 +14,12 @@ import type {
   SessionScreenshotList,
   SetAuditRetentionRequest,
   ShutdownResponse,
+  Skill,
+  SkillCreate,
+  SkillDetail,
+  SkillList,
+  SkillRunList,
+  SkillUpdate,
   SystemInfo,
   TelemetryState,
 } from '@browseros/claw-api'
@@ -56,6 +62,19 @@ export interface AppendRecordingEventsRequest {
 
 export type SessionRequest = operations['getSession']['parameters']['path']
 export type HarnessRequest = operations['connectHarness']['parameters']['path']
+
+export type SkillNameRequest = operations['getSkill']['parameters']['path']
+
+export interface UpdateSkillRequest {
+  name: SkillNameRequest['name']
+  body: SkillUpdate
+}
+
+export interface ListSkillRunsRequest {
+  name: SkillNameRequest['name']
+  cursor?: number
+  limit?: number
+}
 
 type ApiResult<T> =
   | { data: T; response: Response }
@@ -250,6 +269,48 @@ export class ClawApiClient {
     )
   }
 
+  async listSkills(): Promise<SkillList> {
+    return this.unwrap(await this.client.GET('/api/v1/skills'))
+  }
+
+  async getSkill(request: SkillNameRequest): Promise<SkillDetail> {
+    return this.unwrap(
+      await this.client.GET('/api/v1/skills/{name}', {
+        params: { path: request },
+      }),
+    )
+  }
+
+  async createSkill(body: SkillCreate): Promise<Skill> {
+    return this.unwrap(await this.client.POST('/api/v1/skills', { body }))
+  }
+
+  async updateSkill(request: UpdateSkillRequest): Promise<SkillDetail> {
+    return this.unwrap(
+      await this.client.PUT('/api/v1/skills/{name}', {
+        params: { path: { name: request.name } },
+        body: request.body,
+      }),
+    )
+  }
+
+  async deleteSkill(request: SkillNameRequest): Promise<void> {
+    this.expectSuccess(
+      await this.client.DELETE('/api/v1/skills/{name}', {
+        params: { path: request },
+      }),
+    )
+  }
+
+  async listSkillRuns(request: ListSkillRunsRequest): Promise<SkillRunList> {
+    const { name, ...query } = request
+    return this.unwrap(
+      await this.client.GET('/api/v1/skills/{name}/runs', {
+        params: { path: { name }, query },
+      }),
+    )
+  }
+
   private unwrap<T>(result: ApiResult<T | undefined>): T {
     const errorResponse = this.responseClones.get(result.response)
     this.responseClones.delete(result.response)
@@ -260,5 +321,14 @@ export class ClawApiClient {
       throw new Error('BrowserOS neo API returned an empty success response')
     }
     return result.data
+  }
+
+  // A 204 response carries no body, so this only surfaces a failure.
+  private expectSuccess(result: { error?: unknown; response: Response }): void {
+    const errorResponse = this.responseClones.get(result.response)
+    this.responseClones.delete(result.response)
+    if ('error' in result) {
+      throw new ApiResponseError(errorResponse ?? result.response)
+    }
   }
 }

--- a/packages/browseros-agent/packages/claw-api-client/src/generated/openapi.ts
+++ b/packages/browseros-agent/packages/claw-api-client/src/generated/openapi.ts
@@ -819,8 +819,13 @@ export interface components {
     }
     SkillUpdate: {
       description?: string
+      /** @description Primary site the skill operates on. An empty string clears it. */
       site?: string
-      /** @description Replacement SKILL.md contents for a manual edit. */
+      /** @description Replacement steps. Re-renders the SKILL.md from structured fields. */
+      steps?: string[]
+      /** @description Replacement learned notes. Re-renders the SKILL.md from structured fields. */
+      learnedNotes?: string[]
+      /** @description Replacement SKILL.md contents for a raw manual edit or agent authoring. */
       body?: string
     }
     DirectorySkill: {

--- a/packages/browseros-agent/packages/claw-api/src/generated/models/skills.ts
+++ b/packages/browseros-agent/packages/claw-api/src/generated/models/skills.ts
@@ -398,13 +398,25 @@ export interface SkillUpdate {
      */
     description?: string;
     /**
-     *
+     * Primary site the skill operates on. An empty string clears it.
      * @type {string}
      * @memberof SkillUpdate
      */
     site?: string;
     /**
-     * Replacement SKILL.md contents for a manual edit.
+     * Replacement steps. Re-renders the SKILL.md from structured fields.
+     * @type {Array<string>}
+     * @memberof SkillUpdate
+     */
+    steps?: Array<string>;
+    /**
+     * Replacement learned notes. Re-renders the SKILL.md from structured fields.
+     * @type {Array<string>}
+     * @memberof SkillUpdate
+     */
+    learnedNotes?: Array<string>;
+    /**
+     * Replacement SKILL.md contents for a raw manual edit or agent authoring.
      * @type {string}
      * @memberof SkillUpdate
      */


### PR DESCRIPTION
Adds the Tasks rail page to the local app: the surface where skills BrowserOS neo links into the connected coding agents are listed, inspected, and managed.

## What's here

**List** (`/skills`)
- One row per skill: its `/command`, run count, cost per run (latest run tokens with a getting-cheaper delta), clean-run ratio, a Run action that copies the command to the clipboard, and inline delete.
- Loading, error, and empty states.

**Detail** (`/skills/:name`)
- The raw SKILL.md.
- "Getting cheaper": the first run's token cost bar against the latest run's, with the percentage delta.
- "Safe to leave alone": the clean-run ratio and last-run time.
- "Linked into": the coding agents the skill is currently linked into.
- Run history table.

**Create / edit / delete**
- Create and edit through a form dialog (name, description, site, steps/notes on create; description, site, and the raw SKILL.md on edit).
- Delete behind a confirmation dialog.

## Implementation notes

- Typed end to end against the generated skills client; data access goes through `react-query-kit` hooks with call-site invalidation.
- Styled with the existing ledger design tokens and shadcn table primitives, matching the Audit screen.
- Route wrappers stay thin; all logic lives under `screens/skills/` with the satellite-file layout (`skills.data.ts`, `skill-detail.data.ts`, `skills.helpers.ts`).

## Verification

- Typecheck (app + client package), formatter, and the new unit + static-markup tests all pass.