### PR TITLE
fix(cli): report command errors instead of exiting silently

### DIFF
--- a/packages/browseros-agent/apps/cli/cmd/root.go
+++ b/packages/browseros-agent/apps/cli/cmd/root.go
@@ -125,12 +125,11 @@ const usageTemplate = `{{helpHeader "Usage:"}}{{if .Runnable}}
 `
 
 var rootCmd = &cobra.Command{
-	Use:           "browseros-cli",
-	Short:         "Browser control CLI for BrowserOS",
-	Long:          "browseros-cli — command-line interface for controlling BrowserOS via MCP",
-	SilenceUsage:  true,
-	SilenceErrors: true,
-	Run:           runRoot,
+	Use:          "browseros-cli",
+	Short:        "Browser control CLI for BrowserOS",
+	Long:         "browseros-cli — command-line interface for controlling BrowserOS via MCP",
+	SilenceUsage: true,
+	Run:          runRoot,
 }
 
 // runRoot prints the agent guide to stdout for `--llm-txt`, otherwise grouped help.

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -468,5 +469,47 @@ func TestDrainAutomaticUpdateCheckWithTimeoutStopsWaiting(t *testing.T) {
 	case <-returned:
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("drainAutomaticUpdateCheckWithTimeout() did not return after timeout")
+	}
+}
+
+func TestCommandErrorsAreReportedToStderr(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"unknown flag", []string{"snapshot", "--definitely-not-a-flag"}, "unknown flag"},
+		{"unknown shorthand flag", []string{"snapshot", "-Z"}, "unknown shorthand flag"},
+		{"unknown command", []string{"definitely-not-a-command"}, "unknown command"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			rootCmd.SetOut(&stdout)
+			rootCmd.SetErr(&stderr)
+			rootCmd.SetArgs(tt.args)
+			t.Cleanup(func() {
+				rootCmd.SetOut(nil)
+				rootCmd.SetErr(nil)
+				rootCmd.SetArgs(nil)
+			})
+
+			err := rootCmd.Execute()
+
+			if err == nil {
+				t.Fatalf("rootCmd.Execute() = nil, want an error for %v", tt.args)
+			}
+			got := stderr.String()
+			if got == "" {
+				t.Fatalf("%v failed silently; the error must reach stderr", tt.args)
+			}
+			if !strings.HasPrefix(got, "Error:") {
+				t.Fatalf("stderr = %q, want it to start with the CLI's %q prefix", got, "Error:")
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("stderr = %q, want it to mention %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`browseros-cli` exited with code 1 and **no output at all** on every command-line error — unknown flag, unknown shorthand, unknown subcommand, or any error returned from a `RunE` handler. A typo was indistinguishable from a crash or an unreachable server.

Fixes #2429.

## Root cause

`rootCmd` set `SilenceErrors: true`, which tells Cobra not to print errors, but `Execute()` discarded the returned error rather than printing it itself:

```go
err := rootCmd.Execute()
...
if err != nil {
    os.Exit(1)   // err is never printed
}
```

`SilenceErrors` is only safe when the caller reports the error. Nothing here did.

## Fix

Drop `SilenceErrors` so Cobra reports the failure. Its default `ErrPrefix()` is already `Error:`, which matches the format `output.Error` already uses for in-command failures, so the two paths now read identically:

```
$ browseros-cli snapshot            # in-command error (unchanged)
Error: page id is required: pass -p/--page <id> ...

$ browseros-cli tabs --bogus        # Cobra-level error (was silent)
Error: unknown flag: --bogus
```

`SilenceUsage: true` is kept, so errors stay one line and don't dump the full usage block. Exit code 1 is unchanged.

## Before / after

| Command | Before | After |
|---|---|---|
| `tabs --bogus` | exit 1, 0 bytes out | `Error: unknown flag: --bogus` |
| `snapshot -Z` | exit 1, 0 bytes out | `Error: unknown shorthand flag: 'Z' in -Z` |
| `definitely-not-a-command` | exit 1, 0 bytes out | `Error: unknown command "definitely-not-a-command" for "browseros-cli"` |

This also surfaces the wrapped errors `config` returns from its `RunE` (`loading config: %w`, `saving config: %w`), which were swallowed the same way.

## Tests

Added `TestCommandErrorsAreReportedToStderr` — a table test over unknown flag / unknown shorthand / unknown command that asserts the message reaches stderr and keeps the `Error:` prefix. Confirmed it is a real regression test: with `SilenceErrors` restored it fails on all three cases with `failed silently; the error must reach stderr`, and passes with the fix.

Verified locally from `packages/browseros-agent/apps/cli`:

```
gofmt -l .   # clean
go vet ./... # clean
go build ./...
go test ./...
ok  browseros-cli
ok  browseros-cli/analytics
ok  browseros-cli/cmd
ok  browseros-cli/cmd/raw
ok  browseros-cli/mcp
ok  browseros-cli/update
```

## Note

While reproducing this I noticed `snapshot` registers no flags, yet the agent guide shipped as `browseros-cli --llm-txt` documents `snapshot -i` five times (`cmd/llm_txt.md` lines 34, 36, 51, 61, 152) along with `-c` and `-d N`. The MCP `snapshot` tool does accept `mode` and `depth`, so the flags appear simply unwired. That is out of scope here and I'll file it separately.
