### PR TITLE
fix(release): persist extension feeds before CDN publish

### DIFF
--- a/.github/workflows/release-extension-feeds.yml
+++ b/.github/workflows/release-extension-feeds.yml
@@ -75,13 +75,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch || 'main' }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Generate, persist, and publish extension update feeds
         env:

--- a/.github/workflows/release-extension-feeds.yml
+++ b/.github/workflows/release-extension-feeds.yml
@@ -67,13 +67,17 @@ concurrency:
 jobs:
   feeds:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch || 'main' }}
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v8.3.2
@@ -83,25 +87,27 @@ jobs:
         env:
           CHANNEL: ${{ inputs.channel }}
           PINS: ${{ inputs.pins }}
-          PUBLISH: ${{ inputs.publish }}
           ALLOW_DOWNGRADE: ${{ inputs.allow_downgrade }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
-        # Inputs are validated and appended to an args array, never a command string.
+        # Rendering is the pre-publication boundary: these exact files cross the
+        # snapshot-PR handoff below, so R2 must remain untouched in this step.
         run: |
           set -euo pipefail
 
           case "$CHANNEL" in
-            alpha|prod|both) ;;
+            alpha) channels=(alpha) ;;
+            prod) channels=(prod) ;;
+            both) channels=(alpha prod) ;;
             *)
               echo "::error::Invalid channel '$CHANNEL'; expected alpha, prod, or both" >&2
               exit 1
               ;;
           esac
 
