### PR TITLE
fix(app): persist the third-party agent default across the sidebar and home

### DIFF
--- a/packages/browseros-agent/apps/app/modules/agents/agents.helpers.test.ts
+++ b/packages/browseros-agent/apps/app/modules/agents/agents.helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test'
+import { computeAgentsSettled } from './agents.helpers'
+
+describe('computeAgentsSettled', () => {
+  const base = {
+    capabilitiesLoading: false,
+    agentsSupported: true,
+    urlLoading: false,
+    agentsQuerySucceeded: true,
+  }
+
+  it('is false while capabilities are loading', () => {
+    expect(computeAgentsSettled({ ...base, capabilitiesLoading: true })).toBe(
+      false,
+    )
+  })
+
+  it('is true when agents are not supported (nothing to load)', () => {
+    expect(computeAgentsSettled({ ...base, agentsSupported: false })).toBe(true)
+  })
+
+  it('is false while the agent server url is still loading', () => {
+    expect(computeAgentsSettled({ ...base, urlLoading: true })).toBe(false)
+  })
+
+  it('is false when the agents fetch has not succeeded (loading or failed)', () => {
+    // Regression guard: a failed fetch must not be treated as authoritative,
+    // otherwise the empty list would repair a persisted ACP default away.
+    expect(computeAgentsSettled({ ...base, agentsQuerySucceeded: false })).toBe(
+      false,
+    )
+  })
+
+  it('is true only after a successful agents fetch', () => {
+    expect(computeAgentsSettled(base)).toBe(true)
+  })
+})

--- a/packages/browseros-agent/apps/app/modules/agents/agents.helpers.ts
+++ b/packages/browseros-agent/apps/app/modules/agents/agents.helpers.ts
@@ -1,0 +1,23 @@
+export interface AgentsSettledInput {
+  capabilitiesLoading: boolean
+  agentsSupported: boolean
+  urlLoading: boolean
+  agentsQuerySucceeded: boolean
+}
+
+/**
+ * Whether the ACP agent list is authoritative enough to repair a stored
+ * selection against. Uses the query's success (not merely "fetched"), so a
+ * failed agents request does not make an empty list look authoritative and wipe
+ * a persisted third-party-agent default. Not-supported means nothing to load.
+ */
+export function computeAgentsSettled({
+  capabilitiesLoading,
+  agentsSupported,
+  urlLoading,
+  agentsQuerySucceeded,
+}: AgentsSettledInput): boolean {
+  if (capabilitiesLoading) return false
+  if (!agentsSupported) return true
+  return !urlLoading && agentsQuerySucceeded
+}

--- a/packages/browseros-agent/apps/app/modules/agents/agents.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/agents/agents.hooks.ts
@@ -4,6 +4,7 @@ import { useAgentServerUrl } from '@/modules/browseros/agent-server-url.hooks'
 import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
 import type { AcpAgent, AcpAgentType } from './acp-agent-types'
 import { buildAgentApiUrl } from './agent-api-url'
