### PR TITLE
feat(app): typed hc client for conversations and agents via idiomatic protected-route middleware

### DIFF
--- a/packages/browseros-agent/apps/app/lib/rpc/getClient.ts
+++ b/packages/browseros-agent/apps/app/lib/rpc/getClient.ts
@@ -1,19 +1,23 @@
-import type { AppType } from '@browseros/server'
+import type { AgentRoutes, ConversationRoutes } from '@browseros/server'
 import { hc } from 'hono/client'
 import { getAgentServerUrl } from '../browseros/helpers'
 
-export type RpcClient = ReturnType<typeof hc<AppType>>
+// Per-domain typed clients. The server exports one contract per protected route
+// group (see rpc.ts); each client is pointed at that group's mount path so the
+// paths address directly (client.conversations.index.$get()).
+export interface RpcClient {
+  conversations: ReturnType<typeof hc<ConversationRoutes>>
+  agents: ReturnType<typeof hc<AgentRoutes>>
+}
 
 let clientPromise: Promise<RpcClient> | null = null
 
 export const getClient = (): Promise<RpcClient> => {
   if (!clientPromise) {
-    clientPromise = getAgentServerUrl().then((serverUrl) =>
-      hc<AppType>(serverUrl),
-    )
+    clientPromise = getAgentServerUrl().then((serverUrl) => ({
+      conversations: hc<ConversationRoutes>(`${serverUrl}/conversations`),
+      agents: hc<AgentRoutes>(`${serverUrl}/agents`),
+    }))
   }
   return clientPromise
 }
-
-// Pre-resolve the client immediately when the module is imported
-getClient()

--- a/packages/browseros-agent/apps/app/modules/agents/agents.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/agents/agents.hooks.ts
@@ -1,14 +1,11 @@
+import type { AgentRoutes } from '@browseros/server'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { hc } from 'hono/client'
 import { Feature } from '@/lib/browseros/capabilities'
 import { useAgentServerUrl } from '@/modules/browseros/agent-server-url.hooks'
 import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
-import type { AcpAgent, AcpAgentType } from './acp-agent-types'
-import { buildAgentApiUrl } from './agent-api-url'
+import type { AcpAgentType } from './acp-agent-types'
 import { computeAgentsSettled } from './agents.helpers'
