### PR TITLE
fix(cli): fall back to compatible status endpoint

### DIFF
--- a/packages/browseros-agent/apps/cli/mcp/client.go
+++ b/packages/browseros-agent/apps/cli/mcp/client.go
@@ -146,9 +146,13 @@ func (c *Client) Health() (map[string]any, error) {
 	return data, err
 }
 
-// Status checks the /status endpoint (REST, not MCP).
+// Status checks BrowserOS-compatible REST status endpoints.
 func (c *Client) Status() (map[string]any, error) {
-	return c.restGET("/status")
+	data, err := c.restGET("/status")
+	if isHTTPStatus(err, http.StatusNotFound) {
+		return c.Health()
+	}
+	return data, err
 }
 
 func (c *Client) restGET(path string) (map[string]any, error) {

--- a/packages/browseros-agent/apps/cli/mcp/client_test.go
+++ b/packages/browseros-agent/apps/cli/mcp/client_test.go
@@ -95,6 +95,75 @@ func TestHealthDoesNotFallbackOnCanonicalHealthFailure(t *testing.T) {
 	assertPaths(t, paths, []string{"/system/health"})
 }
 
+func TestStatusUsesRuntimeStatusEndpoint(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path != "/status" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, `{"status":"ok","cdpConnected":true,"can_update":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	data, err := NewClient(server.URL, "test", time.Second).Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if data["can_update"] != true {
+		t.Fatalf("Status() can_update = %v, want true", data["can_update"])
+	}
+	assertPaths(t, paths, []string{"/status"})
+}
+
+func TestStatusFallsBackToCompatibleHealthEndpoint(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/status":
+			http.NotFound(w, r)
+		case "/system/health":
+			fmt.Fprint(w, `{"status":"ok","cdpConnected":true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	data, err := NewClient(server.URL, "test", time.Second).Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if data["cdpConnected"] != true {
+		t.Fatalf("Status() cdpConnected = %v, want true", data["cdpConnected"])
+	}
+	assertPaths(t, paths, []string{"/status", "/system/health"})
+}
+
+func TestStatusDoesNotFallbackOnRuntimeStatusFailure(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path == "/status" {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := NewClient(server.URL, "test", time.Second).Status()
+	if err == nil {
+		t.Fatal("Status() error = nil, want HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Fatalf("Status() error = %q, want HTTP 500", err)
+	}
+	assertPaths(t, paths, []string{"/status"})
+}
+
 func assertPaths(t *testing.T, got, want []string) {
 	t.Helper()
 


### PR DESCRIPTION
## What changed

The CLI `status` command now preserves the richer `/status` response when that endpoint exists, but falls back to BrowserOS-compatible health endpoints when `/status` returns HTTP 404.

Only a missing endpoint triggers the fallback. Authentication and server failures such as HTTP 500 are still returned to the caller instead of being hidden.

Regression tests cover the primary `/status` path, the `/system/health` compatibility path, and non-404 failures.

## Verification

- `go test ./...`
- `go vet ./...`
- `go build ./...`