### PR TITLE
fix(claw-server): fully serve MCP 2026-07-28 (subscriptions/listen + cache hints)

### DIFF
--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -890,7 +890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1461,6 +1461,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2122,7 +2124,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2361,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
+checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2373,6 +2375,7 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "indexmap",
  "pastey",
  "pin-project-lite",
  "rand 0.10.2",
@@ -2392,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
 dependencies = [
  "darling 0.24.0",
  "proc-macro2",
@@ -2458,7 +2461,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2516,7 +2519,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3183,10 +3186,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3784,7 +3787,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/packages/browseros-agent/Cargo.toml
+++ b/packages/browseros-agent/Cargo.toml
@@ -26,7 +26,7 @@ pulldown-cmark = { version = "0.13", default-features = false }
 sha2 = "0.10"
 jsonc-parser = { version = "0.33", features = ["cst", "serde_json"] }
 toml_edit = "0.22"
-rmcp = { version = "3", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "3.2", features = ["server", "transport-io", "transport-streamable-http-server"] }
 schemars = "1.0"
 axum = "0.8"
 http = "1"

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -22,9 +22,10 @@ use rmcp::{
     ErrorData as McpError, RoleServer,
     handler::server::ServerHandler,
     model::{
-        CallToolRequestMethod, CallToolRequestParams, CallToolResponse, CallToolResult,
+        CacheScope, CallToolRequestMethod, CallToolRequestParams, CallToolResponse, CallToolResult,
         Implementation, InitializeRequestParams, InitializeResult, JsonObject, ListToolsResult,
-        PaginatedRequestParams, ProtocolVersion, ServerCapabilities, Tool, ToolAnnotations,
+        PaginatedRequestParams, ProtocolVersion, ServerCapabilities, SubscriptionFilter, Tool,
+        ToolAnnotations,
     },
     service::{NotificationContext, RequestContext},
 };
@@ -497,7 +498,10 @@ const SUPPORTED_PROTOCOL_VERSIONS: &[ProtocolVersion] = &[
 
 impl ServerHandler for ClawMcpService {
     fn get_info(&self) -> InitializeResult {
-        let capabilities = ServerCapabilities::builder().enable_tools().build();
+        let capabilities = ServerCapabilities::builder()
+            .enable_tools()
+            .enable_tool_list_changed()
+            .build();
         let mut implementation = Implementation::new(SERVER_NAME, VERSION);
         implementation.title = Some(SERVER_TITLE.to_string());
         InitializeResult::new(capabilities)
@@ -531,9 +535,32 @@ impl ServerHandler for ClawMcpService {
     fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
-        std::future::ready(Ok(ListToolsResult::with_all_items(self.listed_tools())))
+        // SEP-2549: 2026-07-28 clients require ttlMs + cacheScope on list results;
+        // emit them only for that revision so legacy peers keep the old wire shape
+        // (mirrors rmcp's #[tool_handler] macro). ttl 0 = do-not-cache; the tool
+        // catalog is identical across users, so the scope is public.
+        let supports_cache_hints = context
+            .protocol_version()
+            .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28);
+        let mut result = ListToolsResult::with_all_items(self.listed_tools());
+        if supports_cache_hints {
+            result = result.with_ttl_ms(0).with_cache_scope(CacheScope::Public);
+        }
+        std::future::ready(Ok(result))
+    }
+
+    // Accept the 2026-07-28 `subscriptions/listen` stream instead of returning
+    // method-not-found. rmcp's default `accepted_subscription_filter` returns None,
+    // which becomes JSON-RPC -32601 and an HTTP 404 that kills the transport before
+    // tools/list can run. Returning the capability-supported subset opens the stream;
+    // the default `listen` holds it until the client cancels or the server shuts down.
+    fn accepted_subscription_filter(
+        &self,
+        requested: &SubscriptionFilter,
+    ) -> Option<SubscriptionFilter> {
+        Some(requested.supported_by(&self.get_info().capabilities))
     }
 
     fn get_tool(&self, name: &str) -> Option<Tool> {
@@ -1002,6 +1029,23 @@ mod tests {
     fn supported_protocol_versions_includes_modern_and_legacy() {
         assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2026_07_28));
         assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&ProtocolVersion::V_2025_11_25));
+    }
+
+    #[tokio::test]
+    async fn subscriptions_listen_is_accepted_not_method_not_found() -> anyhow::Result<()> {
+        // rmcp turns a None subscription filter into JSON-RPC -32601 for subscriptions/listen,
+        // which its streamable-http transport maps to a 404 that kills the connection. Accepting
+        // the capability-supported subset opens the stream instead.
+        let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let service = ClawMcpService::new(call.state);
+        let requested = SubscriptionFilter::builder().tools_list_changed().build();
+        let accepted = service.accepted_subscription_filter(&requested);
+        assert_eq!(
+            accepted.and_then(|filter| filter.tools_list_changed),
+            Some(true),
+            "subscriptions/listen must be accepted (Some), not method-not-found"
+        );
+        Ok(())
     }
 
     #[tokio::test]

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -481,6 +481,16 @@ async fn mcp_name_session_lists_and_renames_while_disconnected() -> anyhow::Resu
     )
     .await?;
     assert_eq!(status, StatusCode::OK);
