### PR TITLE
chore(ci): disable nightly update schedules

### DIFF
--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -1,8 +1,6 @@
 name: "Nightly: BrowserOS neo macOS (signed)"
 
 on:
-  schedule:
-    - cron: "47 6 * * *"
   workflow_dispatch:
     inputs:
       upload_to_r2:

--- a/.github/workflows/nightly-browseros.yml
+++ b/.github/workflows/nightly-browseros.yml
@@ -1,8 +1,6 @@
 name: "Nightly: BrowserOS macOS (signed)"
 
 on:
-  schedule:
-    - cron: "17 4 * * *"
   workflow_dispatch:
     inputs:
       upload_to_r2:

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -1251,7 +1251,6 @@ class NightlyWorkflowTest(unittest.TestCase):
             "extension": "agent",
             "extension_secret": "BROWSEROS_AGENT_V2_KEY",
             "tag": "nightly-browseros",
-            "cron": "17 4 * * *",
         },
         "nightly-browserclaw.yml": {
             "product": "browserclaw",
@@ -1260,7 +1259,6 @@ class NightlyWorkflowTest(unittest.TestCase):
             "extension": "browserclaw",
             "extension_secret": "BROWSERCLAW_KEY",
             "tag": "nightly-browserclaw",
-            "cron": "47 6 * * *",
         },
     }
 
@@ -1285,7 +1283,7 @@ class NightlyWorkflowTest(unittest.TestCase):
             )
             text = (WORKFLOW_DIR / workflow_name).read_text(encoding="utf-8")
             with self.subTest(workflow=workflow_name):
-                self.assertEqual(triggers["schedule"], [{"cron": config["cron"]}])
+                self.assertNotIn("schedule", triggers)
                 self.assertEqual(checkout["with"]["ref"], "${{ github.sha }}")
                 for token in (
                     '"$DEFAULT_BRANCH" != "main"',

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -1131,12 +1131,12 @@ class PublisherTestCase(unittest.TestCase):
         self.assertEqual((spec.kind, spec.channel), ("extensions", "alpha"))
         self.assertEqual(
             set(extract_manifest_versions(manifest).values()),
-            {"0.0.132.0", "54.0.0.0", "0.2.7.0"},
+            {"0.0.139.0", "54.0.0.0", "0.2.15.0"},
         )
         original = manifest.replace("</gupdate>", "  </app>\n</gupdate>")
         self.assertEqual(
             hashlib.sha256(original.encode()).hexdigest(),
-            "9ba4ec047af45f6e54551f5100096de09d9ba5229a3ecd2853f0e4ddc94ee262",
+            "d2a7b386ea9928cb4ae4f0a8537f304db19e7e17e51178feecbe2f5a90f08fb7",
         )
 
     def test_browserclaw_snapshots_use_current_product_title(self):


### PR DESCRIPTION
## Summary

- disable scheduled BrowserOS and BrowserOS neo nightly updates
- preserve manual workflow dispatch for both workflows
- update the workflow contract test to require no nightly schedule
- refresh the alpha-feed snapshot to the final versions published before the pause

## Validation

- full Build System Tests job passed locally: 1,137 bos_build tests, release-secret tests, Ruff, CLI smoke, and 47 vendor-upload tests
- `actionlint -ignore 'unexpected key \"queue\"' .github/workflows/nightly-browseros.yml .github/workflows/nightly-browserclaw.yml`
- parsed both workflows with `yq`
- asserted `workflow_dispatch` is present and `schedule` is absent in both workflows

The ignored `concurrency.queue` diagnostic exists on `main` and is unrelated to this change.