### PR TITLE
perf(rust): share cargo intermediates across checkouts

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+[build]
+# Keep intermediate artifacts outside the checkout so every clone and worktree
+# on a machine shares one copy instead of each rebuilding the dependency graph.
+# {cargo-cache-home} expands to CARGO_HOME, so this is portable: no absolute
+# path, no assumption about where the repo lives. Cargo does not expand ~ or
+# $HOME, and target-dir does not support templating, so build-dir is the only
+# form that gets this.
+#
+# Final artifacts still land in <checkout>/target, so anything locating a built
+# binary by path keeps working.
+build-dir = "{cargo-cache-home}/build/browseros"

--- a/.github/workflows/rust-cache-bust.yml
+++ b/.github/workflows/rust-cache-bust.yml
@@ -1,0 +1,69 @@
+name: Rust Cache Bust
+
+# The shared cargo build directory is cached as an extra `cache-directories`
+# entry, and rust-cache prunes only workspace target dirs, never extra ones. So
+# that entry is cached wholesale and accumulates artifacts for dependencies and
+# profiles that no longer exist. Left alone it grows against the repository's
+# 10GB Actions cache allowance and evicts entries that are still wanted.
+#
+# Dropping it on a schedule keeps that bounded. The next warm run rebuilds it
+# from scratch, so the only cost is one cold Rust compile.
+on:
+  schedule:
+    # 1st and 15th, so roughly fortnightly. Ahead of the Monday 06:00 warm run
+    # rather than alongside it, and the warm workflow is dispatched below in any
+    # case so a fresh cache does not wait for the next merge.
+    - cron: "0 5 1,15 * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+concurrency:
+  group: rust-cache-bust
+  cancel-in-progress: false
+
+jobs:
+  bust:
+    name: Drop Rust caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Delete Rust caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # rust-cache prefixes every key it writes with `prefix-key`, which is
+          # left at its default. Matching on that keeps Turbo and any other
+          # cache in this repository untouched.
+          ids="$(gh api --paginate "/repos/$REPO/actions/caches?per_page=100" \
+            --jq '.actions_caches[] | select(.key | startswith("v0-rust")) | .id')"
+
+          if [ -z "$ids" ]; then
+            echo "No Rust caches to drop."
+            echo "No Rust caches to drop." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          count=0
+          while read -r id; do
+            [ -n "$id" ] || continue
+            gh api -X DELETE "/repos/$REPO/actions/caches/$id"
+            count=$((count + 1))
+          done <<< "$ids"
+
+          echo "Dropped $count Rust cache entries."
+          echo "Dropped $count Rust cache entries." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Request a fresh warm run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Rebuild immediately rather than leaving every branch cold until the
+          # next merge or the Monday schedule.
+          gh workflow run turbo-cache-warm.yml --repo "$REPO" --ref main
+          echo "Dispatched Turbo Cache Warm on main." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: packages/browseros-agent
+          # Intermediate artifacts live outside the checkout so worktrees can
+          # share them, and rust-cache only saves workspace target dirs plus the
+          # registry and git caches by default. Name the build dir explicitly or
+          # every run would recompile the dependency graph from scratch.
+          cache-directories: ~/.cargo/build/browseros
 
       - name: Install dependencies
         run: bun ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: packages/browseros-agent
+          # Without this the key embeds GITHUB_JOB, so the warm cache produced
+          # on main by a differently named job could never be restored here.
+          shared-key: browseros-agent
           # Intermediate artifacts live outside the checkout so worktrees can
           # share them, and rust-cache only saves workspace target dirs plus the
           # registry and git caches by default. Name the build dir explicitly or

--- a/.github/workflows/turbo-cache-warm.yml
+++ b/.github/workflows/turbo-cache-warm.yml
@@ -1,14 +1,16 @@
 name: Turbo Cache Warm
 
-# Populates the Turbo cache on `main` so PR branches inherit warm cache.
-# GitHub Actions caches restore only from the same branch or the base/default
-# branch, so without a run on `main` every PR would start cold. Neither the
-# Tests nor Code Quality workflows run on `main`, so this is that run.
+# Populates the Turbo and Rust caches on `main` so PR branches inherit warm
+# cache. GitHub Actions caches restore only from the same branch or the
+# base/default branch, so without a run on `main` every PR would start cold.
+# Neither the Tests nor Code Quality workflows run on `main`, so this is that
+# run.
 on:
   push:
     branches: [main]
     paths:
       - .github/workflows/turbo-cache-warm.yml
