### PR TITLE
feat(skills): task detail Tokens saved + Success rate cards

### DIFF
--- a/packages/browseros-agent/apps/claw-app/screens/skills/SkillDetail.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/SkillDetail.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Static-markup checks for the task detail stat cards (Tokens saved + Success
+ * rate). Stubs the data hook so no backend is needed.
+ */
+
+import { describe, expect, it, mock } from 'bun:test'
+import type { Skill, SkillDetail as SkillDetailDto } from '@browseros/claw-api'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+import type { SkillDetailScreenData } from './skill-detail.data'
+
+const sampleSkill: Skill = {
+  name: 'inbox-sweep',
+  description: 'Check the inbox and draft what is owed',
+  origin: 'agent',
+  version: 2,
+  linkedAgents: ['Claude Code'],
+  runCount: 5,
+  cleanRunCount: 4,
+  createdAt: 900_000_000_000,
+  updatedAt: 1_000_000_000_000,
+}
+
+function detail(over: Partial<SkillDetailDto> = {}): SkillDetailDto {
+  return {
+    skill: sampleSkill,
+    body: '---\nname: inbox-sweep\n---\n\n## Steps\n',
+    runs: [],
+    tokenSavings: {
+      saved: 45_000,
+      otherBrowsers: 60_000,
+      used: 15_000,
+      measuredRunCount: 5,
+    },
+    ...over,
+  }
+}
+
+let dataOverride: SkillDetailScreenData = {
+  name: 'inbox-sweep',
+  detail: detail(),
+  isLoading: false,
+  isError: false,
+}
+
+mock.module('./skill-detail.data', () => ({
+  useSkillDetailData: () => dataOverride,
+}))
+
+const { SkillDetail } = await import('./SkillDetail')
+
+function renderApp(): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <SkillDetail />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('Task detail stat cards', () => {
+  it('shows Tokens saved with the saved total and the other-browsers comparison', () => {
+    dataOverride = { ...dataOverride, detail: detail() }
+    const html = renderApp()
+    expect(html).toContain('Tokens saved')
+    expect(html).toContain('45.0k')
+    expect(html).toContain('tokens in other browsers')
+    expect(html).toContain('60.0k')
+    expect(html).not.toContain('Getting cheaper')
+  })
+
+  it('shows the empty state when no runs are measured', () => {
+    dataOverride = {
+      ...dataOverride,
+      detail: detail({
+        tokenSavings: {
+          saved: 0,
+          otherBrowsers: 0,
+          used: 0,
+          measuredRunCount: 0,
+        },
+      }),
+    }
+    expect(renderApp()).toContain('No measured runs yet')
+  })
+
+  it('shows a color-coded Success rate and keeps the without-error line', () => {
+    dataOverride = { ...dataOverride, detail: detail() }
+    const html = renderApp()
+    expect(html).toContain('Success rate')
+    // 4 of 5 clean = 80% -> amber band
+    expect(html).toContain('80%')
+    expect(html).toContain('text-amber')
+    expect(html).toContain('4 of 5 runs finished without a tool error')
+    expect(html).not.toContain('Safe to leave alone')
+  })
+
+  it('greens a perfect success rate and reds a poor one', () => {
+    dataOverride = {
+      ...dataOverride,
+      detail: detail({
+        skill: { ...sampleSkill, runCount: 5, cleanRunCount: 5 },
+      }),
+    }
+    expect(renderApp()).toContain('text-green')
+    dataOverride = {
+      ...dataOverride,
+      detail: detail({
+        skill: { ...sampleSkill, runCount: 5, cleanRunCount: 2 },
+      }),
+    }
+    expect(renderApp()).toContain('text-red')
+  })
+
+  it('shows "not run" for a skill with no runs', () => {
+    dataOverride = {
+      ...dataOverride,
+      detail: detail({
+        skill: { ...sampleSkill, runCount: 0, cleanRunCount: 0 },
+        tokenSavings: {
+          saved: 0,
+          otherBrowsers: 0,
+          used: 0,
+          measuredRunCount: 0,
+        },
+      }),
+    }
+    const html = renderApp()
+    expect(html).toContain('not run')
+    expect(html).toContain('0 of 0 runs finished without a tool error')
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/skills/SkillDetail.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/SkillDetail.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { Skill, SkillRun } from '@browseros/claw-api'
+import type { Skill, SkillRun, SkillTokenSavings } from '@browseros/claw-api'
 import { ArrowLeft, Check } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useNavigate } from 'react-router'
@@ -26,7 +26,6 @@ import {
   formatRelativeTime,
   formatTokens,
   skillCommand,
-  tokenDeltaPercent,
 } from './skills.helpers'
 
 const AGENT_LABELS: Record<string, string> = {
@@ -40,8 +39,8 @@ function agentLabel(id: string): string {
   return AGENT_LABELS[id] ?? id
 }
 
-/** Task detail: the SKILL.md, whether it is getting cheaper and safe to leave
- *  alone, which agents it is linked into, and its run history. */
+/** Task detail: the SKILL.md, its token savings and success rate, which agents
+ *  it is linked into, and its run history. */
 export function SkillDetail() {
   const { detail, isLoading, isError } = useSkillDetailData()
   const navigate = useNavigate()
@@ -69,6 +68,7 @@ export function SkillDetail() {
           skill={detail.skill}
           body={detail.body}
           runs={detail.runs}
+          tokenSavings={detail.tokenSavings}
           onDeleted={() => navigate('/skills')}
         />
       )}
@@ -80,11 +80,13 @@ function DetailBody({
   skill,
   body,
   runs,
+  tokenSavings,
   onDeleted,
 }: {
   skill: Skill
   body: string
   runs: SkillRun[]
+  tokenSavings: SkillTokenSavings
   onDeleted: () => void
 }) {
   return (
@@ -118,8 +120,8 @@ function DetailBody({
       </header>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <GettingCheaperCard skill={skill} />
-        <SafeToLeaveCard skill={skill} />
+        <TokensSavedCard tokenSavings={tokenSavings} />
+        <SuccessRateCard skill={skill} />
         <LinkedIntoCard skill={skill} />
       </div>
 
@@ -146,89 +148,60 @@ function StatCard({ title, children }: { title: string; children: ReactNode }) {
   )
 }
 
-/** Two bars comparing the first run's token cost to the latest run's. */
-function GettingCheaperCard({ skill }: { skill: Skill }) {
-  const { firstRunTokens, latestRunTokens } = skill
-  const delta = tokenDeltaPercent(firstRunTokens, latestRunTokens)
-  const max = Math.max(firstRunTokens ?? 0, latestRunTokens ?? 0, 1)
-
-  if (firstRunTokens === undefined || latestRunTokens === undefined) {
+/** Tokens this skill saved versus a screenshot-first agent, and what those
+ *  same runs would have cost in other browsers. */
+function TokensSavedCard({
+  tokenSavings,
+}: {
+  tokenSavings: SkillTokenSavings
+}) {
+  if (tokenSavings.measuredRunCount === 0) {
     return (
-      <StatCard title="Getting cheaper">
-        <p className="text-ink-3 text-sm">
-          Not enough runs to compare cost yet.
-        </p>
+      <StatCard title="Tokens saved">
+        <p className="text-ink-3 text-sm">No measured runs yet.</p>
       </StatCard>
     )
   }
-
+  const saved = Math.max(0, tokenSavings.saved)
   return (
-    <StatCard title="Getting cheaper">
-      <div className="flex flex-col gap-2">
-        <CostBar label="Run 1" tokens={firstRunTokens} max={max} muted />
-        <CostBar label="Latest" tokens={latestRunTokens} max={max} />
+    <StatCard title="Tokens saved">
+      <div className="flex items-baseline gap-1">
+        <span className="font-extrabold text-3xl text-ink tabular-nums">
+          {formatTokens(saved)}
+        </span>
+        <span className="text-ink-2 text-sm">tokens</span>
       </div>
-      {delta !== null && (
-        <p
-          className={cn(
-            'font-medium text-sm',
-            delta < 0 ? 'text-green' : delta > 0 ? 'text-red' : 'text-ink-2',
-          )}
-        >
-          {delta < 0
-            ? `${Math.abs(delta)}% cheaper than the first run`
-            : delta > 0
-              ? `${delta}% pricier than the first run`
-              : 'Same cost as the first run'}
-        </p>
-      )}
+      <p className="text-ink-2 text-sm">
+        <span className="tabular-nums">
+          {formatTokens(tokenSavings.otherBrowsers)}
+        </span>{' '}
+        tokens in other browsers
+      </p>
     </StatCard>
   )
 }
 
-function CostBar({
-  label,
-  tokens,
-  max,
-  muted = false,
-}: {
-  label: string
-  tokens: number
-  max: number
-  muted?: boolean
-}) {
-  const width = `${Math.max(4, Math.round((tokens / max) * 100))}%`
+/** How often the skill runs end to end without a tool error, color-coded. */
+function SuccessRateCard({ skill }: { skill: Skill }) {
+  const hasRuns = skill.runCount > 0
+  const percent = hasRuns
+    ? Math.round((skill.cleanRunCount / skill.runCount) * 100)
+    : 0
+  const colorClass = !hasRuns
+    ? 'text-ink-3'
+    : percent >= 90
+      ? 'text-green'
+      : percent >= 70
+        ? 'text-amber'
+        : 'text-red'
   return (
-    <div className="flex items-center gap-2">
-      <span className="w-12 shrink-0 text-[11px] text-ink-3">{label}</span>
-      <div className="h-4 flex-1 overflow-hidden rounded bg-card-tint">
-        <div
-          className={cn('h-full rounded', muted ? 'bg-ink-4' : 'bg-primary')}
-          style={{ width }}
-        />
-      </div>
-      <span className="w-12 shrink-0 text-right text-[11px] text-ink-2">
-        {formatTokens(tokens)}
-      </span>
-    </div>
-  )
-}
-
-/** Clean-run ratio: how often the skill ran end to end without a tool error. */
-function SafeToLeaveCard({ skill }: { skill: Skill }) {
-  const ratio =
-    skill.runCount > 0
-      ? Math.round((skill.cleanRunCount / skill.runCount) * 100)
-      : 0
-  return (
-    <StatCard title="Safe to leave alone">
+    <StatCard title="Success rate">
       <div className="flex items-baseline gap-1">
-        <span className="font-extrabold text-3xl text-ink">
-          {skill.runCount > 0 ? `${ratio}%` : 'not run'}
+        <span
+          className={cn('font-extrabold text-3xl tabular-nums', colorClass)}
+        >
+          {hasRuns ? `${percent}%` : 'not run'}
         </span>
-        {skill.runCount > 0 && (
-          <span className="text-ink-2 text-sm">clean</span>
-        )}
       </div>
       <p className="text-ink-2 text-sm">
         {skill.cleanRunCount} of {skill.runCount} runs finished without a tool

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/skills.rs
@@ -2,7 +2,7 @@ use super::{error, internal};
 use crate::{
     AppState,
     db::entities::skill_runs,
-    error::{AppError, CanonicalError, RequestId},
+    error::{AppError, AppResult, CanonicalError, RequestId},
     services::skills::{CreateSkill, SkillDetailView, SkillOrigin, SkillView, UpdateSkill},
 };
 use axum::{
@@ -45,7 +45,10 @@ pub(super) async fn get(
         .get(&name)
         .await
         .map_err(|source| map_error(&request_id, source))?;
-    Ok(Json(detail_to_dto(detail)))
+    let token_savings = skill_token_savings(&state, &detail.runs)
+        .await
+        .map_err(|source| map_error(&request_id, source))?;
+    Ok(Json(detail_to_dto(detail, token_savings)))
 }
 
 pub(super) async fn create(
@@ -89,7 +92,10 @@ pub(super) async fn update(
         )
         .await
         .map_err(|source| map_error(&request_id, source))?;
-    Ok(Json(detail_to_dto(detail)))
+    let token_savings = skill_token_savings(&state, &detail.runs)
+        .await
+        .map_err(|source| map_error(&request_id, source))?;
+    Ok(Json(detail_to_dto(detail, token_savings)))
 }
 
 pub(super) async fn delete(
@@ -170,13 +176,35 @@ fn skill_to_dto(view: SkillView) -> Skill {
     skill
 }
 
-fn detail_to_dto(detail: SkillDetailView) -> SkillDetail {
+fn detail_to_dto(detail: SkillDetailView, token_savings: models::SkillTokenSavings) -> SkillDetail {
     let SkillDetailView { view, body, runs } = detail;
     SkillDetail::new(
         skill_to_dto(view),
         body,
         runs.into_iter().map(run_to_dto).collect(),
+        token_savings,
     )
+}
+
+/// Aggregates the token efficiency of the skill's run sessions into the detail
+/// DTO: how many tokens BrowserOS neo saved versus a screenshot-first agent,
+/// what those runs used, and what other browsers would have spent. Unmeasured
+/// runs contribute nothing and are excluded from `measuredRunCount`.
+async fn skill_token_savings(
+    state: &AppState,
+    runs: &[skill_runs::Model],
+) -> AppResult<models::SkillTokenSavings> {
+    let session_ids: Vec<String> = runs.iter().map(|run| run.session_id.clone()).collect();
+    let (window, measured_run_count) = state
+        .session_efficiency
+        .aggregate_for_sessions(&session_ids)
+        .await?;
+    Ok(models::SkillTokenSavings::new(
+        window.raw_token_savings_estimate,
+        window.screenshot_first_token_estimate,
+        window.browser_claw_token_estimate,
+        measured_run_count,
+    ))
 }
 
 fn run_to_dto(run: skill_runs::Model) -> SkillRun {

--- a/packages/browseros-agent/apps/claw-server-rust/src/db/session_efficiency_stats.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/db/session_efficiency_stats.rs
@@ -133,6 +133,21 @@ impl SessionEfficiencyStatsRepository {
             .await?)
     }
 
+    /// The projected efficiency rows for a set of sessions (e.g. one skill's
+    /// runs). Sessions without a projection simply do not appear.
+    pub(crate) async fn rows_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> AppResult<Vec<session_efficiency_stats::Model>> {
+        if session_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        Ok(SessionEfficiencyStats::find()
+            .filter(session_efficiency_stats::Column::SessionId.is_in(session_ids.iter().cloned()))
+            .all(self.db.connection())
+            .await?)
+    }
+
     #[cfg(test)]
     pub(crate) async fn find(
         &self,

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/session_efficiency.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/session_efficiency.rs
@@ -173,6 +173,23 @@ impl SessionEfficiencyService {
         Ok(aggregate_rows(&rows, now_ms))
     }
 
+    /// Aggregates the efficiency of a specific set of sessions (e.g. one skill's
+    /// run sessions). Sessions with no projected efficiency row (unmeasured or
+    /// still live) are skipped; the count of matched sessions is returned so
+    /// callers can distinguish "no measured runs" from "zero savings".
+    pub async fn aggregate_for_sessions(
+        &self,
+        session_ids: &[String],
+    ) -> AppResult<(SessionEfficiencyWindow, i64)> {
+        let rows = self.repository.rows_for_sessions(session_ids).await?;
+        let mut accumulator = WindowAccumulator::default();
+        for row in &rows {
+            accumulator.add(row);
+        }
+        let measured = i64::try_from(rows.len()).unwrap_or(i64::MAX);
+        Ok((accumulator.finish(), measured))
+    }
+
     fn emit_computed(&self, finalized: &FinalizedSessionEfficiency) {
         let stats = &finalized.stats;
         let input = i128::from(stats.tool_input_token_estimate.max(0));
@@ -1075,6 +1092,42 @@ mod tests {
         );
         assert_eq!(aggregate.all_time.human_time_saved_ms, JS_SAFE_INTEGER);
         assert_eq!(aggregate.all_time.tool_call_count, JS_SAFE_INTEGER);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn aggregate_for_sessions_sums_only_matching_projections() -> anyhow::Result<()> {
+        let (_dir, _audit, service, repository) = test_services().await?;
+        assert!(
+            repository
+                .insert_if_absent(&stats_row("run-a", 1, 2, 100, 10, 20, 6_000))
+                .await?
+        );
+        assert!(
+            repository
+                .insert_if_absent(&stats_row("run-b", 2, 3, 200, 30, 40, 9_000))
+                .await?
+        );
+
+        let (window, measured) = service
+            .aggregate_for_sessions(&[
+                "run-a".to_owned(),
+                "run-b".to_owned(),
+                "unmeasured".to_owned(),
+            ])
+            .await?;
+        assert_eq!(measured, 2);
+        // used = (10+20) + (30+40)
+        assert_eq!(window.browser_claw_token_estimate, 100);
+        // other browsers = (10+6000) + (30+9000)
+        assert_eq!(window.screenshot_first_token_estimate, 15_040);
+        // saved = (6000-20) + (9000-40)
+        assert_eq!(window.raw_token_savings_estimate, 14_940);
+
+        let (empty, none) = service.aggregate_for_sessions(&[]).await?;
+        assert_eq!(none, 0);
+        assert_eq!(empty.browser_claw_token_estimate, 0);
+        assert_eq!(empty.raw_token_savings_estimate, 0);
         Ok(())
     }
 

--- a/packages/browseros-agent/contracts/claw-api/openapi.yaml
+++ b/packages/browseros-agent/contracts/claw-api/openapi.yaml
@@ -170,6 +170,8 @@ components:
       $ref: ./schemas/skills.yaml#/SkillRunList
     SkillDetail:
       $ref: ./schemas/skills.yaml#/SkillDetail
+    SkillTokenSavings:
+      $ref: ./schemas/skills.yaml#/SkillTokenSavings
     SkillCreate:
       $ref: ./schemas/skills.yaml#/SkillCreate
     SkillUpdate:

--- a/packages/browseros-agent/contracts/claw-api/schemas/skills.yaml
+++ b/packages/browseros-agent/contracts/claw-api/schemas/skills.yaml
@@ -142,7 +142,7 @@ SkillRunList:
 SkillDetail:
   type: object
   additionalProperties: false
-  required: [skill, body, runs]
+  required: [skill, body, runs, tokenSavings]
   properties:
     skill:
       $ref: '#/Skill'
@@ -153,6 +153,29 @@ SkillDetail:
       type: array
       items:
         $ref: '#/SkillRun'
+    tokenSavings:
+      $ref: '#/SkillTokenSavings'
+SkillTokenSavings:
+  type: object
+  additionalProperties: false
+  required: [saved, otherBrowsers, used, measuredRunCount]
+  properties:
+    saved:
+      type: integer
+      format: int64
+      description: Tokens saved versus a screenshot-first agent, summed across the skill's measured runs. Signed; clamp to zero for display.
+    otherBrowsers:
+      type: integer
+      format: int64
+      description: Tokens a screenshot-first agent (other browsers) would have spent across the same runs.
+    used:
+      type: integer
+      format: int64
+      description: Tokens BrowserOS neo actually used across the measured runs.
+    measuredRunCount:
+      type: integer
+      format: int64
+      description: How many of the skill's runs had a measured efficiency projection.
 SkillCreate:
   type: object
   additionalProperties: false

--- a/packages/browseros-agent/crates/claw-api/src/generated/skills.rs
+++ b/packages/browseros-agent/crates/claw-api/src/generated/skills.rs
@@ -195,14 +195,22 @@ pub struct SkillDetail {
     pub body: String,
     #[serde(rename = "runs")]
     pub runs: Vec<models::SkillRun>,
+    #[serde(rename = "tokenSavings")]
+    pub token_savings: Box<models::SkillTokenSavings>,
 }
 
 impl SkillDetail {
-    pub fn new(skill: models::Skill, body: String, runs: Vec<models::SkillRun>) -> SkillDetail {
+    pub fn new(
+        skill: models::Skill,
+        body: String,
+        runs: Vec<models::SkillRun>,
+        token_savings: models::SkillTokenSavings,
+    ) -> SkillDetail {
         SkillDetail {
             skill: Box::new(skill),
             body,
             runs,
+            token_savings: Box::new(token_savings),
         }
     }
 }
@@ -315,6 +323,38 @@ impl SkillRunList {
         SkillRunList {
             items,
             next_cursor: None,
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SkillTokenSavings {
+    /// Tokens saved versus a screenshot-first agent, summed across the skill's measured runs. Signed; clamp to zero for display.
+    #[serde(rename = "saved")]
+    pub saved: i64,
+    /// Tokens a screenshot-first agent (other browsers) would have spent across the same runs.
+    #[serde(rename = "otherBrowsers")]
+    pub other_browsers: i64,
+    /// Tokens BrowserOS neo actually used across the measured runs.
+    #[serde(rename = "used")]
+    pub used: i64,
+    /// How many of the skill's runs had a measured efficiency projection.
+    #[serde(rename = "measuredRunCount")]
+    pub measured_run_count: i64,
+}
+
+impl SkillTokenSavings {
+    pub fn new(
+        saved: i64,
+        other_browsers: i64,
+        used: i64,
+        measured_run_count: i64,
+    ) -> SkillTokenSavings {
+        SkillTokenSavings {
+            saved,
+            other_browsers,
+            used,
+            measured_run_count,
         }
     }
 }

--- a/packages/browseros-agent/packages/claw-api-client/src/generated/openapi.ts
+++ b/packages/browseros-agent/packages/claw-api-client/src/generated/openapi.ts
@@ -807,6 +807,29 @@ export interface components {
       /** @description The raw SKILL.md contents. */
       body: string
       runs: components['schemas']['SkillRun'][]
+      tokenSavings: components['schemas']['SkillTokenSavings']
+    }
+    SkillTokenSavings: {
+      /**
+       * Format: int64
+       * @description Tokens saved versus a screenshot-first agent, summed across the skill's measured runs. Signed; clamp to zero for display.
+       */
+      saved: number
+      /**
+       * Format: int64
+       * @description Tokens a screenshot-first agent (other browsers) would have spent across the same runs.
+       */
+      otherBrowsers: number
+      /**
+       * Format: int64
+       * @description Tokens BrowserOS neo actually used across the measured runs.
+       */
+      used: number
+      /**
+       * Format: int64
+       * @description How many of the skill's runs had a measured efficiency projection.
+       */
+      measuredRunCount: number
     }
     SkillCreate: {
       name: string

--- a/packages/browseros-agent/packages/claw-api/src/generated/models/skills.ts
+++ b/packages/browseros-agent/packages/claw-api/src/generated/models/skills.ts
@@ -264,6 +264,12 @@ export interface SkillDetail {
      * @memberof SkillDetail
      */
     runs: Array<SkillRun>;
+    /**
+     *
+     * @type {SkillTokenSavings}
+     * @memberof SkillDetail
+     */
+    tokenSavings: SkillTokenSavings;
 }
 
 /**
@@ -383,6 +389,38 @@ export interface SkillRunList {
      * @memberof SkillRunList
      */
     nextCursor?: number;
+}
+
+/**
+ *
+ * @export
+ * @interface SkillTokenSavings
+ */
+export interface SkillTokenSavings {
+    /**
+     * Tokens saved versus a screenshot-first agent, summed across the skill's measured runs. Signed; clamp to zero for display.
+     * @type {number}
+     * @memberof SkillTokenSavings
+     */
+    saved: number;
+    /**
+     * Tokens a screenshot-first agent (other browsers) would have spent across the same runs.
+     * @type {number}
+     * @memberof SkillTokenSavings
+     */
+    otherBrowsers: number;
+    /**
+     * Tokens BrowserOS neo actually used across the measured runs.
+     * @type {number}
+     * @memberof SkillTokenSavings
+     */
+    used: number;
+    /**
+     * How many of the skill's runs had a measured efficiency projection.
+     * @type {number}
+     * @memberof SkillTokenSavings
+     */
+    measuredRunCount: number;
 }
 
 /**


### PR DESCRIPTION
Replaces the two misleading left-hand stat cards on the task detail page (`/skills/:name`).

## Before
- "Getting cheaper / Not enough runs to compare cost yet." A skill does not make its runs cheaper over time, so the framing is wrong.
- "Safe to leave alone / not run / 0 of 0 runs..." buries the clean-run rate.

## After
- **Tokens saved**: a big compact total of the tokens this skill saved versus a screenshot-first agent, plus the amount those same runs would have spent in other browsers. Reuses the cockpit homepage's session-efficiency logic. Shows "No measured runs yet" until a run is measured.
- **Success rate**: the clean-run rate as a big color-coded percentage (green >= 90, amber >= 70, red otherwise), keeping the useful "X of Y runs finished without a tool error" line and the last-run time.

## How the token savings are computed
Each skill run is a session, and `session_efficiency_stats` already stores the per-session input/output/screenshot-baseline token estimates the cockpit uses. `SkillDetail` gains a `tokenSavings` object (`saved`, `otherBrowsers`, `used`, `measuredRunCount`) computed by aggregating those rows over the skill's run sessions (new `SessionEfficiencyService::aggregate_for_sessions` + a batch repo query). Unmeasured runs contribute nothing and are excluded from `measuredRunCount`, which drives the empty state.

Scope is the two detail cards only; the list page and the "Linked into" card are unchanged.

## Verified
- Backend: cargo check/clippy/rustfmt clean; new `aggregate_for_sessions` test; the full `claw-server-rust` suite green (session_efficiency 20, skills 10); codegen drift gate clean.
- Frontend: app typecheck clean, Biome clean, new `SkillDetail` static-markup tests (card titles, the saved/other-browsers values, the color bands, and both empty states) plus the existing skills tests all pass.