### PR TITLE
fix: package product-specific onboarding resources

### DIFF
--- a/.github/workflows/bos-build-tests.yml
+++ b/.github/workflows/bos-build-tests.yml
@@ -19,6 +19,7 @@ on:
       - ".github/workflows/nightly-macos-product.yml"
       - ".github/workflows/publish-server-ota.yml"
       - ".github/workflows/repair-update-feed.yml"
+      - ".github/workflows/release-app-onboard.yml"
       - ".github/workflows/release-browseros.yml"
       - ".github/workflows/release-browserclaw.yml"
       - ".github/workflows/release-claw-onboard.yml"

--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -390,7 +390,7 @@ jobs:
           BROWSEROS_BUILD_SOURCE_SHA: ${{ steps.source.outputs.sha }}
           BROWSEROS_SERVER_RESOURCE_VERSION: ${{ inputs.product == 'browseros' && inputs.server-version || '' }}
           BROWSERCLAW_SERVER_RESOURCE_VERSION: ${{ inputs.product == 'browserclaw' && inputs.server-version || '' }}
-          BROWSERCLAW_ONBOARD_RESOURCE_VERSION: ${{ inputs.onboarding-version }}
+          ONBOARDING_RESOURCE_VERSION: ${{ inputs.onboarding-version }}
           BUNDLED_EXTENSIONS_MANIFEST_URL: ${{ inputs.extension-version && format('{0}/updates/extensions/bundled-manifest.xml', github.workspace) || '' }}
           BUNDLED_PRODUCT_EXTENSION_VERSION: ${{ inputs.extension-version }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}

--- a/.github/workflows/nightly-macos-product.yml
+++ b/.github/workflows/nightly-macos-product.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Build signed nightly
         env:
-          BROWSERCLAW_ONBOARD_RESOURCE_VERSION: ${{ inputs.onboarding_version }}
+          ONBOARDING_RESOURCE_VERSION: ${{ inputs.onboarding_version }}
           BROWSERCLAW_SERVER_RESOURCE_VERSION: ${{ inputs.product == 'browserclaw' && inputs.server_version || '' }}
           BROWSEROS_BUILD_RESERVATION_SHA: ${{ inputs.reservation_sha }}
           BROWSEROS_BUILD_SOURCE_SHA: ${{ inputs.source_sha }}

--- a/.github/workflows/release-browseros.yml
+++ b/.github/workflows/release-browseros.yml
@@ -45,7 +45,7 @@ jobs:
           source_sha="$(git rev-parse HEAD)"
           test "$source_sha" = "$GITHUB_SHA"
           version="$(uv run python bos_build/scripts/bump_version.py --mode none)"
-          onboarding_version="$(jq -er '.version' "$GITHUB_WORKSPACE/packages/browseros-agent/apps/claw-onboard/package.json")"
+          onboarding_version="$(jq -er '.version' "$GITHUB_WORKSPACE/packages/browseros-agent/apps/app-onboard/package.json")"
           {
             echo "onboarding_version=$onboarding_version"
             echo "source_sha=$source_sha"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -344,7 +344,7 @@ jobs:
           BROWSEROS_BUILD_SOURCE_SHA: ${{ steps.sync.outputs.source_sha }}
           BROWSEROS_SERVER_RESOURCE_VERSION: ${{ steps.inputs.outputs.products == 'browseros' && inputs.server_version || '' }}
           BROWSERCLAW_SERVER_RESOURCE_VERSION: ${{ steps.inputs.outputs.products == 'browserclaw' && inputs.server_version || '' }}
-          BROWSERCLAW_ONBOARD_RESOURCE_VERSION: ${{ inputs.onboarding_version }}
+          ONBOARDING_RESOURCE_VERSION: ${{ inputs.onboarding_version }}
           BROWSEROS_CONFIG_URL: ${{ secrets.BROWSEROS_CONFIG_URL }}
           BUNDLED_EXTENSIONS_MANIFEST_URL: ${{ inputs.extension_version && format('{0}/updates/extensions/bundled-manifest.xml', steps.inputs.outputs.browseros_repo) || '' }}
           BUNDLED_PRODUCT_EXTENSION_VERSION: ${{ inputs.extension_version }}

--- a/packages/browseros-agent/apps/app-onboard/tests/build.test.ts
+++ b/packages/browseros-agent/apps/app-onboard/tests/build.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, describe, it } from 'bun:test'
+import assert from 'node:assert'
+import { existsSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const R2_ENV_KEYS = [
+  'R2_ACCOUNT_ID',
+  'R2_ACCESS_KEY_ID',
+  'R2_SECRET_ACCESS_KEY',
+  'R2_BUCKET',
+  'R2_UPLOAD_PREFIX',
+  'R2_DOWNLOAD_PREFIX',
+] as const
+
+const EXPECTED_RESOURCE_FILES = [
+  'index.html',
+  'app.js',
+  'app.css',
+  'icon/16.png',
+  'icon/32.png',
+  'icon/48.png',
+  'icon/96.png',
+  'icon/128.png',
+  'icon/keychain-prompt.png',
+  'icon/hermes.png',
+] as const
+
+/** Exercises the complete Vite → staging → metadata → ZIP handoff used by CI. */
+describe('app onboard resources archive', () => {
+  const rootDir = resolve(import.meta.dir, '../../..')
+  const versionPkgPath = resolve(rootDir, 'apps/app-onboard/package.json')
+  const buildScript = resolve(rootDir, 'scripts/build/app-onboard.ts')
+  const artifactRoot = resolve(rootDir, 'dist/prod/app-onboard/universal')
+  const resourcesDir = resolve(artifactRoot, 'resources')
+  const metadataPath = resolve(artifactRoot, 'artifact-metadata.json')
+  const zipPath = resolve(
+    rootDir,
+    'dist/prod/app-onboard/browseros-app-onboard-resources.zip',
+  )
+
+  afterAll(() => {
+    rmSync(resolve(rootDir, 'dist/prod/app-onboard'), {
+      recursive: true,
+      force: true,
+    })
+  })
+
+  it('builds the universal Chromium archive without R2 credentials', async () => {
+    rmSync(zipPath, { force: true })
+    const pkg = await Bun.file(versionPkgPath).json()
+    const build = await collectProcess(
+      Bun.spawn(['bun', buildScript, '--no-upload'], {
+        cwd: rootDir,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: buildEnv(),
+      }),
+    )
+
+    assert.strictEqual(
+      build.exitCode,
+      0,
+      `Onboard build failed:\n${build.stdout}\n${build.stderr}`,
+    )
+    assert.ok(existsSync(zipPath), `Expected archive at ${zipPath}`)
+
+    const metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'))
+    assert.strictEqual(metadata.version, pkg.version)
+    assert.strictEqual(metadata.target, 'universal')
+    const metadataPaths: string[] = metadata.files.map(
+      (entry: { path: string }) => entry.path,
+    )
+
+    for (const file of EXPECTED_RESOURCE_FILES) {
+      const filePath = join(resourcesDir, file)
+      assert.ok(existsSync(filePath), `Expected staged resource ${filePath}`)
+      assert.ok(
+        metadataPaths.includes(`resources/${file}`),
+        `Expected metadata entry for resources/${file}`,
+      )
+    }
+    for (const entry of metadata.files) {
+      assert.match(entry.sha256, /^[a-f0-9]{64}$/)
+      assert.strictEqual(
+        entry.size,
+        statSync(join(artifactRoot, entry.path)).size,
+      )
+    }
+
+    const zipListing = await collectProcess(
+      Bun.spawn(['unzip', '-l', zipPath], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }),
+    )
+    assert.strictEqual(
+      zipListing.exitCode,
+      0,
+      `Unable to inspect zip:\n${zipListing.stderr}`,
+    )
+    assert.match(zipListing.stdout, /resources\/index\.html/)
+    assert.match(zipListing.stdout, /resources\/icon\/hermes\.png/)
+    assert.match(zipListing.stdout, /artifact-metadata\.json/)
+  }, 300_000)
+})
+
+interface CollectableProcess {
+  stdout: ReadableStream
+  stderr: ReadableStream
+  exited: Promise<number>
+}
+
+async function collectProcess(process: CollectableProcess) {
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ])
+
+  return { stdout, stderr, exitCode }
+}
+
+function buildEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env }
+  for (const key of R2_ENV_KEYS) {
+    delete env[key]
+  }
+  return env
+}

