### PR TITLE
fix(server): spawn ACP probe in a writable home dir, not the sidecar cwd

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/acpx-probe/probeAgent.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/acpx-probe/probeAgent.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { homedir } from 'node:os'
 import type { AcpAgentType } from '@browseros/shared/schemas/agent'
 import { type AgentProbeResult, probeAgent as runProbe } from 'acp-probe'
 import { resolveAcpSpawnCommand } from '../../../lib/agents/host-acp/launcher'
@@ -76,8 +77,12 @@ export async function probeAcpAgent(
     launcherSource: launcher.source,
   })
 
+  // Spawn the adapter in a writable dir: acp-probe defaults to the server's
+  // process.cwd(), which is the read-only app bundle in a packaged build, so
+  // the adapter fails to create session files. Matches the chat provider's cwd.
   const result = await runProbe({
     argv: launcher.argv,
+    cwd: homedir(),
     authPolicy: 'skip',
     timeoutMs,
   })

--- a/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.test.ts
@@ -84,6 +84,13 @@ describe('probeAcpAgent — input shape', () => {
     expect(lastCall?.timeoutMs).toBe(120_000)
   })
 
+  it('spawns the probe in the home directory, never the sidecar process.cwd()', async () => {
+    const os = await import('node:os')
+    nextResult = baseProbeResult()
+    await probeAcpAgent({ type: 'claude' })
+    expect(lastCall?.cwd).toBe(os.homedir())
+  })
+
   it('honours an explicit timeoutMs', async () => {
     nextResult = baseProbeResult()
     await probeAcpAgent({ type: 'claude', timeoutMs: 5_000 })


### PR DESCRIPTION
## Problem

Configuring a coding (ACP) agent runs a discovery probe to list the agent's models and reasoning levels. The probe launches the adapter through `acp-probe`, which defaults its working directory to the server's `process.cwd()`. In a packaged build that directory is the read-only application bundle, so the spawned adapter cannot create its session files and the probe fails on end-user machines even though it works in local development.

The chat provider path never hit this: it always spawns adapters with an explicit writable cwd (`workingDirectory || homedir()`). The probe was the only ACP entry point inheriting the process cwd.

## Fix

Pass an explicit writable cwd (the user's home directory) into the probe, matching the chat provider's behavior, so both ACP entry points spawn adapters from the same writable location.

## Testing

- Added a unit test asserting the probe spawns in the home directory, never the sidecar `process.cwd()`.
- Probe service suite: 20 pass.
- `tsc --noEmit` clean; Biome clean.