### PR TITLE
feat(mcp): recolour endpoint strip

### DIFF
--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/styles.css
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/styles.css
@@ -58,6 +58,8 @@
   --color-bg-sunken: var(--bg-sunken);
   --color-card-tint: var(--card-tint);
   --color-ink-deep: var(--ink-deep);
+  /* MCP endpoint strip's brand-blue chip; keep separate from ink-deep. */
+  --color-mcp-endpoint: var(--mcp-endpoint);
   --color-border-2: var(--border-2);
   --color-border-strong: var(--border-strong);
 
@@ -330,6 +332,7 @@ body {
   --bg-sunken: #dae5ff;
   --card-tint: #f5f8ff;
   --ink-deep: #01123f;
+  --mcp-endpoint: #0454ec;
   --border-2: #dae5ff;
   /* --border-strong is a real step deeper than --border so it has
      visual weight when used on elevated panels, focused inputs, or
@@ -461,6 +464,7 @@ body {
      read as pressed into the page, matching the light-mode metaphor
      where they sit as Navy Deep chips on Sky Tint. */
   --ink-deep: #050912;
+  --mcp-endpoint: #0454ec;
   --border-2: #212c40;
   --border-strong: #334159;
 

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
@@ -22,7 +22,7 @@ export function EndpointStrip({ label, value }: EndpointStripProps) {
   return (
     <div className="space-y-2">
       <span className="text-[12px] text-cyanotype-muted">{label}</span>
-      <div className="flex items-center gap-3 overflow-hidden rounded-9 bg-ink-deep px-4 py-3 shadow-card">
+      <div className="flex items-center gap-3 overflow-hidden rounded-9 bg-mcp-endpoint px-4 py-3 shadow-card">
         {hasValue ? (
           <>
             <code


### PR DESCRIPTION
## Summary
- add a dedicated `mcp-endpoint` semantic colour token for the MCP URL strip
- set the brand-blue token to `#0454ec` in both light and dark themes
- preserve the shared `ink-deep` token and replay viewport styling

## Design
The endpoint strip now consumes `bg-mcp-endpoint`, backed by the existing Tailwind theme-variable pattern. This scopes the requested brand colour to the MCP surface and avoids retinting the shared recessed-chrome token.

## Test plan
- [x] `bun run check`
- [x] `bun test apps/claw-app/screens/mcp/Mcp.test.tsx` (11 passed)
- [x] source contract and `git diff --check`
- [x] context-free local review (clean)