--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -287,13 +287,14 @@ workflow for normal publication.
 
 ## Servers and nightlies
 
-Server bundles version independently of the browser, each from its own package
-file:
+Server and onboarding bundles version independently of the browser, each from
+its own package file:
 
 | Bundle | Version source | Workflow | Tag |
 | --- | --- | --- | --- |
 | BrowserOS agent server | `packages/browseros-agent/apps/server/package.json` | `release-server.yml` | `agent-server/v*` |
 | BrowserClaw server | `.../apps/claw-server-rust/Cargo.toml` | `release-claw-server.yml` | `claw-server-rust/v*` |
+| BrowserOS onboarding | `.../apps/app-onboard/package.json` | `release-app-onboard.yml` | `app-onboard/v*` |
 | BrowserClaw onboarding | `.../apps/claw-onboard/package.json` | `release-claw-onboard.yml` | `claw-onboard/v*` |
 
 BrowserClaw browser builds and server OTA both consume the server bundles

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -817,6 +817,16 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
             pull_request_paths,
         )
 
+    def test_app_onboard_release_changes_trigger_build_system_tests(self):
+        test_workflow = self.load_workflow("bos-build-tests.yml")
+        triggers = test_workflow.get("on", test_workflow.get(True))
+        pull_request_paths = triggers["pull_request"]["paths"]
+
+        self.assertIn(
+            ".github/workflows/release-app-onboard.yml",
+            pull_request_paths,
+        )
+
     def test_macos_signing_helper_changes_trigger_build_system_tests(self):
         test_workflow = self.load_workflow("bos-build-tests.yml")
         triggers = test_workflow.get("on", test_workflow.get(True))
@@ -2630,6 +2640,18 @@ class ReleaseDocumentationTest(unittest.TestCase):
         ):
             with self.subTest(token=token):
                 self.assertIn(token, self.release)
+
+    def test_readme_lists_both_independent_onboarding_bundles(self):
+        for token in (
+            "apps/app-onboard/package.json",
+            "release-app-onboard.yml",
+            "app-onboard/v*",
+            "apps/claw-onboard/package.json",
+            "release-claw-onboard.yml",
+            "claw-onboard/v*",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, self.readme)
 
     def test_runbooks_state_native_host_and_publication_boundaries(self):
         for token in (

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -138,6 +138,11 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
             self.assertIn(value, build_step["run"])
         self.assertEqual(upload["if"], "inputs.resource-mode == 'source'")
         self.assertEqual(upload["with"]["if-no-files-found"], "error")
+        self.assertEqual(
+            build_step["env"]["ONBOARDING_RESOURCE_VERSION"],
+            "${{ inputs.onboarding-version }}",
+        )
+        self.assertNotIn("BROWSERCLAW_ONBOARD_RESOURCE_VERSION", build_step["env"])
 
     def test_reusable_platform_workflows_forward_source_contract(self):
         for workflow_name in ("release-linux.yml", "release-windows.yml"):
@@ -233,6 +238,11 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
         ):
             self.assertIn(value, build_step["run"])
         self.assertEqual(upload["with"]["if-no-files-found"], "error")
+        self.assertEqual(
+            build_step["env"]["ONBOARDING_RESOURCE_VERSION"],
+            "${{ inputs.onboarding_version }}",
+        )
+        self.assertNotIn("BROWSERCLAW_ONBOARD_RESOURCE_VERSION", build_step["env"])
 
     def test_macos_release_sets_up_ci_keychain_before_build_and_cleans_up(self):
         workflow = self.load_workflow("release-macos.yml")
@@ -308,6 +318,11 @@ class ChromiumBuildWorkflowTest(unittest.TestCase):
             build["env"]["BROWSEROS_BUILD_SOURCE_SHA"],
             "${{ steps.source.outputs.sha }}",
         )
+        self.assertEqual(
+            build["env"]["ONBOARDING_RESOURCE_VERSION"],
+            "${{ inputs.onboarding-version }}",
+        )
+        self.assertNotIn("BROWSERCLAW_ONBOARD_RESOURCE_VERSION", build["env"])
 
     def test_browser_lanes_do_not_receive_extension_build_secrets(self):
         secret_names = (
@@ -849,11 +864,13 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
             "product": "browseros",
             "server_workflow": "release-server.yml",
             "extension": "agent",
+            "onboarding_manifest": "apps/app-onboard/package.json",
         },
         "release-browserclaw.yml": {
             "product": "browserclaw",
             "server_workflow": "release-claw-server.yml",
             "extension": "browserclaw",
+            "onboarding_manifest": "apps/claw-onboard/package.json",
         },
     }
 
