### PR TITLE
fix(ci): stop the rust cache key fragmenting across runner images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,14 @@ jobs:
           # Without this the key embeds GITHUB_JOB, so the warm cache produced
           # on main by a differently named job could never be restored here.
           shared-key: browseros-agent
+          # rust-cache hashes every toolchain `rustup toolchain list` reports,
+          # not just the pinned one, and the runner image ships its own Rust
+          # alongside it. That set changes as images roll out, so the key
+          # fragmented across runners and a warm cache was a coin flip. The
+          # lockfile hash still keys the cache, so dependency changes bust it;
+          # cargo fingerprints by rustc version itself, so a toolchain change
+          # rebuilds rather than reusing the wrong artifacts.
+          add-rust-environment-hash-key: false
           # Intermediate artifacts live outside the checkout so worktrees can
           # share them, and rust-cache only saves workspace target dirs plus the
           # registry and git caches by default. Name the build dir explicitly or

--- a/.github/workflows/turbo-cache-warm.yml
+++ b/.github/workflows/turbo-cache-warm.yml
@@ -88,6 +88,14 @@ jobs:
           # Must match the Tests workflow exactly. Without it the key embeds
           # GITHUB_JOB and this cache would be unreadable there.
           shared-key: browseros-agent
+          # rust-cache hashes every toolchain `rustup toolchain list` reports,
+          # not just the pinned one, and the runner image ships its own Rust
+          # alongside it. That set changes as images roll out, so the key
+          # fragmented across runners and a warm cache was a coin flip. The
+          # lockfile hash still keys the cache, so dependency changes bust it;
+          # cargo fingerprints by rustc version itself, so a toolchain change
+          # rebuilds rather than reusing the wrong artifacts.
+          add-rust-environment-hash-key: false
           cache-directories: ~/.cargo/build/browseros
           # Save even though nothing here is a pass/fail gate; warming is the
           # entire point of the job.


### PR DESCRIPTION
## The symptom

The Rust warm run added in #2446 is not restorable. On the same commit:

```
warm job saved:   v0-rust-browseros-agent-Linux-x64-77f289fb-641bdc68
test job wanted:  v0-rust-browseros-agent-Linux-x64-b588fbb1-641bdc68
restore key:      v0-rust-browseros-agent-Linux-x64-b588fbb1
                                                   ^^^^^^^^ no match
```

The test job logged `No cache found.` and compiled the dependency graph from scratch.

## The cause

`shared-key` correctly removed the job name from the key. But rust-cache also appends a hash of the Rust environment, and that hash is **not** built from the pinned toolchain alone. From `config.ts:390-415`:

```js
versions.add(parseRustVersion(await getCmdOutput(cmdFormat, "rustc -vV")));
const stdout = await getCmdOutput(cmdFormat, "rustup toolchain list --quiet");
for (const toolchain of stdout.split(/[\n\r]+/)) {
  versions.add(parseRustVersion(await getCmdOutput(cmdFormat, `rustup run ${toolchain} rustc -vV`)));
}
```

Every toolchain installed on the runner is hashed. The runner image ships its own Rust alongside the pinned `1.95.0`, and that set changes as images roll out, so identical workflow configuration hashes differently depending on which runner a job happens to land on.

Verified it is nothing else: both jobs install the same toolchain (`1.95.0 (59807616e 2026-04-14)`, clippy and rustfmt, minimal profile), and the env vars rust-cache actually hashes (`CARGO`, `CC`, `CFLAGS`, `CXX`, `CMAKE`, `RUST` prefixes, per `config.ts:111`) are identical in both: `CARGO_HOME`, `CARGO_INCREMENTAL`, `CARGO_TERM_COLOR`, same values. `BROWSEROS_APPIMAGE_URL` differs between the workflows but matches no hashed prefix.

## Why it went unnoticed

This predates #2446. The existing caches split almost evenly across two variants:

| env hash | entries |
|---|---|
| `77f289fb` | 11 |
| `b588fbb1` | 11 |
| two others | 1 each |

So roughly half of all Rust jobs were already missing cache and recompiling. That reads as "CI is a bit slow", not as a fault.

## The fix

Drop that segment on both steps. The key becomes prefix, shared key, OS and arch, and the lockfile hash, so **dependency changes still bust the cache**.

Sharing across toolchains stays safe: cargo fingerprints by rustc version internally and rebuilds anything that does not match, rather than reusing artifacts from a different compiler. Worst case is some unused entries in the cache, which the fortnightly bust from #2446 already clears.

Both steps keep identical `workspaces`, `shared-key`, `cache-directories` and toolchain pin, since every one of those feeds the key.

## Note

The toolchain pin no longer invalidates the cache by itself. Both workflows pin `dtolnay/rust-toolchain@1.95.0`, so a bump is a deliberate edit; bumping `prefix-key` at the same time is the clean way to force a fresh cache if a future toolchain change ever warrants it.