### PR TITLE
fix(server): serve the 2026-07-28 revision on /mcp and harden the endpoint

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/middleware/reject-browser-fetch.ts
+++ b/packages/browseros-agent/apps/server/src/api/middleware/reject-browser-fetch.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { MiddlewareHandler } from 'hono'
+
+// Browsers always send a Sec-Fetch-Site header; native MCP clients and the
+// internal ACP client never do. Rejecting it blocks browser-originated requests
+// (DNS rebinding, CSRF) against the LAN-exposed MCP endpoint without restricting
+// the bind address. Mirrors the claw-server's request hygiene.
+export function rejectBrowserFetch(): MiddlewareHandler {
+  return async (c, next) => {
+    if (c.req.header('Sec-Fetch-Site') !== undefined) {
+      return c.json(
+        {
+          error: {
+            name: 'ForbiddenBrowserRequest',
+            message: 'Browser requests are not allowed on this endpoint',
+            code: 'FORBIDDEN_BROWSER_REQUEST',
+            statusCode: 403,
+          },
+        },
+        403,
+      )
+    }
+    return next()
+  }
+}

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -5,7 +5,12 @@
  */
 
 import type { BrowserSession } from '@browseros/browser-core/core/session'
-import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server'
+import {
+  createMcpHandler,
+  isLegacyRequest,
+  type McpRequestContext,
+  WebStandardStreamableHTTPServerTransport,
+} from '@modelcontextprotocol/server'
 import { Hono } from 'hono'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