+import { computeAgentsSettled } from './agents.helpers'
 
 interface AcpAgentsResponse {
   agents: AcpAgent[]
@@ -56,13 +57,14 @@ export function useAcpAgents(enabled = true) {
       (agentsSupported && (query.isLoading || urlLoading)),
     // `loading` (via query.isLoading) briefly reads false on the render the
     // query flips enabled, while `agents` is still empty. `settled` instead
-    // stays false until the fetch has actually resolved, so callers can tell a
-    // not-yet-loaded agent from a genuinely absent one.
-    settled: capabilitiesLoading
-      ? false
-      : !agentsSupported
-        ? true
-        : !urlLoading && query.isFetched,
+    // stays false until the fetch has succeeded, so callers can tell a
+    // not-yet-loaded (or failed) agent list from a genuinely absent one.
+    settled: computeAgentsSettled({
+      capabilitiesLoading,
+      agentsSupported,
+      urlLoading,
+      agentsQuerySucceeded: query.isSuccess,
+    }),
     error: agentsSupported ? (query.error ?? urlError) : null,
     refetch: query.refetch,
   }

--- a/packages/browseros-agent/apps/app/modules/agents/agents.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/agents/agents.hooks.ts
@@ -54,6 +54,15 @@ export function useAcpAgents(enabled = true) {
     loading:
       capabilitiesLoading ||
       (agentsSupported && (query.isLoading || urlLoading)),
+    // `loading` (via query.isLoading) briefly reads false on the render the
+    // query flips enabled, while `agents` is still empty. `settled` instead
+    // stays false until the fetch has actually resolved, so callers can tell a
+    // not-yet-loaded agent from a genuinely absent one.
+    settled: capabilitiesLoading
+      ? false
+      : !agentsSupported
+        ? true
+        : !urlLoading && query.isFetched,
     error: agentsSupported ? (query.error ?? urlError) : null,
     refetch: query.refetch,
   }

--- a/packages/browseros-agent/apps/app/modules/chat/chat-refs.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-refs.hooks.ts
@@ -1,19 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import useDeepCompareEffect from 'use-deep-compare-effect'
-import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { type McpServer, useMcpServers } from '@/lib/mcp/mcpServerStorage'
 import { usePersonalization } from '@/lib/personalization/personalizationStorage'
-import { useAcpAgents } from '@/modules/agents/agents.hooks'
-import { useLlmProviders } from '@/modules/llm-providers/llm-providers.hooks'
-import {
-  buildSidepanelChatTargets,
-  loadSidepanelChatTargetSelection,
-  persistSidepanelChatTargetSelection,
-  resolveRepairedSelection,
-  resolveSidepanelChatTarget,
-  type SidepanelChatTarget,
-  type SidepanelChatTargetSelection,
-} from './sidepanel-chat-targets'
+import { useChatTargetSelection } from './use-chat-target-selection'
 
 const constructMcpServers = (servers: McpServer[]) => {
   return servers
@@ -31,111 +20,27 @@ const constructCustomServers = (servers: McpServer[]) => {
 }
 
 export const useChatRefs = () => {
+  const selection = useChatTargetSelection()
   const { servers: mcpServers } = useMcpServers()
-  const {
-    providers: llmProviders,
-    selectedProvider: selectedLlmProvider,
-    setDefaultProvider,
-    isLoading: isLoadingProviders,
-  } = useLlmProviders()
-  const {
-    agents,
-    loading: isLoadingAgents,
-    settled: agentsSettled,
-  } = useAcpAgents()
   const { personalization } = usePersonalization()
-  const [targetSelection, setTargetSelection] =
-    useState<SidepanelChatTargetSelection | null>(null)
 
-  useEffect(() => {
-    let cancelled = false
-    loadSidepanelChatTargetSelection().then((selection) => {
-      if (!cancelled) setTargetSelection(selection)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  const chatTargets = useMemo(
-    () =>
-      buildSidepanelChatTargets({
-        providers: llmProviders,
-        agents,
-      }),
-    [llmProviders, agents],
-  )
-
-  const selectedChatTarget = useMemo(
-    () =>
-      resolveSidepanelChatTarget({
-        targets: chatTargets,
-        defaultProviderId: selectedLlmProvider?.id ?? llmProviders[0]?.id ?? '',
-        selection: targetSelection,
-      }),
-    [chatTargets, llmProviders, selectedLlmProvider, targetSelection],
-  )
-
-  useEffect(() => {
-    // Only repair once providers and agents are settled. Otherwise a stored ACP
-    // selection is wiped to the LLM fallback during the startup window where the
-    // agents fetch has not resolved yet and the agent is absent from the list.
-    const ready = !isLoadingProviders && agentsSettled
-    const decision = resolveRepairedSelection({
-      selection: targetSelection,
-      resolvedTarget: selectedChatTarget,
-      ready,
-    })
-    if (!decision.repair) return
-    setTargetSelection(decision.selection)
-    void persistSidepanelChatTargetSelection(selectedChatTarget)
-  }, [agentsSettled, isLoadingProviders, selectedChatTarget, targetSelection])
-
-  const selectedLlmProviderRef = useRef<LlmProviderConfig | null>(
-    selectedLlmProvider,
-  )
-  const selectedChatTargetRef = useRef<SidepanelChatTarget | undefined>(
-    selectedChatTarget,
-  )
   const enabledMcpServersRef = useRef(constructMcpServers(mcpServers))
   const enabledCustomServersRef = useRef(constructCustomServers(mcpServers))
   const personalizationRef = useRef(personalization)
 
   useDeepCompareEffect(() => {
-    selectedLlmProviderRef.current = selectedLlmProvider
     enabledMcpServersRef.current = constructMcpServers(mcpServers)
     enabledCustomServersRef.current = constructCustomServers(mcpServers)
-  }, [selectedLlmProvider, mcpServers])
-
-  useEffect(() => {
-    selectedChatTargetRef.current = selectedChatTarget
-  }, [selectedChatTarget])
+  }, [mcpServers])
 
   useEffect(() => {
     personalizationRef.current = personalization
   }, [personalization])
 
-  const selectChatTarget = useCallback(
-    async (target: SidepanelChatTarget | undefined) => {
-      selectedChatTargetRef.current = target
-      setTargetSelection(target ? { kind: target.kind, id: target.id } : null)
-      await persistSidepanelChatTargetSelection(target)
-    },
-    [],
-  )
-
   return {
-    selectedLlmProviderRef,
-    selectedChatTargetRef,
+    ...selection,
     enabledMcpServersRef,
     enabledCustomServersRef,
     personalizationRef,
-    llmProviders,
-    setDefaultProvider,
-    chatTargets,
-    selectedChatTarget,
-    selectChatTarget,
-    selectedLlmProvider,
-    isLoadingProviders: isLoadingProviders || isLoadingAgents,
   }
 }

--- a/packages/browseros-agent/apps/app/modules/chat/chat-refs.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-refs.hooks.ts
@@ -9,6 +9,7 @@ import {
   buildSidepanelChatTargets,
   loadSidepanelChatTargetSelection,
   persistSidepanelChatTargetSelection,
+  resolveRepairedSelection,
   resolveSidepanelChatTarget,
   type SidepanelChatTarget,
   type SidepanelChatTargetSelection,
@@ -37,7 +38,11 @@ export const useChatRefs = () => {
     setDefaultProvider,
     isLoading: isLoadingProviders,
   } = useLlmProviders()
-  const { agents, loading: isLoadingAgents } = useAcpAgents()
+  const {
+    agents,
+    loading: isLoadingAgents,
+    settled: agentsSettled,
+  } = useAcpAgents()
   const { personalization } = usePersonalization()
   const [targetSelection, setTargetSelection] =
     useState<SidepanelChatTargetSelection | null>(null)
@@ -72,20 +77,19 @@ export const useChatRefs = () => {
   )
 
   useEffect(() => {
-    if (isLoadingProviders || isLoadingAgents || !targetSelection) return
-    if (
-      selectedChatTarget?.kind === targetSelection.kind &&
-      selectedChatTarget.id === targetSelection.id
-    ) {
-      return
-    }
-
-    const repairedSelection = selectedChatTarget
-      ? { kind: selectedChatTarget.kind, id: selectedChatTarget.id }
-      : null
-    setTargetSelection(repairedSelection)
+    // Only repair once providers and agents are settled. Otherwise a stored ACP
+    // selection is wiped to the LLM fallback during the startup window where the
+    // agents fetch has not resolved yet and the agent is absent from the list.
+    const ready = !isLoadingProviders && agentsSettled
+    const decision = resolveRepairedSelection({
+      selection: targetSelection,
+      resolvedTarget: selectedChatTarget,
+      ready,
+    })
+    if (!decision.repair) return
+    setTargetSelection(decision.selection)
     void persistSidepanelChatTargetSelection(selectedChatTarget)
-  }, [isLoadingAgents, isLoadingProviders, selectedChatTarget, targetSelection])
+  }, [agentsSettled, isLoadingProviders, selectedChatTarget, targetSelection])
 
   const selectedLlmProviderRef = useRef<LlmProviderConfig | null>(
     selectedLlmProvider,

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -181,7 +181,6 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     enabledMcpServersRef,
     enabledCustomServersRef,
     personalizationRef,
-    setDefaultProvider,
     chatTargets,
     selectedChatTarget,
     selectChatTarget,
@@ -864,7 +863,6 @@ export const useChatSession = (options?: ChatSessionOptions) => {
         },
       })
     })
