### PR TITLE
feat(cockpit): collapse Recent activity and remember the state

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.test.tsx
@@ -1,5 +1,8 @@
-import { describe, expect, it, mock } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { parseHTML } from 'linkedom'
+import { act } from 'react'
+import type { Root } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router'
 import type { TaskSummary } from '@/modules/api/audit.hooks'
@@ -25,6 +28,29 @@ mock.module('@/modules/api/audit.hooks', () => ({
     `${baseUrl ?? ''}/api/v1/sessions/${sessionId}/screenshots/${id}`,
   useTaskScreenshotBaseUrl: () => screenshotBaseUrl,
 }))
+
+// Bun has no localStorage; the collapse preference needs one that can also be
+// made to throw, the way a tab without storage access does.
+const COLLAPSED_KEY = 'cockpitRecentActivityCollapsed'
+const memoryStore: Record<string, string> = {}
+let storageThrows = false
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: (key: string) => {
+      if (storageThrows) throw new Error('storage access denied')
+      return memoryStore[key] ?? null
+    },
+    setItem: (key: string, value: string) => {
+      if (storageThrows) throw new Error('storage access denied')
+      memoryStore[key] = value
+    },
+    removeItem: (key: string) => {
+      delete memoryStore[key]
+    },
+  },
+})
 
 const { RecentActivity } = await import('./RecentActivity')
 const { AuditHoverPreview } = await import('../audit/AuditHoverPreview')
@@ -57,6 +83,22 @@ const sampleTask: TaskSummary = {
   errorCount: 0,
   latestScreenshotId: 7,
 }
