### PR TITLE
fix(server): stop replaying reasoning to the model in local history mode

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/message-validation.ts
+++ b/packages/browseros-agent/apps/server/src/agent/message-validation.ts
@@ -46,6 +46,29 @@ export function filterValidMessages(messages: UIMessage[]): UIMessage[] {
 }
 
 /**
+ * Remove `reasoning` parts from a message list before it is sent to the model.
+ *
+ * Reasoning is ephemeral. It stays in the durable and client-displayed history,
+ * but must not be replayed to the provider: convertToModelMessages can turn a
+ * multi-step assistant message into a reasoning-only assistant message (no text,
+ * no tool call), which serializes to `content: null` with no `tool_calls`. Strict
+ * OpenAI-compatible providers reject that with "The content field is a required
+ * field", so a conversation cannot continue past the first turn once a reasoning
+ * model has answered. Stripping reasoning from the request copy keeps replay
+ * provider-agnostic; the model still generates fresh reasoning for the new turn.
+ */
+export function stripReasoningParts(messages: UIMessage[]): UIMessage[] {
+  return messages
+    .map((message) => {
+      const parts = message.parts.filter((part) => part.type !== 'reasoning')
+      return parts.length === message.parts.length
+        ? message
+        : { ...message, parts }
+    })
+    .filter(hasMessageContent)
+}
+
+/**
  * Remove tool parts that reference tools not present in the given toolset.
  *
  * When a session is rebuilt with a different set of tools (e.g., workspace

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -21,6 +21,7 @@ import { formatUserMessage } from '../../agent/format-message'
 import {
   filterValidMessages,
   sanitizeMessagesForToolset,
+  stripReasoningParts,
 } from '../../agent/message-validation'
 import type { AgentSession, SessionStore } from '../../agent/session-store'
 import type { ResolvedAgentConfig } from '../../agent/types'
@@ -332,8 +333,11 @@ export class ChatService {
     const wrappedUserMessageId =
       session.agent.messages[session.agent.messages.length - 1]?.id
 
-    const promptUiMessages: UIMessage[] = filterValidMessages(
-      session.agent.messages,
+    // Strip reasoning from the request copy only. session.agent.messages keeps
+    // reasoning so it still persists to SQLite and renders in the client history;
+    // the model must not see replayed reasoning (see stripReasoningParts).
+    const promptUiMessages: UIMessage[] = stripReasoningParts(
+      filterValidMessages(session.agent.messages),
     ).map((message) =>
       message.id === wrappedUserMessageId && message.role === 'user'
         ? {
@@ -369,12 +373,23 @@ export class ChatService {
             : message,
         )
         session.agent.messages = filterValidMessages(restored)
+
+        // Only persist a turn that produced an assistant reply. A stream that
+        // errored before any output leaves the history ending on the user
+        // message; persisting that corrupts durable history, because the next
+        // turn reloads it and appends another user message, and the provider
+        // rejects back-to-back user messages.
+        const turnCompleted =
+          session.agent.messages[session.agent.messages.length - 1]?.role ===
+          'assistant'
+
         logger.info('Agent execution complete', {
           conversationId: request.conversationId,
           totalMessages: session.agent.messages.length,
+          turnCompleted,
         })
 
-        if (request.historyMode === 'local') {
+        if (request.historyMode === 'local' && turnCompleted) {
           await this.persistConversation({
             id: request.conversationId,
             messages: session.agent.messages,

--- a/packages/browseros-agent/apps/server/tests/agent/message-validation.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/message-validation.test.ts
@@ -13,10 +13,11 @@
  */
 
 import { describe, expect, it } from 'bun:test'
-import type { UIMessage } from 'ai'
+import { convertToModelMessages, type ModelMessage, type UIMessage } from 'ai'
 import {
   hasMessageContent,
   sanitizeMessagesForToolset,
+  stripReasoningParts,
 } from '../../src/agent/message-validation'
 
 // ---------------------------------------------------------------------------