@@ -82,6 +87,68 @@ export function createMcpRoutes(deps: McpRouteDeps) {
     deps.createMcpTransport ??
     ((options) => new WebStandardStreamableHTTPServerTransport(options))
 
+  // Reads the per-request BrowserOS scope from headers + query. Used by the
+  // POST handler (metrics/logging on every request, including rejected ones)
+  // and by the factory (per-request server construction).
+  function readScope(req: Request) {
+    const url = new URL(req.url)
+    const scopeId = req.headers.get('X-BrowserOS-Scope-Id') || 'ephemeral'
+    const includeStructuredContent = url.searchParams.get('structured') === '1'
+    const defaultWindowId = parseOptionalNumber(
+      req.headers.get('X-BrowserOS-Default-Window-Id') ?? undefined,
+    )
+    const defaultTabGroupId =
+      req.headers.get('X-BrowserOS-Default-Tab-Group-Id') ?? undefined
+    const selectedServerNames = parseManagedMcpServersHeader(
+      req.headers.get(MANAGED_MCP_SERVERS_HEADER) ?? undefined,
+    )
+    const logContext: McpRequestLogContext = {
+      scopeId,
+      selectedServerNames,
+      selectedServerCount: selectedServerNames.length,
+      defaultWindowId,
+      defaultTabGroupId,
+    }
+    return {
+      scopeId,
+      includeStructuredContent,
+      defaultWindowId,
+      defaultTabGroupId,
+      selectedServerNames,
+      logContext,
+    }
+  }
+
+  // One factory backs both eras: createMcpHandler's modern leg and the
+  // hand-wired legacy JSON leg. The factory receives the request, so per-request
+  // header scoping is preserved.
+  const buildServer = (ctx: McpRequestContext) => {
+    const scope = ctx.requestInfo
+      ? readScope(ctx.requestInfo)
+      : {
+          includeStructuredContent: false,
+          defaultWindowId: undefined,
+          defaultTabGroupId: undefined,
+          selectedServerNames: [] as string[],
+        }
+    return makeMcpServer({
+      version: deps.version,
+      browserSession: deps.browserSession,
+      klavis: deps.klavis,
+      connectorScope: { selectedServerNames: scope.selectedServerNames },
+      defaultWindowId: scope.defaultWindowId,
+      defaultTabGroupId: scope.defaultTabGroupId,
+      includeStructuredContent: scope.includeStructuredContent,
+      activity: deps.activity,
+    })
+  }
+
+  // Modern (2026-07-28) leg. `legacy: 'reject'` keeps 2025-era traffic off this
+  // handler; isLegacyRequest routes those to the legacy JSON transport below,
+  // which preserves the existing single-JSON (non-SSE) response shape that the
+  // internal ACP client depends on.
+  const modern = createMcpHandler(buildServer, { legacy: 'reject' })
+
   app.get('/', (c) =>
     c.json({
       status: 'ok',
@@ -90,54 +157,37 @@ export function createMcpRoutes(deps: McpRouteDeps) {
   )
 
   app.post('/', async (c) => {
-    const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
+    const raw = c.req.raw
+    const { scopeId, logContext } = readScope(raw)
     metrics.log('mcp.request', { scopeId })
-    const includeStructuredContent = c.req.query('structured') === '1'
-
-    const defaultWindowId = parseOptionalNumber(
-      c.req.header('X-BrowserOS-Default-Window-Id'),
-    )
-    const defaultTabGroupId =
-      c.req.header('X-BrowserOS-Default-Tab-Group-Id') ?? undefined
-    const selectedServerNames = parseManagedMcpServersHeader(
-      c.req.header(MANAGED_MCP_SERVERS_HEADER),
-    )
-
-    const logContext: McpRequestLogContext = {
-      scopeId,
-      selectedServerNames,
-      selectedServerCount: selectedServerNames.length,
-      defaultWindowId,
-      defaultTabGroupId,
-    }
-
     logger.debug('MCP request received', logContext)
 
-    // Per-request server + transport: no shared state, no race conditions, no
-    // ID collisions. This is also the stateless (sessionless) model the
-    // 2026-07-28 era expects; legacy requests are still served per-request.
-    const mcpServer = makeMcpServer({
-      version: deps.version,
-      browserSession: deps.browserSession,
-      klavis: deps.klavis,
-      connectorScope: { selectedServerNames },
-      defaultWindowId,
-      defaultTabGroupId,
-      includeStructuredContent,
-      activity: deps.activity,
-    })
-    const transport = makeMcpTransport({
-      sessionIdGenerator: undefined,
-      enableJsonResponse: true,
-    })
-
     try {
-      await mcpServer.connect(transport)
-      logger.debug('MCP request transport connected', logContext)
-      const response = await transport.handleRequest(c.req.raw)
+      // Legacy (2025-era) stays byte-for-byte identical: hand-wired stateless
+      // transport with enableJsonResponse, so the internal ACP client keeps its
+      // single-JSON responses. isLegacyRequest reads a clone, leaving `raw`
+      // consumable by whichever leg serves the request.
+      if (await isLegacyRequest(raw)) {
+        const mcpServer = buildServer({ era: 'legacy', requestInfo: raw })
+        const transport = makeMcpTransport({
+          sessionIdGenerator: undefined,
+          enableJsonResponse: true,
+        })
+        await mcpServer.connect(transport)
+        logger.debug('MCP request transport connected', logContext)
+        const response = await transport.handleRequest(raw)
+        logger.debug('MCP request handled', {
+          ...logContext,
+          status: response?.status,
+        })
+        return response
+      }
+
+      // Modern (2026-07-28) requests: server/discover + stateless dispatch.
+      const response = await modern.fetch(raw)
       logger.debug('MCP request handled', {
         ...logContext,
-        status: response?.status,
+        status: response.status,
       })
       return response
     } catch (error) {

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -10,6 +10,7 @@ import { Hono } from 'hono'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { Sentry } from '../../lib/sentry'
+import { rejectBrowserFetch } from '../middleware/reject-browser-fetch'
 import type { KlavisService } from '../services/klavis'
 import { createMcpServer } from '../services/mcp/mcp-server'
 import type { ServerActivity } from '../services/server-activity'
@@ -75,6 +76,7 @@ export function parseManagedMcpServersHeader(
 /** Creates the Hono routes that expose BrowserOS as a request-scoped MCP server. */
 export function createMcpRoutes(deps: McpRouteDeps) {
   const app = new Hono<Env>()
+  app.use('/*', rejectBrowserFetch())
   const makeMcpServer = deps.createMcpServer ?? createMcpServer
   const makeMcpTransport =
     deps.createMcpTransport ??

--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp-dual-era.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp-dual-era.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'bun:test'
+import { createMcpRoutes } from '../../../src/api/routes/mcp'
+
+const BASE = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json, text/event-stream',
+}
+const CLIENT_META = {
+  'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+  'io.modelcontextprotocol/clientInfo': { name: 'test', version: '1.0.0' },
+  'io.modelcontextprotocol/clientCapabilities': {},
+}
+
+function route(browserSession: unknown = {}) {
+  return createMcpRoutes({
+    version: '0.0.0-test',
+    browserSession: browserSession as never,
+  })
+}
+
+async function post(
+  app: ReturnType<typeof createMcpRoutes>,
+  body: unknown,
+  headers: Record<string, string> = {},
+) {
+  const res = await app.request('/', {
+    method: 'POST',
+    headers: { ...BASE, ...headers },
+    body: JSON.stringify(body),
+  })
+  return {
+    status: res.status,
+    contentType: res.headers.get('content-type') ?? '',
+    json: (await res.json()) as {
+      result?: Record<string, unknown>
+      error?: { code: number }
+    },
+  }
+}
+
+describe('mcp dual-era serving', () => {
+  it('serves legacy clients over initialize, as JSON, negotiating 2025-11-25', async () => {
+    const app = route()
+
+    const init = await post(app, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-11-25',
+        capabilities: {},
+        clientInfo: { name: 't', version: '1' },
+      },
+    })
+
+    expect(init.status).toBe(200)
+    // The split keeps legacy on the enableJsonResponse transport, not SSE.
+    expect(init.contentType).toContain('application/json')
+    expect(
+      (init.json.result as { protocolVersion?: string })?.protocolVersion,
+    ).toBe('2025-11-25')
+
+    const list = await post(app, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+    })
+    expect(list.status).toBe(200)
+    const tools = (list.json.result as { tools?: unknown[] })?.tools ?? []
+    expect(tools).toHaveLength(17)
+  })
+
+  it('serves modern clients over server/discover, advertising 2026-07-28', async () => {
+    const app = route()
+
+    const discover = await post(
+      app,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'server/discover',
+        params: { _meta: CLIENT_META },
+      },
+      { 'MCP-Protocol-Version': '2026-07-28', 'Mcp-Method': 'server/discover' },
+    )
+
+    expect(discover.status).toBe(200)
+    expect(discover.json.error).toBeUndefined()
+    const supportedVersions = (
+      discover.json.result as { supportedVersions?: string[] }
+    )?.supportedVersions
+    expect(supportedVersions).toContain('2026-07-28')
+  })
+
+  it('runs a modern tool call', async () => {
+    const app = route()
+
+    const call = await post(
+      app,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'run',
+          arguments: { code: 'return 42' },
+          _meta: CLIENT_META,
+        },
+      },
+      {
+        'MCP-Protocol-Version': '2026-07-28',
+        'Mcp-Method': 'tools/call',
+        'Mcp-Name': 'run',
+      },
+    )
+
+    expect(call.status).toBe(200)
+    const structured = (
+      call.json.result as { structuredContent?: { value?: number } }
+    )?.structuredContent
+    expect(structured?.value).toBe(42)
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
@@ -181,4 +181,16 @@ describe('createMcpRoutes', () => {
     expect(res.status).toBe(500)
     expect(body.error.code).toBe(-32603)
   })
+
+  it('rejects browser-originated requests carrying Sec-Fetch-Site', async () => {
+    const app = createTestMcpRoutes()
+
+    const blocked = await postMcp(app, { 'Sec-Fetch-Site': 'cross-site' })
+    const allowed = await postMcp(app)
+
+    expect(blocked.status).toBe(403)
+    const body = (await blocked.json()) as { error: { code: string } }
+    expect(body.error.code).toBe('FORBIDDEN_BROWSER_REQUEST')
+    expect(allowed.status).toBe(200)
+  })
 })

--- a/packages/browseros-agent/packages/browser-mcp/src/mcp-server.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/mcp-server.test.ts
@@ -8,7 +8,7 @@ type RegisteredTool = {
   description: string
   handler: (
     args: Record<string, unknown>,
-    extra?: { signal?: AbortSignal },
+    extra?: { mcpReq?: { signal?: AbortSignal } },
   ) => Promise<{
     content: unknown
     isError?: boolean
@@ -272,5 +272,26 @@ describe('createBrowserMcpServer', () => {
     expect((reused?.structuredContent as { session?: string })?.session).toBe(
       'agent-supplied-handle',
     )
+  })
+
+  it('threads the abort signal from extra.mcpReq.signal into the tool', async () => {
+    const server = inspect(
+      createBrowserMcpServer({
+        name: 'browseros_mcp',
+        title: 'BrowserOS MCP server',
+        version: '1.2.3',
+        browserSession: { pages: {} } as unknown as BrowserSession,
+      }),
+    )
+
+    // The signal is delivered where the v2 SDK actually puts it (mcpReq.signal),
+    // so `wait` aborts immediately instead of pausing. The previous top-level
+    // `extra.signal` read was always undefined and never reached the tool.
+    const result = await server._registeredTools.wait.handler(
+      { page: 1, for: 'time', value: 60000 },
+      { mcpReq: { signal: AbortSignal.abort() } },
+    )
+
+    expect(result?.isError).toBe(true)
   })
 })

--- a/packages/browseros-agent/packages/browser-mcp/src/mcp-server.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/mcp-server.ts
@@ -1,11 +1,20 @@
 import type { BrowserSession } from '@browseros/browser-core/core/session'
-import { McpServer } from '@modelcontextprotocol/server'
+import {
+  McpServer,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from '@modelcontextprotocol/server'
 import { BROWSER_MCP_INSTRUCTIONS } from './mcp-prompt'
 import {
   type BrowserToolDefaults,
   type BrowserToolRegistrationOptions,
   registerBrowserTools,
 } from './register'
+
+// The SDK's default supportedProtocolVersions is legacy-only, so it never
+// registers server/discover and rejects 2026-07-28. Advertise the modern
+// revision (selectable only via server/discover) alongside the legacy list so
+// the endpoint serves both eras. The SDK does not export a modern-versions list.
+const MODERN_PROTOCOL_VERSION = '2026-07-28'
 
 export interface BrowserMcpServerOptions extends BrowserToolDefaults {
   name: string
@@ -28,6 +37,10 @@ export function createBrowserMcpServer(
     },
     {
       instructions: options.instructions ?? BROWSER_MCP_INSTRUCTIONS,
+      supportedProtocolVersions: [
+        MODERN_PROTOCOL_VERSION,
+        ...SUPPORTED_PROTOCOL_VERSIONS,
+      ],
     },
   )
 

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
@@ -42,7 +42,7 @@ type RegisterFn = (
   },
   handler: (
     args: Record<string, unknown>,
-    extra?: { signal?: AbortSignal },
+    extra?: { mcpReq?: { signal?: AbortSignal } },
   ) => Promise<{
     content: unknown
     isError?: boolean
@@ -203,7 +203,7 @@ export function registerBrowserTools(
               executeTool(tool, toolArgs, {
                 session,
                 ...defaults,
-                signal: extra?.signal,
+                signal: extra?.mcpReq?.signal,
               }),
           )
           options.onToolExecuted?.({


### PR DESCRIPTION
## What

Completes the epic's dual-era goal for the TS agent server and hardens the `/mcp` endpoint.

### Serve the modern 2026-07-28 revision (the main fix)
The TS `/mcp` endpoint advertised only legacy protocol versions and rejected `2026-07-28` (`server/discover` returned `-32601`), so modern clients silently fell back to legacy. Two causes, both fixed:
- The `McpServer` was built without `supportedProtocolVersions`, so it defaulted to legacy-only and never registered `server/discover`. It now advertises `2026-07-28` alongside the legacy list.
- The route dispatched through the bare streamable-HTTP transport, which does not run the modern request machinery. The route now splits by era: legacy (2025-era) requests keep the existing `enableJsonResponse` transport so the internal client still receives single-JSON responses, while modern requests go through `createMcpHandler`, which serves `server/discover` and the stateless 2026-07-28 dispatch.

New end-to-end tests exercise both eras: legacy `initialize` negotiates `2025-11-25` as JSON, `tools/list` returns all 17 tools, modern `server/discover` advertises `2026-07-28`, and a modern tool call succeeds.

### Reject browser-originated `/mcp` requests
The endpoint is intentionally reachable across the LAN, so a loopback bind is not an option. Browsers always send a `Sec-Fetch-Site` header while native MCP clients and the internal client never do, so rejecting requests that carry it filters browser-based attacks (DNS rebinding, CSRF) without restricting the bind address. Scoped to `/mcp`, and mirrors the claw-server's request hygiene.

### Fix `/mcp` tool cancellation
The browser tool wrapper read the abort signal from a non-existent top-level `extra.signal` (always undefined under the v2 SDK), so cancellation never reached the tool over `/mcp`. It now reads `extra.mcpReq.signal`. The internal agent path was already correct.

## Tests
`tsc`, `biome`, and the browser-mcp suite (36), the `/mcp` route suite (8), the new dual-era suite (3), and the mcp-service suite (2) all pass. The legacy transport path is unchanged, so the real-legacy-client integration test is covered.
