### PR TITLE
fix(mcp): reject unknown arguments on every browser tool

### DIFF
--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -1282,3 +1282,16 @@ fn collect_schema_reference_paths(value: &Value, path: String, paths: &mut Vec<S
         _ => {}
     }
 }
+
+#[test]
+fn every_tool_rejects_unknown_arguments() {
+    for tool in catalog() {
+        let schema = Value::Object(tool.input_schema.as_ref().clone());
+        assert_eq!(
+            schema.pointer("/additionalProperties"),
+            Some(&json!({ "not": {} })),
+            "{} accepts unknown arguments; add #[serde(deny_unknown_fields)] to its args struct",
+            tool.name
+        );
+    }
+}

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -1287,11 +1287,37 @@ fn collect_schema_reference_paths(value: &Value, path: String, paths: &mut Vec<S
 fn every_tool_rejects_unknown_arguments() {
     for tool in catalog() {
         let schema = Value::Object(tool.input_schema.as_ref().clone());
-        assert_eq!(
-            schema.pointer("/additionalProperties"),
-            Some(&json!({ "not": {} })),
-            "{} accepts unknown arguments; add #[serde(deny_unknown_fields)] to its args struct",
-            tool.name
+        let mut permissive = Vec::new();
+        collect_permissive_object_paths(&schema, "$".to_string(), &mut permissive);
+        assert!(
+            permissive.is_empty(),
+            "{} accepts unknown arguments at {}; add #[serde(deny_unknown_fields)] to the \
+             matching args struct",
+            tool.name,
+            permissive.join(", ")
         );
+    }
+}
+
+/// Walks a generated input schema and reports every object node - nested ones included - that
+/// still accepts unknown properties.
+fn collect_permissive_object_paths(value: &Value, path: String, paths: &mut Vec<String>) {
+    match value {
+        Value::Object(object) => {
+            if object.contains_key("properties")
+                && object.get("additionalProperties") != Some(&json!({ "not": {} }))
+            {
+                paths.push(path.clone());
+            }
+            for (key, child) in object {
+                collect_permissive_object_paths(child, format!("{path}.{key}"), paths);
+            }
+        }
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                collect_permissive_object_paths(item, format!("{path}[{index}]"), paths);
+            }
+        }
+        _ => {}
     }
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/act.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/act.rs
@@ -94,6 +94,7 @@ struct FillField {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct ActArgs {
     page: u32,
     kind: ActKind,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/act.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/act.rs
@@ -88,6 +88,7 @@ enum ActMouseButton {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct FillField {
     r#ref: String,
     value: String,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/diff.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/diff.rs
@@ -15,6 +15,7 @@ Show what changed on the page since the last snapshot/diff - a cheap way to see 
 an action's effect without re-dumping the whole tree.";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct DiffArgs {
     page: u32,
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/download.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/download.rs
@@ -18,6 +18,7 @@ Click an element (by ref from the last snapshot) to trigger a file download, \
 and save it to a BrowserOS output file. Returns the saved path and filename.";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct DownloadArgs {
     /// Page id from `tabs`.
     page: u32,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/evaluate.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/evaluate.rs
@@ -24,6 +24,7 @@ Provide `code` (an async body; use `return` to read a value) or `func` (a functi
 expression like `() => {...}` that gets invoked). Return a value to read it back.";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct EvaluateArgs {
     /// Page id from `tabs`.
     page: u32,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/grep.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/grep.rs
@@ -29,6 +29,7 @@ enum GrepOver {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct GrepArgs {
     page: u32,
     /// Case-insensitive regular expression.

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/navigate.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/navigate.rs
@@ -21,6 +21,7 @@ enum NavigateAction {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct NavigateArgs {
     /// Page id from `tabs`.
     page: u32,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/pdf.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/pdf.rs
@@ -14,6 +14,7 @@ Print the page to a PDF and save it to a BrowserOS output file, returning the pa
 Use for archiving or reading a page as a document; prefer read for extracting text.";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct PdfArgs {
     /// Page id from `tabs`.
     page: u32,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/read.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/read.rs
@@ -31,6 +31,7 @@ enum ReadFormat {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct ReadArgs {
     page: u32,
     #[serde(default)]

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -207,6 +207,7 @@ const BOOTSTRAP_JS: &str = r#"
 "#;
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct RunArgs {
     /// Async-capable JS body. Use top-level await; `return` a value.
     code: String,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/screenshot.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/screenshot.rs
@@ -43,6 +43,7 @@ impl Default for ScreenshotSize {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct ScreenshotArgs {
     page: u32,
     #[serde(default)]

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/screenshot.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/screenshot.rs
@@ -24,6 +24,7 @@ enum ScreenshotFormat {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct ScreenshotSize {
     #[serde(default = "default_width")]
     #[schemars(range(min = 1, max = 4096))]

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/snapshot.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/snapshot.rs
@@ -49,6 +49,7 @@ impl From<SnapshotModeArg> for SnapshotMode {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct SnapshotArgs {
     /// Page id from `tabs` or `navigate`.
     page: u32,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/tab_groups.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/tab_groups.rs
@@ -38,6 +38,7 @@ enum TabGroupColor {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct TabGroupsArgs {
     #[serde(default)]
     action: TabGroupsAction,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/upload.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/upload.rs
@@ -13,6 +13,7 @@ Set local file path(s) on a file input using a ref from the last snapshot. \
 Use for <input type=\"file\"> upload flows; files must exist on the server filesystem.";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct UploadArgs {
     /// Page id from `tabs`.
     page: u32,

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/wait.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/wait.rs
@@ -34,6 +34,7 @@ enum WaitValue {
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 struct WaitArgs {
     page: u32,
     /// What to wait for. Defaults to "time" (a fixed pause).

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/act.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/act.ts
@@ -15,52 +15,60 @@ export const act = defineTool({
   name: 'act',
   description:
     'Act on the page using refs from the last snapshot. kinds: click, type (into focused element), fill (one field via ref+value, or many via fields[]), press (a key/combo), hover, focus, check, uncheck, select (an option value), scroll, drag. Reads back a diff of what changed - re-snapshot if you need fresh refs.',
-  input: z.object({
-    page: z.number().int(),
-    kind: z.enum([
-      'click',
-      'click_at',
-      'type',
-      'type_at',
-      'fill',
-      'press',
-      'hover',
-      'hover_at',
-      'focus',
-      'check',
-      'uncheck',
-      'select',
-      'scroll',
-      'drag',
-      'drag_at',
-    ]),
-    ref: z.string().optional().describe('Target element ref, e.g. "e12".'),
-    text: z.string().optional().describe('Text for kind=type.'),
-    value: z.string().optional().describe('Value for kind=fill/select.'),
-    fields: z
-      .array(z.object({ ref: z.string(), value: z.string() }))
-      .optional()
-      .describe('Multiple fields for kind=fill, filled in order.'),
-    key: z
-      .string()
-      .optional()
-      .describe('Key/combo for kind=press, e.g. "Enter", "Control+a".'),
-    direction: z.enum(['up', 'down', 'left', 'right']).optional(),
-    amount: z
-      .number()
-      .optional()
-      .describe('Scroll amount (wheel notches), default 3.'),
-    x: z.number().optional().describe('Viewport x coordinate for *_at kinds.'),
-    y: z.number().optional().describe('Viewport y coordinate for *_at kinds.'),
-    targetRef: z.string().optional().describe('Target ref for kind=drag.'),
-    startX: z.number().optional().describe('Drag start x coordinate.'),
-    startY: z.number().optional().describe('Drag start y coordinate.'),
-    endX: z.number().optional().describe('Drag end x coordinate.'),
-    endY: z.number().optional().describe('Drag end y coordinate.'),
-    button: z.enum(['left', 'middle', 'right']).optional(),
-    clickCount: z.number().int().optional(),
-    clear: z.boolean().optional(),
-  }),
+  input: z
+    .object({
+      page: z.number().int(),
+      kind: z.enum([
+        'click',
+        'click_at',
+        'type',
+        'type_at',
+        'fill',
+        'press',
+        'hover',
+        'hover_at',
+        'focus',
+        'check',
+        'uncheck',
+        'select',
+        'scroll',
+        'drag',
+        'drag_at',
+      ]),
+      ref: z.string().optional().describe('Target element ref, e.g. "e12".'),
+      text: z.string().optional().describe('Text for kind=type.'),
+      value: z.string().optional().describe('Value for kind=fill/select.'),
+      fields: z
+        .array(z.object({ ref: z.string(), value: z.string() }))
+        .optional()
+        .describe('Multiple fields for kind=fill, filled in order.'),
+      key: z
+        .string()
+        .optional()
+        .describe('Key/combo for kind=press, e.g. "Enter", "Control+a".'),
+      direction: z.enum(['up', 'down', 'left', 'right']).optional(),
+      amount: z
+        .number()
+        .optional()
+        .describe('Scroll amount (wheel notches), default 3.'),
+      x: z
+        .number()
+        .optional()
+        .describe('Viewport x coordinate for *_at kinds.'),
+      y: z
+        .number()
+        .optional()
+        .describe('Viewport y coordinate for *_at kinds.'),
+      targetRef: z.string().optional().describe('Target ref for kind=drag.'),
+      startX: z.number().optional().describe('Drag start x coordinate.'),
+      startY: z.number().optional().describe('Drag start y coordinate.'),
+      endX: z.number().optional().describe('Drag end x coordinate.'),
+      endY: z.number().optional().describe('Drag end y coordinate.'),
+      button: z.enum(['left', 'middle', 'right']).optional(),
+      clickCount: z.number().int().optional(),
+      clear: z.boolean().optional(),
+    })
+    .strict(),
   annotations: {
     title: 'Interact with page',
     destructiveHint: true,

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/act.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/act.ts
@@ -39,7 +39,7 @@ export const act = defineTool({
       text: z.string().optional().describe('Text for kind=type.'),
       value: z.string().optional().describe('Value for kind=fill/select.'),
       fields: z
-        .array(z.object({ ref: z.string(), value: z.string() }))
+        .array(z.object({ ref: z.string(), value: z.string() }).strict())
         .optional()
         .describe('Multiple fields for kind=fill, filled in order.'),
       key: z

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/diff.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/diff.ts
@@ -6,7 +6,7 @@ export const diff = defineTool({
   name: 'diff',
   description:
     "Show what changed on the page since the last snapshot/diff - a cheap way to see an action's effect without re-dumping the whole tree.",
-  input: z.object({ page: z.number().int() }),
+  input: z.object({ page: z.number().int() }).strict(),
   annotations: { title: 'Diff page state', readOnlyHint: true },
   handler: async (args, ctx) => {
     const d = await ctx.session.observe(args.page).diff()

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/download.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/download.ts
@@ -11,12 +11,14 @@ export const download = defineTool({
   name: 'download',
   description:
     'Click an element (by ref from the last snapshot) to trigger a file download, and save it to a BrowserOS output file. Returns the saved path and filename.',
-  input: z.object({
-    page: z.number().int().describe('Page id from `tabs`.'),
-    ref: z
-      .string()
-      .describe('Ref of the element that triggers the download, e.g. "e12".'),
-  }),
+  input: z
+    .object({
+      page: z.number().int().describe('Page id from `tabs`.'),
+      ref: z
+        .string()
+        .describe('Ref of the element that triggers the download, e.g. "e12".'),
+    })
+    .strict(),
   annotations: {
     title: 'Download from page',
     destructiveHint: true,

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/evaluate.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/evaluate.ts
@@ -12,18 +12,20 @@ const DESCRIPTION = `Evaluate JavaScript in a page context through CDP Runtime.e
 export const evaluate = defineTool({
   name: 'evaluate',
   description: DESCRIPTION,
-  input: z.object({
-    page: z.number().int().describe('Page id from `tabs`.'),
-    code: z
-      .string()
-      .describe(
-        'Async-capable JS body evaluated inside the page. Use `return` to read a value.',
-      ),
-    timeout: z
-      .number()
-      .optional()
-      .describe('Max evaluation time in ms (default 30000).'),
-  }),
+  input: z
+    .object({
+      page: z.number().int().describe('Page id from `tabs`.'),
+      code: z
+        .string()
+        .describe(
+          'Async-capable JS body evaluated inside the page. Use `return` to read a value.',
+        ),
+      timeout: z
+        .number()
+        .optional()
+        .describe('Max evaluation time in ms (default 30000).'),
+    })
+    .strict(),
   annotations: {
     title: 'Run JavaScript in page',
     destructiveHint: true,

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/grep.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/grep.ts
@@ -12,12 +12,14 @@ export const grep = defineTool({
   name: 'grep',
   description:
     'Search the page without dumping it. over="ax" greps the snapshot lines (matches keep their [ref=eN]); over="content" greps visible text. Returns matching lines.',
-  input: z.object({
-    page: z.number().int(),
-    pattern: z.string().describe('Case-insensitive regular expression.'),
-    over: z.enum(['ax', 'content']).default('ax'),
-    limit: z.number().optional().describe('Max matching lines (default 50).'),
-  }),
+  input: z
+    .object({
+      page: z.number().int(),
+      pattern: z.string().describe('Case-insensitive regular expression.'),
+      over: z.enum(['ax', 'content']).default('ax'),
+      limit: z.number().optional().describe('Max matching lines (default 50).'),
+    })
+    .strict(),
   annotations: { title: 'Search page', readOnlyHint: true },
   handler: async (args, ctx) => {
     let regex: RegExp

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/navigate.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/navigate.ts
@@ -5,11 +5,13 @@ export const navigate = defineTool({
   name: 'navigate',
   description:
     'Navigate a page: load a url, or go back/forward/reload. Returns a fresh snapshot of the resulting page (navigation invalidates refs, so old [ref=eN] handles no longer apply).',
-  input: z.object({
-    page: z.number().int().describe('Page id from `tabs`.'),
-    action: z.enum(['url', 'back', 'forward', 'reload']).default('url'),
-    url: z.string().optional().describe('Required when action is "url".'),
-  }),
+  input: z
+    .object({
+      page: z.number().int().describe('Page id from `tabs`.'),
+      action: z.enum(['url', 'back', 'forward', 'reload']).default('url'),
+      url: z.string().optional().describe('Required when action is "url".'),
+    })
+    .strict(),
   annotations: {
     title: 'Navigate page',
     destructiveHint: true,

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/pdf.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/pdf.ts
@@ -6,22 +6,24 @@ export const pdf = defineTool({
   name: 'pdf',
   description:
     'Print the page to a PDF and save it to a BrowserOS output file, returning the path. Use for archiving or reading a page as a document; prefer read for extracting text.',
-  input: z.object({
-    page: z.number().int().describe('Page id from `tabs`.'),
-    landscape: z.boolean().optional().describe('Use landscape orientation.'),
-    background: z
-      .boolean()
-      .optional()
-      .describe('Compatibility alias for printBackground.'),
-    printBackground: z
-      .boolean()
-      .optional()
-      .describe('Print background graphics.'),
-    preferCSSPageSize: z
-      .boolean()
-      .default(false)
-      .describe('Use CSS page size when the page defines one.'),
-  }),
+  input: z
+    .object({
+      page: z.number().int().describe('Page id from `tabs`.'),
+      landscape: z.boolean().optional().describe('Use landscape orientation.'),
+      background: z
+        .boolean()
+        .optional()
+        .describe('Compatibility alias for printBackground.'),
+      printBackground: z
+        .boolean()
+        .optional()
+        .describe('Print background graphics.'),
+      preferCSSPageSize: z
+        .boolean()
+        .default(false)
+        .describe('Use CSS page size when the page defines one.'),
+    })
+    .strict(),
   annotations: { title: 'Save page as PDF', readOnlyHint: true },
   handler: async (args, ctx) => {
     const { session } = await ctx.session.pages.getSession(args.page)

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/read.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/read.ts
@@ -21,23 +21,25 @@ export const read = defineTool({
   name: 'read',
   description:
     'Extract page content as markdown (default), plain text, or a list of links. For reading/scraping, not acting.',
-  input: z.object({
-    page: z.number().int(),
-    format: z.enum(['markdown', 'text', 'links']).default('markdown'),
-    selector: z.string().optional().describe('Restrict to a CSS subtree.'),
-    viewportOnly: z
-      .boolean()
-      .optional()
-      .describe('For markdown reads, include only visible viewport content.'),
-    includeLinks: z
-      .boolean()
-      .optional()
-      .describe('For markdown reads, render links as markdown links.'),
-    includeImages: z
-      .boolean()
-      .optional()
-      .describe('For markdown reads, include image references.'),
-  }),
+  input: z
+    .object({
+      page: z.number().int(),
+      format: z.enum(['markdown', 'text', 'links']).default('markdown'),
+      selector: z.string().optional().describe('Restrict to a CSS subtree.'),
+      viewportOnly: z
+        .boolean()
+        .optional()
+        .describe('For markdown reads, include only visible viewport content.'),
+      includeLinks: z
+        .boolean()
+        .optional()
+        .describe('For markdown reads, render links as markdown links.'),
+      includeImages: z
+        .boolean()
+        .optional()
+        .describe('For markdown reads, include image references.'),
+    })
+    .strict(),
   annotations: { title: 'Read page content', readOnlyHint: true },
   handler: async (args, ctx) => {
     const { session } = await ctx.session.pages.getSession(args.page)

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/run.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/run.ts
@@ -30,17 +30,19 @@ interface RunOutcome {
 export const run = defineTool({
   name: 'run',
   description: DESCRIPTION,
-  input: z.object({
-    code: z
-      .string()
-      .describe(
-        'Async-capable JS body. Use top-level await; `return` a value.',
-      ),
-    timeout: z
-      .number()
-      .optional()
-      .describe('Max run time in ms (default 30000).'),
-  }),
+  input: z
+    .object({
+      code: z
+        .string()
+        .describe(
+          'Async-capable JS body. Use top-level await; `return` a value.',
+        ),
+      timeout: z
+        .number()
+        .optional()
+        .describe('Max run time in ms (default 30000).'),
+    })
+    .strict(),
   output: z.object({
     ok: z.boolean(),
     value: z.unknown().optional(),

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
@@ -50,19 +50,23 @@ export const screenshot = defineTool({
   name: 'screenshot',
   description:
     'Capture a screenshot of the page, returned inline. Defaults to JPEG quality 80 around 1024x768; prefer snapshot for structure/actions.',
-  input: z.object({
-    page: z.number().int(),
-    format: screenshotFormat.default(DEFAULT_SCREENSHOT_FORMAT),
-    quality: z.number().int().min(0).max(100).optional(),
-    size: screenshotSize
-      .optional()
-      .describe('Max viewport capture size. Defaults to 1024x768.'),
-    fullPage: z.boolean().optional().describe('Capture beyond the viewport.'),
-    annotate: z
-      .boolean()
-      .optional()
-      .describe('Overlay numbered refs from a fresh snapshot. Defaults false.'),
-  }),
+  input: z
+    .object({
+      page: z.number().int(),
+      format: screenshotFormat.default(DEFAULT_SCREENSHOT_FORMAT),
+      quality: z.number().int().min(0).max(100).optional(),
+      size: screenshotSize
+        .optional()
+        .describe('Max viewport capture size. Defaults to 1024x768.'),
+      fullPage: z.boolean().optional().describe('Capture beyond the viewport.'),
+      annotate: z
+        .boolean()
+        .optional()
+        .describe(
+          'Overlay numbered refs from a fresh snapshot. Defaults false.',
+        ),
+    })
+    .strict(),
   annotations: { title: 'Take screenshot', readOnlyHint: true },
   handler: async (args, ctx) => {
     const fullPage = args.fullPage ?? false

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
@@ -8,10 +8,12 @@ const DEFAULT_SCREENSHOT_FORMAT = 'jpeg'
 const DEFAULT_SCREENSHOT_QUALITY = 80
 const DEFAULT_SCREENSHOT_SIZE = { width: 1024, height: 768 } as const
 const screenshotFormat = z.enum(['jpeg', 'png', 'webp'])
-const screenshotSize = z.object({
-  width: z.number().int().positive().max(4096).default(1024),
-  height: z.number().int().positive().max(4096).default(768),
-})
+const screenshotSize = z
+  .object({
+    width: z.number().int().positive().max(4096).default(1024),
+    height: z.number().int().positive().max(4096).default(768),
+  })
+  .strict()
 
 type ScreenshotFormat = z.infer<typeof screenshotFormat>
 type ScreenshotSize = z.infer<typeof screenshotSize>

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/snapshot.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/snapshot.ts
@@ -6,9 +6,11 @@ export const snapshot = defineTool({
   name: 'snapshot',
   description:
     'Capture the page as an indented accessibility tree. Each actionable element carries a stable [ref=eN] you pass to `act`. Iframe content is stitched in inline. Re-snapshot after navigation or large changes (refs are invalidated). This is the start of the loop: snapshot -> act -> (reads back a diff).',
-  input: z.object({
-    page: z.number().int().describe('Page id from `tabs` or `navigate`.'),
-  }),
+  input: z
+    .object({
+      page: z.number().int().describe('Page id from `tabs` or `navigate`.'),
+    })
+    .strict(),
   annotations: { title: 'Snapshot accessibility tree', readOnlyHint: true },
   handler: async (args, ctx) => {
     const { text } = await ctx.session.observe(args.page).snapshot()

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/strict-input.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/strict-input.test.ts
@@ -15,6 +15,26 @@ describe('browser tool input schemas', () => {
     }
     expect(permissive).toEqual([])
   })
+
+  it('rejects unknown arguments nested inside object and array fields', () => {
+    const screenshot = BROWSER_TOOLS.find((tool) => tool.name === 'screenshot')
+    // A misspelled nested dimension must not be silently dropped and defaulted.
+    expect(
+      screenshot?.input.safeParse({
+        page: 1,
+        size: { width: 100, heigth: 200 },
+      }).success,
+    ).toBe(false)
+
+    const act = BROWSER_TOOLS.find((tool) => tool.name === 'act')
+    expect(
+      act?.input.safeParse({
+        page: 1,
+        kind: 'fill',
+        fields: [{ ref: 'e1', value: 'x', typo: true }],
+      }).success,
+    ).toBe(false)
+  })
 })
 
 /** Minimal valid arguments per tool, so the only parse failure can be the unknown key. */

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/strict-input.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/strict-input.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test'
+import { BROWSER_TOOLS } from './registry'
+
+describe('browser tool input schemas', () => {
+  it('rejects unknown arguments on every tool', () => {
+    const permissive: string[] = []
+    for (const tool of BROWSER_TOOLS) {
+      const parsed = tool.input.safeParse({
+        ...sampleFor(tool.name),
+        __unknown_argument__: true,
+      })
+      if (parsed.success) {
+        permissive.push(tool.name)
+      }
+    }
+    expect(permissive).toEqual([])
+  })
+})
+
+/** Minimal valid arguments per tool, so the only parse failure can be the unknown key. */
+function sampleFor(name: string): Record<string, unknown> {
+  switch (name) {
+    case 'act':
+      return { page: 1, kind: 'click', ref: 'e1' }
+    case 'grep':
+      return { page: 1, pattern: 'x' }
+    case 'navigate':
+      return { page: 1, action: 'reload' }
+    case 'evaluate':
+      return { page: 1, code: 'return 1' }
+    case 'run':
+      return { code: 'return 1' }
+    case 'wait':
+      return { page: 1, for: 'text', value: 'x' }
+    case 'upload':
+      return { page: 1, ref: 'e1', file: '/tmp/x' }
+    case 'download':
+      return { page: 1, ref: 'e1' }
+    case 'tabs':
+      return { action: 'list' }
+    case 'windows':
+      return { action: 'list' }
+    case 'tab_groups':
+      return { action: 'list' }
+    case 'history':
+      return {}
+    default:
+      return { page: 1 }
+  }
+}

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/tab-groups.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/tab-groups.ts
@@ -28,30 +28,35 @@ export const tab_groups = defineTool({
   name: 'tab_groups',
   description:
     'Manage tab groups: list groups, group pages, update a group (title/color/collapsed), ungroup pages, or close a group. Page ids come from the tabs tool.',
-  input: z.object({
-    action: z
-      .enum(['list', 'create', 'update', 'ungroup', 'close'])
-      .default('list'),
-    pages: z
-      .array(z.number().int())
-      .optional()
-      .describe('Page ids for action="create" or "ungroup".'),
-    groupId: z
-      .string()
-      .optional()
-      .describe(
-        'Group id. Required for "update"/"close". Optional on "create" to add pages to an existing group.',
-      ),
-    title: z.string().optional().describe('Group title for "create"/"update".'),
-    color: z
-      .enum(TAB_GROUP_COLORS)
-      .optional()
-      .describe('Group color for "update".'),
-    collapsed: z
-      .boolean()
-      .optional()
-      .describe('Collapse/expand the group for "update".'),
-  }),
+  input: z
+    .object({
+      action: z
+        .enum(['list', 'create', 'update', 'ungroup', 'close'])
+        .default('list'),
+      pages: z
+        .array(z.number().int())
+        .optional()
+        .describe('Page ids for action="create" or "ungroup".'),
+      groupId: z
+        .string()
+        .optional()
+        .describe(
+          'Group id. Required for "update"/"close". Optional on "create" to add pages to an existing group.',
+        ),
+      title: z
+        .string()
+        .optional()
+        .describe('Group title for "create"/"update".'),
+      color: z
+        .enum(TAB_GROUP_COLORS)
+        .optional()
+        .describe('Group color for "update".'),
+      collapsed: z
+        .boolean()
+        .optional()
+        .describe('Collapse/expand the group for "update".'),
+    })
+    .strict(),
   annotations: {
     title: 'Manage tab groups',
     destructiveHint: true,

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/tabs.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/tabs.ts
@@ -5,18 +5,20 @@ export const tabs = defineTool({
   name: 'tabs',
   description:
     "Manage browser tabs. `list` returns every open page grouped by ownership: `Your tabs` (pages you opened via `tabs new`), `User's tabs` (pages the operator opened), and `Other agents' tabs` (pages another AI agent opened). You can act freely on your own tabs. Page-targeted tools (snapshot, act, navigate, close, etc.) reject dispatches on pages you do not own with an error asking you to call `tabs new`. `active` shows the current front page; `new` opens a fresh page; `close` closes one of yours.",
-  input: z.object({
-    action: z.enum(['list', 'active', 'new', 'close']).default('list'),
-    url: z
-      .string()
-      .optional()
-      .describe('URL for action="new" (defaults to about:blank).'),
-    background: z
-      .boolean()
-      .default(true)
-      .describe('Open without stealing focus for action="new".'),
-    page: z.number().int().optional().describe('Page id for action="close".'),
-  }),
+  input: z
+    .object({
+      action: z.enum(['list', 'active', 'new', 'close']).default('list'),
+      url: z
+        .string()
+        .optional()
+        .describe('URL for action="new" (defaults to about:blank).'),
+      background: z
+        .boolean()
+        .default(true)
+        .describe('Open without stealing focus for action="new".'),
+      page: z.number().int().optional().describe('Page id for action="close".'),
+    })
+    .strict(),
   annotations: {
     title: 'Manage tabs',
     destructiveHint: true,

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/upload.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/upload.ts
@@ -5,17 +5,19 @@ export const upload = defineTool({
   name: 'upload',
   description:
     'Set local file path(s) on a file input using a ref from the last snapshot. Use for <input type="file"> upload flows; files must exist on the server filesystem.',
-  input: z.object({
-    page: z.number().int().describe('Page id from `tabs`.'),
-    ref: z
-      .string()
-      .describe('Ref of the <input type="file"> element, e.g. "e12".'),
-    file: z.string().optional().describe('Single local file path to upload.'),
-    files: z
-      .array(z.string())
-      .optional()
-      .describe('Local file paths to upload.'),
-  }),
+  input: z
+    .object({
+      page: z.number().int().describe('Page id from `tabs`.'),
+      ref: z
+        .string()
+        .describe('Ref of the <input type="file"> element, e.g. "e12".'),
+      file: z.string().optional().describe('Single local file path to upload.'),
+      files: z
+        .array(z.string())
+        .optional()
+        .describe('Local file paths to upload.'),
+    })
+    .strict(),
   annotations: {
     title: 'Upload file to page',
     destructiveHint: true,

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/wait.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/wait.ts
@@ -19,23 +19,25 @@ export const wait = defineTool({
   name: 'wait',
   description:
     'Pause before continuing. Prefer acting directly and reading the diff; use wait only when there is no reliable UI signal yet. for="time" (default) pauses for value ms; "text" waits for a substring to appear; "selector" waits for a CSS selector to match. value is optional — for "time" it defaults to 2000ms, so calling wait with just a page pauses ~2s.',
-  input: z.object({
-    page: z.number().int(),
-    for: z
-      .enum(['text', 'selector', 'time'])
-      .default('time')
-      .describe('What to wait for. Defaults to "time" (a fixed pause).'),
-    value: z
-      .union([z.string(), z.number()])
-      .optional()
-      .describe(
-        'Optional. For for="time", ms to pause (default 2000). For "text"/"selector", the substring or CSS selector to wait for.',
-      ),
-    timeout: z
-      .number()
-      .optional()
-      .describe('Max wait in ms before giving up (default 2000).'),
-  }),
+  input: z
+    .object({
+      page: z.number().int(),
+      for: z
+        .enum(['text', 'selector', 'time'])
+        .default('time')
+        .describe('What to wait for. Defaults to "time" (a fixed pause).'),
+      value: z
+        .union([z.string(), z.number()])
+        .optional()
+        .describe(
+          'Optional. For for="time", ms to pause (default 2000). For "text"/"selector", the substring or CSS selector to wait for.',
+        ),
+      timeout: z
+        .number()
+        .optional()
+        .describe('Max wait in ms before giving up (default 2000).'),
+    })
+    .strict(),
   annotations: { title: 'Wait', readOnlyHint: true },
   handler: async (args, ctx) => {
     const timeout = clampTimeout(

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/windows.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/windows.ts
@@ -8,14 +8,16 @@ export const windows = defineTool({
   name: 'windows',
   description:
     'Manage browser windows: list, create, close, or activate a window.',
-  input: z.object({
-    action: z.enum(ACTIONS).default('list'),
-    windowId: z
-      .number()
-      .int()
-      .optional()
-      .describe('Window id for close and activate.'),
-  }),
+  input: z
+    .object({
+      action: z.enum(ACTIONS).default('list'),
+      windowId: z
+        .number()
+        .int()
+        .optional()
+        .describe('Window id for close and activate.'),
+    })
+    .strict(),
   annotations: {
     title: 'Manage windows',
     destructiveHint: true,


### PR DESCRIPTION
## Summary

14 of the 17 MCP browser tools silently accepted unknown arguments. A misspelled or hallucinated parameter was dropped during deserialization and the tool ran anyway with defaults, returning a **successful result that was quietly wrong**.

Fixes #2431.

## The problem

Parsed against the real schemas on `main`:

```
screenshot {page: 1, fullpage: true}          -> ACCEPTED, parsed as {"page":1,"format":"jpeg"}
grep {page: 1, pattern: "x", maxResults: 5}   -> ACCEPTED, parsed as {"page":1,"pattern":"x","over":"ax"}
```

`fullpage` (real field: `fullPage`) is dropped, so a full-page screenshot request silently returns a viewport-only shot. `maxResults` (real field: `limit`) is dropped, so a request for 5 matches silently returns the default 50. Both report success, and the caller cannot tell.

This is the same failure mode as #2161 — and the reason that bug was *caught* is that `tabs` already has `deny_unknown_fields`, so the retired `hidden` input raised `unknown field 'hidden'` instead of being ignored. The other 14 tools had no such safety net.

Casing is the likely real-world trigger, since the schemas mix conventions: `fullPage`, `viewportOnly`, `includeLinks`, `clickCount`, `targetRef`, `printBackground`, `preferCSSPageSize`, `groupId`.

## The change

- `#[serde(deny_unknown_fields)]` on the 14 permissive Rust arg structs
- `.strict()` on the 16 matching zod input schemas

This also closes a parity gap: `tabs` and `windows` were strict in `crates/browseros-mcp` but permissive in `packages/browser-mcp`, so the two implementations disagreed on identical input. `history` was already strict in both and is unchanged.

After:

```
screenshot {page: 1, fullpage: true}          -> REJECTED
grep {page: 1, pattern: "x", maxResults: 5}   -> REJECTED
```

Callers get the existing `Invalid arguments for <tool>: ...` error.

## Why this is safe

- **The schema pipeline already handles it.** `normalize_schema_value` rewrites `additionalProperties: false` into `{"not": {}}`, which is why the three already-strict tools pass `assert_no_boolean_schema_nodes`. Confirmed the generated value is exactly `{"not": {}}`.
- **Nothing injects extra fields.** `execute_tool` passes `raw_args` through untouched; `extract_page_id` only reads it.
- **The CLI is unaffected.** I compared every argument the Go CLI sends against all 17 schemas. The only mismatches are the two `hidden` cases from #2161 — both in tools that were *already* strict, so this PR does not change them.

## Tests

Two new regression tests, each naming the offending tool:

- `every_tool_rejects_unknown_arguments` (Rust) — asserts every catalog entry's input schema carries `additionalProperties: {"not": {}}`
- `rejects unknown arguments on every tool` (`strict-input.test.ts`) — parses minimal valid args plus one unknown key per tool

Both verified to be real regression tests: removing strictness from `grep` alone fails each with `grep accepts unknown arguments; add #[serde(deny_unknown_fields)] to its args struct` and `+ "grep"` respectively.

Full verification:

```
cargo test -p browseros-mcp        71 passed + 4 passed
bun test (browser-mcp)             37 pass, 0 fail
bun test tests/tools (apps/server) 254 pass, 0 fail
cargo fmt --check                  clean
biome check                        clean
tsc --noEmit                       clean
```