-
-interface AcpAgentsResponse {
-  agents: AcpAgent[]
-}
 
 interface CreateAcpAgentInput {
   name: string
@@ -19,21 +16,15 @@ interface CreateAcpAgentInput {
 
 const AGENTS_QUERY_KEY = 'acp-agents'
 
-async function agentsFetch<T>(
-  baseUrl: string,
-  path: string,
-  init?: RequestInit,
-): Promise<T> {
-  const response = await fetch(buildAgentApiUrl(baseUrl, path), init)
-  if (!response.ok) {
-    const body = (await response.json().catch(() => ({}))) as {
-      error?: string
-    }
-    throw new Error(
-      body.error ?? `Request failed with status ${response.status}`,
-    )
-  }
-  return response.json() as Promise<T>
+function agentsClient(baseUrl: string) {
+  return hc<AgentRoutes>(`${baseUrl}/agents`)
+}
+
+async function agentRequestError(response: Response): Promise<Error> {
+  const body = (await response.json().catch(() => ({}))) as { error?: string }
+  return new Error(
+    body.error ?? `Request failed with status ${response.status}`,
+  )
 }
 
 export function useAcpAgents(enabled = true) {
@@ -44,9 +35,13 @@ export function useAcpAgents(enabled = true) {
     isLoading: urlLoading,
     error: urlError,
   } = useAgentServerUrl()
-  const query = useQuery<AcpAgentsResponse, Error>({
+  const query = useQuery({
     queryKey: [AGENTS_QUERY_KEY, baseUrl],
-    queryFn: () => agentsFetch(baseUrl as string, '/'),
+    queryFn: async () => {
+      const response = await agentsClient(baseUrl as string).index.$get()
+      if (!response.ok) throw await agentRequestError(response)
+      return response.json()
+    },
     enabled: Boolean(baseUrl) && !urlLoading && enabled && agentsSupported,
   })
 
@@ -79,11 +74,9 @@ export function useCreateAcpAgent() {
       if (!baseUrl || isLoading) {
         throw new Error('BrowserOS agent server URL is not ready')
       }
-      const result = await agentsFetch<{ agent: AcpAgent }>(baseUrl, '/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(input),
-      })
+      const response = await agentsClient(baseUrl).index.$post({ json: input })
+      if (!response.ok) throw await agentRequestError(response)
+      const result = await response.json()
       return result.agent
     },
     onSuccess: () =>
@@ -100,11 +93,11 @@ export function useDeleteAcpAgent() {
       if (!baseUrl || isLoading) {
         throw new Error('BrowserOS agent server URL is not ready')
       }
-      return agentsFetch<{ success: true }>(
-        baseUrl,
-        `/${encodeURIComponent(agentId)}`,
-        { method: 'DELETE' },
-      )
+      const response = await agentsClient(baseUrl)[':agentId'].$delete({
+        param: { agentId },
+      })
+      if (!response.ok) throw await agentRequestError(response)
+      return response.json()
     },
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: [AGENTS_QUERY_KEY] }),

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations.hooks.ts
@@ -1,5 +1,7 @@
+import type { ConversationRoutes } from '@browseros/server'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { UIMessage } from 'ai'
+import { hc } from 'hono/client'
 import { removeConversationExecutionHistory } from '@/lib/execution-history/storage'
 import { resolveAgentServerUrlWithRetry } from '@/modules/browseros/agent-server-url.helpers'
 import { useAgentServerUrl } from '@/modules/browseros/agent-server-url.hooks'
@@ -12,31 +14,20 @@ export interface ServerConversationSummary {
   lastUserMessage: string
 }
 
-interface ConversationListResponse {
-  conversations: Array<{
-    id: string
-    lastMessagedAt: number
-    lastUserMessage?: string
-  }>
-}
-
-interface ConversationDetailResponse {
-  conversation: { id: string; messages: UIMessage[] }
-}
-
-async function conversationsUrl(path: string): Promise<string> {
+async function conversationsClient() {
   const baseUrl = await resolveAgentServerUrlWithRetry()
-  return `${baseUrl}/conversations${path}`
+  return hc<ConversationRoutes>(`${baseUrl}/conversations`)
 }
 
 export async function fetchServerConversations(): Promise<
   ServerConversationSummary[]
 > {
-  const response = await fetch(await conversationsUrl(''))
+  const client = await conversationsClient()
+  const response = await client.index.$get()
   if (!response.ok) {
     throw new Error(`Failed to load conversations (${response.status})`)
   }
-  const { conversations } = (await response.json()) as ConversationListResponse
+  const { conversations } = await response.json()
   return conversations.map((conversation) => ({
     id: conversation.id,
     lastMessagedAt: conversation.lastMessagedAt,
@@ -47,15 +38,24 @@ export async function fetchServerConversations(): Promise<
 export async function fetchServerConversation(
   conversationId: string,
 ): Promise<{ id: string; messages: UIMessage[] } | null> {
-  const response = await fetch(
-    await conversationsUrl(`/${encodeURIComponent(conversationId)}`),
-  )
+  const client = await conversationsClient()
+  const response = await client[':conversationId'].$get({
+    param: { conversationId },
+  })
   if (response.status === 404) return null
   if (!response.ok) {
     throw new Error(`Failed to load conversation (${response.status})`)
   }
-  const { conversation } = (await response.json()) as ConversationDetailResponse
-  return { id: conversation.id, messages: conversation.messages }
+  const data = await response.json()
+  if (!('conversation' in data)) {
+    throw new Error('Failed to load conversation')
+  }
+  // hc applies a JSON transform to the response type, and UIMessage[]'s union is
+  // too deep for the compiler to instantiate through it (TS2589). The runtime
+  // shape is UIMessage[] exactly as the server stored it, so assert it here at
+  // the JSON boundary.
+  const messages = data.conversation.messages as UIMessage[]
+  return { id: data.conversation.id, messages }
 }
 
 export async function importServerConversation(conversation: {
@@ -63,17 +63,14 @@ export async function importServerConversation(conversation: {
   messages: UIMessage[]
   lastMessagedAt: number
 }): Promise<void> {
-  const response = await fetch(
-    await conversationsUrl(`/${encodeURIComponent(conversation.id)}`),
-    {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        messages: conversation.messages,
-        lastMessagedAt: conversation.lastMessagedAt,
-      }),
+  const client = await conversationsClient()
+  const response = await client[':conversationId'].$put({
+    param: { conversationId: conversation.id },
+    json: {
+      messages: conversation.messages,
+      lastMessagedAt: conversation.lastMessagedAt,
     },
-  )
+  })
   if (!response.ok) {
     throw new Error(`Failed to import conversation (${response.status})`)
   }
@@ -83,10 +80,10 @@ export async function importServerConversation(conversation: {
 export async function deleteServerConversationRow(
   conversationId: string,
 ): Promise<void> {
-  const response = await fetch(
-    await conversationsUrl(`/${encodeURIComponent(conversationId)}`),
-    { method: 'DELETE' },
-  )
+  const client = await conversationsClient()
+  const response = await client[':conversationId'].$delete({
+    param: { conversationId },
+  })
   if (!response.ok && response.status !== 404) {
     throw new Error(`Failed to delete conversation (${response.status})`)
   }

--- a/packages/browseros-agent/apps/server/src/api/routes/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/index.ts
@@ -72,10 +72,6 @@ export function createApiRoutes(deps: CreateApiRoutesDeps) {
       .route('/shutdown', createShutdownRoute({ onShutdown }))
       .route('/status', createStatusRoute({ browser, activity }))
       .route('/test-provider', createProviderRoutes({ browserosId }))
-      .route(
-        '/acpx/probe',
-        protectedAppRoutes(createAcpxProbeRoutes({ resourcesDir })),
-      )
       .route('/refine-prompt', createRefinePromptRoutes({ browserosId }))
       .route('/oauth', oauthRoutes(tokenManager))
       .route('/klavis', createKlavisRoutes({ klavis }))
@@ -115,13 +111,18 @@ export function createApiRoutes(deps: CreateApiRoutesDeps) {
           acpRuntime,
         }),
       )
-      .route('/agents', protectedAppRoutes(resolvedAgentRoutes))
-      .route('/conversations', protectedAppRoutes(createConversationRoutes()))
+      // Protected routes. The extension-origin auth middleware is applied per
+      // path prefix (Hono's `/prefix/*` also matches the bare list route), so
+      // unregistered paths stay 404 and public routes are untouched. Routes are
+      // mounted directly; the typed client derives per-route types from the
+      // factories (see rpc.ts), not from this composition.
+      .use('/acpx/probe/*', requireTrustedAppOrigin())
+      .use('/agents/*', requireTrustedAppOrigin())
+      .use('/conversations/*', requireTrustedAppOrigin())
+      .route('/acpx/probe', createAcpxProbeRoutes({ resourcesDir }))
+      .route('/agents', resolvedAgentRoutes)
+      .route('/conversations', createConversationRoutes())
   )
-}
-
-function protectedAppRoutes(routes: Hono<Env>) {
-  return new Hono<Env>().use('/*', requireTrustedAppOrigin()).route('/', routes)
 }
 
 function oauthRoutes(tokenManager: OAuthTokenManager | null) {

--- a/packages/browseros-agent/apps/server/src/rpc.ts
+++ b/packages/browseros-agent/apps/server/src/rpc.ts
@@ -1,4 +1,14 @@
-import type { createHttpServer } from './api/server'
+import type { createAgentRoutes } from './api/routes/agents'
+import type { createConversationRoutes } from './api/routes/conversations'
 
-// Export type for client inference (e.g., hono/client)
-export type AppType = Awaited<ReturnType<typeof createHttpServer>>['app']
+// Per-route client contracts for `hc`. Each protected route module is mounted at
+// its own path in createApiRoutes, and the extension builds a small typed client
+// per domain: hc<ConversationRoutes>(`${serverUrl}/conversations`).
+//
+// These are derived per-route (not from the whole app) on purpose: the full app
+// type overflows the compiler (TS2589) because of /chat's AI-SDK types, and the
+// Hono RPC guide recommends splitting so tsserver does not instantiate every
+// route at once. Deriving from the factory's ReturnType keeps this type-only (no
+// runtime, no wrapper) while tracking the route definitions automatically.
+export type ConversationRoutes = ReturnType<typeof createConversationRoutes>
+export type AgentRoutes = ReturnType<typeof createAgentRoutes>

--- a/packages/browseros-agent/apps/server/tests/api/routes/conversations-rpc.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/conversations-rpc.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Exercises the conversations routes through the typed hc client (the same
+ * contract the extension consumes), asserting the typed response shapes resolve
+ * end to end. This locks the `ConversationRoutes` type export against server
+ * route changes.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { UIMessage } from 'ai'
+import { hc } from 'hono/client'
+import { createConversationRoutes } from '../../../src/api/routes/conversations'
+import type { ConversationRoutes } from '../../../src/rpc'
+
+const ID = '00000000-0000-4000-8000-000000000001'
+const MISSING = '00000000-0000-4000-8000-0000000009ff'
+
+function memoryStore() {
+  const rows = new Map<string, { id: string; messages: UIMessage[] }>([
+    [ID, { id: ID, messages: [{ id: 'm1', role: 'user', parts: [] }] }],
+  ])
+  return {
+    list: async () =>
+      [...rows.values()].map((r) => ({
+        id: r.id,
+        lastMessagedAt: 1,
+        lastUserMessage: 'hi',
+      })),
+    get: async (id: string) => rows.get(id) ?? null,
+    delete: async (id: string) => rows.delete(id),
+    insertIfAbsent: async (input: { id: string; messages: UIMessage[] }) => {
+      if (rows.has(input.id)) return null
+      const row = { id: input.id, messages: input.messages }
+      rows.set(input.id, row)
+      return row
+    },
+  }
+}
+
+function client() {
+  const routes = createConversationRoutes({ store: memoryStore() as never })
+  return hc<ConversationRoutes>('http://local', {
+    fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+      routes.request(input as never, init),
+  })
+}
+
+describe('conversations routes via typed hc', () => {
+  it('lists conversations with typed summaries', async () => {
+    const res = await client().index.$get()
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.conversations[0]?.id).toBe(ID)
+  })
+
+  it('gets a conversation and narrows the found branch', async () => {
+    const res = await client()[':conversationId'].$get({
+      param: { conversationId: ID },
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect('conversation' in data && data.conversation.id).toBe(ID)
+  })
+
+  it('returns 404 for a missing conversation', async () => {
+    const res = await client()[':conversationId'].$get({
+      param: { conversationId: MISSING },
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('imports (insert-if-absent) and reports imported', async () => {
+    const res = await client()[':conversationId'].$put({
+      param: { conversationId: '00000000-0000-4000-8000-0000000000aa' },
+      json: { messages: [], lastMessagedAt: 2 },
+    })
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.imported).toBe(true)
+  })
+
+  it('deletes a conversation', async () => {
+    const res = await client()[':conversationId'].$delete({
+      param: { conversationId: ID },
+    })
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## Problem

The extension's local-server calls were all hand-built `fetch` with hand-typed response shapes, and the typed Hono `hc` client was mounted but never used (the "dead RPC seam"). The blocker was a route-wrapping helper, `protectedAppRoutes(routes: Hono<Env>)`, whose `Hono<Env>` parameter widened the mounted routes and stripped their sub-route types, so `hc<AppType>` could not resolve `/conversations` or `/agents`.

## Fix (server)

- Replace the `protectedAppRoutes` wrapper with the existing `requireTrustedAppOrigin()` middleware applied per path prefix (`.use('/agents/*', ...)` etc.) and mount the routes directly. Hono's `/prefix/*` also matches the bare list route, so gating is unchanged; unregistered paths stay 404 and public routes are untouched (verified by runtime probe and the existing integration test, including the `/chat-v2` 404 case).
- Export per-route client contracts (`ConversationRoutes`, `AgentRoutes`) from the route factories via `ReturnType`, instead of a whole-app type. The whole-app type overflows the compiler (TS2589) via `/chat`'s AI-SDK types; this is Hono's documented split for large apps and keeps the client type small.

## Fix (extension)

- Migrate the `conversations` (list/get/import/delete) and `agents` (list/create/delete) lanes from hand-built `fetch` to the typed `hc` client, one per route group pointed at its mount path. Request params and response shapes are now inferred from the server routes, so the client cannot drift from the contract. Behavior is unchanged (same requests, same 404 handling).
- One JSON-boundary assert remains, for `UIMessage[]` only: its union is too deep for the compiler to instantiate through hc's response transform (TS2589), and the runtime shape is `UIMessage[]` exactly as stored.

## Tests

A server-side test exercises the conversations routes through the typed `hc` client (the same contract the extension consumes), locking the type export against route changes. Existing routing, gating, integration, conversations, and agents suites pass; server + app typecheck and Biome clean.

## Scope

This is Track A of the route-architecture plan: the type unlock. It removes the genuine anti-patterns (the type-widening wrapper) without touching the `createXxxRoutes` factories, which per the Hono docs are not the discouraged pattern (they define handlers inline, so params infer). Eliminating the factories in favor of module-const routes with context-based DI is a separate, larger refactor (Track B) to be decided deliberately. The now-repurposed `RpcClientProvider`/`getClient` seam is left compiling; its full removal is a trivial follow-up.
