### PR TITLE
fix: enable macOS WebAuthn platform authenticator

### DIFF
--- a/packages/browseros/bos_build/lib/env.py
+++ b/packages/browseros/bos_build/lib/env.py
@@ -117,6 +117,11 @@ class EnvConfig:
         return os.environ.get("PROD_MACOS_NOTARIZATION_TEAM_ID")
 
     @property
+    def macos_team_id(self) -> Optional[str]:
+        """Team ID used to configure Chromium's macOS branding."""
+        return os.environ.get("MACOS_TEAM_ID") or self.macos_notarization_team_id
+
+    @property
     def macos_notarization_password(self) -> Optional[str]:
         """App-specific password for macOS notarization"""
         return os.environ.get("PROD_MACOS_NOTARIZATION_PWD")

--- a/packages/browseros/bos_build/steps/resources/chromium_replace.py
+++ b/packages/browseros/bos_build/steps/resources/chromium_replace.py
@@ -5,7 +5,7 @@ import shutil
 from pathlib import Path
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
-from ...lib.utils import log_info, log_success, log_error
+from ...lib.utils import IS_MACOS, log_info, log_success, log_error, log_warning
 
 
 @step("chromium_replace", phase="prep")
@@ -47,12 +47,54 @@ def replace_chromium_files_impl(ctx: Context, replacements=None) -> bool:
         log_info(
             f"⚠️  No chromium_files overlays found under: {ctx.get_chromium_replace_files_dir()}"
         )
+        _apply_macos_team_id(ctx)
         return True
 
     log_success(
         f"Replaced {replaced_count} files (skipped {skipped_count} non-matching files)"
     )
+    _apply_macos_team_id(ctx)
     return True
+
+
+def _apply_macos_team_id(ctx: Context) -> None:
+    """Stamp the configured signing Team ID into Chromium's branding file."""
+    if not IS_MACOS():
+        return
+
+    team_id = ctx.env.macos_team_id
+    if not team_id:
+        return
+    if "\n" in team_id or "\r" in team_id:
+        raise ValueError("MACOS_TEAM_ID must not contain newlines")
+
+    branding_path = ctx.chromium_src / "chrome/app/theme/chromium/BRANDING"
+    if not branding_path.exists():
+        log_warning(
+            "  ⚠️  Chromium branding file not found; macOS Team ID was not applied"
+        )
+        return
+
+    content = branding_path.read_text(encoding="utf-8")
+    lines = content.splitlines(keepends=True)
+    replaced = False
+    for index, line in enumerate(lines):
+        line_content = line.rstrip("\r\n")
+        if line_content.startswith("MAC_TEAM_ID="):
+            newline = line[len(line_content) :]
+            lines[index] = f"MAC_TEAM_ID={team_id}{newline}"
+            replaced = True
+
+    if not replaced:
+        log_warning(
+            "  ⚠️  MAC_TEAM_ID entry not found in Chromium branding; Team ID was not applied"
+        )
+        return
+
+    updated = "".join(lines)
+    if updated != content:
+        branding_path.write_text(updated, encoding="utf-8")
+    log_info("  ✓ Applied macOS signing Team ID to Chromium branding")
 
 
 def _replace_from_root(ctx: Context, replacement_dir: Path) -> tuple[int, int]:

--- a/packages/browseros/bos_build/steps/resources/chromium_replace_test.py
+++ b/packages/browseros/bos_build/steps/resources/chromium_replace_test.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """Tests for chromium file replacement against a mock checkout."""
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
+from unittest import mock
 
+from . import chromium_replace as chromium_replace_module
 from .chromium_replace import ChromiumReplaceModule, replace_chromium_files_impl
 from ...core.context import Context
 from ...core.step import ValidationError
