### PR TITLE
fix(cli): stop sending the retired hidden input to tabs/windows

### DIFF
--- a/packages/browseros-agent/apps/cli/CHANGELOG.md
+++ b/packages/browseros-agent/apps/cli/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- Fix `open` and `window create` failing with an `unknown field "hidden"` schema error: the server retired the `hidden` input, so the CLI no longer sends it. Also restores the `page` field in `open --json` output. Removes the `--hidden` flag from `open` and `window create`.
 - Add `--llm-txt`: prints a concise agent usage guide for the CLI to stdout (`browseros-cli --llm-txt`).

--- a/packages/browseros-agent/apps/cli/README.md
+++ b/packages/browseros-agent/apps/cli/README.md
@@ -227,7 +227,7 @@ apps/cli/
 │   ├── root.go         # Root command, global flags
 │   ├── init.go         # Server URL configuration (URL arg or interactive)
 │   ├── launch.go       # launch (find and start BrowserOS, wait for server)
-│   ├── open.go         # open (new_page / new_hidden_page)
+│   ├── open.go         # open (new_page)
 │   ├── nav.go          # nav, back, forward, reload
 │   ├── tabs.go         # tabs/pages alias, active, close
 │   ├── snap.go         # snapshot/snap

--- a/packages/browseros-agent/apps/cli/cmd/llm_txt.md
+++ b/packages/browseros-agent/apps/cli/cmd/llm_txt.md
@@ -39,7 +39,7 @@ browseros-cli -p "$page" snapshot -i                                  # 4. re-sn
 ## Page handles
 
 ```bash
-browseros-cli open --json <url> | jq -r .page   # open a tab; returns its page id (--bg, --hidden, --window <id>)
+browseros-cli open --json <url> | jq -r .page   # open a tab; returns its page id (--bg, --window <id>)
 browseros-cli tabs --json                        # list open tabs with page ids (alias: pages)
 browseros-cli active --json                      # the focused tab's page id
 browseros-cli -p "$page" close                   # close a tab

--- a/packages/browseros-agent/apps/cli/cmd/open.go
+++ b/packages/browseros-agent/apps/cli/cmd/open.go
@@ -17,7 +17,6 @@ func init() {
 		Short:       "Open a new page (tab) and navigate to a URL",
 		Args:        cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			hidden, _ := cmd.Flags().GetBool("hidden")
 			bg, _ := cmd.Flags().GetBool("bg")
 			windowID, _ := cmd.Flags().GetInt("window")
 
@@ -27,13 +26,13 @@ func init() {
 
 			if cmd.Flags().Changed("window") {
 				var result any
-				_, result, err = browserRunValue(c, openInWindowCode(args[0], hidden, bg, windowID))
+				_, result, err = browserRunValue(c, openInWindowCode(args[0], bg, windowID))
 				if err == nil {
 					resultData, _ := valueMap(result)
 					toolResult = textResult("", resultData)
 				}
 			} else {
-				toolResult, err = c.CallTool("tabs", openTabsToolArgs(args[0], hidden, bg))
+				toolResult, err = c.CallTool("tabs", openTabsToolArgs(args[0], bg))
 			}
 
 			if err != nil {
@@ -48,7 +47,6 @@ func init() {
 		},
 	}
 
-	cmd.Flags().Bool("hidden", false, "Open as hidden tab")
 	cmd.Flags().Bool("bg", false, "Open in background")
 	cmd.Flags().Int("window", 0, "Window ID to open in")
 
@@ -88,25 +86,22 @@ func openResult(url string, result *mcp.ToolResult) *mcp.ToolResult {
 	return textResult(strings.Join(lines, "\n"), data)
 }
 
-func openTabsToolArgs(url string, hidden, background bool) map[string]any {
+func openTabsToolArgs(url string, background bool) map[string]any {
 	return map[string]any{
 		"action":     "new",
 		"url":        url,
-		"hidden":     hidden,
 		"background": background,
 	}
 }
 
-func openInWindowCode(url string, hidden, background bool, windowID int) string {
+func openInWindowCode(url string, background bool, windowID int) string {
 	return fmt.Sprintf(
-		`const page = await browser.pages.newPage(%s, { hidden: %t, background: %t, windowId: %d })
-return { page, url: %s, hidden: %t, background: %t, windowId: %d }`,
+		`const page = await browser.pages.newPage(%s, { background: %t, windowId: %d })
+return { page, url: %s, background: %t, windowId: %d }`,
 		jsLiteral(url),
-		hidden,
 		background,
 		windowID,
 		jsLiteral(url),
-		hidden,
 		background,
 		windowID,
 	)

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -52,11 +52,10 @@ func TestCompactToolMappings(t *testing.T) {
 		},
 		{
 			name: "open tab",
-			got:  openTabsToolArgs("https://example.com", true, false),
+			got:  openTabsToolArgs("https://example.com", false),
 			want: map[string]any{
 				"action":     "new",
 				"url":        "https://example.com",
-				"hidden":     true,
 				"background": false,
 			},
 		},
@@ -436,17 +435,20 @@ func TestFillToolArgsFromNoClearFlag(t *testing.T) {
 }
 
 func TestOpenInWindowCodeUsesCompactRunBridge(t *testing.T) {
-	code := openInWindowCode("https://example.com/?q=one two", true, false, 9)
+	code := openInWindowCode("https://example.com/?q=one two", false, 9)
 	for _, want := range []string{
 		"browser.pages.newPage",
 		`"https://example.com/?q=one two"`,
-		"hidden: true",
 		"background: false",
 		"windowId: 9",
 	} {
 		if !strings.Contains(code, want) {
 			t.Fatalf("openInWindowCode() missing %q in:\n%s", want, code)
 		}
+	}
+	// The server retired hidden: pages.newPage rejects the option outright.
+	if strings.Contains(code, "hidden") {
+		t.Fatalf("openInWindowCode() still sends retired hidden option:\n%s", code)
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/window.go
+++ b/packages/browseros-agent/apps/cli/cmd/window.go
@@ -38,12 +38,9 @@ func init() {
 		Short: "Create a new browser window",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			hidden, _ := cmd.Flags().GetBool("hidden")
-
 			c := newClient()
 			result, err := c.CallTool("windows", map[string]any{
 				"action": "create",
-				"hidden": hidden,
 			})
 			if err != nil {
 				output.Error(err.Error(), 1)
@@ -55,7 +52,6 @@ func init() {
 			}
 		},
 	}
-	createCmd.Flags().Bool("hidden", false, "Create hidden window")
 
 	closeCmd := &cobra.Command{
 		Use:   "close <windowId>",


### PR DESCRIPTION
## Summary

`browseros-cli open` is broken on every code path because the CLI still sends the `hidden` input that the server retired.

Both tool schemas are `#[serde(deny_unknown_fields)]` and `pages.newPage` rejects the option explicitly, so the call fails before a tab is ever opened:

