### PR TITLE
feat(server): add local storage for llm providers and scheduled jobs

### DIFF
--- a/packages/browseros-agent/apps/app/package.json
+++ b/packages/browseros-agent/apps/app/package.json
@@ -77,6 +77,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-hook-form": "^7.85.0",
+    "react-query-kit": "^3.3.4",
     "react-resizable-panels": "^4.12.2",
     "react-router": "^7.18.2",
     "shiki": "^3.23.0",

--- a/packages/browseros-agent/apps/server/.gitignore
+++ b/packages/browseros-agent/apps/server/.gitignore
@@ -1,5 +1,8 @@
 tmp-shot-*/
 tmp-upload-*/
 .devtools
-db/
-identity/
+# Runtime directories at the app root. Anchored with a leading slash: an
+# unanchored `db/` also matches src/lib/db/ and tests/lib/db/, which silently
+# swallowed new schema files and migrations until they were force-added.
+/db/
+/identity/

--- a/packages/browseros-agent/apps/server/src/api/routes/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/index.ts
@@ -22,11 +22,13 @@ import { createConversationRoutes } from './conversations'
 import { createCreditsRoutes } from './credits'
 import { createHealthRoute } from './health'
 import { createKlavisRoutes } from './klavis'
+import { createLlmProviderRoutes } from './llm-providers'
 import { createMcpRoutes } from './mcp'
 import { createMcpManagerRoutes } from './mcp-manager'
 import { createOAuthRoutes } from './oauth'
 import { createProviderRoutes } from './provider'
 import { createRefinePromptRoutes } from './refine-prompt'
+import { createScheduledJobRoutes } from './scheduled-jobs'
 import { createShutdownRoute } from './shutdown'
 import { createStatusRoute } from './status'
 
@@ -137,6 +139,8 @@ export function createApiRoutes(deps: CreateApiRoutesDeps) {
       .route('/acpx/probe', createAcpxProbeRoutes({ resourcesDir }))
       .route('/agents', resolvedAgentRoutes)
       .route('/conversations', createConversationRoutes())
+      .route('/llm-providers', createLlmProviderRoutes())
+      .route('/scheduled-jobs', createScheduledJobRoutes())
   )
 }
 

--- a/packages/browseros-agent/apps/server/src/api/routes/llm-providers.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/llm-providers.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import {
+  dbLlmProviderStore,
+  type LlmProviderStore,
+} from '../../lib/llm-providers/provider-store'
+import type { Env } from '../types'
+
+const IdParamSchema = z.object({ providerId: z.string().min(1) })
+
+/**
+ * Mirrors the extension's LlmProviderConfig. `id` comes from the client rather
+ * than the database so a provider keeps one identity across the extension, the
+ * migration and this table, which is what makes re-importing idempotent.
+ */
+const UpsertProviderSchema = z.object({
+  profileId: z.string().nullish(),
+  type: z.string().min(1),
+  name: z.string().min(1),
+  baseUrl: z.string().nullish(),
+  modelId: z.string().min(1),
+  supportsImages: z.boolean().optional(),
+  contextWindow: z.number(),
+  temperature: z.number().optional(),
+  apiKey: z.string().nullish(),
+  accessKeyId: z.string().nullish(),
+  secretAccessKey: z.string().nullish(),
+  sessionToken: z.string().nullish(),
+  resourceName: z.string().nullish(),
+  region: z.string().nullish(),
+  reasoningEffort: z.string().nullish(),
+  reasoningSummary: z.string().nullish(),
+  createdAt: z.number().optional(),
+})
+
+export function createLlmProviderRoutes(
+  options: { store?: LlmProviderStore } = {},
+) {
+  const store = options.store ?? dbLlmProviderStore
+
+  return new Hono<Env>()
+    .get('/', async (c) => c.json({ providers: await store.list() }))
+    .get('/:providerId', zValidator('param', IdParamSchema), async (c) => {
+      const provider = await store.get(c.req.valid('param').providerId)
+      if (!provider) return c.json({ error: 'Unknown provider' }, 404)
+      return c.json({ provider })
+    })
+    .put(
+      '/:providerId',
+      zValidator('param', IdParamSchema),
+      zValidator('json', UpsertProviderSchema),
+      async (c) => {
+        const provider = await store.upsert({
+          ...c.req.valid('json'),
+          id: c.req.valid('param').providerId,
+        })
+        return c.json({ provider })
+      },
+    )
+    .delete('/:providerId', zValidator('param', IdParamSchema), async (c) => {
+      const deleted = await store.remove(c.req.valid('param').providerId)
+      if (!deleted) return c.json({ error: 'Unknown provider' }, 404)
+      return c.json({ success: true })
+    })
+}

