### PR TITLE
fix(claw-server): install the neo skill under browseros-neo and migrate legacy dirs

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness.rs
@@ -641,6 +641,19 @@ fn reconcile_managed_skill(
     workspace_dir: &Path,
     managed_skill: &ManagedSkill,
 ) -> Result<SkillReconcileOutcome, ManagerError> {
+    // Heal installs from before the skill directory was renamed: remove the legacy
+    // `browserclaw` directories (marker-verified) so the reconcile below replants the
+    // skill under its current `browseros-neo` name. Idempotent and a no-op once done.
+    let migrated = managed_skill.reconciler.remove_legacy_directories(
+        super::harness_skills::LEGACY_SKILL_DIRECTORY_NAME,
+        &managed_skill.environment,
+    )?;
+    if !migrated.is_empty() {
+        tracing::info!(
+            agents = ?migrated,
+            "migrated legacy BrowserOS neo skill directories to the current name"
+        );
+    }
     let consumers = recognized_browseros_links(manager, workspace_dir)?
         .into_iter()
         .map(|link| link.agent)

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness_skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness_skills.rs
@@ -10,7 +10,12 @@ use crate::error::{AppError, AppResult};
 const EMBEDDED_BROWSERCLAW_SKILL: &str =
     include_str!("../../../../resources/skills/browserclaw/SKILL.md");
 const SKILL_FRONTMATTER_NAME: &str = "browseros-neo";
-const LEGACY_MANAGED_SKILL_DIRECTORY: &str = "browserclaw";
+/// On-disk directory name for the managed skill; matches the SKILL.md frontmatter
+/// `name` so agents that require `name == parent directory` accept it.
+const MANAGED_SKILL_DIRECTORY: &str = "browseros-neo";
+/// The pre-rename directory name earlier builds installed the skill under. Existing
+/// installs at this name are migrated to `MANAGED_SKILL_DIRECTORY` on reconcile.
+pub(crate) const LEGACY_SKILL_DIRECTORY_NAME: &str = "browserclaw";
 
 #[derive(Deserialize)]
 struct SkillFrontmatter {
@@ -67,7 +72,7 @@ fn parse_browserclaw_skill(content: String) -> Result<SkillSpec, String> {
     if frontmatter.description.trim().is_empty() {
         return Err("frontmatter requires a non-empty `description`".to_string());
     }
-    SkillSpec::new(LEGACY_MANAGED_SKILL_DIRECTORY, content).map_err(|error| error.to_string())
+    SkillSpec::new(MANAGED_SKILL_DIRECTORY, content).map_err(|error| error.to_string())
 }
 
 #[cfg(test)]
@@ -112,7 +117,7 @@ mod tests {
 
         let loaded = load_browserclaw_skill(root.path())?;
 
-        assert_eq!(loaded.name(), "browserclaw");
+        assert_eq!(loaded.name(), "browseros-neo");
         assert_eq!(loaded.content(), runtime);
         Ok(())
     }

--- a/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/connections.rs
@@ -96,7 +96,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
         browserclaw_dir.join("mcp-manager"),
         browserclaw_dir.join("harness-integrations"),
         home.clone(),
-        SkillSpec::new("browserclaw", "managed skill v1\n")?,
+        SkillSpec::new("browseros-neo", "managed skill v1\n")?,
         analytics.clone(),
     );
     let paths = config_paths()?;
@@ -156,7 +156,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
         claude.message,
         "BrowserOS registered as an MCP server in Claude Code."
     );
