### PR TITLE
feat(skills): structured skill edit keeps SKILL.md and metadata in sync

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/skills.rs
@@ -82,6 +82,8 @@ pub(super) async fn update(
             UpdateSkill {
                 description: body.description,
                 site: body.site,
+                steps: body.steps,
+                learned_notes: body.learned_notes,
                 body: body.body,
             },
         )

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -40,6 +40,8 @@ pub struct CreateSkill {
 pub struct UpdateSkill {
     pub description: Option<String>,
     pub site: Option<String>,
+    pub steps: Option<Vec<String>>,
+    pub learned_notes: Option<Vec<String>>,
     pub body: Option<String>,
 }
 
@@ -268,21 +270,60 @@ impl SkillService {
         let mut previous_body: Option<String> = None;
         let body_path = model.body_path.clone();
 
-        if let Some(body) = input.body {
+        let UpdateSkill {
+            description,
+            site,
+            steps,
+            learned_notes,
+            body,
+        } = input;
+
+        // The description that the rendered/patched frontmatter must carry: the
+        // incoming value if present, otherwise the one already stored.
+        let effective_description = description
+            .clone()
+            .unwrap_or_else(|| model.description.clone());
+
+        // Decide what, if anything, to write to disk. A structured edit renders
+        // the whole SKILL.md so its frontmatter description can never drift from
+        // the stored column. A raw `body` is written verbatim (agent authoring
+        // or a manual override). A metadata-only description change patches just
+        // the frontmatter line so the file matches the new column without
+        // disturbing the rest of the body.
+        let rewrite: Option<String> = if steps.is_some() || learned_notes.is_some() {
+            Some(render_skill_markdown(
+                name,
+                &effective_description,
+                &steps.unwrap_or_default(),
+                &learned_notes.unwrap_or_default(),
+            ))
+        } else if let Some(raw) = body {
+            Some(raw)
+        } else if description.is_some() {
+            let current = self.read_body(&body_path).await;
+            Some(sync_frontmatter_description(
+                &current,
+                &effective_description,
+            ))
+        } else {
+            None
+        };
+
+        if let Some(content) = rewrite {
             previous_body = Some(self.read_body(&body_path).await);
-            self.write_body_at(&body_path, &body).await?;
-            let spec = SkillSpec::new(name, body)
+            self.write_body_at(&body_path, &content).await?;
+            let spec = SkillSpec::new(name, content)
                 .map_err(|error| AppError::bad_request(error.to_string()))?;
             relinked = Some(self.harness.install_skill(spec).await?);
             model.version += 1;
         }
-        if let Some(description) = input.description {
+        if let Some(description) = description {
             model.description = description;
         }
-        // A nullable `site` cannot be explicitly cleared through the current
-        // contract; clearing is deferred to a later contract revision.
-        if let Some(site) = input.site {
-            model.site = Some(site);
+        // An empty string clears the site; a non-empty value sets it; an absent
+        // value leaves it unchanged.
+        if let Some(site) = site {
+            model.site = (!site.is_empty()).then_some(site);
         }
         if let Some(linked) = &relinked {
             model.linked_agents_json = linked_agents_json(linked);
@@ -343,6 +384,8 @@ impl SkillService {
                         UpdateSkill {
                             description: Some(description),
                             site,
+                            steps: None,
+                            learned_notes: None,
                             body: Some(content),
                         },
                     )
@@ -470,6 +513,42 @@ fn render_skill_markdown(
         for note in learned_notes {
             out.push_str(&format!("- {note}\n"));
         }
+    }
+    out
+}
+
+/// Rewrite the `description:` line inside a SKILL.md frontmatter block so the
+/// on-disk file matches the stored description, leaving the rest of the body
+/// untouched. The description is JSON-encoded to stay a valid YAML scalar, the
+/// same way `render_skill_markdown` emits it. A body without a leading `---`
+/// frontmatter fence is returned unchanged.
+fn sync_frontmatter_description(body: &str, description: &str) -> String {
+    let encoded = serde_json::to_string(description).unwrap_or_else(|_| "\"\"".to_string());
+    let mut lines: Vec<String> = body.lines().map(str::to_string).collect();
+    if lines.first().map(|line| line.trim_end()) != Some("---") {
+        return body.to_string();
+    }
+    let Some(closing) = lines
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, line)| line.trim_end() == "---")
+        .map(|(index, _)| index)
+    else {
+        return body.to_string();
+    };
+    let description_line = lines
+        .iter_mut()
+        .take(closing)
+        .skip(1)
+        .find(|line| line.trim_start().starts_with("description:"));
+    match description_line {
+        Some(line) => *line = format!("description: {encoded}"),
+        None => lines.insert(1, format!("description: {encoded}")),
+    }
+    let mut out = lines.join("\n");
+    if body.ends_with('\n') {
+        out.push('\n');
     }
     out
 }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -278,6 +278,22 @@ impl SkillService {
             body,
         } = input;
 
+        // A raw body and structured fields are two representations of the same
+        // file; accepting both would silently persist one and discard the other.
+        if body.is_some() && (steps.is_some() || learned_notes.is_some()) {
+            return Err(AppError::bad_request(
+                "provide either a raw body or structured steps/learnedNotes, not both",
+            ));
+        }
+        // A structured edit replaces both sections at once, so both must be sent
+        // together; otherwise the omitted section would be silently erased. An
+        // explicit empty array clears a section.
+        if steps.is_some() != learned_notes.is_some() {
+            return Err(AppError::bad_request(
+                "steps and learnedNotes must be provided together",
+            ));
+        }
+
         // The description that the rendered/patched frontmatter must carry: the
         // incoming value if present, otherwise the one already stored.
         let effective_description = description
@@ -302,6 +318,7 @@ impl SkillService {
         } else if description.is_some() {
             let current = self.read_body(&body_path).await;
             Some(sync_frontmatter_description(
+                name,
                 &current,
                 &effective_description,
             ))
@@ -520,22 +537,28 @@ fn render_skill_markdown(
 /// Rewrite the `description:` line inside a SKILL.md frontmatter block so the
 /// on-disk file matches the stored description, leaving the rest of the body
 /// untouched. The description is JSON-encoded to stay a valid YAML scalar, the
-/// same way `render_skill_markdown` emits it. A body without a leading `---`
-/// frontmatter fence is returned unchanged.
-fn sync_frontmatter_description(body: &str, description: &str) -> String {
+/// same way `render_skill_markdown` emits it. A body with no `---` frontmatter
+/// fence (a raw body written without one) gets a fresh frontmatter block
+/// prepended so the description is always present in the file.
+fn sync_frontmatter_description(name: &str, body: &str, description: &str) -> String {
     let encoded = serde_json::to_string(description).unwrap_or_else(|_| "\"\"".to_string());
     let mut lines: Vec<String> = body.lines().map(str::to_string).collect();
-    if lines.first().map(|line| line.trim_end()) != Some("---") {
-        return body.to_string();
-    }
-    let Some(closing) = lines
-        .iter()
-        .enumerate()
-        .skip(1)
-        .find(|(_, line)| line.trim_end() == "---")
-        .map(|(index, _)| index)
-    else {
-        return body.to_string();
+    let closing = lines
+        .first()
+        .map(|line| line.trim_end())
+        .filter(|first| *first == "---")
+        .and_then(|_| {
+            lines
+                .iter()
+                .enumerate()
+                .skip(1)
+                .find(|(_, line)| line.trim_end() == "---")
+                .map(|(index, _)| index)
+        });
+    let Some(closing) = closing else {
+        let front =
+            format!("---\nname: {name}\ndescription: {encoded}\ntools: {SKILL_TOOLS}\n---\n\n");
+        return format!("{front}{body}");
     };
     let description_line = lines
         .iter_mut()

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -159,6 +159,92 @@ async fn skill_crud_round_trips_and_writes_the_canonical_file() -> anyhow::Resul
 }
 
 #[tokio::test]
+async fn skill_structured_edit_re_renders_frontmatter_and_clears_site() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({
+            "name": "inbox-sweep",
+            "description": "First description",
+            "site": "mail.google.com",
+            "steps": ["Old step"]
+        })),
+    )
+    .await?;
+
+    let (status, updated) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/inbox-sweep",
+        Some(json!({
+            "description": "Second description",
+            "site": "",
+            "steps": ["New step"],
+            "learnedNotes": ["Prefer the DOM snapshot"]
+        })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(updated["skill"]["description"], "Second description");
+    assert_eq!(updated["skill"]["version"].as_i64(), Some(2));
+    // An empty site string clears the column, so it is omitted from the DTO.
+    assert!(updated["skill"]["site"].is_null());
+
+    // The on-disk frontmatter description tracks the column: agents reading the
+    // file see the new description, never the stale one.
+    let skill_md = app.root.join("skills").join("inbox-sweep").join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_md)?;
+    assert!(content.contains(r#"description: "Second description""#));
+    assert!(!content.contains("First description"));
+    assert!(content.contains("New step"));
+    assert!(content.contains("Prefer the DOM snapshot"));
+    assert!(!content.contains("Old step"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn skill_metadata_only_description_edit_patches_frontmatter() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({
+            "name": "daily-brief",
+            "description": "Old description",
+            "steps": ["Keep this step"]
+        })),
+    )
+    .await?;
+
+    let (status, updated) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/daily-brief",
+        Some(json!({ "description": "Fresh description" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(updated["skill"]["description"], "Fresh description");
+
+    // Only the frontmatter description line changes; the body is preserved.
+    let skill_md = app.root.join("skills").join("daily-brief").join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_md)?;
+    assert!(content.contains(r#"description: "Fresh description""#));
+    assert!(!content.contains("Old description"));
+    assert!(content.contains("Keep this step"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn skill_create_rejects_bad_names_and_duplicates() -> anyhow::Result<()> {
     let app = test_app().await?;
     let router = &app.router;

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -245,6 +245,98 @@ async fn skill_metadata_only_description_edit_patches_frontmatter() -> anyhow::R
 }
 
 #[tokio::test]
+async fn skill_update_rejects_ambiguous_field_combinations() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({ "name": "inbox-sweep", "description": "First", "steps": ["Old step"] })),
+    )
+    .await?;
+
+    // A raw body plus structured fields is ambiguous: reject it rather than
+    // silently discard one representation.
+    let (status, _) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/inbox-sweep",
+        Some(json!({
+            "body": "---\nname: inbox-sweep\ndescription: X\ntools: browseros-neo\n---\n",
+            "steps": ["New step"],
+            "learnedNotes": []
+        })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // Only one of the two structured sections would silently erase the other.
+    let (status, _) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/inbox-sweep",
+        Some(json!({ "steps": ["New step"] })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // The original steps survive both rejected updates.
+    let (_, detail) = request(router, "GET", "/api/v1/skills/inbox-sweep", None).await?;
+    assert!(
+        detail["body"]
+            .as_str()
+            .is_some_and(|body| body.contains("Old step"))
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn skill_description_edit_adds_frontmatter_to_a_raw_body() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({ "name": "raw-note", "description": "First" })),
+    )
+    .await?;
+
+    // Store a raw body that has no frontmatter fence.
+    let (status, _) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/raw-note",
+        Some(json!({ "body": "Just prose, no frontmatter\n" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+
+    // A description-only edit must still land in the file: a frontmatter block
+    // is prepended so linked agents read the new description.
+    let (status, _) = request(
+        router,
+        "PUT",
+        "/api/v1/skills/raw-note",
+        Some(json!({ "description": "Now described" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+
+    let skill_md = app.root.join("skills").join("raw-note").join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_md)?;
+    assert!(content.starts_with("---\nname: raw-note\n"));
+    assert!(content.contains(r#"description: "Now described""#));
+    assert!(content.contains("Just prose, no frontmatter"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn skill_create_rejects_bad_names_and_duplicates() -> anyhow::Result<()> {
     let app = test_app().await?;
     let router = &app.router;

--- a/packages/browseros-agent/contracts/claw-api/schemas/skills.yaml
+++ b/packages/browseros-agent/contracts/claw-api/schemas/skills.yaml
@@ -186,9 +186,20 @@ SkillUpdate:
       type: string
     site:
       type: string
+      description: Primary site the skill operates on. An empty string clears it.
+    steps:
+      type: array
+      items:
+        type: string
+      description: Replacement steps. Re-renders the SKILL.md from structured fields.
+    learnedNotes:
+      type: array
+      items:
+        type: string
+      description: Replacement learned notes. Re-renders the SKILL.md from structured fields.
     body:
       type: string
-      description: Replacement SKILL.md contents for a manual edit.
+      description: Replacement SKILL.md contents for a raw manual edit or agent authoring.
 DirectorySkill:
   type: object
   additionalProperties: false

--- a/packages/browseros-agent/crates/claw-api/src/generated/skills.rs
+++ b/packages/browseros-agent/crates/claw-api/src/generated/skills.rs
@@ -323,9 +323,16 @@ impl SkillRunList {
 pub struct SkillUpdate {
     #[serde(rename = "description", skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Primary site the skill operates on. An empty string clears it.
     #[serde(rename = "site", skip_serializing_if = "Option::is_none")]
     pub site: Option<String>,
-    /// Replacement SKILL.md contents for a manual edit.
+    /// Replacement steps. Re-renders the SKILL.md from structured fields.
+    #[serde(rename = "steps", skip_serializing_if = "Option::is_none")]
+    pub steps: Option<Vec<String>>,
+    /// Replacement learned notes. Re-renders the SKILL.md from structured fields.
+    #[serde(rename = "learnedNotes", skip_serializing_if = "Option::is_none")]
+    pub learned_notes: Option<Vec<String>>,
+    /// Replacement SKILL.md contents for a raw manual edit or agent authoring.
     #[serde(rename = "body", skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
 }
@@ -335,6 +342,8 @@ impl SkillUpdate {
         SkillUpdate {
             description: None,
             site: None,
+            steps: None,
+            learned_notes: None,
             body: None,
         }
     }

--- a/packages/browseros-agent/packages/claw-api-client/src/generated/openapi.ts
+++ b/packages/browseros-agent/packages/claw-api-client/src/generated/openapi.ts
@@ -819,8 +819,13 @@ export interface components {
     }
     SkillUpdate: {
       description?: string
+      /** @description Primary site the skill operates on. An empty string clears it. */
       site?: string
-      /** @description Replacement SKILL.md contents for a manual edit. */
+      /** @description Replacement steps. Re-renders the SKILL.md from structured fields. */
+      steps?: string[]
+      /** @description Replacement learned notes. Re-renders the SKILL.md from structured fields. */
+      learnedNotes?: string[]
+      /** @description Replacement SKILL.md contents for a raw manual edit or agent authoring. */
       body?: string
     }
     DirectorySkill: {

--- a/packages/browseros-agent/packages/claw-api/src/generated/models/skills.ts
+++ b/packages/browseros-agent/packages/claw-api/src/generated/models/skills.ts
@@ -398,13 +398,25 @@ export interface SkillUpdate {
      */
     description?: string;
     /**
-     *
+     * Primary site the skill operates on. An empty string clears it.
      * @type {string}
      * @memberof SkillUpdate
      */
     site?: string;
     /**
-     * Replacement SKILL.md contents for a manual edit.
+     * Replacement steps. Re-renders the SKILL.md from structured fields.
+     * @type {Array<string>}
+     * @memberof SkillUpdate
+     */
+    steps?: Array<string>;
+    /**
+     * Replacement learned notes. Re-renders the SKILL.md from structured fields.
+     * @type {Array<string>}
+     * @memberof SkillUpdate
+     */
+    learnedNotes?: Array<string>;
+    /**
+     * Replacement SKILL.md contents for a raw manual edit or agent authoring.
      * @type {string}
      * @memberof SkillUpdate
      */


### PR DESCRIPTION
Follow-up to the Tasks page work: makes editing a skill a structured operation whose on-disk `SKILL.md` and stored metadata can never diverge, and lets an emptied site actually clear.

## Problem
The update path wrote a raw `body` verbatim and updated the `description`/`site` columns separately, never reconciling the two. So an edit that changed only the description updated the stored metadata (and the Tasks UI) while the file's frontmatter kept the old description; linked agents read the file, so they saw the stale value. Separately, an emptied site could not be cleared: an absent value was treated as "no change" with no way to express "clear".

## Change
- `SkillUpdate` gains `steps` and `learnedNotes`. When either is present, the server re-renders the whole `SKILL.md` from the structured fields, so its frontmatter description always matches the stored column.
- A metadata-only description change patches just the frontmatter `description:` line, leaving the rest of the body untouched.
- An empty `site` string clears the site; a non-empty value sets it; an absent value leaves it unchanged.
- A raw `body` is still written verbatim, which is what agent authoring uses (it renders a body whose frontmatter already matches the description it passes, so that path stays consistent).

## Tests
- A structured edit re-renders the file with the new frontmatter description and clears the site.
- A metadata-only description change patches the frontmatter while preserving the body.
- The existing raw-body update and agent-authoring paths are unchanged.

Full server suite green; the contract codegen drift gate is clean. The Tasks page edit form will move to these structured fields on its own PR.