### PR TITLE
fix(chat): surface the full upstream error body in the chat error card

### DIFF
--- a/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.test.tsx
@@ -130,7 +130,7 @@ describe('ChatError envelope handling', () => {
     expect(html).toContain('Try again')
   })
 
-  it('offers a details disclosure when raw upstream text is present', () => {
+  it('always shows the raw upstream detail with no toggle', () => {
     const html = renderError(
       envelopeError({
         message: 'The model request failed.',
@@ -138,13 +138,41 @@ describe('ChatError envelope handling', () => {
       }),
     )
 
-    expect(html).toContain('Show details')
+    expect(html).not.toContain('Show details')
+    expect(html).toContain('Full error')
+    expect(html).toContain('upstream said: connection reset by peer')
   })
 
-  it('omits the disclosure when there is no extra detail', () => {
+  it('renders no detail block when there is no extra detail', () => {
     const html = renderError(envelopeError({ details: undefined }))
 
+    expect(html).not.toContain('Full error')
+  })
+
+  it('renders the full server error JSON, pretty-printed and always visible', () => {
+    const html = renderError(
+      envelopeError({
+        code: 'credits_exhausted',
+        title: 'Daily limit reached',
+        message: 'You have used all your BrowserOS credits.',
+        retryable: false,
+        provider: 'browseros',
+        details: JSON.stringify({
+          error: {
+            code: 'CREDITS_EXHAUSTED',
+            metadata: { raw: 'quota 0 of 100' },
+          },
+        }),
+      }),
+    )
+
+    // Always-expanded: no toggle, the block and its copy control are present.
     expect(html).not.toContain('Show details')
+    expect(html).toContain('Full error')
+    expect(html).toContain('Copy')
+    // The raw upstream specifics the generic message hid are now visible.
+    expect(html).toContain('CREDITS_EXHAUSTED')
+    expect(html).toContain('quota 0 of 100')
   })
 
   it('falls back to the server-supplied title for an unknown code', () => {

--- a/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.tsx
@@ -167,12 +167,21 @@ function buildView(message: string, providerType?: string): ChatErrorView {
   return envelope ? fromEnvelope(envelope) : fromMessage(message, providerType)
 }
 
+/** Pretty-print JSON details; leave already-formatted or non-JSON text as-is. */
+function formatErrorDetails(details: string): string {
+  try {
+    return JSON.stringify(JSON.parse(details), null, 2)
+  } catch {
+    return details
+  }
+}
+
 export const ChatError: FC<ChatErrorProps> = ({
   error,
   onRetry,
   providerType,
 }) => {
-  const [showDetails, setShowDetails] = useState(false)
+  const [copiedDetails, setCopiedDetails] = useState(false)
   const view = buildView(error.message, providerType)
 
   const surveyUrl = useMemo(
@@ -182,6 +191,17 @@ export const ChatError: FC<ChatErrorProps> = ({
   )
 
   const canRetry = !!onRetry && view.canRetry
+
+  const copyDetails = async () => {
+    if (!view.details) return
+    try {
+      await navigator.clipboard.writeText(view.details)
+      setCopiedDetails(true)
+      window.setTimeout(() => setCopiedDetails(false), 1500)
+    } catch {
+      setCopiedDetails(false)
+    }
+  }
 
   return (
     <div className="mx-4 flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
@@ -225,20 +245,23 @@ export const ChatError: FC<ChatErrorProps> = ({
           </a>
         </p>
       )}
-      {view.details && view.details !== view.text && (
+      {view.details && (
         <div className="w-full">
-          <button
-            type="button"
-            onClick={() => setShowDetails((shown) => !shown)}
-            className="w-full text-center text-muted-foreground text-xs underline hover:text-foreground"
-          >
-            {showDetails ? 'Hide details' : 'Show details'}
-          </button>
-          {showDetails && (
-            <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-muted p-2 text-left text-[10px] text-muted-foreground">
-              {view.details}
-            </pre>
-          )}
+          <div className="mb-1 flex items-center justify-between px-0.5">
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+              Full error
+            </span>
+            <button
+              type="button"
+              onClick={copyDetails}
+              className="text-[10px] text-muted-foreground underline hover:text-foreground"
+            >
+              {copiedDetails ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+          <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-muted p-2 text-left text-[10px] text-muted-foreground">
+            {formatErrorDetails(view.details)}
+          </pre>
         </div>
       )}
       {canRetry && (

--- a/packages/browseros-agent/apps/server/src/agent/chat-error.ts
+++ b/packages/browseros-agent/apps/server/src/agent/chat-error.ts
@@ -31,6 +31,12 @@ export interface ChatErrorContext {
 
 const DETAILS_MAX_LENGTH = 500
 
+// The raw upstream body is JSON, not a sentence, so it gets a larger bound: a
+// credit/quota error carries its actionable specifics in the body, and a 500
+// char cut mid-JSON would strip exactly that. Still bounded so a pathological
+// body cannot flood the card.
+const DETAILS_MAX_LENGTH_RAW = 4000
+
 const USAGE_DOCS_URL = 'https://dub.sh/browseros-usage-limit'
 const USAGE_PAGE_URL = '/app.html#/settings/usage'
 const CONNECTION_DOCS_URL =
@@ -54,13 +60,41 @@ function redact(text: string): string {
   )
 }
 
-function toDetails(text: string | undefined): string | undefined {
+function toDetails(
+  text: string | undefined,
+  maxLength: number = DETAILS_MAX_LENGTH,
+): string | undefined {
   if (!text) return undefined
   const redacted = redact(text).trim()
   if (!redacted) return undefined
-  return redacted.length > DETAILS_MAX_LENGTH
-    ? `${redacted.slice(0, DETAILS_MAX_LENGTH)}…`
+  return redacted.length > maxLength
+    ? `${redacted.slice(0, maxLength)}…`
     : redacted
+}
+
+/**
+ * The full upstream body is the actionable evidence a generic gateway message
+ * hides: OpenRouter-style gateways wrap the real reason in `metadata.raw` while
+ * `message` stays vague. Prefer the response body (pretty-printed when it is
+ * JSON), then the structured `data.raw`, then the message. Redacted and capped
+ * like any other detail.
+ */
+function upstreamDetails(error: APICallError): string | undefined {
+  if (error.responseBody) {
+    try {
+      return toDetails(
+        JSON.stringify(JSON.parse(error.responseBody), null, 2),
+        DETAILS_MAX_LENGTH_RAW,
+      )
+    } catch {
+      return toDetails(error.responseBody, DETAILS_MAX_LENGTH_RAW)
+    }
+  }
+  const raw = (error.data as { raw?: unknown } | undefined)?.raw
+  if (raw !== undefined) {
+    return toDetails(JSON.stringify(raw, null, 2), DETAILS_MAX_LENGTH_RAW)
+  }
+  return toDetails(error.message)
 }
 
 /** Upstream text reaches the user, so it gets the same scrub as `details`. */
@@ -111,7 +145,7 @@ function fromApiCallError(
   const base = {
     provider: ctx.provider,
     statusCode: error.statusCode,
-    details: toDetails(error.message),
+    details: upstreamDetails(error),
   }
   const code = gatewayCode(error)
   const isBrowserOs = ctx.provider === 'browseros'

--- a/packages/browseros-agent/apps/server/tests/agent/chat-error.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/chat-error.test.ts
@@ -162,6 +162,61 @@ describe('toChatError', () => {
     expect(error.details).not.toContain('aaaaaaaaaa')
     expect((error.details ?? '').length).toBeLessThanOrEqual(501)
   })
+
+  it('carries the full upstream response body as pretty-printed details', () => {
+    const error = toChatError(
+      apiCallError({
+        message: 'Provider returned error',
+        statusCode: 429,
+        data: { code: 'CREDITS_EXHAUSTED' },
+        responseBody: JSON.stringify({
+          error: {
+            code: 'CREDITS_EXHAUSTED',
+            message: 'Provider returned error',
+            metadata: { raw: 'quota 0 of 100 for today' },
+          },
+        }),
+      }),
+      { provider: 'browseros' },
+    )
+
+    // The real reason the generic message hid is preserved in details...
+    expect(error.details).toContain('quota 0 of 100 for today')
+    // ...pretty-printed onto its own lines.
+    expect(error.details).toContain('\n')
+  })
+
+  it('falls back to structured data.raw when there is no response body', () => {
+    const error = toChatError(
+      apiCallError({
+        message: 'Provider returned error',
+        statusCode: 429,
+        data: { code: 'CREDITS_EXHAUSTED', raw: { remaining: 0 } },
+      }),
+      { provider: 'browseros' },
+    )
+
+    expect(error.details).toContain('remaining')
+    expect(error.details).toContain('0')
+  })
+
+  it('redacts secrets and caps the raw body in details', () => {
+    const secret = `sk-${'c'.repeat(40)}`
+    const error = toChatError(
+      apiCallError({
+        statusCode: 500,
+        responseBody: JSON.stringify({
+          error: { message: `boom ${secret}`, note: 'x'.repeat(5000) },
+        }),
+      }),
+    )
+
+    expect(error.details).toContain('[REDACTED]')
+    expect(error.details).not.toContain('cccccccccc')
+    // The raw-body bound is larger than the 500-char message cap, still bounded.
+    expect((error.details ?? '').length).toBeLessThanOrEqual(4001)
+    expect((error.details ?? '').length).toBeGreaterThan(501)
+  })
 })
 
 describe('toChatErrorText', () => {


### PR DESCRIPTION
## Problem
Chat uses the Vercel AI SDK `useChat`. When the gateway fails a turn (most visibly: credits exhausted, thrown by the worker in front of the default provider), the user only saw a short, generic sentence. The full error the server actually received was discarded, so there was no way to see what really happened.

## Root cause
The error-envelope pipeline already un-masks AI SDK stream errors and classifies them, but it built the envelope's `details` from the short constructed `error.message` and capped it at 500 characters. The gateway's real, actionable specifics live in the response body (OpenRouter-style gateways hide them in `metadata.raw`), which is captured on the custom fetch as `APICallError.responseBody` / `data.raw` but never forwarded. On top of that, the card only revealed `details` behind a toggle, and hid it entirely when it matched the message.

## Change
- Classifier: forward the full upstream response body (or structured `data.raw`) into the envelope `details`, pretty-printed as JSON. Secret redaction is unchanged; the raw body gets a larger-but-bounded cap so a pathological body cannot flood the card.
- Error card: render that detail always-expanded with a copy control instead of behind a toggle, so the real reason is visible without a click. The side panel and new tab share this component, so both surfaces are covered.

No wire or schema change: this reuses the envelope's existing `details` field, which was defined for exactly this.

## Tests
- Classifier: full response body is preserved and pretty-printed in `details`; falls back to `data.raw`; secrets stay redacted and the raw body is bounded.
- Card: the raw detail renders always-expanded (no toggle), and the full JSON is shown pretty-printed with a copy control.
- Type-check and lint clean across both packages.

## Follow-up
If credits exhaustion is ever returned as HTTP 200 with the error embedded in the SSE stream (rather than a 4xx the custom fetch already intercepts), the stream body would need inspecting too. The current 429 handling indicates the HTTP-error path, so that is a separate, verifiable follow-up.