### PR TITLE
feat: enable BrowserOS onboarding

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
 new file mode 100644
-index 0000000000000000000000000000000000000000..a403ca0c367402c1e47cf1a91f2cdcdc7569a6d6
+index 0000000000000000000000000000000000000000..7cdf1c58ed69aa67d0ed7e8ce8244ba64bdc7b96
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,47 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -12,7 +12,6 @@ index 0000000000000000000000000000000000000000..a403ca0c367402c1e47cf1a91f2cdcdc
 +
 +#include "chrome/browser/browser_process.h"
 +#include "chrome/browser/browseros/core/browseros_prefs.h"
-+#include "chrome/browser/browseros/core/browseros_product.h"
 +#include "chrome/browser/profiles/profile.h"
 +#include "chrome/common/chrome_constants.h"
 +#include "chrome/common/pref_names.h"
@@ -21,10 +20,6 @@ index 0000000000000000000000000000000000000000..a403ca0c367402c1e47cf1a91f2cdcdc
 +namespace browseros::onboarding {
 +
 +bool ShouldShow(Profile* profile) {
-+  if (browseros::IsBrowserOSProduct()) {
-+    return false;
-+  }
-+
 +  if (!profile || !profile->IsRegularProfile() || profile->IsOffTheRecord()) {
 +    return false;
 +  }


### PR DESCRIPTION
## Summary
- remove the BrowserOS product exclusion from the existing onboarding eligibility check
- preserve regular-profile, initial-profile, off-the-record, and completion restrictions
- refresh the canonical Chromium patch without changing onboarding UI resources or startup plumbing

## Design
The existing ProfilePicker launch and onboarding bridge are already product-neutral. This change only allows BrowserOS builds through `ShouldShow()`; the patch remains owned by the existing `onboarding-import` feature.

## Test plan
- [x] `sfmux pool build -- autoninja -C out/Default_browseros_arm64 chrome`
- [x] extraction verifier: 1/1 byte-match and 1/1 apply-check