### PR TITLE
feat(server): give /mcp clients a server-minted session identity handle

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
@@ -45,6 +45,7 @@ export function createMcpServer(deps: McpServiceDeps) {
     instructions: MCP_INSTRUCTIONS,
     registration: {
       includeStructuredContent: deps.includeStructuredContent ?? false,
+      sessionIdentity: true,
       logger,
       onToolExecutionStart: () => deps.activity?.beginMcpToolExecution(),
       onToolExecutionEnd: () => deps.activity?.endMcpToolExecution(),

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/mcp-server.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/mcp-server.test.ts
@@ -31,7 +31,7 @@ function browserSession(): BrowserSession {
 }
 
 describe('createMcpServer structured browser results', () => {
-  it('strips ordinary envelopes by default while retaining run output', async () => {
+  it('adds only the session handle to ordinary envelopes and retains run output', async () => {
     const server = inspect(
       createMcpServer({
         version: 'test',
@@ -42,8 +42,15 @@ describe('createMcpServer structured browser results', () => {
     const tabs = await server._registeredTools.tabs.handler({ action: 'new' })
     const run = await server._registeredTools.run.handler({ code: 'return 42' })
 
-    expect(tabs).not.toHaveProperty('structuredContent')
-    expect(run.structuredContent).toEqual({ ok: true, value: 42, logs: [] })
+    // The ordinary tool envelope is still stripped by default; only the
+    // server-minted session identity handle is surfaced.
+    expect(tabs.structuredContent).toEqual({ session: expect.any(String) })
+    expect(run.structuredContent).toEqual({
+      ok: true,
+      value: 42,
+      logs: [],
+      session: expect.any(String),
+    })
   })
 
   it('returns grep matches for opted-in machine clients', async () => {
@@ -66,6 +73,7 @@ describe('createMcpServer structured browser results', () => {
       over: 'ax',
       count: 1,
       matches: ['button "Save" [ref=e1]'],
+      session: expect.any(String),
     })
   })
 })

--- a/packages/browseros-agent/packages/browser-mcp/src/mcp-server.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/mcp-server.test.ts
@@ -216,4 +216,54 @@ describe('createBrowserMcpServer', () => {
       }),
     ])
   })
+
+  it('mints, echoes, and strips a session handle when sessionIdentity is on', async () => {
+    const events: Array<Record<string, unknown>> = []
+    const raw = createBrowserMcpServer({
+      name: 'browseros_mcp',
+      title: 'BrowserOS MCP server',
+      version: '1.2.3',
+      browserSession: {
+        pages: {
+          newPage: async () => 42,
+        },
+      } as unknown as BrowserSession,
+      registration: {
+        sessionIdentity: true,
+        onToolExecuted: (event) => events.push(event),
+      },
+    })
+    const server = inspect(raw)
+
+    const schema = (
+      raw as unknown as {
+        toolInputSchemaJson(name: string): {
+          properties?: Record<string, unknown>
+        }
+      }
+    ).toolInputSchemaJson('tabs')
+    expect(Object.keys(schema?.properties ?? {})).toContain('session')
+
+    // No handle provided: the server mints one and returns it, and the tool
+    // still runs (the session key is stripped before the tool parses args).
+    const minted = await server._registeredTools.tabs.handler({
+      action: 'new',
+      url: 'https://example.com',
+    })
+    const mintedSession = (minted?.structuredContent as { session?: string })
+      ?.session
+    expect(typeof mintedSession).toBe('string')
+    expect(mintedSession).toHaveLength(36)
+    expect(events[0]?.session).toBe(mintedSession)
+
+    // A provided handle is echoed back unchanged.
+    const reused = await server._registeredTools.tabs.handler({
+      action: 'new',
+      url: 'https://example.com',
+      session: 'agent-supplied-handle',
+    })
+    expect((reused?.structuredContent as { session?: string })?.session).toBe(
+      'agent-supplied-handle',
+    )
+  })
 })

--- a/packages/browseros-agent/packages/browser-mcp/src/mcp-server.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/mcp-server.test.ts
@@ -218,7 +218,7 @@ describe('createBrowserMcpServer', () => {
   })
 
   it('mints, echoes, and strips a session handle when sessionIdentity is on', async () => {
-    const events: Array<Record<string, unknown>> = []
+    const debugLogs: Array<{ msg: string; meta?: Record<string, unknown> }> = []
     const raw = createBrowserMcpServer({
       name: 'browseros_mcp',
       title: 'BrowserOS MCP server',
@@ -230,7 +230,10 @@ describe('createBrowserMcpServer', () => {
       } as unknown as BrowserSession,
       registration: {
         sessionIdentity: true,
-        onToolExecuted: (event) => events.push(event),
+        logger: {
+          debug: (msg: string, meta?: Record<string, unknown>) =>
+            debugLogs.push({ msg, meta }),
+        },
       },
     })
     const server = inspect(raw)
@@ -254,7 +257,11 @@ describe('createBrowserMcpServer', () => {
       ?.session
     expect(typeof mintedSession).toBe('string')
     expect(mintedSession).toHaveLength(36)
-    expect(events[0]?.session).toBe(mintedSession)
+    // The handle is attributed on the per-call log, not the aggregated metric.
+    const started = debugLogs.find(
+      (entry) => entry.msg === 'MCP browser tool started',
+    )
+    expect(started?.meta?.session).toBe(mintedSession)
 
     // A provided handle is echoed back unchanged.
     const reused = await server._registeredTools.tabs.handler({

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
@@ -1,11 +1,36 @@
 import type { BrowserSession } from '@browseros/browser-core/core/session'
 import type { McpServer } from '@modelcontextprotocol/server'
+import { z } from 'zod/v4'
 import { executeTool } from './framework'
 import {
   type BrowserOutputFileAccess,
   withBrowserOutputFileAccess,
 } from './output-file'
 import { BROWSER_TOOLS } from './registry'
+
+const SESSION_ARG_DESCRIPTION =
+  'Opaque session handle returned by the server. Pass it back on every call to keep working in the same browser session; omit it to start a new session.'
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function resolveSessionHandle(
+  args: Record<string, unknown>,
+  enabled: boolean | undefined,
+): { sessionHandle?: string; toolArgs: Record<string, unknown> } {
+  if (!enabled) return { toolArgs: args }
+  const provided = typeof args.session === 'string' ? args.session.trim() : ''
+  const sessionHandle = provided.length > 0 ? provided : crypto.randomUUID()
+  const toolArgs = { ...args }
+  delete toolArgs.session
+  return { sessionHandle, toolArgs }
+}
+
+function mergeSessionHandle(base: unknown, sessionHandle: string | undefined) {
+  if (sessionHandle === undefined) return base
+  return { ...(isPlainObject(base) ? base : {}), session: sessionHandle }
+}
 
 type RegisterFn = (
   name: string,
@@ -44,6 +69,8 @@ export interface BrowserToolRegistrationOptions {
   shouldLogToolRegistration?: () => boolean
   logger?: BrowserToolLogger
   source?: string
+  /** When set, expose an optional server-minted session handle argument for caller session identity (2026-07-28). */
+  sessionIdentity?: boolean
 }
 
 export interface BrowserToolLifecycleEvent extends Record<string, unknown> {
@@ -57,6 +84,7 @@ export interface BrowserToolExecutionEvent extends Record<string, unknown> {
   success: boolean
   source: string
   error_message?: string
+  session?: string
 }
 
 function summarizeBrowserToolArgs(
@@ -128,11 +156,16 @@ export function registerBrowserTools(
   const register = server.registerTool.bind(server) as unknown as RegisterFn
 
   for (const tool of BROWSER_TOOLS) {
+    const inputSchema = options.sessionIdentity
+      ? tool.input.extend({
+          session: z.string().optional().describe(SESSION_ARG_DESCRIPTION),
+        })
+      : tool.input
     register(
       tool.name,
       {
         description: tool.description,
-        inputSchema: tool.input,
+        inputSchema,
         ...(tool.output && { outputSchema: tool.output }),
         ...(tool.annotations && {
           annotations: tool.annotations as Record<string, unknown>,
@@ -142,6 +175,12 @@ export function registerBrowserTools(
         const source = options.source ?? 'mcp'
         const startTime = performance.now()
         const duration = () => Math.round(performance.now() - startTime)
+        const { sessionHandle, toolArgs } = resolveSessionHandle(
+          args,
+          options.sessionIdentity,
+        )
+        const sessionField =
+          sessionHandle !== undefined ? { session: sessionHandle } : undefined
         const logBase = {
           toolName: tool.name,
           source,
@@ -152,7 +191,7 @@ export function registerBrowserTools(
         }
         options.logger?.debug?.('MCP browser tool started', {
           ...logBase,
-          args: summarizeBrowserToolArgs(args),
+          args: summarizeBrowserToolArgs(toolArgs),
           defaultWindowId: defaults.defaultWindowId,
           defaultTabGroupId: defaults.defaultTabGroupId,
         })
@@ -161,7 +200,7 @@ export function registerBrowserTools(
           const result = await withBrowserOutputFileAccess(
             options.outputFileAccess,
             () =>
-              executeTool(tool, args, {
+              executeTool(tool, toolArgs, {
                 session,
                 ...defaults,
                 signal: extra?.signal,
@@ -172,16 +211,21 @@ export function registerBrowserTools(
             duration_ms: duration(),
             success: !result.isError,
             source,
+            ...sessionField,
           })
           const durationMs = duration()
           const errorSummary = result.isError
             ? resultTextSummary(result.content)
             : undefined
-          const structuredContent =
+          const baseStructuredContent =
             (options.includeStructuredContent ?? true) ||
             tool.output !== undefined
               ? result.structuredContent
               : undefined
+          const structuredContent = mergeSessionHandle(
+            baseStructuredContent,
+            sessionHandle,
+          )
           options.logger?.debug?.('MCP browser tool completed', {
             ...logBase,
             durationMs,
@@ -209,6 +253,7 @@ export function registerBrowserTools(
             success: false,
             error_message: errorText,
             source,
+            ...sessionField,
           })
           options.logger?.info?.('MCP browser tool threw', {
             ...logBase,
@@ -218,6 +263,7 @@ export function registerBrowserTools(
           return {
             content: [{ type: 'text' as const, text: errorText }],
             isError: true,
+            ...(sessionField && { structuredContent: sessionField }),
           }
         } finally {
           options.onToolExecutionEnd?.(lifecycleEvent)

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
@@ -84,7 +84,6 @@ export interface BrowserToolExecutionEvent extends Record<string, unknown> {
   success: boolean
   source: string
   error_message?: string
-  session?: string
 }
 
 function summarizeBrowserToolArgs(
@@ -184,6 +183,7 @@ export function registerBrowserTools(
         const logBase = {
           toolName: tool.name,
           source,
+          ...sessionField,
         }
         const lifecycleEvent = {
           tool_name: tool.name,
@@ -211,7 +211,6 @@ export function registerBrowserTools(
             duration_ms: duration(),
             success: !result.isError,
             source,
-            ...sessionField,
           })
           const durationMs = duration()
           const errorSummary = result.isError
@@ -253,7 +252,6 @@ export function registerBrowserTools(
             success: false,
             error_message: errorText,
             source,
-            ...sessionField,
           })
           options.logger?.info?.('MCP browser tool threw', {
             ...logBase,


### PR DESCRIPTION
## What

Every `/mcp` browser tool now carries an optional `session` string argument, giving an agent a server-minted identity for its own calls under the modern stateless transport. Same mechanism the claw-server uses, applied here for identity only.

- The server mints a UUID when the caller omits `session` and returns it in the result's `structuredContent`, so the agent can thread it back on later calls.
- A supplied `session` is echoed back unchanged.
- The handle is stripped from the arguments before the tool runs, so tool logic and validation are untouched, including the one tool that uses a strict schema.
- It is gated behind an opt-in registration flag, so only the `/mcp` surface exposes it. The internal AI-SDK agent shares the tool schemas and is unaffected.
- The handle is attributed in the per-tool execution metric.

Identity only: no isolation, no per-session state store, no change to browser behavior. Each agent still drives the full shared browser.

## Tests

- New browser-mcp test: the schema surfaces the optional `session`; a call without one mints and returns a handle (and the tool still runs with the key stripped); a supplied handle is echoed; the handle reaches the execution metric.
- Updated `/mcp` service tests: the ordinary tool envelope is still stripped by default with only the session handle added, and `run` retains its output plus the handle.

`tsc`, `biome check`, and the browser-mcp plus `/mcp` service, route, and register test files pass.
