### PR TITLE
fix(release): bound macOS notarization waits

### DIFF
--- a/packages/browseros/bos_build/lib/notarization.py
+++ b/packages/browseros/bos_build/lib/notarization.py
@@ -1,0 +1,14 @@
+"""Shared client-side wait policy for Apple notarization submissions."""
+
+NOTARYTOOL_WAIT_TIMEOUT = "2h"
+
+
+def notarytool_wait_args() -> list[str]:
+    """Return a fresh bounded-wait argument list for ``notarytool submit``.
+
+    Apple continues processing after this client timeout. The bound exists to
+    release the serialized Mac runner with a diagnosable failure when the
+    external service stalls, rather than consuming the 20-hour job limit.
+    """
+
+    return ["--wait", "--timeout", NOTARYTOOL_WAIT_TIMEOUT]

--- a/packages/browseros/bos_build/steps/package/macos.py
+++ b/packages/browseros/bos_build/steps/package/macos.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional, List, Dict
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
+from ...lib.notarization import notarytool_wait_args
 from ...lib.utils import (
     run_command,
     log_info,
@@ -208,7 +209,7 @@ def notarize_dmg(
             str(dmg_path),
             "--keychain-profile",
             keychain_profile,
-            "--wait",
+            *notarytool_wait_args(),
         ]
         if keychain_path:
             submit_cmd.extend(["--keychain", str(keychain_path)])
@@ -232,7 +233,7 @@ def notarize_dmg(
                     notarization_env["team_id"],
                     "--password",
                     notarization_env["notarization_pwd"],
-                    "--wait",
+                    *notarytool_wait_args(),
                 ],
                 check=False,
             )

--- a/packages/browseros/bos_build/steps/package/macos_test.py
+++ b/packages/browseros/bos_build/steps/package/macos_test.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest import mock
 
 from . import macos as macos_module
+from ...lib.notarization import NOTARYTOOL_WAIT_TIMEOUT
 from .macos import notarize_dmg, sign_dmg
 
 
@@ -40,7 +41,7 @@ class MacOSPackageKeychainTest(unittest.TestCase):
                 str(keychain),
             )
 
-    def test_notarize_dmg_passes_configured_keychain_to_notarytool(self):
+    def test_notarize_dmg_passes_keychain_and_bounded_wait_to_notarytool(self):
         with tempfile.TemporaryDirectory() as tmp:
             dmg_path = Path(tmp) / "BrowserOS.dmg"
             dmg_path.write_text("dmg")
@@ -69,8 +70,50 @@ class MacOSPackageKeychainTest(unittest.TestCase):
                 submit[submit.index("--keychain") + 1],
                 str(keychain),
             )
+            self.assertEqual(
+                submit[submit.index("--timeout") + 1],
+                NOTARYTOOL_WAIT_TIMEOUT,
+            )
+
+    def test_notarize_dmg_bounds_direct_credentials_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dmg_path = Path(tmp) / "BrowserOS.dmg"
+            dmg_path.write_text("dmg")
+            calls = []
+            submit_count = 0
+
+            def run(cmd, cwd=None, check=True):
+                nonlocal submit_count
+                calls.append(cmd)
+                if cmd[:3] == ["xcrun", "notarytool", "submit"]:
+                    submit_count += 1
+                    if submit_count == 1:
+                        return _completed(cmd, returncode=1)
+                    return _completed(cmd, stdout="status: Accepted\n")
+                return _completed(cmd)
+
+            with mock.patch.object(macos_module, "run_command", run):
+                self.assertTrue(
+                    notarize_dmg(
+                        dmg_path,
+                        notarization_env={
+                            "apple_id": "release@example.com",
+                            "team_id": "TEAMID",
+                            "notarization_pwd": "app-password",
+                        },
+                    )
+                )
+
+            submit_calls = [
+                call for call in calls if call[:3] == ["xcrun", "notarytool", "submit"]
+            ]
+            self.assertEqual(len(submit_calls), 2)
+            for submit in submit_calls:
+                self.assertEqual(
+                    submit[submit.index("--timeout") + 1],
+                    NOTARYTOOL_WAIT_TIMEOUT,
+                )
 
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/packages/browseros/bos_build/steps/sign/macos.py
+++ b/packages/browseros/bos_build/steps/sign/macos.py
@@ -10,6 +10,7 @@ from typing import Optional, List, Dict, Tuple
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
 from ...lib.env import EnvConfig