+
+/** Twelve runs: six as cards, six as list rows. */
+function fullFeed(): TaskSummary[] {
+  return Array.from({ length: 12 }, (_, index) => ({
+    ...sampleTask,
+    sessionId: `cyanotype-${index}`,
+    name: `Task ${index}`,
+    startedAt: sampleTask.startedAt - index,
+  }))
+}
+
+// Every test starts from a machine that has never toggled the section.
+beforeEach(() => {
+  storageThrows = false
+  delete memoryStore[COLLAPSED_KEY]
+})
 
 describe('RecentActivity', () => {
   it('renders skeleton while pending', () => {
@@ -147,11 +189,8 @@ describe('RecentActivity', () => {
 
   it('renders a compact card grid, then a minimal list for the rest', () => {
     screenshotBaseUrl = null
-    const tasks = Array.from({ length: 12 }, (_, index) => ({
-      ...sampleTask,
-      sessionId: `cyanotype-${index}`,
-      name: `Task ${index}`,
-      startedAt: sampleTask.startedAt - index,
+    const tasks = fullFeed().map((task, index) => ({
+      ...task,
       status: index === 0 ? ('live' as const) : ('done' as const),
     }))
     queryOverride = { isPending: false, data: { pages: [{ items: tasks }] } }
@@ -167,5 +206,189 @@ describe('RecentActivity', () => {
     expect(html).not.toContain('>Tool chain<')
     // The live run still surfaces its LIVE chip.
     expect(html).toContain('>LIVE<')
+    // A machine that has never toggled the section starts expanded.
+    expect(html).toContain('aria-expanded="true"')
+  })
+
+  it('renders the body collapsed when the preference was persisted', () => {
+    screenshotBaseUrl = null
+    memoryStore[COLLAPSED_KEY] = 'true'
+    queryOverride = {
+      isPending: false,
+      data: { pages: [{ items: fullFeed() }] },
+    }
+
+    const html = render()
+    // The body is gone...
+    expect(html).not.toContain('data-testid="recent-activity-list"')
+    expect(html).not.toContain('data-testid="support-tile-')
+    // ...but the header, its count, and the way through to /audit remain.
+    expect(html).toContain('Recent activity')
+    expect(html).toContain('12 sessions')
+    expect(html).toContain('View all activity')
+    expect(html).toContain('aria-expanded="false"')
+    expect(html).toContain('aria-controls="recent-activity-body"')
+  })
+
+  it('falls back to expanded when localStorage throws', () => {
+    screenshotBaseUrl = null
+    storageThrows = true
+    queryOverride = {
+      isPending: false,
+      data: { pages: [{ items: fullFeed() }] },
+    }
+
+    const html = render()
+    expect(html).toContain('Recent activity')
+    expect(html).toContain('data-testid="recent-activity-list"')
+    expect(html).toContain('aria-expanded="true"')
+  })
+})
+
+const globalDescriptors = new Map(
+  ['window', 'document', 'navigator', 'HTMLElement', 'Node', 'Event'].map(
+    (name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)],
+  ),
+)
+
+describe('RecentActivity collapse', () => {
+  let root: Root
+  let container: HTMLElement
+  let queryClient: QueryClient
+
+  beforeEach(async () => {
+    screenshotBaseUrl = null
+    queryOverride = {
+      isPending: false,
+      data: { pages: [{ items: fullFeed() }] },
+    }
+    const dom = parseHTML(
+      '<!doctype html><html><body><div id="root"></div></body></html>',
+    )
+    const globals = {
+      window: dom.window,
+      document: dom.document,
+      navigator: dom.window.navigator,
+      HTMLElement: dom.window.HTMLElement,
+      Node: dom.window.Node,
+      Event: dom.window.Event,
+    }
+    for (const [name, value] of Object.entries(globals)) {
+      Object.defineProperty(globalThis, name, {
+        configurable: true,
+        writable: true,
+        value,
+      })
+    }
+    Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+      configurable: true,
+      writable: true,
+      value: true,
+    })
+    container = dom.document.getElementById('root') as unknown as HTMLElement
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const { createRoot } = await import('react-dom/client')
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    for (const [name, descriptor] of globalDescriptors) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor)
+      else Reflect.deleteProperty(globalThis, name)
+    }
+    Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT')
+  })
+
+  async function mount(): Promise<void> {
+    await act(async () =>
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <RecentActivity />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      ),
+    )
+  }
+
+  /** Throws the component away and builds it again, as a new tab would. */
+  async function remount(): Promise<void> {
+    await act(async () => root.unmount())
+    const { createRoot } = await import('react-dom/client')
+    root = createRoot(container)
+    await mount()
+  }
+
+  function toggle(): HTMLElement {
+    const button = container.querySelector(
+      '[data-testid="recent-activity-toggle"]',
+    )
+    if (!button) throw new Error('recent-activity toggle missing')
+    return button as unknown as HTMLElement
+  }
+
+  async function clickToggle(): Promise<void> {
+    await act(async () => {
+      toggle().dispatchEvent(new window.Event('click', { bubbles: true }))
+    })
+  }
+
+  function bodyIsVisible(): boolean {
+    return (
+      container.querySelector('[data-testid="recent-activity-list"]') !== null
+    )
+  }
+
+  it('collapses the body on click and leaves the header and audit link', async () => {
+    await mount()
+    expect(bodyIsVisible()).toBe(true)
+
+    await clickToggle()
+
+    expect(bodyIsVisible()).toBe(false)
+    expect(container.querySelector('[data-testid^="support-tile-"]')).toBeNull()
+    expect(toggle().getAttribute('aria-expanded')).toBe('false')
+    expect(container.textContent).toContain('Recent activity')
+    expect(container.textContent).toContain('12 sessions')
+    expect(container.textContent).toContain('View all activity')
+  })
+
+  it('remembers a collapsed section across a remount', async () => {
+    await mount()
+    await clickToggle()
+    expect(memoryStore[COLLAPSED_KEY]).toBe('true')
+
+    await remount()
+
+    expect(bodyIsVisible()).toBe(false)
+    expect(toggle().getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('remembers an expanded section across a remount', async () => {
+    memoryStore[COLLAPSED_KEY] = 'true'
+    await mount()
+    expect(bodyIsVisible()).toBe(false)
+
+    await clickToggle()
+    expect(memoryStore[COLLAPSED_KEY]).toBe('false')
+
+    await remount()
+
+    expect(bodyIsVisible()).toBe(true)
+    expect(toggle().getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('still toggles when localStorage writes throw', async () => {
+    storageThrows = true
+    await mount()
+
+    await clickToggle()
+
+    // The tab forgets the choice, but the section still collapses.
+    expect(bodyIsVisible()).toBe(false)
+    expect(memoryStore[COLLAPSED_KEY]).toBeUndefined()
   })
 })

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
@@ -1,6 +1,8 @@
-import { History } from 'lucide-react'
+import { ChevronDown, History } from 'lucide-react'
+import { useState } from 'react'
 import { NavLink, useLocation } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
 import { type TaskSummary, useSessions } from '@/modules/api/audit.hooks'
 import { formatDuration, formatRelative } from '@/screens/audit/audit.helpers'
 import { EmptyState } from './EmptyState'
@@ -11,7 +13,34 @@ import { SupportingTile } from './SupportingTile'
 const HOME_GRID_COUNT = 6
 const HOME_TASK_LIMIT = 12
 
+// The header collapses the body, and the choice is remembered per machine so a
+// section collapsed once stays collapsed on every new tab after it. Default is
+// expanded, so a first run still shows that activity exists. Same localStorage
+// shape as ProductHuntBanner, try/catch included: a tab without storage access
+// must fall back to the default rather than throw.
+const COLLAPSED_KEY = 'cockpitRecentActivityCollapsed'
+const BODY_ID = 'recent-activity-body'
+
+function readCollapsed(): boolean {
+  try {
+    return localStorage.getItem(COLLAPSED_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+function persistCollapsed(collapsed: boolean): void {
+  try {
+    localStorage.setItem(COLLAPSED_KEY, collapsed ? 'true' : 'false')
+  } catch {
+    // A tab without storage access simply forgets the preference.
+  }
+}
+
 export function RecentActivity() {
+  // Lazy initialiser: the persisted value is read during the first render, so
+  // a collapsed section never flashes open on mount.
+  const [collapsed, setCollapsed] = useState(readCollapsed)
   const query = useSessions({
     variables: { limit: HOME_TASK_LIMIT },
     // Homepage feed: poll so new sessions surface without a manual refresh.
@@ -22,30 +51,26 @@ export function RecentActivity() {
     .slice(0, HOME_TASK_LIMIT)
   const now = Date.now()
   const ordered = orderByLiveThenRecency(tasks)
-  const gridTasks = ordered.slice(0, HOME_GRID_COUNT)
-  const listTasks = ordered.slice(HOME_GRID_COUNT)
+
+  const handleToggle = () => {
+    const next = !collapsed
+    setCollapsed(next)
+    persistCollapsed(next)
+  }
 
   return (
     <section className="ph-no-capture space-y-5">
-      <SectionHeader sessionCount={ordered.length} />
-      {query.isPending ? (
-        <ActivityGridSkeleton />
-      ) : ordered.length === 0 ? (
-        <EmptyState
-          title="No recent activity"
-          hint="Tool calls from connected agents will appear here."
-          icon={<History className="size-5" />}
-        />
-      ) : (
-        <div className="space-y-4">
-          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {gridTasks.map((task) => (
-              <SupportingTile key={task.sessionId} task={task} now={now} />
-            ))}
-          </div>
-          {listTasks.length > 0 && <ActivityList tasks={listTasks} now={now} />}
-        </div>
-      )}
+      <SectionHeader
+        sessionCount={ordered.length}
+        collapsed={collapsed}
+        bodyId={BODY_ID}
+        onToggle={handleToggle}
+      />
+      <div id={BODY_ID} hidden={collapsed}>
+        {!collapsed && (
+          <ActivityBody isPending={query.isPending} tasks={ordered} now={now} />
+        )}
+      </div>
       <div className="pt-0.5">
         <NavLink
           to="/audit"
@@ -62,17 +87,85 @@ export function RecentActivity() {
   )
 }
 
-function SectionHeader({ sessionCount }: { sessionCount: number }) {
+/**
+ * The whole header row is the disclosure control. The session count stays
+ * visible in both states: it is the at-a-glance value of a collapsed section.
+ */
+function SectionHeader({
+  sessionCount,
+  collapsed,
+  bodyId,
+  onToggle,
+}: {
+  sessionCount: number
+  collapsed: boolean
+  bodyId: string
+  onToggle: () => void
+}) {
   return (
-    <header className="flex items-center gap-3.5 pb-1">
-      <h2 className="shrink-0 font-medium text-[15px] text-cyanotype-ink leading-[18px]">
-        Recent activity
+    <header className="pb-1">
+      <h2>
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={!collapsed}
+          aria-controls={bodyId}
+          data-testid="recent-activity-toggle"
+          className="group flex w-full cursor-pointer items-center gap-3.5 rounded-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyanotype-blue/40"
+        >
+          <span className="shrink-0 font-medium text-[15px] text-cyanotype-ink leading-[18px]">
+            Recent activity
+          </span>
+          <span aria-hidden className="h-px flex-1 bg-cyanotype-border" />
+          <span className="flex shrink-0 items-center gap-2">
+            <span className="text-[11px] text-cyanotype-muted tabular-nums leading-[14px]">
+              {sessionCount} {sessionCount === 1 ? 'session' : 'sessions'}
+            </span>
+            <ChevronDown
+              aria-hidden
+              className={cn(
+                'size-3.5 shrink-0 text-cyanotype-muted transition-transform duration-150 group-hover:text-cyanotype-soft',
+                !collapsed && 'rotate-180',
+              )}
+            />
+          </span>
+        </button>
       </h2>
-      <span aria-hidden className="h-px flex-1 bg-cyanotype-border" />
-      <span className="shrink-0 text-[11px] text-cyanotype-muted tabular-nums leading-[14px]">
-        {sessionCount} {sessionCount === 1 ? 'session' : 'sessions'}
-      </span>
     </header>
+  )
+}
+
+/** Skeleton, empty state, or the card grid plus the overflow list. */
+function ActivityBody({
+  isPending,
+  tasks,
+  now,
+}: {
+  isPending: boolean
+  tasks: TaskSummary[]
+  now: number
+}) {
+  if (isPending) return <ActivityGridSkeleton />
+  if (tasks.length === 0) {
+    return (
+      <EmptyState
+        title="No recent activity"
+        hint="Tool calls from connected agents will appear here."
+        icon={<History className="size-5" />}
+      />
+    )
+  }
+  const gridTasks = tasks.slice(0, HOME_GRID_COUNT)
+  const listTasks = tasks.slice(HOME_GRID_COUNT)
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        {gridTasks.map((task) => (
+          <SupportingTile key={task.sessionId} task={task} now={now} />
+        ))}
+      </div>
+      {listTasks.length > 0 && <ActivityList tasks={listTasks} now={now} />}
+    </div>
   )
 }
 


### PR DESCRIPTION
The Recent activity header is now a disclosure button. Collapsing it persists to `localStorage` under `cockpitRecentActivityCollapsed`, so a section collapsed once stays collapsed on every new tab after it.

- Body only collapses — the header stays as the toggle and `View all activity` stays reachable, so a collapsed section is still navigable.
- Default is expanded, so a first run still shows that activity exists.
- Same `localStorage` + `try/catch` shape as `ProductHuntBanner`; a tab without storage access falls back to the default rather than throwing.
- Lazy `useState` initialiser, so a collapsed section never flashes open on mount.
- Real `<button>` with `aria-expanded` / `aria-controls`; session count stays visible in both states.

Verified: 24 tests pass across `RecentActivity.test.tsx` and `Cockpit.test.tsx`. `claw-app` typecheck exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)