### PR TITLE
ci(release-cli): use frozen-lockfile install to match other workflows

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -69,7 +69,7 @@ jobs:
         run: make release VERSION=${{ steps.release.outputs.version }} POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
         working-directory: packages/browseros-agent
 
       - name: Upload to CDN


### PR DESCRIPTION
## What

The CLI release workflow installed dependencies with a plain `bun install`; switch it to `bun ci` (Bun's alias for `bun install --frozen-lockfile`).

## Why

Every other CI workflow already uses `bun ci` (`audit`, `build-browseros`, `code-quality`, `release-claw-onboard`, `release-macos`, `release-server`, `test`, `turbo-cache-warm`). `release-cli.yml` was the only one on plain `bun install`, which updates `bun.lock` at build time and can silently mask lockfile drift. Using the frozen install makes the release build fail loudly if `bun.lock` is out of sync with `package.json`, matching the reproducibility guarantee the rest of CI relies on.

## Scope

One line in `.github/workflows/release-cli.yml`. No behavior change when the lockfile is already in sync.