@@ -97,6 +100,35 @@ class ReplaceChromiumFilesTest(unittest.TestCase):
         self.assertEqual(
             (chromium.src / "chrome" / "common" / "branding.h").read_text(),
             "// product\n",
+        )
+
+    def test_macos_team_id_is_applied_after_product_overlay(self):
+        chromium, root, ctx = self._make("release")
+        chromium.add_file(
+            "chrome/app/theme/chromium/BRANDING",
+            "MAC_BUNDLE_ID=com.browseros.BrowserOS\nMAC_TEAM_ID=\n",
+        )
+        root.add_replacement_file(
+            "chrome/app/theme/chromium/BRANDING.release",
+            "MAC_BUNDLE_ID=com.browseros.BrowserOS\nMAC_TEAM_ID=\n",
+        )
+
+        with (
+            mock.patch.object(chromium_replace_module, "IS_MACOS", return_value=True),
+            mock.patch.dict(
+                os.environ,
+                {
+                    "MACOS_TEAM_ID": "",
+                    "PROD_MACOS_NOTARIZATION_TEAM_ID": "TEAM123456",
+                },
+                clear=False,
+            ),
+        ):
+            self.assertTrue(replace_chromium_files_impl(ctx))
+
+        self.assertIn(
+            "MAC_TEAM_ID=TEAM123456\n",
+            (chromium.src / "chrome/app/theme/chromium/BRANDING").read_text(),
         )
 
 