-    if (target.kind === 'llm') setDefaultProvider(target.provider.id)
 
     if (
       previousTarget &&

--- a/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.test.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.test.ts
@@ -5,6 +5,7 @@ import {
   buildSidepanelChatTargets,
   clearSidepanelChatTargetSelectionForAgent,
   persistSidepanelChatTargetSelection,
+  resolveRepairedSelection,
   resolveSidepanelChatTarget,
   type SidepanelChatTargetSelection,
 } from './sidepanel-chat-targets'
@@ -87,6 +88,67 @@ describe('resolveSidepanelChatTarget', () => {
         selection: { kind: 'acp', id: 'deleted-agent' },
       }),
     ).toMatchObject({ kind: 'llm', id: provider.id })
+  })
+})
+
+describe('resolveRepairedSelection', () => {
+  const targets = buildSidepanelChatTargets({
+    providers: [provider],
+    agents: [agent],
+  })
+  const llmTarget = targets[0]
+  const acpTarget = targets[1]
+
+  it('keeps an ACP selection while agents are still loading (not ready)', () => {
+    // Regression guard: agents not settled yet, so the resolved target has
+    // fallen back to the LLM provider. The stored ACP selection must survive.
+    expect(
+      resolveRepairedSelection({
+        selection: { kind: 'acp', id: agent.id },
+        resolvedTarget: llmTarget,
+        ready: false,
+      }),
+    ).toEqual({ repair: false })
+  })
+
+  it('keeps a selection that matches the resolved target', () => {
+    expect(
+      resolveRepairedSelection({
+        selection: { kind: 'acp', id: agent.id },
+        resolvedTarget: acpTarget,
+        ready: true,
+      }),
+    ).toEqual({ repair: false })
+  })
+
+  it('repairs a stale selection to the resolved fallback once ready', () => {
+    expect(
+      resolveRepairedSelection({
+        selection: { kind: 'acp', id: 'deleted-agent' },
+        resolvedTarget: llmTarget,
+        ready: true,
+      }),
+    ).toEqual({ repair: true, selection: { kind: 'llm', id: provider.id } })
+  })
+
+  it('repairs to null when nothing resolves', () => {
+    expect(
+      resolveRepairedSelection({
+        selection: { kind: 'llm', id: 'gone' },
+        resolvedTarget: undefined,
+        ready: true,
+      }),
+    ).toEqual({ repair: true, selection: null })
+  })
+
+  it('never repairs when there is no stored selection', () => {
+    expect(
+      resolveRepairedSelection({
+        selection: null,
+        resolvedTarget: llmTarget,
+        ready: true,
+      }),
+    ).toEqual({ repair: false })
   })
 })
 

