### PR TITLE
fix(klavis): pass connector tool JSON schemas through unchanged

### DIFF
--- a/packages/browseros-agent/apps/server/package.json
+++ b/packages/browseros-agent/apps/server/package.json
@@ -94,7 +94,6 @@
     "pino": "^9.14.0",
     "posthog-node": "^4.18.0",
     "zod": "^3.25.76",
-    "zod-from-json-schema": "^0.5.6",
     "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/strata-session.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/strata-session.ts
@@ -10,7 +10,6 @@ import {
   Client,
   StreamableHTTPClientTransport,
 } from '@modelcontextprotocol/client'
-import { jsonSchemaObjectToZodRawShape } from 'zod-from-json-schema'
 import type { KlavisClient } from './client'
 import type { KlavisStrataCache } from './strata-cache'
 import type { KlavisSessionHandle } from './types'
@@ -54,19 +53,9 @@ export async function connectKlavisStrataSession(
 
   const { tools } = await withTimeout(client.listTools(), 'listTools')
 
-  const inputSchemas = new Map(
-    tools.map((t) => [
-      t.name,
-      jsonSchemaObjectToZodRawShape(
-        t.inputSchema as never,
-      ) as unknown as Record<string, never>,
-    ]),
-  )
-
   return {
     browserosId: deps.browserosId,
     tools,
-    inputSchemas,
     callTool: (name, args) =>
       withTimeout(
         client.callTool({ name, arguments: args }) as Promise<CallToolResult>,

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/tool-adapters.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/tool-adapters.ts
@@ -7,7 +7,7 @@
 import type { JSONValue } from '@ai-sdk/provider'
 import type { CallToolResult } from '@modelcontextprotocol/client'
 import { fromJsonSchema, type McpServer } from '@modelcontextprotocol/server'
-import type { ToolSet } from 'ai'
+import { jsonSchema, type ToolSet } from 'ai'
 import { z } from 'zod'
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import { logger } from '../../../lib/logger'
@@ -216,11 +216,15 @@ export function buildKlavisToolSet(deps: KlavisToolAdapterDeps): ToolSet {
   }
 
   for (const t of session.tools) {
-    const rawShape = session.inputSchemas.get(t.name)
     const name = t.name
     toolSet[name] = {
       description: t.description ?? '',
-      inputSchema: z.object((rawShape ?? {}) as z.ZodRawShape),
+      // Pass the remote JSON schema straight through. Round-tripping it through
+      // Zod (zod-from-json-schema -> zod-to-json-schema under zod v3) silently
+      // drops every property, leaving the connector's tools unusable.
+      inputSchema: jsonSchema(
+        t.inputSchema as Parameters<typeof jsonSchema>[0],
+      ),
       execute: async (args: Record<string, unknown>) =>
         session.callTool(name, args),
       toModelOutput: ({ output }: { output: unknown }) =>
@@ -231,11 +235,11 @@ export function buildKlavisToolSet(deps: KlavisToolAdapterDeps): ToolSet {
   return toolSet
 }
 
-// Stopgap: Klavis tool schemas are still Zod v3 (they flow through the Strata
-// client, which is migrated separately). v2 registerTool derives a tools/list
-// JSON schema only from Zod v4, so bridge the v3 raw shape through JSON.
-// Replaced once the client migration passes the remote JSON schema straight to
-// fromJsonSchema.
+// Bridge a locally hand-built Zod v3 shape (the connector tool's schema) into a
+// v2 registerTool input schema. v2 derives a tools/list JSON schema only from
+// Zod v4, so convert the v3 shape to JSON Schema first, then wrap it. Remote
+// Strata tools do NOT use this path: their JSON schema goes straight to
+// fromJsonSchema (round-tripping through Zod drops every property under v3).
 function toV2InputSchema(rawShape: z.ZodRawShape) {
   // The bridged value is a StandardSchemaWithJSON; type it as a raw shape so
   // registerTool's overload and handler typing resolve as before. At runtime
@@ -243,6 +247,13 @@ function toV2InputSchema(rawShape: z.ZodRawShape) {
   return fromJsonSchema(
     zodToJsonSchema(z.object(rawShape)) as never,
   ) as unknown as Record<string, never>
+}
+
+// Wrap a remote Strata tool's JSON schema for v2 registerTool without any Zod
+// round-trip. Same cast rationale as toV2InputSchema: the typed overload wants a
+// raw shape, while the StandardSchemaWithJSON flows through at runtime.
+function remoteJsonInputSchema(schema: Parameters<typeof fromJsonSchema>[0]) {
+  return fromJsonSchema(schema) as unknown as Record<string, never>
 }
 
 export function registerKlavisTools(
@@ -333,13 +344,16 @@ export function registerKlavisTools(
 
   const selectedServers = selectedServerNames(deps.scope)
   for (const strataTool of session.tools) {
-    const inputSchema = session.inputSchemas.get(strataTool.name)
-
     mcpServer.registerTool(
       strataTool.name,
       {
         description: strataTool.description,
-        inputSchema: toV2InputSchema((inputSchema ?? {}) as z.ZodRawShape),
+        // Pass the remote JSON schema straight through. The old Zod round-trip
+        // dropped every property (zod v3 + zod-from-json-schema), so registerTool
+        // advertised an empty schema that rejected all arguments.
+        inputSchema: remoteJsonInputSchema(
+          strataTool.inputSchema as Parameters<typeof fromJsonSchema>[0],
+        ),
       },
       async (args: Record<string, unknown>) => {
         const startTime = performance.now()

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/types.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/types.ts
@@ -65,7 +65,6 @@ export interface SubmitApiKeyInput {
 export interface KlavisSessionHandle {
   browserosId: string
   tools: Tool[]
-  inputSchemas: Map<string, Record<string, never>>
   callTool: (
     name: string,
     args: Record<string, unknown>,

--- a/packages/browseros-agent/apps/server/tests/api/services/klavis/service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/klavis/service.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, expect, it, mock } from 'bun:test'
+import { asSchema } from 'ai'
 import type { KlavisClient } from '../../../../src/api/services/klavis/client'
 import { KlavisService } from '../../../../src/api/services/klavis/service'
 import type {
@@ -55,7 +56,6 @@ function createHandle(
         inputSchema: { type: 'object' },
       } as never,
     ],
-    inputSchemas: new Map([['gmail_search', {} as never]]),
     callTool: mock(async () => ({
       content: [
         { type: 'text', text: 'Found 2 threads' },
@@ -135,6 +135,51 @@ describe('KlavisService', () => {
     })
   })
 
+  it('keeps parameterized connector tool schemas intact for the model', async () => {
+    const parameterizedSchema = {
+      type: 'object',
+      properties: {
+        category_names: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Categories to expand.',
+        },
+      },
+      required: ['category_names'],
+      additionalProperties: false,
+    }
+    const handle = createHandle({
+      tools: [
+        {
+          name: 'get_category_actions',
+          description: 'Expand categories',
+          inputSchema: parameterizedSchema,
+        } as never,
+      ],
+    })
+    const service = new KlavisService({
+      browserosId: 'browseros-1',
+      client: asClient(new StubKlavisClient()),
+      connect: async () => handle,
+    })
+
+    service.start()
+    await nextTick()
+
+    const tool = service.buildAiSdkToolSet().get_category_actions
+    expect(tool).toBeDefined()
+
+    // Regression: the remote JSON schema must reach the model unchanged. Routing
+    // it through Zod (zod-from-json-schema -> zod-to-json-schema under zod v3)
+    // dropped every property, so the model could never supply category_names.
+    const advertised = asSchema(tool.inputSchema).jsonSchema as {
+      properties?: Record<string, unknown>
+      required?: string[]
+    }
+    expect(advertised.properties?.category_names).toBeDefined()
+    expect(advertised.required).toContain('category_names')
+  })
+
   it('maps null MCP results into JSON model output', async () => {
     const handle = createHandle({
       tools: [
@@ -144,7 +189,6 @@ describe('KlavisService', () => {
           inputSchema: { type: 'object' },
         } as never,
       ],
-      inputSchemas: new Map([['notion_lookup', {} as never]]),
       callTool: mock(async () => null as never),
     })
     const service = new KlavisService({

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -257,7 +257,6 @@
         "pino": "^9.14.0",
         "posthog-node": "^4.18.0",
         "zod": "^3.25.76",
-        "zod-from-json-schema": "^0.5.6",
         "zod-to-json-schema": "^3.25.2",
       },
       "devDependencies": {
@@ -4278,8 +4277,6 @@
     "zip-dir": ["zip-dir@2.0.0", "", { "dependencies": { "async": "^3.2.0", "jszip": "^3.2.2" } }, "sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
-
-    "zod-from-json-schema": ["zod-from-json-schema@0.5.6", "", { "dependencies": { "zod": "^4.0.17" } }, "sha512-U33AJ7ZWS6y9XNSzMWcdy8hRAvZmWhTtpYJu0SXPT5AArbc9nq2ur7Magzmn5RF9KBV4b3FP0nCpmqqlfXlR9w=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 


### PR DESCRIPTION
## Symptom

Connector (Klavis/Strata) tools were unusable from agents. Any parameterized call, e.g. Linear's `get_category_actions`, `get_action_details`, `search_documentation`, failed with contradictory validation errors:

```
Error: category_names parameter is required
Input validation error: ... data must NOT have additional properties
```

The connection itself was fine (`connector_mcp_servers` reported Linear connected with 6 tools). Only tools that take arguments broke; no-argument tools worked.

## Root cause

Those two errors together are the signature of a tool whose advertised input schema has `additionalProperties: false` and **no declared properties**: the model's correct arguments are rejected as "additional", while the remote server still reports them "required".

Strata tool schemas were routed JSON Schema -> Zod -> JSON Schema:

```
remote tool.inputSchema (JSON Schema, has category_names)
  -> jsonSchemaObjectToZodRawShape()   (zod-from-json-schema)
  -> zodToJsonSchema(z.object(shape))   (zod-to-json-schema)
  -> registerTool / AI SDK tool
```

Under this repo's zod v3, `zod-to-json-schema` does not recognize the shapes produced by `zod-from-json-schema`, so the middle step emits `properties: {}` and every property is silently dropped. Confirmed empirically: the Zod raw shape kept `category_names`, but the re-serialized JSON Schema was empty.

## Fix

Pass the remote JSON schema straight through, which the MCP SDK explicitly supports (its own error text says "wrap your JSON Schema with fromJsonSchema()"):

- MCP server path: `fromJsonSchema(tool.inputSchema)`.
- AI SDK tool set: the `ai` package's `jsonSchema(tool.inputSchema)` helper.

No Zod in the middle, so nothing is dropped. The hand-built `connector_mcp_servers` schema (a local Zod v3 shape that round-trips correctly) is unchanged. Removes the now-unused per-session schema map and the dead `zod-from-json-schema` dependency.

## Tests

- Added a regression test asserting a parameterized connector tool keeps its `properties` and `required` after adapting, the exact thing the round-trip destroyed.
- Existing Klavis service, MCP route, and dual-era tests pass; server typecheck and biome clean.
