### PR TITLE
fix(agent): propagate LLM errors to the chat UI with real detail

### DIFF
--- a/packages/browseros-agent/apps/app/lib/schedules/getChatServerResponse.ts
+++ b/packages/browseros-agent/apps/app/lib/schedules/getChatServerResponse.ts
@@ -1,3 +1,4 @@
+import { chatErrorMessage } from '@browseros/shared/schemas/chat-error'
 import { createParser, type EventSourceMessage } from 'eventsource-parser'
 import { getAgentServerUrl } from '@/lib/browseros/helpers'
 import {
@@ -144,8 +145,11 @@ export async function getChatServerResponse(
   })
 
   if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    const reason = body ? chatErrorMessage(body) : ''
     throw new Error(
-      `Chat request failed: ${response.status} ${response.statusText}`,
+      reason ||
+        `Chat request failed: ${response.status} ${response.statusText}`,
     )
   }
 
@@ -192,10 +196,12 @@ function processEvent(event: UIMessageEvent, state: StreamParseState): void {
   } else if (event.type === 'tool-output-error') {
     const existingCall = state.toolCallsMap.get(event.toolCallId)
     if (existingCall) {
-      existingCall.error = event.errorText
+      // Run history renders these strings verbatim, so unwrap the envelope the
+      // server serializes into errorText.
+      existingCall.error = chatErrorMessage(event.errorText)
     }
   } else if (event.type === 'error') {
-    state.error = event.errorText
+    state.error = chatErrorMessage(event.errorText)
   } else if (event.type === 'finish') {
     state.receivedFinish = true
   }

--- a/packages/browseros-agent/apps/app/package.json
+++ b/packages/browseros-agent/apps/app/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@ai-sdk/react": "^3.0.248",
     "@browseros/server": "workspace:*",
+    "@browseros/shared": "workspace:*",
     "@hookform/resolvers": "^5.7.1",
     "@lobehub/icons": "^2.48.0",
     "@mdxeditor/editor": "^4.2.0",

