### PR TITLE
feat(skills): namespace every task under a neo- prefix

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/skills/SkillFormDialog.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/skills/SkillFormDialog.tsx
@@ -38,7 +38,7 @@ import {
   useSkills,
   useUpdateSkill,
 } from '@/modules/api/skills.hooks'
-import { parseSkillBody } from '@/screens/skills/skills.helpers'
+import { neoName, parseSkillBody } from '@/screens/skills/skills.helpers'
 
 const createSchema = z.object({
   name: z
@@ -116,10 +116,11 @@ function CreateForm({ onClose }: { onClose: () => void }) {
   })
 
   const onSubmit = form.handleSubmit((values) => {
+    const name = neoName(values.name)
     void toast.promise(
       create
         .mutateAsync({
-          name: values.name,
+          name,
           description: values.description,
           site: trimmedOrUndefined(values.site),
           steps: toLines(values.steps),
@@ -131,7 +132,7 @@ function CreateForm({ onClose }: { onClose: () => void }) {
         }),
       {
         loading: 'Saving the task…',
-        success: `Saved /${values.name}`,
+        success: `Saved /${name}`,
         error: 'Could not save the task',
       },
     )
@@ -154,14 +155,21 @@ function CreateForm({ onClose }: { onClose: () => void }) {
             <FormItem>
               <FormLabel>Name</FormLabel>
               <FormControl>
-                <Input
-                  placeholder="inbox-sweep"
-                  className="font-mono"
-                  {...field}
-                />
+                <div className="flex h-9 w-full items-center overflow-hidden rounded-md border border-input bg-transparent shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50">
+                  <span className="flex h-full select-none items-center bg-card-tint px-2.5 font-mono text-ink-2 text-sm">
+                    neo-
+                  </span>
+                  <Input
+                    placeholder="inbox-sweep"
+                    className="h-full flex-1 rounded-none border-0 font-mono shadow-none focus-visible:ring-0"
+                    {...field}
+                  />
+                </div>
               </FormControl>
               <FormDescription>
-                Lowercase letters, digits, and hyphens. Used as the /command.
+                Saved as /{field.value ? neoName(field.value) : 'neo-<name>'} so
+                you can find it with /neo in your agent. Lowercase letters,
+                digits, and hyphens.
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   formatRelativeTime,
   formatTokens,
+  neoName,
   parseSkillBody,
   skillCommand,
   tokenDeltaPercent,
@@ -10,6 +11,20 @@ import {
 describe('skillCommand', () => {
   it('prefixes the name with a slash', () => {
     expect(skillCommand('inbox-sweep')).toBe('/inbox-sweep')
+  })
+})
+
+describe('neoName', () => {
+  it('namespaces a bare suffix under neo-', () => {
+    expect(neoName('weather')).toBe('neo-weather')
+  })
+
+  it('does not double an over-typed neo- prefix', () => {
+    expect(neoName('neo-weather')).toBe('neo-weather')
+  })
+
+  it('leaves an interior neo- untouched', () => {
+    expect(neoName('weather-neo-check')).toBe('neo-weather-neo-check')
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.ts
@@ -6,6 +6,18 @@
  * Pure formatters for the Tasks list and detail. No React, no side effects.
  */
 
+/** Every skill is namespaced under this prefix so it never collides with a
+ *  user's own agent skills and the whole set autocompletes on `/neo`. */
+export const NEO_SKILL_PREFIX = 'neo-'
+
+/**
+ * The canonical, neo-namespaced name for a user-typed suffix. Mirrors the
+ * server: a bare suffix is prefixed, and an over-typed `neo-` is not doubled.
+ */
+export function neoName(suffix: string): string {
+  return `${NEO_SKILL_PREFIX}${suffix.replace(/^neo-/, '')}`
+}
+
 /** The command a user pastes into a coding agent to run a skill. */
 export function skillCommand(name: string): string {
   return `/${name}`

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -47,7 +47,7 @@ const NAME_SESSION_TOOL_NAME: &str = "name_session";
 const NAME_SESSION_DESCRIPTION: &str = "Rename this browser session: a small lowercase 2-3 word label for what this session is doing, e.g. \"invoice processing\". Tabs are grouped as <client>/<name>. Call again to rename.";
 const NAME_SESSION_INPUT_MAX_LEN: usize = 64;
 const SAVE_SKILL_TOOL_NAME: &str = "save_skill";
-const SAVE_SKILL_DESCRIPTION: &str = "Save the current repeatable browser task as a BrowserOS neo skill so it can be re-run by name later. Give a lowercase-hyphen name, a one-line description, the ordered steps, and any shortcuts learned this run. In the steps, name the exact browser SDK calls you actually used this session (e.g. browser.wait, browser.read, browser.pages.newPage) so a later run reuses them verbatim; never invent, rename, or guess a method that is not in the run tool's SDK (there is no browser.waitFor, for example). Call again with the same name to update it in place.";
+const SAVE_SKILL_DESCRIPTION: &str = "Save the current repeatable browser task as a BrowserOS neo skill so it can be re-run by name later. Give a lowercase-hyphen name, a one-line description, the ordered steps, and any shortcuts learned this run. In the steps, name the exact browser SDK calls you actually used this session (e.g. browser.wait, browser.read, browser.pages.newPage) so a later run reuses them verbatim; never invent, rename, or guess a method that is not in the run tool's SDK (there is no browser.waitFor, for example). The skill is saved and linked into your agents under a neo- prefix (neo-<name>) so it never clobbers your own skills and you can list them all by typing /neo; a name given without the prefix is namespaced automatically. Call again with the same name to update it in place.";
 const MARK_SKILL_RUN_TOOL_NAME: &str = "mark_skill_run";
 const MARK_SKILL_RUN_DESCRIPTION: &str = "Mark this browser session as a run of a saved skill so BrowserOS neo records the run and its cost once the session ends. Call this once, at the start, when you are running a skill, with the skill's name.";
 
@@ -231,10 +231,15 @@ impl ClawMcpService {
         let started_at = StdInstant::now();
         let session_id = started.session.id().as_str().to_string();
         let result = match parse_skill_name(raw_args) {
-            Ok(name) => match self.state.skill_runs.mark(&session_id, &name).await {
-                Ok(()) => ToolResult::text(format!("recording this run of /{name}"), None),
-                Err(error) => ToolResult::error(error.to_string()),
-            },
+            Ok(name) => {
+                // Skills are namespaced under neo-; accept a bare name too so a
+                // run is still recorded if the agent drops the prefix.
+                let name = crate::services::skills::neo_prefixed(&name);
+                match self.state.skill_runs.mark(&session_id, &name).await {
+                    Ok(()) => ToolResult::text(format!("recording this run of /{name}"), None),
+                    Err(error) => ToolResult::error(error.to_string()),
+                }
+            }
             Err(message) => ToolResult::error(message),
         };
         if let Err(error) = record_local_tool_dispatch(
@@ -1045,7 +1050,7 @@ mod tests {
             )
             .await;
 
-        let created = call.state.skills.get("inbox-sweep").await?;
+        let created = call.state.skills.get("neo-inbox-sweep").await?;
         assert_eq!(created.view.model.origin, "agent");
         assert_eq!(
             created.view.model.source_session_id.as_deref(),
@@ -1071,10 +1076,53 @@ mod tests {
                 }),
             )
             .await;
-        let updated = call.state.skills.get("inbox-sweep").await?;
+        let updated = call.state.skills.get("neo-inbox-sweep").await?;
         assert_eq!(updated.view.model.version, 2);
         assert_eq!(updated.view.model.description, "Check the inbox and reply");
         assert!(updated.body.contains("Draft and send"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mark_skill_run_resolves_a_bare_name_to_the_neo_skill() -> anyhow::Result<()> {
+        let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let session = call
+            .identity
+            .as_ref()
+            .map(|identity| identity.session.clone())
+            .ok_or_else(|| anyhow::anyhow!("session missing"))?;
+        let service = ClawMcpService::new(call.state.clone());
+        let started = StartedSession {
+            session: session.clone(),
+            agent_label: "codex".to_string(),
+        };
+
+        // Author a skill; it is stored under the neo- namespace.
+        service
+            .call_save_skill(
+                &started,
+                &json!({
+                    "name": "weather",
+                    "description": "Check the weather",
+                    "steps": ["Open the forecast"]
+                }),
+            )
+            .await;
+        assert!(call.state.skills.get("neo-weather").await.is_ok());
+
+        // Marking with the bare name resolves to the stored neo-weather, so the
+        // run is recorded rather than rejected as an unknown skill.
+        let bare = service
+            .call_mark_skill_run(&started, &json!({ "name": "weather" }))
+            .await;
+        assert_ne!(bare.is_error, Some(true));
+
+        // A name that resolves to no skill still errors.
+        let unknown = service
+            .call_mark_skill_run(&started, &json!({ "name": "not-a-skill" }))
+            .await;
+        assert_eq!(unknown.is_error, Some(true));
 
         Ok(())
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/skills.rs
@@ -19,6 +19,11 @@ use tokio::sync::Mutex;
 /// The embedded product skill owns this directory name; user skills may not
 /// reuse it or they would clobber the managed BrowserOS skill.
 const RESERVED_SKILL_NAMES: [&str; 1] = ["browserclaw"];
+
+/// Every user- and agent-authored skill is namespaced under this prefix so its
+/// on-disk and linked-agent directory can never collide with a user's own
+/// skill, and so a user can list them all by typing `/neo` in their agent.
+const NEO_SKILL_PREFIX: &str = "neo-";
 const DEFAULT_RUN_LIMIT: u64 = 25;
 const MAX_RUN_LIMIT: u64 = 100;
 
@@ -166,16 +171,9 @@ impl SkillService {
     }
 
     async fn create_locked(&self, input: CreateSkill) -> AppResult<SkillView> {
-        if !is_valid_skill_name(&input.name) {
-            return Err(AppError::bad_request(
-                "skill name must contain only lowercase letters, digits, and hyphens",
-            ));
-        }
-        if RESERVED_SKILL_NAMES.contains(&input.name.as_str()) {
-            return Err(AppError::conflict("skill name is reserved"));
-        }
+        let name = normalized_skill_name(&input.name)?;
         let CreateSkill {
-            name,
+            name: _,
             description,
             site,
             steps,
@@ -365,16 +363,9 @@ impl SkillService {
     /// agent-facing MCP tool calls so re-authoring a task updates it in place.
     pub async fn upsert(&self, input: CreateSkill) -> AppResult<SkillView> {
         let _guard = self.mutate.lock().await;
-        if !is_valid_skill_name(&input.name) {
-            return Err(AppError::bad_request(
-                "skill name must contain only lowercase letters, digits, and hyphens",
-            ));
-        }
-        if RESERVED_SKILL_NAMES.contains(&input.name.as_str()) {
-            return Err(AppError::conflict("skill name is reserved"));
-        }
+        let name = normalized_skill_name(&input.name)?;
         let CreateSkill {
-            name,
+            name: _,
             description,
             site,
             steps,
@@ -504,6 +495,35 @@ fn is_valid_skill_name(name: &str) -> bool {
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
 }
 
+/// Namespace a name under `neo-`. Idempotent: an already-prefixed name is
+/// returned unchanged, so an agent may pass either `weather` or `neo-weather`.
+pub(crate) fn neo_prefixed(name: &str) -> String {
+    if name.starts_with(NEO_SKILL_PREFIX) {
+        name.to_owned()
+    } else {
+        format!("{NEO_SKILL_PREFIX}{name}")
+    }
+}
+
+/// Validate a raw skill name and return its canonical `neo-`-prefixed form.
+fn normalized_skill_name(raw: &str) -> AppResult<String> {
+    if !is_valid_skill_name(raw) {
+        return Err(AppError::bad_request(
+            "skill name must contain only lowercase letters, digits, and hyphens",
+        ));
+    }
+    let name = neo_prefixed(raw);
+    if name.len() <= NEO_SKILL_PREFIX.len() {
+        return Err(AppError::bad_request(
+            "skill name must have a slug after the neo- prefix",
+        ));
+    }
+    if RESERVED_SKILL_NAMES.contains(&name.as_str()) {
+        return Err(AppError::conflict("skill name is reserved"));
+    }
+    Ok(name)
+}
+
 fn render_skill_markdown(
     name: &str,
     description: &str,
@@ -581,4 +601,34 @@ fn now_ms() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|elapsed| elapsed.as_millis() as i64)
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{neo_prefixed, normalized_skill_name};
+
+    #[test]
+    fn neo_prefixed_is_idempotent() {
+        assert_eq!(neo_prefixed("weather"), "neo-weather");
+        assert_eq!(neo_prefixed("neo-weather"), "neo-weather");
+        // Only a leading prefix is collapsed; an interior "neo-" is untouched.
+        assert_eq!(neo_prefixed("weather-neo-check"), "neo-weather-neo-check");
+    }
+
+    #[test]
+    fn normalized_skill_name_prefixes_and_validates() {
+        assert_eq!(
+            normalized_skill_name("weather").ok().as_deref(),
+            Some("neo-weather")
+        );
+        assert_eq!(
+            normalized_skill_name("neo-weather").ok().as_deref(),
+            Some("neo-weather")
+        );
+        // Charset is rejected before prefixing.
+        assert!(normalized_skill_name("Bad Name").is_err());
+        assert!(normalized_skill_name("").is_err());
+        // A bare prefix has no slug after neo-.
+        assert!(normalized_skill_name("neo-").is_err());
+    }
 }

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -103,7 +103,11 @@ async fn skill_crud_round_trips_and_writes_the_canonical_file() -> anyhow::Resul
     assert_eq!(created["runCount"].as_i64(), Some(0));
     assert_eq!(created["site"], "mail.google.com");
 
-    let skill_md = app.root.join("skills").join("neo-inbox-sweep").join("SKILL.md");
+    let skill_md = app
+        .root
+        .join("skills")
+        .join("neo-inbox-sweep")
+        .join("SKILL.md");
     let content = std::fs::read_to_string(&skill_md)?;
     assert!(content.contains("name: neo-inbox-sweep"));
     assert!(content.contains("tools: browseros-neo"));
@@ -123,7 +127,8 @@ async fn skill_crud_round_trips_and_writes_the_canonical_file() -> anyhow::Resul
     let (_, list) = request(router, "GET", "/api/v1/skills", None).await?;
     assert_eq!(list["items"].as_array().map(Vec::len), Some(1));
 
-    let (status, runs) = request(router, "GET", "/api/v1/skills/neo-inbox-sweep/runs", None).await?;
+    let (status, runs) =
+        request(router, "GET", "/api/v1/skills/neo-inbox-sweep/runs", None).await?;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(runs["items"].as_array().map(Vec::len), Some(0));
 
@@ -196,7 +201,11 @@ async fn skill_structured_edit_re_renders_frontmatter_and_clears_site() -> anyho
 
     // The on-disk frontmatter description tracks the column: agents reading the
     // file see the new description, never the stale one.
-    let skill_md = app.root.join("skills").join("neo-inbox-sweep").join("SKILL.md");
+    let skill_md = app
+        .root
+        .join("skills")
+        .join("neo-inbox-sweep")
+        .join("SKILL.md");
     let content = std::fs::read_to_string(&skill_md)?;
     assert!(content.contains(r#"description: "Second description""#));
     assert!(!content.contains("First description"));
@@ -235,7 +244,11 @@ async fn skill_metadata_only_description_edit_patches_frontmatter() -> anyhow::R
     assert_eq!(updated["skill"]["description"], "Fresh description");
 
     // Only the frontmatter description line changes; the body is preserved.
-    let skill_md = app.root.join("skills").join("neo-daily-brief").join("SKILL.md");
+    let skill_md = app
+        .root
+        .join("skills")
+        .join("neo-daily-brief")
+        .join("SKILL.md");
     let content = std::fs::read_to_string(&skill_md)?;
     assert!(content.contains(r#"description: "Fresh description""#));
     assert!(!content.contains("Old description"));
@@ -327,7 +340,11 @@ async fn skill_description_edit_adds_frontmatter_to_a_raw_body() -> anyhow::Resu
     .await?;
     assert_eq!(status, StatusCode::OK);
 
-    let skill_md = app.root.join("skills").join("neo-raw-note").join("SKILL.md");
+    let skill_md = app
+        .root
+        .join("skills")
+        .join("neo-raw-note")
+        .join("SKILL.md");
     let content = std::fs::read_to_string(&skill_md)?;
     assert!(content.starts_with("---\nname: neo-raw-note\n"));
     assert!(content.contains(r#"description: "Now described""#));
@@ -403,8 +420,12 @@ async fn skill_create_escapes_yaml_sensitive_descriptions() -> anyhow::Result<()
     .await?;
     assert_eq!(status, StatusCode::CREATED);
 
-    let content =
-        std::fs::read_to_string(app.root.join("skills").join("neo-tricky-desc").join("SKILL.md"))?;
+    let content = std::fs::read_to_string(
+        app.root
+            .join("skills")
+            .join("neo-tricky-desc")
+            .join("SKILL.md"),
+    )?;
     // The description is emitted as a quoted scalar, so a raw newline or colon
     // cannot break the frontmatter block.
     assert!(content.contains(r#"description: "Reply within 24h: keep it brief\nthen stop""#));

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -88,7 +88,7 @@ async fn skill_crud_round_trips_and_writes_the_canonical_file() -> anyhow::Resul
         "POST",
         "/api/v1/skills",
         Some(json!({
-            "name": "inbox-sweep",
+            "name": "neo-inbox-sweep",
             "description": "Check the inbox and draft replies",
             "site": "mail.google.com",
             "steps": ["Open the inbox", "Draft replies", "Leave drafts unsent"],
@@ -97,43 +97,43 @@ async fn skill_crud_round_trips_and_writes_the_canonical_file() -> anyhow::Resul
     )
     .await?;
     assert_eq!(status, StatusCode::CREATED);
-    assert_eq!(created["name"], "inbox-sweep");
+    assert_eq!(created["name"], "neo-inbox-sweep");
     assert_eq!(created["origin"], "manual");
     assert_eq!(created["version"].as_i64(), Some(1));
     assert_eq!(created["runCount"].as_i64(), Some(0));
     assert_eq!(created["site"], "mail.google.com");
 
-    let skill_md = app.root.join("skills").join("inbox-sweep").join("SKILL.md");
+    let skill_md = app.root.join("skills").join("neo-inbox-sweep").join("SKILL.md");
     let content = std::fs::read_to_string(&skill_md)?;
-    assert!(content.contains("name: inbox-sweep"));
+    assert!(content.contains("name: neo-inbox-sweep"));
     assert!(content.contains("tools: browseros-neo"));
     assert!(content.contains("## Steps"));
     assert!(content.contains("Read the DOM snapshot, not screenshots"));
 
-    let (status, detail) = request(router, "GET", "/api/v1/skills/inbox-sweep", None).await?;
+    let (status, detail) = request(router, "GET", "/api/v1/skills/neo-inbox-sweep", None).await?;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(detail["skill"]["name"], "inbox-sweep");
+    assert_eq!(detail["skill"]["name"], "neo-inbox-sweep");
     assert!(
         detail["body"]
             .as_str()
-            .is_some_and(|body| body.contains("name: inbox-sweep"))
+            .is_some_and(|body| body.contains("name: neo-inbox-sweep"))
     );
     assert_eq!(detail["runs"].as_array().map(Vec::len), Some(0));
 
     let (_, list) = request(router, "GET", "/api/v1/skills", None).await?;
     assert_eq!(list["items"].as_array().map(Vec::len), Some(1));
 
-    let (status, runs) = request(router, "GET", "/api/v1/skills/inbox-sweep/runs", None).await?;
+    let (status, runs) = request(router, "GET", "/api/v1/skills/neo-inbox-sweep/runs", None).await?;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(runs["items"].as_array().map(Vec::len), Some(0));
 
     let (status, updated) = request(
         router,
         "PUT",
-        "/api/v1/skills/inbox-sweep",
+        "/api/v1/skills/neo-inbox-sweep",
         Some(json!({
             "description": "Updated description",
-            "body": "---\nname: inbox-sweep\ndescription: Updated\ntools: browseros-neo\n---\n\n## Steps\n1. A brand new step\n"
+            "body": "---\nname: neo-inbox-sweep\ndescription: Updated\ntools: browseros-neo\n---\n\n## Steps\n1. A brand new step\n"
         })),
     )
     .await?;
@@ -148,12 +148,12 @@ async fn skill_crud_round_trips_and_writes_the_canonical_file() -> anyhow::Resul
     let content = std::fs::read_to_string(&skill_md)?;
     assert!(content.contains("A brand new step"));
 
-    let (status, _) = request(router, "DELETE", "/api/v1/skills/inbox-sweep", None).await?;
+    let (status, _) = request(router, "DELETE", "/api/v1/skills/neo-inbox-sweep", None).await?;
     assert_eq!(status, StatusCode::NO_CONTENT);
 
-    let (status, _) = request(router, "GET", "/api/v1/skills/inbox-sweep", None).await?;
+    let (status, _) = request(router, "GET", "/api/v1/skills/neo-inbox-sweep", None).await?;
     assert_eq!(status, StatusCode::NOT_FOUND);
-    assert!(!app.root.join("skills").join("inbox-sweep").exists());
+    assert!(!app.root.join("skills").join("neo-inbox-sweep").exists());
 
     Ok(())
 }
@@ -168,7 +168,7 @@ async fn skill_structured_edit_re_renders_frontmatter_and_clears_site() -> anyho
         "POST",
         "/api/v1/skills",
         Some(json!({
-            "name": "inbox-sweep",
+            "name": "neo-inbox-sweep",
             "description": "First description",
             "site": "mail.google.com",
             "steps": ["Old step"]
@@ -179,7 +179,7 @@ async fn skill_structured_edit_re_renders_frontmatter_and_clears_site() -> anyho
     let (status, updated) = request(
         router,
         "PUT",
-        "/api/v1/skills/inbox-sweep",
+        "/api/v1/skills/neo-inbox-sweep",
         Some(json!({
             "description": "Second description",
             "site": "",
@@ -196,7 +196,7 @@ async fn skill_structured_edit_re_renders_frontmatter_and_clears_site() -> anyho
 
     // The on-disk frontmatter description tracks the column: agents reading the
     // file see the new description, never the stale one.
-    let skill_md = app.root.join("skills").join("inbox-sweep").join("SKILL.md");
+    let skill_md = app.root.join("skills").join("neo-inbox-sweep").join("SKILL.md");
     let content = std::fs::read_to_string(&skill_md)?;
     assert!(content.contains(r#"description: "Second description""#));
     assert!(!content.contains("First description"));
@@ -217,7 +217,7 @@ async fn skill_metadata_only_description_edit_patches_frontmatter() -> anyhow::R
         "POST",
         "/api/v1/skills",
         Some(json!({
-            "name": "daily-brief",
+            "name": "neo-daily-brief",
             "description": "Old description",
             "steps": ["Keep this step"]
         })),
@@ -227,7 +227,7 @@ async fn skill_metadata_only_description_edit_patches_frontmatter() -> anyhow::R
     let (status, updated) = request(
         router,
         "PUT",
-        "/api/v1/skills/daily-brief",
+        "/api/v1/skills/neo-daily-brief",
         Some(json!({ "description": "Fresh description" })),
     )
     .await?;
@@ -235,7 +235,7 @@ async fn skill_metadata_only_description_edit_patches_frontmatter() -> anyhow::R
     assert_eq!(updated["skill"]["description"], "Fresh description");
 
     // Only the frontmatter description line changes; the body is preserved.
-    let skill_md = app.root.join("skills").join("daily-brief").join("SKILL.md");
+    let skill_md = app.root.join("skills").join("neo-daily-brief").join("SKILL.md");
     let content = std::fs::read_to_string(&skill_md)?;
     assert!(content.contains(r#"description: "Fresh description""#));
     assert!(!content.contains("Old description"));
@@ -253,7 +253,7 @@ async fn skill_update_rejects_ambiguous_field_combinations() -> anyhow::Result<(
         router,
         "POST",
         "/api/v1/skills",
-        Some(json!({ "name": "inbox-sweep", "description": "First", "steps": ["Old step"] })),
+        Some(json!({ "name": "neo-inbox-sweep", "description": "First", "steps": ["Old step"] })),
     )
     .await?;
 
@@ -262,9 +262,9 @@ async fn skill_update_rejects_ambiguous_field_combinations() -> anyhow::Result<(
     let (status, _) = request(
         router,
         "PUT",
-        "/api/v1/skills/inbox-sweep",
+        "/api/v1/skills/neo-inbox-sweep",
         Some(json!({
-            "body": "---\nname: inbox-sweep\ndescription: X\ntools: browseros-neo\n---\n",
+            "body": "---\nname: neo-inbox-sweep\ndescription: X\ntools: browseros-neo\n---\n",
             "steps": ["New step"],
             "learnedNotes": []
         })),
@@ -276,14 +276,14 @@ async fn skill_update_rejects_ambiguous_field_combinations() -> anyhow::Result<(
     let (status, _) = request(
         router,
         "PUT",
-        "/api/v1/skills/inbox-sweep",
+        "/api/v1/skills/neo-inbox-sweep",
         Some(json!({ "steps": ["New step"] })),
     )
     .await?;
     assert_eq!(status, StatusCode::BAD_REQUEST);
 
     // The original steps survive both rejected updates.
-    let (_, detail) = request(router, "GET", "/api/v1/skills/inbox-sweep", None).await?;
+    let (_, detail) = request(router, "GET", "/api/v1/skills/neo-inbox-sweep", None).await?;
     assert!(
         detail["body"]
             .as_str()
@@ -302,7 +302,7 @@ async fn skill_description_edit_adds_frontmatter_to_a_raw_body() -> anyhow::Resu
         router,
         "POST",
         "/api/v1/skills",
-        Some(json!({ "name": "raw-note", "description": "First" })),
+        Some(json!({ "name": "neo-raw-note", "description": "First" })),
     )
     .await?;
 
@@ -310,7 +310,7 @@ async fn skill_description_edit_adds_frontmatter_to_a_raw_body() -> anyhow::Resu
     let (status, _) = request(
         router,
         "PUT",
-        "/api/v1/skills/raw-note",
+        "/api/v1/skills/neo-raw-note",
         Some(json!({ "body": "Just prose, no frontmatter\n" })),
     )
     .await?;
@@ -321,15 +321,15 @@ async fn skill_description_edit_adds_frontmatter_to_a_raw_body() -> anyhow::Resu
     let (status, _) = request(
         router,
         "PUT",
-        "/api/v1/skills/raw-note",
+        "/api/v1/skills/neo-raw-note",
         Some(json!({ "description": "Now described" })),
     )
     .await?;
     assert_eq!(status, StatusCode::OK);
 
-    let skill_md = app.root.join("skills").join("raw-note").join("SKILL.md");
+    let skill_md = app.root.join("skills").join("neo-raw-note").join("SKILL.md");
     let content = std::fs::read_to_string(&skill_md)?;
-    assert!(content.starts_with("---\nname: raw-note\n"));
+    assert!(content.starts_with("---\nname: neo-raw-note\n"));
     assert!(content.contains(r#"description: "Now described""#));
     assert!(content.contains("Just prose, no frontmatter"));
 
@@ -350,20 +350,24 @@ async fn skill_create_rejects_bad_names_and_duplicates() -> anyhow::Result<()> {
     .await?;
     assert_eq!(status, StatusCode::BAD_REQUEST);
 
-    let (status, _) = request(
+    // The embedded product skill occupies "browserclaw"; the neo- namespace
+    // neutralizes the old collision, so a user "browserclaw" now saves cleanly
+    // as "neo-browserclaw" instead of being rejected.
+    let (status, created) = request(
         router,
         "POST",
         "/api/v1/skills",
-        Some(json!({ "name": "browserclaw", "description": "reserved name" })),
+        Some(json!({ "name": "browserclaw", "description": "no longer collides" })),
     )
     .await?;
-    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["name"], "neo-browserclaw");
 
     let (status, _) = request(
         router,
         "POST",
         "/api/v1/skills",
-        Some(json!({ "name": "daily-brief", "description": "first" })),
+        Some(json!({ "name": "neo-daily-brief", "description": "first" })),
     )
     .await?;
     assert_eq!(status, StatusCode::CREATED);
@@ -372,7 +376,7 @@ async fn skill_create_rejects_bad_names_and_duplicates() -> anyhow::Result<()> {
         router,
         "POST",
         "/api/v1/skills",
-        Some(json!({ "name": "daily-brief", "description": "duplicate" })),
+        Some(json!({ "name": "neo-daily-brief", "description": "duplicate" })),
     )
     .await?;
     assert_eq!(status, StatusCode::CONFLICT);
@@ -392,7 +396,7 @@ async fn skill_create_escapes_yaml_sensitive_descriptions() -> anyhow::Result<()
         "POST",
         "/api/v1/skills",
         Some(json!({
-            "name": "tricky-desc",
+            "name": "neo-tricky-desc",
             "description": "Reply within 24h: keep it brief\nthen stop"
         })),
     )
@@ -400,11 +404,60 @@ async fn skill_create_escapes_yaml_sensitive_descriptions() -> anyhow::Result<()
     assert_eq!(status, StatusCode::CREATED);
 
     let content =
-        std::fs::read_to_string(app.root.join("skills").join("tricky-desc").join("SKILL.md"))?;
+        std::fs::read_to_string(app.root.join("skills").join("neo-tricky-desc").join("SKILL.md"))?;
     // The description is emitted as a quoted scalar, so a raw newline or colon
     // cannot break the frontmatter block.
     assert!(content.contains(r#"description: "Reply within 24h: keep it brief\nthen stop""#));
     assert_eq!(content.matches("---").count(), 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn skill_create_namespaces_a_bare_name_under_neo() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let router = &app.router;
+
+    // A bare name is namespaced under neo- on the way in.
+    let (status, created) = request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({
+            "name": "weather",
+            "description": "Check today's weather",
+            "steps": ["Open the forecast", "Read the high and low"]
+        })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["name"], "neo-weather");
+
+    // The canonical file lives under the prefixed name, and its frontmatter and
+    // the mark step both carry the prefixed name so a re-run marks correctly.
+    let skill_md = app.root.join("skills").join("neo-weather").join("SKILL.md");
+    let content = std::fs::read_to_string(&skill_md)?;
+    assert!(content.contains("name: neo-weather"));
+    assert!(content.contains("mark_skill_run tool with name: neo-weather"));
+    assert!(!app.root.join("skills").join("weather").exists());
+
+    // The read path is exact: the prefixed name resolves, the bare one does not.
+    let (status, _) = request(router, "GET", "/api/v1/skills/neo-weather", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    let (status, _) = request(router, "GET", "/api/v1/skills/weather", None).await?;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // Re-posting the already-prefixed name hits the same skill (a duplicate),
+    // never nesting into neo-neo-weather.
+    let (status, _) = request(
+        router,
+        "POST",
+        "/api/v1/skills",
+        Some(json!({ "name": "neo-weather", "description": "Now with the hourly view" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(!app.root.join("skills").join("neo-neo-weather").exists());
 
     Ok(())
 }
@@ -441,7 +494,7 @@ async fn skill_run_recorded_from_a_marked_session() -> anyhow::Result<()> {
     state
         .skills
         .create(CreateSkill {
-            name: "inbox-sweep".to_string(),
+            name: "neo-inbox-sweep".to_string(),
             description: "Check the inbox".to_string(),
             site: None,
             steps: vec!["Read the inbox".to_string()],
@@ -476,12 +529,12 @@ async fn skill_run_recorded_from_a_marked_session() -> anyhow::Result<()> {
         .record_session_end("run-sess", "closed", None)
         .await?;
 
-    state.skill_runs.mark("run-sess", "inbox-sweep").await?;
+    state.skill_runs.mark("run-sess", "neo-inbox-sweep").await?;
     assert!(state.skill_runs.finalize("run-sess").await?);
     // Projecting again is a no-op.
     assert!(!state.skill_runs.finalize("run-sess").await?);
 
-    let detail = state.skills.get("inbox-sweep").await?;
+    let detail = state.skills.get("neo-inbox-sweep").await?;
     assert_eq!(detail.runs.len(), 1);
     let run = &detail.runs[0];
     assert_eq!(run.run_number, 1);
@@ -513,7 +566,7 @@ async fn skill_run_recorded_from_a_marked_session() -> anyhow::Result<()> {
         .record_session_end("plain-sess", "closed", None)
         .await?;
     assert!(!state.skill_runs.finalize("plain-sess").await?);
-    assert_eq!(state.skills.get("inbox-sweep").await?.runs.len(), 1);
+    assert_eq!(state.skills.get("neo-inbox-sweep").await?.runs.len(), 1);
 
     Ok(())
 }
@@ -536,7 +589,7 @@ async fn mark_rejects_unknown_skill_and_finalize_skips_a_deleted_one() -> anyhow
     state
         .skills
         .create(CreateSkill {
-            name: "brief".to_string(),
+            name: "neo-brief".to_string(),
             description: "Daily brief".to_string(),
             site: None,
             steps: vec![],
@@ -564,8 +617,8 @@ async fn mark_rejects_unknown_skill_and_finalize_skips_a_deleted_one() -> anyhow
         .audit_log
         .record_session_end("gone-sess", "closed", None)
         .await?;
-    state.skill_runs.mark("gone-sess", "brief").await?;
-    state.skills.delete("brief").await?;
+    state.skill_runs.mark("gone-sess", "neo-brief").await?;
+    state.skills.delete("neo-brief").await?;
     assert!(!state.skill_runs.finalize("gone-sess").await?);
 
     Ok(())
@@ -576,7 +629,7 @@ async fn concurrent_upserts_of_a_new_name_keep_one_skill_intact() -> anyhow::Res
     let app = test_app().await?;
     let skills = app.state.skills.clone();
     let input = |description: &str| CreateSkill {
-        name: "race-skill".to_string(),
+        name: "neo-race-skill".to_string(),
         description: description.to_string(),
         site: None,
         steps: vec!["Do the thing".to_string()],
@@ -591,11 +644,11 @@ async fn concurrent_upserts_of_a_new_name_keep_one_skill_intact() -> anyhow::Res
     first?;
     second?;
 
-    let detail = skills.get("race-skill").await?;
+    let detail = skills.get("neo-race-skill").await?;
     assert!(
         app.root
             .join("skills")
-            .join("race-skill")
+            .join("neo-race-skill")
             .join("SKILL.md")
             .exists()
     );


### PR DESCRIPTION
## What

Prefix every user- and agent-created skill with `neo-` so its canonical name is `neo-<slug>` everywhere: the DB primary key, the on-disk `SKILL.md`, the linked agent directories, and the `/command`.

Two wins:
- **No collisions.** Skills are deployed into shared agent skill directories (`~/.claude/skills/`, `~/.agents/skills/`, etc.). The namespace guarantees a task can never overwrite or shadow a user's own agent skill.
- **One-keystroke browsing.** A user types `/neo` in their coding agent and every BrowserOS neo task autocompletes.

## How

- Normalization lives on the write path only. `create` and `upsert` route the raw name through a new `normalized_skill_name` (charset check, then idempotent `neo_prefixed`, then a guard against a bare `neo-` and the reserved list). The MCP `save_skill` tool inherits this through `upsert`.
- `mark_skill_run` resolves the looked-up name with `neo_prefixed`, so an agent that passes a bare name still records the run against the prefixed skill.
- The reserved-name check now runs on the prefixed name, so a user "browserclaw" saves cleanly as `neo-browserclaw` (the namespace neutralizes the old collision); the list is kept as forward-looking defense.
- The create form shows a fixed `neo-` prefix affordance and submits the namespaced name via a small pure `neoName` helper that mirrors the server (an over-typed `neo-` is not doubled). The read path stays exact, and display is unchanged since the stored name already carries the prefix.

The name stays a plain string in the contract, so there is no schema or codegen change.

## Tests

- Backend: `neo_prefixed` idempotence and `normalized_skill_name` prefix/validate/reject unit tests; a bare-name create test asserting `weather` -> `neo-weather` on disk and over HTTP (with no `neo-neo-` nesting and an exact read path); an MCP `mark_skill_run` test proving a bare name resolves; existing skills/CRUD tests re-pointed to the namespaced identity.
- Frontend: `neoName` unit tests.

Verified locally: fmt, clippy `--all-targets`, and the skills backend tests; app typecheck, Biome, and the skills frontend tests.