### PR TITLE
feat: migrate providers and scheduled jobs into local storage

### DIFF
--- a/packages/browseros-agent/apps/app/entrypoints/background/index.ts
+++ b/packages/browseros-agent/apps/app/entrypoints/background/index.ts
@@ -23,6 +23,7 @@ import { authRedirectPathStorage } from '@/lib/onboarding/onboardingStorage'
 import { searchActionsStorage } from '@/lib/search-actions/searchActionsStorage'
 import { selectedTextStorage } from '@/lib/selected-text/selectedTextStorage'
 import { stopAgentStorage } from '@/lib/stop-agent/stop-agent-storage'
+import { startLocalFirstMigration } from '@/modules/local-first-migration/start-local-first-migration'
 import { scheduledJobRuns } from './scheduledJobRuns'
 
 const LEGACY_TOOL_APPROVAL_STORAGE_KEYS = [
@@ -50,6 +51,7 @@ export default defineBackground(() => {
 
   Capabilities.initialize().catch(() => null)
   setupLlmProvidersBackupToBrowserOS()
+  startLocalFirstMigration()
 
   scheduledJobRuns()
 

--- a/packages/browseros-agent/apps/app/lib/llm-providers/removed-provider-types.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/removed-provider-types.ts
@@ -1,0 +1,22 @@
+import type { LlmProviderConfig } from './types'
+
+/**
+ * Provider types that no longer exist. Storage migrations 4 and 5 strip these,
+ * but the `browseros.providers` pref backup has no migration path, so a stale
+ * backup can still be holding them.
+ */
+export const REMOVED_PROVIDER_TYPES = new Set([
+  'remote-hermes',
+  'claude-code',
+  'codex',
+  'acp-custom',
+])
+
+export function dropRemovedProviderConfigs(
+  providers: LlmProviderConfig[] | null,
+): LlmProviderConfig[] | null {
+  if (!providers) return providers
+  return providers.filter(
+    (provider) => !REMOVED_PROVIDER_TYPES.has(String(provider.type)),
+  )
+}

--- a/packages/browseros-agent/apps/app/lib/llm-providers/storage.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/storage.ts
@@ -9,25 +9,10 @@ import {
   DEFAULT_PROVIDER_ID,
   DEFAULT_PROVIDER_NAME,
 } from './provider-selection'
+import { dropRemovedProviderConfigs } from './removed-provider-types'
 import type { LlmProviderConfig, LlmProvidersBackup } from './types'
 
 export { DEFAULT_PROVIDER_ID } from './provider-selection'
-
-const REMOVED_PROVIDER_TYPES = new Set([
-  'remote-hermes',
-  'claude-code',
-  'codex',
-  'acp-custom',
-])
-
-function dropRemovedProviderConfigs(
-  providers: LlmProviderConfig[] | null,
-): LlmProviderConfig[] | null {
-  if (!providers) return providers
-  return providers.filter(
-    (provider) => !REMOVED_PROVIDER_TYPES.has(String(provider.type)),
-  )
-}
 
 export const providersStorage = storage.defineItem<LlmProviderConfig[]>(
   'local:llm-providers',

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.helpers.test.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.helpers.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'bun:test'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import type { ScheduledJob } from '@/lib/schedules/scheduleTypes'
 import {
+  isImportableJob,
+  isImportableProvider,
   mergeProviderSources,
   parseProviderBackup,
   toProviderImport,
@@ -133,5 +135,105 @@ describe('toScheduledJobImport', () => {
 
   it('leaves an absent lastRunAt absent', () => {
     expect(toScheduledJobImport(job()).lastRunAt).toBeUndefined()
+  })
+})
+
+describe('isImportableProvider', () => {
+  it('accepts a well formed provider', () => {
+    expect(isImportableProvider(provider())).toBe(true)
+  })
+
+  // A single entry the server rejects returns 400 for the whole batch, and
+  // because the pref backup has no migration path that failure would repeat on
+  // every startup with nothing the user could do about it.
+  it.each([
+    ['no id', { id: '' }],
+    ['no type', { type: '' }],
+    ['no name', { name: '' }],
+    ['no model', { modelId: '' }],
+  ])('rejects a provider with %s', (_label, overrides) => {
+    expect(isImportableProvider(provider(overrides as never))).toBe(false)
+  })
+
+  it('rejects a provider whose context window is not a number', () => {
+    expect(
+      isImportableProvider({ ...provider(), contextWindow: '200000' }),
+    ).toBe(false)
+    expect(isImportableProvider({ ...provider(), contextWindow: NaN })).toBe(
+      false,
+    )
+  })
+
+  // Storage migrations drop these; the pref backup never gets that treatment.
+  it('rejects provider types that no longer exist', () => {
+    for (const type of [
+      'remote-hermes',
+      'claude-code',
+      'codex',
+      'acp-custom',
+    ]) {
+      expect(isImportableProvider(provider({ type } as never))).toBe(false)
+    }
+  })
+
+  it('rejects values that are not objects', () => {
+    expect(isImportableProvider(null)).toBe(false)
+    expect(isImportableProvider('provider')).toBe(false)
+  })
+})
+
+describe('isImportableJob', () => {
+  it('accepts a well formed job', () => {
+    expect(isImportableJob(job())).toBe(true)
+  })
+
+  it('rejects a job missing the fields the server requires', () => {
+    expect(isImportableJob(job({ name: '' }))).toBe(false)
+    expect(isImportableJob(job({ query: '' }))).toBe(false)
+  })
+
+  it('rejects an unrecognised schedule type', () => {
+    expect(isImportableJob(job({ scheduleType: 'weekly' } as never))).toBe(
+      false,
+    )
+  })
+})
+
+describe('optional field sanitising', () => {
+  // The provider is valid where it matters, so it should still import; the
+  // junk field is dropped and the server applies its own default.
+  it('drops an optional field holding the wrong type', () => {
+    const imported = toProviderImport({
+      ...provider(),
+      temperature: 'warm',
+      supportsImages: 'yes',
+      baseUrl: 42,
+    } as never)
+
+    expect(imported.temperature).toBeUndefined()
+    expect(imported.supportsImages).toBeUndefined()
+    expect(imported.baseUrl).toBeUndefined()
+    expect(imported.modelId).toBe('gpt-5.5')
+  })
+
+  it('keeps optional fields that are the right type', () => {
+    const imported = toProviderImport(
+      provider({ baseUrl: 'https://api.openai.com/v1' }),
+    )
+    expect(imported.baseUrl).toBe('https://api.openai.com/v1')
+    expect(imported.temperature).toBe(0.2)
+    expect(imported.supportsImages).toBe(true)
+  })
+
+  it('drops a job field holding the wrong type', () => {
+    const imported = toScheduledJobImport({
+      ...job(),
+      scheduleInterval: 'hourly',
+      enabled: 'true',
+    } as never)
+
+    expect(imported.scheduleInterval).toBeUndefined()
+    expect(imported.enabled).toBeUndefined()
+    expect(imported.name).toBe('Morning digest')
   })
 })

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.helpers.test.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.helpers.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'bun:test'
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import type { ScheduledJob } from '@/lib/schedules/scheduleTypes'
+import {
+  mergeProviderSources,
+  parseProviderBackup,
+  toProviderImport,
+  toScheduledJobImport,
+} from './local-first-migration.helpers'
+
+function provider(
+  overrides: Partial<LlmProviderConfig> = {},
+): LlmProviderConfig {
+  return {
+    id: 'provider-1',
+    type: 'openai',
+    name: 'My OpenAI',
+    modelId: 'gpt-5.5',
+    supportsImages: true,
+    contextWindow: 200000,
+    temperature: 0.2,
+    createdAt: 10,
+    updatedAt: 20,
+    ...overrides,
+  }
+}
+
+function job(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
+  return {
+    id: 'job-1',
+    name: 'Morning digest',
+    query: 'summarise my inbox',
+    scheduleType: 'daily',
+    scheduleTime: '09:00',
+    enabled: true,
+    createdAt: '2026-01-02T03:04:05.000Z',
+    updatedAt: '2026-01-02T03:04:05.000Z',
+    ...overrides,
+  }
+}
+
+describe('parseProviderBackup', () => {
+  it('reads the provider list out of the pref payload', () => {
+    const raw = JSON.stringify({
+      defaultProviderId: 'provider-1',
+      providers: [provider()],
+    })
+    expect(parseProviderBackup(raw).map((p) => p.id)).toEqual(['provider-1'])
+  })
+
+  // The backup is a fallback source, so a corrupt one must not stop the
+  // extension-storage providers from importing.
+  it('yields nothing rather than throwing on unusable input', () => {
+    expect(parseProviderBackup('not json')).toEqual([])
+    expect(parseProviderBackup('null')).toEqual([])
+    expect(parseProviderBackup(JSON.stringify({ providers: 'nope' }))).toEqual(
+      [],
+    )
+    expect(parseProviderBackup(undefined)).toEqual([])
+    expect(parseProviderBackup('')).toEqual([])
+  })
+
+  it('drops entries with no id', () => {
+    const raw = JSON.stringify({ providers: [provider(), { name: 'junk' }] })
+    expect(parseProviderBackup(raw)).toHaveLength(1)
+  })
+})
+
+describe('mergeProviderSources', () => {
+  // Extension storage is written on every save, so it is the current copy.
+  it('keeps the stored provider when both sources have the id', () => {
+    const merged = mergeProviderSources(
+      [provider({ name: 'Current' })],
+      [provider({ name: 'Stale backup' })],
+    )
+    expect(merged).toHaveLength(1)
+    expect(merged[0].name).toBe('Current')
+  })
+
+  // The reinstall case: extension storage was cleared, the per-profile pref
+  // outlived it, and the backup is the only remaining copy.
+  it('contributes backup providers that storage no longer has', () => {
+    const merged = mergeProviderSources([], [provider({ id: 'from-backup' })])
+    expect(merged.map((p) => p.id)).toEqual(['from-backup'])
+  })
+
+  it('does not duplicate a provider repeated within the backup', () => {
+    const merged = mergeProviderSources([], [provider(), provider()])
+    expect(merged).toHaveLength(1)
+  })
+})
+
+describe('toProviderImport', () => {
+  it('carries the credentials across', () => {
+    expect(
+      toProviderImport(
+        provider({
+          apiKey: 'sk-test',
+          accessKeyId: 'AKIA',
+          secretAccessKey: 'secret',
+          sessionToken: 'token',
+        }),
+      ),
+    ).toMatchObject({
+      apiKey: 'sk-test',
+      accessKeyId: 'AKIA',
+      secretAccessKey: 'secret',
+      sessionToken: 'token',
+    })
+  })
+
+  it('preserves the original creation time', () => {
+    expect(toProviderImport(provider()).createdAt).toBe(10)
+  })
+})
+
+describe('toScheduledJobImport', () => {
+  it('converts the ISO timestamps the extension holds to epoch', () => {
+    const imported = toScheduledJobImport(
+      job({ lastRunAt: '2026-01-03T00:00:00.000Z' }),
+    )
+    expect(imported.createdAt).toBe(Date.parse('2026-01-02T03:04:05.000Z'))
+    expect(imported.lastRunAt).toBe(Date.parse('2026-01-03T00:00:00.000Z'))
+  })
+
+  // NaN would fail validation and take the whole batch down with it, so the
+  // job lands with the server's own timestamp instead.
+  it('drops an unparseable timestamp rather than sending NaN', () => {
+    const imported = toScheduledJobImport(job({ createdAt: 'whenever' }))
+    expect(imported.createdAt).toBeUndefined()
+    expect(imported.name).toBe('Morning digest')
+  })
+
+  it('leaves an absent lastRunAt absent', () => {
+    expect(toScheduledJobImport(job()).lastRunAt).toBeUndefined()
+  })
+})

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.helpers.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.helpers.ts
@@ -1,0 +1,134 @@
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import type { ScheduledJob } from '@/lib/schedules/scheduleTypes'
+
+/** Payload for `POST /llm-providers/import`. */
+export interface ProviderImport {
+  id: string
+  type: string
+  name: string
+  baseUrl?: string
+  modelId: string
+  supportsImages: boolean
+  contextWindow: number
+  temperature: number
+  apiKey?: string
+  accessKeyId?: string
+  secretAccessKey?: string
+  sessionToken?: string
+  resourceName?: string
+  region?: string
+  reasoningEffort?: string
+  reasoningSummary?: string
+  createdAt?: number
+}
+
+/** Payload for `POST /scheduled-jobs/import`. */
+export interface ScheduledJobImport {
+  id: string
+  name: string
+  query: string
+  scheduleType: ScheduledJob['scheduleType']
+  scheduleTime?: string
+  scheduleInterval?: number
+  enabled: boolean
+  providerId?: string
+  lastRunAt?: number
+  createdAt?: number
+}
+
+/**
+ * Reads the provider list out of the `browseros.providers` pref backup.
+ *
+ * The pref holds a JSON string of `LlmProvidersBackup`. It is a fallback
+ * source, so anything unparseable yields nothing rather than throwing: a
+ * corrupt backup must not stop the extension-storage providers from importing.
+ */
+export function parseProviderBackup(raw: unknown): LlmProviderConfig[] {
+  if (typeof raw !== 'string' || raw.length === 0) return []
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return []
+    const providers = (parsed as { providers?: unknown }).providers
+    if (!Array.isArray(providers)) return []
+    return providers.filter(
+      (provider): provider is LlmProviderConfig =>
+        typeof provider === 'object' &&
+        provider !== null &&
+        typeof (provider as LlmProviderConfig).id === 'string',
+    )
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Unions the two local provider sources, extension storage winning on id.
+ *
+ * Extension storage is what the app writes on every save, so it is the current
+ * copy. The pref backup only contributes providers missing from it, which is
+ * the reinstall case: extension storage was cleared and the per-profile pref
+ * outlived it.
+ */
+export function mergeProviderSources(
+  stored: readonly LlmProviderConfig[],
+  backup: readonly LlmProviderConfig[],
+): LlmProviderConfig[] {
+  const merged = [...stored]
+  const seen = new Set(stored.map((provider) => provider.id))
+  for (const provider of backup) {
+    if (seen.has(provider.id)) continue
+    seen.add(provider.id)
+    merged.push(provider)
+  }
+  return merged
+}
+
+export function toProviderImport(config: LlmProviderConfig): ProviderImport {
+  return {
+    id: config.id,
+    type: config.type,
+    name: config.name,
+    baseUrl: config.baseUrl,
+    modelId: config.modelId,
+    supportsImages: config.supportsImages,
+    contextWindow: config.contextWindow,
+    temperature: config.temperature,
+    apiKey: config.apiKey,
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    sessionToken: config.sessionToken,
+    resourceName: config.resourceName,
+    region: config.region,
+    reasoningEffort: config.reasoningEffort,
+    reasoningSummary: config.reasoningSummary,
+    createdAt: config.createdAt,
+  }
+}
+
+/**
+ * Jobs hold ISO strings here and epoch numbers in the database.
+ *
+ * An unparseable timestamp is dropped rather than sent as NaN, which would
+ * fail validation and take the whole batch with it. The server then stamps its
+ * own `createdAt`, so the job still lands.
+ */
+function toEpoch(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+export function toScheduledJobImport(job: ScheduledJob): ScheduledJobImport {
+  return {
+    id: job.id,
+    name: job.name,
+    query: job.query,
+    scheduleType: job.scheduleType,
+    scheduleTime: job.scheduleTime,
+    scheduleInterval: job.scheduleInterval,
+    enabled: job.enabled,
+    providerId: job.providerId,
+    lastRunAt: toEpoch(job.lastRunAt),
+    createdAt: toEpoch(job.createdAt),
+  }
+}

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.helpers.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.helpers.ts
@@ -1,3 +1,4 @@
+import { REMOVED_PROVIDER_TYPES } from '@/lib/llm-providers/removed-provider-types'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import type { ScheduledJob } from '@/lib/schedules/scheduleTypes'
 
@@ -8,9 +9,9 @@ export interface ProviderImport {
   name: string
   baseUrl?: string
   modelId: string
-  supportsImages: boolean
+  supportsImages?: boolean
   contextWindow: number
-  temperature: number
+  temperature?: number
   apiKey?: string
   accessKeyId?: string
   secretAccessKey?: string
@@ -30,7 +31,7 @@ export interface ScheduledJobImport {
   scheduleType: ScheduledJob['scheduleType']
   scheduleTime?: string
   scheduleInterval?: number
-  enabled: boolean
+  enabled?: boolean
   providerId?: string
   lastRunAt?: number
   createdAt?: number
@@ -61,6 +62,64 @@ export function parseProviderBackup(raw: unknown): LlmProviderConfig[] {
   }
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function optionalString(value: unknown): string | undefined {
+  return isNonEmptyString(value) ? value : undefined
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined
+}
+
+/**
+ * Whether a provider can be sent to the import endpoint.
+ *
+ * The required fields are exactly the ones the server requires, because a
+ * single entry it rejects returns 400 for the whole batch. That would be
+ * permanent rather than transient: the pref backup has no migration path, so
+ * the same bad entry would fail the import, block the scheduled jobs behind
+ * it, and leave the done marker unset to retry forever.
+ *
+ * Removed types are excluded for a related reason. Storage migrations drop
+ * them, the pref backup never gets that treatment, and importing one would
+ * put a provider of a type the app no longer supports into the database.
+ */
+export function isImportableProvider(
+  value: unknown,
+): value is LlmProviderConfig {
+  if (typeof value !== 'object' || value === null) return false
+  const provider = value as Partial<LlmProviderConfig>
+  return (
+    isNonEmptyString(provider.id) &&
+    isNonEmptyString(provider.type) &&
+    !REMOVED_PROVIDER_TYPES.has(provider.type) &&
+    isNonEmptyString(provider.name) &&
+    isNonEmptyString(provider.modelId) &&
+    optionalNumber(provider.contextWindow) !== undefined
+  )
+}
+
+/** Same contract as `isImportableProvider`, for the scheduled jobs batch. */
+export function isImportableJob(value: unknown): value is ScheduledJob {
+  if (typeof value !== 'object' || value === null) return false
+  const job = value as Partial<ScheduledJob>
+  return (
+    isNonEmptyString(job.id) &&
+    isNonEmptyString(job.name) &&
+    isNonEmptyString(job.query) &&
+    (job.scheduleType === 'daily' ||
+      job.scheduleType === 'hourly' ||
+      job.scheduleType === 'minutes')
+  )
+}
+
 /**
  * Unions the two local provider sources, extension storage winning on id.
  *
@@ -83,25 +142,31 @@ export function mergeProviderSources(
   return merged
 }
 
+/**
+ * Optional fields pass through a type check rather than straight across, so a
+ * provider that is well formed where it matters still imports when one of its
+ * optional fields holds junk. Dropping the field lets the server apply its own
+ * default; sending the wrong type would fail the whole batch.
+ */
 export function toProviderImport(config: LlmProviderConfig): ProviderImport {
   return {
     id: config.id,
     type: config.type,
     name: config.name,
-    baseUrl: config.baseUrl,
+    baseUrl: optionalString(config.baseUrl),
     modelId: config.modelId,
-    supportsImages: config.supportsImages,
+    supportsImages: optionalBoolean(config.supportsImages),
     contextWindow: config.contextWindow,
-    temperature: config.temperature,
-    apiKey: config.apiKey,
-    accessKeyId: config.accessKeyId,
-    secretAccessKey: config.secretAccessKey,
-    sessionToken: config.sessionToken,
-    resourceName: config.resourceName,
-    region: config.region,
-    reasoningEffort: config.reasoningEffort,
-    reasoningSummary: config.reasoningSummary,
-    createdAt: config.createdAt,
+    temperature: optionalNumber(config.temperature),
+    apiKey: optionalString(config.apiKey),
+    accessKeyId: optionalString(config.accessKeyId),
+    secretAccessKey: optionalString(config.secretAccessKey),
+    sessionToken: optionalString(config.sessionToken),
+    resourceName: optionalString(config.resourceName),
+    region: optionalString(config.region),
+    reasoningEffort: optionalString(config.reasoningEffort),
+    reasoningSummary: optionalString(config.reasoningSummary),
+    createdAt: optionalNumber(config.createdAt),
   }
 }
 
@@ -112,8 +177,8 @@ export function toProviderImport(config: LlmProviderConfig): ProviderImport {
  * fail validation and take the whole batch with it. The server then stamps its
  * own `createdAt`, so the job still lands.
  */
-function toEpoch(value: string | undefined): number | undefined {
-  if (!value) return undefined
+function toEpoch(value: unknown): number | undefined {
+  if (!isNonEmptyString(value)) return undefined
   const parsed = Date.parse(value)
   return Number.isNaN(parsed) ? undefined : parsed
 }
@@ -124,10 +189,10 @@ export function toScheduledJobImport(job: ScheduledJob): ScheduledJobImport {
     name: job.name,
     query: job.query,
     scheduleType: job.scheduleType,
-    scheduleTime: job.scheduleTime,
-    scheduleInterval: job.scheduleInterval,
-    enabled: job.enabled,
-    providerId: job.providerId,
+    scheduleTime: optionalString(job.scheduleTime),
+    scheduleInterval: optionalNumber(job.scheduleInterval),
+    enabled: optionalBoolean(job.enabled),
+    providerId: optionalString(job.providerId),
     lastRunAt: toEpoch(job.lastRunAt),
     createdAt: toEpoch(job.createdAt),
   }

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.test.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'bun:test'
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import type { ScheduledJob } from '@/lib/schedules/scheduleTypes'
+import {
+  type LocalFirstMigrationDeps,
+  runLocalFirstMigration,
+} from './local-first-migration'
+import type {
+  ProviderImport,
+  ScheduledJobImport,
+} from './local-first-migration.helpers'
+
+function provider(
+  overrides: Partial<LlmProviderConfig> = {},
+): LlmProviderConfig {
+  return {
+    id: 'provider-1',
+    type: 'openai',
+    name: 'My OpenAI',
+    modelId: 'gpt-5.5',
+    supportsImages: true,
+    contextWindow: 200000,
+    temperature: 0.2,
+    apiKey: 'sk-test',
+    createdAt: 10,
+    updatedAt: 20,
+    ...overrides,
+  }
+}
+
+function job(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
+  return {
+    id: 'job-1',
+    name: 'Morning digest',
+    query: 'summarise my inbox',
+    scheduleType: 'daily',
+    enabled: true,
+    createdAt: '2026-01-02T03:04:05.000Z',
+    updatedAt: '2026-01-02T03:04:05.000Z',
+    ...overrides,
+  }
+}
+
+interface Harness {
+  deps: LocalFirstMigrationDeps
+  done: () => boolean
+  importedProviders: ProviderImport[][]
+  importedJobs: ScheduledJobImport[][]
+}
+
+function harness(overrides: Partial<LocalFirstMigrationDeps> = {}): Harness {
+  let done = false
+  const importedProviders: ProviderImport[][] = []
+  const importedJobs: ScheduledJobImport[][] = []
+
+  return {
+    done: () => done,
+    importedProviders,
+    importedJobs,
+    deps: {
+      isDone: async () => done,
+      markDone: async () => {
+        done = true
+      },
+      loadStoredProviders: async () => [],
+      loadBackupProviders: async () => [],
+      loadScheduledJobs: async () => [],
+      importProviders: async (providers) => {
+        importedProviders.push(providers)
+      },
+      importScheduledJobs: async (jobs) => {
+        importedJobs.push(jobs)
+      },
+      ...overrides,
+    },
+  }
+}
+
+describe('runLocalFirstMigration', () => {
+  it('imports providers and jobs, then records that it ran', async () => {
+    const h = harness({
+      loadStoredProviders: async () => [provider()],
+      loadScheduledJobs: async () => [job()],
+    })
+
+    const result = await runLocalFirstMigration(h.deps)
+
+    expect(result).toEqual({
+      ranMigration: true,
+      providerCount: 1,
+      jobCount: 1,
+    })
+    expect(h.importedProviders[0][0]).toMatchObject({
+      id: 'provider-1',
+      apiKey: 'sk-test',
+    })
+    expect(h.importedJobs[0][0]).toMatchObject({ id: 'job-1' })
+    expect(h.done()).toBe(true)
+  })
+
+  // The whole point of the marker: providers the user has since deleted must
+  // not come back on the next startup.
+  it('does nothing once it has already run', async () => {
+    const h = harness({
+      isDone: async () => true,
+      loadStoredProviders: async () => [provider()],
+    })
+
+    const result = await runLocalFirstMigration(h.deps)
+
+    expect(result.ranMigration).toBe(false)
+    expect(h.importedProviders).toHaveLength(0)
+  })
+
+  it('unions the pref backup with extension storage', async () => {
+    const h = harness({
+      loadStoredProviders: async () => [provider()],
+      loadBackupProviders: async () => [provider({ id: 'from-backup' })],
+    })
+
+    await runLocalFirstMigration(h.deps)
+
+    expect(h.importedProviders[0].map((p) => p.id)).toEqual([
+      'provider-1',
+      'from-backup',
+    ])
+  })
+
+  it('marks itself done with nothing to import so it stops retrying', async () => {
+    const h = harness()
+
+    const result = await runLocalFirstMigration(h.deps)
+
+    expect(result).toEqual({
+      ranMigration: true,
+      providerCount: 0,
+      jobCount: 0,
+    })
+    expect(h.importedProviders).toHaveLength(0)
+    expect(h.importedJobs).toHaveLength(0)
+    expect(h.done()).toBe(true)
+  })
+
+  // A failed run must retry on the next startup, which is only safe because
+  // the server inserts what is absent rather than replacing.
+  it('leaves itself unmarked when the import fails', async () => {
+    const h = harness({
+      loadStoredProviders: async () => [provider()],
+      importProviders: async () => {
+        throw new Error('server not up')
+      },
+    })
+
+    await expect(runLocalFirstMigration(h.deps)).rejects.toThrow(
+      'server not up',
+    )
+    expect(h.done()).toBe(false)
+  })
+
+  it('does not mark itself done when the jobs import fails after providers landed', async () => {
+    const h = harness({
+      loadStoredProviders: async () => [provider()],
+      loadScheduledJobs: async () => [job()],
+      importScheduledJobs: async () => {
+        throw new Error('server not up')
+      },
+    })
+
+    await expect(runLocalFirstMigration(h.deps)).rejects.toThrow(
+      'server not up',
+    )
+    expect(h.importedProviders).toHaveLength(1)
+    expect(h.done()).toBe(false)
+  })
+})

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.test.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.test.ts
@@ -141,6 +141,54 @@ describe('runLocalFirstMigration', () => {
     expect(h.done()).toBe(true)
   })
 
+  // The whole batch is one request, so an entry the server rejects would take
+  // the valid providers down with it, block the jobs queued behind it, and
+  // leave the marker unset to fail again on every startup.
+  it('drops an unusable backup entry instead of failing the batch', async () => {
+    const h = harness({
+      loadStoredProviders: async () => [provider()],
+      loadBackupProviders: async () =>
+        [
+          { id: 'stale', name: 'half a provider' },
+          provider({ id: 'removed-type', type: 'remote-hermes' as never }),
+        ] as never,
+      loadScheduledJobs: async () => [job()],
+    })
+
+    const result = await runLocalFirstMigration(h.deps)
+
+    expect(h.importedProviders[0].map((p) => p.id)).toEqual(['provider-1'])
+    expect(h.importedJobs).toHaveLength(1)
+    expect(result.ranMigration).toBe(true)
+    expect(h.done()).toBe(true)
+  })
+
+  it('drops a job the server would reject without losing the rest', async () => {
+    const h = harness({
+      loadScheduledJobs: async () =>
+        [job(), { id: 'broken', name: '', query: '' }] as never,
+    })
+
+    await runLocalFirstMigration(h.deps)
+
+    expect(h.importedJobs[0].map((j) => j.id)).toEqual(['job-1'])
+    expect(h.done()).toBe(true)
+  })
+
+  // Filtering runs before the merge, so an unusable stored entry cannot win
+  // the id and take a perfectly good backup copy down with it.
+  it('falls back to the backup copy when the stored one is unusable', async () => {
+    const h = harness({
+      loadStoredProviders: async () => [{ id: 'provider-1' }] as never,
+      loadBackupProviders: async () => [provider({ name: 'From backup' })],
+    })
+
+    await runLocalFirstMigration(h.deps)
+
+    expect(h.importedProviders[0]).toHaveLength(1)
+    expect(h.importedProviders[0][0].name).toBe('From backup')
+  })
+
   // A failed run must retry on the next startup, which is only safe because
   // the server inserts what is absent rather than replacing.
   it('leaves itself unmarked when the import fails', async () => {

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.ts
@@ -5,6 +5,8 @@ import type {
   ScheduledJobImport,
 } from './local-first-migration.helpers'
 import {
+  isImportableJob,
+  isImportableProvider,
   mergeProviderSources,
   toProviderImport,
   toScheduledJobImport,
@@ -56,8 +58,14 @@ export async function runLocalFirstMigration(
     deps.loadScheduledJobs(),
   ])
 
-  const providers = mergeProviderSources(stored, backup).map(toProviderImport)
-  const scheduledJobs = jobs.map(toScheduledJobImport)
+  // Filtering happens before the merge, not after: an unusable stored entry
+  // would otherwise win the id and then be dropped, losing a provider whose
+  // backup copy was perfectly good.
+  const providers = mergeProviderSources(
+    stored.filter(isImportableProvider),
+    backup.filter(isImportableProvider),
+  ).map(toProviderImport)
+  const scheduledJobs = jobs.filter(isImportableJob).map(toScheduledJobImport)
 
   if (providers.length > 0) await deps.importProviders(providers)
   if (scheduledJobs.length > 0) await deps.importScheduledJobs(scheduledJobs)

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/local-first-migration.ts
@@ -1,0 +1,72 @@
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import type { ScheduledJob } from '@/lib/schedules/scheduleTypes'
+import type {
+  ProviderImport,
+  ScheduledJobImport,
+} from './local-first-migration.helpers'
+import {
+  mergeProviderSources,
+  toProviderImport,
+  toScheduledJobImport,
+} from './local-first-migration.helpers'
+
+export interface LocalFirstMigrationDeps {
+  isDone: () => Promise<boolean>
+  markDone: () => Promise<void>
+  loadStoredProviders: () => Promise<LlmProviderConfig[]>
+  loadBackupProviders: () => Promise<LlmProviderConfig[]>
+  loadScheduledJobs: () => Promise<ScheduledJob[]>
+  importProviders: (providers: ProviderImport[]) => Promise<void>
+  importScheduledJobs: (jobs: ScheduledJobImport[]) => Promise<void>
+}
+
+export interface LocalFirstMigrationResult {
+  ranMigration: boolean
+  providerCount: number
+  jobCount: number
+}
+
+const SKIPPED: LocalFirstMigrationResult = {
+  ranMigration: false,
+  providerCount: 0,
+  jobCount: 0,
+}
+
+/**
+ * Moves providers and scheduled jobs from extension storage into the server
+ * database, once.
+ *
+ * Only local sources are read. The cloud is deliberately not one: its
+ * scheduled jobs include every job deleted since the deletion queue lost its
+ * only reader, and its providers never carried credentials, so they are
+ * already handled by the incomplete-provider prompt in AI settings.
+ *
+ * The done marker is set only after both imports land. A failed run leaves it
+ * unset and retries on the next startup, which is safe because the server side
+ * inserts only what is absent.
+ */
+export async function runLocalFirstMigration(
+  deps: LocalFirstMigrationDeps,
+): Promise<LocalFirstMigrationResult> {
+  if (await deps.isDone()) return SKIPPED
+
+  const [stored, backup, jobs] = await Promise.all([
+    deps.loadStoredProviders(),
+    deps.loadBackupProviders(),
+    deps.loadScheduledJobs(),
+  ])
+
+  const providers = mergeProviderSources(stored, backup).map(toProviderImport)
+  const scheduledJobs = jobs.map(toScheduledJobImport)
+
+  if (providers.length > 0) await deps.importProviders(providers)
+  if (scheduledJobs.length > 0) await deps.importScheduledJobs(scheduledJobs)
+
+  await deps.markDone()
+
+  return {
+    ranMigration: true,
+    providerCount: providers.length,
+    jobCount: scheduledJobs.length,
+  }
+}

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/start-local-first-migration.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/start-local-first-migration.ts
@@ -1,0 +1,66 @@
+import type { LlmProviderRoutes, ScheduledJobRoutes } from '@browseros/server'
+import { storage } from '@wxt-dev/storage'
+import { hc } from 'hono/client'
+import { getBrowserOSAdapter } from '@/lib/browseros/adapter'
+import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
+import { providersStorage } from '@/lib/llm-providers/storage'
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import { scheduledJobStorage } from '@/lib/schedules/scheduleStorage'
+import { resolveAgentServerUrlWithRetry } from '@/modules/browseros/agent-server-url.helpers'
+import { runLocalFirstMigration } from './local-first-migration'
+import {
+  type ProviderImport,
+  parseProviderBackup,
+  type ScheduledJobImport,
+} from './local-first-migration.helpers'
+
+/**
+ * Per profile, because extension storage is per profile. Losing it costs a
+ * redundant import that inserts nothing, never a lost or overwritten row,
+ * which is what insert-if-absent on the server buys.
+ */
+export const migrationDoneStorage = storage.defineItem<boolean>(
+  'local:local-first-migration-done',
+  { fallback: false },
+)
+
+async function loadBackupProviders(): Promise<LlmProviderConfig[]> {
+  try {
+    const pref = await getBrowserOSAdapter().getPref(BROWSEROS_PREFS.PROVIDERS)
+    return parseProviderBackup(pref?.value)
+  } catch {
+    // No BrowserOS API, or no backup written yet. Extension storage still runs.
+    return []
+  }
+}
+
+async function importProviders(providers: ProviderImport[]): Promise<void> {
+  const baseUrl = await resolveAgentServerUrlWithRetry()
+  const client = hc<LlmProviderRoutes>(`${baseUrl}/llm-providers`)
+  const response = await client.import.$post({ json: { providers } })
+  if (!response.ok) {
+    throw new Error(`Failed to import providers (${response.status})`)
+  }
+}
+
+async function importScheduledJobs(jobs: ScheduledJobImport[]): Promise<void> {
+  const baseUrl = await resolveAgentServerUrlWithRetry()
+  const client = hc<ScheduledJobRoutes>(`${baseUrl}/scheduled-jobs`)
+  const response = await client.import.$post({ json: { jobs } })
+  if (!response.ok) {
+    throw new Error(`Failed to import scheduled jobs (${response.status})`)
+  }
+}
+
+/** Fire and forget from the background; a failure retries on next startup. */
+export function startLocalFirstMigration(): void {
+  void runLocalFirstMigration({
+    isDone: () => migrationDoneStorage.getValue(),
+    markDone: () => migrationDoneStorage.setValue(true),
+    loadStoredProviders: async () => (await providersStorage.getValue()) ?? [],
+    loadBackupProviders,
+    loadScheduledJobs: async () => (await scheduledJobStorage.getValue()) ?? [],
+    importProviders,
+    importScheduledJobs,
+  }).catch(() => null)
+}

--- a/packages/browseros-agent/apps/server/src/api/routes/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/index.ts
@@ -136,6 +136,12 @@ export function createApiRoutes(deps: CreateApiRoutesDeps) {
       .use('/acpx/probe/*', requireTrustedAppOrigin())
       .use('/agents/*', requireTrustedAppOrigin())
       .use('/conversations/*', requireTrustedAppOrigin())
+      // These carry provider credentials in the clear, so they need the
+      // localhost + extension-origin check. The blanket requireTrustedOrigin
+      // above only rejects a request that carries a disallowed Origin header;
+      // one with no Origin at all passes it.
+      .use('/llm-providers/*', requireTrustedAppOrigin())
+      .use('/scheduled-jobs/*', requireTrustedAppOrigin())
       .route('/acpx/probe', createAcpxProbeRoutes({ resourcesDir }))
       .route('/agents', resolvedAgentRoutes)
       .route('/conversations', createConversationRoutes())

--- a/packages/browseros-agent/apps/server/src/api/routes/llm-providers.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/llm-providers.ts
@@ -40,6 +40,18 @@ const UpsertProviderSchema = z.object({
   createdAt: z.number().optional(),
 })
 
+/**
+ * Bulk one-time import from extension storage.
+ *
+ * Insert-if-absent, not upsert: the app writes to this table directly, so a
+ * second run must fill gaps without replacing a provider edited since. Each id
+ * comes back in exactly one of the two lists so the caller can report what was
+ * already present.
+ */
+const ImportProvidersSchema = z.object({
+  providers: z.array(UpsertProviderSchema.extend({ id: z.string().min(1) })),
+})
+
 export function createLlmProviderRoutes(
   options: { store?: LlmProviderStore } = {},
 ) {
@@ -47,6 +59,15 @@ export function createLlmProviderRoutes(
 
   return new Hono<Env>()
     .get('/', async (c) => c.json({ providers: await store.list() }))
+    .post('/import', zValidator('json', ImportProvidersSchema), async (c) => {
+      const imported: string[] = []
+      const skipped: string[] = []
+      for (const provider of c.req.valid('json').providers) {
+        const saved = await store.insertIfAbsent(provider)
+        ;(saved ? imported : skipped).push(provider.id)
+      }
+      return c.json({ imported, skipped })
+    })
     .get('/:providerId', zValidator('param', IdParamSchema), async (c) => {
       const provider = await store.get(c.req.valid('param').providerId)
       if (!provider) return c.json({ error: 'Unknown provider' }, 404)

--- a/packages/browseros-agent/apps/server/src/api/routes/scheduled-jobs.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/scheduled-jobs.ts
@@ -33,6 +33,11 @@ const UpsertJobSchema = z.object({
   createdAt: z.number().optional(),
 })
 
+/** Bulk one-time import. Insert-if-absent, for the reason on the provider route. */
+const ImportJobsSchema = z.object({
+  jobs: z.array(UpsertJobSchema.extend({ id: z.string().min(1) })),
+})
+
 export function createScheduledJobRoutes(
   options: { store?: ScheduledJobStore } = {},
 ) {
@@ -40,6 +45,15 @@ export function createScheduledJobRoutes(
 
   return new Hono<Env>()
     .get('/', async (c) => c.json({ jobs: await store.list() }))
+    .post('/import', zValidator('json', ImportJobsSchema), async (c) => {
+      const imported: string[] = []
+      const skipped: string[] = []
+      for (const job of c.req.valid('json').jobs) {
+        const saved = await store.insertIfAbsent(job)
+        ;(saved ? imported : skipped).push(job.id)
+      }
+      return c.json({ imported, skipped })
+    })
     .get('/:jobId', zValidator('param', IdParamSchema), async (c) => {
       const job = await store.get(c.req.valid('param').jobId)
       if (!job) return c.json({ error: 'Unknown scheduled job' }, 404)

--- a/packages/browseros-agent/apps/server/src/lib/llm-providers/provider-store.ts
+++ b/packages/browseros-agent/apps/server/src/lib/llm-providers/provider-store.ts
@@ -27,8 +27,17 @@ export type LlmProviderUpsert = Omit<
 export interface LlmProviderStore {
   list(): Promise<LlmProviderRow[]>
   get(id: string): Promise<LlmProviderRow | null>
-  /** Insert or replace by id. The migration relies on this being idempotent. */
+  /** Insert or replace by id. This is the app's ordinary write path. */
   upsert(row: LlmProviderUpsert): Promise<LlmProviderRow>
+  /**
+   * Insert only when the id is absent; returns null when a row already exists.
+   *
+   * The one-time import uses this rather than `upsert` because the app writes
+   * directly to this table as well. A second import run must never replace a
+   * provider the user has edited since with the stale copy still sitting in
+   * extension storage.
+   */
+  insertIfAbsent(row: LlmProviderUpsert): Promise<LlmProviderRow | null>
   remove(id: string): Promise<boolean>
 }
 
@@ -60,6 +69,20 @@ async function upsert(row: LlmProviderUpsert): Promise<LlmProviderRow> {
   return saved
 }
 
+async function insertIfAbsent(
+  row: LlmProviderUpsert,
+): Promise<LlmProviderRow | null> {
+  const now = Date.now()
+  // onConflictDoNothing returns no row on conflict, so the absent/present
+  // decision and the write are one statement rather than a select then insert.
+  const [saved] = await getDb()
+    .insert(llmProviders)
+    .values({ ...row, createdAt: row.createdAt ?? now, updatedAt: now })
+    .onConflictDoNothing({ target: llmProviders.id })
+    .returning()
+  return saved ?? null
+}
+
 async function remove(id: string): Promise<boolean> {
   const deleted = await getDb()
     .delete(llmProviders)
@@ -72,5 +95,6 @@ export const dbLlmProviderStore: LlmProviderStore = {
   list,
   get,
   upsert,
+  insertIfAbsent,
   remove,
 }

--- a/packages/browseros-agent/apps/server/src/lib/schedules/schedule-store.ts
+++ b/packages/browseros-agent/apps/server/src/lib/schedules/schedule-store.ts
@@ -27,8 +27,14 @@ export type ScheduledJobUpsert = Omit<
 export interface ScheduledJobStore {
   list(): Promise<ScheduledJobRow[]>
   get(id: string): Promise<ScheduledJobRow | null>
-  /** Insert or replace by id. The migration relies on this being idempotent. */
+  /** Insert or replace by id. This is the app's ordinary write path. */
   upsert(row: ScheduledJobUpsert): Promise<ScheduledJobRow>
+  /**
+   * Insert only when the id is absent; returns null when a row already exists.
+   * See the note on the provider store: the import must never overwrite a job
+   * the user has edited since.
+   */
+  insertIfAbsent(row: ScheduledJobUpsert): Promise<ScheduledJobRow | null>
   remove(id: string): Promise<boolean>
 }
 
@@ -58,6 +64,18 @@ async function upsert(row: ScheduledJobUpsert): Promise<ScheduledJobRow> {
   return saved
 }
 
+async function insertIfAbsent(
+  row: ScheduledJobUpsert,
+): Promise<ScheduledJobRow | null> {
+  const now = Date.now()
+  const [saved] = await getDb()
+    .insert(scheduledJobs)
+    .values({ ...row, createdAt: row.createdAt ?? now, updatedAt: now })
+    .onConflictDoNothing({ target: scheduledJobs.id })
+    .returning()
+  return saved ?? null
+}
+
 async function remove(id: string): Promise<boolean> {
   const deleted = await getDb()
     .delete(scheduledJobs)
@@ -70,5 +88,6 @@ export const dbScheduledJobStore: ScheduledJobStore = {
   list,
   get,
   upsert,
+  insertIfAbsent,
   remove,
 }

--- a/packages/browseros-agent/apps/server/src/rpc.ts
+++ b/packages/browseros-agent/apps/server/src/rpc.ts
@@ -1,5 +1,7 @@
 import type { createAgentRoutes } from './api/routes/agents'
 import type { createConversationRoutes } from './api/routes/conversations'
+import type { createLlmProviderRoutes } from './api/routes/llm-providers'
+import type { createScheduledJobRoutes } from './api/routes/scheduled-jobs'
 
 // Per-route client contracts for `hc`. Each protected route module is mounted at
 // its own path in createApiRoutes, and the extension builds a small typed client
@@ -12,3 +14,5 @@ import type { createConversationRoutes } from './api/routes/conversations'
 // runtime, no wrapper) while tracking the route definitions automatically.
 export type ConversationRoutes = ReturnType<typeof createConversationRoutes>
 export type AgentRoutes = ReturnType<typeof createAgentRoutes>
+export type LlmProviderRoutes = ReturnType<typeof createLlmProviderRoutes>
+export type ScheduledJobRoutes = ReturnType<typeof createScheduledJobRoutes>

--- a/packages/browseros-agent/apps/server/tests/api/routes/index.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/index.test.ts
@@ -210,4 +210,36 @@ describe('createApiRoutes', () => {
 
     expect(response.status).toBe(403)
   })
+
+  // These rows hold provider API keys in the clear. The blanket
+  // requireTrustedOrigin only rejects a request that carries a disallowed
+  // Origin, so a request with none passes it and the prefix guard is the only
+  // thing standing between another local process and the credentials.
+  it('keeps provider credentials behind app-origin auth', async () => {
+    const app = createTestApp()
+
+    expect((await app.request('/llm-providers')).status).toBe(403)
+    expect(
+      (
+        await app.request('/llm-providers', {}, {
+          server: { requestIP: () => ({ address: '192.168.1.20' }) },
+        } as never)
+      ).status,
+    ).toBe(403)
+  })
+
+  it('keeps scheduled jobs behind app-origin auth', async () => {
+    const app = createTestApp()
+
+    expect((await app.request('/scheduled-jobs')).status).toBe(403)
+    expect(
+      (
+        await app.request('/scheduled-jobs/import', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jobs: [] }),
+        })
+      ).status,
+    ).toBe(403)
+  })
 })

--- a/packages/browseros-agent/apps/server/tests/api/routes/llm-providers.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/llm-providers.test.ts
@@ -49,6 +49,10 @@ function memoryStore(initial: LlmProviderRow[] = []) {
       rows.set(saved.id, saved)
       return saved
     },
+    insertIfAbsent: async (input: LlmProviderUpsert) => {
+      if (rows.has(input.id)) return null
+      return store.upsert(input)
+    },
     remove: async (id) => rows.delete(id),
   }
   return { store, rows }
@@ -180,6 +184,70 @@ describe('llm provider routes', () => {
       accessKeyId: 'AKIA',
       secretAccessKey: 'secret',
       sessionToken: 'token',
+    })
+  })
+
+  describe('import', () => {
+    async function importProviders(
+      routes: ReturnType<typeof createLlmProviderRoutes>,
+      providers: unknown[],
+    ) {
+      return routes.request('/import', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ providers }),
+      })
+    }
+
+    it('inserts a provider that is not there yet', async () => {
+      const { store, rows } = memoryStore()
+      const routes = createLlmProviderRoutes({ store })
+      const response = await importProviders(routes, [
+        { ...body, id: PROVIDER_ID },
+      ])
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({
+        imported: [PROVIDER_ID],
+        skipped: [],
+      })
+      expect(rows.get(PROVIDER_ID)).toMatchObject({ apiKey: 'sk-test' })
+    })
+
+    // The whole reason import is insert-if-absent: the app writes here
+    // directly, so a second run must not restore the pre-edit copy that is
+    // still sitting in extension storage.
+    it('leaves an existing provider untouched and reports it skipped', async () => {
+      const { store, rows } = memoryStore([row({ name: 'Edited since' })])
+      const routes = createLlmProviderRoutes({ store })
+      const response = await importProviders(routes, [
+        { ...body, id: PROVIDER_ID, name: 'Stale copy' },
+      ])
+
+      expect(await response.json()).toEqual({
+        imported: [],
+        skipped: [PROVIDER_ID],
+      })
+      expect(rows.get(PROVIDER_ID)?.name).toBe('Edited since')
+    })
+
+    it('partitions a mixed batch', async () => {
+      const { store } = memoryStore([row()])
+      const routes = createLlmProviderRoutes({ store })
+      const response = await importProviders(routes, [
+        { ...body, id: PROVIDER_ID },
+        { ...body, id: 'provider-2' },
+      ])
+
+      expect(await response.json()).toEqual({
+        imported: ['provider-2'],
+        skipped: [PROVIDER_ID],
+      })
+    })
+
+    it('rejects a provider with no id', async () => {
+      const routes = createLlmProviderRoutes(memoryStore())
+      expect((await importProviders(routes, [body])).status).toBe(400)
     })
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/routes/scheduled-jobs.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/scheduled-jobs.test.ts
@@ -42,6 +42,10 @@ function memoryStore(initial: ScheduledJobRow[] = []) {
       rows.set(saved.id, saved)
       return saved
     },
+    insertIfAbsent: async (input: ScheduledJobUpsert) => {
+      if (rows.has(input.id)) return null
+      return store.upsert(input)
+    },
     remove: async (id) => rows.delete(id),
   }
   return { store, rows }
@@ -140,5 +144,44 @@ describe('scheduled job routes', () => {
     expect(
       (await routes.request(`/${JOB_ID}`, { method: 'DELETE' })).status,
     ).toBe(404)
+  })
+
+  describe('import', () => {
+    async function importJobs(
+      routes: ReturnType<typeof createScheduledJobRoutes>,
+      jobs: unknown[],
+    ) {
+      return routes.request('/import', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jobs }),
+      })
+    }
+
+    it('inserts a job that is not there yet', async () => {
+      const { store, rows } = memoryStore()
+      const routes = createScheduledJobRoutes({ store })
+      const response = await importJobs(routes, [{ ...body, id: JOB_ID }])
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual({ imported: [JOB_ID], skipped: [] })
+      expect(rows.get(JOB_ID)).toMatchObject({ name: 'Morning digest' })
+    })
+
+    it('leaves an existing job untouched and reports it skipped', async () => {
+      const { store, rows } = memoryStore([row({ name: 'Edited since' })])
+      const routes = createScheduledJobRoutes({ store })
+      const response = await importJobs(routes, [
+        { ...body, id: JOB_ID, name: 'Stale copy' },
+      ])
+
+      expect(await response.json()).toEqual({ imported: [], skipped: [JOB_ID] })
+      expect(rows.get(JOB_ID)?.name).toBe('Edited since')
+    })
+
+    it('rejects a job with no id', async () => {
+      const routes = createScheduledJobRoutes(memoryStore())
+      expect((await importJobs(routes, [body])).status).toBe(400)
+    })
   })
 })

--- a/packages/browseros-agent/apps/server/tests/lib/llm-providers/provider-store.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/llm-providers/provider-store.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { closeDb, initializeDb } from '../../../src/lib/db'
+import { dbLlmProviderStore } from '../../../src/lib/llm-providers/provider-store'
+
+const PROVIDER_ID = 'provider-1'
+
+function baseProvider() {
+  return {
+    id: PROVIDER_ID,
+    type: 'openai',
+    name: 'My OpenAI',
+    modelId: 'gpt-5.5',
+    contextWindow: 200000,
+    apiKey: 'sk-test',
+  }
+}
+
+describe('dbLlmProviderStore', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    closeDb()
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    )
+    tempDirs.length = 0
+  })
+
+  function useTempDb() {
+    const dir = mkdtempSync(join(tmpdir(), 'browseros-providers-test-'))
+    tempDirs.push(dir)
+    initializeDb({ dbPath: join(dir, 'db', 'browseros.sqlite') })
+  }
+
+  test('insertIfAbsent writes a provider that is not there yet', async () => {
+    useTempDb()
+
+    const saved = await dbLlmProviderStore.insertIfAbsent(baseProvider())
+
+    expect(saved?.id).toBe(PROVIDER_ID)
+    expect(saved?.apiKey).toBe('sk-test')
+    expect(await dbLlmProviderStore.list()).toHaveLength(1)
+  })
+
+  // The behaviour the whole import design rests on: onConflictDoNothing must
+  // return no row, and must leave the existing one exactly as it was.
+  test('insertIfAbsent returns null and changes nothing when the id exists', async () => {
+    useTempDb()
+    await dbLlmProviderStore.upsert({ ...baseProvider(), name: 'Edited since' })
+
+    const saved = await dbLlmProviderStore.insertIfAbsent({
+      ...baseProvider(),
+      name: 'Stale copy',
+      apiKey: 'sk-stale',
+    })
+
+    expect(saved).toBeNull()
+    const existing = await dbLlmProviderStore.get(PROVIDER_ID)
+    expect(existing?.name).toBe('Edited since')
+    expect(existing?.apiKey).toBe('sk-test')
+  })
+
+  // Integer would floor this to 0 and silently make every model deterministic.
+  test('temperature survives as a fraction', async () => {
+    useTempDb()
+    await dbLlmProviderStore.insertIfAbsent({
+      ...baseProvider(),
+      temperature: 0.2,
+    })
+
+    expect((await dbLlmProviderStore.get(PROVIDER_ID))?.temperature).toBe(0.2)
+  })
+
+  test('insertIfAbsent preserves the creation time it is given', async () => {
+    useTempDb()
+    await dbLlmProviderStore.insertIfAbsent({
+      ...baseProvider(),
+      createdAt: 42,
+    })
+
+    expect((await dbLlmProviderStore.get(PROVIDER_ID))?.createdAt).toBe(42)
+  })
+})


### PR DESCRIPTION
Moves LLM providers and scheduled jobs out of extension storage and into the server database, once. Nothing user visible changes: extension storage stays the read path until the next phase, so this only fills the tables ahead of the switch.

## Insert-if-absent, not upsert

The import fills gaps and never replaces. That matters because the app will write to these tables directly, so an upsert would let a second run restore a stale copy over a provider the user has edited since. `onConflictDoNothing().returning()` gives the absent-or-present decision in one statement, and a store test against real SQLite pins the behaviour the design rests on.

It also makes the done marker an optimisation rather than something correctness depends on: losing it costs a redundant import that inserts nothing.

## The cloud is not a source

Both cloud domains were considered and both were rejected, for different reasons.

**Scheduled jobs would resurrect deletions.** `local:scheduledJobsPendingDeletion` is the queue of jobs deleted locally whose deletion still had to reach the cloud. Its only reader was removed when sync was turned off, so the queue is now write-only: deletes still get appended and nothing ever drains them. The cloud therefore holds every job deleted since that release, and importing them would bring them all back with their alarms. Separately, the query for cloud jobs has no consumer anywhere in the app, so those jobs are already invisible on this machine.

**Providers already have a better path.** Cloud provider rows never carried `apiKey`, `accessKeyId`, `secretAccessKey` or `sessionToken`, so importing one produces an unusable row. AI settings already renders a cloud provider missing locally as an incomplete provider prompting for a key, which ends with a complete provider on the ordinary write path.

So the sources are extension storage and the `browseros.providers` pref backup, both local and both per profile. The pref backup covers the case where extension storage was cleared but the per-profile pref outlived it, and storage wins on any id present in both.

## Security fix included

`/llm-providers` and `/scheduled-jobs` were mounted without the app-origin check that `/agents` and `/conversations` carry. The blanket trusted-origin middleware only rejects a request that *carries* a disallowed `Origin` header; one with no `Origin` at all passes it. The tables are empty today, which is why this was latent, but this is the change that starts filling them with plaintext API keys, so the guard belongs here rather than in a follow-up. Composition-level tests cover both prefixes and fail without the guard.

## Verification

- 43 server tests across the route, composition and store suites
- 17 app tests covering the transforms and the one-time behaviour, including that a failed import leaves the marker unset so it retries
- `tsc --noEmit` clean on both apps, biome clean on every changed file

## Not included

The orphaned pending-deletion queue is left as is: `removeJob` still appends to a list nothing reads. It is dead weight rather than a fault, and removing it changes delete behaviour, so it belongs with the rest of the cloud teardown.