| CLI path | sends | server response |
|---|---|---|
| `open` → `tabs` action=new | `"hidden": false` | ``Invalid arguments for tabs: hidden: unknown field `hidden` `` |
| `open --window N` → `browser.pages.newPage(url, { hidden, … })` | `hidden: false` | `pages.newPage: hidden is no longer supported` |
| `window create` → `windows` action=create | `"hidden": false` | ``Invalid arguments for windows: hidden: unknown field `hidden` `` |

The retirement is intentional and pinned by the server's own tests — `retired_hidden_inputs_are_rejected` and `tab_and_window_schemas_omit_hidden_controls` in `crates/browseros-mcp/src/tests.rs`. Only the Go CLI was left behind.

## Fix

Drop the `hidden` argument and the `--hidden` flag from `open` and `window create`, per the rule in `apps/cli/CLAUDE.md`:

> **MCP tool names are the contract.** A command only shapes args; the server owns the tool. Keep command tool names and arg keys in sync with the compact MCP surface.

## This also fixes #2162

`open --json` was reported as returning `{"url":"…"}` with no `page`. That was a symptom, not a second bug — `tabs` action=new already returns `{ "page": <id> }` (`tools/tabs.rs`), and `openResult` already maps it (`cmd/open.go`). The field was missing only because the call never succeeded. With `hidden` gone, `open --json` emits the documented shape again:

```json
{"page":123,"url":"https://example.com"}
```

which is what `cmd/llm_txt.md` tells agents to rely on:

```bash
page=$(browseros-cli open --json https://example.com | jq -r .page)
browseros-cli -p "$page" snapshot
```

## Changes

- `cmd/open.go` — remove `hidden` from `openTabsToolArgs` and `openInWindowCode`; drop the `--hidden` flag
- `cmd/window.go` — remove `hidden` from `window create`; drop the `--hidden` flag
- `cmd/tool_mapping_test.go` — update the two mapping tests, plus a guard asserting `openInWindowCode` never re-introduces `hidden`
- `cmd/llm_txt.md`, `README.md`, `CHANGELOG.md` — drop the stale `--hidden` references

## Verification

Per `apps/cli/CLAUDE.md`, run from `apps/cli/`:

```
gofmt -l .     # clean
go vet ./...   # clean
go build ./... # ok
go test ./...  # all packages pass
```

`--hidden` is gone from both help outputs:

```
$ browseros-cli open --help
Flags:
      --bg           Open in background
  -h, --help         help for open
      --window int   Window ID to open in
```

## Noted, not addressed

`browseros-cli window activate <id>` (`cmd/window.go`) sends `action: "activate"`, but `WindowsAction` intentionally omits `Activate` ("so MCP callers cannot steal window focus"), so that subcommand is dead too. Removing a user-facing command felt like a maintainer call rather than part of this fix — happy to fold it in or open a separate issue, whichever you prefer.

Fixes #2161
Fixes #2162
