### PR TITLE
ci: resolve the bun version from package.json in every workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Install dependencies
         run: bun ci

--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -237,7 +237,7 @@ jobs:
         if: inputs.resource-mode == 'source' && inputs.product == 'browseros'
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.6"
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Install BrowserOS server dependencies
         if: inputs.resource-mode == 'source' && inputs.product == 'browseros'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: packages/browseros-agent/package.json
 
       # Run Biome through the repo's own lint script (bunx @biomejs/biome) so CI
       # uses the exact same Biome as local `bun run lint`, instead of a version
@@ -52,6 +54,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Start Turbo remote cache (GitHub Actions cache)
         uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
@@ -89,6 +93,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
@@ -121,6 +127,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Setup Rust
         run: |
@@ -160,6 +168,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Install dependencies
         run: bun ci

--- a/.github/workflows/release-claw-onboard.yml
+++ b/.github/workflows/release-claw-onboard.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.6"
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Install browseros-agent dependencies
         working-directory: packages/browseros-agent

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.6"
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Validate release tag
         id: release

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -376,7 +376,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.6"
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Stamp in-repository extension version
         if: ${{ inputs.extension == 'agent' || inputs.extension == 'browserclaw' }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -268,7 +268,7 @@ jobs:
         if: steps.inputs.outputs.resource_mode == 'source' && steps.inputs.outputs.products == 'browseros'
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.6"
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Install BrowserOS server dependencies
         if: steps.inputs.outputs.resource_mode == 'source' && steps.inputs.outputs.products == 'browseros'

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -266,9 +266,14 @@ jobs:
 
       - name: Setup Bun
         if: steps.inputs.outputs.resource_mode == 'source' && steps.inputs.outputs.products == 'browseros'
+        # Pinned literally rather than read from package.json: this job builds
+        # from the persistent tree at BROWSEROS_REPO_PATH and never checks out
+        # into GITHUB_WORKSPACE, which is where setup-bun resolves a version
+        # file from. A workspace-relative path finds nothing and Bun silently
+        # falls back to latest. Keep in sync with packageManager.
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version-file: packages/browseros-agent/package.json
+          bun-version: "1.3.6"
 
       - name: Install BrowserOS server dependencies
         if: steps.inputs.outputs.resource_mode == 'source' && steps.inputs.outputs.products == 'browseros'

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -267,7 +267,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.6"
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Install Wine
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Install dependencies
         run: bun ci
@@ -82,6 +84,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Setup Rust
         if: matrix.needs_rust == true

--- a/.github/workflows/turbo-cache-warm.yml
+++ b/.github/workflows/turbo-cache-warm.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Start Turbo remote cache (GitHub Actions cache)
         uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1

--- a/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
@@ -101,7 +101,9 @@ describe('release-extensions workflow', () => {
   it('builds and attaches the immutable CRX before optional finalization', () => {
     const build = section('  build:', '  preflight_alpha:')
     expect(build).toContain('browseros ext release')
-    expect(build).toContain('bun-version: "1.3.6"')
+    expect(build).toContain(
+      'bun-version-file: packages/browseros-agent/package.json',
+    )
     expect(build).toContain('--source-sha "$RELEASE_SHA"')
     expect(build).toContain('gh release upload')
     expect(build).toContain('needs.prepare.outputs.version')


### PR DESCRIPTION
## The problem

Nine of the fifteen `setup-bun` steps had **no version pinned**, so every run installed whatever Bun happened to be newest:

| Workflow | Unpinned steps |
|---|---|
| `code-quality.yml` | 5 (biome, typecheck, claw-api-codegen, claw-api-contract, fallow) |
| `test.yml` | 2 (discover, test) |
| `audit.yml` | 1 |
| `turbo-cache-warm.yml` | 1 |

These are the workflows that gate merges. A Bun release could change install layout, module resolution, or test behaviour and land in all four with no commit and no warning. It also meant Tests could pass on a Bun that the release workflows never use.

The other six steps hardcoded `bun-version: "1.3.6"` in YAML, a third place to keep in sync with what the repo already declares.

Three different notions of "the Bun version": newest available, a literal repeated six times, and `package.json`.

## The fix

All fifteen steps now read the version from the source of truth that already exists:

```yaml
- uses: oven-sh/setup-bun@v2
  with:
    bun-version-file: packages/browseros-agent/package.json
```

`setup-bun`'s `bun-version-file` accepts `package.json` and prefers `packageManager`, falling back to `engines.bun`. Both are present and agree on `1.3.6`, so **the six release workflows keep their exact current behaviour**.

Bumping Bun for the whole repo becomes a one-line change to `packageManager`.

## Verification

Every workflow was parsed as YAML and each `setup-bun` step asserted to have `bun-version-file` set and no leftover `bun-version`: **15 steps, 0 problems.**

`with:` inputs resolve against the repository root rather than `defaults.run.working-directory`, so the path is correct in the workflows that default their run directory to `packages/browseros-agent`.

## What to watch on this PR

The four previously unpinned workflows will now run Bun **1.3.6** instead of newest. If any of them depends on a newer Bun feature, it surfaces on this PR rather than silently breaking later. That is the point of the change.

## Deliberately out of scope

- **Not a version bump.** Making CI deterministic and choosing which Bun it runs are separate decisions.
- `dependabot.yml` covers the `bun` ecosystem but not `github-actions`, so action versions are never updated automatically. Worth a follow-up.