### PR TITLE
fix(claw): reconcile historical live session status

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/sessions.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/sessions.rs
@@ -206,7 +206,7 @@ async fn contract_summary(task: TaskSummary, live: Option<&Arc<Session>>) -> Ses
         task.duration_ms.max(0),
         task.dispatch_count,
         task.tool_sequence,
-        contract_status(task.status),
+        contract_status(task.status, live.is_some()),
         task.error_count,
     );
     summary.profile_id = live
@@ -304,8 +304,9 @@ fn contract_live_tab(projection: LiveTabProjection) -> SessionBrowserTab {
     tab
 }
 
-fn contract_status(status: TaskStatus) -> SessionStatus {
+fn contract_status(status: TaskStatus, is_live: bool) -> SessionStatus {
     match status {
+        TaskStatus::Live if !is_live => SessionStatus::Done,
         TaskStatus::Live => SessionStatus::Live,
         TaskStatus::Done => SessionStatus::Done,
         TaskStatus::Failed => SessionStatus::Failed,

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/sessions.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/sessions.rs
@@ -62,11 +62,13 @@ pub(super) async fn list(
             .collect();
         return Ok(Json(SessionList::new(items)));
     }
+    let response_status_filter = query.status;
+    let stored_status_filter = query.status.filter(|status| *status != TaskStatus::Done);
     let result = state
         .audit_log
         .list_tasks(ListTasksQuery {
             slug: query.slug,
-            status: query.status,
+            status: stored_status_filter,
             site: query.site,
             search: query.search,
             since: query.since,
@@ -77,18 +79,19 @@ pub(super) async fn list(
         .await
         .map_err(|source| internal(&request_id, source))?;
     let live = live_sessions(&state).await;
-    // profile_id lives on the live session's agent, not in the audit
-    // store, so a profileId filter can only match live sessions — and
-    // it applies after pagination, so a filtered page may come back
-    // short rather than backfilled.
+    // profile_id lives on the live session's agent, and a done filter
+    // must reconcile persisted-live rows. Both apply after pagination,
+    // so a filtered page may come back short rather than backfilled.
     let mut items = Vec::with_capacity(result.tasks.len());
     for task in result.tasks {
         let session = live.get(task.session_id.as_str());
         let summary = contract_summary(task, session).await;
-        if query
-            .profile_id
-            .as_ref()
-            .is_none_or(|profile_id| summary.profile_id.as_ref() == Some(profile_id))
+        if response_status_filter
+            .is_none_or(|status| summary.status == contract_status(status, true))
+            && query
+                .profile_id
+                .as_ref()
+                .is_none_or(|profile_id| summary.profile_id.as_ref() == Some(profile_id))
         {
             items.push(summary);
         }

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -1107,6 +1107,19 @@ async fn historical_sessions_reconcile_stored_live_status() -> anyhow::Result<()
         assert_eq!(status, StatusCode::OK);
         assert_eq!(detail["session"]["status"], expected_status);
     }
+
+    let (status, done) =
+        request_json(&app.router, "GET", "/api/v1/sessions?status=done", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        done["items"].as_array().map(|items| {
+            items
+                .iter()
+                .map(|item| item["sessionId"].as_str())
+                .collect::<Vec<_>>()
+        }),
+        Some(vec![Some(disconnected.id().as_str())])
+    );
     Ok(())
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -7,7 +7,7 @@ use browseros_core::{PageId, TargetId, screenshot::ScreenshotCaptureOptions};
 use claw_server_rust::{
     AppState, build_router,
     config::Config,
-    db::audit_log::{RecordToolDispatchInput, bounded_args_json, result_meta},
+    db::audit_log::{RecordToolDispatchInput, TaskStatus, bounded_args_json, result_meta},
     identity::{ClientIdentity, ConversationIdentity},
     ids::{ConvoId, DispatchId, ProfileId, SessionId},
     services::sessions::Session,
@@ -1048,6 +1048,65 @@ async fn canonical_cancel_endpoint_aborts_in_flight_dispatch() -> anyhow::Result
             .is_some_and(|items| items.iter().any(|item| item["sessionId"] == session_id))
     );
     drop(mock);
+    Ok(())
+}
+
+#[tokio::test]
+async fn historical_sessions_reconcile_stored_live_status() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let disconnected = test_session(
+        SessionId::new("disconnected-session"),
+        "disconnected-agent",
+        "codex",
+    );
+    let connected = test_session(
+        SessionId::new("connected-session"),
+        "connected-agent",
+        "codex",
+    );
+    record_session_with_dispatch(&app, &disconnected).await?;
+    record_session_with_dispatch(&app, &connected).await?;
+    app.state
+        .sessions
+        .insert_for_testing(connected.clone())
+        .await;
+
+    for session in [&disconnected, &connected] {
+        assert_eq!(
+            app.state
+                .audit_log
+                .get_task_summary(session.id().as_str())
+                .await?
+                .map(|summary| summary.status),
+            Some(TaskStatus::Live)
+        );
+    }
+
+    let (status, body) = request_json(&app.router, "GET", "/api/v1/sessions", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    let items = body["items"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("sessions not array"))?;
+    for (session_id, expected_status) in [
+        (disconnected.id().as_str(), "done"),
+        (connected.id().as_str(), "live"),
+    ] {
+        let summary = items
+            .iter()
+            .find(|item| item["sessionId"] == session_id)
+            .ok_or_else(|| anyhow::anyhow!("missing session {session_id}"))?;
+        assert_eq!(summary["status"], expected_status);
+
+        let (status, detail) = request_json(
+            &app.router,
+            "GET",
+            &format!("/api/v1/sessions/{session_id}"),
+            None,
+        )
+        .await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(detail["session"]["status"], expected_status);
+    }
     Ok(())
 }
 

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -1108,8 +1108,26 @@ async fn historical_sessions_reconcile_stored_live_status() -> anyhow::Result<()
         assert_eq!(detail["session"]["status"], expected_status);
     }
 
-    let (status, done) =
-        request_json(&app.router, "GET", "/api/v1/sessions?status=done", None).await?;
+    let (status, first_done_page) = request_json(
+        &app.router,
+        "GET",
+        "/api/v1/sessions?status=done&limit=1",
+        None,
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(first_done_page["items"], json!([]));
+    let next_cursor = first_done_page["nextCursor"]
+        .as_i64()
+        .ok_or_else(|| anyhow::anyhow!("filtered page dropped its cursor"))?;
+
+    let (status, done) = request_json(
+        &app.router,
+        "GET",
+        &format!("/api/v1/sessions?status=done&limit=1&cursor={next_cursor}"),
+        None,
+    )
+    .await?;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(
         done["items"].as_array().map(|items| {


### PR DESCRIPTION
## Summary

- Reconcile stored Live history rows against the authoritative connected-session registry in HTTP list and detail responses.
- Apply the Done filter after reconciliation while preserving storage cursors across empty filtered pages.
- Add an HTTP regression covering connected and disconnected rows, unchanged persistence, and cursor pagination.

## Design

The live registry remains authoritative for whether a historical row is currently Live. A stored Live row absent from that registry is presented as Done at the HTTP read-model boundary; storage classification and dedicated live APIs remain unchanged.

## Test plan

- [x] bunx bun@1.3.6 run check
- [x] bunx bun@1.3.6 run test
- [x] cargo test
- [x] cargo test --test routes historical_sessions_reconcile_stored_live_status -- --exact