--- a/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.test.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import type { AcpAgent } from '@/modules/agents/acp-agent-types'
 import {
   buildSidepanelChatTargets,
   clearSidepanelChatTargetSelectionForAgent,
+  commitChatTargetSelection,
   persistSidepanelChatTargetSelection,
   resolveRepairedSelection,
   resolveSidepanelChatTarget,
@@ -171,6 +172,46 @@ describe('target selection storage', () => {
     await clearSidepanelChatTargetSelectionForAgent(agent.id, store)
 
     expect(await store.getValue()).toBeNull()
+  })
+})
+
+describe('commitChatTargetSelection', () => {
+  it('persists an LLM selection and updates the default provider id', async () => {
+    const store = createSelectionStore()
+    const setDefaultProvider = mock(async (_id: string) => {})
+
+    await commitChatTargetSelection(
+      { kind: 'llm', id: provider.id },
+      { setDefaultProvider },
+      store,
+    )
+
+    expect(await store.getValue()).toEqual({ kind: 'llm', id: provider.id })
+    expect(setDefaultProvider).toHaveBeenCalledWith(provider.id)
+  })
+
+  it('persists an ACP selection without touching the default provider id', async () => {
+    const store = createSelectionStore()
+    const setDefaultProvider = mock(async (_id: string) => {})
+
+    await commitChatTargetSelection(
+      { kind: 'acp', id: agent.id },
+      { setDefaultProvider },
+      store,
+    )
+
+    expect(await store.getValue()).toEqual({ kind: 'acp', id: agent.id })
+    expect(setDefaultProvider).not.toHaveBeenCalled()
+  })
+
+  it('clears the selection without touching the default provider id', async () => {
+    const store = createSelectionStore({ kind: 'acp', id: agent.id })
+    const setDefaultProvider = mock(async (_id: string) => {})
+
+    await commitChatTargetSelection(null, { setDefaultProvider }, store)
+
+    expect(await store.getValue()).toBeNull()
+    expect(setDefaultProvider).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.ts
@@ -170,6 +170,21 @@ export async function saveSidepanelChatTargetSelection(
   await targetStore.setValue(selection)
 }
 
+/**
+ * The single "change the selected chat target" side effect, shared by every
+ * surface (sidebar, home, settings). Persists the selection and, for an LLM
+ * target, also updates the default-provider id so both stores stay consistent.
+ * Keeping this in one place is what prevents surfaces from drifting apart.
+ */
+export async function commitChatTargetSelection(
+  selection: SidepanelChatTargetSelection | null,
+  deps: { setDefaultProvider: (providerId: string) => Promise<void> },
+  store?: SidepanelChatTargetSelectionWriter,
+): Promise<void> {
+  await saveSidepanelChatTargetSelection(selection, store)
+  if (selection?.kind === 'llm') await deps.setDefaultProvider(selection.id)
+}
+
 export async function clearSidepanelChatTargetSelectionForAgent(
   agentId: string,
   store?: SidepanelChatTargetSelectionReader &

--- a/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.ts
@@ -111,6 +111,41 @@ export function resolveSidepanelChatTarget({
     : undefined
 }
 
+export type RepairSelectionDecision =
+  | { repair: false }
+  | { repair: true; selection: SidepanelChatTargetSelection | null }
+
+/**
+ * Decides whether a persisted sidebar selection needs repair. It only repairs
+ * once the target lists are settled, so an ACP selection is never wiped while
+ * its agent is still loading (which would silently downgrade an ACP default to
+ * the LLM fallback on every startup).
+ */
+export function resolveRepairedSelection({
+  selection,
+  resolvedTarget,
+  ready,
+}: {
+  selection: SidepanelChatTargetSelection | null
+  resolvedTarget: SidepanelChatTarget | undefined
+  ready: boolean
+}): RepairSelectionDecision {
+  if (!ready || !selection) return { repair: false }
+  if (
+    resolvedTarget &&
+    resolvedTarget.kind === selection.kind &&
+    resolvedTarget.id === selection.id
+  ) {
+    return { repair: false }
+  }
+  return {
+    repair: true,
+    selection: resolvedTarget
+      ? { kind: resolvedTarget.kind, id: resolvedTarget.id }
+      : null,
+  }
+}
+
 export function toLlmProviderConfig(
   target: SidepanelChatTarget | undefined,
 ): LlmProviderConfig | undefined {

--- a/packages/browseros-agent/apps/app/modules/chat/use-chat-target-selection.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/use-chat-target-selection.ts
@@ -13,6 +13,7 @@ import {
   resolveSidepanelChatTarget,
   type SidepanelChatTarget,
   type SidepanelChatTargetSelection,
+  watchSidepanelChatTargetSelection,
 } from './sidepanel-chat-targets'
 
 /**
@@ -46,8 +47,17 @@ export function useChatTargetSelection() {
     loadSidepanelChatTargetSelection().then((selection) => {
       if (!cancelled) setTargetSelection(selection)
     })
+    // Live-sync across surfaces: changing the selection in the sidebar, home, or
+    // settings writes storage, and WXT's storage.watch (over browser.storage
+    // .onChanged) fires in every extension context, so the other surfaces update
+    // without a reload. Re-persisting the same value is a no-op, so this cannot
+    // loop with the repair effect.
+    const unwatch = watchSidepanelChatTargetSelection((selection) => {
+      setTargetSelection(selection)
+    })
     return () => {
       cancelled = true
+      unwatch()
     }
   }, [])
 

--- a/packages/browseros-agent/apps/app/modules/chat/use-chat-target-selection.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/use-chat-target-selection.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import useDeepCompareEffect from 'use-deep-compare-effect'
+import type { Provider } from '@/components/chat/chatComponentTypes'
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import { useAcpAgents } from '@/modules/agents/agents.hooks'
+import { useLlmProviders } from '@/modules/llm-providers/llm-providers.hooks'
+import { toProviderOption } from './chat-session-request'
+import {
+  buildSidepanelChatTargets,
+  commitChatTargetSelection,
+  loadSidepanelChatTargetSelection,
+  persistSidepanelChatTargetSelection,
+  resolveRepairedSelection,
+  resolveSidepanelChatTarget,
+  type SidepanelChatTarget,
+  type SidepanelChatTargetSelection,
+} from './sidepanel-chat-targets'
+
+/**
+ * Single source of truth for the selected chat target across every surface that
+ * picks one (the sidebar, the home composer, and anything added later). Owns the
+ * whole lifecycle: build targets from providers + agents, load the persisted
+ * selection, resolve the selected target (selection-first with a non-destructive
+ * fallback), repair genuinely-stale selections once loads settle, and change the
+ * selection via the shared `commitChatTargetSelection` side effect. Consolidating
+ * this here is what stops the "agent default does not persist" bug from recurring
+ * as new surfaces are added.
+ */
+export function useChatTargetSelection() {
+  const {
+    providers: llmProviders,
+    selectedProvider: selectedLlmProvider,
+    setDefaultProvider,
+    isLoading: isLoadingProviders,
+  } = useLlmProviders()
+  const {
+    agents,
+    loading: isLoadingAgents,
+    settled: agentsSettled,
+  } = useAcpAgents()
+
+  const [targetSelection, setTargetSelection] =
+    useState<SidepanelChatTargetSelection | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    loadSidepanelChatTargetSelection().then((selection) => {
+      if (!cancelled) setTargetSelection(selection)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const chatTargets = useMemo(
+    () =>
+      buildSidepanelChatTargets({
+        providers: llmProviders,
+        agents,
+      }),
+    [llmProviders, agents],
+  )
+  const providerOptions = useMemo(
+    () => chatTargets.map(toProviderOption),
+    [chatTargets],
+  )
+
+  const selectedChatTarget = useMemo(
+    () =>
+      resolveSidepanelChatTarget({
+        targets: chatTargets,
+        defaultProviderId: selectedLlmProvider?.id ?? llmProviders[0]?.id ?? '',
+        selection: targetSelection,
+      }),
+    [chatTargets, llmProviders, selectedLlmProvider, targetSelection],
+  )
+  const selectedProvider = useMemo(
+    () => (selectedChatTarget ? toProviderOption(selectedChatTarget) : null),
+    [selectedChatTarget],
+  )
+
+  useEffect(() => {
+    // Only repair once providers and agents are settled. Otherwise a stored ACP
+    // selection is wiped to the LLM fallback during the startup window where the
+    // agents fetch has not resolved yet and the agent is absent from the list.
+    const ready = !isLoadingProviders && agentsSettled
+    const decision = resolveRepairedSelection({
+      selection: targetSelection,
+      resolvedTarget: selectedChatTarget,
+      ready,
+    })
+    if (!decision.repair) return
+    setTargetSelection(decision.selection)
+    void persistSidepanelChatTargetSelection(selectedChatTarget)
+  }, [agentsSettled, isLoadingProviders, selectedChatTarget, targetSelection])
+
+  const selectedLlmProviderRef = useRef<LlmProviderConfig | null>(
+    selectedLlmProvider,
+  )
+  const selectedChatTargetRef = useRef<SidepanelChatTarget | undefined>(
+    selectedChatTarget,
+  )
+
+  useDeepCompareEffect(() => {
+    selectedLlmProviderRef.current = selectedLlmProvider
+  }, [selectedLlmProvider])
+
+  useEffect(() => {
+    selectedChatTargetRef.current = selectedChatTarget
+  }, [selectedChatTarget])
+
+  const selectChatTarget = useCallback(
+    async (target: SidepanelChatTarget | undefined) => {
+      selectedChatTargetRef.current = target
+      const selection = target ? { kind: target.kind, id: target.id } : null
+      setTargetSelection(selection)
+      await commitChatTargetSelection(selection, { setDefaultProvider })
+    },
+    [setDefaultProvider],
+  )
+
+  const selectProvider = useCallback(
+    (provider: Provider) => {
+      const target = chatTargets.find(
+        (entry) => entry.kind === provider.kind && entry.id === provider.id,
+      )
+      if (!target) return undefined
+      return selectChatTarget(target)
+    },
+    [chatTargets, selectChatTarget],
+  )
+
+  return {
+    llmProviders,
+    selectedLlmProvider,
+    selectedLlmProviderRef,
+    setDefaultProvider,
+    isLoadingProviders: isLoadingProviders || isLoadingAgents,
+    agents,
+    chatTargets,
+    providerOptions,
+    selectedChatTarget,
+    selectedChatTargetRef,
+    selectedProvider,
+    selectChatTarget,
+    selectProvider,
+  }
+}

--- a/packages/browseros-agent/apps/app/modules/chat/use-chat-target-selection.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/use-chat-target-selection.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import useDeepCompareEffect from 'use-deep-compare-effect'
 import type { Provider } from '@/components/chat/chatComponentTypes'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { useAcpAgents } from '@/modules/agents/agents.hooks'
@@ -101,7 +100,11 @@ export function useChatTargetSelection() {
     selectedChatTarget,
   )
 
-  useDeepCompareEffect(() => {
+  // selectedLlmProvider is memoized in useLlmProviders (stable reference until it
+  // actually changes), so a plain effect fires exactly when it changes. Not
+  // useDeepCompareEffect: its single dep is null before providers load, and that
+  // library throws when every dependency is a primitive.
+  useEffect(() => {
     selectedLlmProviderRef.current = selectedLlmProvider
   }, [selectedLlmProvider])
 

--- a/packages/browseros-agent/apps/app/screens/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/app/screens/agent-command/AgentCommandHome.tsx
@@ -12,8 +12,10 @@ import { toProviderOption } from '@/modules/chat/chat-session-request'
 import { stagePendingHomeMessage } from '@/modules/chat/pending-home-message'
 import {
   buildSidepanelChatTargets,
+  loadSidepanelChatTargetSelection,
   persistSidepanelChatTargetSelection,
   resolveSidepanelChatTarget,
+  type SidepanelChatTargetSelection,
 } from '@/modules/chat/sidepanel-chat-targets'
 import { useLlmProviders } from '@/modules/llm-providers/llm-providers.hooks'
 import { useActiveHint } from '@/screens/newtab/index/active-hint.hooks'
@@ -42,12 +44,6 @@ export const AgentCommandHome: FC = () => {
     capabilitiesLoading,
     supportsInlineChat,
   })
-  const [selectedProvider, setSelectedProvider] = useState<Provider | null>(
-    null,
-  )
-  const waitingForLlmCapabilities =
-    selectedProvider?.kind === 'llm' && llmRoutingMode === 'wait'
-
   const targets = useMemo(
     () =>
       buildSidepanelChatTargets({
@@ -61,22 +57,48 @@ export const AgentCommandHome: FC = () => {
     [targets],
   )
 
-  // Default the picker to the user's default LLM provider (BrowserOS out of the
-  // box) so the composer works with zero agents. Re-resolve if the current
-  // selection disappears (e.g. its provider/agent was removed).
+  const [targetSelection, setTargetSelection] =
+    useState<SidepanelChatTargetSelection | null>(null)
+
   useEffect(() => {
-    if (targets.length === 0) return
-    const stillValid =
-      selectedProvider &&
-      providerOptions.some(
-        (option) =>
-          option.id === selectedProvider.id &&
-          option.kind === selectedProvider.kind,
-      )
-    if (stillValid) return
-    const fallback = resolveSidepanelChatTarget({ targets, defaultProviderId })
-    setSelectedProvider(fallback ? toProviderOption(fallback) : null)
-  }, [targets, providerOptions, selectedProvider, defaultProviderId])
+    let cancelled = false
+    loadSidepanelChatTargetSelection().then((selection) => {
+      if (!cancelled) setTargetSelection(selection)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Derive the picker from the persisted selection so a third-party agent chosen
+  // here (or in the sidebar/settings) is restored on load. resolveSidepanelChatTarget
+  // falls back to the default LLM provider (BrowserOS out of the box) until an ACP
+  // agent finishes loading, so the composer stays usable with zero agents.
+  const selectedChatTarget = useMemo(
+    () =>
+      resolveSidepanelChatTarget({
+        targets,
+        defaultProviderId,
+        selection: targetSelection,
+      }),
+    [targets, defaultProviderId, targetSelection],
+  )
+  const selectedProvider = useMemo(
+    () => (selectedChatTarget ? toProviderOption(selectedChatTarget) : null),
+    [selectedChatTarget],
+  )
+  const waitingForLlmCapabilities =
+    selectedProvider?.kind === 'llm' && llmRoutingMode === 'wait'
+
+  const handleSelectProvider = (provider: Provider) => {
+    const target = targets.find(
+      (entry) => entry.kind === provider.kind && entry.id === provider.id,
+    )
+    if (!target) return
+    setTargetSelection({ kind: target.kind, id: target.id })
+    void persistSidepanelChatTargetSelection(target)
+    if (target.kind === 'llm') void setDefaultProvider(target.id)
+  }
 
   const handleSend = async (input: ConversationInputSendInput) => {
     if (!selectedProvider) return
@@ -142,7 +164,7 @@ export const AgentCommandHome: FC = () => {
               variant="home"
               providers={providerOptions}
               selectedProvider={selectedProvider}
-              onSelectProvider={setSelectedProvider}
+              onSelectProvider={handleSelectProvider}
               onSend={handleSend}
               streaming={false}
               disabled={!selectedProvider || waitingForLlmCapabilities}

--- a/packages/browseros-agent/apps/app/screens/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/app/screens/agent-command/AgentCommandHome.tsx
@@ -1,23 +1,13 @@
-import { type FC, useEffect, useMemo, useState } from 'react'
+import type { FC } from 'react'
 import { useNavigate } from 'react-router'
-import type { Provider } from '@/components/chat/chatComponentTypes'
 import { BrowserClawPromoBanner } from '@/components/promo/BrowserClawPromoBanner'
 import { ProductHuntBanner } from '@/components/promo/ProductHuntBanner'
 import { Feature } from '@/lib/browseros/capabilities'
 import { createBrowserOSAction } from '@/lib/chat-actions/types'
 import { openSidePanelWithSearch } from '@/lib/messaging/sidepanel/openSidepanelWithSearch'
-import { useAcpAgents } from '@/modules/agents/agents.hooks'
 import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
-import { toProviderOption } from '@/modules/chat/chat-session-request'
 import { stagePendingHomeMessage } from '@/modules/chat/pending-home-message'
-import {
-  buildSidepanelChatTargets,
-  loadSidepanelChatTargetSelection,
-  persistSidepanelChatTargetSelection,
-  resolveSidepanelChatTarget,
-  type SidepanelChatTargetSelection,
-} from '@/modules/chat/sidepanel-chat-targets'
-import { useLlmProviders } from '@/modules/llm-providers/llm-providers.hooks'
+import { useChatTargetSelection } from '@/modules/chat/use-chat-target-selection'
 import { useActiveHint } from '@/screens/newtab/index/active-hint.hooks'
 import { ImportDataHint } from '@/screens/newtab/index/ImportDataHint'
 import { RecentSites } from '@/screens/newtab/index/RecentSites'
@@ -32,85 +22,35 @@ import { resolveHomeLlmRoutingMode } from './home-compose.helpers'
 export const AgentCommandHome: FC = () => {
   const navigate = useNavigate()
   const activeHint = useActiveHint()
-  const {
-    providers: llmProviders,
-    defaultProviderId,
-    setDefaultProvider,
-  } = useLlmProviders()
-  const { agents } = useAcpAgents()
   const { supports, isLoading: capabilitiesLoading } = useCapabilities()
   const supportsInlineChat = supports(Feature.NEWTAB_CHAT_SUPPORT)
   const llmRoutingMode = resolveHomeLlmRoutingMode({
     capabilitiesLoading,
     supportsInlineChat,
   })
-  const targets = useMemo(
-    () =>
-      buildSidepanelChatTargets({
-        providers: llmProviders,
-        agents,
-      }),
-    [llmProviders, agents],
-  )
-  const providerOptions = useMemo(
-    () => targets.map(toProviderOption),
-    [targets],
-  )
-
-  const [targetSelection, setTargetSelection] =
-    useState<SidepanelChatTargetSelection | null>(null)
-
-  useEffect(() => {
-    let cancelled = false
-    loadSidepanelChatTargetSelection().then((selection) => {
-      if (!cancelled) setTargetSelection(selection)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  // Derive the picker from the persisted selection so a third-party agent chosen
-  // here (or in the sidebar/settings) is restored on load. resolveSidepanelChatTarget
-  // falls back to the default LLM provider (BrowserOS out of the box) until an ACP
-  // agent finishes loading, so the composer stays usable with zero agents.
-  const selectedChatTarget = useMemo(
-    () =>
-      resolveSidepanelChatTarget({
-        targets,
-        defaultProviderId,
-        selection: targetSelection,
-      }),
-    [targets, defaultProviderId, targetSelection],
-  )
-  const selectedProvider = useMemo(
-    () => (selectedChatTarget ? toProviderOption(selectedChatTarget) : null),
-    [selectedChatTarget],
-  )
+  // Shared selection: the picker is derived from the persisted selection (kept in
+  // sync with the sidebar and settings), so a third-party agent chosen here is
+  // restored on load and falls back to the default LLM provider while agents load.
+  const {
+    chatTargets,
+    providerOptions,
+    selectedProvider,
+    selectProvider,
+    selectChatTarget,
+  } = useChatTargetSelection()
   const waitingForLlmCapabilities =
     selectedProvider?.kind === 'llm' && llmRoutingMode === 'wait'
-
-  const handleSelectProvider = (provider: Provider) => {
-    const target = targets.find(
-      (entry) => entry.kind === provider.kind && entry.id === provider.id,
-    )
-    if (!target) return
-    setTargetSelection({ kind: target.kind, id: target.id })
-    void persistSidepanelChatTargetSelection(target)
-    if (target.kind === 'llm') void setDefaultProvider(target.id)
-  }
 
   const handleSend = async (input: ConversationInputSendInput) => {
     if (!selectedProvider) return
     if (selectedProvider.kind === 'llm' && llmRoutingMode === 'wait') return
-    const target = targets.find(
+    const target = chatTargets.find(
       (entry) =>
         entry.kind === selectedProvider.kind &&
         entry.id === selectedProvider.id,
     )
     if (!target) return
-    await persistSidepanelChatTargetSelection(target)
-    if (target.kind === 'llm') await setDefaultProvider(target.id)
+    await selectChatTarget(target)
     if (target.kind === 'llm' && llmRoutingMode === 'sidepanel') {
       const action = createBrowserOSAction({
         mode: 'chat',
@@ -164,7 +104,7 @@ export const AgentCommandHome: FC = () => {
               variant="home"
               providers={providerOptions}
               selectedProvider={selectedProvider}
-              onSelectProvider={handleSelectProvider}
+              onSelectProvider={selectProvider}
               onSend={handleSend}
               streaming={false}
               disabled={!selectedProvider || waitingForLlmCapabilities}

--- a/packages/browseros-agent/apps/app/screens/ai-settings/default-chat-target.hooks.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/default-chat-target.hooks.ts
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { sentry } from '@/lib/sentry/sentry'
 import {
+  commitChatTargetSelection,
   loadSidepanelChatTargetSelection,
   type SidepanelChatTargetSelection,
-  saveSidepanelChatTargetSelection,
   watchSidepanelChatTargetSelection,
 } from '@/modules/chat/sidepanel-chat-targets'
 import { resolveEffectiveDefaultTarget } from './default-chat-target.helpers'
@@ -59,12 +59,12 @@ export function useDefaultChatTarget({
     }
   }, [])
 
-  const persistSelection = (next: SidepanelChatTargetSelection) => {
+  const selectTarget = (next: SidepanelChatTargetSelection) => {
     setSelection(next)
-    saveSidepanelChatTargetSelection(next).catch((error) => {
+    commitChatTargetSelection(next, { setDefaultProvider }).catch((error) => {
       sentry.captureException(error, {
         extra: {
-          message: 'Failed to persist default chat-target selection',
+          message: 'Failed to change default chat target',
           targetId: next.id,
           targetKind: next.kind,
         },
@@ -73,27 +73,11 @@ export function useDefaultChatTarget({
   }
 
   const selectProvider = (providerId: string) => {
-    setDefaultProvider(providerId).catch((error) => {
-      sentry.captureException(error, {
-        extra: {
-          message: 'Failed to persist default provider id',
-          providerId,
-        },
-      })
-    })
-    persistSelection({ kind: 'llm', id: providerId })
+    selectTarget({ kind: 'llm', id: providerId })
   }
 
   const selectAgent = (agentId: string) => {
-    persistSelection({ kind: 'acp', id: agentId })
-  }
-
-  const selectTarget = (next: SidepanelChatTargetSelection) => {
-    if (next.kind === 'llm') {
-      selectProvider(next.id)
-    } else {
-      selectAgent(next.id)
-    }
+    selectTarget({ kind: 'acp', id: agentId })
   }
 
   const effectiveTarget = resolveEffectiveDefaultTarget({


### PR DESCRIPTION
## Problem

Selecting a third-party ("3p") agent as the default does not stick. It reverts to the default LLM provider. This showed up in two surfaces: the sidebar provider picker and the home-page composer.

## Root causes

Both surfaces persist the selection to the shared `sidepanel-chat-target-selection` storage but fail to honor it for agents.

- Sidebar: a repair effect in `useChatRefs` overwrote the stored selection on startup. The stored selection and LLM providers load from local storage immediately, but agents load from a fetch to the local agent server. `useAcpAgents().loading` (via `query.isLoading`) briefly reads false on the render the query flips enabled, with an empty agent list, so the repair effect resolved the stored agent to the LLM fallback and re-persisted it before the agents arrived. A failed agents fetch triggered the same wipe (`query.isFetched` is also true after an error).
- Home composer: `AgentCommandHome` resolved its picker on load via `resolveSidepanelChatTarget` without passing the stored selection, and persisted only on send, so an agent choice was never restored: it always reset to the default LLM provider.

## Fix

- `useAcpAgents`: add a gap-free `settled` signal, based on `query.isSuccess` (extracted into a pure `computeAgentsSettled` helper), so a not-yet-loaded or failed agent list is never treated as authoritative.
- Sidebar (`useChatRefs`): gate the repair on providers and agents both being settled, and route the decision through a pure `resolveRepairedSelection` helper, so a stored agent selection is never repaired away while agents load.
- Home (`AgentCommandHome`): derive the picker from the persisted selection (shared with the sidebar and settings) and persist on select, so an agent default is restored on load. It still falls back to the default LLM provider while agents load, so the composer stays usable with zero agents.

## Surface sweep

Checked every place that selects or persists a chat target:
- Sidebar (`useChatRefs`) and `/home/chat` (which reuses the same chat session) are both covered by the sidebar fix.
- Settings (`useDefaultChatTarget`) already persists an agent selection on explicit select and only derives its display, so it has no destructive auto-repair. No change.
- The scheduled-task dialog uses a per-task form field, not a persisted default. Out of scope.
- The home composer was the remaining gap, fixed here.

## Tests

Pure-helper unit tests for `resolveRepairedSelection` (including the not-ready keep case) and `computeAgentsSettled` (including the failed-fetch case). The home composer reuses `resolveSidepanelChatTarget`, whose agent-restore path is already covered. Typecheck and Biome clean; target and agent suites pass.

## Unification (same PR)

Beyond the fixes above, the selection orchestration is consolidated so this class of bug cannot recur: a shared `commitChatTargetSelection` change-provider side effect (persist selection + LLM default coupling) used by all surfaces, and a `useChatTargetSelection` hook owning the selection lifecycle that the sidebar (`useChatRefs`) and home composer (`AgentCommandHome`) now delegate to. Settings routes its radio actions through the same shared side effect while keeping its own display. Pure refactor, behavior parity; typecheck, Biome, and the target/agent suites pass.
