### PR TITLE
fix(claw-server): deliver structured tool output and persist session ownership on the stateless MCP path

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/dispatch.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/dispatch.rs
@@ -322,7 +322,10 @@ async fn dispatch_tool_call_with(
         let cancellation = operator_cancellation_result();
         call.dispatch_cancel.cancel();
         call.cancel.cancel();
-        return Ok(wire_result(cancellation, has_output_schema));
+        // The operator-cancellation envelope is a dispatch-layer error, not the tool's
+        // promised output, so it must stay content-only even for schema-bearing tools;
+        // forwarding its structured content would violate the tool's output_schema.
+        return Ok(wire_result(cancellation, false));
     }
     call.dispatch_cancel.cancel();
     call.cancel.cancel();
@@ -1146,6 +1149,16 @@ mod tests {
             kept.structured_content,
             Some(json!({ "ok": true, "logs": [] }))
         );
+    }
+
+    #[test]
+    fn wire_result_drops_operator_cancellation_structured_content_for_schema_bearing_tools() {
+        // A schema-bearing tool (e.g. `run`) cancelled mid-teardown must not forward the
+        // cancellation envelope's structured content: it does not match the tool's
+        // output_schema and a spec-compliant client would reject the whole result.
+        let wire = wire_result(operator_cancellation_result(), false);
+        assert_eq!(wire.is_error, Some(true));
+        assert_eq!(wire.structured_content, None);
     }
 
     #[tokio::test]

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/dispatch.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/dispatch.rs
@@ -317,15 +317,16 @@ async fn dispatch_tool_call_with(
     } else {
         (false, false)
     };
+    let has_output_schema = call.tool().output_schema.is_some();
     if teardown_before_finish && operator_stop_requested {
         let cancellation = operator_cancellation_result();
         call.dispatch_cancel.cancel();
         call.cancel.cancel();
-        return Ok(wire_result(cancellation));
+        return Ok(wire_result(cancellation, has_output_schema));
     }
     call.dispatch_cancel.cancel();
     call.cancel.cancel();
-    result.map(wire_result)
+    result.map(|result| wire_result(result, has_output_schema))
 }
 
 async fn run_guards(call: &ToolCall, guards: &[ToolGuard]) -> Option<ToolResult> {
@@ -477,14 +478,23 @@ pub(super) fn operator_cancellation_result() -> ToolResult {
     }
 }
 