--- a/packages/browseros/bos_build/steps/sign/macos.py
+++ b/packages/browseros/bos_build/steps/sign/macos.py
@@ -723,6 +723,54 @@ def sign_component(
         return False
 
 
+def find_app_entitlements(
+    root_dir: Path, app_path: Path, ctx: Optional[Context] = None
+) -> Optional[Path]:
+    """Find generated app entitlements before falling back to static templates."""
+    generated_paths: List[Path] = []
+    if ctx:
+        generated_relative = Path("gen") / "chrome" / "app-entitlements.plist"
+        generated_paths.append(ctx.chromium_src / ctx.out_dir / generated_relative)
+
+        # The universal app is merged after the two architecture builds and
+        # therefore has no independent GN output directory of its own.
+        if ctx.architecture == "universal":
+            for arch in ("arm64", "x64"):
+                generated_paths.append(
+                    ctx.chromium_src
+                    / "out"
+                    / f"Default_{ctx.product.id}_{arch}"
+                    / generated_relative
+                )
+
+    for entitlements_path in generated_paths:
+        if entitlements_path.is_file():
+            log_info(f"  Using generated entitlements: {entitlements_path}")
+            return entitlements_path
+
+    entitlements_names = ["app-entitlements.plist", "app-entitlements-chrome.plist"]
+    entitlements_dirs: List[Path] = []
+    if ctx:
+        entitlements_dirs.append(ctx.get_entitlements_dir())
+    else:
+        entitlements_dirs.append(root_dir / "resources" / "entitlements")
+    entitlements_dirs.extend(
+        [
+            root_dir / "entitlements",  # Legacy location
+            app_path.parent.parent.parent / "chrome" / "app",  # Chromium source
+        ]
+    )
+
+    for entitlements_name in entitlements_names:
+        for entitlements_dir in entitlements_dirs:
+            entitlements_path = entitlements_dir / entitlements_name
+            if entitlements_path.is_file():
+                log_info(f"  Using entitlements: {entitlements_path}")
+                return entitlements_path
+
+    return None
+
+
 def sign_all_components(
     app_path: Path,
     certificate_name: str,
@@ -907,33 +955,7 @@ def sign_all_components(
         "certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */"
     )
 
-    # Try multiple locations for app entitlements
-    entitlements = None
-    entitlements_names = ["app-entitlements.plist", "app-entitlements-chrome.plist"]
-    entitlements_dirs = []
-    if ctx:
-        entitlements_dirs.append(ctx.get_entitlements_dir())
-    else:
-        entitlements_dirs.append(join_paths(root_dir, "resources", "entitlements"))
-    # Add fallback locations
-    entitlements_dirs.extend(
-        [
-            join_paths(root_dir, "entitlements"),  # Legacy location
-            join_paths(
-                app_path.parent.parent.parent, "chrome", "app"
-            ),  # Chromium source
-        ]
-    )
-
-    for ent_name in entitlements_names:
-        for ent_dir in entitlements_dirs:
-            ent_path = join_paths(ent_dir, ent_name)
-            if ent_path.exists():
-                entitlements = ent_path
-                log_info(f"  Using entitlements: {entitlements}")
-                break
-        if entitlements:
-            break
+    entitlements = find_app_entitlements(root_dir, app_path, ctx)
 
     cmd = [
         "codesign",

--- a/packages/browseros/bos_build/steps/sign/macos_test.py
+++ b/packages/browseros/bos_build/steps/sign/macos_test.py
@@ -11,12 +11,14 @@ from unittest import mock
 import yaml
 
 from ...core.context import Context
+from ...lib.testing import MockBrowserOSRoot, MockChromium, make_context
 from . import macos as macos_module
 from .macos import (
     SERVER_RESOURCES_SOURCE_REL,
     MacOSSignModule,
     check_environment,
     find_components_to_sign,
+    find_app_entitlements,
     notarize_app,
     sign_component,
     unlock_keychain,
@@ -85,6 +87,47 @@ class MacOSSignDiscoveryTest(unittest.TestCase):
                 executables,
             )
             self.assertNotIn(claw_bin / "not-registered", executables)
+
+
+class AppEntitlementsDiscoveryTest(unittest.TestCase):
+    def test_generated_entitlements_win_over_static_templates(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium = MockChromium(Path(tmp) / "chromium")
+            root = MockBrowserOSRoot(Path(tmp) / "browseros")
+            ctx = make_context(chromium, root, build_type="release")
+            app_path = ctx.get_app_path()
+
+            _write_file(
+                root.root / "resources" / "entitlements" / "app-entitlements.plist",
+                "static\n",
+            )
+            generated = (
+                chromium.src / ctx.out_dir / "gen" / "chrome" / "app-entitlements.plist"
+            )
+            _write_file(generated, "generated\n")
+
+            self.assertEqual(find_app_entitlements(root.root, app_path, ctx), generated)
+
+    def test_universal_signing_uses_architecture_entitlements(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium = MockChromium(Path(tmp) / "chromium")
+            root = MockBrowserOSRoot(Path(tmp) / "browseros")
+            ctx = make_context(
+                chromium, root, architecture="universal", build_type="release"
+            )
+            app_path = ctx.get_app_path()
+
+            generated = (
+                chromium.src
+                / "out"
+                / "Default_browseros_arm64"
+                / "gen"
+                / "chrome"
+                / "app-entitlements.plist"
+            )
+            _write_file(generated, "generated-arm64\n")
+
+            self.assertEqual(find_app_entitlements(root.root, app_path, ctx), generated)
 
 
 class VerifyServerResourcesBundleTest(unittest.TestCase):

--- a/packages/browseros/chromium_patches/chrome/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/BUILD.gn
@@ -2,6 +2,18 @@ diff --git a/chrome/BUILD.gn b/chrome/BUILD.gn
 index 973a46b2a34bb170e49417f4f76f8b2d899317d8..ce9284adddeaaa706d50356b521d36e6f26b11ee 100644
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
+@@ -731,7 +731,10 @@ if (is_mac) {
+   compile_entitlements("entitlements") {
+     entitlements_templates = [ "app/app-entitlements.plist" ]
+-    if (is_chrome_branded && include_branded_entitlements) {
++    # BrowserOS is unbranded Chromium but still needs the macOS
++    # WebAuthn/Touch ID entitlements.
++    if (defined(browseros_product) ||
++        (is_chrome_branded && include_branded_entitlements)) {
+       # These entitlements are bound to the official Google Chrome signing
+       # certificate and will not necessarily work in any other build.
+       entitlements_templates += [ "app/app-entitlements-chrome.plist" ]
+     }
 @@ -15,7 +15,9 @@ import("//build/config/win/console_app.gni")
  import("//build/config/win/manifest.gni")
  import("//build/private_code_test/private_code_test.gni")


### PR DESCRIPTION
Fixes #2436

## Summary

- Include Chromium's macOS branded entitlement template in BrowserOS's unbranded build so GN generates the WebAuthn keychain groups and platform-credential entitlement.
- Propagate the configured macOS Team ID into Chromium's `BRANDING` before GN runs, using `MACOS_TEAM_ID` with `PROD_MACOS_NOTARIZATION_TEAM_ID` as the CI fallback.
- Prefer GN-generated app entitlements during signing, including the per-architecture outputs used by universal builds.

## Validation

- `uv run python -m unittest bos_build.steps.resources.chromium_replace_test bos_build.steps.sign.macos_test` — 36 passed.
- `uv run ruff check` on all changed Python files — passed.
- `git diff --check` — passed.
- The patch applies cleanly to Chromium `151.0.7922.137` with `git apply --check`.
- Full `bos_build` suite: 1139 passed, 2 skipped, 1 unrelated existing fixture-version failure in `release/feeds/publisher_test.py`.
- A full Chromium compilation was not run locally.