-          args=(--channel "$CHANNEL")
+          base_args=()
           normalized=${PINS//,/ }
           normalized=${normalized//$'\n'/ }
           normalized=${normalized//$'\r'/ }
@@ -111,32 +117,90 @@ jobs:
               echo "::error::Invalid pin '$pin'; expected name=version (for example, agent=0.0.119)" >&2
               exit 1
             fi
-            args+=(--set "$pin")
+            base_args+=(--set "$pin")
           done
-          if [ "$PUBLISH" = "true" ]; then
-            args+=(--publish)
-          fi
           if [ "$ALLOW_DOWNGRADE" = "true" ]; then
-            args+=(--allow-downgrade)
+            base_args+=(--allow-downgrade)
           fi
 
-          if [ "$CHANNEL" = "both" ]; then
-            for ch in alpha prod; do
-              args[1]="$ch"
-              {
-                echo "### Extension feed command ($ch)"
-                echo '```bash'
-                echo "browseros release extensions ${args[*]}"
-                echo '```'
-              } >> "$GITHUB_STEP_SUMMARY"
-              uv run browseros release extensions "${args[@]}"
-            done
-          else
+          snapshot_paths_file="$RUNNER_TEMP/extension-feed-snapshot-paths"
+          feed_keys_file="$RUNNER_TEMP/extension-feed-keys"
+          : > "$snapshot_paths_file"
+          : > "$feed_keys_file"
+
+          for feed_channel in "${channels[@]}"; do
+            args=(--channel "$feed_channel" "${base_args[@]}")
             {
-              echo "### Extension feed command"
+              echo "### Extension feed command ($feed_channel)"
               echo '```bash'
               echo "browseros release extensions ${args[*]}"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
             uv run browseros release extensions "${args[@]}"
+
+            if [ "$feed_channel" = "alpha" ]; then
+              printf '%s\n' \
+                updates/extensions/update-manifest.alpha.xml \
+                updates/extensions/extensions.alpha.json \
+                >> "$snapshot_paths_file"
+              printf '%s\n' \
+                extensions/update-manifest.alpha.xml \
+                extensions/extensions.alpha.json \
+                >> "$feed_keys_file"
+            else
+              printf '%s\n' \
+                updates/extensions/update-manifest.xml \
+                updates/extensions/extensions.json \
+                >> "$snapshot_paths_file"
+              printf '%s\n' \
+                extensions/update-manifest.xml \
+                extensions/extensions.json \
+                >> "$feed_keys_file"
+            fi
+          done
+
+          printf '%s\n' updates/extensions/bundled-manifest.xml \
+            >> "$snapshot_paths_file"
+          printf '%s\n' extensions/bundled-manifest.xml >> "$feed_keys_file"
+
+      - name: Persist and publish extension update feeds
+        env:
+          ALLOW_DOWNGRADE: ${{ inputs.allow_downgrade }}
+          CHANNEL: ${{ inputs.channel }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISH: ${{ inputs.publish }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        # The merged snapshot is the durability barrier. If publication fails
+        # afterward, rerunning is safe; publishing first would recreate drift.
+        run: |
+          set -euo pipefail
+          if [ "$PUBLISH" != "true" ]; then
+            echo "Dry run complete; snapshots were not committed or published"
+            exit 0
           fi
+
+          mapfile -t snapshot_paths \
+            < "$RUNNER_TEMP/extension-feed-snapshot-paths"
+          mapfile -t feed_keys < "$RUNNER_TEMP/extension-feed-keys"
+          if [ "${#snapshot_paths[@]}" -eq 0 ] || [ "${#feed_keys[@]}" -eq 0 ]; then
+            echo "::error::Generation did not select any extension feed files" >&2
+            exit 1
+          fi
+
+          packages/browseros-agent/scripts/release/commit-update-snapshot.sh \
+            "$DEFAULT_BRANCH" \
+            "chore(release): update extension ${CHANNEL} feeds" \
+            "${snapshot_paths[@]}"
+
+          publish_flags=(--publish)
+          if [ "$ALLOW_DOWNGRADE" = "true" ]; then
+            publish_flags+=(--allow-downgrade)
+          fi
+          uv run --directory packages/browseros browseros \
+            release feeds publish-local \
+            "${feed_keys[@]}" \
+            "${publish_flags[@]}"

--- a/.github/workflows/release-extension-feeds.yml
+++ b/.github/workflows/release-extension-feeds.yml
@@ -82,18 +82,21 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v8.3.2
 
-      - name: Generate extension update feeds
-        working-directory: packages/browseros
+      - name: Generate, persist, and publish extension update feeds
         env:
-          CHANNEL: ${{ inputs.channel }}
-          PINS: ${{ inputs.pins }}
           ALLOW_DOWNGRADE: ${{ inputs.allow_downgrade }}
+          CHANNEL: ${{ inputs.channel }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PINS: ${{ inputs.pins }}
+          PUBLISH: ${{ inputs.publish }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
-        # Rendering is the pre-publication boundary: these exact files cross the
-        # snapshot-PR handoff below, so R2 must remain untouched in this step.
+        # Each channel is one ordered transaction. For `both`, alpha must be live
+        # before prod renders because bundled resolution carries newer versions
+        # across channels from live R2; batching both renders can lose that state.
         run: |
           set -euo pipefail
 
@@ -123,11 +126,6 @@ jobs:
             base_args+=(--allow-downgrade)
           fi
 
-          snapshot_paths_file="$RUNNER_TEMP/extension-feed-snapshot-paths"
-          feed_keys_file="$RUNNER_TEMP/extension-feed-keys"
-          : > "$snapshot_paths_file"
-          : > "$feed_keys_file"
-
           for feed_channel in "${channels[@]}"; do
             args=(--channel "$feed_channel" "${base_args[@]}")
             {
@@ -136,71 +134,49 @@ jobs:
               echo "browseros release extensions ${args[*]}"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
-            uv run browseros release extensions "${args[@]}"
+            uv run --directory packages/browseros browseros \
+              release extensions "${args[@]}"
 
             if [ "$feed_channel" = "alpha" ]; then
-              printf '%s\n' \
-                updates/extensions/update-manifest.alpha.xml \
-                updates/extensions/extensions.alpha.json \
-                >> "$snapshot_paths_file"
-              printf '%s\n' \
-                extensions/update-manifest.alpha.xml \
-                extensions/extensions.alpha.json \
-                >> "$feed_keys_file"
+              feed_keys=(
+                extensions/update-manifest.alpha.xml
+                extensions/extensions.alpha.json
+                extensions/bundled-manifest.xml
+              )
             else
-              printf '%s\n' \
-                updates/extensions/update-manifest.xml \
-                updates/extensions/extensions.json \
-                >> "$snapshot_paths_file"
-              printf '%s\n' \
-                extensions/update-manifest.xml \
-                extensions/extensions.json \
-                >> "$feed_keys_file"
+              feed_keys=(
+                extensions/update-manifest.xml
+                extensions/extensions.json
+                extensions/bundled-manifest.xml
+              )
             fi
+
+            snapshot_paths=()
+            for feed_key in "${feed_keys[@]}"; do
+              snapshot_paths+=("updates/$feed_key")
+            done
+
+            if [ "$PUBLISH" != "true" ]; then
+              continue
+            fi
+
+            # The merged snapshot is the durability barrier. A later R2 failure
+            # is retryable; publishing before this returns would recreate drift.
+            packages/browseros-agent/scripts/release/commit-update-snapshot.sh \
+              "$DEFAULT_BRANCH" \
+              "chore(release): update extension ${feed_channel} feeds" \
+              "${snapshot_paths[@]}"
+
+            publish_flags=(--publish)
+            if [ "$ALLOW_DOWNGRADE" = "true" ]; then
+              publish_flags+=(--allow-downgrade)
+            fi
+            uv run --directory packages/browseros browseros \
+              release feeds publish-local \
+              "${feed_keys[@]}" \
+              "${publish_flags[@]}"
           done
 
-          printf '%s\n' updates/extensions/bundled-manifest.xml \
-            >> "$snapshot_paths_file"
-          printf '%s\n' extensions/bundled-manifest.xml >> "$feed_keys_file"
-
-      - name: Persist and publish extension update feeds
-        env:
-          ALLOW_DOWNGRADE: ${{ inputs.allow_downgrade }}
-          CHANNEL: ${{ inputs.channel }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PUBLISH: ${{ inputs.publish }}
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
-        # The merged snapshot is the durability barrier. If publication fails
-        # afterward, rerunning is safe; publishing first would recreate drift.
-        run: |
-          set -euo pipefail
           if [ "$PUBLISH" != "true" ]; then
             echo "Dry run complete; snapshots were not committed or published"
-            exit 0
           fi
-
-          mapfile -t snapshot_paths \
-            < "$RUNNER_TEMP/extension-feed-snapshot-paths"
-          mapfile -t feed_keys < "$RUNNER_TEMP/extension-feed-keys"
-          if [ "${#snapshot_paths[@]}" -eq 0 ] || [ "${#feed_keys[@]}" -eq 0 ]; then
-            echo "::error::Generation did not select any extension feed files" >&2
-            exit 1
-          fi
-
-          packages/browseros-agent/scripts/release/commit-update-snapshot.sh \
-            "$DEFAULT_BRANCH" \
-            "chore(release): update extension ${CHANNEL} feeds" \
-            "${snapshot_paths[@]}"
-
-          publish_flags=(--publish)
-          if [ "$ALLOW_DOWNGRADE" = "true" ]; then
-            publish_flags+=(--allow-downgrade)
-          fi
-          uv run --directory packages/browseros browseros \
-            release feeds publish-local \
-            "${feed_keys[@]}" \
-            "${publish_flags[@]}"

--- a/.github/workflows/release-extension-feeds.yml
+++ b/.github/workflows/release-extension-feeds.yml
@@ -67,7 +67,8 @@ concurrency:
 jobs:
   feeds:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # `both` can consume two independent 15-minute snapshot-PR retry budgets.
+    timeout-minutes: 40
     permissions:
       contents: write
       pull-requests: write

--- a/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
@@ -20,20 +20,15 @@ const browserClawWorkflow = readFileSync(
   'utf8',
 )
 
-function section(start: string, end?: string): string {
-  const startIndex = workflow.indexOf(start)
+function section(
+  start: string,
+  end?: string,
+  source: string = workflow,
+): string {
+  const startIndex = source.indexOf(start)
   expect(startIndex).toBeGreaterThanOrEqual(0)
-  const endIndex = end ? workflow.indexOf(end, startIndex + start.length) : -1
-  return workflow.slice(startIndex, endIndex >= 0 ? endIndex : undefined)
-}
-
-function feedSection(start: string, end?: string): string {
-  const startIndex = feedWorkflow.indexOf(start)
-  expect(startIndex).toBeGreaterThanOrEqual(0)
-  const endIndex = end
-    ? feedWorkflow.indexOf(end, startIndex + start.length)
-    : -1
-  return feedWorkflow.slice(startIndex, endIndex >= 0 ? endIndex : undefined)
+  const endIndex = end ? source.indexOf(end, startIndex + start.length) : -1
+  return source.slice(startIndex, endIndex >= 0 ? endIndex : undefined)
 }
 
 describe('release-extensions workflow', () => {
@@ -230,14 +225,17 @@ describe('release-extensions workflow', () => {
   })
 
   it('persists manual feed snapshots before publishing their exact files', () => {
-    const job = feedSection('  feeds:')
-    const generation = feedSection(
-      '- name: Generate extension update feeds',
-      '- name: Persist and publish extension update feeds',
+    const job = section('  feeds:', undefined, feedWorkflow)
+    const transaction = section(
+      '- name: Generate, persist, and publish extension update feeds',
+      undefined,
+      feedWorkflow,
     )
-    const publication = feedSection(
-      '- name: Persist and publish extension update feeds',
+    const channelLoopStart = transaction.indexOf(
+      `for feed_channel in "\${channels[@]}"`,
     )
+    expect(channelLoopStart).toBeGreaterThanOrEqual(0)
+    const channelLoop = transaction.slice(channelLoopStart)
 
     expect(job).toMatch(
       /permissions:\n\s+contents: write\n\s+pull-requests: write/,
@@ -246,20 +244,28 @@ describe('release-extensions workflow', () => {
     expect(job).toContain(
       `ref: ${'$'}{{ github.event.repository.default_branch || 'main' }}`,
     )
-    expect(generation).toContain('browseros release extensions')
-    expect(generation).not.toContain('--publish')
-    expect(generation).toContain('updates/extensions/update-manifest.alpha.xml')
-    expect(generation).toContain('updates/extensions/extensions.alpha.json')
-    expect(generation).toContain('updates/extensions/update-manifest.xml')
-    expect(generation).toContain('updates/extensions/extensions.json')
-    expect(generation).toContain('updates/extensions/bundled-manifest.xml')
-    expect(publication).toContain('if [ "$PUBLISH" != "true" ]')
-    expect(publication).toContain('commit-update-snapshot.sh')
-    expect(publication).toContain('release feeds publish-local')
-    expect(publication).toContain('--publish')
-    expect(publication).toContain('--allow-downgrade')
-    expect(publication.indexOf('commit-update-snapshot.sh')).toBeLessThan(
-      publication.indexOf('release feeds publish-local'),
+    expect(transaction).toContain('both) channels=(alpha prod)')
+    expect(transaction).toContain('extensions/update-manifest.alpha.xml')
+    expect(transaction).toContain('extensions/extensions.alpha.json')
+    expect(transaction).toContain('extensions/update-manifest.xml')
+    expect(transaction).toContain('extensions/extensions.json')
+    expect(transaction).toContain('extensions/bundled-manifest.xml')
+    expect(transaction).toContain('snapshot_paths+=("updates/$feed_key")')
+    expect(transaction).not.toContain('updates/extensions/update-manifest')
+    expect(transaction).toContain('if [ "$PUBLISH" != "true" ]')
+    expect(transaction).toContain('continue')
+    expect(transaction).toContain('commit-update-snapshot.sh')
+    expect(transaction).toContain('release feeds publish-local')
+    expect(transaction).toContain('--publish')
+    expect(transaction).toContain('--allow-downgrade')
+    expect(channelLoop.indexOf('release extensions')).toBeLessThan(
+      channelLoop.indexOf('commit-update-snapshot.sh'),
+    )
+    expect(channelLoop.indexOf('commit-update-snapshot.sh')).toBeLessThan(
+      channelLoop.indexOf('release feeds publish-local'),
+    )
+    expect(channelLoop.indexOf('release feeds publish-local')).toBeLessThan(
+      channelLoop.lastIndexOf('done'),
     )
   })
 

--- a/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
@@ -27,6 +27,15 @@ function section(start: string, end?: string): string {
   return workflow.slice(startIndex, endIndex >= 0 ? endIndex : undefined)
 }
 
+function feedSection(start: string, end?: string): string {
+  const startIndex = feedWorkflow.indexOf(start)
+  expect(startIndex).toBeGreaterThanOrEqual(0)
+  const endIndex = end
+    ? feedWorkflow.indexOf(end, startIndex + start.length)
+    : -1
+  return feedWorkflow.slice(startIndex, endIndex >= 0 ? endIndex : undefined)
+}
+
 describe('release-extensions workflow', () => {
   it('exposes optional allocation and build/finalize outputs', () => {
     const dispatch = section('  workflow_dispatch:', '  workflow_call:')
@@ -218,6 +227,40 @@ describe('release-extensions workflow', () => {
       /concurrency:\n\s+group: release-extensions-and-feeds\n\s+cancel-in-progress: false/,
     )
     expect(section('on:', '\npermissions:')).not.toMatch(/\n {2}push:/)
+  })
+
+  it('persists manual feed snapshots before publishing their exact files', () => {
+    const job = feedSection('  feeds:')
+    const generation = feedSection(
+      '- name: Generate extension update feeds',
+      '- name: Persist and publish extension update feeds',
+    )
+    const publication = feedSection(
+      '- name: Persist and publish extension update feeds',
+    )
+
+    expect(job).toMatch(
+      /permissions:\n\s+contents: write\n\s+pull-requests: write/,
+    )
+    expect(job).toContain('fetch-depth: 0')
+    expect(job).toContain(
+      `ref: ${'$'}{{ github.event.repository.default_branch || 'main' }}`,
+    )
+    expect(generation).toContain('browseros release extensions')
+    expect(generation).not.toContain('--publish')
+    expect(generation).toContain('updates/extensions/update-manifest.alpha.xml')
+    expect(generation).toContain('updates/extensions/extensions.alpha.json')
+    expect(generation).toContain('updates/extensions/update-manifest.xml')
+    expect(generation).toContain('updates/extensions/extensions.json')
+    expect(generation).toContain('updates/extensions/bundled-manifest.xml')
+    expect(publication).toContain('if [ "$PUBLISH" != "true" ]')
+    expect(publication).toContain('commit-update-snapshot.sh')
+    expect(publication).toContain('release feeds publish-local')
+    expect(publication).toContain('--publish')
+    expect(publication).toContain('--allow-downgrade')
+    expect(publication.indexOf('commit-update-snapshot.sh')).toBeLessThan(
+      publication.indexOf('release feeds publish-local'),
+    )
   })
 
   it('requires the BrowserClaw PostHog key and keeps the host optional', () => {

--- a/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
@@ -236,10 +236,22 @@ describe('release-extensions workflow', () => {
     )
     expect(channelLoopStart).toBeGreaterThanOrEqual(0)
     const channelLoop = transaction.slice(channelLoopStart)
+    const renderCommand = [
+      'uv run --directory packages/browseros browseros \\',
+      `              release extensions "\${args[@]}"`,
+    ].join('\n')
+    const publishCommand = [
+      'uv run --directory packages/browseros browseros \\',
+      '              release feeds publish-local \\',
+    ].join('\n')
+    const channelLoopEnd = channelLoop.indexOf(
+      '\n          done\n\n          if [ "$PUBLISH"',
+    )
 
     expect(job).toMatch(
       /permissions:\n\s+contents: write\n\s+pull-requests: write/,
     )
+    expect(job).toContain('timeout-minutes: 40')
     expect(job).toContain('fetch-depth: 0')
     expect(job).toContain(
       `ref: ${'$'}{{ github.event.repository.default_branch || 'main' }}`,
@@ -250,6 +262,9 @@ describe('release-extensions workflow', () => {
     expect(transaction).toContain('extensions/update-manifest.xml')
     expect(transaction).toContain('extensions/extensions.json')
     expect(transaction).toContain('extensions/bundled-manifest.xml')
+    expect(
+      transaction.match(/extensions\/bundled-manifest\.xml/g),
+    ).toHaveLength(2)
     expect(transaction).toContain('snapshot_paths+=("updates/$feed_key")')
     expect(transaction).not.toContain('updates/extensions/update-manifest')
     expect(transaction).toContain('if [ "$PUBLISH" != "true" ]')
@@ -258,15 +273,18 @@ describe('release-extensions workflow', () => {
     expect(transaction).toContain('release feeds publish-local')
     expect(transaction).toContain('--publish')
     expect(transaction).toContain('--allow-downgrade')
-    expect(channelLoop.indexOf('release extensions')).toBeLessThan(
+    expect(transaction).not.toContain('base_args+=(--publish)')
+    expect(transaction).not.toContain('args+=(--publish)')
+    expect(channelLoop.indexOf(renderCommand)).toBeGreaterThanOrEqual(0)
+    expect(channelLoop.indexOf(publishCommand)).toBeGreaterThanOrEqual(0)
+    expect(channelLoopEnd).toBeGreaterThanOrEqual(0)
+    expect(channelLoop.indexOf(renderCommand)).toBeLessThan(
       channelLoop.indexOf('commit-update-snapshot.sh'),
     )
     expect(channelLoop.indexOf('commit-update-snapshot.sh')).toBeLessThan(
-      channelLoop.indexOf('release feeds publish-local'),
+      channelLoop.indexOf(publishCommand),
     )
-    expect(channelLoop.indexOf('release feeds publish-local')).toBeLessThan(
-      channelLoop.lastIndexOf('done'),
-    )
+    expect(channelLoop.indexOf(publishCommand)).toBeLessThan(channelLoopEnd)
   })
 
   it('requires the BrowserClaw PostHog key and keeps the host optional', () => {

--- a/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
@@ -240,9 +240,17 @@ describe('release-extensions workflow', () => {
       'uv run --directory packages/browseros browseros \\',
       `              release extensions "\${args[@]}"`,
     ].join('\n')
+    const commitCommand = [
+      'packages/browseros-agent/scripts/release/commit-update-snapshot.sh \\',
+      '              "$DEFAULT_BRANCH" \\',
+      `              "chore(release): update extension \${feed_channel} feeds" \\`,
+      `              "\${snapshot_paths[@]}"`,
+    ].join('\n')
     const publishCommand = [
       'uv run --directory packages/browseros browseros \\',
       '              release feeds publish-local \\',
+      `              "\${feed_keys[@]}" \\`,
+      `              "\${publish_flags[@]}"`,
     ].join('\n')
     const channelLoopEnd = channelLoop.indexOf(
       '\n          done\n\n          if [ "$PUBLISH"',
@@ -272,16 +280,19 @@ describe('release-extensions workflow', () => {
     expect(transaction).toContain('commit-update-snapshot.sh')
     expect(transaction).toContain('release feeds publish-local')
     expect(transaction).toContain('--publish')
-    expect(transaction).toContain('--allow-downgrade')
     expect(transaction).not.toContain('base_args+=(--publish)')
     expect(transaction).not.toContain('args+=(--publish)')
+    expect(transaction).toContain('base_args+=(--allow-downgrade)')
+    expect(transaction).toContain('publish_flags=(--publish)')
+    expect(transaction).toContain('publish_flags+=(--allow-downgrade)')
     expect(channelLoop.indexOf(renderCommand)).toBeGreaterThanOrEqual(0)
+    expect(channelLoop.indexOf(commitCommand)).toBeGreaterThanOrEqual(0)
     expect(channelLoop.indexOf(publishCommand)).toBeGreaterThanOrEqual(0)
     expect(channelLoopEnd).toBeGreaterThanOrEqual(0)
     expect(channelLoop.indexOf(renderCommand)).toBeLessThan(
-      channelLoop.indexOf('commit-update-snapshot.sh'),
+      channelLoop.indexOf(commitCommand),
     )
-    expect(channelLoop.indexOf('commit-update-snapshot.sh')).toBeLessThan(
+    expect(channelLoop.indexOf(commitCommand)).toBeLessThan(
       channelLoop.indexOf(publishCommand),
     )
     expect(channelLoop.indexOf(publishCommand)).toBeLessThan(channelLoopEnd)

--- a/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-extensions-workflow.test.ts
@@ -259,6 +259,8 @@ describe('release-extensions workflow', () => {
     expect(job).toMatch(
       /permissions:\n\s+contents: write\n\s+pull-requests: write/,
     )
+    expect(job).toMatch(/uses: actions\/checkout@[0-9a-f]{40} # v7/)
+    expect(job).toMatch(/uses: astral-sh\/setup-uv@[0-9a-f]{40} # v8\.3\.2/)
     expect(job).toContain('timeout-minutes: 40')
     expect(job).toContain('fetch-depth: 0')
     expect(job).toContain(

--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -246,9 +246,12 @@ gh workflow run release-extension-feeds.yml \
 Pins are optional; extensions not set carry over from the live manifests. The
 per-product browser release orchestrators still only stage extension feed
 previews; the standalone extension workflow is the automatic alpha entrypoint.
-With `publish=true`, the feed workflow merges the exact generated snapshots into
-the default branch before it uploads those same files to R2. A failed snapshot
-merge therefore leaves the live feeds untouched.
+With `publish=true`, the feed workflow merges each channel's exact generated
+snapshots into the default branch before it uploads those same files to R2. A
+failed snapshot merge therefore leaves that channel's live feeds untouched. For
+`channel=both`, alpha completes before production so production sees alpha's
+newer bundled versions. If production later fails, alpha remains durably
+committed and published; rerun the workflow to resume production.
 
 Locally there are two commands, and the difference matters:
 

--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -246,6 +246,9 @@ gh workflow run release-extension-feeds.yml \
 Pins are optional; extensions not set carry over from the live manifests. The
 per-product browser release orchestrators still only stage extension feed
 previews; the standalone extension workflow is the automatic alpha entrypoint.
+With `publish=true`, the feed workflow merges the exact generated snapshots into
+the default branch before it uploads those same files to R2. A failed snapshot
+merge therefore leaves the live feeds untouched.
 
 Locally there are two commands, and the difference matters:
 
@@ -259,7 +262,9 @@ browseros release extensions --channel alpha --set browserclaw=0.1.4 --publish
 ```
 
 `release extensions` regenerates the update manifest, `extensions.json`, and the
-bundled manifest together, so they cannot drift apart.
+bundled manifest together, so they cannot drift apart. Local `--publish` is an
+emergency escape hatch and does not persist `updates/` through git; use the feed
+workflow for normal publication.
 
 ## Servers and nightlies
 

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -25,6 +25,7 @@ from .render import (
     render_update_manifest,
 )
 from .spec import (
+    EXTENSIONS,
     all_feeds,
     browser_feeds_for_product,
     feed_by_key,
@@ -1075,69 +1076,43 @@ class PublisherTestCase(unittest.TestCase):
         )
         self.assertEqual(self.client.calls, [])
 
-    def test_repaired_snapshots_preserve_versions_and_original_payloads(self):
+    def test_tracked_snapshots_have_canonical_metadata(self):
         updates = Path(__file__).resolve().parents[5] / "updates"
-        server_cases = (
-            (
-                "appcast-server.xml",
-                "0.0.127",
-                (
-                    ("BrowserOS Server", "BrowserOS Server (Alpha)"),
-                    ("appcast-server.xml", "appcast-server.alpha.xml"),
-                    (
-                        "BrowserOS Server binary updates",
-                        "BrowserOS Server (Alpha) binary updates",
-                    ),
-                ),
-                "45a2ee4835b11d964584bdfc6c8d3c555d1384cbcbc91e7eb14aa97c3ba8fedf",
-            ),
-            (
-                "appcast-claw-server.xml",
-                "0.0.15",
-                (
-                    (
-                        "BrowserOS Claw Server",
-                        "BrowserOS Claw Server (Alpha)",
-                    ),
-                    (
-                        "appcast-claw-server.xml",
-                        "appcast-claw-server.alpha.xml",
-                    ),
-                    (
-                        "BrowserOS Claw Server binary updates",
-                        "BrowserOS Claw Server (Alpha) binary updates",
-                    ),
-                ),
-                "1df47182d63006294b87323d276896e489f141f2aed1f0266a2119c9ffef3eef",
-            ),
-        )
 
-        for filename, version, replacements, old_hash in server_cases:
-            with self.subTest(filename=filename):
-                content = (updates / "server" / filename).read_text()
-                spec = feed_by_key(filename)
+        # These files are release outputs, so pin stable schema and ownership
+        # invariants instead of versions or whole-file hashes. Otherwise every
+        # valid snapshot promotion makes the default branch's test suite stale.
+        for bundle_id in ("browseros-server", "browserclaw-server"):
+            spec = server_feed(bundle_id, "prod")
+            with self.subTest(key=spec.key):
+                content = (updates / "server" / spec.key).read_text()
                 self.assertEqual((spec.kind, spec.channel), ("server", "prod"))
-                self.assertEqual(extract_appcast_version(content), version)
-                original = content
-                for corrected, invalid in replacements:
-                    original = original.replace(corrected, invalid, 1)
                 self.assertEqual(
-                    hashlib.sha256(original.encode()).hexdigest(), old_hash
+                    extract_channel_metadata(content),
+                    (spec.title, spec.link),
                 )
+                self.assertIn(
+                    f"<description>{spec.title} binary updates</description>",
+                    content,
+                )
+                self.assertIsNotNone(extract_appcast_version(content))
 
-        manifest_path = updates / "extensions" / "update-manifest.alpha.xml"
-        manifest = manifest_path.read_text()
-        spec = feed_by_key("extensions/update-manifest.alpha.xml")
-        self.assertEqual((spec.kind, spec.channel), ("extensions", "alpha"))
-        self.assertEqual(
-            set(extract_manifest_versions(manifest).values()),
-            {"0.0.139.0", "54.0.0.0", "0.2.15.0"},
-        )
-        original = manifest.replace("</gupdate>", "  </app>\n</gupdate>")
-        self.assertEqual(
-            hashlib.sha256(original.encode()).hexdigest(),
-            "d2a7b386ea9928cb4ae4f0a8537f304db19e7e17e51178feecbe2f5a90f08fb7",
-        )
+        expected_extension_ids = {
+            extension.extension_id
+            for extension in EXTENSIONS
+            if extension.in_update_feed
+        }
+        for channel in ("alpha", "prod"):
+            spec = update_manifest_feed(channel)
+            with self.subTest(key=spec.key):
+                manifest = (updates / spec.key).read_text()
+                self.assertEqual(
+                    (spec.kind, spec.channel), ("extensions", channel)
+                )
+                self.assertEqual(
+                    set(extract_manifest_versions(manifest)),
+                    expected_extension_ids,
+                )
 
     def test_browserclaw_snapshots_use_current_product_title(self):
         updates = Path(__file__).resolve().parents[5] / "updates" / "browser"

--- a/updates/extensions/update-manifest.xml
+++ b/updates/extensions/update-manifest.xml
@@ -7,6 +7,6 @@
     <updatecheck codebase="https://cdn.browseros.com/extensions/agent-0.0.124.0.crx" version="0.0.124.0" />
   </app>
   <app appid="pjimfkbpehlcllblajnpfamdfjhhlgkc">
-    <updatecheck codebase="https://cdn.browseros.com/extensions/browserclaw-0.2.15.0.crx" version="0.2.15.0" />
+    <updatecheck codebase="https://cdn.browseros.com/extensions/browserclaw-0.2.17.0.crx" version="0.2.17.0" />
   </app>
 </gupdate>


### PR DESCRIPTION
## Summary

- Persist each generated extension feed snapshot on the default branch before publishing those exact local bytes to R2.
- Preserve alpha-then-production ordering so bundled-version carry-forward remains monotonic.
- Cover both snapshot-PR retry budgets and document safe partial success for channel=both.
- Make tracked-snapshot tests version-agnostic so normal releases cannot leave main red.
- Pin actions used by the newly write-enabled job to immutable commits.

## Context

An audit of all 17 tracked feed objects found that manual production extension publication could move R2 ahead of git. The one-time BrowserClaw 0.2.17.0 manifest reconciliation landed independently in #2455 while this change was under review; this PR fixes the causal workflow gap.

## Test plan

- [x] 66 release workflow tests
- [x] 1,137 bos_build Python tests and Ruff
- [x] actionlint (ignoring the repository-wide custom concurrency.queue key)
- [x] Biome check
- [x] XML validation and git diff check
- [x] All 17 CDN feed keys audited with wget