@@ -295,5 +296,136 @@ describe('hasMessageContent', () => {
       ],
     }
     expect(hasMessageContent(msg)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// stripReasoningParts
+// ---------------------------------------------------------------------------
+
+function reasoningPart(text: string): UIMessage['parts'][number] {
+  return {
+    type: 'reasoning',
+    text,
+    state: 'done',
+  } as unknown as UIMessage['parts'][number]
+}
+
+function toolPart(name: string, callId: string): UIMessage['parts'][number] {
+  return {
+    type: `tool-${name}`,
+    toolCallId: callId,
+    state: 'output-available',
+    input: {},
+    output: { ok: true },
+  } as unknown as UIMessage['parts'][number]
+}
+
+const stepStart = {
+  type: 'step-start',
+} as unknown as UIMessage['parts'][number]
+
+// An assistant message with no text and no tool call is invalid on the
+// OpenAI-compatible wire format (content: null, no tool_calls) and strict
+// providers reject it with "The content field is a required field".
+function invalidAssistantCount(model: ModelMessage[]): number {
+  return model.filter((m) => {
+    if (m.role !== 'assistant') return false
+    const content = m.content
+    if (typeof content === 'string') return content.trim().length === 0
+    if (Array.isArray(content)) {
+      const hasText = content.some(
+        (p) => p.type === 'text' && p.text.trim().length > 0,
+      )
+      const hasToolCall = content.some((p) => p.type === 'tool-call')
+      return !hasText && !hasToolCall
+    }
+    return true
+  }).length
+}
+
+describe('stripReasoningParts', () => {
+  it('removes reasoning parts while keeping text and tool parts', () => {
+    const messages: UIMessage[] = [
+      makeAssistantMessage([
+        stepStart,
+        reasoningPart('thinking'),
+        toolPart('tabs', 'c1'),
+        { type: 'text', text: 'done' },
+      ]),
+    ]
+
+    const [result] = stripReasoningParts(messages)
+    expect(result.parts.map((p) => p.type)).toEqual([
+      'step-start',
+      'tool-tabs',
+      'text',
+    ])
+  })
+
+  it('drops a message whose only content was reasoning', () => {
+    const messages: UIMessage[] = [
+      makeUserMessage('hi'),
+      makeAssistantMessage([reasoningPart('private thought')]),
+    ]
+
+    const result = stripReasoningParts(messages)
+    expect(result).toHaveLength(1)
+    expect(result[0].role).toBe('user')
+  })
+
+  it('returns the same reference when there is no reasoning to strip', () => {
+    const messages: UIMessage[] = [
+      makeUserMessage('hi'),
+      makeAssistantMessage([{ type: 'text', text: 'hello' }]),
+    ]
+
+    const result = stripReasoningParts(messages)
+    expect(result[0]).toBe(messages[0])
+    expect(result[1]).toBe(messages[1])
+  })
+
+  it('handles an empty array', () => {
+    expect(stripReasoningParts([])).toHaveLength(0)
+  })
+
+  // Regression guard for the real bug: a persisted assistant turn with
+  // reasoning replayed to a strict provider produced a reasoning-only assistant
+  // model message and a 400 "content field is required".
+  it('makes replayed history convert to a valid provider request', async () => {
+    const history: UIMessage[] = [
+      makeUserMessage('weather in singapore'),
+      makeAssistantMessage([
+        stepStart,
+        reasoningPart('look up the weather'),
+        toolPart('tabs', 'c1'),
+        { type: 'text', text: 'It is sunny in Singapore.' },
+      ]),
+      makeUserMessage('and in malaysia?'),
+      // A reasoning-only step converts to an assistant model message with no
+      // text and no tool call: the exact shape the provider rejects.
+      makeAssistantMessage([reasoningPart('the user asked about malaysia')]),
+    ]
+
+    // Without the fix, the reasoning-only step yields an invalid assistant
+    // message ("content field is required").
+    expect(
+      invalidAssistantCount(await convertToModelMessages(history)),
+    ).toBeGreaterThan(0)
+
+    // With the fix, nothing invalid reaches the provider...
+    const fixed = await convertToModelMessages(stripReasoningParts(history))
+    expect(invalidAssistantCount(fixed)).toBe(0)
+    // ...and the prior tool call and text still survive (higher fidelity than
+    // the cloud lane's text-only projection).
+    expect(fixed.some((m) => m.role === 'tool')).toBe(true)
+    expect(
+      fixed.some(
+        (m) =>
+          m.role === 'assistant' &&
+          Array.isArray(m.content) &&
+          m.content.some((p) => p.type === 'text'),
+      ),
+    ).toBe(true)
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -963,7 +963,17 @@ describe('ChatService history persistence', () => {
     const agent = createFakeAgent()
     agentToReturn = agent
     streamResponseHandler = async ({ onFinish }) => {
-      await onFinish({ messages: agent.messages })
+      // A completed turn ends with the assistant reply.
+      await onFinish({
+        messages: [
+          ...agent.messages,
+          {
+            id: crypto.randomUUID(),
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'hi there' }],
+          },
+        ],
+      })
       return new Response('ok')
     }
     const conversationStore = {
@@ -1010,6 +1020,45 @@ describe('ChatService history persistence', () => {
       | undefined
     expect(saved?.id).toBe(conversationId)
     expect(saved?.targetType).toBe('browseros')
+  })
+
+  it('does not persist and drops the dangling user message when a turn errors', async () => {
+    const agent = createFakeAgent()
+    agentToReturn = agent
+    // The stream errored before any output: onFinish reports the history
+    // ending on the user message, with no assistant reply appended.
+    streamResponseHandler = async ({ onFinish }) => {
+      await onFinish({ messages: agent.messages })
+      return new Response('ok')
+    }
+    const conversationStore = {
+      get: mock(async () => null),
+      save: mock(async () => ({
+        id: 'stored',
+        targetType: 'browseros',
+        lastMessagedAt: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      })),
+    }
+    const sessionStore = createSessionStore()
+    const conversationId = crypto.randomUUID()
+    const service = new ChatService({
+      sessionStore: sessionStore as never,
+      klavis: createKlavisStub() as never,
+      browser: persistenceBrowser() as never,
+      conversationStore: conversationStore as never,
+    })
+
+    await service.processMessage(
+      browserOsRequest(conversationId, 'local'),
+      new AbortController().signal,
+    )
+
+    // The errored turn produced no assistant reply, so nothing is persisted and
+    // durable history stays clean (no trailing user message to corrupt reload).
+    expect(conversationStore.save).not.toHaveBeenCalled()
+    expect(sessionStore.get(conversationId)).toBeDefined()
   })
 
   it('never touches the store and seeds from previousConversation in cloud mode', async () => {

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -1055,8 +1055,9 @@ describe('ChatService history persistence', () => {
       new AbortController().signal,
     )
 
-    // The errored turn produced no assistant reply, so nothing is persisted and
-    // durable history stays clean (no trailing user message to corrupt reload).
+    // The errored turn produced no assistant reply, so nothing is persisted:
+    // a cold reload from SQLite stays clean. The in-memory session still holds
+    // the unanswered user message; the guard is persistence, not a session trim.
     expect(conversationStore.save).not.toHaveBeenCalled()
     expect(sessionStore.get(conversationId)).toBeDefined()
   })


### PR DESCRIPTION
## Problem

In server-owned (logged-out) history mode, a chat cannot continue past the first message. The second turn returns a provider 400 and the conversation gets permanently stuck.

```
[400] invalid_request_error: "The content field is a required field."
```

## Root cause

In this mode the server owns history and replays the full persisted message list on every turn. A persisted assistant turn carries `reasoning` parts, and `convertToModelMessages` can turn a multi-step assistant message into a **reasoning-only assistant message** (no text, no tool call). On the OpenAI-compatible wire format that serializes to `content: null` with no `tool_calls`, which is invalid, so strict providers (e.g. OpenRouter/qwen) reject it.

The logged-in lane never hit this because it replays history as text-only (the client projection keeps only text parts, and the server injects previous messages as text parts). The server-owned lane replays full-fidelity messages, which reintroduced reasoning into the request.

A second defect compounded it: the finish handler persisted history even when the turn errored before producing a reply, writing a history that ends on a user message. The next turn reloaded that and appended another user message, producing back-to-back user messages that the provider also rejects, so the conversation stayed broken across reloads.

## Fix

- Strip `reasoning` parts from the request copy only. The durable and client-displayed history keeps reasoning, so the UI can still show it. This mirrors the logged-in lane's text-only projection while preserving tool calls and results for higher fidelity than text-only.
- Only persist a turn that produced an assistant reply, so a stream that errors before any output never writes a history ending on a user message.

## Tests

- A regression guard converts a replayed history containing reasoning through `convertToModelMessages` and asserts no assistant message has empty content without tool calls, and that prior tool calls and text survive.
- Unit coverage for the reasoning-strip helper (removes reasoning, drops emptied messages, leaves untouched messages by reference).
- A finish-handler test that an errored turn (no assistant reply) is not persisted.
- `tsc` and Biome clean; existing store, routes, and chat-service suites pass.
