### PR TITLE
feat(ai-settings): auto-discover models for OpenAI-compatible providers

### DIFF
--- a/packages/browseros-agent/apps/app/lib/llm-providers/listModels.test.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/listModels.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { listModels } from './listModels'
+
+let originalFetch: typeof globalThis.fetch
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function mockFetchJson(body: unknown, ok = true) {
+  globalThis.fetch = (async () =>
+    ({
+      ok,
+      json: async () => body,
+    }) as unknown as Response) as unknown as typeof globalThis.fetch
+}
+
+describe('listModels — success', () => {
+  it('maps modelId and contextLength', async () => {
+    mockFetchJson({
+      models: [{ modelId: 'llama3.2', contextLength: 131072 }],
+    })
+    const models = await listModels(
+      { type: 'ollama', baseUrl: 'http://localhost:11434' },
+      'http://127.0.0.1:9200',
+    )
+    expect(models).toEqual([{ modelId: 'llama3.2', contextLength: 131072 }])
+  })
+
+  it('defaults contextLength to 128000 when missing', async () => {
+    mockFetchJson({ models: [{ modelId: 'qwen2.5' }] })
+    const models = await listModels(
+      { type: 'lmstudio', baseUrl: 'http://localhost:1234' },
+      'http://127.0.0.1:9200',
+    )
+    expect(models).toEqual([{ modelId: 'qwen2.5', contextLength: 128000 }])
+  })
+})
+
+describe('listModels — soft failures return []', () => {
+  it('network failure → []', async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError('Failed to fetch')
+    }) as unknown as typeof globalThis.fetch
+
+    const models = await listModels(
+      { type: 'openai-compatible', baseUrl: 'http://x' },
+      'http://127.0.0.1:9200',
+    )
+    expect(models).toEqual([])
+  })
+
+  it('non-200 response → []', async () => {
+    mockFetchJson({ models: [{ modelId: 'm' }] }, false)
+    const models = await listModels(
+      { type: 'openai-compatible', baseUrl: 'http://x' },
+      'http://127.0.0.1:9200',
+    )
+    expect(models).toEqual([])
+  })
+})

--- a/packages/browseros-agent/apps/app/lib/llm-providers/listModels.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/listModels.ts
@@ -1,0 +1,46 @@
+import type { ModelInfo } from '../../screens/ai-settings/models'
+
+/**
+ * @public
+ */
+export interface ListModelsInput {
+  type: string
+  baseUrl?: string
+  apiKey?: string
+}
+
+/**
+ * Discover the models an OpenAI-compatible endpoint actually serves via the
+ * agent server's /list-models proxy. Never throws: any failure returns [] so
+ * the picker silently falls back to the bundled catalog / free-form entry.
+ * @public
+ */
+export async function listModels(
+  input: ListModelsInput,
+  agentServerUrl: string,
+): Promise<ModelInfo[]> {
+  try {
+    const response = await fetch(`${agentServerUrl}/list-models`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: input.type,
+        baseUrl: input.baseUrl,
+        apiKey: input.apiKey,
+      }),
+    })
+    if (!response.ok) return []
+
+    const result = (await response.json()) as {
+      models?: Array<{ modelId: string; contextLength?: number }>
+    }
+    if (!Array.isArray(result.models)) return []
+
+    return result.models.map((m) => ({
+      modelId: m.modelId,
+      contextLength: m.contextLength ?? 128000,
+    }))
+  } catch {
+    return []
+  }
+}

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -6,6 +6,7 @@ import {
   ChevronDown,
   ExternalLink,
   Loader2,
+  RotateCw,
   XCircle,
 } from 'lucide-react'
 import { type FC, useEffect, useMemo, useRef, useState } from 'react'
@@ -57,6 +58,7 @@ import {
   KIMI_API_KEY_GUIDE_CLICKED_EVENT,
   MODEL_SELECTED_EVENT,
 } from '@/lib/constants/analyticsEvents'
