### PR TITLE
fix(mcp): restore AA contrast on the endpoint Copy button

### DIFF
--- a/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
@@ -35,7 +35,7 @@ export function EndpointStrip({ label, value }: EndpointStripProps) {
               type="button"
               onClick={copy}
               aria-label={`Copy ${label}`}
-              className="shrink-0 rounded px-1.5 py-0.5 text-[12px] text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+              className="shrink-0 rounded px-1.5 py-0.5 text-[12px] text-white/90 transition-colors hover:bg-white/10 hover:text-white"
             >
               {copied ? 'Copied ✓' : 'Copy'}
             </button>


### PR DESCRIPTION
Follow-up to #2396, which recoloured the endpoint strip from `#01123f` to `#0454ec`.

The strip carries hardcoded white text at two opacities. The URL is fine; the Copy button was not:

| Element | Opacity | on `#01123f` | on `#0454ec` |
|---|---|---:|---:|
| URL `<code>` | `text-white/90` | 20.5:1 | **5.17:1** ✅ |
| `Copy` button | `text-white/70` | 9.12:1 | **3.71:1** ❌ |

WCAG AA needs 4.5:1 for normal text. The button matches the URL at `/90` (5.17:1); hover already goes solid white.

Found by an independent contrast audit of the gray-mode design review, which flagged `EndpointStrip.tsx:38` as failing in both proposed palettes — it turned out to be failing on `main` today, in light mode, independent of gray mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)