### PR TITLE
fix: repair tracked appcast CDN metadata

### DIFF
--- a/.github/workflows/bos-build-tests.yml
+++ b/.github/workflows/bos-build-tests.yml
@@ -18,6 +18,7 @@ on:
       - ".github/workflows/nightly.yml"
       - ".github/workflows/nightly-macos-product.yml"
       - ".github/workflows/publish-server-ota.yml"
+      - ".github/workflows/repair-update-feed.yml"
       - ".github/workflows/release-browseros.yml"
       - ".github/workflows/release-browserclaw.yml"
       - ".github/workflows/release-claw-onboard.yml"

--- a/.github/workflows/repair-update-feed.yml
+++ b/.github/workflows/repair-update-feed.yml
@@ -1,0 +1,78 @@
+name: "Repair: Tracked update appcast"
+
+on:
+  workflow_dispatch:
+    inputs:
+      feed:
+        description: "Tracked appcast to validate against live R2"
+        required: true
+        type: choice
+        options:
+          - appcast.xml
+          - appcast-x86_64.xml
+          - appcast-win.xml
+          - appcast-win-arm64.xml
+          - appcast-claw.xml
+          - appcast-claw-x86_64.xml
+          - appcast-claw-win.xml
+          - appcast-claw-win-arm64.xml
+          - appcast-server.xml
+          - appcast-server.alpha.xml
+          - appcast-claw-server.xml
+          - appcast-claw-server.alpha.xml
+      publish:
+        description: "Write to R2 after validation and backup (unchecked = dry run)"
+        required: false
+        type: boolean
+        default: false
+      repair_invalid_live:
+        description: "Replace malformed or wrong-channel live metadata when version-safe"
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+# Server alpha publication uses the same group. A manual repair must not race
+# another appcast writer between validation, backup, and replacement.
+concurrency:
+  group: release-feed-snapshots
+  cancel-in-progress: false
+  queue: max
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout tracked feed source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch || 'main' }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+
+      - name: Publish tracked appcast
+        env:
+          FEED: ${{ inputs.feed }}
+          PUBLISH: ${{ inputs.publish }}
+          REPAIR_INVALID_LIVE: ${{ inputs.repair_invalid_live }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          args=("$FEED")
+          if [ "$REPAIR_INVALID_LIVE" = "true" ]; then
+            args+=(--repair-invalid-live)
+          fi
+          if [ "$PUBLISH" = "true" ]; then
+            args+=(--publish)
+          fi
+          uv run --directory packages/browseros browseros \
+            release feeds publish-local "${args[@]}"

--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -33,6 +33,7 @@ live.
 | Make a staged release live | `browseros release publish`, then `browseros release appcast --publish` |
 | Release an extension CRX to alpha | `gh workflow run release-extensions.yml` |
 | Preview or promote extension feeds | `gh workflow run release-extension-feeds.yml` |
+| Repair a tracked browser/server appcast | `gh workflow run repair-update-feed.yml` |
 | Grab today's signed mac build | Download the `nightly-browseros` / `nightly-browserclaw` prerelease |
 | Check the patch stack | `browseros dev doctor` |
 
@@ -253,6 +254,20 @@ failed snapshot merge therefore leaves that channel's live feeds untouched. For
 `channel=both`, alpha completes before production so production sees alpha's
 newer bundled versions. If production later fails, alpha remains durably
 committed and published; rerun the workflow to resume production.
+
+To republish one tracked browser or server appcast through the same validation,
+backup, and downgrade guards:
+
+```bash
+gh workflow run repair-update-feed.yml \
+  -f feed=appcast-server.xml \
+  -f repair_invalid_live=true \
+  -f publish=true
+```
+
+Leave `publish` unchecked for a full dry-run diff. Enable
+`repair_invalid_live` only when the live object is malformed or carries the
+wrong channel metadata; the repair path still refuses a recoverable downgrade.
 
 Locally there are two commands, and the difference matters:
 

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import yaml
 
+from bos_build.release.feeds.spec import all_feeds
 from bos_build.steps.source import provision
 
 
@@ -2724,6 +2725,55 @@ class ChromiumGitRunbookTest(unittest.TestCase):
         self.assertIn("index flags", troubleshooting)
         self.assertIn("`--repair-cached-depot-tools`", troubleshooting)
         self.assertIn("`v2`", troubleshooting)
+
+
+class RepairUpdateFeedWorkflowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = WORKFLOW_DIR / "repair-update-feed.yml"
+        cls.workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    def test_dispatch_only_selects_registered_appcasts(self):
+        triggers = self.workflow.get("on", self.workflow.get(True))
+        inputs = triggers["workflow_dispatch"]["inputs"]
+        self.assertEqual(
+            inputs["feed"]["options"],
+            [feed.key for feed in all_feeds() if feed.kind in ("browser", "server")],
+        )
+        self.assertFalse(inputs["publish"]["default"])
+        self.assertFalse(inputs["repair_invalid_live"]["default"])
+        self.assertNotIn("allow_downgrade", inputs)
+
+    def test_uses_tracked_default_branch_and_guarded_publisher(self):
+        self.assertEqual(
+            self.workflow["concurrency"],
+            {
+                "group": "release-feed-snapshots",
+                "cancel-in-progress": False,
+                "queue": "max",
+            },
+        )
+        job = self.workflow["jobs"]["repair"]
+        self.assertEqual(job["permissions"], {"contents": "read"})
+        checkout = next(
+            step
+            for step in job["steps"]
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        )
+        self.assertEqual(
+            checkout["with"]["ref"],
+            "${{ github.event.repository.default_branch || 'main' }}",
+        )
+        publish = next(
+            step
+            for step in job["steps"]
+            if step.get("name") == "Publish tracked appcast"
+        )["run"]
+        self.assertIn('args=("$FEED")', publish)
+        self.assertIn("args+=(--repair-invalid-live)", publish)
+        self.assertIn("args+=(--publish)", publish)
+        self.assertIn('release feeds publish-local "${args[@]}"', publish)
+        self.assertNotIn("--allow-downgrade", publish)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/release/feeds/publisher.py
+++ b/packages/browseros/bos_build/release/feeds/publisher.py
@@ -166,6 +166,20 @@ def _is_empty_appcast_shell(content: str) -> bool:
     channel = next(
         element for element in root if _xml_local_name(element.tag) == "channel"
     )
+    metadata_counts: dict[str, int] = {}
+    allowed_metadata = {"title", "link", "description", "language"}
+    for child in channel:
+        name = _xml_local_name(child.tag)
+        if name == "item":
+            continue
+        # Versionless placeholders have no downgrade comparison. Treat only
+        # scalar channel metadata as empty; unknown, attributed, or nested
+        # children could be malformed release data outside an <item>.
+        if name not in allowed_metadata or child.attrib or list(child):
+            return False
+        metadata_counts[name] = metadata_counts.get(name, 0) + 1
+        if metadata_counts[name] > 1:
+            return False
     direct_items = [
         element for element in channel if _xml_local_name(element.tag) == "item"
     ]

--- a/packages/browseros/bos_build/release/feeds/publisher.py
+++ b/packages/browseros/bos_build/release/feeds/publisher.py
@@ -398,14 +398,14 @@ class FeedPublisher:
         if not self._check_channel_metadata(spec, content):
             return False
 
-        # Every appcast item must carry exactly one strict version, even on a
-        # first publish to an absent key — the guard below only runs live.
+        new_empty_appcast = False
         if spec.kind in ("browser", "server"):
             new_versions = _strict_appcast_versions(content)
-            if not new_versions:
+            new_empty_appcast = _is_empty_appcast_shell(content)
+            if not new_versions and not new_empty_appcast:
                 self._log_appcast_version_error(spec, content)
                 return False
-            if not _has_complete_appcast_download_urls(content):
+            if new_versions and not _has_complete_appcast_download_urls(content):
                 log_error(
                     f"{spec.key}: every appcast item must have an enclosure "
                     "and every enclosure must have a download URL"
@@ -427,6 +427,11 @@ class FeedPublisher:
             return False
 
         live = self.fetch_live(spec.key)
+        if live is None and new_empty_appcast:
+            # A placeholder may migrate metadata on an existing empty object,
+            # but must not establish a versionless feed at a new CDN key.
+            self._log_appcast_version_error(spec, content)
+            return False
         if live is not None and not self._check_version_guard(
             spec,
             content,
@@ -571,6 +576,21 @@ class FeedPublisher:
     ) -> bool:
         new_versions = _strict_appcast_versions(content)
         if not new_versions:
+            if _is_empty_appcast_shell(content) and _is_empty_appcast_shell(live):
+                title, link = extract_channel_metadata(live)
+                if title == spec.title and link == spec.link:
+                    return True
+                if title in spec.legacy_titles and link == spec.link:
+                    # Empty appcasts have no version to compare. Restrict this
+                    # path to a registered title migration on the same key so
+                    # it cannot become an escape hatch for erasing releases.
+                    log_warning(
+                        f"{spec.key}: migrating live channel title {title!r} "
+                        f"to {spec.title!r}"
+                    )
+                    return True
+                self._check_channel_metadata(spec, live)
+                return False
             self._log_appcast_version_error(spec, content)
             return False
         new_version = max(

--- a/packages/browseros/bos_build/release/feeds/publisher.py
+++ b/packages/browseros/bos_build/release/feeds/publisher.py
@@ -159,41 +159,46 @@ def _is_empty_appcast_shell(content: str) -> bool:
         root = ET.fromstring(content)
     except ET.ParseError:
         return False
-    if root.tag != "rss":
-        return False
-    if not _has_single_direct_channel(root):
-        return False
-    channel = next(
-        element for element in root if _xml_local_name(element.tag) == "channel"
-    )
-    metadata_counts: dict[str, int] = {}
-    allowed_metadata = {"title", "link", "description", "language"}
-    for child in channel:
-        name = _xml_local_name(child.tag)
-        if name == "item":
-            continue
-        # Versionless placeholders have no downgrade comparison. Treat only
-        # scalar channel metadata as empty; unknown, attributed, or nested
-        # children could be malformed release data outside an <item>.
-        if name not in allowed_metadata or child.attrib or list(child):
-            return False
-        metadata_counts[name] = metadata_counts.get(name, 0) + 1
-        if metadata_counts[name] > 1:
-            return False
-    direct_items = [
-        element for element in channel if _xml_local_name(element.tag) == "item"
-    ]
-    all_items = [
-        element for element in root.iter() if _xml_local_name(element.tag) == "item"
-    ]
-    if len(all_items) != len(direct_items) or any(
-        item not in direct_items for item in all_items
+    if (
+        root.tag != "rss"
+        or root.attrib != {"version": "2.0"}
+        or (root.text or "").strip()
+        or (root.tail or "").strip()
     ):
         return False
-    return all(
-        not item.attrib and not list(item) and not (item.text or "").strip()
-        for item in direct_items
-    )
+
+    root_children = list(root)
+    if len(root_children) != 1 or root_children[0].tag != "channel":
+        return False
+    channel = root_children[0]
+    if channel.attrib or (channel.text or "").strip() or (channel.tail or "").strip():
+        return False
+
+    metadata_counts: dict[str, int] = {}
+    allowed_metadata = {"title", "link", "description", "language"}
+    item_count = 0
+    for child in channel:
+        if (child.tail or "").strip():
+            return False
+        if child.tag == "item":
+            item_count += 1
+            if (
+                item_count > 1
+                or child.attrib
+                or list(child)
+                or (child.text or "").strip()
+            ):
+                return False
+            continue
+        # Versionless placeholders have no downgrade comparison. Treat only
+        # the exact RSS shell as empty; extra structure or mixed content could
+        # be malformed release data outside an <item>.
+        if child.tag not in allowed_metadata or child.attrib or list(child):
+            return False
+        metadata_counts[child.tag] = metadata_counts.get(child.tag, 0) + 1
+        if metadata_counts[child.tag] > 1:
+            return False
+    return True
 
 
 def _default_http_head(url: str) -> int:

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -510,6 +510,21 @@ class PublisherTestCase(unittest.TestCase):
             ],
         )
 
+    def test_empty_placeholder_migration_rejects_release_markers(self):
+        spec = feed_by_key("appcast-claw-win-arm64.xml")
+        canonical = _empty_browserclaw_win_arm_appcast()
+        live = canonical.replace(spec.title, spec.legacy_titles[0]).replace(
+            "    <item>\n    </item>",
+            "    <sparkle:version>10000.0.99.0</sparkle:version>\n"
+            '    <enclosure url="https://cdn.browseros.com/release.dmg"/>',
+        )
+        publisher = self._publisher({spec.key: live.encode()})
+
+        ok = publisher.publish(spec, canonical, publish=True)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.client.calls, [])
+
     def test_browserclaw_legacy_title_migration_refuses_downgrade(self):
         spec = feed_by_key("appcast-claw.xml")
         publisher = self._publisher(

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -513,17 +513,41 @@ class PublisherTestCase(unittest.TestCase):
     def test_empty_placeholder_migration_rejects_release_markers(self):
         spec = feed_by_key("appcast-claw-win-arm64.xml")
         canonical = _empty_browserclaw_win_arm_appcast()
-        live = canonical.replace(spec.title, spec.legacy_titles[0]).replace(
-            "    <item>\n    </item>",
-            "    <sparkle:version>10000.0.99.0</sparkle:version>\n"
-            '    <enclosure url="https://cdn.browseros.com/release.dmg"/>',
-        )
-        publisher = self._publisher({spec.key: live.encode()})
+        legacy = canonical.replace(spec.title, spec.legacy_titles[0])
+        malformed_live = {
+            "channel release children": legacy.replace(
+                "    <item>\n    </item>",
+                "    <sparkle:version>10000.0.99.0</sparkle:version>\n"
+                '    <enclosure url="https://cdn.browseros.com/release.dmg"/>',
+            ),
+            "root release child": legacy.replace(
+                "</rss>",
+                "  <sparkle:version>10000.0.99.0</sparkle:version>\n</rss>",
+            ),
+            "root release attribute": legacy.replace(
+                '<rss version="2.0"',
+                '<rss version="2.0" release-version="10000.0.99.0"',
+            ),
+            "channel release attribute": legacy.replace(
+                "  <channel>", '  <channel release-version="10000.0.99.0">'
+            ),
+            "channel mixed content": legacy.replace(
+                "  <channel>\n", "  <channel>release-version=10000.0.99.0\n"
+            ),
+            "metadata tail content": legacy.replace(
+                f"<title>{spec.legacy_titles[0]}</title>",
+                f"<title>{spec.legacy_titles[0]}</title>release-version=10000.0.99.0",
+            ),
+        }
 
-        ok = publisher.publish(spec, canonical, publish=True)
+        for label, live in malformed_live.items():
+            with self.subTest(shape=label):
+                publisher = self._publisher({spec.key: live.encode()})
 
-        self.assertFalse(ok)
-        self.assertEqual(self.client.calls, [])
+                ok = publisher.publish(spec, canonical, publish=True)
+
+                self.assertFalse(ok)
+                self.assertEqual(self.client.calls, [])
 
     def test_browserclaw_legacy_title_migration_refuses_downgrade(self):
         spec = feed_by_key("appcast-claw.xml")

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -132,6 +132,21 @@ def _empty_item_mac_appcast():
     )
 
 
+def _empty_browserclaw_win_arm_appcast():
+    spec = feed_by_key("appcast-claw-win-arm64.xml")
+    return f"""\
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>{spec.title}</title>
+    <link>{spec.link}</link>
+    <item>
+    </item>
+  </channel>
+</rss>
+"""
+
+
 def _server_appcast(bundle_id, channel, version):
     spec = server_feed(bundle_id, channel)
     artifact = SignedArtifact(
@@ -460,6 +475,27 @@ class PublisherTestCase(unittest.TestCase):
         )
 
         ok = publisher.publish(spec, _browserclaw_appcast(), publish=True)
+
+        self.assertTrue(ok)
+        self.assertEqual(
+            self.client.calls,
+            [
+                (
+                    "copy",
+                    spec.key,
+                    f"feeds-history/{spec.key}.20260701T120000Z",
+                ),
+                ("put", spec.key, "application/xml"),
+            ],
+        )
+
+    def test_browserclaw_legacy_title_migrates_on_empty_placeholder(self):
+        spec = feed_by_key("appcast-claw-win-arm64.xml")
+        canonical = _empty_browserclaw_win_arm_appcast()
+        legacy = canonical.replace(spec.title, spec.legacy_titles[0])
+        publisher = self._publisher({spec.key: legacy.encode()})
+
+        ok = publisher.publish(spec, canonical, publish=True)
 
         self.assertTrue(ok)
         self.assertEqual(


### PR DESCRIPTION
## Summary
- add a dry-run-by-default workflow that republishes selected tracked browser/server appcasts through validation, backup, and monotonic version guards
- support the registered BrowserClaw title migration for an existing empty placeholder without allowing versionless creation or release erasure
- document and test the repair path, including malformed-shell fail-closed cases

## Design
The workflow checks out the repository default branch, exposes only registered appcast choices, shares the server appcast writer concurrency group, and deliberately offers no downgrade override. FeedPublisher recognizes a versionless placeholder only when both tracked and live XML are the exact empty RSS 2.0 shell; populated or malformed live objects remain on the strict version/repair path.

## Test plan
- [x] uv run python -m unittest discover -s bos_build -t . -p '*_test.py' (1,193 passed, 2 skipped)
- [x] uv run ruff check bos_build
- [x] actionlint on repair-update-feed.yml and bos-build-tests.yml
- [x] git diff --check
- [x] preflight freshly downloaded live appcast-claw-win-arm64.xml and appcast-server.xml against tracked bytes with the committed publisher code