### PR TITLE
fix(skills): ground save_skill so authored steps name real SDK calls

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -47,7 +47,7 @@ const NAME_SESSION_TOOL_NAME: &str = "name_session";
 const NAME_SESSION_DESCRIPTION: &str = "Rename this browser session: a small lowercase 2-3 word label for what this session is doing, e.g. \"invoice processing\". Tabs are grouped as <client>/<name>. Call again to rename.";
 const NAME_SESSION_INPUT_MAX_LEN: usize = 64;
 const SAVE_SKILL_TOOL_NAME: &str = "save_skill";
-const SAVE_SKILL_DESCRIPTION: &str = "Save the current repeatable browser task as a BrowserOS neo skill so it can be re-run by name later. Give a lowercase-hyphen name, a one-line description, the ordered steps, and any shortcuts learned this run. Call again with the same name to update it in place.";
+const SAVE_SKILL_DESCRIPTION: &str = "Save the current repeatable browser task as a BrowserOS neo skill so it can be re-run by name later. Give a lowercase-hyphen name, a one-line description, the ordered steps, and any shortcuts learned this run. In the steps, name the exact browser SDK calls you actually used this session (e.g. browser.wait, browser.read, browser.pages.newPage) so a later run reuses them verbatim; never invent, rename, or guess a method that is not in the run tool's SDK (there is no browser.waitFor, for example). Call again with the same name to update it in place.";
 const MARK_SKILL_RUN_TOOL_NAME: &str = "mark_skill_run";
 const MARK_SKILL_RUN_DESCRIPTION: &str = "Mark this browser session as a run of a saved skill so BrowserOS neo records the run and its cost once the session ends. Call this once, at the start, when you are running a skill, with the skill's name.";
 


### PR DESCRIPTION
## Problem

An agent can author a skill that fails when a later run regenerates its code against a method that does not exist. Observed live: `chennai-weather-today` ran and its first code-mode `run` errored because the generated code called `browser.waitFor(pageId, { text: "Chennai" })` — there is no `waitFor` in the code-mode SDK; the method is `browser.wait(pageId, { for: "text", value: "Chennai" })`.

The Tasks feature behaved correctly (the run was recorded `clean: false, erroredTool: "run"`); the skill itself was mis-authored. Because skills are prose and the code is re-derived each run, an agent can re-hallucinate a call even when the authoring run worked.

## Fix

Ground the authoring guidance: tighten the `save_skill` tool description so the agent names the exact browser SDK calls it actually used in the steps (so a later run reuses them verbatim) and never invents, renames, or guesses a method that is not in the `run` tool's SDK. The real failure (`browser.waitFor` vs `browser.wait`) is used as the concrete example.

Deliberately scoped to the description only: skills stay prose-only, with no code embedded in the SKILL.md.

## Notes

This is guidance, not a hard guarantee (an LLM can still slip). The existing run-recording plus the "Learned from past runs" loop remains the self-healing backstop; a stricter verify-before-save gate is a possible future follow-up.

Verified: cargo check, clippy, and rustfmt clean; the MCP service surface test compares the listed tool description to the const, so it stays green.