+      - .cargo/config.toml
       - packages/browseros-agent/**
   schedule:
     # Weekly full warm to backstop GitHub's 7-day unused-cache eviction for
@@ -63,3 +65,38 @@ jobs:
             # Per-merge: warm only what this merge changed.
             bunx turbo run typecheck --affected
           fi
+
+  warm-rust:
+    name: Warm Rust cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Rust
+        # Pinned to match the Tests workflow. A different toolchain hashes into
+        # a different cache key, which would warm a cache nothing else reads.
+        uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          components: clippy,rustfmt
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/browseros-agent
+          # Must match the Tests workflow exactly. Without it the key embeds
+          # GITHUB_JOB and this cache would be unreadable there.
+          shared-key: browseros-agent
+          cache-directories: ~/.cargo/build/browseros
+          # Save even though nothing here is a pass/fail gate; warming is the
+          # entire point of the job.
+          save-if: "true"
+
+      - name: Warm Rust cache
+        # Mirrors what the Rust suites compile: test binaries and clippy's
+        # separate artifacts. -D warnings is deliberately omitted, since this
+        # job exists to populate a cache, not to gate on lints.
+        run: |
+          cargo test --workspace --locked --no-run
+          cargo clippy --workspace --all-targets --locked


### PR DESCRIPTION
> Draft pending a second opinion on the tradeoff below. The change itself is measured and CI-verified.

## What

Moves cargo's **intermediate** build artifacts out of the checkout into one shared location, so multiple clones or worktrees stop each compiling their own copy of the dependency graph.

```toml
# .cargo/config.toml
[build]
build-dir = "{cargo-cache-home}/build/browseros"
```

## Why this form

A checkout currently owns its entire build output, roughly 1.8G once warm. With several worktrees open that is paid in full every time.

`target-dir` is the obvious lever and does not work here:

| Attempt | Result |
|---|---|
| `target-dir = "~/shared/browseros"` | creates a directory literally named `~` **inside the checkout** |
| `target-dir = "$HOME/shared/browseros"` | creates one literally named `$HOME` inside the checkout |
| `target-dir = "{cargo-cache-home}/…"` | literal `{cargo-cache-home}` directory; target-dir has no templating |
| `target-dir = "../shared-target"` | works, but only shares between *sibling* directories, and moves the final artifacts too |

Cargo expands neither `~` nor `$HOME`, and paths in a config file resolve relative to that file's parent. So a committed `target-dir` could only ever be checkout-relative, which limits sharing to siblings and would break the three places `release-claw-server.yml` locates a built binary (the PostHog key check, the stamped version check, and packaging).

`build-dir` avoids all of it. It supports templating, `{cargo-cache-home}` resolves to `CARGO_HOME`, and it moves **only** intermediates. Final artifacts still land in `<checkout>/target`.

## Measured

Two checkouts of the same branch:

| | cold | second checkout |
|---|---|---|
| build time | 52.36s | **16.14s** |
| own `target/` | 227M | 227M |
| shared dir | 1.6G | 2.1G |

A release build against a warm shared directory still produces `target/release/browseros-claw-server-rs`, which is the path the release workflow reads.

## The CI half

`Swatinem/rust-cache` computes its cache paths as the registry, the git cache, and each workspace's `target` (`config.ts:265`), and never reads a build-dir setting. Left alone it would cache only the 227M of final artifacts and recompile every dependency on each run, so the shared directory is named to it explicitly.

Two further gaps turned up while wiring that, both pre-existing and both worth fixing here because this change depends on them.

### The Rust cache was never warm for a pull request

`test.yml` runs only on `pull_request`, so rust-cache only ever saved under a PR branch's scope, and branches cannot read each other's caches. This is precisely the problem `turbo-cache-warm.yml` already solves for Turbo; Rust was simply never covered. It matters more once intermediates live in a `cache-directories` entry, because without a warm run every PR recompiles the dependency graph.

A warm job alone would not have been enough. rust-cache derives its key from `GITHUB_JOB` unless `shared-key` is set, and the existing keys in this repository show it plainly:

```
v0-rust-test-Linux-x64-<hash>-<hash>
      ^^^^ the job name
```

A warm job under any other name would have written a cache nothing else could read. Both steps now pin the same `shared-key`, `workspaces`, `cache-directories`, and toolchain version, since the toolchain hashes into the key as well.

The new `warm-rust` job mirrors what the Rust suites actually compile, test binaries and clippy's separate artifacts, and deliberately omits `-D warnings`: it exists to populate a cache, not to gate on lints.

### The shared directory would grow without bound

rust-cache prunes only workspace `target` dirs, never extra `cache-directories`, so the shared build directory is cached wholesale. Measured against the live repository, it is already the larger half of a real problem:

| | entries | size |
|---|---|---|
| `v0-rust` caches | 25 | **6.97 GB** |
| all caches | 262 | **10.35 GB** |

The allowance is 10 GB, so the repository is already over it and LRU eviction is discarding other caches to make room. `rust-cache-bust.yml` drops the Rust entries on the 1st and 15th, matched on the `v0-rust` prefix so Turbo and everything else is untouched, then dispatches the warm workflow so no branch waits for the next merge.

## Tradeoffs

- **~227M stays per checkout** rather than nothing. That is the price of leaving final artifacts in place, and it is what keeps the release paths working.
- The shared directory grows monolithically and wants an occasional `cargo clean` locally. In CI the fortnightly bust covers it.
- Concurrent cargo invocations across checkouts serialize on its lock.
- The fortnightly bust means one cold Rust compile every two weeks, absorbed by the warm run on `main` rather than by a contributor's pull request.

## Scope

Independent of #2442, which covers the Bun dependency store. No overlapping files, either can land first.