--- a/packages/browseros-agent/apps/server/src/api/routes/scheduled-jobs.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/scheduled-jobs.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import {
+  dbScheduledJobStore,
+  type ScheduledJobStore,
+} from '../../lib/schedules/schedule-store'
+import type { Env } from '../types'
+
+const IdParamSchema = z.object({ jobId: z.string().min(1) })
+
+/**
+ * Timestamps arrive as epoch numbers. The extension holds ISO strings today,
+ * so the conversion belongs on its side of this boundary, keeping the database
+ * consistent with the other tables here.
+ */
+const UpsertJobSchema = z.object({
+  profileId: z.string().nullish(),
+  name: z.string().min(1),
+  query: z.string().min(1),
+  scheduleType: z.enum(['daily', 'hourly', 'minutes']),
+  scheduleTime: z.string().nullish(),
+  scheduleInterval: z.number().nullish(),
+  enabled: z.boolean().optional(),
+  providerId: z.string().nullish(),
+  lastRunAt: z.number().nullish(),
+  createdAt: z.number().optional(),
+})
+
+export function createScheduledJobRoutes(
+  options: { store?: ScheduledJobStore } = {},
+) {
+  const store = options.store ?? dbScheduledJobStore
+
+  return new Hono<Env>()
+    .get('/', async (c) => c.json({ jobs: await store.list() }))
+    .get('/:jobId', zValidator('param', IdParamSchema), async (c) => {
+      const job = await store.get(c.req.valid('param').jobId)
+      if (!job) return c.json({ error: 'Unknown scheduled job' }, 404)
+      return c.json({ job })
+    })
+    .put(
+      '/:jobId',
+      zValidator('param', IdParamSchema),
+      zValidator('json', UpsertJobSchema),
+      async (c) => {
+        const job = await store.upsert({
+          ...c.req.valid('json'),
+          id: c.req.valid('param').jobId,
+        })
+        return c.json({ job })
+      },
+    )
+    .delete('/:jobId', zValidator('param', IdParamSchema), async (c) => {
+      const deleted = await store.remove(c.req.valid('param').jobId)
+      if (!deleted) return c.json({ error: 'Unknown scheduled job' }, 404)
+      return c.json({ success: true })
+    })
+}

--- a/packages/browseros-agent/apps/server/src/lib/db/migrations/0008_add_llm_providers_and_scheduled_jobs.sql
+++ b/packages/browseros-agent/apps/server/src/lib/db/migrations/0008_add_llm_providers_and_scheduled_jobs.sql
@@ -1,0 +1,41 @@
+CREATE TABLE `llm_providers` (
+	`id` text PRIMARY KEY NOT NULL,
+	`profile_id` text,
+	`type` text NOT NULL,
+	`name` text NOT NULL,
+	`base_url` text,
+	`model_id` text NOT NULL,
+	`supports_images` integer DEFAULT true NOT NULL,
+	`context_window` integer NOT NULL,
+	`temperature` real DEFAULT 0.2 NOT NULL,
+	`api_key` text,
+	`access_key_id` text,
+	`secret_access_key` text,
+	`session_token` text,
+	`resource_name` text,
+	`region` text,
+	`reasoning_effort` text,
+	`reasoning_summary` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `llm_providers_profile_id_idx` ON `llm_providers` (`profile_id`);--> statement-breakpoint
+CREATE TABLE `scheduled_jobs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`profile_id` text,
+	`name` text NOT NULL,
+	`query` text NOT NULL,
+	`schedule_type` text NOT NULL,
+	`schedule_time` text,
+	`schedule_interval` integer,
+	`enabled` integer DEFAULT true NOT NULL,
+	`provider_id` text,
+	`last_run_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`provider_id`) REFERENCES `llm_providers`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `scheduled_jobs_profile_id_idx` ON `scheduled_jobs` (`profile_id`);--> statement-breakpoint
+CREATE INDEX `scheduled_jobs_enabled_idx` ON `scheduled_jobs` (`enabled`);

