### PR TITLE
test(release): refresh the live feed pins after shipped releases

### DIFF
--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -1093,7 +1093,7 @@ class PublisherTestCase(unittest.TestCase):
             ),
             (
                 "appcast-claw-server.xml",
-                "0.0.15",
+                "0.0.44",
                 (
                     (
                         "BrowserOS Claw Server",
@@ -1108,7 +1108,7 @@ class PublisherTestCase(unittest.TestCase):
                         "BrowserOS Claw Server (Alpha) binary updates",
                     ),
                 ),
-                "1df47182d63006294b87323d276896e489f141f2aed1f0266a2119c9ffef3eef",
+                "ad5b3243ba935f9cced98a18a48c850bb11e2012e81be53ae265399c87ec5610",
             ),
         )
 
@@ -1131,12 +1131,12 @@ class PublisherTestCase(unittest.TestCase):
         self.assertEqual((spec.kind, spec.channel), ("extensions", "alpha"))
         self.assertEqual(
             set(extract_manifest_versions(manifest).values()),
-            {"0.0.139.0", "54.0.0.0", "0.2.15.0"},
+            {"0.0.139.0", "54.0.0.0", "0.2.17.0"},
         )
         original = manifest.replace("</gupdate>", "  </app>\n</gupdate>")
         self.assertEqual(
             hashlib.sha256(original.encode()).hexdigest(),
-            "d2a7b386ea9928cb4ae4f0a8537f304db19e7e17e51178feecbe2f5a90f08fb7",
+            "1844d1c76722f5423b1a48fa2f7d5636cbb9cba6b98dd5c4daf56113b2737bc1",
         )
 
     def test_browserclaw_snapshots_use_current_product_title(self):


### PR DESCRIPTION
## What

`test_repaired_snapshots_preserve_versions_and_original_payloads` has been failing on `main`. Two of the live release feeds it pins have shipped new versions since the expectations were last set.

| Pin | Was | Now |
|---|---|---|
| `appcast-claw-server.xml` version | `0.0.15` | `0.0.44` |
| `appcast-claw-server.xml` payload hash | `1df47182…` | `ad5b3243…` |
| `update-manifest.alpha.xml` versions | `{0.0.139.0, 54.0.0.0, 0.2.15.0}` | `{0.0.139.0, 54.0.0.0, 0.2.17.0}` |
| `update-manifest.alpha.xml` payload hash | `d2a7b386…` | `1844d1c7…` |

`appcast-server.xml` has not shipped since and keeps its existing version and hash.

Both hashes were recomputed by running the module's own `extract_appcast_version` and `extract_manifest_versions` against the current files and applying the same replacement steps the test performs, rather than transcribed by hand.

The unrelated synthetic `"0.0.15"` fixture further up the file belongs to a constructed appcast, not to the live feed, and is deliberately untouched.

## Verification

Every step of the `bos_build` job, run locally:

| Step | Result |
|---|---|
| `bos_build` tests | 1137 pass, 2 skipped |
| release secrets tests | 10 pass |
| `vendor_uploads` tests | 47 pass |
| `ruff check bos_build` | all checks passed |
| CLI smoke | `build --list` and `product doctor` ok |

## Note on the underlying fragility

This test asserts version strings and sha256 payload hashes of files that change on every release, so it is guaranteed to break again the next time the claw server or the alpha extensions manifest ships. Refreshing the pins is the intended maintenance action for a guard of this shape, and this PR does only that.

If the intent is to detect unexpected drift rather than to track every release, moving the assertions onto committed fixture files instead of the live `updates/` tree would make it stable. That is a larger change and is deliberately out of scope here.