+from ...lib.notarization import notarytool_wait_args
 from ...products.server_binaries import (
     all_server_bundles,
     ServerBundle,
@@ -1056,7 +1057,7 @@ def notarize_app(
             str(notarize_zip),
             "--keychain-profile",
             profile,
-            "--wait",
+            *notarytool_wait_args(),
         ]
         if keychain_path:
             submit_cmd.extend(["--keychain", str(keychain_path)])
@@ -1073,7 +1074,7 @@ def notarize_app(
             env_vars["team_id"],
             "--password",
             env_vars["notarization_pwd"],
-            "--wait",
+            *notarytool_wait_args(),
         ]
     result = run_command(submit_cmd, check=False)
 

--- a/packages/browseros/bos_build/steps/sign/macos_test.py
+++ b/packages/browseros/bos_build/steps/sign/macos_test.py
@@ -11,6 +11,7 @@ from unittest import mock
 import yaml
 
 from ...core.context import Context
+from ...lib.notarization import NOTARYTOOL_WAIT_TIMEOUT
 from . import macos as macos_module
 from .macos import (
     SERVER_RESOURCES_SOURCE_REL,
@@ -398,6 +399,46 @@ class MacOSKeychainSelectionTest(unittest.TestCase):
             for cmd in (store, submit):
                 self.assertIn("--keychain", cmd)
                 self.assertEqual(cmd[cmd.index("--keychain") + 1], str(keychain))
+            self.assertEqual(
+                submit[submit.index("--timeout") + 1],
+                NOTARYTOOL_WAIT_TIMEOUT,
+            )
+
+    def test_notarize_app_bounds_direct_credentials_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app_path = Path(tmp) / "BrowserOS.app"
+            app_path.mkdir()
+            calls = []
+
+            def run(cmd, cwd=None, check=True):
+                calls.append(cmd)
+                if cmd[0] == "ditto":
+                    Path(cmd[-1]).write_text("zip")
+                    return _completed(cmd)
+                if cmd[:3] == ["xcrun", "notarytool", "store-credentials"]:
+                    return _completed(cmd, returncode=1)
+                if cmd[:3] == ["xcrun", "notarytool", "submit"]:
+                    return _completed(cmd, stdout="status: Accepted\n")
+                return _completed(cmd)
+
+            env_vars = {
+                "apple_id": "dev@example.com",
+                "team_id": "TEAMID1234",
+                "notarization_pwd": "notary-password",
+                "keychain_profile": "notarytool-profile",
+            }
+
+            with mock.patch.object(macos_module, "run_command", run):
+                self.assertTrue(notarize_app(app_path, Path(tmp), env_vars))
+
+            submit = next(
+                c for c in calls if c[:3] == ["xcrun", "notarytool", "submit"]
+            )
+            self.assertIn("--apple-id", submit)
+            self.assertEqual(
+                submit[submit.index("--timeout") + 1],
+                NOTARYTOOL_WAIT_TIMEOUT,
+            )
 
     def test_notarize_app_requires_profile_storage_for_configured_keychain(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Bound every macOS app and DMG `notarytool submit --wait` call to two hours.
- Apply the same policy to keychain-profile and direct-credential fallback paths.
- Add command-contract tests for all four submission paths.

## Design
A small shared notarization policy owns the client-side wait bound. Apple continues processing after the client exits, but the serialized Mac runner now fails with a diagnosable notarization error instead of silently consuming the workflow's 20-hour limit. This does not alter the already-running 0.50.0 job because that run is frozen to its original source SHA.

## Test plan
- [x] `uv run python -m unittest discover -s . -p '*_test.py'` (1,189 passed, 2 skipped)
- [x] `uv run ruff check bos_build`
- [x] Confirm local `notarytool submit --help` supports `--wait --timeout <duration>` and leaves server-side processing running after client timeout.
