### PR TITLE
fix(claw-app): calm the audit + mcp electric-blue bars

### DIFF
--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/styles.css
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/styles.css
@@ -377,15 +377,15 @@ body {
   --red-tint: hsl(4 65% 95%);
   --blue: #0e7490;
 
-  /* Ledger table. A deeper cobalt than --primary #0254ec: the header is a
-     filled bar, not a CTA, so it carries more weight without competing
-     with the buttons on the same screen. The three ledger inks are a
+  /* Ledger table. The header is a quiet cool-tint strip with muted
+     labels and a hairline underline, not a filled cobalt bar: the loud
+     solid header fought the cool-blue page. The three ledger inks are a
      blue-shifted parallel of the neutral ink scale, so column text reads
-     as one family with the cobalt chrome rather than as grey on blue. */
-  --ledger-head: #0043cd;
-  --ledger-head-ink: #ffffff;
+     as one family with the chrome rather than as grey on blue. */
+  --ledger-head: #eef2f9;
+  --ledger-head-ink: #5f7794;
   --ledger-band: #eaf1fd;
-  --ledger-band-ink: #0043cd;
+  --ledger-band-ink: #3f5d86;
   --ledger-border: #c8d4e0;
   --ledger-divider: #dfe7ee;
   --ledger-link: #155da8;
@@ -501,13 +501,13 @@ body {
   --red-tint: #2b1414;
   --blue: #56b8d8;
 
-  /* Ledger table, dark. The header bar drops to a deep cobalt that still
-     reads as a filled band against --card, and the link / ink roles
-     invert to the light end of the blue ramp. */
-  --ledger-head: #16306e;
-  --ledger-head-ink: #eaf1ff;
+  /* Ledger table, dark. The header is a quiet strip a step above --card
+     rather than a filled cobalt band; the link / ink roles invert to the
+     light end of the blue ramp. */
+  --ledger-head: #151d31;
+  --ledger-head-ink: #a4acbd;
   --ledger-band: #16203a;
-  --ledger-band-ink: #8fb4ff;
+  --ledger-band-ink: #8697b8;
   --ledger-border: #212c40;
   --ledger-divider: #1b2537;
   --ledger-link: #8fb4ff;

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
@@ -41,9 +41,9 @@ const CELL_PADDING = 'px-2 py-2.5 first:pl-4 last:pr-4'
 
 /**
  * Audit ledger. Preserves the tanstack-table + shadcn Table primitives
- * and restyles them as a single bordered card: a cobalt header bar,
- * tinted day bands separating date groups, and hairline-separated rows
- * beneath. Rows are ordered LIVE-first then newest-first and are not
+ * and restyles them as a single bordered card: a quiet tinted header
+ * strip, tinted day bands separating date groups, and hairline-separated
+ * rows beneath. Rows are ordered LIVE-first then newest-first and are not
  * re-sortable — arbitrary column sorts would shred the day bands, and
  * the filter bar covers retrieval instead. On row hover, a fixed
  * top-right panel shows the session's screenshot preview.
@@ -214,8 +214,8 @@ export function Audit() {
 
 /**
  * White card the ledger sits in. `overflow-clip` is what rounds the
- * cobalt header bar's top corners and the last row's bottom corners —
- * neither element carries a radius of its own.
+ * header strip's top corners and the last row's bottom corners: neither
+ * element carries a radius of its own.
  */
 function LedgerCard({ children }: { children: ReactNode }) {
   return (
@@ -229,14 +229,14 @@ interface LedgerTableProps {
   table: ReturnType<typeof useReactTable<TaskSummary>>
 }
 
-/** Cobalt header bar. Labels only — the ledger is not operator-sortable. */
+/** Quiet header strip. Labels only: the ledger is not operator-sortable. */
 function LedgerHeader({ table }: LedgerTableProps) {
   return (
     <TableHeader>
       {table.getHeaderGroups().map((hg) => (
         <TableRow
           key={hg.id}
-          className="border-none bg-ledger-head hover:bg-ledger-head"
+          className="border-ledger-border border-b bg-ledger-head hover:bg-ledger-head"
         >
           {hg.headers.map((h) => (
             <TableHead

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
@@ -21,35 +21,25 @@ export function EndpointStrip({ label, value }: EndpointStripProps) {
   }
   return (
     <div className="space-y-2">
-      <div className="flex items-baseline justify-between gap-3">
-        <span className="text-[12px] text-cyanotype-muted">{label}</span>
-        {hasValue && (
-          <button
-            type="button"
-            onClick={copy}
-            aria-label={`Copy ${label}`}
-            className="group inline-flex items-center gap-1 text-[12px] text-cyanotype-blue transition-colors hover:text-cyanotype-blue-hover"
-          >
-            {copied ? 'Copied ✓' : 'Copy'}
-            {!copied && (
-              <span
-                aria-hidden
-                className="font-mono text-[10.5px] text-ink-3 tracking-[0.08em] transition-transform group-hover:translate-x-0.5"
-              >
-                →
-              </span>
-            )}
-          </button>
-        )}
-      </div>
-      <div className="overflow-hidden rounded-9 bg-cyanotype-blue px-4 py-3">
+      <span className="text-[12px] text-cyanotype-muted">{label}</span>
+      <div className="flex items-center gap-3 overflow-hidden rounded-9 bg-ink-deep px-4 py-3 shadow-card">
         {hasValue ? (
-          <code
-            className="block truncate font-mono text-[12.5px] text-white/95"
-            title={value}
-          >
-            {value}
-          </code>
+          <>
+            <code
+              className="min-w-0 flex-1 truncate font-mono text-[12.5px] text-white/90"
+              title={value}
+            >
+              {value}
+            </code>
+            <button
+              type="button"
+              onClick={copy}
+              aria-label={`Copy ${label}`}
+              className="shrink-0 rounded px-1.5 py-0.5 text-[12px] text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+            >
+              {copied ? 'Copied ✓' : 'Copy'}
+            </button>
+          </>
         ) : (
           <div className="h-[18px] w-full max-w-sm animate-pulse rounded bg-white/15" />
         )}


### PR DESCRIPTION
The Audit and MCP new-tab pages each carried a solid electric-cobalt bar that fought the cool-blue page around it. This softens both.

## Audit
The table header was a solid cobalt bar with white labels. It is now a quiet cool-tint strip with muted column labels and a hairline underline, and the day-band date labels drop from electric cobalt to a calm slate-blue. The ledger keeps its structure; only the header and band ink are recolored, via the ledger design tokens (light and dark) so nothing else on the screen shifts.

## MCP
The endpoint URL sat in a solid cobalt bar that read like a call to action. It is actually a value you copy into an agent config, so it now renders as a dark code block: monospace on a deep-navy surface with an inline copy control. This uses the existing terminal-surface token, so it stays coherent in both themes.

Both bars are the only consumers of the tokens/classes touched, so the change is contained to these two screens.

## Verification
- Audit and MCP screen tests pass; type-check and lint are clean.
- Previewed both pages in the running new tab: the audit header reads as a calm labeled strip and the MCP endpoint reads as a proper code block.