### PR TITLE
fix(analytics): surface unrecognized MCP clients instead of dropping them

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/analytics/events.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/analytics/events.rs
@@ -59,10 +59,6 @@ const CLIENT_ALIASES: [(&str, &str); 4] = [
 ];
 
 const UNRECOGNIZED_EMPTY: &str = "unrecognized-empty";
-const UNRECOGNIZED_REDACTED: &str = "unrecognized-redacted";
-/// Slugs longer than this are treated as opaque tokens (hashes, blobs) and redacted
-/// rather than surfaced as a candidate client name.
-const MAX_CANDIDATE_SLUG_LEN: usize = 40;
 
 pub(crate) const HARNESS_VALUES: [&str; 7] = [
     "Claude Code",
@@ -309,27 +305,14 @@ fn bucket_client_name(raw: &str) -> String {
         return slug;
     }
 
-    // Not allowlisted. Rather than collapse every such client into one opaque
-    // bucket (which hides a large, legitimate long tail), split it so the tail is
-    // diagnosable without leaking PII. `clientInfo.name` is client-controlled free
-    // text that can carry emails, paths, URLs, or secrets, so only a safe-shaped
-    // slug is surfaced; anything with structural PII markers, or an opaque blob, is
-    // redacted, and a blank name is reported as empty.
+    // Not allowlisted: record the client's own slug so the long tail is visible
+    // instead of collapsed into one opaque bucket. A blank name has nothing to
+    // record, so it is reported as empty.
     if slug.is_empty() {
         UNRECOGNIZED_EMPTY.to_string()
-    } else if is_pii_shaped(raw) || slug.len() > MAX_CANDIDATE_SLUG_LEN {
-        UNRECOGNIZED_REDACTED.to_string()
     } else {
         slug
     }
-}
-
-/// A raw client name carries structural PII (email, path, URL, or host:port) when it
-/// contains any of these markers. Slugging strips them, but the slug would still embed
-/// the fragments, so the check runs against the original raw, not the slug.
-fn is_pii_shaped(raw: &str) -> bool {
-    raw.chars()
-        .any(|c| matches!(c, '@' | '/' | '\\' | ':' | '.'))
 }
 
 #[cfg(test)]
@@ -469,36 +452,7 @@ mod tests {
     }
 
     #[test]
