### PR TITLE
fix(app): never repair an ACP chat-target selection (agent default reverts to BrowserOS)

### DIFF
--- a/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.test.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.test.ts
@@ -122,10 +122,24 @@ describe('resolveRepairedSelection', () => {
     ).toEqual({ repair: false })
   })
 
-  it('repairs a stale selection to the resolved fallback once ready', () => {
+  it('keeps a stale ACP selection even when ready (never wiped by the fetch-backed list)', () => {
+    // Regression guard: the agents list is fetch-backed and can be stale or
+    // cross-context-stale (a persisted cache, or another context that has not
+    // refetched a newly-created agent). An absent agent must NOT trigger a repair
+    // that silently downgrades the ACP default to the LLM fallback.
     expect(
       resolveRepairedSelection({
         selection: { kind: 'acp', id: 'deleted-agent' },
+        resolvedTarget: llmTarget,
+        ready: true,
+      }),
+    ).toEqual({ repair: false })
+  })
+
+  it('repairs a stale LLM selection to the resolved fallback once ready', () => {
+    expect(
+      resolveRepairedSelection({
+        selection: { kind: 'llm', id: 'removed-provider' },
         resolvedTarget: llmTarget,
         ready: true,
       }),

--- a/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/sidepanel-chat-targets.ts
@@ -116,10 +116,15 @@ export type RepairSelectionDecision =
   | { repair: true; selection: SidepanelChatTargetSelection | null }
 
 /**
- * Decides whether a persisted sidebar selection needs repair. It only repairs
- * once the target lists are settled, so an ACP selection is never wiped while
- * its agent is still loading (which would silently downgrade an ACP default to
- * the LLM fallback on every startup).
+ * Decides whether a persisted sidebar selection needs repair. It never repairs
+ * an ACP selection: the agents list is fetch-backed and can be stale (a
+ * persisted react-query cache, or a different extension context that has not
+ * refetched a newly-created agent), so repairing here would wipe a valid ACP
+ * default and silently downgrade it to the LLM fallback. Stale ACP selections
+ * are cleaned by `clearSidepanelChatTargetSelectionForAgent` on delete, and
+ * `resolveSidepanelChatTarget` already falls back non-destructively at render.
+ * Only LLM selections are repaired, since providers load reliably from local
+ * storage, and only once loads are settled.
  */
 export function resolveRepairedSelection({
   selection,
@@ -131,6 +136,7 @@ export function resolveRepairedSelection({
   ready: boolean
 }): RepairSelectionDecision {
   if (!ready || !selection) return { repair: false }
+  if (selection.kind === 'acp') return { repair: false }
   if (
     resolvedTarget &&
     resolvedTarget.kind === selection.kind &&


### PR DESCRIPTION
## Problem

Selecting a coding agent as the default (in `/settings/ai` or the picker) could revert to BrowserOS. It looked intermittent and only hit a newly-created agent, and a server restart made it go away.

## Root cause (confirmed by runtime tracing)

The selection is shared across contexts via storage. The settings page resolves it correctly. But the selection **repair effect** lives in the sidebar / newtab-chat context (`useChatTargetSelection`), and it runs against the **fetch-backed agents list**, which can be stale:

- a persisted react-query cache, or
- a different extension context that has not refetched a just-created agent.

When that context doesn't find the just-selected agent in its stale list, `resolveRepairedSelection` treats the selection as stale, repairs it to the LLM fallback, and overwrites shared storage. The settings page watches that overwrite and reverts to BrowserOS. Restarting the server refetched the agents in that context, the list became complete, and the repair stopped firing — which is exactly why it self-healed. Tracing confirmed the settings side resolves correctly while a separate context does the overwrite.

This is the residual flagged on the ACP-default PR (#2359): "cached success still permits repair."

## Fix

`resolveRepairedSelection` **never repairs an ACP selection**. The agents list is fetch-backed and cannot be trusted as authoritative for a destructive repair. Nothing is lost:

- genuine agent removal is already handled by `clearSidepanelChatTargetSelectionForAgent` on delete, and
- `resolveSidepanelChatTarget` already falls back to the default LLM provider non-destructively at render.

Only LLM selections are repaired, since providers load reliably from local storage.

## Tests

New regression guard: a stale ACP selection is kept (never wiped) even when loads are settled. Updated the fallback-repair test to use a stale LLM selection (which still repairs). Target and chat-session suites pass; app typecheck and Biome clean.
