### PR TITLE
chore: sync production BrowserClaw manifest

### DIFF
--- a/updates/extensions/update-manifest.xml
+++ b/updates/extensions/update-manifest.xml
@@ -7,6 +7,6 @@
     <updatecheck codebase="https://cdn.browseros.com/extensions/agent-0.0.124.0.crx" version="0.0.124.0" />
   </app>
   <app appid="pjimfkbpehlcllblajnpfamdfjhhlgkc">
-    <updatecheck codebase="https://cdn.browseros.com/extensions/browserclaw-0.2.15.0.crx" version="0.2.15.0" />
+    <updatecheck codebase="https://cdn.browseros.com/extensions/browserclaw-0.2.17.0.crx" version="0.2.17.0" />
   </app>
 </gupdate>


### PR DESCRIPTION
## Summary
- Sync the tracked production BrowserClaw update entry from `0.2.15.0` to `0.2.17.0`.
- Preserve the production agent `0.0.124.0` and bugreporter `54.0.0.0` entries.
- Match the manifest currently served by the production CDN byte-for-byte.

## Design
This is a narrow production snapshot correction: only the BrowserClaw codebase URL and version are updated to the values already served by the live CDN.

## Test plan
- [x] Compare `updates/extensions/update-manifest.xml` byte-for-byte with a fresh CDN response.
- [x] Validate the tracked manifest with `xmllint --noout`.
- [x] Verify the `browserclaw-0.2.17.0.crx` CDN asset is reachable.
- [x] Run `git diff --check` and review the complete branch diff.