-    let claude_skill = home.join("skills/browserclaw");
+    let claude_skill = home.join("skills/browseros-neo");
     assert_eq!(
         fs::read_to_string(claude_skill.join("SKILL.md"))?,
         "managed skill v1\n"
@@ -165,12 +165,12 @@ async fn run_connections_case() -> anyhow::Result<()> {
     let codex = service.connect_browseros(Harness::Codex, MCP_URL).await?;
     let zed = service.connect_browseros(Harness::Zed, MCP_URL).await?;
     assert!(codex.installed && zed.installed);
-    let shared_skill = home.join(".agents/skills/browserclaw");
+    let shared_skill = home.join(".agents/skills/browseros-neo");
     assert_eq!(
         fs::read_to_string(shared_skill.join("SKILL.md"))?,
         "managed skill v1\n"
     );
-    let shared_target_path = fs::canonicalize(parent(&shared_skill)?)?.join("browserclaw");
+    let shared_target_path = fs::canonicalize(parent(&shared_skill)?)?.join("browseros-neo");
     let skill_manifest_path = browserclaw_dir.join("harness-integrations/skills.json");
     let skill_manifest: Value = serde_json::from_str(&fs::read_to_string(&skill_manifest_path)?)?;
     let shared_record = skill_manifest["targets"]
@@ -272,7 +272,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
         browserclaw_dir.join("mcp-manager"),
         browserclaw_dir.join("harness-integrations"),
         home.clone(),
-        SkillSpec::new("browserclaw", "managed skill v2\n")?,
+        SkillSpec::new("browseros-neo", "managed skill v2\n")?,
         analytics.clone(),
     );
     let ota_update = ota_service.run_skill_reconciliation().await?;
@@ -366,7 +366,7 @@ async fn run_connections_case() -> anyhow::Result<()> {
     assert!(!codex.installed);
     assert_eq!(codex.message, "Codex is not configured.");
 
-    let antigravity_skill = home.join(".gemini/config/skills/browserclaw");
+    let antigravity_skill = home.join(".gemini/config/skills/browseros-neo");
     fs::create_dir_all(&antigravity_skill)?;
     fs::write(antigravity_skill.join("SKILL.md"), "foreign skill")?;
     fs::write(antigravity_skill.join("keep.txt"), "keep")?;

--- a/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/skills.rs
@@ -367,9 +367,9 @@ async fn skill_create_rejects_bad_names_and_duplicates() -> anyhow::Result<()> {
     .await?;
     assert_eq!(status, StatusCode::BAD_REQUEST);
 
-    // The embedded product skill occupies "browserclaw"; the neo- namespace
-    // neutralizes the old collision, so a user "browserclaw" now saves cleanly
-    // as "neo-browserclaw" instead of being rejected.
+    // Every user skill is saved under the neo- namespace, so a user-authored
+    // "browserclaw" saves cleanly as "neo-browserclaw" and never collides with a
+    // product-managed directory.
     let (status, created) = request(
         router,
         "POST",

--- a/packages/browseros-agent/crates/harness-integrations/src/skills/reconciler.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/skills/reconciler.rs
@@ -91,9 +91,12 @@ impl SkillReconciler {
 
         let mut manifest = read_manifest(&self.workspace_dir)?;
         let before = manifest.targets.len();
+        // Only drop a legacy record once its directory is actually gone. A directory
+        // we could not remove (or could not inspect) still exists, so keeping its
+        // record leaves disk and manifest consistent and lets the next reconcile retry.
         manifest
             .targets
-            .retain(|entry| entry.skill_name != legacy_name);
+            .retain(|entry| entry.skill_name != legacy_name || entry.target_path.exists());
         if manifest.targets.len() != before {
             write_manifest(&self.workspace_dir, &manifest)?;
         }
@@ -1021,6 +1024,43 @@ mod tests {
                 .remove_legacy_directories("browserclaw", &environment)?
                 .is_empty()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn remove_legacy_directories_keeps_records_for_directories_that_remain()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let root = tempdir()?;
+        let home = root.path().join("home");
+        let state = root.path().join("state");
+        let environment = SkillEnvironment::new(&home, TargetPlatform::Linux);
+        let reconciler = SkillReconciler::new(&state);
+
+        // Install under the legacy name, then replace its ownership marker with a
+        // foreign one so the sweep declines to remove the directory (standing in for
+        // any case where the directory is left on disk).
+        let legacy_spec = SkillSpec::new("browserclaw", "---\nname: browseros-neo\n---\nlegacy\n")?;
+        reconciler.reconcile(
+            &legacy_spec,
+            &BTreeSet::from([AgentId::ClaudeCode]),
+            &environment,
+        )?;
+        let legacy_dir =
+            resolve_agent_skill_target(AgentId::ClaudeCode, "browserclaw", &environment)?;
+        fs::write(
+            legacy_dir.join(".browserclaw-managed.json"),
+            r#"{"version":1,"managedBy":"other-tool","skillName":"browserclaw","contentHash":"x"}"#,
+        )?;
+        let manifest_path = state.join("skills.json");
+        assert!(fs::read_to_string(&manifest_path)?.contains("browserclaw"));
+
+        let removed = reconciler.remove_legacy_directories("browserclaw", &environment)?;
+
+        // The directory still exists, so its manifest record is preserved rather than
+        // orphaned; the next reconcile retries it.
+        assert!(removed.is_empty());
+        assert!(legacy_dir.join("SKILL.md").exists());
+        assert!(fs::read_to_string(&manifest_path)?.contains("browserclaw"));
         Ok(())
     }
 }

--- a/packages/browseros-agent/crates/harness-integrations/src/skills/reconciler.rs
+++ b/packages/browseros-agent/crates/harness-integrations/src/skills/reconciler.rs
@@ -45,6 +45,61 @@ impl SkillReconciler {
         self.reconcile_with(spec, consumers, environment, replace_managed_directory)
     }
 
+    /// One-time, idempotent migration for a renamed managed skill: removes the
+    /// directories a previous name installed across every catalog harness and purges
+    /// their manifest records, so a subsequent [`reconcile`](Self::reconcile) with the
+    /// new spec replants the skill under the current name. Only directories whose
+    /// ownership marker confirms this product controls `legacy_name` are removed;
+    /// user-authored directories sharing the legacy name are left untouched, and
+    /// anything that cannot be inspected is left in place. Returns the agents whose
+    /// legacy directory was removed (for logging).
+    pub fn remove_legacy_directories(
+        &self,
+        legacy_name: &str,
+        environment: &SkillEnvironment,
+    ) -> Result<BTreeSet<AgentId>, Error> {
+        let mut removed = BTreeSet::new();
+        for agent in AgentId::ALL {
+            if resolve_harness_definition(agent).skill.is_none() {
+                continue;
+            }
+            let Ok(target) = resolve_agent_skill_target(agent, legacy_name, environment) else {
+                continue;
+            };
+            let metadata = match fs::symlink_metadata(&target) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == ErrorKind::NotFound => continue,
+                // Best-effort: never delete a directory we could not inspect.
+                Err(_) => continue,
+            };
+            if !metadata.is_dir() {
+                continue;
+            }
+            // Ownership proof: only remove directories this product planted under the
+            // legacy name. An unreadable or foreign marker leaves the directory alone.
+            let controlled = read_marker(&target)
+                .ok()
+                .flatten()
+                .is_some_and(|marker| marker.controls(legacy_name));
+            if !controlled {
+                continue;
+            }
+            if remove_path(&target).is_ok() {
+                removed.insert(agent);
+            }
+        }
+
+        let mut manifest = read_manifest(&self.workspace_dir)?;
+        let before = manifest.targets.len();
+        manifest
+            .targets
+            .retain(|entry| entry.skill_name != legacy_name);
+        if manifest.targets.len() != before {
+            write_manifest(&self.workspace_dir, &manifest)?;
+        }
+        Ok(removed)
+    }
+
     fn reconcile_with(
         &self,
         spec: &SkillSpec,
@@ -870,6 +925,102 @@ mod tests {
         assert_eq!(outcome.warnings.len(), 1);
         assert_eq!(fs::read_to_string(target.join("SKILL.md"))?, "old");
         assert_eq!(fs::read(manifest_path)?, manifest_before);
+        Ok(())
+    }
+
+    #[test]
+    fn remove_legacy_directories_migrates_managed_directories_and_replants()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let root = tempdir()?;
+        let home = root.path().join("home");
+        let state = root.path().join("state");
+        let environment = SkillEnvironment::new(&home, TargetPlatform::Linux);
+        let reconciler = SkillReconciler::new(&state);
+
+        // Install under the legacy name (writes the directory, ownership marker, and
+        // manifest record).
+        let legacy_spec = SkillSpec::new("browserclaw", "---\nname: browseros-neo\n---\nlegacy\n")?;
+        reconciler.reconcile(
+            &legacy_spec,
+            &BTreeSet::from([AgentId::ClaudeCode]),
+            &environment,
+        )?;
+        let legacy_dir =
+            resolve_agent_skill_target(AgentId::ClaudeCode, "browserclaw", &environment)?;
+        assert!(legacy_dir.join("SKILL.md").exists());
+        let manifest_path = state.join("skills.json");
+        assert!(fs::read_to_string(&manifest_path)?.contains("browserclaw"));
+
+        // Migrate: the managed legacy directory is removed, its agent is reported, and
+        // the manifest record is purged.
+        let removed = reconciler.remove_legacy_directories("browserclaw", &environment)?;
+        assert_eq!(removed, BTreeSet::from([AgentId::ClaudeCode]));
+        assert!(!legacy_dir.exists());
+        assert!(!fs::read_to_string(&manifest_path)?.contains("browserclaw"));
+
+        // Replanting under the current name yields a directory that matches the
+        // frontmatter, with the legacy directory gone.
+        let new_spec = SkillSpec::new("browseros-neo", "---\nname: browseros-neo\n---\nnew\n")?;
+        reconciler.reconcile(
+            &new_spec,
+            &BTreeSet::from([AgentId::ClaudeCode]),
+            &environment,
+        )?;
+        let new_dir =
+            resolve_agent_skill_target(AgentId::ClaudeCode, "browseros-neo", &environment)?;
+        assert!(new_dir.join("SKILL.md").exists());
+        assert!(!legacy_dir.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn remove_legacy_directories_leaves_unmanaged_directories_untouched()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let root = tempdir()?;
+        let home = root.path().join("home");
+        let state = root.path().join("state");
+        let environment = SkillEnvironment::new(&home, TargetPlatform::Linux);
+        let reconciler = SkillReconciler::new(&state);
+
+        // A user-authored directory sharing the legacy name, with no ownership marker.
+        let legacy_dir =
+            resolve_agent_skill_target(AgentId::ClaudeCode, "browserclaw", &environment)?;
+        fs::create_dir_all(&legacy_dir)?;
+        fs::write(legacy_dir.join("SKILL.md"), "user skill")?;
+
+        let removed = reconciler.remove_legacy_directories("browserclaw", &environment)?;
+
+        assert!(removed.is_empty());
+        assert_eq!(
+            fs::read_to_string(legacy_dir.join("SKILL.md"))?,
+            "user skill"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn remove_legacy_directories_is_idempotent() -> Result<(), Box<dyn std::error::Error>> {
+        let root = tempdir()?;
+        let home = root.path().join("home");
+        let state = root.path().join("state");
+        let environment = SkillEnvironment::new(&home, TargetPlatform::Linux);
+        let reconciler = SkillReconciler::new(&state);
+
+        let legacy_spec = SkillSpec::new("browserclaw", "---\nname: browseros-neo\n---\nlegacy\n")?;
+        reconciler.reconcile(
+            &legacy_spec,
+            &BTreeSet::from([AgentId::ClaudeCode]),
+            &environment,
+        )?;
+        assert_eq!(
+            reconciler.remove_legacy_directories("browserclaw", &environment)?,
+            BTreeSet::from([AgentId::ClaudeCode])
+        );
+        assert!(
+            reconciler
+                .remove_legacy_directories("browserclaw", &environment)?
+                .is_empty()
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
## What

The BrowserOS neo managed skill's `SKILL.md` declares `name: browseros-neo`, but the server installed it into a directory named `browserclaw`. Agents that require the skill name to equal its parent directory reject it:

```
auto (user) ~/.agents/skills/browserclaw/SKILL.md
  name "browseros-neo" does not match parent directory "browserclaw"
```

A prior rename updated the SKILL.md frontmatter but left the install directory at the legacy `browserclaw` name (the constant was even prefixed `LEGACY_`).

## Changes

- **Install under `browseros-neo`** so the directory matches the frontmatter (`harness_skills.rs`: `MANAGED_SKILL_DIRECTORY = "browseros-neo"` passed to `SkillSpec::new`).
- **One-time, idempotent migration** (`SkillReconciler::remove_legacy_directories`): across every catalog harness, remove the legacy `browserclaw` directory **only when its ownership marker proves BrowserOS installed it** (`managed_by == "browserclaw" && skill_name == "browserclaw"`), and purge the matching manifest records. A subsequent reconcile replants the skill under the new name for the connected harnesses. User-authored `browserclaw` directories, and anything that cannot be inspected, are left untouched.
- **Wired into `reconcile_managed_skill`**, which runs at startup and on connect, so existing users heal automatically with no action. Marker internals (`managed_by`) stay stable so legacy directories remain recognizable.
- Updated integration tests that encoded the old product name; the user-skill `neo-` namespace test is unchanged.

## Why not a plain rename

The reconciler preserves any manifest target whose recorded `skill_name` differs from the current spec, so a naive constant change would leave the broken `browserclaw` directories orphaned on disk and the error would persist. The migration removes them explicitly, marker-guarded.

## Verification

harness-integrations 61 tests, claw-server-rust 395 tests (incl. 3 new migration tests: migrate+replant, user-dir safety, idempotency), clippy `-D warnings` clean, fmt clean.

## Follow-up (separable)

The internal resource path `resources/skills/browserclaw/SKILL.md` still uses the legacy name; renaming it is cosmetic and left out to keep this change focused.