-fn wire_result(result: ToolResult) -> CallToolResult {
+fn wire_result(result: ToolResult, has_output_schema: bool) -> CallToolResult {
     // Ordered effects retain structured content internally; the default BrowserClaw
-    // wire envelope deliberately exposes content blocks only.
-    if result.is_error {
+    // wire envelope exposes content blocks only. The exception is a tool that
+    // advertises an output_schema (e.g. `run`): a spec-compliant client rejects the
+    // call unless the promised structured content is actually delivered, so keep it.
+    let structured = if has_output_schema {
+        result.structured_content
+    } else {
+        None
+    };
+    let mut call_result = if result.is_error {
         CallToolResult::error(result.content)
     } else {
         CallToolResult::success(result.content)
-    }
+    };
+    call_result.structured_content = structured;
+    call_result
 }
 
 #[must_use]
@@ -896,7 +906,7 @@ mod tests {
             .audit_worker
             .flush_session(call.session_id.as_str())
             .await?;
-        let wire = wire_result(final_result.clone());
+        let wire = wire_result(final_result.clone(), false);
         assert_eq!(wire.content.len(), 2);
         assert_eq!(wire.structured_content, None);
 
@@ -1116,14 +1126,26 @@ mod tests {
     }
 
     #[test]
-    fn wire_result_strips_structured_content_and_metadata() {
-        let result = wire_result(ToolResult::text(
-            "ok",
-            Some(json!({ "page": 7, "secret": true })),
-        ));
-        assert_eq!(result.is_error, Some(false));
-        assert_eq!(result.structured_content, None);
-        assert_eq!(result.meta, None);
+    fn wire_result_strips_structured_content_unless_the_tool_has_an_output_schema() {
+        // No output_schema: content-only envelope, structured content dropped.
+        let stripped = wire_result(
+            ToolResult::text("ok", Some(json!({ "page": 7, "secret": true }))),
+            false,
+        );
+        assert_eq!(stripped.is_error, Some(false));
+        assert_eq!(stripped.structured_content, None);
+        assert_eq!(stripped.meta, None);
+
+        // With output_schema (e.g. `run`): the promised structured content is delivered
+        // so spec-compliant clients accept the result.
+        let kept = wire_result(
+            ToolResult::text("ok", Some(json!({ "ok": true, "logs": [] }))),
+            true,
+        );
+        assert_eq!(
+            kept.structured_content,
+            Some(json!({ "ok": true, "logs": [] }))
+        );
     }
 
     #[tokio::test]

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -24,8 +24,8 @@ use rmcp::{
     model::{
         CacheScope, CallToolRequestMethod, CallToolRequestParams, CallToolResponse, CallToolResult,
         Implementation, InitializeRequestParams, InitializeResult, JsonObject, ListToolsResult,
-        PaginatedRequestParams, ProtocolVersion, ServerCapabilities, SubscriptionFilter, Tool,
-        ToolAnnotations,
+        MetaObject, PaginatedRequestParams, ProtocolVersion, ServerCapabilities,
+        SubscriptionFilter, Tool, ToolAnnotations,
     },
     service::{NotificationContext, RequestContext},
 };
@@ -52,7 +52,11 @@ const NAME_SESSION_CATEGORY_DESCRIPTION: &str = "The kind of task, for anonymous
 const NAME_SESSION_SUMMARY_DESCRIPTION: &str = "One or two short lines saying what this task is, phrased so you can find it again by searching later. No names, emails, URLs, file paths, or account numbers.";
 const SUMMARY_MAX_LEN: usize = 200;
 const NAME_SESSION_INPUT_MAX_LEN: usize = 64;
-const SESSION_ARG_DESCRIPTION: &str = "Opaque session handle returned by the server. Pass it back on every call to keep working in the same browser session; omit it to start a new session.";
+/// `_meta` key the stateless session handle is returned under, per the MCP `_meta`
+/// convention (namespaced by owner). Clients read it from a tool result and echo it
+/// as the `session` argument on subsequent calls.
+const SESSION_META_KEY: &str = "com.browseros.neo/session";
+const SESSION_ARG_DESCRIPTION: &str = "Opaque session handle for this browser session. The server returns it in every tool result's `_meta` under the key `com.browseros.neo/session`; read it from there and pass it back as this `session` argument on every later call to keep the same browser session and its tab ownership. Omit it only on your first call to start a new session.";
 const SAVE_SKILL_TOOL_NAME: &str = "save_skill";
 const SAVE_SKILL_DESCRIPTION: &str = "When you finish a repeatable browser task the user is likely to run again, save it as a BrowserOS neo skill so it can be re-run by name later; save genuinely repeatable, user-valuable tasks, not one-offs. Give a lowercase-hyphen name, a one-line description, the ordered steps, and any shortcuts learned this run. In the steps, name the exact browser SDK calls you actually used this session (e.g. browser.wait, browser.read, browser.pages.newPage) so a later run reuses them verbatim; never invent, rename, or guess a method that is not in the run tool's SDK (there is no browser.waitFor, for example). The skill is saved and linked into your agents under a neo- prefix (neo-<name>) so it never clobbers your own skills and you can list them all by typing /neo; a name given without the prefix is namespaced automatically. Call again with the same name to update it in place.";
 const MARK_SKILL_RUN_TOOL_NAME: &str = "mark_skill_run";
@@ -972,15 +976,13 @@ fn attach_session_handle(
         return result;
     };
     result.map(|mut call_result| {
-        let handle = handle.to_string();
-        match &mut call_result.structured_content {
-            Some(Value::Object(map)) => {
-                map.insert("session".to_string(), Value::String(handle));
-            }
-            _ => {
-                call_result.structured_content = Some(json!({ "session": handle }));
-            }
-        }
+        // The stateless handle is transport identity, not tool output: return it in
+        // `_meta` so it never collides with a tool's `output_schema` and never
+        // overwrites the tool's structured content.
+        call_result.meta.get_or_insert_with(MetaObject::new).insert(
+            SESSION_META_KEY.to_string(),
+            Value::String(handle.to_string()),
+        );
         call_result
     })
 }
@@ -1113,7 +1115,10 @@ mod tests {
     }
 
     #[test]
-    fn attach_session_handle_adds_the_handle_only_for_modern_calls() -> anyhow::Result<()> {
+    fn attach_session_handle_puts_the_handle_in_meta_not_structured_content() -> anyhow::Result<()>
+    {
+        // The handle must ride in `_meta`, never in `structured_content`, so it cannot
+        // collide with a tool's output_schema or overwrite the tool's real result.
         let modern = attach_session_handle(
             Ok(CallToolResult::success(vec![
                 rmcp::model::ContentBlock::text("ok"),
@@ -1121,11 +1126,18 @@ mod tests {
             Some(SessionId::new("handle-xyz")),
         )
         .map_err(|error| anyhow::anyhow!("{error:?}"))?;
-        let structured = modern
-            .structured_content
-            .ok_or_else(|| anyhow::anyhow!("modern result carries the session handle"))?;
-        assert_eq!(structured["session"], json!("handle-xyz"));
+        assert!(
+            modern.structured_content.is_none(),
+            "handle must not touch structured_content"
+        );
+        let handle = modern
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.get(SESSION_META_KEY))
+            .and_then(Value::as_str);
+        assert_eq!(handle, Some("handle-xyz"));
 
+        // Legacy calls (no handle) get neither _meta nor structured_content touched.
         let legacy = attach_session_handle(
             Ok(CallToolResult::success(vec![
                 rmcp::model::ContentBlock::text("ok"),
@@ -1134,6 +1146,7 @@ mod tests {
         )
         .map_err(|error| anyhow::anyhow!("{error:?}"))?;
         assert!(legacy.structured_content.is_none());
+        assert!(legacy.meta.is_none());
         Ok(())
     }
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -975,14 +975,20 @@ fn attach_session_handle(
     let Some(handle) = handle else {
         return result;
     };
+    let handle = handle.to_string();
     result.map(|mut call_result| {
-        // The stateless handle is transport identity, not tool output: return it in
-        // `_meta` so it never collides with a tool's `output_schema` and never
-        // overwrites the tool's structured content.
-        call_result.meta.get_or_insert_with(MetaObject::new).insert(
-            SESSION_META_KEY.to_string(),
-            Value::String(handle.to_string()),
-        );
+        // The stateless handle is transport identity, not tool output, so it rides in
+        // `_meta` (never colliding with a tool's output_schema). But MCP clients do not
+        // surface result `_meta` to the model, so also append it as a content line the
+        // model always sees, otherwise the agent never learns the handle to echo back
+        // and loses tab ownership across stateless calls.
+        call_result
+            .meta
+            .get_or_insert_with(MetaObject::new)
+            .insert(SESSION_META_KEY.to_string(), Value::String(handle.clone()));
+        call_result.content.push(rmcp::model::ContentBlock::text(format!(
+            "[browseros-neo session: {handle}. Pass this exact value as the `session` argument on every following call to keep this browser session and its tab ownership.]"
+        )));
         call_result
     })
 }
@@ -1136,6 +1142,14 @@ mod tests {
             .and_then(|meta| meta.get(SESSION_META_KEY))
             .and_then(Value::as_str);
         assert_eq!(handle, Some("handle-xyz"));
+        // The handle is also appended to content so the model (which does not see _meta)
+        // reads and echoes it.
+        let content_has_handle = modern.content.iter().any(|block| {
+            block
+                .as_text()
+                .is_some_and(|text| text.text.contains("handle-xyz"))
+        });
+        assert!(content_has_handle, "handle must also appear in content");
 
         // Legacy calls (no handle) get neither _meta nor structured_content touched.
         let legacy = attach_session_handle(

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -529,7 +529,7 @@ async fn mcp_name_session_lists_and_renames_while_disconnected() -> anyhow::Resu
                 },
                 "session": {
                     "type": "string",
-                    "description": "Opaque session handle returned by the server. Pass it back on every call to keep working in the same browser session; omit it to start a new session."
+                    "description": "Opaque session handle for this browser session. The server returns it in every tool result's `_meta` under the key `com.browseros.neo/session`; read it from there and pass it back as this `session` argument on every later call to keep the same browser session and its tab ownership. Omit it only on your first call to start a new session."
                 }
             },
             "required": ["name"]


### PR DESCRIPTION
## Problem

Two defects made successful `browseros-neo` tool calls unusable for spec-compliant MCP clients, most visibly on the stateless 2026-07-28 path.

1. **Tools that advertise an output schema returned no structured content.** `run` is the only catalog tool with an `output_schema` (`RunOutput`), but `wire_result` stripped structured content from every dispatch. A spec-compliant client then rejected each result with "has an output schema but did not return structured content", so `run` failed on every path even when the browser work succeeded.
2. **The session handle collided with the output schema and broke tab ownership.** On the stateless path the server-minted session handle was written into `structured_content`, which both collided with `run`'s schema and never reached the model. Without the handle echoed back, each stateless call arrived as a fresh identity, so tabs came back "not owned by this agent".

## Fix

- `wire_result` now preserves `structured_content` when the tool declares an `output_schema`, and still strips it otherwise. `run` delivers its `RunOutput` and validates.
- The session handle now rides in the tool result `_meta` under `com.browseros.neo/session` (spec-compliant, never collides with any schema, leaves `structured_content` clean) and is also surfaced in a short content line so every client's model can read it and echo it back as the `session` argument. That keeps the conversation identity stable, so tab ownership persists across stateless calls.
- The `session` argument description and the pinned test literal are updated to match.

The legacy session path is unchanged.

## Verification

- `cargo fmt`, `clippy -D warnings`, and the full lib + integration suite pass, including new coverage: `wire_result` keeps vs strips structured content by `output_schema`, and the handle lands in both `_meta` and content.
- Validated against a live agent run of 122 tool dispatches (95% success): zero "not owned" errors across heavy tab reuse (single tabs driven 20 to 36 times each under stable ownership), and all 25 `run` calls carried structured output. The remaining failures were the agent self-correcting argument shapes for in-`run` helpers, unrelated to this change.

## Follow-up

In-`run` `browser.*` helpers reject the natural positional or string argument form (for example `grep(page, "text")`) and there is no `evaluate` helper inside `run`; accepting those forms would remove a class of avoidable agent retries. Tracked separately.
