### PR TITLE
chore(deps): require a 3-day minimum release age for bun installs

### DIFF
--- a/packages/browseros-agent/bunfig.toml
+++ b/packages/browseros-agent/bunfig.toml
@@ -13,3 +13,11 @@ timeout = 30000
 
 [install]
 linker = "isolated"
+
+# Do not install dependency versions published less than 3 days ago: a brand
+# new release has not had time to be flagged if it is malicious or broken.
+# Applies to fresh resolutions (bun add / non-frozen bun install). CI runs
+# --frozen-lockfile, which validates the committed lock and is unaffected.
+# Packages that must track latest are excluded per developer in the user-level
+# bunfig, not here.
+minimumReleaseAge = 259200 # 3 days in seconds


### PR DESCRIPTION
Adds `minimumReleaseAge = 259200` (3 days) to the workspace `bunfig.toml` so `bun install` refuses dependency versions published less than 3 days ago. A brand-new release has not had time to be flagged if it is malicious or broken.

Scope and safety:
- Applies to fresh resolutions (`bun add`, non-frozen `bun install`), which is the gap Dependabot's cooldown does not cover: manual dependency changes.
- CI runs `bun install --frozen-lockfile`, which validates the committed lockfile without re-resolving, so it is unaffected (verified: a frozen install with the gate present reports no changes).
- Packages that must track latest stay excluded per developer in the user-level bunfig, not in the repo.

Dependabot already enforces the same 3-day window via `cooldown: default-days: 3` in `.github/dependabot.yml`, so no change is needed there; this covers the non-Dependabot path.