@@ -884,7 +901,7 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
                 self.assertEqual(workflow["permissions"], {})
 
     def test_preflight_freezes_the_default_branch_dispatch_sha(self):
-        for workflow_name in self.RELEASES:
+        for workflow_name, config in self.RELEASES.items():
             with self.subTest(workflow=workflow_name):
                 workflow = self.load_workflow(workflow_name)
                 preflight = workflow["jobs"]["preflight"]
@@ -907,6 +924,7 @@ class ReleaseIntegrityWorkflowTest(unittest.TestCase):
                     'source_sha="$(git rev-parse HEAD)"',
                     'test "$source_sha" = "$GITHUB_SHA"',
                     "bump_version.py --mode none",
+                    config["onboarding_manifest"],
                 ):
                     self.assertIn(token, resolve["run"])
 
@@ -1815,6 +1833,11 @@ class FamilyNightlyWorkflowTest(unittest.TestCase):
             "${{ inputs.reservation_sha }}",
         )
         self.assertEqual(build["env"]["BROWSEROS_DEFER_R2_UPLOAD"], "1")
+        self.assertEqual(
+            build["env"]["ONBOARDING_RESOURCE_VERSION"],
+            "${{ inputs.onboarding_version }}",
+        )
+        self.assertNotIn("BROWSERCLAW_ONBOARD_RESOURCE_VERSION", build["env"])
         for secret in (
             "R2_ACCESS_KEY_ID",
             "R2_ACCOUNT_ID",

--- a/packages/browseros/bos_build/cli/release_browser_test.py
+++ b/packages/browseros/bos_build/cli/release_browser_test.py
@@ -24,7 +24,7 @@ CANDIDATE_SHA = "2" * 40
 COMPONENTS = {
     "server": "0.0.128",
     "agent": "0.0.101.0",
-    "claw-onboard": "0.0.12",
+    "app-onboard": "0.0.12",
 }
 runner = CliRunner()
 

--- a/packages/browseros/bos_build/cli/release_resources.py
+++ b/packages/browseros/bos_build/cli/release_resources.py
@@ -10,6 +10,7 @@ import typer
 
 from ..lib.paths import get_package_root
 from ..lib.utils import log_error
+from ..products.resource_sources import source_resources_for_product
 from ..release.candidate import CandidateRecord
 from ..release.components import read_component_version
 from ..release.prepared_resources import (
@@ -102,9 +103,10 @@ def prepare(
                 raise ValueError(
                     "Local preparation requires --product, --source-sha, and --browser-version"
                 )
-        if "claw-onboard" not in versions:
-            versions["claw-onboard"] = read_component_version(
-                root, "claw-onboard"
+        onboarding_component = source_resources_for_product(product).onboarding_component
+        if onboarding_component not in versions:
+            versions[onboarding_component] = read_component_version(
+                root, onboarding_component
             )
         request = PreparationRequest(
             product=product,

--- a/packages/browseros/bos_build/cli/release_resources_test.py
+++ b/packages/browseros/bos_build/cli/release_resources_test.py
@@ -17,10 +17,11 @@ runner = CliRunner()
 
 
 class ReleaseResourcesCliTest(unittest.TestCase):
+    @patch("bos_build.cli.release_resources.read_component_version")
     @patch("bos_build.cli.release_resources.LocalPreparationOperations")
     @patch("bos_build.cli.release_resources.prepare_common_resources")
     def test_prepare_accepts_candidate_record_and_emits_manifest_digest(
-        self, prepare, operations
+        self, prepare, operations, read_version
     ) -> None:
         manifest = PreparedResourcesManifest(
             product="browseros",
@@ -30,7 +31,7 @@ class ReleaseResourcesCliTest(unittest.TestCase):
             component_versions={
                 "server": "0.0.128",
                 "agent": "0.0.101.0",
-                "claw-onboard": "0.0.12",
+                "app-onboard": "0.0.0",
             },
             files={},
         )
@@ -66,6 +67,67 @@ class ReleaseResourcesCliTest(unittest.TestCase):
             self.assertEqual(values["prepared_resources"], str(output.resolve()))
             self.assertEqual(values["manifest_sha256"], manifest.digest())
             operations.assert_called_once()
+            request = prepare.call_args.args[0]
+            self.assertEqual(request.component_versions, manifest.component_versions)
+            read_version.assert_not_called()
+
+    def test_explicit_prepare_fills_the_products_onboarding_version(self) -> None:
+        cases = {
+            "browseros": "app-onboard",
+            "browserclaw": "claw-onboard",
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for product, onboarding_component in cases.items():
+                with (
+                    self.subTest(product=product),
+                    patch(
+                        "bos_build.cli.release_resources.read_component_version",
+                        return_value="0.0.9",
+                    ) as read_version,
+                    patch(
+                        "bos_build.cli.release_resources.LocalPreparationOperations"
+                    ),
+                    patch(
+                        "bos_build.cli.release_resources.prepare_common_resources"
+                    ) as prepare,
+                ):
+                    manifest = PreparedResourcesManifest(
+                        product=product,
+                        parent_sha="",
+                        source_sha="1" * 40,
+                        browser_version="0.31.0",
+                        component_versions={onboarding_component: "0.0.9"},
+                        files={},
+                    )
+                    prepare.return_value = manifest
+                    result = runner.invoke(
+                        app,
+                        [
+                            "release",
+                            "resources",
+                            "prepare",
+                            "--product",
+                            product,
+                            "--source-sha",
+                            "1" * 40,
+                            "--browser-version",
+                            "0.31.0",
+                            "--output",
+                            str(root / product),
+                            "--repo-root",
+                            str(root),
+                        ],
+                    )
+
+                    self.assertEqual(result.exit_code, 0, result.output)
+                    request = prepare.call_args.args[0]
+                    self.assertEqual(
+                        request.component_versions[onboarding_component], "0.0.9"
+                    )
+                    read_version.assert_called_once_with(
+                        root.resolve(), onboarding_component
+                    )
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/config/copy_resources.yaml
+++ b/packages/browseros/bos_build/config/copy_resources.yaml
@@ -245,20 +245,13 @@ copy_operations:
     os: ["windows"]
     arch: ["x64"]
 
-  - name: "BrowserOS Onboarding Resources"
-    source: "resources/binaries/browseros_app_onboard/resources"
+  # Product selection happens while building or downloading the archive. Both
+  # apps implement the same Chromium WebUI contract, so the copy layer consumes
+  # one normalized directory and never requires the non-selected app.
+  - name: "Browser Onboarding Resources"
+    source: "resources/binaries/browseros_onboarding/resources"
     destination: "chrome/browser/browseros/onboarding/resources"
     type: "directory"
     managed: true
     required: true
     clear_destination: true
-    product: "browseros"
-
-  - name: "BrowserOS Claw Onboarding Resources"
-    source: "resources/binaries/browseros_claw_onboard/resources"
-    destination: "chrome/browser/browseros/onboarding/resources"
-    type: "directory"
-    managed: true
-    required: true
-    clear_destination: true
-    product: "browserclaw"

--- a/packages/browseros/bos_build/config/download_resources.yaml
+++ b/packages/browseros/bos_build/config/download_resources.yaml
@@ -109,16 +109,17 @@ download_operations:
     arch: ["x64"]
 
   # Onboarding static resources - platform-independent, feeds the onboarding
-  # grit pak. Each product bakes its own onboarding SPA, so these are gated by
-  # product and land in separate destinations.
+  # grit pak. Each product selects its own independently versioned SPA, then
+  # both archives normalize into one staging path because Chromium consumes one
+  # product-neutral WebUI resource contract.
   - name: "BrowserOS Onboarding Resources"
     r2_key: "app-onboard/prod-resources/latest/browseros-app-onboard-resources.zip"
-    destination: "resources/binaries/browseros_app_onboard"
+    destination: "resources/binaries/browseros_onboarding"
     download_type: "artifact_zip"
     product: "browseros"
 
   - name: "BrowserOS Claw Onboarding Resources"
     r2_key: "claw-onboard/prod-resources/latest/browseros-claw-onboard-resources.zip"
-    destination: "resources/binaries/browseros_claw_onboard"
+    destination: "resources/binaries/browseros_onboarding"
     download_type: "artifact_zip"
     product: "browserclaw"

--- a/packages/browseros/bos_build/core/resume.py
+++ b/packages/browseros/bos_build/core/resume.py
@@ -335,7 +335,7 @@ def _resource_identity(ctx: Context) -> dict[str, Any]:
     components = {
         source.server_component: server_version,
         source.extension_component: ctx.env.bundled_product_extension_version,
-        source.onboarding_component: ctx.env.browserclaw_onboard_resource_version,
+        source.onboarding_component: ctx.env.onboarding_resource_version,
     }
     missing = [name for name, value in components.items() if not value]
     if missing:

--- a/packages/browseros/bos_build/core/resume_test.py
+++ b/packages/browseros/bos_build/core/resume_test.py
@@ -53,7 +53,7 @@ class ResumeCheckpointTest(unittest.TestCase):
             {
                 "BROWSEROS_SERVER_RESOURCE_VERSION": "0.0.138",
                 "BUNDLED_PRODUCT_EXTENSION_VERSION": "0.0.132.0",
-                "BROWSERCLAW_ONBOARD_RESOURCE_VERSION": "0.0.36",
+                "ONBOARDING_RESOURCE_VERSION": "0.0.36",
             },
         )
         self.env.start()
@@ -117,6 +117,18 @@ class ResumeCheckpointTest(unittest.TestCase):
         validate_resume_before_execution([(resumed, ("sign_macos",))])
 
         self.assertEqual(resumed.artifact_registry.get("built_app"), app)
+
+    def test_published_checkpoint_records_product_owned_onboarding_pin(self):
+        ctx = self._context()
+
+        self.assertEqual(
+            ctx.resume_state.candidate["resources"]["component_versions"],
+            {
+                "server": "0.0.138",
+                "agent": "0.0.132.0",
+                "app-onboard": "0.0.36",
+            },
+        )
 
     def test_modified_artifact_fails_before_resume(self):
         _ctx, app = self._write_compile_checkpoint()

--- a/packages/browseros/bos_build/lib/env.py
+++ b/packages/browseros/bos_build/lib/env.py
@@ -82,9 +82,9 @@ class EnvConfig:
         return os.environ.get("BROWSERCLAW_SERVER_RESOURCE_VERSION")
 
     @property
-    def browserclaw_onboard_resource_version(self) -> Optional[str]:
-        """Exact BrowserClaw onboarding resource version for release builds."""
-        return os.environ.get("BROWSERCLAW_ONBOARD_RESOURCE_VERSION")
+    def onboarding_resource_version(self) -> Optional[str]:
+        """Exact product-selected onboarding version for release builds."""
+        return os.environ.get("ONBOARDING_RESOURCE_VERSION")
 
     @property
     def bundled_extensions_manifest_url(self) -> Optional[str]:

--- a/packages/browseros/bos_build/products/resource_sources.py
+++ b/packages/browseros/bos_build/products/resource_sources.py
@@ -6,13 +6,13 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class SourceResources:
-    """In-repository and external resources embedded by one product."""
+    """Product-owned inputs selected before shared resource staging."""
 
     product_id: str
     server_component: str
     extension_component: str
     extension_name: str
-    onboarding_component: str = "claw-onboard"
+    onboarding_component: str
     external_extension_names: tuple[str, ...] = ("bugreporter",)
 
 
@@ -29,6 +29,7 @@ SOURCE_RESOURCES = {
         server_component="claw-server-rust",
         extension_component="browserclaw",
         extension_name="browserclaw",
+        onboarding_component="claw-onboard",
     ),
 }
 

--- a/packages/browseros/bos_build/release/browser_finalize_test.py
+++ b/packages/browseros/bos_build/release/browser_finalize_test.py
@@ -23,7 +23,7 @@ MERGE_SHA = "3" * 40
 COMPONENTS = {
     "server": "0.0.128",
     "agent": "0.0.101.0",
-    "claw-onboard": "0.0.12",
+    "app-onboard": "0.0.12",
 }
 ARTIFACTS = {
     "macos": {

--- a/packages/browseros/bos_build/release/candidate.py
+++ b/packages/browseros/bos_build/release/candidate.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Mapping, Protocol, Sequence
 
 from ..lib.versions import load_semantic_version
+from ..products.resource_sources import source_resources_for_product
 from .components import (
     AllocationRecord,
     component_by_id,
@@ -189,9 +190,10 @@ def _validate_recovered(
     if record.default_branch != request.default_branch or record.branch != branch:
         raise ValueError("Recovered candidate branch metadata does not match")
     _validate_sha(record.candidate_sha, "candidate_sha")
+    source = source_resources_for_product(request.product)
     expected = {
         *(spec.id for spec in components_for_candidate(request.product)),
-        "claw-onboard",
+        source.onboarding_component,
     }
     if set(record.component_versions) != expected:
         raise ValueError("Recovered candidate component set is incomplete")
@@ -224,7 +226,12 @@ def ensure_candidate(
         allocations=backend.discover_allocations(request.product),
         candidate_id=branch,
     )
-    versions["claw-onboard"] = committed_versions["claw-onboard"]
+    # Onboarding releases independently, so a browser candidate freezes the
+    # committed product-owned version without allocating a new app version.
+    onboarding_component = source_resources_for_product(
+        request.product
+    ).onboarding_component
+    versions[onboarding_component] = committed_versions[onboarding_component]
     created = backend.create_candidate(
         request,
         branch,
@@ -666,8 +673,9 @@ class GitHubCandidateBackend:
             spec.id: read_component_version(self.repo_root, spec.id)
             for spec in components_for_candidate(product)
         }
-        versions["claw-onboard"] = read_component_version(
-            self.repo_root, "claw-onboard"
+        onboarding_component = source_resources_for_product(product).onboarding_component
+        versions[onboarding_component] = read_component_version(
+            self.repo_root, onboarding_component
         )
         return versions
 

--- a/packages/browseros/bos_build/release/candidate_test.py
+++ b/packages/browseros/bos_build/release/candidate_test.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from dataclasses import replace
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from bos_build.release.candidate import (
     CandidateRecord,
@@ -25,19 +25,29 @@ PARENT_SHA = "1" * 40
 CANDIDATE_SHA = "2" * 40
 
 
-def candidate_record(state: str = "open") -> CandidateRecord:
+def candidate_record(
+    state: str = "open", *, product: str = "browseros"
+) -> CandidateRecord:
+    component_versions = {
+        "browseros": {
+            "server": "0.0.128",
+            "agent": "0.0.101.0",
+            "app-onboard": "0.0.0",
+        },
+        "browserclaw": {
+            "claw-server-rust": "0.0.46",
+            "browserclaw": "0.0.83.0",
+            "claw-onboard": "0.0.15",
+        },
+    }
     return CandidateRecord(
-        product="browseros",
+        product=product,
         parent_sha=PARENT_SHA,
         candidate_sha=CANDIDATE_SHA,
         default_branch="main",
-        branch=f"bot/release-browseros-{PARENT_SHA[:12]}",
+        branch=f"bot/release-{product}-{PARENT_SHA[:12]}",
         browser_version="0.31.0",
-        component_versions={
-            "server": "0.0.128",
-            "agent": "0.0.101.0",
-            "claw-onboard": "0.0.12",
-        },
+        component_versions=component_versions[product],
         pull_request_number=42,
         pull_request_url="https://github.com/browseros-ai/BrowserOS/pull/42",
         state=state,
@@ -76,18 +86,26 @@ class FakeBackend:
         return self.allocations
 
     def read_committed_versions(self, product: str):
-        return {
-            "server": "0.0.127",
-            "agent": "0.0.100",
-            "claw-onboard": "0.0.12",
-        }
+        return (
+            {
+                "server": "0.0.127",
+                "agent": "0.0.100",
+                "app-onboard": "0.0.0",
+            }
+            if product == "browseros"
+            else {
+                "claw-server-rust": "0.0.45",
+                "browserclaw": "0.0.82.0",
+                "claw-onboard": "0.0.15",
+            }
+        )
 
     def read_browser_version(self) -> str:
         return "0.31.0"
 
     def create_candidate(self, request, branch, versions, browser_version):
         self.created.append((request, branch, versions, browser_version))
-        return candidate_record()
+        return candidate_record(product=request.product)
 
     def inspect_pull_request(self, number: int) -> PullRequestState:
         return self.pr
@@ -148,10 +166,25 @@ class CandidateEnsureTest(unittest.TestCase):
             {
                 "server": "0.0.128",
                 "agent": "0.0.101.0",
-                "claw-onboard": "0.0.12",
+                "app-onboard": "0.0.0",
             },
         )
         self.assertEqual(browser_version, "0.31.0")
+
+    def test_creates_browserclaw_candidate_with_claw_onboarding(self) -> None:
+        request = replace(self.request, product="browserclaw")
+
+        record = ensure_candidate(request, self.backend)
+
+        self.assertEqual(record, candidate_record(product="browserclaw"))
+        self.assertEqual(
+            self.backend.created[0][2],
+            {
+                "claw-server-rust": "0.0.46",
+                "browserclaw": "0.0.83.0",
+                "claw-onboard": "0.0.15",
+            },
+        )
 
     def test_recovers_existing_candidate_without_allocating_or_mutating(self) -> None:
         self.backend.existing = candidate_record()
@@ -184,9 +217,24 @@ class CandidateEnsureTest(unittest.TestCase):
             {
                 "server": "0.0.129",
                 "agent": "0.0.102.0",
-                "claw-onboard": "0.0.12",
+                "app-onboard": "0.0.0",
             },
         )
+
+    def test_rejects_recovered_candidate_with_other_products_onboarding(
+        self,
+    ) -> None:
+        self.backend.existing = replace(
+            candidate_record(),
+            component_versions={
+                "server": "0.0.128",
+                "agent": "0.0.101.0",
+                "claw-onboard": "0.0.15",
+            },
+        )
+
+        with self.assertRaisesRegex(ValueError, "component set"):
+            ensure_candidate(self.request, self.backend)
 
     def test_github_backend_reads_semantic_browser_version(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -202,6 +250,31 @@ class CandidateEnsureTest(unittest.TestCase):
             backend = GitHubCandidateBackend(root, "owner/repo", "main")
 
             self.assertEqual(backend.read_browser_version(), "0.49.2")
+
+    def test_github_backend_reads_product_owned_onboarding_version(self) -> None:
+        versions = {
+            "server": "0.0.128",
+            "agent": "0.0.101.0",
+            "app-onboard": "0.0.0",
+            "claw-server-rust": "0.0.46",
+            "browserclaw": "0.0.83.0",
+            "claw-onboard": "0.0.15",
+        }
+        backend = GitHubCandidateBackend(Path("/repo"), "owner/repo", "main")
+
+        with patch(
+            "bos_build.release.candidate.read_component_version",
+            side_effect=lambda _root, component: versions[component],
+        ) as read_version:
+            browseros = backend.read_committed_versions("browseros")
+            browserclaw = backend.read_committed_versions("browserclaw")
+
+        self.assertEqual(browseros["app-onboard"], "0.0.0")
+        self.assertNotIn("claw-onboard", browseros)
+        self.assertEqual(browserclaw["claw-onboard"], "0.0.15")
+        self.assertNotIn("app-onboard", browserclaw)
+        self.assertIn(call(Path("/repo"), "app-onboard"), read_version.call_args_list)
+        self.assertIn(call(Path("/repo"), "claw-onboard"), read_version.call_args_list)
 
     def test_accepts_only_same_repository_canonical_candidate_pull_requests(
         self,
@@ -317,7 +390,7 @@ class CandidateBackendVersionGuardTest(unittest.TestCase):
 
         def version_at_ref(component: str, ref: str) -> str:
             observed.append(component)
-            if component == "claw-onboard" and ref == "origin/main":
+            if component == "app-onboard" and ref == "origin/main":
                 return "0.0.13"
             return self.record.component_versions[component]
 
@@ -331,7 +404,7 @@ class CandidateBackendVersionGuardTest(unittest.TestCase):
         ):
             self.assertFalse(self.backend.default_branch_contains_versions(self.record))
 
-        self.assertNotIn("claw-onboard", observed)
+        self.assertNotIn("app-onboard", observed)
 
     def test_merged_candidate_retry_ignores_independent_onboarding_release(
         self,
@@ -340,7 +413,7 @@ class CandidateBackendVersionGuardTest(unittest.TestCase):
 
         def version_at_ref(component: str, ref: str) -> str:
             observed.append(component)
-            if component == "claw-onboard":
+            if component == "app-onboard":
                 return "0.0.13"
             return self.record.component_versions[component]
 
@@ -363,7 +436,7 @@ class CandidateBackendVersionGuardTest(unittest.TestCase):
                 )
             )
 
-        self.assertNotIn("claw-onboard", observed)
+        self.assertNotIn("app-onboard", observed)
 
     def test_merged_candidate_retry_decodes_chrome_package_version(self) -> None:
         for package_version, release_version in (

--- a/packages/browseros/bos_build/release/component_release_test.py
+++ b/packages/browseros/bos_build/release/component_release_test.py
@@ -378,7 +378,7 @@ class ComponentAllocationDiscoveryTest(unittest.TestCase):
             component_versions={
                 "server": "0.0.128",
                 "agent": "0.0.101.0",
-                "claw-onboard": "0.0.12",
+                "app-onboard": "0.0.12",
             },
             pull_request_number=42,
             pull_request_url="https://github.com/browseros-ai/BrowserOS/pull/42",

--- a/packages/browseros/bos_build/release/lane_test.py
+++ b/packages/browseros/bos_build/release/lane_test.py
@@ -55,7 +55,7 @@ def _manifest(
         component_versions={
             "server": "0.0.128",
             "agent": "0.0.116.0",
-            "claw-onboard": "0.0.12",
+            "app-onboard": "0.0.12",
         },
         common_manifest_digest=COMMON_DIGEST,
         server_checksums=servers,

--- a/packages/browseros/bos_build/steps/extensions/bundled_extensions_test.py
+++ b/packages/browseros/bos_build/steps/extensions/bundled_extensions_test.py
@@ -310,6 +310,7 @@ class BundledExtensionsTest(unittest.TestCase):
 
         component = "agent" if product == "browseros" else "browserclaw"
         server = "server" if product == "browseros" else "claw-server-rust"
+        onboarding = "app-onboard" if product == "browseros" else "claw-onboard"
         return PreparedResourcesManifest(
             product=product,
             parent_sha="1" * 40,
@@ -318,7 +319,7 @@ class BundledExtensionsTest(unittest.TestCase):
             component_versions={
                 server: "0.0.1",
                 component: product_version,
-                "claw-onboard": "0.0.1",
+                onboarding: "0.0.1",
             },
             files={
                 "product_crx": prepared(product_path, product_version, product_id),

--- a/packages/browseros/bos_build/steps/resources/resources.py
+++ b/packages/browseros/bos_build/steps/resources/resources.py
@@ -33,13 +33,18 @@ class ResourcesModule(Step):
 
 
 def stage_prepared_onboarding(ctx: Context) -> Path:
-    """Extract validated onboarding resources into the managed source path."""
+    """Normalize the product-selected source archive into the copy-stage path.
+
+    Source preparation records which app produced the archive; after this seam
+    the Chromium copy is deliberately product-neutral because both apps satisfy
+    the same WebUI resource contract.
+    """
     manifest = validated_common_resources(ctx)
     prepared = manifest.files["onboarding"]
     if ctx.prepared_resources is None:
         raise RuntimeError("Prepared resources were not registered")
     archive = ctx.prepared_resources / prepared.path
-    destination = ctx.root_dir / "resources/binaries/browseros_claw_onboard"
+    destination = ctx.root_dir / "resources/binaries/browseros_onboarding"
     clear_path(destination)
     extract_artifact_zip(archive, destination)
     ctx.artifact_registry.add("onboarding_resources", destination)

--- a/packages/browseros/bos_build/steps/resources/resources_test.py
+++ b/packages/browseros/bos_build/steps/resources/resources_test.py
@@ -353,10 +353,10 @@ class CopyResourcesTest(unittest.TestCase):
             parent_sha="1" * 40,
             source_sha="2" * 40,
             browser_version="0.0.1",
-            component_versions={"claw-onboard": "0.0.12"},
+            component_versions={"app-onboard": "0.0.12"},
             files={"onboarding": prepared_file},
         )
-        destination = self.root.root / "resources/binaries/browseros_claw_onboard"
+        destination = self.root.root / "resources/binaries/browseros_onboarding"
         destination.mkdir(parents=True)
         (destination / "stale").write_text("stale")
         self.ctx.resource_mode = "source"
@@ -462,20 +462,15 @@ class CopyResourcesTest(unittest.TestCase):
                 self.assertTrue(op["managed"])
                 self.assertTrue(op["required"])
 
-    def test_real_config_copies_each_products_own_onboarding_resources(self):
+    def test_real_config_copies_neutral_onboarding_for_each_product(self):
         self.root.write_copy_config(self._real_copy_config())
-        onboard_sources = {
-            "browseros": "browseros_app_onboard",
-            "browserclaw": "browseros_claw_onboard",
-        }
-        for product, binary_dir in onboard_sources.items():
-            source = (
-                self.root.root / "resources" / "binaries" / binary_dir / "resources"
-            )
-            (source / "icon").mkdir(parents=True)
-            (source / "index.html").write_text(f"<html>{product}</html>")
-            (source / "icon" / "32.png").write_text(f"{product}-icon-bytes")
-
+        onboard_source = (
+            self.root.root
+            / "resources"
+            / "binaries"
+            / "browseros_onboarding"
+            / "resources"
+        )
         onboard_dest = (
             self.chromium.src
             / "chrome"
@@ -485,8 +480,17 @@ class CopyResourcesTest(unittest.TestCase):
             / "resources"
         )
 
-        for product in onboard_sources:
+        for product in ("browseros", "browserclaw"):
             with self.subTest(product=product):
+                if onboard_source.exists():
+                    shutil.rmtree(onboard_source)
+                (onboard_source / "icon").mkdir(parents=True)
+                (onboard_source / "index.html").write_text(
+                    f"<html>{product}</html>"
+                )
+                (onboard_source / "icon" / "32.png").write_text(
+                    f"{product}-icon-bytes"
+                )
                 self._seed_required_resources(product, "arm64")
                 if onboard_dest.exists():
                     shutil.rmtree(onboard_dest)
@@ -513,6 +517,53 @@ class CopyResourcesTest(unittest.TestCase):
                     f"{product}-icon-bytes",
                 )
 
+    def test_real_config_has_one_required_neutral_onboarding_copy(self):
+        config = self._real_copy_config()
+        operations = [
+            operation
+            for operation in config["copy_operations"]
+            if operation["destination"]
+            == "chrome/browser/browseros/onboarding/resources"
+        ]
+
+        self.assertEqual(1, len(operations))
+        self.assertEqual(
+            "resources/binaries/browseros_onboarding/resources",
+            operations[0]["source"],
+        )
+        self.assertTrue(operations[0]["managed"])
+        self.assertTrue(operations[0]["required"])
+        self.assertNotIn("product", operations[0])
+
+    def test_real_config_debug_needs_only_neutral_onboarding_directory(self):
+        self.root.write_copy_config(self._real_copy_config())
+        self._seed_required_resources("browseros", "arm64")
+        self._seed_required_resources("browserclaw", "arm64")
+        source = (
+            self.root.root
+            / "resources/binaries/browseros_onboarding/resources/index.html"
+        )
+        source.write_text("debug-onboarding")
+
+        with patch(
+            "bos_build.steps.resources.resources.get_platform",
+            return_value="macos",
+        ):
+            ctx = make_context(
+                self.chromium,
+                self.root,
+                architecture="arm64",
+                build_type="debug",
+                product="browseros",
+            )
+            self.assertTrue(copy_resources_impl(ctx))
+
+        destination = (
+            self.chromium.src
+            / "chrome/browser/browseros/onboarding/resources/index.html"
+        )
+        self.assertEqual("debug-onboarding", destination.read_text())
+
     def _real_copy_config(self) -> dict:
         config_path = (
             Path(__file__).resolve().parents[2] / "config" / "copy_resources.yaml"
@@ -536,13 +587,8 @@ class CopyResourcesTest(unittest.TestCase):
         )
         server.mkdir(parents=True, exist_ok=True)
         (server / binary).write_text(product)
-        onboard_binary = (
-            "browseros_app_onboard"
-            if product == "browseros"
-            else "browseros_claw_onboard"
-        )
         onboarding = (
-            self.root.root / f"resources/binaries/{onboard_binary}/resources"
+            self.root.root / "resources/binaries/browseros_onboarding/resources"
         )
         onboarding.mkdir(parents=True, exist_ok=True)
         index = onboarding / "index.html"

--- a/packages/browseros/bos_build/steps/setup/clean_test.py
+++ b/packages/browseros/bos_build/steps/setup/clean_test.py
@@ -186,7 +186,7 @@ class CleanPruneOrphanBinariesTest(unittest.TestCase):
             },
             {
                 "name": "Onboard",
-                "destination": "resources/binaries/browseros_claw_onboard",
+                "destination": "resources/binaries/browseros_onboarding",
             },
         ]
     }
@@ -219,6 +219,18 @@ class CleanPruneOrphanBinariesTest(unittest.TestCase):
             staged.mkdir(parents=True)
             (staged / "browseros_claw_server_rust").write_text("binary")
 
+            onboarding = binaries / "browseros_onboarding" / "resources"
+            onboarding.mkdir(parents=True)
+            (onboarding / "index.html").write_text("onboarding")
+
+            retired_onboarding = [
+                binaries / "browseros_app_onboard",
+                binaries / "browseros_claw_onboard",
+            ]
+            for retired in retired_onboarding:
+                retired.mkdir()
+                (retired / "stale").write_text("stale")
+
             loose_file = binaries / "README.txt"
             loose_file.write_text("not a family dir")
 
@@ -227,6 +239,8 @@ class CleanPruneOrphanBinariesTest(unittest.TestCase):
             self.assertFalse(orphan.exists())
             self.assertTrue(managed.exists())
             self.assertTrue(staged.exists())
+            self.assertTrue(onboarding.exists())
+            self.assertTrue(all(not retired.exists() for retired in retired_onboarding))
             self.assertTrue(loose_file.exists())
 
     def test_empty_managed_set_prunes_nothing(self):

--- a/packages/browseros/bos_build/steps/storage/download.py
+++ b/packages/browseros/bos_build/steps/storage/download.py
@@ -36,13 +36,13 @@ RESOURCE_VERSION_FAMILIES = (
     ),
     (
         ("claw-onboard", "prod-resources"),
-        "browserclaw_onboard_resource_version",
+        "onboarding_resource_version",
     ),
     # One build bakes one onboarding component, so both families read the same
     # per-build version; the product-gated download key decides which applies.
     (
         ("app-onboard", "prod-resources"),
-        "browserclaw_onboard_resource_version",
+        "onboarding_resource_version",
     ),
 )
 

--- a/packages/browseros/bos_build/steps/storage/download_test.py
+++ b/packages/browseros/bos_build/steps/storage/download_test.py
@@ -391,7 +391,7 @@ class ResourceVersionOverrideTest(unittest.TestCase):
                 env=SimpleNamespace(
                     browseros_server_resource_version=browseros,
                     browserclaw_server_resource_version=browserclaw,
-                    browserclaw_onboard_resource_version=onboard,
+                    onboarding_resource_version=onboard,
                 )
             ),
         )
@@ -433,7 +433,7 @@ class ResourceVersionOverrideTest(unittest.TestCase):
                         r2_bucket="browseros",
                         browseros_server_resource_version=override,
                         browserclaw_server_resource_version="",
-                        browserclaw_onboard_resource_version="",
+                        onboarding_resource_version="",
                     ),
                     get_download_resources_config=lambda: config_path,
                 ),

--- a/packages/browseros/bos_build/steps/storage/download_test.py
+++ b/packages/browseros/bos_build/steps/storage/download_test.py
@@ -216,7 +216,7 @@ class ManagedBinaryFamiliesTest(unittest.TestCase):
                 },
                 {
                     "name": "Onboard",
-                    "destination": "resources/binaries/browseros_claw_onboard",
+                    "destination": "resources/binaries/browseros_onboarding",
                 },
                 {
                     "name": "Elsewhere",
@@ -230,7 +230,7 @@ class ManagedBinaryFamiliesTest(unittest.TestCase):
             config_path.write_text(yaml.safe_dump(config))
 
             self.assertEqual(
-                {"browseros_server", "browseros_claw_onboard"},
+                {"browseros_server", "browseros_onboarding"},
                 managed_binary_families(config_path),
             )
 
@@ -259,7 +259,9 @@ class ManagedBinaryFamiliesTest(unittest.TestCase):
 
         self.assertIn("browseros_server", families)
         self.assertIn("browseros_claw_server_rust", families)
-        self.assertIn("browseros_claw_onboard", families)
+        self.assertIn("browseros_onboarding", families)
+        self.assertNotIn("browseros_app_onboard", families)
+        self.assertNotIn("browseros_claw_onboard", families)
         # Retired by #1948; its leftover dir is exactly what pruning removes.
         self.assertNotIn("browseros_claw_server", families)
 
@@ -617,12 +619,12 @@ class DownloadResourceConfigTest(unittest.TestCase):
             "browseros": (
                 "BrowserOS Onboarding Resources",
                 "app-onboard/prod-resources/latest/browseros-app-onboard-resources.zip",
-                "resources/binaries/browseros_app_onboard",
+                "resources/binaries/browseros_onboarding",
             ),
             "browserclaw": (
                 "BrowserOS Claw Onboarding Resources",
                 "claw-onboard/prod-resources/latest/browseros-claw-onboard-resources.zip",
-                "resources/binaries/browseros_claw_onboard",
+                "resources/binaries/browseros_onboarding",
             ),
         }
         onboard_names = {value[0] for value in expected_by_product.values()}

--- a/packages/browseros/bos_build/steps/storage/upload.py
+++ b/packages/browseros/bos_build/steps/storage/upload.py
@@ -74,7 +74,7 @@ def _release_provenance(ctx: Context) -> dict[str, object]:
         component_versions = {
             source.server_component: server_version,
             source.extension_component: ctx.env.bundled_product_extension_version,
-            source.onboarding_component: ctx.env.browserclaw_onboard_resource_version,
+            source.onboarding_component: ctx.env.onboarding_resource_version,
         }
         if all(component_versions.values()):
             provenance["component_versions"] = component_versions

--- a/packages/browseros/bos_build/steps/storage/upload_test.py
+++ b/packages/browseros/bos_build/steps/storage/upload_test.py
@@ -28,7 +28,7 @@ def _upload_ctx(
 ) -> SimpleNamespace:
     return SimpleNamespace(
         env=SimpleNamespace(
-            browserclaw_onboard_resource_version=None,
+            onboarding_resource_version=None,
             browserclaw_server_resource_version=None,
             browseros_server_resource_version=None,
             bundled_product_extension_version=None,
@@ -136,7 +136,7 @@ class UploadMetadataTest(unittest.TestCase):
             ctx = _upload_ctx(Path(tmp))
             ctx.env.browseros_server_resource_version = "0.0.129"
             ctx.env.bundled_product_extension_version = "0.0.125.0"
-            ctx.env.browserclaw_onboard_resource_version = "0.0.15"
+            ctx.env.onboarding_resource_version = "0.0.15"
 
             release = generate_release_json(
                 ctx,
@@ -163,7 +163,7 @@ class UploadMetadataTest(unittest.TestCase):
             )
             ctx.env.browserclaw_server_resource_version = "0.0.29"
             ctx.env.bundled_product_extension_version = "0.2.2.0"
-            ctx.env.browserclaw_onboard_resource_version = "0.0.15"
+            ctx.env.onboarding_resource_version = "0.0.15"
 
             release = generate_release_json(
                 ctx,

--- a/packages/browseros/bos_build/steps/storage/upload_test.py
+++ b/packages/browseros/bos_build/steps/storage/upload_test.py
@@ -196,7 +196,7 @@ class UploadMetadataTest(unittest.TestCase):
                 component_versions={
                     "server": "0.0.128",
                     "agent": "0.0.116.0",
-                    "claw-onboard": "0.0.12",
+                    "app-onboard": "0.0.12",
                 },
                 files={},
             )


### PR DESCRIPTION
## Summary
- select app-onboard for BrowserOS and claw-onboard for BrowserClaw throughout candidate creation, local preparation, and release provenance
- normalize the selected archive into one required Chromium onboarding staging and copy contract
- verify the BrowserOS onboarding production ZIP and cover its workflow trigger and release documentation

## Design
Product identity is resolved once through SourceResources. Each independently versioned onboarding archive keeps its own R2 identity, then converges on a product-neutral staging directory and version interface before Chromium consumes it.

## Test plan
- [x] uv run python -m unittest discover -s bos_build -t . -p "*_test.py"
- [x] uv run ruff check bos_build
- [x] bun run --filter @browseros/app-onboard typecheck
- [x] bun run --filter @browseros/app-onboard lint
- [x] bun run --filter @browseros/app-onboard test
