### PR TITLE
feat(app-onboard): show ACP agents on the agent setup step

### DIFF
--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/components/AgentBrandMarks.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/components/AgentBrandMarks.tsx
@@ -1,0 +1,53 @@
+/**
+ * Marks for agents that @lobehub/icons does not carry.
+ *
+ * These are inline single-colour SVGs rather than imported image files: the
+ * Chromium build emits exactly app.js, app.css and the icon/ directory listed
+ * in that target's BUILD.gn, so any Vite-processed asset either throws during
+ * the build or trips the data: URL guard in verify-chromium-build.
+ */
+
+interface MarkProps {
+  size?: number
+}
+
+/**
+ * OpenClaw. Silhouette of the mark the app ships, flattened to one colour.
+ *
+ * The eyes are cut out of the body with evenodd rather than painted over, so
+ * the shape stays legible against any chip background, and the claws are kept
+ * clear of the body so the outline does not read as one blob at chip size.
+ */
+export function OpenClaw({ size = 24 }: MarkProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 120 120"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="OpenClaw"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M60 22c-19 0-30 16-30 35 0 19 12 35 30 43 18-8 30-24 30-43 0-19-11-35-30-35Zm-9 22a6 6 0 1 1 0 12 6 6 0 0 1 0-12Zm18 0a6 6 0 1 1 0 12 6 6 0 0 1 0-12Z"
+      />
+      <path d="M24 48c-13-6-19 3-15 12 4 9 14 6 19-3 3-5 1-8-4-9Z" />
+      <path d="M96 48c13-6 19 3 15 12-4 9-14 6-19-3-3-5-1-8 4-9Z" />
+      <path
+        d="M48 24 38 10"
+        stroke="currentColor"
+        strokeWidth="7"
+        strokeLinecap="round"
+      />
+      <path
+        d="M72 24 82 10"
+        stroke="currentColor"
+        strokeWidth="7"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/steps/SetupAgentStep.test.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/steps/SetupAgentStep.test.tsx
@@ -49,11 +49,32 @@ describe('SetupAgentStep', () => {
 
     expect(html).toContain('Set up your')
     expect(html).toContain('Any LLM provider')
-    expect(html).toContain('Or a coding agent you already use')
+    expect(html).toContain('Or a coding agent harness you already use')
+    expect(html).toContain('or any other ACP compatible agent')
     expect(html).toContain('+40')
     expect(html).toContain('Set up my agent')
     // Every chip is a brand SVG; there should be many.
     expect((html.match(/<svg/g) ?? []).length).toBeGreaterThan(10)
+  })
+
+  it('lists the ACP agents alongside the built-in harnesses', () => {
+    const html = renderToStaticMarkup(
+      <SetupAgentStep onSetup={() => undefined} onLater={() => undefined} />,
+    )
+
+    for (const label of ['Claude Code', 'Codex', 'OpenClaw', 'Hermes']) {
+      expect(html).toContain(`title="${label}"`)
+    }
+  })
+
+  it('renders a monogram for an agent with no single-colour mark', () => {
+    const html = renderToStaticMarkup(
+      <SetupAgentStep onSetup={() => undefined} onLater={() => undefined} />,
+    )
+
+    // Hermes' mark is a raster illustration, so the chip falls back to a letter
+    // rather than importing an image the Chromium resource target cannot carry.
+    expect(html).toMatch(/title="Hermes"[^>]*>(?:(?!<svg)[\s\S])*?>H</)
   })
 
   it('wires the primary CTA to setup', () => {

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/steps/SetupAgentStep.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/steps/SetupAgentStep.tsx
@@ -18,6 +18,7 @@ import {
 import { ArrowRight } from 'lucide-react'
 import type { ComponentType } from 'react'
 import { Button } from '@/components/ui/button'
+import { OpenClaw } from '../components/AgentBrandMarks'
 import { DisplayHeading, Em, StepCopy } from '../components/DisplayHeading'
 import { StepWrap } from '../components/StepWrap'
 
@@ -29,7 +30,9 @@ interface SetupAgentStepProps {
 type MonoIcon = ComponentType<{ size?: number }>
 interface IconEntry {
   label: string
-  Icon: MonoIcon
+  Icon?: MonoIcon
+  /** Shown instead of an icon for agents with no single-colour brand mark. */
+  monogram?: string
 }
 
 // Real brand marks from @lobehub/icons (the same source the app uses). The
@@ -57,15 +60,25 @@ const CODING_AGENTS: IconEntry[] = [
   { label: 'GitHub Copilot', Icon: Github },
   { label: 'Gemini CLI', Icon: Gemini },
   { label: 'Qwen Code', Icon: Qwen },
+  { label: 'OpenClaw', Icon: OpenClaw },
+  // Hermes' mark is a detailed illustration with no single-colour form, so it
+  // uses the same monogram the app falls back to in its agent picker.
+  { label: 'Hermes', monogram: 'H' },
 ]
 
-function IconChip({ label, Icon }: IconEntry) {
+function IconChip({ label, Icon, monogram }: IconEntry) {
   return (
     <span
       title={label}
       className="grid size-[42px] place-items-center rounded-[10px] border border-border bg-card text-foreground transition-all duration-150 hover:-translate-y-0.5 hover:border-accent hover:shadow-[0_6px_14px_var(--color-accent-tint)]"
     >
-      <Icon size={23} />
+      {Icon ? (
+        <Icon size={23} />
+      ) : (
+        <span className="font-semibold text-[17px] leading-none">
+          {monogram}
+        </span>
+      )}
     </span>
   )
 }
@@ -84,8 +97,8 @@ export function SetupAgentStep({ onSetup, onLater }: SetupAgentStepProps) {
         Set up your <Em>agent</Em>
       </DisplayHeading>
       <StepCopy>
-        Connect an LLM provider or a coding agent you already use. We will open
-        BrowserOS so you can finish.
+        Connect an LLM provider or a coding agent harness you already use. We
+        will open BrowserOS so you can finish.
       </StepCopy>
       <div className="mb-6 flex max-w-[480px] flex-col gap-[18px]">
         <div>
@@ -103,12 +116,15 @@ export function SetupAgentStep({ onSetup, onLater }: SetupAgentStepProps) {
         </div>
         <div>
           <div className="mb-2.5 font-bold text-[11px] text-ink-3 uppercase tracking-[0.08em]">
-            Or a coding agent you already use
+            Or a coding agent harness you already use
           </div>
           <div className="flex flex-wrap gap-2">
             {CODING_AGENTS.map((entry) => (
               <IconChip key={entry.label} {...entry} />
             ))}
+          </div>
+          <div className="mt-2.5 text-[13px] text-ink-3">
+            or any other ACP compatible agent
           </div>
         </div>
       </div>


### PR DESCRIPTION
Three changes to the agent setup step.

## Coding agent row

Adds **OpenClaw** and **Hermes**, and a caption underneath: *or any other ACP compatible agent*. The row can only ever show a handful of what actually works, so the caption carries the breadth the icons cannot.

```
OR A CODING AGENT HARNESS YOU ALREADY USE
[Claude][Codex][Copilot][Gemini][Qwen][OpenClaw][H]
or any other ACP compatible agent
```

## Wording

The group title becomes **"Or a coding agent harness you already use"**, and the body copy above it follows. Harness is the accurate word here: what the user connects is the tool that drives a model, not the model itself. That distinction is exactly what this row is for, since the row above it is the models.

## Why the marks are inline SVG

The app renders Hermes from a PNG import. This app cannot do that. The Chromium target emits only `app.js`, `app.css` and the `icon/` directory enumerated in its `BUILD.gn`, enforced three ways: `assetsInlineLimit: 0`, an `assetFileNames` hook that throws on any non-CSS asset, and a `data:` URL guard in `verify-chromium-build`. A PNG would need a new entry in that `BUILD.gn` patch plus the verifier allowlist, which is a lot of machinery for one row icon.

So both marks are single-colour inline SVGs, matching the currentColor chips already in the row:

- **OpenClaw** is the silhouette of the mark the app ships. The eyes are cut out with `evenodd` rather than painted over so the shape survives any chip background, and the claws are kept clear of the body so it does not read as one blob at 23px.
- **Hermes** has no single-colour form (its mark is a detailed illustration), so its chip falls back to the same monogram the app already uses for Hermes in its agent picker.

## Verification

- `@browseros/app-onboard` tests: 6 pass, 0 fail. Two new ones cover the agent labels and the monogram fallback.
- `typecheck` and `lint` clean.
- `build:chromium` passes and `verify-chromium-build` reports exactly the allowlisted resources, so the inline SVGs add no new assets and no `data:` URLs.
- Rendered and checked visually on the real step.

## Follow-up worth considering

OpenClaw's mark here is derived from the one the app ships, which is itself a stand-in rather than an official logo. If a real vector mark turns up for either agent, both are a one-component swap.