### PR TITLE
perf(rust): drop dependency debug info from the dev profile

### DIFF
--- a/packages/browseros-agent/Cargo.toml
+++ b/packages/browseros-agent/Cargo.toml
@@ -66,6 +66,15 @@ print_stdout = "warn"
 print_stderr = "warn"
 dbg_macro = "warn"
 
+[profile.dev]
+# Dependencies are never stepped into, so their DWARF is pure disk cost: a strip
+# probe put debug info at 81% of the largest dependency rlib. Workspace crates
+# keep line tables so panics and backtraces still resolve to file and line.
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false
+
 [profile.release]
 lto = "thin"
 codegen-units = 1


### PR DESCRIPTION
## What

Adds a `[profile.dev]` block that stops Cargo emitting debug info for dependencies.

```toml
[profile.dev]
debug = "line-tables-only"

[profile.dev.package."*"]
debug = false
```

## Why

A clean dev build of the workspace produces a **3.0G** `target/` directory, and every git worktree pays that in full. Dependencies dominate it, and their debug info is the bulk.

A `strip -S` probe on the largest dependency rlib measured it directly: **224M drops to 42M, so 81% of that artifact is debug info**. Nobody steps into third-party crates during normal work, so it is pure disk cost.

`[profile.dev.package."*"]` applies to dependencies only, never to workspace members. First-party crates keep `line-tables-only`, which preserves file and line in panics and backtraces while dropping variable and type DWARF.

## Measured

Clean build, same commit, same machine, before and after:

| | `target/` | `target/debug/deps` | `incremental/` | build time |
|---|---|---|---|---|
| before | 3.0G | 2.1G | 403M | 57.33s |
| after | **1.8G** | **1.1G** | 394M | **51.00s** |

**40% smaller, and 11% faster** because there is less debug info to write.

Object files carrying DWARF drop from 9964 (1349M) to 1461 (121M). The largest dependency rlib goes from 224M to 85M.

## Verification

- `cargo build --workspace` succeeds.
- `cargo clippy --workspace --all-targets -- -D warnings` passes clean.
- `.debug_line` is still present in the first-party binary, so backtraces continue to resolve to file and line.

## CI impact

`Cargo.toml` is listed in `turbo.json` `globalDependencies`, so merging this invalidates every Turbo cache entry once. It self-heals in the same push: the cache warmer's path filter (`packages/browseros-agent/**`) covers this file, a changed global dependency marks all packages affected so the `--affected` run becomes a full warm, and the weekly cron backstops it. The warmer only runs `typecheck`, which a Cargo profile change cannot alter, so the re-warmed artifacts are identical to the evicted ones.

`Swatinem/rust-cache` in the test workflow keys on the `Cargo.toml` hash, so there is one cold Rust rebuild after merge. Every run after that caches a `target/` roughly 40% smaller, which reduces LRU eviction pressure on the per-repo Actions cache limit.

## Not included

`incremental` accounts for a further 394M but stays on. Disabling it would slow every rebuild, which is a developer experience regression rather than a free win.