### PR TITLE
fix(chat): surface the full error in a copyable block

### DIFF
--- a/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.test.tsx
@@ -130,7 +130,7 @@ describe('ChatError envelope handling', () => {
     expect(html).toContain('Try again')
   })
 
-  it('offers a details disclosure when raw upstream text is present', () => {
+  it('shows the full error always-expanded with a copy control, no toggle', () => {
     const html = renderError(
       envelopeError({
         message: 'The model request failed.',
@@ -138,13 +138,56 @@ describe('ChatError envelope handling', () => {
       }),
     )
 
-    expect(html).toContain('Show details')
+    expect(html).not.toContain('Show details')
+    expect(html).toContain('Full error')
+    expect(html).toContain('Copy')
+    expect(html).toContain('upstream said: connection reset by peer')
   })
 
-  it('omits the disclosure when there is no extra detail', () => {
+  it('renders no full-error block when there is no extra detail', () => {
     const html = renderError(envelopeError({ details: undefined }))
 
+    expect(html).not.toContain('Full error')
+  })
+
+  it('suppresses the block when the detail only repeats the message', () => {
+    const html = renderError(
+      envelopeError({
+        message: 'Anthropic session expired. Please re-login.',
+        details: 'Anthropic session expired. Please re-login.',
+      }),
+    )
+
+    // The message already shows the whole error, so no redundant block.
+    expect(html).toContain('Anthropic session expired. Please re-login.')
+    expect(html).not.toContain('Full error')
+  })
+
+  it('keeps the classified message and shows the full server JSON pretty-printed', () => {
+    const html = renderError(
+      envelopeError({
+        code: 'credits_exhausted',
+        title: 'Daily limit reached',
+        message: 'You have used all your BrowserOS credits.',
+        retryable: false,
+        provider: 'browseros',
+        details: JSON.stringify({
+          error: {
+            code: 'CREDITS_EXHAUSTED',
+            metadata: { raw: 'quota 0 of 100' },
+          },
+        }),
+      }),
+    )
+
+    // Classified message stays on top...
+    expect(html).toContain('You have used all your BrowserOS credits.')
+    // ...and the raw specifics the generic message hid are visible with copy.
     expect(html).not.toContain('Show details')
+    expect(html).toContain('Full error')
+    expect(html).toContain('Copy')
+    expect(html).toContain('CREDITS_EXHAUSTED')
+    expect(html).toContain('quota 0 of 100')
   })
 
   it('falls back to the server-supplied title for an unknown code', () => {

--- a/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatError.tsx
@@ -167,12 +167,21 @@ function buildView(message: string, providerType?: string): ChatErrorView {
   return envelope ? fromEnvelope(envelope) : fromMessage(message, providerType)
 }
 
+/** Pretty-print JSON details; leave already-formatted or non-JSON text as-is. */
+function formatErrorDetails(details: string): string {
+  try {
+    return JSON.stringify(JSON.parse(details), null, 2)
+  } catch {
+    return details
+  }
+}
+
 export const ChatError: FC<ChatErrorProps> = ({
   error,
   onRetry,
   providerType,
 }) => {
-  const [showDetails, setShowDetails] = useState(false)
+  const [copiedDetails, setCopiedDetails] = useState(false)
   const view = buildView(error.message, providerType)
 
   const surveyUrl = useMemo(
@@ -182,6 +191,21 @@ export const ChatError: FC<ChatErrorProps> = ({
   )
 
   const canRetry = !!onRetry && view.canRetry
+
+  const detailsText = view.details ? formatErrorDetails(view.details) : ''
+
+  // Copy targets the full string, not the DOM, so the whole error is copied even
+  // though the block clips it to a scroll area on screen.
+  const copyDetails = async () => {
+    if (!detailsText) return
+    try {
+      await navigator.clipboard.writeText(detailsText)
+      setCopiedDetails(true)
+      window.setTimeout(() => setCopiedDetails(false), 1500)
+    } catch {
+      setCopiedDetails(false)
+    }
+  }
 
   return (
     <div className="mx-4 flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
@@ -225,20 +249,23 @@ export const ChatError: FC<ChatErrorProps> = ({
           </a>
         </p>
       )}
-      {view.details && view.details !== view.text && (
+      {detailsText && detailsText !== view.text && (
         <div className="w-full">
-          <button
-            type="button"
-            onClick={() => setShowDetails((shown) => !shown)}
-            className="w-full text-center text-muted-foreground text-xs underline hover:text-foreground"
-          >
-            {showDetails ? 'Hide details' : 'Show details'}
-          </button>
-          {showDetails && (
-            <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-muted p-2 text-left text-[10px] text-muted-foreground">
-              {view.details}
-            </pre>
-          )}
+          <div className="mb-1 flex items-center justify-between px-0.5">
+            <span className="text-[10px] text-muted-foreground uppercase tracking-wide">
+              Full error
+            </span>
+            <button
+              type="button"
+              onClick={copyDetails}
+              className="text-[10px] text-muted-foreground underline hover:text-foreground"
+            >
+              {copiedDetails ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+          <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-border bg-muted p-2 text-left text-[10px] text-muted-foreground">
+            {detailsText}
+          </pre>
         </div>
       )}
       {canRetry && (

--- a/packages/browseros-agent/apps/server/src/agent/chat-error.ts
+++ b/packages/browseros-agent/apps/server/src/agent/chat-error.ts
@@ -39,20 +39,48 @@ const USAGE_PAGE_URL = '/app.html#/settings/usage'
 const CONNECTION_DOCS_URL =
   'https://docs.browseros.com/troubleshooting/connection-issues'
 
+const REDACTED = '[REDACTED]'
+
 /**
- * Key-shaped tokens get scrubbed out of free-text upstream messages. The shared
- * Sentry sanitizer only redacts by object key, so it cannot help here.
+ * Value-shaped secrets scrubbed out of the full upstream body before it is shown
+ * or copied. Redacting by object key is not enough here: the body is arbitrary
+ * text (JSON, HTML, or a plain sentence) and a credential can sit inside a
+ * non-sensitive field, so these match on the value's shape. Each entry pairs a
+ * pattern with its replacement so URL and JSON-value rules can keep surrounding
+ * context. Skewed toward over-redaction: a missed token is copied into a bug
+ * report, a false positive only hides a value the user did not need.
  */
-const SECRET_PATTERNS: RegExp[] = [
-  /\b(?:sk|pk|rk)-[A-Za-z0-9_-]{12,}/g,
-  /\bBearer\s+[A-Za-z0-9._-]{12,}/gi,
-  /\bAKIA[0-9A-Z]{16}\b/g,
-  /\bgh[pousr]_[A-Za-z0-9]{20,}/g,
+const SECRET_PATTERNS: [RegExp, string][] = [
+  // Provider API keys (OpenAI/Anthropic/Stripe sk-/pk-/rk-) and AWS access keys.
+  [/\b(?:sk|pk|rk)[-_][A-Za-z0-9_-]{12,}/g, REDACTED],
+  [/\bAKIA[0-9A-Z]{16}\b/g, REDACTED],
+  // Bearer tokens and JWTs (three base64url segments).
+  [/\bBearer\s+[A-Za-z0-9._-]{12,}/gi, REDACTED],
+  [/\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}/g, REDACTED],
+  // Vendor tokens: GitHub classic + fine-grained, GitLab, Google, Slack.
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}/g, REDACTED],
+  [/\bgithub_pat_[A-Za-z0-9_]{22,}/g, REDACTED],
+  [/\bglpat-[A-Za-z0-9_-]{20}/g, REDACTED],
+  [/\bAIza[0-9A-Za-z_-]{35}/g, REDACTED],
+  [/\bya29\.[0-9A-Za-z_-]{20,}/g, REDACTED],
+  [/\bxox[baprs]-[A-Za-z0-9-]{10,}/g, REDACTED],
+  // PEM private key blocks.
+  [
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+    REDACTED,
+  ],
+  // Credentials embedded in a URL (scheme://user:pass@host): keep host, drop userinfo.
+  [/([a-z][a-z0-9+.-]*:\/\/)[^\s:@/]+:[^\s:@/]+@/gi, `$1${REDACTED}@`],
+  // Sensitive JSON string values, matched on the raw text so no object parse is needed.
+  [
+    /("[^"]*(?:token|secret|password|passwd|api[_-]?key|authorization|credential)[^"]*"\s*:\s*)"[^"]*"/gi,
+    `$1"${REDACTED}"`,
+  ],
 ]
 
 function redact(text: string): string {
   return SECRET_PATTERNS.reduce(
-    (acc, pattern) => acc.replace(pattern, '[REDACTED]'),
+    (acc, [pattern, replacement]) => acc.replace(pattern, replacement),
     text,
   )
 }

--- a/packages/browseros-agent/apps/server/src/agent/chat-error.ts
+++ b/packages/browseros-agent/apps/server/src/agent/chat-error.ts
@@ -13,7 +13,6 @@
  */
 
 import {
-  AISDKError,
   APICallError,
   InvalidPromptError,
   LoadAPIKeyError,
@@ -29,7 +28,11 @@ export interface ChatErrorContext {
   provider?: string
 }
 
-const DETAILS_MAX_LENGTH = 500
+// `details` carries the full scrubbed upstream error so the card can show it and
+// the user can copy the whole thing. A credit/quota error's actionable specifics
+// live in a JSON body, so a small cut would strip exactly what the user needs.
+// Bounded, but large, so a pathological body still cannot flood the wire or card.
+const DETAILS_MAX_LENGTH = 20000
 
 const USAGE_DOCS_URL = 'https://dub.sh/browseros-usage-limit'
 const USAGE_PAGE_URL = '/app.html#/settings/usage'
@@ -61,6 +64,28 @@ function toDetails(text: string | undefined): string | undefined {
   return redacted.length > DETAILS_MAX_LENGTH
     ? `${redacted.slice(0, DETAILS_MAX_LENGTH)}…`
     : redacted
+}
+
+/**
+ * The full upstream body is the actionable evidence a generic gateway message
+ * hides: OpenRouter-style gateways wrap the real reason in `metadata.raw` while
+ * `message` stays vague. Prefer the response body (pretty-printed when it is
+ * JSON), then the structured `data.raw`, then the message. Redacted and capped
+ * like any other detail.
+ */
+function upstreamDetails(error: APICallError): string | undefined {
+  if (error.responseBody) {
+    try {
+      return toDetails(JSON.stringify(JSON.parse(error.responseBody), null, 2))
+    } catch {
+      return toDetails(error.responseBody)
+    }
+  }
+  const raw = (error.data as { raw?: unknown } | undefined)?.raw
+  if (raw !== undefined) {
+    return toDetails(JSON.stringify(raw, null, 2))
+  }
+  return toDetails(error.message)
 }
 
 /** Upstream text reaches the user, so it gets the same scrub as `details`. */
@@ -111,7 +136,7 @@ function fromApiCallError(
   const base = {
     provider: ctx.provider,
     statusCode: error.statusCode,
-    details: toDetails(error.message),
+    details: upstreamDetails(error),
   }
   const code = gatewayCode(error)
   const isBrowserOs = ctx.provider === 'browseros'
@@ -256,6 +281,7 @@ function fromMessage(message: string, ctx: ChatErrorContext): ChatError | null {
       message: safeMessage(message, 'This provider is not fully configured.'),
       retryable: false,
       provider: ctx.provider,
+      details: toDetails(message),
     }
   }
 
@@ -286,6 +312,7 @@ export function toChatError(
       ),
       retryable: false,
       provider: ctx.provider,
+      details: toDetails(error.message),
     }
   }
 
@@ -296,6 +323,7 @@ export function toChatError(
       message: safeMessage(error.message, 'This message could not be sent.'),
       retryable: false,
       provider: ctx.provider,
+      details: toDetails(error.message),
     }
   }
 
@@ -309,7 +337,9 @@ export function toChatError(
     message: safeMessage(message, 'An unexpected error occurred.'),
     retryable: true,
     provider: ctx.provider,
-    details: AISDKError.isInstance(error) ? toDetails(error.name) : undefined,
+    // The raw error is the only evidence for an error the AI SDK could not
+    // classify; carry it scrubbed so the card can show it when it adds detail.
+    details: toDetails(message),
   }
 }
 

--- a/packages/browseros-agent/apps/server/tests/agent/chat-error.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/chat-error.test.ts
@@ -150,7 +150,7 @@ describe('toChatError', () => {
     expect(error.message).not.toContain('bbbbbbbbbb')
   })
 
-  it('redacts key-shaped tokens and caps details', () => {
+  it('redacts key-shaped tokens out of details', () => {
     const error = toChatError(
       apiCallError({
         message: `rejected key sk-${'a'.repeat(40)} for org`,
@@ -160,7 +160,70 @@ describe('toChatError', () => {
 
     expect(error.details).toContain('[REDACTED]')
     expect(error.details).not.toContain('aaaaaaaaaa')
-    expect((error.details ?? '').length).toBeLessThanOrEqual(501)
+  })
+
+  it('carries the full upstream response body as pretty-printed details', () => {
+    const error = toChatError(
+      apiCallError({
+        message: 'Provider returned error',
+        statusCode: 429,
+        data: { code: 'CREDITS_EXHAUSTED' },
+        responseBody: JSON.stringify({
+          error: {
+            code: 'CREDITS_EXHAUSTED',
+            message: 'Provider returned error',
+            metadata: { raw: 'quota 0 of 100 for today' },
+          },
+        }),
+      }),
+      { provider: 'browseros' },
+    )
+
+    // The real reason the generic message hid is preserved in details...
+    expect(error.details).toContain('quota 0 of 100 for today')
+    // ...pretty-printed onto its own lines.
+    expect(error.details).toContain('\n')
+  })
+
+  it('falls back to structured data.raw when there is no response body', () => {
+    const error = toChatError(
+      apiCallError({
+        message: 'Provider returned error',
+        statusCode: 429,
+        data: { code: 'CREDITS_EXHAUSTED', raw: { remaining: 0 } },
+      }),
+      { provider: 'browseros' },
+    )
+
+    expect(error.details).toContain('remaining')
+    expect(error.details).toContain('0')
+  })
+
+  it('redacts secrets and bounds a pathological raw body', () => {
+    const secret = `sk-${'c'.repeat(40)}`
+    const error = toChatError(
+      apiCallError({
+        statusCode: 500,
+        responseBody: JSON.stringify({
+          error: { message: `boom ${secret}`, note: 'x'.repeat(30000) },
+        }),
+      }),
+    )
+
+    expect(error.details).toContain('[REDACTED]')
+    expect(error.details).not.toContain('cccccccccc')
+    // Bounded so a pathological body cannot flood the wire or the card.
+    expect((error.details ?? '').length).toBeLessThanOrEqual(20001)
+  })
+
+  it('surfaces a plain error message as copyable details', () => {
+    const error = toChatError(
+      new Error('Anthropic session expired. Please re-login.'),
+      { provider: 'anthropic' },
+    )
+
+    expect(error.code).toBe('unknown')
+    expect(error.details).toContain('session expired')
   })
 })
 

--- a/packages/browseros-agent/apps/server/tests/agent/chat-error.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/chat-error.test.ts
@@ -225,6 +225,72 @@ describe('toChatError', () => {
     expect(error.code).toBe('unknown')
     expect(error.details).toContain('session expired')
   })
+
+  it('redacts a JWT sitting inside a non-sensitive field', () => {
+    // Assembled from segments so the full token is never a literal in source
+    // (scanners match the whole token; the regex sees the runtime value).
+    const jwt = [
+      'eyJhbGciOiJIUzI1NiJ9',
+      'eyJzdWIiOiIxMjM0NTY3ODkwIn0',
+      'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c',
+    ].join('.')
+    const error = toChatError(
+      apiCallError({
+        statusCode: 500,
+        responseBody: JSON.stringify({
+          error: { message: `auth failed: ${jwt}` },
+        }),
+      }),
+    )
+
+    expect(error.details).toContain('[REDACTED]')
+    expect(error.details).not.toContain('eyJhbGci')
+  })
+
+  it('redacts a sensitive JSON value by its key on the raw text', () => {
+    const error = toChatError(
+      apiCallError({
+        statusCode: 401,
+        responseBody: JSON.stringify({
+          access_token: 'ATsecret-value-9f8e7d6c5b4a',
+        }),
+      }),
+    )
+
+    expect(error.details).toContain('[REDACTED]')
+    expect(error.details).not.toContain('ATsecret-value')
+  })
+
+  it('redacts URL userinfo while keeping the host', () => {
+    const password = 'hunter2'.repeat(2)
+    const error = toChatError(
+      new Error(
+        `proxy failed at https://svc:${password}@proxy.internal:8080/v1`,
+      ),
+    )
+
+    expect(error.details).toContain('[REDACTED]')
+    expect(error.details).not.toContain(password)
+    // Host stays so the error is still diagnosable.
+    expect(error.details).toContain('proxy.internal')
+  })
+
+  it('redacts vendor token shapes (Google, Slack)', () => {
+    // Prefixes split from bodies so no full token literal appears in source.
+    const google = 'AIza'.concat('A'.repeat(35))
+    const slack = 'xoxb-'.concat('1234567890-abcdefghijklmnop')
+    const error = toChatError(
+      apiCallError({
+        statusCode: 403,
+        responseBody: JSON.stringify({
+          error: { message: `google ${google} slack ${slack}` },
+        }),
+      }),
+    )
+
+    expect(error.details).not.toContain(google)
+    expect(error.details).not.toContain(slack)
+  })
 })
 
 describe('toChatErrorText', () => {


### PR DESCRIPTION
## Problem
Chat uses the Vercel AI SDK `useChat`. When a turn fails, the classifier built the error envelope's `details` from the short constructed `error.message` and capped it at 500 characters. The gateway's real, actionable reason (OpenRouter-style gateways wrap it in the response body / `metadata.raw`) was captured at the fetch boundary as `APICallError.responseBody` / `data.raw` but never forwarded, so the user saw only a generic sentence. Errors the AI SDK could not classify carried no `details` at all, leaving nothing to copy or act on.

Team decision: any error that cannot be fully expressed through the AI SDK's masked stream should be shown verbatim, after scrubbing secrets, so users are empowered to fix it.

## Change
- Classifier: forward the full upstream response body (or structured `data.raw`), pretty-printed as JSON, into `details` on every path, redacted and bounded at a larger cap so the whole body survives to be copied. Errors that fall through to the generic path now carry the scrubbed raw message too.
- Error card: render that detail always expanded under a `Full error` heading with a copy control. The copy targets the full string, not the DOM, so the entire error is copied even when the block clips it to a scroll area on screen. The classified title and message (credits exhausted, session expired, rate limited, and so on) stay on top, unchanged.
- The block is omitted when the detail only repeats the message, so a clean one-line error is not duplicated.

No wire or schema change: this reuses the envelope's existing `details` field. The side panel and new tab share the card component, so both surfaces are covered.

## Tests
- Classifier: full response body preserved and pretty-printed in `details`; falls back to `data.raw`; secrets redacted and a pathological body bounded; a plain error surfaces its scrubbed message as copyable detail.
- Card: the full error renders always expanded with a copy control and no toggle; the raw specifics a generic message hid are visible; the block is suppressed when it only repeats the message; the classified message stays above it.
- Type-check and lint clean across both packages.

## Follow-up
If credit exhaustion is ever returned as HTTP 200 with the error embedded in the SSE stream (rather than a 4xx the custom fetch already intercepts), the stream body would need inspecting too. The current 4xx handling covers the HTTP-error path, so that is a separate, verifiable follow-up.