+    // SEP-2549 ttlMs/cacheScope are 2026-07-28-only; a legacy (2025-06-18) peer must
+    // not receive them (they are emitted only when the negotiated revision is 2026-07-28).
+    assert!(
+        body["result"]["ttlMs"].is_null(),
+        "ttlMs leaked to legacy peer"
+    );
+    assert!(
+        body["result"]["cacheScope"].is_null(),
+        "cacheScope leaked to legacy peer"
+    );
     let tool = body["result"]["tools"]
         .as_array()
         .and_then(|tools| tools.iter().find(|tool| tool["name"] == "name_session"))


### PR DESCRIPTION
## What

Makes claw-server fully serve the MCP `2026-07-28` revision alongside the legacy revisions, fixing two client-visible failures that share one root cause: the server advertised `2026-07-28` but did not implement all of it.

Reported in browseros-ai/BrowserOS#2505 (a `2026-07-28` client's `subscriptions/listen` gets JSON-RPC `-32601`, which the transport maps to an HTTP 404 that kills the connection before `tools/list` runs) and #2504 (`tools/list` omits the SEP-2549 `ttlMs`/`cacheScope` fields, so spec-compliant clients reject the whole tool list).

## Root cause

Both stem from the `2026-07-28` upgrade shipping the advertisement without the full handler surface:

- The `initialize` handshake echoed `2026-07-28` but then enforced the legacy session model, so sessionless follow-ups failed.
- `subscriptions/listen` returned method-not-found because the handler never accepted a subscription.
- `tools/list` never set the SEP-2549 caching hints.

## Fix

Grounded in rmcp's own reference example (`examples/servers/src/subscriptions_streamhttp.rs`) and the `#[tool_handler]` macro.

- **Upgrade rmcp 3.1 to 3.2.** 3.2 keeps `initialize` on legacy protocol versions: a client that offers `2026-07-28` through the `initialize` handshake is now negotiated down to the newest legacy revision (`2025-11-25`) and issued a session, so it works via the session model instead of being told to go stateless and then failing. This alone repairs today's real clients, which all reach the server through `initialize`.
- **Accept `subscriptions/listen`.** Override `accepted_subscription_filter` to return the capability-supported subset (rather than the default `None`, which becomes `-32601`), and advertise `tool_list_changed`. The stream now opens, sends the acknowledgment, and is held until the client cancels. Clients using the inline stateless lifecycle get a working notification channel.
- **Emit SEP-2549 caching hints.** `tools/list` sets `ttlMs` (`0`, do-not-cache) and `cacheScope` (`public`; the tool catalog is identical across users), gated to negotiated `2026-07-28` so legacy peers keep the old wire shape, mirroring rmcp's macro.

## Verified live against a running server

```
initialize {protocolVersion: "2026-07-28"}
  -> "protocolVersion":"2025-11-25"  + mcp-session-id header   (clamped, session issued)

subscriptions/listen  (inline 2026-07-28, per-request metadata)
  -> HTTP 200, text/event-stream, held open
  -> data: {"method":"notifications/subscriptions/acknowledged",
            "params":{"_meta":{"io.modelcontextprotocol/subscriptionId":1},
                      "notifications":{"toolsListChanged":true}}}
```

The old `-32601` + 404 is gone; the subscription is acknowledged and the stream held.

## Testing

- Full crate suite green (lib + integration targets); clippy `-D warnings` clean; rustfmt clean.
- New unit test: `subscriptions/listen` is accepted (`accepted_subscription_filter` returns `Some`), not method-not-found.
- Updated the HTTP `tools/list` test to assert a legacy peer does not receive `ttlMs`/`cacheScope`.