--- a/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/0008_snapshot.json
+++ b/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,547 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "32fefd99-fdd9-49aa-b9b3-54f485b933c2",
+  "prevId": "573c3669-aa07-4cee-a4b2-ad109a6407b3",
+  "tables": {
+    "acp_agents": {
+      "name": "acp_agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "working_directory": {
+          "name": "working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_config": {
+          "name": "custom_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "acp_agents_updated_at_idx": {
+          "name": "acp_agents_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "acp_agents_type_updated_at_idx": {
+          "name": "acp_agents_type_updated_at_idx",
+          "columns": [
+            "type",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_user_message": {
+          "name": "last_user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_messaged_at": {
+          "name": "last_messaged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversations_last_messaged_at_idx": {
+          "name": "conversations_last_messaged_at_idx",
+          "columns": [
+            "last_messaged_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_providers": {
+      "name": "llm_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "supports_images": {
+          "name": "supports_images",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.2
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_key_id": {
+          "name": "access_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secret_access_key": {
+          "name": "secret_access_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_summary": {
+          "name": "reasoning_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_providers_profile_id_idx": {
+          "name": "llm_providers_profile_id_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_tokens": {
+      "name": "oauth_tokens",
+      "columns": {
+        "browseros_id": {
+          "name": "browseros_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_tokens_browseros_id_idx": {
+          "name": "oauth_tokens_browseros_id_idx",
+          "columns": [
+            "browseros_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauth_tokens_browseros_id_provider_pk": {
+          "columns": [
+            "browseros_id",
+            "provider"
+          ],
+          "name": "oauth_tokens_browseros_id_provider_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_time": {
+          "name": "schedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_profile_id_idx": {
+          "name": "scheduled_jobs_profile_id_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_jobs_enabled_idx": {
+          "name": "scheduled_jobs_enabled_idx",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_jobs_provider_id_llm_providers_id_fk": {
+          "name": "scheduled_jobs_provider_id_llm_providers_id_fk",
+          "tableFrom": "scheduled_jobs",
+          "tableTo": "llm_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/_journal.json
+++ b/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1787580067090,
       "tag": "0007_add_custom_acp_agents",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1788319873053,
+      "tag": "0008_add_llm_providers_and_scheduled_jobs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/browseros-agent/apps/server/src/lib/db/schema/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/schema/index.ts
@@ -6,4 +6,6 @@
 
 export * from './agents'
 export * from './conversations'
+export * from './llm-providers'
+export * from './scheduled-jobs'
 export * from './oauth'

--- a/packages/browseros-agent/apps/server/src/lib/db/schema/llm-providers.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/schema/llm-providers.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
+import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+/**
+ * LLM providers, mirroring the shape the extension holds today.
+ *
+ * Credentials live here in the clear, alongside the OAuth tokens already in
+ * this database. Nothing beyond filesystem permissions protects them, which is
+ * the same posture they had in extension storage.
+ *
+ * `profileId` is reserved and currently always null: every browser profile on
+ * a machine shares one database, because no extension API exposes a profile
+ * identifier. The column exists so isolation can be switched on later without
+ * a second migration.
+ */
+export const llmProviders = sqliteTable(
+  'llm_providers',
+  {
+    id: text('id').primaryKey(),
+    profileId: text('profile_id'),
+    type: text('type').notNull(),
+    name: text('name').notNull(),
+    baseUrl: text('base_url'),
+    modelId: text('model_id').notNull(),
+    supportsImages: integer('supports_images', { mode: 'boolean' })
+      .notNull()
+      .default(true),
+    contextWindow: integer('context_window').notNull(),
+    // Real, not integer: the default is 0.2 and an integer column floors it to 0.
+    temperature: real('temperature').notNull().default(0.2),
+
+    apiKey: text('api_key'),
+    accessKeyId: text('access_key_id'),
+    secretAccessKey: text('secret_access_key'),
+    sessionToken: text('session_token'),
+
+    resourceName: text('resource_name'),
+    region: text('region'),
+
+    reasoningEffort: text('reasoning_effort'),
+    reasoningSummary: text('reasoning_summary'),
+
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [index('llm_providers_profile_id_idx').on(table.profileId)],
+)
+
+export type LlmProviderRow = InferSelectModel<typeof llmProviders>
+export type NewLlmProviderRow = InferInsertModel<typeof llmProviders>

--- a/packages/browseros-agent/apps/server/src/lib/db/schema/scheduled-jobs.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/schema/scheduled-jobs.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { llmProviders } from './llm-providers'
+
+/**
+ * Scheduled jobs, mirroring the shape the extension holds today.
+ *
+ * `providerId` keeps the extension's field name rather than the cloud's
+ * `llmProviderId`, because the extension copy is the migration source and the
+ * one that carries credentials.
+ *
+ * The reference is deliberately not a foreign key with a cascade: a job whose
+ * provider was deleted should surface as a job needing attention, not vanish
+ * silently on a delete the user made elsewhere.
+ *
+ * Timestamps are epoch integers here while the extension holds ISO strings.
+ * The database is internally consistent this way, and the route layer converts.
+ */
+export const scheduledJobs = sqliteTable(
+  'scheduled_jobs',
+  {
+    id: text('id').primaryKey(),
+    profileId: text('profile_id'),
+    name: text('name').notNull(),
+    query: text('query').notNull(),
+    scheduleType: text('schedule_type', {
+      enum: ['daily', 'hourly', 'minutes'],
+    }).notNull(),
+    scheduleTime: text('schedule_time'),
+    scheduleInterval: integer('schedule_interval'),
+    enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+    providerId: text('provider_id').references(() => llmProviders.id, {
+      onDelete: 'set null',
+    }),
+    lastRunAt: integer('last_run_at'),
+    createdAt: integer('created_at').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (table) => [
+    index('scheduled_jobs_profile_id_idx').on(table.profileId),
+    index('scheduled_jobs_enabled_idx').on(table.enabled),
+  ],
+)
+
+export type ScheduledJobRow = InferSelectModel<typeof scheduledJobs>
+export type NewScheduledJobRow = InferInsertModel<typeof scheduledJobs>

--- a/packages/browseros-agent/apps/server/src/lib/llm-providers/provider-store.ts
+++ b/packages/browseros-agent/apps/server/src/lib/llm-providers/provider-store.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { eq } from 'drizzle-orm'
+import { getDb } from '../db'
+import {
+  type LlmProviderRow,
+  llmProviders,
+  type NewLlmProviderRow,
+} from '../db/schema'
+
+/**
+ * The store stamps `updatedAt` and defaults `createdAt`, so callers supply
+ * neither. `createdAt` stays optional so an import can preserve the original
+ * creation time when it has one.
+ */
+export type LlmProviderUpsert = Omit<
+  NewLlmProviderRow,
+  'updatedAt' | 'createdAt'
+> & {
+  createdAt?: number
+}
+
+export interface LlmProviderStore {
+  list(): Promise<LlmProviderRow[]>
+  get(id: string): Promise<LlmProviderRow | null>
+  /** Insert or replace by id. The migration relies on this being idempotent. */
+  upsert(row: LlmProviderUpsert): Promise<LlmProviderRow>
+  remove(id: string): Promise<boolean>
+}
+
+async function list(): Promise<LlmProviderRow[]> {
+  return getDb().select().from(llmProviders).all()
+}
+
+async function get(id: string): Promise<LlmProviderRow | null> {
+  const [row] = await getDb()
+    .select()
+    .from(llmProviders)
+    .where(eq(llmProviders.id, id))
+    .limit(1)
+  return row ?? null
+}
+
+async function upsert(row: LlmProviderUpsert): Promise<LlmProviderRow> {
+  const now = Date.now()
+  const [saved] = await getDb()
+    .insert(llmProviders)
+    .values({ ...row, createdAt: row.createdAt ?? now, updatedAt: now })
+    .onConflictDoUpdate({
+      target: llmProviders.id,
+      // createdAt is deliberately absent: re-importing a provider must not
+      // rewrite when the user originally created it.
+      set: { ...row, createdAt: undefined, updatedAt: now },
+    })
+    .returning()
+  return saved
+}
+
+async function remove(id: string): Promise<boolean> {
+  const deleted = await getDb()
+    .delete(llmProviders)
+    .where(eq(llmProviders.id, id))
+    .returning({ id: llmProviders.id })
+  return deleted.length > 0
+}
+
+export const dbLlmProviderStore: LlmProviderStore = {
+  list,
+  get,
+  upsert,
+  remove,
+}

--- a/packages/browseros-agent/apps/server/src/lib/schedules/schedule-store.ts
+++ b/packages/browseros-agent/apps/server/src/lib/schedules/schedule-store.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { eq } from 'drizzle-orm'
+import { getDb } from '../db'
+import {
+  type NewScheduledJobRow,
+  type ScheduledJobRow,
+  scheduledJobs,
+} from '../db/schema'
+
+/**
+ * The store stamps `updatedAt` and defaults `createdAt`, so callers supply
+ * neither. `createdAt` stays optional so an import can preserve the original
+ * creation time when it has one.
+ */
+export type ScheduledJobUpsert = Omit<
+  NewScheduledJobRow,
+  'updatedAt' | 'createdAt'
+> & {
+  createdAt?: number
+}
+
+export interface ScheduledJobStore {
+  list(): Promise<ScheduledJobRow[]>
+  get(id: string): Promise<ScheduledJobRow | null>
+  /** Insert or replace by id. The migration relies on this being idempotent. */
+  upsert(row: ScheduledJobUpsert): Promise<ScheduledJobRow>
+  remove(id: string): Promise<boolean>
+}
+
+async function list(): Promise<ScheduledJobRow[]> {
+  return getDb().select().from(scheduledJobs).all()
+}
+
+async function get(id: string): Promise<ScheduledJobRow | null> {
+  const [row] = await getDb()
+    .select()
+    .from(scheduledJobs)
+    .where(eq(scheduledJobs.id, id))
+    .limit(1)
+  return row ?? null
+}
+
+async function upsert(row: ScheduledJobUpsert): Promise<ScheduledJobRow> {
+  const now = Date.now()
+  const [saved] = await getDb()
+    .insert(scheduledJobs)
+    .values({ ...row, createdAt: row.createdAt ?? now, updatedAt: now })
+    .onConflictDoUpdate({
+      target: scheduledJobs.id,
+      set: { ...row, createdAt: undefined, updatedAt: now },
+    })
+    .returning()
+  return saved
+}
+
+async function remove(id: string): Promise<boolean> {
+  const deleted = await getDb()
+    .delete(scheduledJobs)
+    .where(eq(scheduledJobs.id, id))
+    .returning({ id: scheduledJobs.id })
+  return deleted.length > 0
+}
+
+export const dbScheduledJobStore: ScheduledJobStore = {
+  list,
+  get,
+  upsert,
+  remove,
+}

--- a/packages/browseros-agent/apps/server/tests/api/routes/llm-providers.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/llm-providers.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'bun:test'
+import { createLlmProviderRoutes } from '../../../src/api/routes/llm-providers'
+import type { LlmProviderRow } from '../../../src/lib/db/schema'
+import type {
+  LlmProviderStore,
+  LlmProviderUpsert,
+} from '../../../src/lib/llm-providers/provider-store'
+
+const PROVIDER_ID = 'provider-1'
+
+function row(overrides: Partial<LlmProviderRow> = {}): LlmProviderRow {
+  return {
+    id: PROVIDER_ID,
+    profileId: null,
+    type: 'openai',
+    name: 'My OpenAI',
+    baseUrl: 'https://api.openai.com/v1',
+    modelId: 'gpt-5.5',
+    supportsImages: true,
+    contextWindow: 200000,
+    temperature: 0.2,
+    apiKey: 'sk-test',
+    accessKeyId: null,
+    secretAccessKey: null,
+    sessionToken: null,
+    resourceName: null,
+    region: null,
+    reasoningEffort: null,
+    reasoningSummary: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+function memoryStore(initial: LlmProviderRow[] = []) {
+  const rows = new Map(initial.map((r) => [r.id, r]))
+  const store: LlmProviderStore = {
+    list: async () => [...rows.values()],
+    get: async (id) => rows.get(id) ?? null,
+    upsert: async (input: LlmProviderUpsert) => {
+      const existing = rows.get(input.id)
+      const saved = {
+        ...row(),
+        ...input,
+        createdAt: existing?.createdAt ?? input.createdAt ?? 100,
+        updatedAt: 200,
+      } as LlmProviderRow
+      rows.set(saved.id, saved)
+      return saved
+    },
+    remove: async (id) => rows.delete(id),
+  }
+  return { store, rows }
+}
+
+const body = {
+  type: 'openai',
+  name: 'My OpenAI',
+  modelId: 'gpt-5.5',
+  contextWindow: 200000,
+  apiKey: 'sk-test',
+}
+
+describe('llm provider routes', () => {
+  it('lists providers', async () => {
+    const routes = createLlmProviderRoutes(memoryStore([row()]))
+    const response = await routes.request('/')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      providers: [{ id: PROVIDER_ID, name: 'My OpenAI' }],
+    })
+  })
+
+  it('gets one provider', async () => {
+    const routes = createLlmProviderRoutes(memoryStore([row()]))
+    const response = await routes.request(`/${PROVIDER_ID}`)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      provider: { id: PROVIDER_ID },
+    })
+  })
+
+  it('returns 404 for an unknown provider', async () => {
+    const routes = createLlmProviderRoutes(memoryStore())
+    expect((await routes.request(`/${PROVIDER_ID}`)).status).toBe(404)
+  })
+
+  it('creates a provider under the id from the path', async () => {
+    const { store, rows } = memoryStore()
+    const routes = createLlmProviderRoutes({ store })
+
+    const response = await routes.request(`/${PROVIDER_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    expect(response.status).toBe(200)
+    expect(rows.get(PROVIDER_ID)?.name).toBe('My OpenAI')
+  })
+
+  // The migration re-runs on every profile and after a partial failure, so a
+  // repeated PUT has to land on the same row rather than a second one.
+  it('is idempotent: putting the same id twice keeps one row', async () => {
+    const { store, rows } = memoryStore()
+    const routes = createLlmProviderRoutes({ store })
+    const put = () =>
+      routes.request(`/${PROVIDER_ID}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+    await put()
+    await put()
+
+    expect(rows.size).toBe(1)
+  })
+
+  it('keeps the original creation time when a provider is re-imported', async () => {
+    const { store, rows } = memoryStore([row({ createdAt: 42 })])
+    const routes = createLlmProviderRoutes({ store })
+
+    await routes.request(`/${PROVIDER_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...body, createdAt: 999 }),
+    })
+
+    expect(rows.get(PROVIDER_ID)?.createdAt).toBe(42)
+  })
+
+  it('rejects a body missing required fields', async () => {
+    const routes = createLlmProviderRoutes(memoryStore())
+    const response = await routes.request(`/${PROVIDER_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'no type or model' }),
+    })
+    expect(response.status).toBe(400)
+  })
+
+  it('deletes a provider', async () => {
+    const { store, rows } = memoryStore([row()])
+    const routes = createLlmProviderRoutes({ store })
+
+    const response = await routes.request(`/${PROVIDER_ID}`, {
+      method: 'DELETE',
+    })
+    expect(response.status).toBe(200)
+    expect(rows.size).toBe(0)
+  })
+
+  it('returns 404 deleting an unknown provider', async () => {
+    const routes = createLlmProviderRoutes(memoryStore())
+    expect(
+      (await routes.request(`/${PROVIDER_ID}`, { method: 'DELETE' })).status,
+    ).toBe(404)
+  })
+
+  // Credentials are the reason this table exists rather than staying remote.
+  it('round-trips credentials, which the cloud never carried', async () => {
+    const { store, rows } = memoryStore()
+    const routes = createLlmProviderRoutes({ store })
+
+    await routes.request(`/${PROVIDER_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...body,
+        type: 'bedrock',
+        accessKeyId: 'AKIA',
+        secretAccessKey: 'secret',
+        sessionToken: 'token',
+      }),
+    })
+
+    expect(rows.get(PROVIDER_ID)).toMatchObject({
+      accessKeyId: 'AKIA',
+      secretAccessKey: 'secret',
+      sessionToken: 'token',
+    })
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/routes/scheduled-jobs.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/scheduled-jobs.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'bun:test'
+import { createScheduledJobRoutes } from '../../../src/api/routes/scheduled-jobs'
+import type { ScheduledJobRow } from '../../../src/lib/db/schema'
+import type {
+  ScheduledJobStore,
+  ScheduledJobUpsert,
+} from '../../../src/lib/schedules/schedule-store'
+
+const JOB_ID = 'job-1'
+
+function row(overrides: Partial<ScheduledJobRow> = {}): ScheduledJobRow {
+  return {
+    id: JOB_ID,
+    profileId: null,
+    name: 'Morning digest',
+    query: 'summarise my inbox',
+    scheduleType: 'daily',
+    scheduleTime: '09:00',
+    scheduleInterval: null,
+    enabled: true,
+    providerId: 'provider-1',
+    lastRunAt: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+function memoryStore(initial: ScheduledJobRow[] = []) {
+  const rows = new Map(initial.map((r) => [r.id, r]))
+  const store: ScheduledJobStore = {
+    list: async () => [...rows.values()],
+    get: async (id) => rows.get(id) ?? null,
+    upsert: async (input: ScheduledJobUpsert) => {
+      const existing = rows.get(input.id)
+      const saved = {
+        ...row(),
+        ...input,
+        createdAt: existing?.createdAt ?? input.createdAt ?? 100,
+        updatedAt: 200,
+      } as ScheduledJobRow
+      rows.set(saved.id, saved)
+      return saved
+    },
+    remove: async (id) => rows.delete(id),
+  }
+  return { store, rows }
+}
+
+const body = {
+  name: 'Morning digest',
+  query: 'summarise my inbox',
+  scheduleType: 'daily' as const,
+  scheduleTime: '09:00',
+  providerId: 'provider-1',
+}
+
+function put(
+  routes: ReturnType<typeof createScheduledJobRoutes>,
+  payload: unknown,
+) {
+  return routes.request(`/${JOB_ID}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+}
+
+describe('scheduled job routes', () => {
+  it('lists jobs', async () => {
+    const routes = createScheduledJobRoutes(memoryStore([row()]))
+    const response = await routes.request('/')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      jobs: [{ id: JOB_ID, name: 'Morning digest' }],
+    })
+  })
+
+  it('returns 404 for an unknown job', async () => {
+    const routes = createScheduledJobRoutes(memoryStore())
+    expect((await routes.request(`/${JOB_ID}`)).status).toBe(404)
+  })
+
+  it('creates a job under the id from the path', async () => {
+    const { store, rows } = memoryStore()
+    const response = await put(createScheduledJobRoutes({ store }), body)
+    expect(response.status).toBe(200)
+    expect(rows.get(JOB_ID)?.query).toBe('summarise my inbox')
+  })
+
+  it('is idempotent: putting the same id twice keeps one row', async () => {
+    const { store, rows } = memoryStore()
+    const routes = createScheduledJobRoutes({ store })
+    await put(routes, body)
+    await put(routes, body)
+    expect(rows.size).toBe(1)
+  })
+
+  // The job keeps pointing at the provider it was created against, which is
+  // the reference the migration has to preserve when both move together.
+  it('preserves the provider reference', async () => {
+    const { store, rows } = memoryStore()
+    await put(createScheduledJobRoutes({ store }), body)
+    expect(rows.get(JOB_ID)?.providerId).toBe('provider-1')
+  })
+
+  it('accepts a job with no provider attached', async () => {
+    const { store, rows } = memoryStore()
+    const response = await put(createScheduledJobRoutes({ store }), {
+      ...body,
+      providerId: null,
+    })
+    expect(response.status).toBe(200)
+    expect(rows.get(JOB_ID)?.providerId).toBeNull()
+  })
+
+  it('rejects an unknown schedule type', async () => {
+    const routes = createScheduledJobRoutes(memoryStore())
+    const response = await put(routes, { ...body, scheduleType: 'weekly' })
+    expect(response.status).toBe(400)
+  })
+
+  it('rejects a body missing the query', async () => {
+    const routes = createScheduledJobRoutes(memoryStore())
+    const response = await put(routes, { name: 'no query' })
+    expect(response.status).toBe(400)
+  })
+
+  it('deletes a job', async () => {
+    const { store, rows } = memoryStore([row()])
+    const routes = createScheduledJobRoutes({ store })
+    expect(
+      (await routes.request(`/${JOB_ID}`, { method: 'DELETE' })).status,
+    ).toBe(200)
+    expect(rows.size).toBe(0)
+  })
+
+  it('returns 404 deleting an unknown job', async () => {
+    const routes = createScheduledJobRoutes(memoryStore())
+    expect(
+      (await routes.request(`/${JOB_ID}`, { method: 'DELETE' })).status,
+    ).toBe(404)
+  })
+})

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -84,6 +84,7 @@
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-hook-form": "^7.85.0",
+        "react-query-kit": "^3.3.4",
         "react-resizable-panels": "^4.12.2",
         "react-router": "^7.18.2",
         "shiki": "^3.23.0",


### PR DESCRIPTION
First phase of moving provider and schedule config off the cloud and onto the machine. **Server side only.** Nothing reads or writes these tables yet, so the extension is unaffected and this ships dark.

## Tables

Two, beside the existing `agents`, `conversations` and `oauth`:

```
llm_providers    id, profile_id, type, name, base_url, model_id,
                 supports_images, context_window, temperature,
                 api_key, access_key_id, secret_access_key, session_token,
                 resource_name, region, reasoning_effort, reasoning_summary,
                 created_at, updated_at

scheduled_jobs   id, profile_id, name, query, schedule_type, schedule_time,
                 schedule_interval, enabled, provider_id, last_run_at,
                 created_at, updated_at
```

Plus `GET`, `PUT` and `DELETE` routes for each, following the shape of the conversations routes.

## Decisions worth reviewing

**Credentials live here in the clear.** Next to the OAuth access and refresh tokens already in this database, protected by filesystem permissions and nothing more. That is the same posture they had in extension storage, and it is the reason the cloud copy of a provider was never usable on a second device: it deliberately never carried a key, which is what the "incomplete provider" flow in settings exists for.

**`profile_id` is reserved and always null.** No extension API exposes a browser profile identifier. `browser_os.idl` declares eight functions and none of them is profile related; `chrome.identity.getProfileUserInfo()` needs a permission this manifest does not request and returns Google account details only when the user is signed into Chrome, which is the dependency this work removes. So every profile on a machine shares one database, and the column exists so isolation can be turned on later without a second migration.

**Upserts key on the client-supplied id and leave `created_at` alone on conflict.** The migration that follows runs once per browser profile and again after any partial failure, so landing twice has to be indistinguishable from landing once. Two tests cover exactly that.

**The job to provider reference sets null rather than cascading.** A job whose provider was deleted should surface as needing attention, not disappear because of a delete the user made somewhere else.

**Stores are modules of named functions rather than classes**, per the repo's functions-first rule, exposed as a plain object so the routes keep the same injectable shape the conversation routes use.

## Two things found along the way

**`temperature` had to be `real`, not `integer`.** The default is `0.2`, and an integer column floors it to `0`. Caught before generating the migration; verified `REAL` in the applied schema.

**The app's `.gitignore` had a bare `db/` rule.** It matches a directory of that name at any depth, so it covered `src/lib/db/` and `tests/lib/db/` as well as the runtime directory it was meant for. The new schema files and the migration landed ignored and had to be force-added, and the existing schema files turn out to be tracked only because they were force-added the same way. Both rules are now anchored with a leading slash. Verified in both directions: source and tests are no longer ignored, a runtime `db/` and `identity/` at the app root still are. Nothing was missing from the repository, so this closes a trap rather than recovering anything.

## Verification

- 20 new route tests, 215 passing across the server API suites.
- Migration applied against a real database and the tables inspected: both present, `temperature` is `REAL`.
- `typecheck` clean, `lint` clean with counts unchanged from base.

## Next phases

Message plus stop syncing, the history union, the app-initiated migration, then the read and write path switch. Only that last one can change behaviour, and it ships alone.