### PR TITLE
feat(mcp-manager): add read-only tool catalogue endpoint for settings UI

### DIFF
--- a/packages/browseros-agent/apps/app/screens/mcp-settings/MCPSettingsPage.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/MCPSettingsPage.test.tsx
@@ -46,10 +46,6 @@ mock.module('@/lib/browseros/helpers', () => ({
   getMcpServerUrl: async () => 'http://127.0.0.1:9200/mcp',
 }))
 
-mock.module('@/lib/messaging/server/serverMessages', () => ({
-  sendServerMessage: async () => ({ tools: [] }),
-}))
-
 let MCPSettingsPage: FC
 
 beforeAll(async () => {

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/MCPSettingsPage.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/MCPSettingsPage.tsx
@@ -1,7 +1,5 @@
 import { type FC, useCallback, useEffect, useState } from 'react'
 import { getMcpServerUrl } from '@/lib/browseros/helpers'
-import type { McpTool } from '@/lib/mcp/client'
-import { sendServerMessage } from '@/lib/messaging/server/serverMessages'
 import { BrowserClawMcpBanner } from './BrowserClawMcpBanner'
 import { IntegrationsSection } from './IntegrationsSection'
 import { MCPServerHeader } from './MCPServerHeader'
@@ -13,67 +11,21 @@ export const MCPSettingsPage: FC = () => {
   const [urlLoading, setUrlLoading] = useState(true)
   const [urlError, setUrlError] = useState<string | null>(null)
 
-  const [tools, setTools] = useState<McpTool[]>([])
-  const [toolsLoading, setToolsLoading] = useState(false)
-  const [toolsError, setToolsError] = useState<string | null>(null)
-
-  const loadServerUrlAndTools = useCallback(async () => {
-    let url: string | null = null
+  const loadServerUrl = useCallback(async () => {
     setUrlLoading(true)
     setUrlError(null)
-    setToolsError(null)
-
     try {
-      url = await getMcpServerUrl()
-      setServerUrl(url)
-      setUrlLoading(false)
-
-      setToolsLoading(true)
-      const result = await sendServerMessage('fetchMcpTools', undefined)
-      if (result.error) {
-        setToolsError(result.error)
-      } else {
-        setTools(result.tools)
-      }
+      setServerUrl(await getMcpServerUrl())
     } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : 'Failed to load'
-      if (!url) {
-        setUrlError(errorMsg)
-      } else {
-        setToolsError(errorMsg)
-      }
+      setUrlError(err instanceof Error ? err.message : 'Failed to load')
     } finally {
       setUrlLoading(false)
-      setToolsLoading(false)
     }
   }, [])
 
   useEffect(() => {
-    loadServerUrlAndTools()
-  }, [loadServerUrlAndTools])
-
-  const handleRefreshTools = async () => {
-    if (!serverUrl) return
-
-    setToolsLoading(true)
-    setToolsError(null)
-    setTools([])
-
-    try {
-      const result = await sendServerMessage('fetchMcpTools', undefined)
-      if (result.error) {
-        setToolsError(result.error)
-      } else {
-        setTools(result.tools)
-      }
-    } catch (err) {
-      setToolsError(
-        err instanceof Error ? err.message : 'Failed to fetch tools',
-      )
-    } finally {
-      setToolsLoading(false)
-    }
-  }
+    loadServerUrl()
+  }, [loadServerUrl])
 
   return (
     <div className="fade-in slide-in-from-bottom-5 animate-in space-y-6 duration-500">
@@ -81,19 +33,14 @@ export const MCPSettingsPage: FC = () => {
         serverUrl={serverUrl}
         isLoading={urlLoading}
         error={urlError}
-        onServerRestart={loadServerUrlAndTools}
+        onServerRestart={loadServerUrl}
       />
 
       <BrowserClawMcpBanner />
 
       <IntegrationsSection serverUrl={serverUrl} />
 
-      <MCPToolsSection
-        tools={tools}
-        isLoading={toolsLoading}
-        error={toolsError}
-        onRefresh={handleRefreshTools}
-      />
+      <MCPToolsSection />
     </div>
   )
 }

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/MCPToolsSection.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/MCPToolsSection.tsx
@@ -6,22 +6,19 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
-import type { McpTool } from '@/lib/mcp/client'
+import { useMcpTools } from './mcp-tools-section.hooks'
 
-export interface MCPToolsSectionProps {
-  tools: McpTool[]
-  isLoading: boolean
-  error: string | null
-  onRefresh: () => void
-}
-
-export const MCPToolsSection: FC<MCPToolsSectionProps> = ({
-  tools,
-  isLoading,
-  error,
-  onRefresh,
-}) => {
+export const MCPToolsSection: FC = () => {
   const [isOpen, setIsOpen] = useState(false)
+  const toolsQuery = useMcpTools()
+
+  const tools = toolsQuery.data ?? []
+  const isLoading = toolsQuery.isFetching
+  const error = toolsQuery.isError
+    ? toolsQuery.error instanceof Error
+      ? toolsQuery.error.message
+      : String(toolsQuery.error)
+    : null
 
   return (
     <Collapsible
@@ -49,7 +46,9 @@ export const MCPToolsSection: FC<MCPToolsSectionProps> = ({
           <Button
             variant="outline"
             size="icon"
-            onClick={onRefresh}
+            onClick={() => {
+              void toolsQuery.refetch()
+            }}
             disabled={isLoading}
             className="border-[var(--accent-orange)] bg-[var(--accent-orange)]/10 text-[var(--accent-orange)] hover:bg-[var(--accent-orange)]/20 hover:text-[var(--accent-orange)]"
             title="Refresh tools"

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/mcp-tools-section.hooks.ts
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/mcp-tools-section.hooks.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query'
+import type { McpTool } from '@/lib/mcp/client'
+import { useAgentServerUrl } from '@/modules/browseros/agent-server-url.hooks'
+
+interface ListToolsResponse {
+  tools: McpTool[]
+}
+
+const TOOLS_QUERY_KEY = ['mcp-manager', 'tools'] as const
+
+async function fetchTools(agentServerUrl: string): Promise<McpTool[]> {
+  const res = await fetch(`${agentServerUrl}/mcp-manager/tools`)
+  if (!res.ok) {
+    throw new Error(`Failed to list tools: ${res.status} ${res.statusText}`)
+  }
+  const body = (await res.json()) as ListToolsResponse
+  return body.tools
+}
+
+/**
+ * Returns the BrowserOS MCP tool catalogue for the settings UI. Reads the
+ * read-only `/mcp-manager/tools` endpoint rather than speaking MCP to `/mcp`,
+ * which the browser cannot reach directly.
+ */
+export function useMcpTools() {
+  const { baseUrl } = useAgentServerUrl()
+  return useQuery({
+    queryKey: TOOLS_QUERY_KEY,
+    enabled: !!baseUrl,
+    staleTime: 5_000,
+    queryFn: () => {
+      if (!baseUrl) throw new Error('Agent server URL is unavailable')
+      return fetchTools(baseUrl)
+    },
+  })
+}

--- a/packages/browseros-agent/apps/server/src/api/routes/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/index.ts
@@ -95,6 +95,7 @@ export function createApiRoutes(deps: CreateApiRoutesDeps) {
         '/mcp-manager',
         createMcpManagerRoutes({
           getMcpUrl: () => `http://127.0.0.1:${port}/mcp`,
+          klavis,
         }),
       )
       .route(

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp-manager.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp-manager.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { BROWSER_TOOLS } from '@browseros/browser-mcp/registry'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import {
@@ -12,6 +13,7 @@ import {
   listAgents,
   uninstallFrom,
 } from '../../lib/mcp-manager'
+import type { KlavisService } from '../services/klavis'
 
 interface McpManagerRouteOptions {
   /**
@@ -27,6 +29,11 @@ interface McpManagerRouteOptions {
    * that have no other source.
    */
   getMcpUrl: () => string
+  /**
+   * Optional Klavis service. When present, its connector tools are included in
+   * `GET /tools` so the list matches what the `/mcp` tools/list exposes.
+   */
+  klavis?: KlavisService
 }
 
 const InstallBodySchema = z
@@ -36,9 +43,32 @@ const InstallBodySchema = z
   .partial()
 
 export function createMcpManagerRoutes(options: McpManagerRouteOptions) {
-  const { getMcpUrl } = options
+  const { getMcpUrl, klavis } = options
 
   return new Hono()
+    .get('/tools', (c) => {
+      // Read-only tool catalogue for the settings UI to display. Lives here (not
+      // under /mcp) so the browser can fetch it without speaking the MCP protocol,
+      // and without tripping the /mcp browser-request guard. Mirrors the tool set
+      // that /mcp tools/list exposes: browser tools plus Klavis connector tools.
+      try {
+        const browserTools = BROWSER_TOOLS.map((tool) => ({
+          name: tool.name,
+          description: tool.description,
+        }))
+        const connectorToolSet = klavis?.buildAiSdkToolSet() ?? {}
+        const connectorTools = Object.entries(connectorToolSet).map(
+          ([name, tool]) => ({
+            name,
+            description: (tool as { description?: string }).description ?? '',
+          }),
+        )
+        return c.json({ tools: [...browserTools, ...connectorTools] })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return c.json({ message }, 500)
+      }
+    })
     .get('/agents', async (c) => {
       try {
         const agents = await listAgents()

--- a/packages/browseros-agent/apps/server/tests/api/routes/index.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/index.test.ts
@@ -124,6 +124,22 @@ describe('createApiRoutes', () => {
     await expect(response.json()).resolves.toEqual({ agents: [] })
   })
 
+  it('serves the tool catalogue for the settings UI', async () => {
+    const response = await createTestApp().request('/mcp-manager/tools')
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      tools: { name: string; description: string }[]
+    }
+    const names = body.tools.map((tool) => tool.name)
+    expect(names).toContain('navigate')
+    expect(names).toContain('run')
+    for (const tool of body.tools) {
+      expect(typeof tool.name).toBe('string')
+      expect(typeof tool.description).toBe('string')
+    }
+  })
+
   it('keeps injected agent routes behind app-origin auth', async () => {
     const agentRoutes = new Hono<Env>().post('/guard-check', (c) =>
       c.json({ ok: true }),


### PR DESCRIPTION
## What

The settings "Available Tools" list now reads a read-only `GET /mcp-manager/tools` endpoint instead of performing an MCP handshake against `/mcp` from the browser.

## Why

The `/mcp` route rejects browser-originated requests, so the extension can no longer speak the MCP protocol directly to list tools. The settings page only needs to display the catalogue, not call it, so a plain REST read is the right shape and keeps the hardening intact.

## Changes

- **Server:** `GET /mcp-manager/tools` returns the same tool set `/mcp` exposes, the built-in browser tools plus any Klavis connector tools, each as `{ name, description }`. It sits alongside the existing manager routes, so nothing about the `/mcp` guard changes.
- **App:** the tools section now owns a `useMcpTools()` react-query hook (mirroring the existing agents hook) that fetches the new endpoint from the agent server URL. The settings surface no longer performs the browser-side MCP handshake.

## Tests

- Added a route test asserting the endpoint serves the browser tool catalogue with name and description pairs.
- Existing settings page test still passes; server typecheck and app typecheck are clean.

## Follow-ups

- The background `fetchMcpTools` message handler and its MCP client are now unused by any UI surface and can be retired in a separate change.