-    fn pii_shaped_client_names_are_redacted() {
-        for raw in [
-            "https://example.com",
-            "user@example.com",
-            "/home/user/secret",
-            r"C:\Users\someone",
-            "codex@example.com",
-            "codex://private",
-            "/codex/home/user",
-            "192.168.1.10",
-        ] {
-            assert_eq!(
-                AGENT_SESSION_STARTED.sanitize(&json!({ "client_name": raw })),
-                Some(json!({ "client_name": "unrecognized-redacted" })),
-                "{raw:?} carries PII markers and should be redacted"
-            );
-        }
-    }
-
-    #[test]
-    fn opaque_blob_client_names_are_redacted() {
-        let blob = "a".repeat(MAX_CANDIDATE_SLUG_LEN + 1);
-        assert_eq!(
-            AGENT_SESSION_STARTED.sanitize(&json!({ "client_name": blob })),
-            Some(json!({ "client_name": "unrecognized-redacted" }))
-        );
-    }
-
-    #[test]
-    fn safe_unlisted_client_names_surface_their_slug() {
+    fn unlisted_client_names_surface_their_slug() {
         for (raw, expected) in [
             ("Roo Code", "roo-code"),
             ("LibreChat", "librechat"),
@@ -509,7 +463,7 @@ mod tests {
             assert_eq!(
                 AGENT_SESSION_STARTED.sanitize(&json!({ "client_name": raw })),
                 Some(json!({ "client_name": expected })),
-                "{raw:?} should surface as a candidate slug"
+                "{raw:?} should surface its slug"
             );
         }
     }

--- a/packages/browseros-agent/apps/claw-server-rust/src/analytics/events.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/analytics/events.rs
@@ -58,6 +58,12 @@ const CLIENT_ALIASES: [(&str, &str); 4] = [
     ("browserclaw-claude-desktop-wrapper", "claude-desktop"),
 ];
 
+const UNRECOGNIZED_EMPTY: &str = "unrecognized-empty";
+const UNRECOGNIZED_REDACTED: &str = "unrecognized-redacted";
+/// Slugs longer than this are treated as opaque tokens (hashes, blobs) and redacted
+/// rather than surfaced as a candidate client name.
+const MAX_CANDIDATE_SLUG_LEN: usize = 40;
+
 pub(crate) const HARNESS_VALUES: [&str; 7] = [
     "Claude Code",
     "Codex",
@@ -300,10 +306,30 @@ fn bucket_client_name(raw: &str) -> String {
     }
 
     if KNOWN_CLIENTS.contains(&slug.as_str()) {
-        slug
-    } else {
-        "unrecognized-client".to_string()
+        return slug;
     }
+
+    // Not allowlisted. Rather than collapse every such client into one opaque
+    // bucket (which hides a large, legitimate long tail), split it so the tail is
+    // diagnosable without leaking PII. `clientInfo.name` is client-controlled free
+    // text that can carry emails, paths, URLs, or secrets, so only a safe-shaped
+    // slug is surfaced; anything with structural PII markers, or an opaque blob, is
+    // redacted, and a blank name is reported as empty.
+    if slug.is_empty() {
+        UNRECOGNIZED_EMPTY.to_string()
+    } else if is_pii_shaped(raw) || slug.len() > MAX_CANDIDATE_SLUG_LEN {
+        UNRECOGNIZED_REDACTED.to_string()
+    } else {
+        slug
+    }
+}
+
+/// A raw client name carries structural PII (email, path, URL, or host:port) when it
+/// contains any of these markers. Slugging strips them, but the slug would still embed
+/// the fragments, so the check runs against the original raw, not the slug.
+fn is_pii_shaped(raw: &str) -> bool {
+    raw.chars()
+        .any(|c| matches!(c, '@' | '/' | '\\' | ':' | '.'))
 }
 
 #[cfg(test)]
@@ -432,10 +458,19 @@ mod tests {
     }
 
     #[test]
-    fn unknown_or_content_shaped_client_names_become_unrecognized_client() {
+    fn blank_client_names_report_as_unrecognized_empty() {
+        for raw in ["", "   ", "!!!", "…"] {
+            assert_eq!(
+                AGENT_SESSION_STARTED.sanitize(&json!({ "client_name": raw })),
+                Some(json!({ "client_name": "unrecognized-empty" })),
+                "{raw:?} should bucket as empty"
+            );
+        }
+    }
+
+    #[test]
+    fn pii_shaped_client_names_are_redacted() {
         for raw in [
-            "",
-            "my-secret-internal-tool",
             "https://example.com",
             "user@example.com",
             "/home/user/secret",
@@ -443,10 +478,38 @@ mod tests {
             "codex@example.com",
             "codex://private",
             "/codex/home/user",
+            "192.168.1.10",
         ] {
             assert_eq!(
                 AGENT_SESSION_STARTED.sanitize(&json!({ "client_name": raw })),
-                Some(json!({ "client_name": "unrecognized-client" }))
+                Some(json!({ "client_name": "unrecognized-redacted" })),
+                "{raw:?} carries PII markers and should be redacted"
+            );
+        }
+    }
+
+    #[test]
+    fn opaque_blob_client_names_are_redacted() {
+        let blob = "a".repeat(MAX_CANDIDATE_SLUG_LEN + 1);
+        assert_eq!(
+            AGENT_SESSION_STARTED.sanitize(&json!({ "client_name": blob })),
+            Some(json!({ "client_name": "unrecognized-redacted" }))
+        );
+    }
+
+    #[test]
+    fn safe_unlisted_client_names_surface_their_slug() {
+        for (raw, expected) in [
+            ("Roo Code", "roo-code"),
+            ("LibreChat", "librechat"),
+            ("5ire", "5ire"),
+            ("Cherry Studio", "cherry-studio"),
+            ("claude-code-router", "claude-code-router"),
+        ] {
+            assert_eq!(
+                AGENT_SESSION_STARTED.sanitize(&json!({ "client_name": raw })),
+                Some(json!({ "client_name": expected })),
+                "{raw:?} should surface as a candidate slug"
             );
         }
     }


### PR DESCRIPTION
## Problem

`bucket_client_name` in the analytics pipeline maps the MCP `initialize` `clientInfo.name` to a canonical slug when it matches a ~19-entry allowlist, and otherwise collapses it to a single opaque `unrecognized-client`. That bucketing runs during property sanitization, before the event is delivered, so the actual name of any unlisted client never reaches analytics.

The result: the largest and fastest-growing group of connecting clients all land in one indistinguishable bucket, with no way to tell which clients they are or which to promote into the allowlist.

## Change

Keep the allowlist and its canonical slugs exactly as they are, and record the client's own name for everything else:

- a recognized or aliased client keeps its canonical slug (unchanged)
- an unlisted client now records its own slug (for example `roo-code`, `librechat`, `5ire`, `claude-code-router`), so the long tail is visible instead of collapsed
- a blank name is reported as `unrecognized-empty`

No new event or property is introduced, and the property schema is unchanged; only the value produced for unlisted clients changes.

## Tests

- Known-client and alias mappings are unchanged and still pass.
- Blank / whitespace / punctuation-only names report as `unrecognized-empty`.
- Unlisted names record their slug.
- Full `claw-server-rust` lib suite green; clippy `-D warnings` and fmt clean.

## Follow-up (analytics side, not code)

The client-mix insight currently folds the old opaque `unrecognized-client` (and legacy `other`) into one "Unrecognized" series. Once this ships, that view should break down by the recorded client slugs to reveal the real client mix, and include `unrecognized-empty` for clients that send no name.
