### PR TITLE
fix(claw-server): derive stateless session client name from inline clientInfo

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -422,7 +422,18 @@ impl ClawMcpService {
         if let Some(handle) = provided
             && let Some(session) = self.state.sessions.lookup(&handle).await
         {
-            return Ok((started_session_from(session, &client), handle));
+            // A reused session keeps the identity it was minted with. This request's
+            // inline clientInfo is optional and may be absent or differ, so relabeling
+            // from it would flip the same session's audit attribution between the real
+            // client and "agent" across dispatches; take the label from the session.
+            let agent_label = session.agent().label().to_string();
+            return Ok((
+                StartedSession {
+                    session,
+                    agent_label,
+                },
+                handle,
+            ));
         }
         let handle = SessionId::new(Uuid::new_v4().to_string());
         let started = self.start_session_in_store(handle.clone(), client).await?;
@@ -1155,11 +1166,21 @@ mod tests {
             version: "9.9.9".to_string(),
             title: None,
         };
-        let (named, _) = service
+        let (named, handle) = service
             .resolve_modern_session(None, Some(client))
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
         assert_eq!(named.session.agent().slug(), "test-harness-client");
+        assert_eq!(named.agent_label, "test-harness-client");
+
+        // Reusing that handle without clientInfo keeps the minted identity and label,
+        // so a session's audit attribution never flips to "agent" mid-conversation.
+        let (reused, _) = service
+            .resolve_modern_session(Some(handle), None)
+            .await
+            .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+        assert_eq!(reused.session.agent().slug(), "test-harness-client");
+        assert_eq!(reused.agent_label, "test-harness-client");
 
         // A stateless client that sends no clientInfo falls back to "agent".
         let (anon, _) = service

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -328,17 +328,7 @@ impl ClawMcpService {
 
     async fn set_client_info(&self, request: &InitializeRequestParams) {
         let mut lifecycle = self.lifecycle.lock().await;
-        lifecycle.client_info = Some(ClientInfo {
-            name: clean_client_field(&request.client_info.name, "agent"),
-            version: clean_client_field(&request.client_info.version, "unknown"),
-            title: request
-                .client_info
-                .title
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(str::to_string),
-        });
+        lifecycle.client_info = Some(client_info_from_implementation(&request.client_info));
     }
 
     /// Looks up an existing store session for `session_id` or mints one under it.
@@ -423,12 +413,12 @@ impl ClawMcpService {
     async fn resolve_modern_session(
         &self,
         provided: Option<SessionId>,
+        client: Option<ClientInfo>,
     ) -> Result<(StartedSession, SessionId), McpError> {
-        let client = ClientInfo {
-            name: "agent".to_string(),
-            version: "unknown".to_string(),
-            title: None,
-        };
+        // 2026-07-28 removed `initialize`, so a stateless call carries no handshake
+        // clientInfo. Use the per-request inline `_meta` clientInfo when the client
+        // sends it; otherwise fall back to the anonymous "agent" identity.
+        let client = client.unwrap_or_else(default_agent_client_info);
         if let Some(handle) = provided
             && let Some(session) = self.state.sessions.lookup(&handle).await
         {
@@ -610,7 +600,15 @@ impl ServerHandler for ClawMcpService {
             .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28)
             && session_id_from_extensions(&context.extensions).is_none();
         let (started, session_handle) = if modern {
-            let (started, handle) = self.resolve_modern_session(provided_handle).await?;
+            let modern_client = request
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.client_info())
+                .as_ref()
+                .map(client_info_from_implementation);
+            let (started, handle) = self
+                .resolve_modern_session(provided_handle, modern_client)
+                .await?;
             (started, Some(handle))
         } else {
             (self.learn_session_from_request(&context).await?, None)
@@ -927,6 +925,31 @@ fn clean_client_field(value: &str, fallback: &str) -> String {
     }
 }
 
+/// Maps an MCP `Implementation` (from `initialize` clientInfo or a stateless
+/// request's inline `_meta` clientInfo) into the session `ClientInfo`, so both
+/// paths derive the same agent name, slug, and tab-group prefix for a client.
+fn client_info_from_implementation(source: &Implementation) -> ClientInfo {
+    ClientInfo {
+        name: clean_client_field(&source.name, "agent"),
+        version: clean_client_field(&source.version, "unknown"),
+        title: source
+            .title
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+    }
+}
+
+/// The anonymous fallback identity for a stateless client that sends no clientInfo.
+fn default_agent_client_info() -> ClientInfo {
+    ClientInfo {
+        name: "agent".to_string(),
+        version: "unknown".to_string(),
+        title: None,
+    }
+}
+
 async fn finish_local_dispatch(
     session: &Session,
     dispatch_id: &DispatchId,
@@ -1093,12 +1116,12 @@ mod tests {
         let service = ClawMcpService::new(call.state);
 
         let (first, minted) = service
-            .resolve_modern_session(None)
+            .resolve_modern_session(None, None)
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
 
         let (again, reused) = service
-            .resolve_modern_session(Some(minted.clone()))
+            .resolve_modern_session(Some(minted.clone()), None)
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
         assert_eq!(reused.to_string(), minted.to_string());
@@ -1109,7 +1132,7 @@ mod tests {
 
         let client_chosen = SessionId::new("client-picked-id");
         let (other, other_handle) = service
-            .resolve_modern_session(Some(client_chosen.clone()))
+            .resolve_modern_session(Some(client_chosen.clone()), None)
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
         assert_ne!(other_handle.to_string(), client_chosen.to_string());
@@ -1117,6 +1140,33 @@ mod tests {
             other.session.id().to_string(),
             first.session.id().to_string()
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn modern_session_adopts_the_inline_client_name() -> anyhow::Result<()> {
+        let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let service = ClawMcpService::new(call.state);
+
+        // A stateless client that sends inline clientInfo is named after it, so its
+        // tabs group under the real client slug rather than the anonymous "agent".
+        let client = ClientInfo {
+            name: "test-harness-client".to_string(),
+            version: "9.9.9".to_string(),
+            title: None,
+        };
+        let (named, _) = service
+            .resolve_modern_session(None, Some(client))
+            .await
+            .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+        assert_eq!(named.session.agent().slug(), "test-harness-client");
+
+        // A stateless client that sends no clientInfo falls back to "agent".
+        let (anon, _) = service
+            .resolve_modern_session(None, None)
+            .await
+            .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+        assert_eq!(anon.session.agent().slug(), "agent");
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

Tab groups in the cockpit are meant to be titled by the connecting client (`claude-code/<task>`, `cursor/<task>`), but on the stateless 2026-07-28 MCP path every session is attributed to the anonymous `agent`, so all stateless clients collapse into one ambiguous `agent/*` group. A recent sessions snapshot showed the same client landing under `agent` 16 times and under `claude-code` only on the 3 occasions it negotiated a legacy handshake.

## Root cause

The client name has two independent sources:

- Legacy path: `set_client_info` maps the `initialize` request's `clientInfo` into the session identity, so a client that runs the handshake is named correctly.
- Stateless path: 2026-07-28 removed `initialize`, so `resolve_modern_session` had no handshake to read and hard-coded the identity to `agent` for every minted session. `ClientIdentity::resolve` then slugged that to `agent`, which became the tab-group prefix.

The client name is still available on stateless calls: the 2026-07-28 inline request `_meta` carries `io.modelcontextprotocol/clientInfo`, exposed as `RequestMetaObject::client_info()`. It was simply never read.

## Fix

- `resolve_modern_session` now takes the resolved client and only falls back to `agent` when none is available.
- `call_tool` reads `clientInfo` from the stateless request's inline `_meta` and passes it through, so a stateless session is named after its real client and its tabs group accordingly.
- A shared `client_info_from_implementation` helper backs both the legacy and stateless paths, so a given client resolves to the same name, slug, and group prefix regardless of which path it took.

`clientInfo` is optional in the 2026-07-28 inline metadata, so the change degrades gracefully: when a client sends it, the group is named correctly; when it does not, behaviour is unchanged (`agent`). No effect on the legacy path.

## Verification

`cargo fmt`, `clippy -D warnings`, and the full lib suite (335 tests) pass, including a new test that a stateless session adopts an inline client name and falls back to `agent` without one.
