### PR TITLE
feat(onboard): end onboarding on "All set!" and fix the dead MCP CTA

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
@@ -129,14 +129,16 @@ describe('OnboardingV2 shell', () => {
     expect(getAssignedUrl()).toBe('chrome://newtab/#/mcp')
   })
 
-  it('does not navigate after completing through the real Chromium bridge', () => {
+  // The shipped browser is the only place the CTA matters, and it is the one
+  // place the old `isMock` gate skipped: completing left the button dead.
+  it('navigates after completing through the real Chromium bridge', () => {
     const getAssignedUrl = installAssignableWindow('')
     const { bridge, getCompleteCount } = stubBridge(false)
 
     finishBrowserOSOnboarding(bridge)
 
     expect(getCompleteCount()).toBe(1)
-    expect(getAssignedUrl()).toBeNull()
+    expect(getAssignedUrl()).toBe('chrome://newtab/#/mcp')
   })
 
   it('keeps navigating after completion in mock standalone onboarding', () => {

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.tsx
@@ -49,15 +49,33 @@ export function importPhaseFor(status: BrowserOSImportStatus): ImportPhase {
   return 'picker'
 }
 
-/** Leaves standalone onboarding for BrowserClaw's MCP connection page. */
+/**
+ * Leaves onboarding for BrowserClaw's MCP page, which lists every agent on this
+ * machine with its connected state.
+ *
+ * Only a `chrome://` document can make this hop. Chromium drops a
+ * renderer-initiated navigation from an `http(s)` page to a WebUI URL without
+ * raising anything — verified in BrowserOS neo, where `location.assign` leaves
+ * `href` untouched and `window.open` returns null — so this call does nothing
+ * under `vite dev`. From `chrome://browseros-onboarding` the same call does
+ * navigate, and `chrome://newtab/#/mcp` resolves to the MCP screen with the
+ * hash intact.
+ */
 export function openBrowserOsMcpPage() {
   window.location.assign(BROWSEROS_MCP_PAGE_URL)
 }
 
-/** Completes onboarding and leaves standalone mock onboarding when needed. */
+/**
+ * Completes onboarding and heads for the MCP page.
+ *
+ * The navigation is not gated on the bridge: the CTA promises the MCP page on
+ * every build, and gating it on `isMock` is what left the button dead in the
+ * shipped browser. `complete()` goes first so the Chromium handler is told
+ * regardless of what the navigation does to this document.
+ */
 export function finishBrowserOSOnboarding(bridge: BrowserOSOnboardingBridge) {
   bridge.complete()
-  if (bridge.isMock) openBrowserOsMcpPage()
+  openBrowserOsMcpPage()
 }
 
 /** Runs the standalone three-step BrowserClaw onboarding flow. */

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.test.tsx
@@ -20,35 +20,44 @@ function headingOf(html: string): string {
 }
 
 describe('ReadyStep', () => {
-  it('frames the step as the remaining connection work', () => {
+  it('frames the step as finished rather than as remaining work', () => {
     const html = render()
 
-    expect(headingOf(html)).toContain('Last step:')
-    expect(headingOf(html)).toContain('connect.')
-    expect(html).toContain('Your agents can')
-    expect(html).toContain('reach this browser yet')
+    expect(headingOf(html)).toContain('All')
+    expect(headingOf(html)).toContain('set!')
+    expect(headingOf(html)).not.toContain('Last step:')
+    expect(html).not.toContain('Three things')
   })
 
-  it('spells out connect, restart, and paste as separate steps', () => {
+  // The browser connects itself to the agents already on this machine, so the
+  // screen states that; a checklist would ask for work that is already done.
+  it('states the connection already happened instead of listing steps', () => {
     const html = render()
 
-    expect(html).toContain('Open the MCP page and click')
-    expect(html).toContain('Connect')
-    expect(html).toContain('Restart Claude Code once')
-    expect(html).toContain('Paste a task into Claude Code')
+    expect(html).toContain('already installed on your machine')
+    expect(html).not.toContain('<ol')
+    expect(html).not.toContain('Open the MCP page and click')
   })
 
   // The restart is the likeliest first-run failure: an agent that has not
-  // reloaded its MCP config looks broken rather than unconnected.
-  it('never drops the restart instruction', () => {
-    expect(render()).toContain('picks up the connection')
-  })
-
-  it('names the paste destination rather than leaving it implied', () => {
+  // reloaded its MCP config looks broken rather than unconnected. It stays, but
+  // below the prompts, so a finished setup does not read as unfinished.
+  it('keeps the restart as a footnote under the prompts, never dropping it', () => {
     const html = render()
 
-    expect(html).toContain('Claude Code')
-    expect(html).not.toContain('Once connected, try one of these.')
+    expect(html).toContain('picks up the connection')
+    expect(html.indexOf('Restart it once')).toBeGreaterThan(
+      html.indexOf(STARTER_PROMPTS[0]),
+    )
+  })
+
+  // Every installed agent is connected, so the paste target is whichever one
+  // the reader uses — naming Claude Code would now be wrong for most of them.
+  it('sends the prompt to whichever agent the reader uses, not a named tool', () => {
+    const html = render()
+
+    expect(html).toContain('into your agent')
+    expect(html).not.toContain('Claude Code')
   })
 
   it('renders the MCP page CTA without claiming to connect anything', () => {

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.tsx
@@ -9,50 +9,36 @@ interface ReadyStepProps {
   onDone: () => void
 }
 
-const CONNECT_STEPS = [
-  <>
-    Open the MCP page and click{' '}
-    <strong className="font-semibold">Connect</strong> next to your tool.
-  </>,
-  <>Restart Claude Code once, so it picks up the connection.</>,
-  <>Paste a task into Claude Code&rsquo;s chat:</>,
-]
-
 /**
- * Final onboarding step. The connection itself happens on the MCP page, so this
- * step's job is to say exactly what to do there and where the copied prompt
- * goes — naming Claude Code rather than leaving the destination implied. The
- * restart gets its own step because an agent that has not reloaded its MCP
- * config looks broken rather than unconnected.
+ * Final onboarding step. Connecting is no longer homework: the browser wires
+ * itself up to the agents already installed on this machine, so the screen
+ * states that and hands over a prompt to paste — the copy buttons are the
+ * action, not a numbered checklist.
+ *
+ * The restart survives as a footnote rather than a step because an agent that
+ * has not reloaded its MCP config looks broken rather than unconnected, and
+ * that is the one way a finished setup still reads as failed. Leading with it
+ * would undo the point of the screen.
  */
 export function ReadyStep({ onDone }: ReadyStepProps) {
   return (
     <StepWrap>
       <DisplayHeading>
-        Last step: <Em>connect.</Em>
+        All <Em>set!</Em>
       </DisplayHeading>
       <StepCopy>
-        Your agents can&rsquo;t reach this browser yet. Three things:
+        We connected this browser to the agents already installed on your
+        machine. Try it out &mdash; copy one of these into your agent:
       </StepCopy>
-      <ol className="mb-5 flex flex-col gap-2.5">
-        {CONNECT_STEPS.map((content, index) => (
-          <li
-            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length static copy, no DOM identity to preserve
-            key={index}
-            className="flex items-start gap-2.5 text-[13.5px] text-ink-2"
-          >
-            <span className="mt-px flex size-[19px] shrink-0 items-center justify-center rounded-md bg-accent font-bold text-[11px] text-card">
-              {index + 1}
-            </span>
-            <span>{content}</span>
-          </li>
-        ))}
-      </ol>
-      <div className="mb-6 flex flex-col gap-2.5">
+      <div className="mb-4 flex flex-col gap-2.5">
         {STARTER_PROMPTS.slice(0, 2).map((prompt) => (
           <StarterPromptTile key={prompt} prompt={prompt} />
         ))}
       </div>
+      <p className="mb-6 max-w-[470px] text-[12.5px] text-ink-3 leading-[1.5]">
+        Agent doesn&rsquo;t see this browser yet? Restart it once, so it picks
+        up the connection.
+      </p>
       <Button type="button" size="lg" onClick={onDone}>
         <PlugZap className="size-4" />
         Open the MCP page


### PR DESCRIPTION
Onboarding no longer asks the user to connect anything by hand. The browser wires itself to the agents already installed on the machine, so the last step says so and hands over a prompt to paste — the copy buttons are the action, not a numbered checklist.

## The dead button

`finishBrowserOSOnboarding` ran the navigation only `if (bridge.isMock)`, so in the shipped browser it called `bridge.complete()` and then did nothing. The gate is removed; the CTA promises the MCP page on every build.

A second, independent problem was checked and ruled out: Chromium silently drops a renderer-initiated navigation from an `http(s)` page to a WebUI URL. Verified in BrowserOS neo — `location.assign` leaves `href` untouched and `window.open` returns null — so `openBrowserOsMcpPage` is inert under `vite dev`. From `chrome://browseros-onboarding` the same call **does** navigate, and `chrome://newtab/#/mcp` resolves to the MCP screen with the hash intact. No workaround needed for the shipped build.

## Copy

- Heading is `All set!`, keeping the serif-italic `<Em>` treatment.
- The three-step `CONNECT_STEPS` list is gone.
- The restart hint survives as a footnote rather than step 2 of 3: an agent that has not reloaded its MCP config looks broken rather than unconnected, which is the one way a finished setup still reads as failed. Leading with it would undo the point of the screen.

## Not changed

`PostHostClearedCallback` in `first_run_flow_controller.cc` is empty on the native side — documented, deliberately out of scope for this repo.

Verified: 16 tests pass (9 `ReadyStep`, 7 `OnboardingV2`) via `run-bun-test.ts --cwd=./apps/claw-onboard`. `claw-onboard` typecheck exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)