--- a/packages/browseros-agent/apps/app/screens/newtab/index/NewTabChat.tsx
+++ b/packages/browseros-agent/apps/app/screens/newtab/index/NewTabChat.tsx
@@ -63,6 +63,7 @@ export const NewTabChat: FC = () => {
     removeTab,
     handleSubmit,
     handleSuggestionClick,
+    retryLastTurn,
   } = useChatActions({
     events: {
       modeChanged: NEWTAB_CHAT_MODE_CHANGED_EVENT,
@@ -195,7 +196,13 @@ export const NewTabChat: FC = () => {
           />
         )}
         {chatError && (
-          <ChatError error={chatError} providerType={selectedProvider?.type} />
+          <ChatError
+            error={chatError}
+            onRetry={() => {
+              void retryLastTurn()
+            }}
+            providerType={selectedProvider?.type}
+          />
         )}
       </main>
 

--- a/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.test.tsx
@@ -1,4 +1,8 @@
 import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import {
+  type ChatError as ChatErrorEnvelope,
+  serializeChatError,
+} from '@browseros/shared/schemas/chat-error'
 import { type ComponentProps, createElement, type FC } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
@@ -37,7 +41,19 @@ function renderError(error: Error, providerType = 'browseros') {
   )
 }
 
-describe('ChatError', () => {
+function envelopeError(overrides: Partial<ChatErrorEnvelope> = {}): Error {
+  return new Error(
+    serializeChatError({
+      code: 'unknown',
+      title: 'Something went wrong',
+      message: 'The model request failed.',
+      retryable: true,
+      ...overrides,
+    }),
+  )
+}
+
+describe('ChatError legacy string handling', () => {
   it('shows retry for connection errors', () => {
     const html = renderError(new Error('Failed to fetch'))
 
@@ -58,5 +74,88 @@ describe('ChatError', () => {
 
     expect(html).toContain('Add your own API key')
     expect(html).not.toContain('Try again')
+  })
+})
+
+describe('ChatError envelope handling', () => {
+  it('renders the real reason for credit exhaustion and hides retry', () => {
+    const html = renderError(
+      envelopeError({
+        code: 'credits_exhausted',
+        title: 'Daily limit reached',
+        message: 'You have used all your BrowserOS credits.',
+        retryable: false,
+        provider: 'browseros',
+        docsUrl: '/app.html#/settings/usage',
+      }),
+    )
+
+    expect(html).toContain('Daily limit reached')
+    expect(html).toContain('You have used all your BrowserOS credits.')
+    expect(html).toContain('View Usage &amp; Billing')
+    expect(html).not.toContain('Try again')
+  })
+
+  it('surfaces auth failures with the provider status and a settings link', () => {
+    const html = renderError(
+      envelopeError({
+        code: 'auth_failed',
+        title: 'Authentication failed',
+        message: 'Incorrect API key provided.',
+        retryable: false,
+        statusCode: 401,
+        provider: 'anthropic',
+      }),
+      'anthropic',
+    )
+
+    expect(html).toContain('Authentication failed')
+    expect(html).toContain('Incorrect API key provided.')
+    expect(html).toContain('Open AI settings')
+    expect(html).not.toContain('Try again')
+  })
+
+  it('offers retry for a transient provider outage', () => {
+    const html = renderError(
+      envelopeError({
+        code: 'provider_unavailable',
+        title: 'Provider unavailable',
+        message: 'The provider returned a server error.',
+        retryable: true,
+        statusCode: 503,
+      }),
+    )
+
+    expect(html).toContain('Provider unavailable')
+    expect(html).toContain('Try again')
+  })
+
+  it('offers a details disclosure when raw upstream text is present', () => {
+    const html = renderError(
+      envelopeError({
+        message: 'The model request failed.',
+        details: 'upstream said: connection reset by peer',
+      }),
+    )
+
+    expect(html).toContain('Show details')
+  })
+
+  it('omits the disclosure when there is no extra detail', () => {
+    const html = renderError(envelopeError({ details: undefined }))
+
+    expect(html).not.toContain('Show details')
+  })
+
+  it('falls back to the server-supplied title for an unknown code', () => {
+    const html = renderError(
+      envelopeError({
+        code: 'unknown',
+        title: 'Something went wrong',
+        message: 'something exotic broke',
+      }),
+    )
+
+    expect(html).toContain('something exotic broke')
   })
 })

--- a/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.tsx
@@ -1,6 +1,10 @@
+import {
+  type ChatError as ChatErrorEnvelope,
+  parseChatErrorEnvelope,
+} from '@browseros/shared/schemas/chat-error'
 import { AlertCircle, RefreshCw } from 'lucide-react'
 import type { FC } from 'react'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 
 const SURVEY_DIRECTIONS = [
@@ -20,29 +24,92 @@ export interface ChatErrorProps {
   providerType?: string
 }
 
-function parseErrorMessage(
-  message: string,
-  providerType?: string,
-): {
+interface ChatErrorView {
+  title: string
   text: string
   url?: string
-  isRateLimit?: boolean
-  isCreditsExhausted?: boolean
-  isConnectionError?: boolean
-} {
+  linkLabel?: string
+  details?: string
+  canRetry: boolean
+  showSurvey: boolean
+}
+
+/**
+ * Copy for codes the extension knows about. The server also sends a title and
+ * message, used as-is for codes shipped after this build.
+ */
+const CODE_COPY: Partial<
+  Record<ChatErrorEnvelope['code'], { title: string; linkLabel: string }>
+> = {
+  credits_exhausted: {
+    title: 'Daily limit reached',
+    linkLabel: 'View Usage & Billing',
+  },
+  rate_limited: { title: 'Rate limited', linkLabel: 'About daily limits' },
+  auth_failed: {
+    title: 'Authentication failed',
+    linkLabel: 'Open AI settings',
+  },
+  provider_config: {
+    title: 'Provider not configured',
+    linkLabel: 'Open AI settings',
+  },
+  connection_failed: {
+    title: 'Connection failed',
+    linkLabel: 'View troubleshooting guide',
+  },
+  context_length: { title: 'Conversation too long', linkLabel: 'Learn more' },
+  content_filter: { title: 'Content was rejected', linkLabel: 'Learn more' },
+  provider_unavailable: {
+    title: 'Provider unavailable',
+    linkLabel: 'Learn more',
+  },
+}
+
+const AI_SETTINGS_URL = '/app.html#/settings/ai'
+
+function fromEnvelope(envelope: ChatErrorEnvelope): ChatErrorView {
+  const known = CODE_COPY[envelope.code]
+  const url =
+    envelope.docsUrl ??
+    (envelope.code === 'auth_failed' || envelope.code === 'provider_config'
+      ? AI_SETTINGS_URL
+      : undefined)
+
+  return {
+    title: known?.title ?? envelope.title,
+    text: envelope.message,
+    url,
+    linkLabel: known?.linkLabel,
+    details: envelope.details,
+    canRetry: envelope.retryable,
+    // The survey belongs to the BrowserOS daily-limit prompt ("add your own
+    // key"), not to plain credit exhaustion, which links to billing instead.
+    showSurvey:
+      envelope.code === 'rate_limited' && envelope.provider === 'browseros',
+  }
+}
+
+/**
+ * Fallback for bare strings: client-side fetch failures, an older agent server,
+ * or an error raised outside the classifier.
+ */
+function fromMessage(message: string, providerType?: string): ChatErrorView {
   const isBrowserosProvider = providerType === 'browseros'
 
   // All chat requests go through the local BrowserOS agent server, so any
   // fetch failure is always a local connection issue.
   if (message.includes('Failed to fetch') || message.includes('fetch failed')) {
     return {
+      title: 'Connection failed',
       text: 'Unable to connect to BrowserOS agent. Follow below instructions.',
       url: 'https://docs.browseros.com/troubleshooting/connection-issues',
-      isConnectionError: true,
+      linkLabel: 'View troubleshooting guide',
+      canRetry: true,
+      showSurvey: false,
     }
   }
 
-  // Detect credit exhaustion from gateway (BrowserOS provider only)
   if (
     isBrowserosProvider &&
     (message.includes('CREDITS_EXHAUSTED') ||
@@ -50,22 +117,26 @@ function parseErrorMessage(
       message.includes('Daily credits exhausted'))
   ) {
     return {
+      title: 'Daily limit reached',
       text: 'Daily credits exhausted. Credits reset at midnight UTC.',
       url: '/app.html#/settings/usage',
-      isRateLimit: true,
-      isCreditsExhausted: true,
+      linkLabel: 'View Usage & Billing',
+      canRetry: false,
+      showSurvey: false,
     }
   }
 
-  // Detect BrowserOS rate limit (BrowserOS provider only)
   if (
     isBrowserosProvider &&
     message.includes('BrowserOS LLM daily limit reached')
   ) {
     return {
+      title: 'Daily limit reached',
       text: 'Add your own API key for unlimited usage.',
       url: 'https://dub.sh/browseros-usage-limit',
-      isRateLimit: true,
+      linkLabel: 'About daily limits',
+      canRetry: false,
+      showSurvey: true,
     }
   }
 
@@ -82,7 +153,18 @@ function parseErrorMessage(
     text = text.replace(url, '').replace(/\s+/g, ' ').trim()
   }
 
-  return { text: text || 'An unexpected error occurred', url }
+  return {
+    title: 'Something went wrong',
+    text: text || 'An unexpected error occurred',
+    url,
+    canRetry: true,
+    showSurvey: false,
+  }
+}
+
+function buildView(message: string, providerType?: string): ChatErrorView {
+  const envelope = parseChatErrorEnvelope(message)
+  return envelope ? fromEnvelope(envelope) : fromMessage(message, providerType)
 }
 
 export const ChatError: FC<ChatErrorProps> = ({
@@ -90,8 +172,8 @@ export const ChatError: FC<ChatErrorProps> = ({
   onRetry,
   providerType,
 }) => {
-  const { text, url, isRateLimit, isCreditsExhausted, isConnectionError } =
-    parseErrorMessage(error.message, providerType)
+  const [showDetails, setShowDetails] = useState(false)
+  const view = buildView(error.message, providerType)
 
   const surveyUrl = useMemo(
     () =>
@@ -99,51 +181,40 @@ export const ChatError: FC<ChatErrorProps> = ({
     [],
   )
 
-  const getTitle = () => {
-    if (isRateLimit) return 'Daily limit reached'
-    if (isConnectionError) return 'Connection failed'
-    return 'Something went wrong'
-  }
-  const canRetry = !!onRetry && !isRateLimit
+  const canRetry = !!onRetry && view.canRetry
 
   return (
     <div className="mx-4 flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
       <div className="flex items-center gap-2 text-muted-foreground">
         <AlertCircle className="h-5 w-5" />
-        <span className="font-medium text-sm">{getTitle()}</span>
+        <span className="font-medium text-sm">{view.title}</span>
       </div>
-      <p className="text-center text-destructive text-xs">{text}</p>
-      {isConnectionError && url && (
+      <p className="text-center text-destructive text-xs">{view.text}</p>
+      {view.url && view.linkLabel && !view.showSurvey && (
         <a
-          href={url}
+          href={view.url}
           target="_blank"
           rel="noopener noreferrer"
           className="text-muted-foreground text-xs underline hover:text-foreground"
         >
-          View troubleshooting guide
+          {view.linkLabel}
         </a>
       )}
-      {isCreditsExhausted && url && (
-        <a
-          href={url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-muted-foreground text-xs underline hover:text-foreground"
-        >
-          View Usage & Billing
-        </a>
-      )}
-      {isRateLimit && !isCreditsExhausted && (
+      {view.showSurvey && (
         <p className="text-muted-foreground text-xs">
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-foreground"
-          >
-            About daily limits
-          </a>
-          {' or '}
+          {view.url && (
+            <>
+              <a
+                href={view.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-foreground"
+              >
+                {view.linkLabel ?? 'About daily limits'}
+              </a>
+              {' or '}
+            </>
+          )}
           <a
             href={surveyUrl}
             target="_blank"
@@ -153,6 +224,22 @@ export const ChatError: FC<ChatErrorProps> = ({
             take a quick survey
           </a>
         </p>
+      )}
+      {view.details && view.details !== view.text && (
+        <div className="w-full">
+          <button
+            type="button"
+            onClick={() => setShowDetails((shown) => !shown)}
+            className="w-full text-center text-muted-foreground text-xs underline hover:text-foreground"
+          >
+            {showDetails ? 'Hide details' : 'Show details'}
+          </button>
+          {showDetails && (
+            <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-muted p-2 text-left text-[10px] text-muted-foreground">
+              {view.details}
+            </pre>
+          )}
+        </div>
       )}
       {canRetry && (
         <Button

--- a/packages/browseros-agent/apps/server/src/agent/chat-error.ts
+++ b/packages/browseros-agent/apps/server/src/agent/chat-error.ts
@@ -1,0 +1,322 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Classifies a failed LLM turn into the shared ChatError envelope.
+ *
+ * The AI SDK masks stream errors by default (`onError = () => "An error
+ * occurred."`) to avoid leaking server internals. Here the "server" is a
+ * loopback process on the user's own machine using the user's own credentials,
+ * so the mask costs diagnosis without buying isolation - we classify instead,
+ * and keep raw upstream text redacted and capped behind `details`.
+ */
+
+import {
+  AISDKError,
+  APICallError,
+  InvalidPromptError,
+  LoadAPIKeyError,
+  NoSuchModelError,
+} from '@ai-sdk/provider'
+import {
+  type ChatError,
+  serializeChatError,
+} from '@browseros/shared/schemas/chat-error'
+import { RetryError } from 'ai'
+
+export interface ChatErrorContext {
+  provider?: string
+}
+
+const DETAILS_MAX_LENGTH = 500
+
+const USAGE_DOCS_URL = 'https://dub.sh/browseros-usage-limit'
+const USAGE_PAGE_URL = '/app.html#/settings/usage'
+const CONNECTION_DOCS_URL =
+  'https://docs.browseros.com/troubleshooting/connection-issues'
+
+/**
+ * Key-shaped tokens get scrubbed out of free-text upstream messages. The shared
+ * Sentry sanitizer only redacts by object key, so it cannot help here.
+ */
+const SECRET_PATTERNS: RegExp[] = [
+  /\b(?:sk|pk|rk)-[A-Za-z0-9_-]{12,}/g,
+  /\bBearer\s+[A-Za-z0-9._-]{12,}/gi,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9]{20,}/g,
+]
+
+function redact(text: string): string {
+  return SECRET_PATTERNS.reduce(
+    (acc, pattern) => acc.replace(pattern, '[REDACTED]'),
+    text,
+  )
+}
+
+function toDetails(text: string | undefined): string | undefined {
+  if (!text) return undefined
+  const redacted = redact(text).trim()
+  if (!redacted) return undefined
+  return redacted.length > DETAILS_MAX_LENGTH
+    ? `${redacted.slice(0, DETAILS_MAX_LENGTH)}…`
+    : redacted
+}
+
+/** Upstream text reaches the user, so it gets the same scrub as `details`. */
+function safeMessage(text: string, fallback: string): string {
+  const redacted = redact(text).trim()
+  return redacted || fallback
+}
+
+function errorText(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  return String(error)
+}
+
+/**
+ * Recover the gateway's error code. `browseros-fetch` and `openrouter-fetch`
+ * stash it on `data`, but the 12 direct-provider paths build their own
+ * APICallError where `responseBody` is the only structured evidence.
+ */
+function gatewayCode(error: APICallError): string | undefined {
+  const fromData = (error.data as { code?: unknown } | undefined)?.code
+  if (typeof fromData === 'string' && fromData) return fromData
+
+  if (!error.responseBody) return undefined
+  try {
+    const parsed = JSON.parse(error.responseBody)
+    const code = parsed?.error?.code
+    return typeof code === 'string' && code ? code : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function retryAfterSeconds(error: APICallError): number | undefined {
+  const headers = error.responseHeaders
+  if (!headers) return undefined
+  const raw = headers['retry-after'] ?? headers['retry-after-ms']
+  if (!raw) return undefined
+  const value = Number(raw)
+  if (!Number.isFinite(value) || value <= 0) return undefined
+  return headers['retry-after-ms'] ? Math.ceil(value / 1000) : Math.ceil(value)
+}
+
+function fromApiCallError(
+  error: APICallError,
+  ctx: ChatErrorContext,
+): ChatError {
+  const base = {
+    provider: ctx.provider,
+    statusCode: error.statusCode,
+    details: toDetails(error.message),
+  }
+  const code = gatewayCode(error)
+  const isBrowserOs = ctx.provider === 'browseros'
+
+  if (code === 'CREDITS_EXHAUSTED') {
+    return {
+      ...base,
+      code: 'credits_exhausted',
+      title: 'Daily limit reached',
+      message: safeMessage(
+        error.message,
+        'You have used all your BrowserOS credits. They reset at midnight UTC.',
+      ),
+      retryable: false,
+      docsUrl: USAGE_PAGE_URL,
+    }
+  }
+
+  switch (error.statusCode) {
+    case 401:
+    case 403:
+      return {
+        ...base,
+        code: 'auth_failed',
+        title: 'Authentication failed',
+        message: safeMessage(
+          error.message,
+          'The provider rejected your credentials. Check your API key in AI settings.',
+        ),
+        retryable: false,
+      }
+    case 429:
+      return {
+        ...base,
+        code: 'rate_limited',
+        title: 'Rate limited',
+        message: safeMessage(
+          error.message,
+          'The provider is rate limiting requests. Wait a moment and try again.',
+        ),
+        retryable: true,
+        docsUrl: isBrowserOs ? USAGE_DOCS_URL : undefined,
+        retryAfterSeconds: retryAfterSeconds(error),
+      }
+    case 413:
+      return {
+        ...base,
+        code: 'context_length',
+        title: 'Conversation too long',
+        message: safeMessage(
+          error.message,
+          'This conversation exceeded the model context window. Start a new chat or pick a model with a larger window.',
+        ),
+        retryable: false,
+      }
+    default:
+      break
+  }
+
+  if (error.statusCode !== undefined && error.statusCode >= 500) {
+    return {
+      ...base,
+      code: 'provider_unavailable',
+      title: 'Provider unavailable',
+      message: safeMessage(
+        error.message,
+        'The model provider returned a server error. This is usually temporary.',
+      ),
+      retryable: true,
+    }
+  }
+
+  return {
+    ...base,
+    code: 'unknown',
+    title: 'Something went wrong',
+    message: safeMessage(error.message, 'The model request failed.'),
+    retryable: error.isRetryable,
+  }
+}
+
+/** Last-resort rungs for errors that carry no structured evidence at all. */
+function fromMessage(message: string, ctx: ChatErrorContext): ChatError | null {
+  const lower = message.toLowerCase()
+
+  if (lower.includes('failed to fetch') || lower.includes('fetch failed')) {
+    return {
+      code: 'connection_failed',
+      title: 'Connection failed',
+      message:
+        'Could not reach the model provider. Check your network connection and any local provider URL.',
+      retryable: true,
+      provider: ctx.provider,
+      docsUrl: CONNECTION_DOCS_URL,
+      details: toDetails(message),
+    }
+  }
+
+  if (
+    lower.includes('context length') ||
+    lower.includes('context_length_exceeded') ||
+    lower.includes('too many tokens') ||
+    lower.includes('maximum context')
+  ) {
+    return {
+      code: 'context_length',
+      title: 'Conversation too long',
+      message:
+        'This conversation exceeded the model context window. Start a new chat or pick a model with a larger window.',
+      retryable: false,
+      provider: ctx.provider,
+      details: toDetails(message),
+    }
+  }
+
+  if (
+    lower.includes('content filter') ||
+    lower.includes('content_filter') ||
+    lower.includes('content policy')
+  ) {
+    return {
+      code: 'content_filter',
+      title: 'Content was rejected',
+      message:
+        'The provider rejected the content being sent or generated. Try rephrasing and send it again.',
+      retryable: false,
+      provider: ctx.provider,
+      details: toDetails(message),
+    }
+  }
+
+  if (
+    lower.includes('requires apikey') ||
+    lower.includes('requires baseurl') ||
+    lower.includes('requires oauth') ||
+    lower.includes('not authenticated with') ||
+    lower.includes('is required for')
+  ) {
+    return {
+      code: 'provider_config',
+      title: 'Provider not configured',
+      message: safeMessage(message, 'This provider is not fully configured.'),
+      retryable: false,
+      provider: ctx.provider,
+    }
+  }
+
+  return null
+}
+
+/** Maps any thrown value onto the envelope the client renders. */
+export function toChatError(
+  error: unknown,
+  ctx: ChatErrorContext = {},
+): ChatError {
+  // The SDK wraps exhausted retries; the last failure is the informative one.
+  if (RetryError.isInstance(error)) {
+    return toChatError(error.lastError ?? error.errors.at(-1), ctx)
+  }
+
+  if (APICallError.isInstance(error)) {
+    return fromApiCallError(error, ctx)
+  }
+
+  if (LoadAPIKeyError.isInstance(error) || NoSuchModelError.isInstance(error)) {
+    return {
+      code: 'provider_config',
+      title: 'Provider not configured',
+      message: safeMessage(
+        error.message,
+        'This provider is not fully configured.',
+      ),
+      retryable: false,
+      provider: ctx.provider,
+    }
+  }
+
+  if (InvalidPromptError.isInstance(error)) {
+    return {
+      code: 'context_length',
+      title: 'Message could not be sent',
+      message: safeMessage(error.message, 'This message could not be sent.'),
+      retryable: false,
+      provider: ctx.provider,
+    }
+  }
+
+  const message = errorText(error)
+  const matched = fromMessage(message, ctx)
+  if (matched) return matched
+
+  return {
+    code: 'unknown',
+    title: 'Something went wrong',
+    message: safeMessage(message, 'An unexpected error occurred.'),
+    retryable: true,
+    provider: ctx.provider,
+    details: AISDKError.isInstance(error) ? toDetails(error.name) : undefined,
+  }
+}
+
+/** Serialized form for the `errorText` field of a UI message stream chunk. */
+export function toChatErrorText(
+  error: unknown,
+  ctx: ChatErrorContext = {},
+): string {
+  return serializeChatError(toChatError(error, ctx))
+}

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -6,6 +6,7 @@
 
 import { websocket } from 'hono/bun'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { toChatError } from '../agent/chat-error'
 import { HttpAgentError } from '../agent/errors'
 import { INLINED_ENV } from '../env'
 import { initializeOAuth, shutdownOAuth } from '../lib/clients/oauth'
@@ -94,13 +95,16 @@ export async function createHttpServer(config: HttpServerConfig) {
       stack: error.stack,
     })
 
+    // Same envelope the chat stream emits, so the client parses failures that
+    // happen before streaming starts with the one parser it already has.
+    // `name`/`statusCode` are kept for callers that read the previous shape.
+    const chatError = toChatError(error)
     return c.json(
       {
         error: {
+          ...chatError,
           name: 'InternalServerError',
-          message: error.message || 'An unexpected error occurred',
-          code: 'INTERNAL_SERVER_ERROR',
-          statusCode: 500,
+          statusCode: chatError.statusCode ?? 500,
         },
       },
       500,

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -16,6 +16,7 @@ import {
   type UIMessageChunk,
 } from 'ai'
 import { AiSdkAgent } from '../../agent/ai-sdk-agent'
+import { toChatErrorText } from '../../agent/chat-error'
 import { formatUserMessage } from '../../agent/format-message'
 import {
   filterValidMessages,
@@ -323,6 +324,18 @@ export class ChatService {
       agent: session.agent.toolLoopAgent,
       uiMessages: promptUiMessages,
       abortSignal,
+      // Without this the SDK substitutes its masking default, which discards
+      // the status code, provider code, and message of every mid-stream
+      // failure - including every rate limit and credit exhaustion.
+      onError: (error: unknown) => {
+        logger.error('Agent stream failed', {
+          conversationId: request.conversationId,
+          provider: agentConfig.provider,
+          model: agentConfig.model,
+          message: error instanceof Error ? error.message : String(error),
+        })
+        return toChatErrorText(error, { provider: agentConfig.provider })
+      },
       onFinish: async ({ messages }: { messages: UIMessage[] }) => {
         const restored = messages.map((message) =>
           message.id === wrappedUserMessageId && message.role === 'user'

--- a/packages/browseros-agent/apps/server/src/lib/browseros-fetch.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-fetch.ts
@@ -15,6 +15,15 @@ function resolveUrl(url: RequestInfo | URL): string {
   return typeof url === 'string' ? url : url.toString()
 }
 
+/** Retry-After and rate-limit headers only reach the SDK via responseHeaders. */
+function headersToRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {}
+  headers.forEach((value, key) => {
+    record[key] = value
+  })
+  return record
+}
+
 function parseErrorBody(
   body: string,
 ): { message?: string; code?: string; metadata?: { raw?: unknown } } | null {
@@ -55,6 +64,12 @@ export function createBrowserOSFetch(browserosId: string): typeof fetch {
       const responseBody = await response.text()
       const error = parseErrorBody(responseBody)
 
+      // `data` keeps the gateway's code structured so the chat error
+      // classifier branches on a field instead of searching the message text.
+      const data = error?.code
+        ? { code: error.code, raw: error.metadata?.raw }
+        : undefined
+
       if (statusCode === 429 && error?.code === 'CREDITS_EXHAUSTED') {
         throw new APICallError({
           message: error.message ?? 'Daily credits exhausted',
@@ -62,7 +77,9 @@ export function createBrowserOSFetch(browserosId: string): typeof fetch {
           requestBodyValues: {},
           statusCode,
           responseBody,
+          responseHeaders: headersToRecord(response.headers),
           isRetryable: false,
+          data,
         })
       }
 
@@ -74,6 +91,8 @@ export function createBrowserOSFetch(browserosId: string): typeof fetch {
         requestBodyValues: {},
         statusCode,
         responseBody,
+        responseHeaders: headersToRecord(response.headers),
+        data,
       })
     }
 

--- a/packages/browseros-agent/apps/server/src/lib/openrouter-fetch.ts
+++ b/packages/browseros-agent/apps/server/src/lib/openrouter-fetch.ts
@@ -1,5 +1,14 @@
 import { APICallError } from '@ai-sdk/provider'
 
+/** Retry-After and rate-limit headers only reach the SDK via responseHeaders. */
+function headersToRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {}
+  headers.forEach((value, key) => {
+    record[key] = value
+  })
+  return record
+}
+
 /**
  * Creates a fetch function that extracts detailed error messages from OpenRouter-style APIs.
  *
@@ -19,10 +28,16 @@ export function createOpenRouterCompatibleFetch(): typeof fetch {
       const statusCode = response.status
       let errorMessage = `HTTP ${statusCode}: ${response.statusText}`
       let responseBody: string | undefined
+      // `data` keeps the upstream code structured so the chat error classifier
+      // branches on a field instead of searching the message text.
+      let data: { code: string; raw?: unknown } | undefined
 
       try {
         responseBody = await response.clone().text()
         const parsed = JSON.parse(responseBody)
+        if (parsed.error?.code) {
+          data = { code: parsed.error.code, raw: parsed.error.metadata?.raw }
+        }
         if (parsed.error?.message) {
           errorMessage = parsed.error.message
           if (parsed.error.code) {
@@ -42,6 +57,8 @@ export function createOpenRouterCompatibleFetch(): typeof fetch {
         requestBodyValues: {},
         statusCode,
         responseBody,
+        responseHeaders: headersToRecord(response.headers),
+        data,
       })
     }
 

--- a/packages/browseros-agent/apps/server/tests/agent/chat-error-stream.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/chat-error-stream.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Proves a model failure survives to the wire. The AI SDK masks stream errors
+ * unless an onError is supplied, so this asserts the emitted SSE frame carries
+ * the classified envelope rather than "An error occurred."
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { APICallError } from '@ai-sdk/provider'
+import { parseChatErrorEnvelope } from '@browseros/shared/schemas/chat-error'
+import { createAgentUIStreamResponse, ToolLoopAgent } from 'ai'
+import { MockLanguageModelV3 } from 'ai/test'
+import { toChatErrorText } from '../../src/agent/chat-error'
+
+function creditsExhausted(): APICallError {
+  return new APICallError({
+    message: 'Daily credits exhausted',
+    url: 'https://llm.browseros.com/v1/chat/completions',
+    requestBodyValues: {},
+    statusCode: 429,
+    responseBody: JSON.stringify({
+      error: { code: 'CREDITS_EXHAUSTED', message: 'Daily credits exhausted' },
+    }),
+    isRetryable: false,
+    data: { code: 'CREDITS_EXHAUSTED' },
+  })
+}
+
+async function readErrorFrame(response: Response): Promise<string | null> {
+  const body = await response.text()
+  for (const line of body.split('\n')) {
+    if (!line.startsWith('data: ')) continue
+    const payload = line.slice(6)
+    if (payload === '[DONE]') continue
+    const chunk = JSON.parse(payload)
+    if (chunk.type === 'error') return chunk.errorText
+  }
+  return null
+}
+
+function agentThatFails(error: unknown): ToolLoopAgent {
+  return new ToolLoopAgent({
+    model: new MockLanguageModelV3({
+      doStream: async () => {
+        throw error
+      },
+    }),
+  })
+}
+
+describe('chat stream error propagation', () => {
+  it('emits the classified envelope instead of the SDK mask', async () => {
+    const response = await createAgentUIStreamResponse({
+      agent: agentThatFails(creditsExhausted()),
+      uiMessages: [
+        { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      ],
+      onError: (error: unknown) =>
+        toChatErrorText(error, { provider: 'browseros' }),
+    })
+
+    const errorText = await readErrorFrame(response)
+
+    expect(errorText).not.toBeNull()
+    expect(errorText).not.toBe('An error occurred.')
+
+    const envelope = parseChatErrorEnvelope(errorText as string)
+    expect(envelope?.code).toBe('credits_exhausted')
+    expect(envelope?.message).toBe('Daily credits exhausted')
+    expect(envelope?.retryable).toBe(false)
+    expect(envelope?.statusCode).toBe(429)
+    expect(envelope?.provider).toBe('browseros')
+  })
+
+  it('masks the failure when no onError is supplied (the bug being fixed)', async () => {
+    const response = await createAgentUIStreamResponse({
+      agent: agentThatFails(creditsExhausted()),
+      uiMessages: [
+        { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      ],
+    })
+
+    expect(await readErrorFrame(response)).toBe('An error occurred.')
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/agent/chat-error.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/chat-error.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'bun:test'
+import { APICallError, LoadAPIKeyError } from '@ai-sdk/provider'
+import { parseChatErrorEnvelope } from '@browseros/shared/schemas/chat-error'
+import { RetryError } from 'ai'
+import { toChatError, toChatErrorText } from '../../src/agent/chat-error'
+
+function apiCallError(
+  overrides: Partial<ConstructorParameters<typeof APICallError>[0]> = {},
+): APICallError {
+  return new APICallError({
+    message: 'upstream failed',
+    url: 'https://llm.browseros.com/v1/chat/completions',
+    requestBodyValues: {},
+    ...overrides,
+  })
+}
+
+describe('toChatError', () => {
+  it('classifies gateway credit exhaustion from the structured code', () => {
+    const error = toChatError(
+      apiCallError({
+        message: 'Daily credits exhausted',
+        statusCode: 429,
+        isRetryable: false,
+        data: { code: 'CREDITS_EXHAUSTED' },
+      }),
+      { provider: 'browseros' },
+    )
+
+    expect(error.code).toBe('credits_exhausted')
+    expect(error.title).toBe('Daily limit reached')
+    expect(error.message).toBe('Daily credits exhausted')
+    expect(error.retryable).toBe(false)
+    expect(error.statusCode).toBe(429)
+    expect(error.provider).toBe('browseros')
+  })
+
+  it('recovers the gateway code from responseBody when data is absent', () => {
+    const error = toChatError(
+      apiCallError({
+        message: 'quota gone',
+        statusCode: 429,
+        responseBody: JSON.stringify({
+          error: { code: 'CREDITS_EXHAUSTED', message: 'quota gone' },
+        }),
+      }),
+      { provider: 'browseros' },
+    )
+
+    expect(error.code).toBe('credits_exhausted')
+    expect(error.retryable).toBe(false)
+  })
+
+  it('treats a plain 429 as retryable rate limiting, not credit exhaustion', () => {
+    const error = toChatError(
+      apiCallError({ message: 'slow down', statusCode: 429 }),
+      { provider: 'anthropic' },
+    )
+
+    expect(error.code).toBe('rate_limited')
+    expect(error.retryable).toBe(true)
+  })
+
+  it('reads Retry-After off the response headers', () => {
+    const error = toChatError(
+      apiCallError({
+        statusCode: 429,
+        responseHeaders: { 'retry-after': '30' },
+      }),
+    )
+
+    expect(error.retryAfterSeconds).toBe(30)
+  })
+
+  it.each([401, 403])('classifies %i as auth failure', (statusCode) => {
+    const error = toChatError(
+      apiCallError({ message: 'invalid api key', statusCode }),
+    )
+
+    expect(error.code).toBe('auth_failed')
+    expect(error.retryable).toBe(false)
+  })
+
+  it('classifies 5xx as a transient provider outage', () => {
+    const error = toChatError(
+      apiCallError({ message: 'overloaded', statusCode: 503 }),
+    )
+
+    expect(error.code).toBe('provider_unavailable')
+    expect(error.retryable).toBe(true)
+  })
+
+  it('unwraps RetryError and classifies the last failure', () => {
+    const last = apiCallError({ message: 'still limited', statusCode: 429 })
+    const error = toChatError(
+      new RetryError({
+        message: 'maxRetriesExceeded',
+        reason: 'maxRetriesExceeded',
+        errors: [last, last],
+      }),
+      { provider: 'browseros' },
+    )
+
+    expect(error.code).toBe('rate_limited')
+    expect(error.statusCode).toBe(429)
+  })
+
+  it('classifies provider construction failures as configuration errors', () => {
+    const error = toChatError(new Error('Anthropic provider requires apiKey'), {
+      provider: 'anthropic',
+    })
+
+    expect(error.code).toBe('provider_config')
+    expect(error.message).toBe('Anthropic provider requires apiKey')
+    expect(error.retryable).toBe(false)
+  })
+
+  it('classifies a missing key error from the SDK class', () => {
+    const error = toChatError(
+      new LoadAPIKeyError({ message: 'OpenAI API key is missing' }),
+    )
+
+    expect(error.code).toBe('provider_config')
+    expect(error.retryable).toBe(false)
+  })
+
+  it('classifies local connection failures', () => {
+    const error = toChatError(new TypeError('fetch failed'))
+
+    expect(error.code).toBe('connection_failed')
+    expect(error.retryable).toBe(true)
+  })
+
+  it('falls back to unknown while still carrying the real message', () => {
+    const error = toChatError(new Error('something exotic broke'))
+
+    expect(error.code).toBe('unknown')
+    expect(error.message).toBe('something exotic broke')
+  })
+
+  it('redacts key-shaped tokens out of the user-facing message', () => {
+    const error = toChatError(
+      apiCallError({
+        message: `Incorrect API key provided: sk-${'b'.repeat(40)}`,
+        statusCode: 401,
+      }),
+    )
+
+    expect(error.message).toContain('[REDACTED]')
+    expect(error.message).not.toContain('bbbbbbbbbb')
+  })
+
+  it('redacts key-shaped tokens and caps details', () => {
+    const error = toChatError(
+      apiCallError({
+        message: `rejected key sk-${'a'.repeat(40)} for org`,
+        statusCode: 401,
+      }),
+    )
+
+    expect(error.details).toContain('[REDACTED]')
+    expect(error.details).not.toContain('aaaaaaaaaa')
+    expect((error.details ?? '').length).toBeLessThanOrEqual(501)
+  })
+})
+
+describe('toChatErrorText', () => {
+  it('round-trips through the shared envelope parser', () => {
+    const text = toChatErrorText(
+      apiCallError({
+        message: 'Daily credits exhausted',
+        statusCode: 429,
+        isRetryable: false,
+        data: { code: 'CREDITS_EXHAUSTED' },
+      }),
+      { provider: 'browseros' },
+    )
+
+    const parsed = parseChatErrorEnvelope(text)
+
+    expect(parsed).not.toBeNull()
+    expect(parsed?.code).toBe('credits_exhausted')
+    expect(parsed?.retryable).toBe(false)
+    expect(parsed?.provider).toBe('browseros')
+  })
+
+  it('produces a string that is safe to put in errorText', () => {
+    const text = toChatErrorText(new Error('boom'))
+
+    expect(typeof text).toBe('string')
+    expect(() => JSON.parse(text)).not.toThrow()
+  })
+})
+
+describe('parseChatErrorEnvelope', () => {
+  it('rejects prose', () => {
+    expect(parseChatErrorEnvelope('An error occurred.')).toBeNull()
+  })
+
+  it('rejects JSON that is not an envelope', () => {
+    expect(
+      parseChatErrorEnvelope(JSON.stringify({ error: { message: 'hi' } })),
+    ).toBeNull()
+  })
+
+  it('rejects an unknown code so older clients fall back cleanly', () => {
+    expect(
+      parseChatErrorEnvelope(
+        JSON.stringify({
+          error: { code: 'invented_code', title: 'x', message: 'y' },
+        }),
+      ),
+    ).toBeNull()
+  })
+})

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "browseros-monorepo",
@@ -29,6 +28,7 @@
       "dependencies": {
         "@ai-sdk/react": "^3.0.248",
         "@browseros/server": "workspace:*",
+        "@browseros/shared": "workspace:*",
         "@hookform/resolvers": "^5.7.1",
         "@lobehub/icons": "^2.48.0",
         "@mdxeditor/editor": "^4.2.0",
@@ -440,7 +440,7 @@
 
     "@ant-design/colors": ["@ant-design/colors@7.2.1", "", { "dependencies": { "@ant-design/fast-color": "^2.0.6" } }, "sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ=="],
 
-    "@ant-design/cssinjs": ["@ant-design/cssinjs@2.1.2", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@emotion/hash": "^0.8.0", "@emotion/unitless": "^0.7.5", "@rc-component/util": "^1.4.0", "clsx": "^2.1.1", "csstype": "^3.1.3", "stylis": "^4.3.4" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-2Hy8BnCEH31xPeSLbhhB2ctCPXE2ZnASdi+KbSeS79BNbUhL9hAEe20SkUk+BR8aKTmqb6+FKFruk7w8z0VoRQ=="],
+    "@ant-design/cssinjs": ["@ant-design/cssinjs@1.24.0", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@emotion/hash": "^0.8.0", "@emotion/unitless": "^0.7.5", "classnames": "^2.3.1", "csstype": "^3.1.3", "rc-util": "^5.35.0", "stylis": "^4.3.4" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-K4cYrJBsgvL+IoozUXYjbT6LHHNt+19a9zkvpBPxLjFHas1UpPM2A5MlhROb0BT8N8WoavM5VsP9MeSeNK/3mg=="],
 
     "@ant-design/cssinjs-utils": ["@ant-design/cssinjs-utils@1.1.3", "", { "dependencies": { "@ant-design/cssinjs": "^1.21.0", "@babel/runtime": "^7.23.2", "rc-util": "^5.38.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg=="],
 
@@ -3586,7 +3586,7 @@
 
     "rc-checkbox": ["rc-checkbox@3.5.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "^2.3.2", "rc-util": "^5.25.2" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg=="],
 
-    "rc-collapse": ["rc-collapse@4.0.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "2.x", "rc-motion": "^2.3.4", "rc-util": "^5.27.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-SwoOByE39/3oIokDs/BnkqI+ltwirZbP8HZdq1/3SkPSBi7xDdvWHTp7cpNI9ullozkR6mwTWQi6/E/9huQVrA=="],
+    "rc-collapse": ["rc-collapse@3.9.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "2.x", "rc-motion": "^2.3.4", "rc-util": "^5.27.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA=="],
 
     "rc-dialog": ["rc-dialog@9.6.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "@rc-component/portal": "^1.0.0-8", "classnames": "^2.2.6", "rc-motion": "^2.3.0", "rc-util": "^5.21.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg=="],
 
@@ -4290,8 +4290,6 @@
 
     "@ant-design/cssinjs/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@ant-design/cssinjs-utils/@ant-design/cssinjs": ["@ant-design/cssinjs@1.24.0", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@emotion/hash": "^0.8.0", "@emotion/unitless": "^0.7.5", "classnames": "^2.3.1", "csstype": "^3.1.3", "rc-util": "^5.35.0", "stylis": "^4.3.4" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-K4cYrJBsgvL+IoozUXYjbT6LHHNt+19a9zkvpBPxLjFHas1UpPM2A5MlhROb0BT8N8WoavM5VsP9MeSeNK/3mg=="],
-
     "@ant-design/cssinjs-utils/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@ant-design/fast-color/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
@@ -4540,11 +4538,15 @@
 
     "@lobehub/icons/lucide-react": ["lucide-react@0.469.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw=="],
 
+    "@lobehub/ui/@ant-design/cssinjs": ["@ant-design/cssinjs@2.1.2", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@emotion/hash": "^0.8.0", "@emotion/unitless": "^0.7.5", "@rc-component/util": "^1.4.0", "clsx": "^2.1.1", "csstype": "^3.1.3", "stylis": "^4.3.4" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-2Hy8BnCEH31xPeSLbhhB2ctCPXE2ZnASdi+KbSeS79BNbUhL9hAEe20SkUk+BR8aKTmqb6+FKFruk7w8z0VoRQ=="],
+
     "@lobehub/ui/@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA=="],
 
     "@lobehub/ui/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
     "@lobehub/ui/motion": ["motion@12.40.0", "", { "dependencies": { "framer-motion": "^12.40.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA=="],
+
+    "@lobehub/ui/rc-collapse": ["rc-collapse@4.0.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "2.x", "rc-motion": "^2.3.4", "rc-util": "^5.27.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-SwoOByE39/3oIokDs/BnkqI+ltwirZbP8HZdq1/3SkPSBi7xDdvWHTp7cpNI9ullozkR6mwTWQi6/E/9huQVrA=="],
 
     "@lobehub/ui/remark-cjk-friendly": ["remark-cjk-friendly@1.2.3", "", { "dependencies": { "micromark-extension-cjk-friendly": "1.2.3" }, "peerDependencies": { "@types/mdast": "^4.0.0", "unified": "^11.0.0" }, "optionalPeers": ["@types/mdast"] }, "sha512-UvAgxwlNk+l9Oqgl/9MWK2eWRS7zgBW/nXX9AthV7nd/3lNejF138E7Xbmk9Zs4WjTJGs721r7fAEc7tNFoH7g=="],
 
@@ -4734,13 +4736,7 @@
 
     "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "antd/@ant-design/cssinjs": ["@ant-design/cssinjs@1.24.0", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@emotion/hash": "^0.8.0", "@emotion/unitless": "^0.7.5", "classnames": "^2.3.1", "csstype": "^3.1.3", "rc-util": "^5.35.0", "stylis": "^4.3.4" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-K4cYrJBsgvL+IoozUXYjbT6LHHNt+19a9zkvpBPxLjFHas1UpPM2A5MlhROb0BT8N8WoavM5VsP9MeSeNK/3mg=="],
-
     "antd/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
-
-    "antd/rc-collapse": ["rc-collapse@3.9.0", "", { "dependencies": { "@babel/runtime": "^7.10.1", "classnames": "2.x", "rc-motion": "^2.3.4", "rc-util": "^5.27.0" }, "peerDependencies": { "react": ">=16.9.0", "react-dom": ">=16.9.0" } }, "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA=="],
-
-    "antd-style/@ant-design/cssinjs": ["@ant-design/cssinjs@1.24.0", "", { "dependencies": { "@babel/runtime": "^7.11.1", "@emotion/hash": "^0.8.0", "@emotion/unitless": "^0.7.5", "classnames": "^2.3.1", "csstype": "^3.1.3", "rc-util": "^5.35.0", "stylis": "^4.3.4" }, "peerDependencies": { "react": ">=16.0.0", "react-dom": ">=16.0.0" } }, "sha512-K4cYrJBsgvL+IoozUXYjbT6LHHNt+19a9zkvpBPxLjFHas1UpPM2A5MlhROb0BT8N8WoavM5VsP9MeSeNK/3mg=="],
 
     "antd-style/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
@@ -5272,9 +5268,13 @@
 
     "@lobehub/fluent-emoji/react-layout-kit/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
+    "@lobehub/ui/@ant-design/cssinjs/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@lobehub/ui/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
 
     "@lobehub/ui/motion/framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
+
+    "@lobehub/ui/rc-collapse/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
     "@lobehub/ui/remark-cjk-friendly/micromark-extension-cjk-friendly": ["micromark-extension-cjk-friendly@1.2.3", "", { "dependencies": { "devlop": "^1.1.0", "micromark-extension-cjk-friendly-util": "2.1.1", "micromark-util-chunked": "^2.0.1", "micromark-util-resolve-all": "^2.0.1", "micromark-util-symbol": "^2.0.1" }, "peerDependencies": { "micromark": "^4.0.0", "micromark-util-types": "^2.0.0" }, "optionalPeers": ["micromark-util-types"] }, "sha512-gRzVLUdjXBLX6zNPSnHGDoo+ZTp5zy+MZm0g3sv+3chPXY7l9gW+DnrcHcZh/jiPR6MjPKO4AEJNp4Aw6V9z5Q=="],
 

--- a/packages/browseros-agent/packages/shared/package.json
+++ b/packages/browseros-agent/packages/shared/package.json
@@ -66,6 +66,10 @@
       "types": "./src/schemas/ui-stream.ts",
       "default": "./src/schemas/ui-stream.ts"
     },
+    "./schemas/chat-error": {
+      "types": "./src/schemas/chat-error.ts",
+      "default": "./src/schemas/chat-error.ts"
+    },
     "./schemas/browser-context": {
       "types": "./src/schemas/browser-context.ts",
       "default": "./src/schemas/browser-context.ts"

--- a/packages/browseros-agent/packages/shared/src/schemas/chat-error.ts
+++ b/packages/browseros-agent/packages/shared/src/schemas/chat-error.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Chat error envelope - the single shape describing why an LLM turn failed.
+ *
+ * The AI SDK's UI message stream can only express an error as
+ * `{ type: 'error', errorText: string }` - a strictObject with one string
+ * field. Structure therefore travels as JSON serialized into that string, and
+ * the same envelope is used for pre-stream HTTP error bodies so both channels
+ * parse identically on the client.
+ *
+ * Intentionally dependency-free rather than a Zod schema like its siblings:
+ * apps/app resolves `zod` to v4 while apps/server and this package resolve v3,
+ * and unlike the other shared schemas this module is imported as a runtime
+ * value on both sides of the wire.
+ */
+
+/** Categories the UI can render a tailored action for. */
+export const CHAT_ERROR_CODES = [
+  'credits_exhausted', // BrowserOS quota spent
+  'rate_limited', // provider 429 that is not credit exhaustion
+  'auth_failed', // 401/403 - key or token rejected
+  'provider_config', // missing/invalid provider setup, caught before streaming
+  'context_length', // prompt exceeded the model's window
+  'content_filter', // upstream refused the content
+  'connection_failed', // provider or agent server unreachable
+  'provider_unavailable', // 5xx, overloaded, or upstream outage
+  'unknown',
+] as const
+
+export type ChatErrorCode = (typeof CHAT_ERROR_CODES)[number]
+
+export interface ChatError {
+  code: ChatErrorCode
+  /** Card heading, e.g. 'Daily limit reached'. */
+  title: string
+  /** One user-facing sentence explaining what happened. */
+  message: string
+  /** Whether retrying the same request could plausibly succeed. */
+  retryable: boolean
+  provider?: string
+  statusCode?: number
+  docsUrl?: string
+  retryAfterSeconds?: number
+  /** Redacted upstream text, shown behind a disclosure. */
+  details?: string
+}
+
+export interface ChatErrorEnvelope {
+  error: ChatError
+}
+
+const CHAT_ERROR_CODE_SET: ReadonlySet<string> = new Set(CHAT_ERROR_CODES)
+
+export function isChatErrorCode(value: unknown): value is ChatErrorCode {
+  return typeof value === 'string' && CHAT_ERROR_CODE_SET.has(value)
+}
+
+export function serializeChatError(error: ChatError): string {
+  return JSON.stringify({ error } satisfies ChatErrorEnvelope)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+/**
+ * Parse an envelope out of an error string. Returns null for anything that is
+ * not a well-formed envelope - plain prose, a foreign JSON body, or an older
+ * server that still sends bare messages.
+ */
+export function parseChatErrorEnvelope(raw: string): ChatError | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+
+  if (!isRecord(parsed) || !isRecord(parsed.error)) return null
+
+  const error = parsed.error
+  if (!isChatErrorCode(error.code)) return null
+  if (typeof error.message !== 'string' || typeof error.title !== 'string') {
+    return null
+  }
+
+  return {
+    code: error.code,
+    title: error.title,
+    message: error.message,
+    retryable: error.retryable === true,
+    provider: optionalString(error.provider),
+    statusCode: optionalNumber(error.statusCode),
+    docsUrl: optionalString(error.docsUrl),
+    retryAfterSeconds: optionalNumber(error.retryAfterSeconds),
+    details: optionalString(error.details),
+  }
+}
+
+/**
+ * Best-effort human-readable text for consumers that render an error string
+ * directly instead of building a card from the envelope.
+ */
+export function chatErrorMessage(raw: string): string {
+  return parseChatErrorEnvelope(raw)?.message ?? raw
+}


### PR DESCRIPTION
## Problem

Every mid-stream model failure rendered the same card: **"Something went wrong — An error occurred."** A rate limit, exhausted BrowserOS credits, a rejected API key, and a provider outage were indistinguishable, and "Try again" was offered for all of them — including the cases where retrying cannot possibly help.

The cause is the AI SDK's secure-by-default mask. `toUIMessageStream` substitutes `onError = () => "An error occurred."` when no callback is supplied ([`ai/dist/index.mjs:8296`](https://ai-sdk.dev/docs/troubleshooting/use-chat-an-error-occurred), comment: *"prevent leaking server error details to the client by default"*). The BrowserOS LLM path never supplied one, so the status code, gateway error code, and message that `browseros-fetch.ts` works to assemble into a rich `APICallError` were all discarded at that boundary.

The ACP path already supplies an `onError` — which is why Claude/Codex turns showed real failure reasons and BrowserOS LLM turns did not. This applies the same pattern to the other half of the same route.

## Approach

Errors now travel as a shared `ChatError` envelope carrying a **category**, a **plain-sentence explanation**, a **retryable flag**, and **redacted upstream text**. The SDK's error chunk is a `strictObject` with one string field, so the envelope is JSON serialized into `errorText` — no schema violation, no second channel.

```
gateway 429 {error:{code:'CREDITS_EXHAUSTED'}}
  → APICallError{statusCode, data:{code}, responseHeaders}   ← code kept structured
  → onError: toChatErrorText(error, {provider})              ← NEW: the whole fix
  → errorText = {"error":{"code":"credits_exhausted","title":…,"retryable":false,…}}
  → ChatError reads fields, no substring matching
```

The same envelope is emitted by Hono's global handler, so pre-stream and in-stream failures share one client parser.

## Changes

| Area | Change |
|---|---|
| `packages/shared/schemas/chat-error` | **New.** Envelope, serializer, tolerant parser |
| `apps/server/agent/chat-error` | **New.** Classifies by field — gateway code → status → SDK error class, unwrapping `RetryError` first |
| `chat-service.ts` | Supplies the missing `onError` |
| `browseros-fetch` / `openrouter-fetch` | Keep the upstream code on `APICallError.data`; forward response headers so `Retry-After` survives |
| `api/server.ts` | 500 body uses the same envelope; `name`/`statusCode` retained for existing callers |
| `ChatError.tsx` | Renders from fields, adds a "Show details" disclosure; legacy substring ladder kept as fallback |
| `getChatServerResponse.ts` | Scheduled-task history unwraps the envelope instead of storing raw JSON |
| `NewTabChat.tsx` | Wires `retryLastTurn`, which was forwarded by the hook but never destructured |

Retry is now driven by the `retryable` flag: credit exhaustion and auth failures no longer offer a button that cannot help, while a transient 429 or provider 5xx does.

### Notes on two deliberate choices

- **The shared module is dependency-free rather than Zod** like its siblings. `apps/app` resolves `zod` to v4 while `apps/server` and `packages/shared` resolve v3, and unlike the other shared schemas this one is imported as a *runtime* value on both sides. Verified the extension bundles it (`dist/chrome-mv3/background.js` + shared chunk).
- **Raw upstream text is redacted before it reaches the user.** The shared Sentry sanitizer only redacts by object key, so it cannot help with free-text provider messages; a narrow regex sweep scrubs key-shaped tokens (`sk-…`, `Bearer …`, `AKIA…`, `gh[pousr]_…`) from both `message` and `details`, and `details` is capped at 500 chars.

## Backward compatibility

`parseChatErrorEnvelope` returns null for anything that isn't a well-formed envelope — including an unrecognized `code` — and the client falls back to the existing substring ladder. So bare prose, an older agent server, and client-side `Failed to fetch` all still render exactly as before. The three pre-existing `ChatError` tests pass unmodified.

## Testing

- `chat-error.test.ts` — table tests across the classifier, including the **first `429` coverage anywhere in the repo** (a grep for `429` in the test tree previously returned nothing)
- `chat-error-stream.test.ts` — drives a failing model through real `createAgentUIStreamResponse` and asserts the envelope reaches the SSE frame, plus a characterization test pinning the SDK's masking default so an SDK upgrade that changes it is caught
- `ChatError.test.tsx` — envelope rendering cases alongside the unchanged legacy ones

Verified: `bun run lint` (0 errors), `bun run fallow` (no new issues), `apps/server` typecheck clean, `test:agent` 285 pass, `test:api` 138 pass, `test:lib` 111 pass, `test:integration` 10 pass, `apps/app` tests pass, extension builds.

`apps/app` typecheck reports 102 errors — all pre-existing in `../server/src/tools/filesystem/*`, confirmed identical on a clean tree. Zero in files touched here.

## Open question for the reviewer

The ticket describes the limit as **"25 credits per week."** Every user-facing string in the repo says *daily* — "Credits reset at midnight UTC", "Resets daily", "Credits used today" — and no numeric limit is hardcoded (`dailyLimit` and `resetInterval` both arrive from the gateway at runtime). This PR **preserves the existing daily copy** rather than changing product wording. If the limit is actually weekly, the app's copy is wrong today and that is a separate, larger fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)