+import { listModels } from '@/lib/llm-providers/listModels'
 import {
   getDefaultBaseUrlForProviders,
   getProviderTemplate,
@@ -71,6 +73,7 @@ import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
 import {
   getIncompleteCatalogHint,
   getModelPickerRows,
+  servesUserLoadedModels,
 } from './model-picker.helpers'
 import {
   getModelContextLength,
@@ -184,6 +187,367 @@ export interface NewProviderDialogProps {
   onSave: (provider: LlmProviderConfig) => Promise<void>
 }
 
+function ReasoningControls({
+  control,
+  effortOptions,
+  showSummary,
+}: {
+  control: ReturnType<typeof useForm<ProviderFormValues>>['control']
+  effortOptions: string[]
+  showSummary: boolean
+}) {
+  return (
+    <div className="space-y-4 border-border border-t pt-4">
+      <h4 className="font-medium text-sm">Reasoning</h4>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <FormField
+          control={control}
+          name="reasoningEffort"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Reasoning Effort</FormLabel>
+              <Select
+                onValueChange={field.onChange}
+                value={
+                  effortOptions.includes(field.value ?? '')
+                    ? field.value
+                    : pickDefaultEffort(effortOptions)
+                }
+              >
+                <FormControl>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {effortOptions.map((value) => (
+                    <SelectItem key={value} value={value}>
+                      {value.charAt(0).toUpperCase() + value.slice(1)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormDescription>
+                How much the model thinks before responding
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {showSummary && (
+          <FormField
+            control={control}
+            name="reasoningSummary"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Reasoning Summary</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value || 'auto'}
+                >
+                  <FormControl>
+                    <SelectTrigger className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="auto">Auto</SelectItem>
+                    <SelectItem value="concise">Concise</SelectItem>
+                    <SelectItem value="detailed">Detailed</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormDescription>
+                  Detail level of visible thinking steps
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Auto-discovers the models the endpoint actually serves (OpenAI-compatible,
+ * Ollama, LM Studio). Falls back silently to the bundled catalog + free-form
+ * entry whenever discovery is unavailable or fails.
+ */
+function useDiscoveredModels(input: {
+  providerType: string
+  baseUrl?: string
+  apiKey?: string
+  agentServerUrl?: string
+  enabled: boolean
+  refreshKey: number
+}) {
+  const agentServerUrl = input.agentServerUrl ?? ''
+  const [discoveredModels, setDiscoveredModels] = useState<ModelInfo[]>([])
+  const [modelsLoading, setModelsLoading] = useState(false)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional - refreshKey re-triggers the debounced fetch
+  useEffect(() => {
+    if (!input.enabled || !input.baseUrl || !input.agentServerUrl) {
+      setDiscoveredModels([])
+      return
+    }
+    let cancelled = false
+    const timer = setTimeout(async () => {
+      setModelsLoading(true)
+      try {
+        const models = await listModels(
+          {
+            type: input.providerType,
+            baseUrl: input.baseUrl,
+            apiKey: input.apiKey || undefined,
+          },
+          agentServerUrl,
+        )
+        if (!cancelled) setDiscoveredModels(models)
+      } finally {
+        if (!cancelled) setModelsLoading(false)
+      }
+    }, 600)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+      setModelsLoading(false)
+    }
+  }, [
+    input.enabled,
+    input.providerType,
+    input.baseUrl,
+    input.apiKey,
+    input.agentServerUrl,
+    input.refreshKey,
+  ])
+
+  return { discoveredModels, modelsLoading }
+}
+
+function ProviderSpecificFields({
+  type,
+  control,
+  setupGuideUrl,
+  setupGuideText,
+  onSetupGuideClick,
+}: {
+  type: ProviderType
+  control: ReturnType<typeof useForm<ProviderFormValues>>['control']
+  setupGuideUrl?: string
+  setupGuideText: string
+  onSetupGuideClick: (e: React.MouseEvent) => void
+}) {
+  if (isCredentiallessProviderType(type) && type !== 'chatgpt-pro') {
+    const name = type === 'github-copilot' ? 'GitHub' : 'Qwen Code'
+    return (
+      <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-green-700 text-sm dark:border-green-800 dark:bg-green-950 dark:text-green-300">
+        Credentials are managed via {name} OAuth. No API key needed.
+      </div>
+    )
+  }
+
+  if (type === 'chatgpt-pro') {
+    return (
+      <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-green-700 text-sm dark:border-green-800 dark:bg-green-950 dark:text-green-300">
+        Credentials are managed via OAuth. No API key needed.
+      </div>
+    )
+  }
+
+  if (type === 'azure') {
+    return (
+      <>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <FormField
+            control={control}
+            name="resourceName"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Resource Name *</FormLabel>
+                <FormControl>
+                  <Input placeholder="your-resource-name" {...field} />
+                </FormControl>
+                <FormDescription>Azure OpenAI resource name</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="baseUrl"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Base URL Override</FormLabel>
+                <FormControl>
+                  <Input placeholder="Optional custom URL" {...field} />
+                </FormControl>
+                <FormDescription>
+                  Overrides resource name if set
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <FormField
+          control={control}
+          name="apiKey"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>API Key *</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder="Enter your Azure API key"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </>
+    )
+  }
+
+  if (type === 'bedrock') {
+    return (
+      <>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <FormField
+            control={control}
+            name="accessKeyId"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Access Key ID *</FormLabel>
+                <FormControl>
+                  <Input placeholder="AKIA..." {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="secretAccessKey"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Secret Access Key *</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="Enter your secret access key"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <FormField
+            control={control}
+            name="region"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Region *</FormLabel>
+                <FormControl>
+                  <Input placeholder="us-east-1" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="sessionToken"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Session Token</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="Optional (for STS credentials)"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Required for temporary credentials
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <FormField
+        control={control}
+        name="baseUrl"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Base URL *</FormLabel>
+            <FormControl>
+              <Input placeholder="https://api.openai.com/v1" {...field} />
+            </FormControl>
+            {type === 'openai' && (
+              <FormDescription>
+                If your custom endpoint doesn't work with OpenAI, try the OpenAI
+                Compatible provider template instead.
+              </FormDescription>
+            )}
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={control}
+        name="apiKey"
+        render={({ field }) => {
+          const isApiKeyOptional = ['ollama', 'lmstudio'].includes(type)
+          return (
+            <FormItem>
+              <FormLabel>API Key{isApiKeyOptional ? '' : ' *'}</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder={
+                    isApiKeyOptional
+                      ? 'Enter your API key (optional)'
+                      : 'Enter your API key'
+                  }
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                Your API key is encrypted and stored locally.{' '}
+                {setupGuideUrl && (
+                  <a
+                    href={setupGuideUrl}
+                    onClick={onSetupGuideClick}
+                    className="inline-flex cursor-pointer items-center gap-1 text-primary hover:underline"
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                    {setupGuideText}
+                  </a>
+                )}
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )
+        }}
+      />
+    </>
+  )
+}
+
 export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   open,
   onOpenChange,
@@ -194,6 +558,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   const [testResult, setTestResult] = useState<TestResult | null>(null)
   const [modelPickerOpen, setModelPickerOpen] = useState(false)
   const [modelSearch, setModelSearch] = useState('')
+  const [modelsRefreshKey, setModelsRefreshKey] = useState(0)
   const modelListRef = useRef<HTMLDivElement>(null)
   const { supports } = useCapabilities()
   const { baseUrl: agentServerUrl } = useAgentServerUrl()
@@ -250,7 +615,30 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     watchedSessionToken,
   ])
 
-  const modelInfoList = getModelsForProvider(watchedType as ProviderType)
+  const canDiscoverModels = useMemo(
+    () =>
+      servesUserLoadedModels(watchedType as ProviderType) &&
+      Boolean(watchedBaseUrl) &&
+      Boolean(agentServerUrl),
+    [watchedType, watchedBaseUrl, agentServerUrl],
+  )
+
+  const { discoveredModels, modelsLoading } = useDiscoveredModels({
+    providerType: watchedType,
+    baseUrl: watchedBaseUrl,
+    apiKey: watchedApiKey,
+    agentServerUrl,
+    enabled: canDiscoverModels,
+    refreshKey: modelsRefreshKey,
+  })
+
+  const modelInfoList = useMemo(
+    () =>
+      discoveredModels.length
+        ? discoveredModels
+        : getModelsForProvider(watchedType as ProviderType),
+    [discoveredModels, watchedType],
+  )
   const selectedModel: ModelInfo | undefined = modelInfoList.find(
     (m) => m.modelId === watchedModelId,
   )
@@ -494,10 +882,14 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     watchedType as ProviderType,
     providerName,
   )
-  const modelCatalogHint = getIncompleteCatalogHint(
-    watchedType as ProviderType,
-    modelInfoList.length,
-    providerName,
+  const modelCatalogHint = useMemo(
+    () =>
+      getIncompleteCatalogHint(
+        watchedType as ProviderType,
+        discoveredModels.length > 0 ? 0 : modelInfoList.length,
+        providerName,
+      ),
+    [watchedType, discoveredModels.length, modelInfoList.length, providerName],
   )
 
   const handleSetupGuideClick = (e: React.MouseEvent) => {
@@ -516,291 +908,22 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     watchedType === 'chatgpt-pro'
 
   const renderReasoningControls = () => (
-    <div className="space-y-4 border-border border-t pt-4">
-      <h4 className="font-medium text-sm">Reasoning</h4>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <FormField
-          control={form.control}
-          name="reasoningEffort"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Reasoning Effort</FormLabel>
-              <Select
-                onValueChange={field.onChange}
-                value={
-                  reasoningEffortOptions.includes(field.value ?? '')
-                    ? field.value
-                    : pickDefaultEffort(reasoningEffortOptions)
-                }
-              >
-                <FormControl>
-                  <SelectTrigger className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  {reasoningEffortOptions.map((value) => (
-                    <SelectItem key={value} value={value}>
-                      {value.charAt(0).toUpperCase() + value.slice(1)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <FormDescription>
-                How much the model thinks before responding
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        {showReasoningSummary && (
-          <FormField
-            control={form.control}
-            name="reasoningSummary"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Reasoning Summary</FormLabel>
-                <Select
-                  onValueChange={field.onChange}
-                  value={field.value || 'auto'}
-                >
-                  <FormControl>
-                    <SelectTrigger className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="auto">Auto</SelectItem>
-                    <SelectItem value="concise">Concise</SelectItem>
-                    <SelectItem value="detailed">Detailed</SelectItem>
-                  </SelectContent>
-                </Select>
-                <FormDescription>
-                  Detail level of visible thinking steps
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        )}
-      </div>
-    </div>
+    <ReasoningControls
+      control={form.control}
+      effortOptions={reasoningEffortOptions}
+      showSummary={showReasoningSummary}
+    />
   )
 
-  const renderProviderSpecificFields = () => {
-    if (
-      isCredentiallessProviderType(watchedType) &&
-      watchedType !== 'chatgpt-pro'
-    ) {
-      const name = watchedType === 'github-copilot' ? 'GitHub' : 'Qwen Code'
-      return (
-        <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-green-700 text-sm dark:border-green-800 dark:bg-green-950 dark:text-green-300">
-          Credentials are managed via {name} OAuth. No API key needed.
-        </div>
-      )
-    }
-
-    if (watchedType === 'chatgpt-pro') {
-      return (
-        <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-green-700 text-sm dark:border-green-800 dark:bg-green-950 dark:text-green-300">
-          Credentials are managed via OAuth. No API key needed.
-        </div>
-      )
-    }
-
-    if (watchedType === 'azure') {
-      return (
-        <>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <FormField
-              control={form.control}
-              name="resourceName"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Resource Name *</FormLabel>
-                  <FormControl>
-                    <Input placeholder="your-resource-name" {...field} />
-                  </FormControl>
-                  <FormDescription>Azure OpenAI resource name</FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="baseUrl"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Base URL Override</FormLabel>
-                  <FormControl>
-                    <Input placeholder="Optional custom URL" {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    Overrides resource name if set
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-          <FormField
-            control={form.control}
-            name="apiKey"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>API Key *</FormLabel>
-                <FormControl>
-                  <Input
-                    type="password"
-                    placeholder="Enter your Azure API key"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </>
-      )
-    }
-
-    if (watchedType === 'bedrock') {
-      return (
-        <>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <FormField
-              control={form.control}
-              name="accessKeyId"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Access Key ID *</FormLabel>
-                  <FormControl>
-                    <Input placeholder="AKIA..." {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="secretAccessKey"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Secret Access Key *</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="password"
-                      placeholder="Enter your secret access key"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <FormField
-              control={form.control}
-              name="region"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Region *</FormLabel>
-                  <FormControl>
-                    <Input placeholder="us-east-1" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="sessionToken"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Session Token</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="password"
-                      placeholder="Optional (for STS credentials)"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Required for temporary credentials
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-        </>
-      )
-    }
-
-    return (
-      <>
-        <FormField
-          control={form.control}
-          name="baseUrl"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Base URL *</FormLabel>
-              <FormControl>
-                <Input placeholder="https://api.openai.com/v1" {...field} />
-              </FormControl>
-              {watchedType === 'openai' && (
-                <FormDescription>
-                  If your custom endpoint doesn't work with OpenAI, try the
-                  OpenAI Compatible provider template instead.
-                </FormDescription>
-              )}
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="apiKey"
-          render={({ field }) => {
-            const isApiKeyOptional = ['ollama', 'lmstudio'].includes(
-              watchedType,
-            )
-            return (
-              <FormItem>
-                <FormLabel>API Key{isApiKeyOptional ? '' : ' *'}</FormLabel>
-                <FormControl>
-                  <Input
-                    type="password"
-                    placeholder={
-                      isApiKeyOptional
-                        ? 'Enter your API key (optional)'
-                        : 'Enter your API key'
-                    }
-                    {...field}
-                  />
-                </FormControl>
-                <FormDescription>
-                  Your API key is encrypted and stored locally.{' '}
-                  {setupGuideUrl && (
-                    <a
-                      href={setupGuideUrl}
-                      onClick={handleSetupGuideClick}
-                      className="inline-flex cursor-pointer items-center gap-1 text-primary hover:underline"
-                    >
-                      <ExternalLink className="h-3 w-3" />
-                      {setupGuideText}
-                    </a>
-                  )}
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )
-          }}
-        />
-      </>
-    )
-  }
+  const renderProviderSpecificFields = () => (
+    <ProviderSpecificFields
+      type={watchedType}
+      control={form.control}
+      setupGuideUrl={setupGuideUrl}
+      setupGuideText={setupGuideText}
+      onSetupGuideClick={handleSetupGuideClick}
+    />
+  )
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -867,7 +990,25 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
               name="modelId"
               render={({ field }) => (
                 <FormItem className="flex flex-col">
-                  <FormLabel>Model *</FormLabel>
+                  <FormLabel>
+                    Model *
+                    {canDiscoverModels && (
+                      <button
+                        type="button"
+                        aria-label="Refresh model list"
+                        title="Refresh model list"
+                        onClick={() => setModelsRefreshKey((k) => k + 1)}
+                        disabled={modelsLoading}
+                        className="ml-1 inline-flex align-middle text-muted-foreground hover:text-foreground disabled:opacity-50"
+                      >
+                        {modelsLoading ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <RotateCw className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                    )}
+                  </FormLabel>
                   {modelInfoList.length === 0 ? (
                     <FormControl>
                       <Input

--- a/packages/browseros-agent/apps/server/src/api/routes/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/index.ts
@@ -23,7 +23,7 @@ import { createKlavisRoutes } from './klavis'
 import { createMcpRoutes } from './mcp'
 import { createMcpManagerRoutes } from './mcp-manager'
 import { createOAuthRoutes } from './oauth'
-import { createProviderRoutes } from './provider'
+import { createListModelRoutes, createProviderRoutes } from './provider'
 import { createRefinePromptRoutes } from './refine-prompt'
 import { createShutdownRoute } from './shutdown'
 import { createStatusRoute } from './status'
@@ -72,6 +72,7 @@ export function createApiRoutes(deps: CreateApiRoutesDeps) {
       .route('/shutdown', createShutdownRoute({ onShutdown }))
       .route('/status', createStatusRoute({ browser, activity }))
       .route('/test-provider', createProviderRoutes({ browserosId }))
+      .route('/list-models', createListModelRoutes())
       .route('/refine-prompt', createRefinePromptRoutes({ browserosId }))
       .route('/oauth', oauthRoutes(tokenManager))
       .route('/klavis', createKlavisRoutes({ klavis }))

--- a/packages/browseros-agent/apps/server/src/api/routes/provider.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/provider.ts
@@ -6,9 +6,17 @@
 
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
+import { z } from 'zod'
+import { listProviderModels } from '../../lib/clients/llm/list-models'
 import { testProviderConnection } from '../../lib/clients/llm/test-provider'
 import { logger } from '../../lib/logger'
 import { AgentLLMConfigSchema } from '../types'
+
+const ListModelsRequestSchema = z.object({
+  provider: z.string().min(1),
+  baseUrl: z.string().min(1),
+  apiKey: z.string().optional(),
+})
 
 interface ProviderRouteDeps {
   browserosId?: string
@@ -36,6 +44,33 @@ export function createProviderRoutes(deps: ProviderRouteDeps = {}) {
       })
 
       return c.json(result, result.success ? 200 : 400)
+    },
+  )
+}
+
+/** Lists the models an OpenAI-compatible endpoint actually serves. */
+export function createListModelRoutes() {
+  return new Hono().post(
+    '/',
+    zValidator('json', ListModelsRequestSchema),
+    async (c) => {
+      const { provider, baseUrl, apiKey } = c.req.valid('json')
+
+      logger.info('Listing provider models', { provider, baseUrl })
+
+      try {
+        const models = await listProviderModels({ provider, baseUrl, apiKey })
+        logger.info('Provider models result', {
+          provider,
+          count: models.length,
+        })
+        return c.json({ models })
+      } catch (error) {
+        // Soft-fail so the client keeps its free-form model entry UX.
+        const message = error instanceof Error ? error.message : String(error)
+        logger.warn('Provider models lookup failed', { provider, message })
+        return c.json({ models: [], message })
+      }
     },
   )
 }

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/list-models.test.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/list-models.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { listProviderModels } from './list-models'
+
+let originalFetch: typeof globalThis.fetch
+let lastUrl: string | null = null
+let lastHeaders: HeadersInit | undefined
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+  lastUrl = null
+  lastHeaders = undefined
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function mockFetchJson(
+  body: unknown,
+  init: { status?: number; statusText?: string } = {},
+) {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    lastUrl = typeof input === 'string' ? input : input.toString()
+    return {
+      ok: (init.status ?? 200) < 400,
+      status: init.status ?? 200,
+      statusText: init.statusText ?? '',
+      json: async () => body,
+    } as unknown as Response
+  }) as unknown as typeof globalThis.fetch
+}
+
+describe('listProviderModels — happy path', () => {
+  test('maps id and context_length', async () => {
+    mockFetchJson({
+      data: [{ id: 'llama3.2', context_length: 131072 }, { id: 'qwen2.5' }],
+    })
+    const models = await listProviderModels({
+      provider: 'openai-compatible',
+      baseUrl: 'http://localhost:11434',
+    })
+    expect(models).toEqual([
+      { modelId: 'llama3.2', contextLength: 131072 },
+      { modelId: 'qwen2.5', contextLength: undefined },
+    ])
+    expect(lastUrl).toBe('http://localhost:11434/v1/models')
+  })
+})
+
+describe('listProviderModels — response shape', () => {
+  test('missing data yields []', async () => {
+    mockFetchJson({})
+    const models = await listProviderModels({
+      provider: 'lmstudio',
+      baseUrl: 'http://localhost:1234',
+    })
+    expect(models).toEqual([])
+  })
+
+  test('filters non-string ids', async () => {
+    mockFetchJson({ data: [{ id: 42 }, { id: 'good' }, {}] })
+    const models = await listProviderModels({
+      provider: 'ollama',
+      baseUrl: 'http://localhost:11434',
+    })
+    expect(models).toEqual([{ modelId: 'good', contextLength: undefined }])
+  })
+})
+
+describe('listProviderModels — failures', () => {
+  test('throws on 401', async () => {
+    mockFetchJson(
+      { error: 'bad key' },
+      { status: 401, statusText: 'Unauthorized' },
+    )
+    expect(
+      listProviderModels({
+        provider: 'openai-compatible',
+        baseUrl: 'http://x',
+      }),
+    ).rejects.toThrow('[openai-compatible] 401 Unauthorized')
+  })
+
+  test('throws on 500', async () => {
+    mockFetchJson({}, { status: 500, statusText: 'Internal Server Error' })
+    expect(
+      listProviderModels({
+        provider: 'openai-compatible',
+        baseUrl: 'http://x',
+      }),
+    ).rejects.toThrow('500')
+  })
+
+  test('throws when baseUrl is missing', async () => {
+    mockFetchJson({ data: [] })
+    expect(
+      listProviderModels({ provider: 'openai-compatible' }),
+    ).rejects.toThrow('baseUrl is required')
+  })
+})
+
+describe('listProviderModels — URL normalization', () => {
+  test.each(['http://x/v1', 'http://x/v1/', 'http://x/', 'http://x'])(
+    '%s → http://x/v1/models',
+    async (baseUrl) => {
+      mockFetchJson({ data: [] })
+      await listProviderModels({ provider: 'p', baseUrl })
+      expect(lastUrl).toBe('http://x/v1/models')
+    },
+  )
+})
+
+describe('listProviderModels — auth header', () => {
+  test('sends Bearer token when apiKey present', async () => {
+    mockFetchJson({ data: [] })
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      lastUrl = input.toString()
+      lastHeaders = init?.headers
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] }),
+      } as Response
+    }) as unknown as typeof globalThis.fetch
+
+    await listProviderModels({
+      provider: 'p',
+      baseUrl: 'http://x',
+      apiKey: 'sk-test',
+    })
+    expect(lastHeaders).toEqual({ Authorization: 'Bearer sk-test' })
+  })
+})

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/list-models.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/list-models.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
+
+export interface ListModelsConfig {
+  provider: string
+  baseUrl?: string
+  apiKey?: string
+}
+
+export interface ProviderModelInfo {
+  modelId: string
+  contextLength?: number
+}
+
+/** Strips a trailing slash and a trailing `/v1` so `${base}/v1/models` is well formed. */
+function normalizeBaseUrl(raw: string): string {
+  let base = raw.trim().replace(/\/+$/, '')
+  if (base.endsWith('/v1')) base = base.slice(0, -3)
+  return base
+}
+
+export async function listProviderModels(
+  config: ListModelsConfig,
+): Promise<ProviderModelInfo[]> {
+  if (!config.baseUrl) {
+    throw new Error(`[${config.provider}] baseUrl is required to list models`)
+  }
+
+  const url = `${normalizeBaseUrl(config.baseUrl)}/v1/models`
+  const response = await fetch(url, {
+    headers: config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {},
+    signal: AbortSignal.timeout(TIMEOUTS.TEST_PROVIDER),
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `[${config.provider}] ${response.status} ${response.statusText || ''}`.trim(),
+    )
+  }
+
+  const body = (await response.json()) as {
+    data?: Array<{ id?: unknown; context_length?: unknown }>
+  }
+
+  return (body.data ?? [])
+    .filter((m) => typeof m.id === 'string' && m.id)
+    .map((m) => ({
+      modelId: m.id as string,
+      contextLength:
+        typeof m.context_length === 'number' ? m.context_length : undefined,
+    }))
+}


### PR DESCRIPTION
Closes #2411

## Problem

For OpenAI-compatible endpoints (including Ollama and LM Studio), the Add Provider dialog showed a bundled models.dev catalog that is only ever a stale sample of what the user's endpoint actually serves. Users with local or proxied models had to paste exact model IDs by hand, and short catalogs (e.g. LM Studio's three entries) read as the complete list, leading users to conclude their loaded models were unsupported.

## Implementation

**Server (apps/server)**

- New `listProviderModels` in `lib/clients/llm/list-models.ts`: normalizes the base URL (strips trailing slash and trailing `/v1`), fetches `GET {base}/v1/models` with optional Bearer auth, 15s timeout, and maps `{ id, context_length }` entries. Non-string ids are filtered out.
- New route factory `createListModelRoutes` in `api/routes/provider.ts`, mounted at `POST /list-models` in `api/routes/index.ts` (separate from `/test-provider` to avoid the ugly `/test-provider/models` path).
- Soft-fail: on any upstream error the route returns 200 with `{ models: [], message }`, so the client always keeps its free-form model entry UX.

**Client (apps/app)**

- New `listModels` in `lib/llm-providers/listModels.ts`: posts to the agent server and maps results to `ModelInfo`, defaulting `contextLength` to 128000 when absent. Any failure returns an empty array (no throw).
- `NewProviderDialog`: a `useDiscoveredModels` hook auto-fetches (600ms debounce) whenever the provider type serves user-loaded models (`openai-compatible`, `ollama`, `lmstudio`) and a base URL is present. Discovered models replace the stale catalog in the picker; the free-form "paste exact ID" path is retained as fallback. A small refresh button next to the Model label re-triggers discovery. The "lists only common models" hint is suppressed once discovery returns results.
- Ollama and LM Studio get this for free (same `USER_LOADED_MODEL_PROVIDERS` set).

## Test plan

- `apps/server/src/lib/clients/llm/list-models.test.ts`: happy path, missing `data`, non-string ids, 401/500 throws, URL normalization (`/v1`, `/v1/`, trailing slash, bare host), Bearer header forwarding. All 15 tests pass.
- `apps/app/lib/llm-providers/listModels.test.ts`: mapping plus contextLength default, network failure returns `[]`, non-200 returns `[]`. Passes.
- `biome check` clean on all touched files; `tsc --noEmit` clean for touched files (pre-existing generated-graphql errors unchanged); full server and app suites show only pre-existing failures (verified identical on clean `main`).

## Out of scope

- Capability detection from `/models` metadata beyond `context_length` (not consistently present across providers).
- Persistent caching of discovered model lists.
