### PR TITLE
feat: agents never steal focus in BrowserClaw

### DIFF
--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-snapshot-concurrency.ts
@@ -452,7 +452,6 @@ export const snapshotConcurrencyCases: ContractCase[] = [
         const result = await ctx.mcp.callTool('tabs', {
           action: 'new',
           url: mixedFrameUrl(ctx),
-          background: false,
         })
         const text = expectOk(result, 'tabs new mixed-frame auto-context')
         page = parsePageId(result)

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-tabs.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-tabs.ts
@@ -21,13 +21,12 @@ function parseGroupId(text: string): string {
 
 export const tabsCases: ContractCase[] = [
   {
-    name: 'tabs: new foreground page opens with auto-context',
+    name: 'tabs: new page opens with auto-context',
     smoke: true,
     async run(ctx) {
       const result = await ctx.mcp.callTool('tabs', {
         action: 'new',
         url: ctx.fixture('/links.html'),
-        background: false,
       })
       const text = expectOk(result, 'tabs new')
       const page = parsePageId(result)
@@ -51,35 +50,31 @@ export const tabsCases: ContractCase[] = [
     },
   },
   {
-    name: 'tabs: active reports the focused page',
+    name: 'tabs: active reports the user tab, never an agent-opened page',
     async run(ctx) {
+      // Agents cannot request a foreground tab, so the page opened here must
+      // stay out of `tabs active`; the user's tab keeps that role.
       const page = await ctx.openPage(ctx.fixture('/form.html'))
-      let text = ''
-      await waitUntil(async () => {
-        text = expectOk(
-          await ctx.mcp.callTool('tabs', { action: 'active' }),
-          'tabs active',
-        )
-        return text.includes('/form.html') || text.includes(`${page}`)
-      }, 'active tab to report the focused form page')
+      const text = expectOk(
+        await ctx.mcp.callTool('tabs', { action: 'active' }),
+        'tabs active',
+      )
+      if (!text.startsWith('Active page:')) {
+        throw new Error(`tabs active did not report a page: ${text}`)
+      }
+      if (text.includes(`[${page}]`)) {
+        throw new Error(`agent-opened page became active: ${text}`)
+      }
     },
   },
   {
-    name: 'tabs: background page stays inactive and hidden is rejected',
+    name: 'tabs: new page stays inactive and hidden is rejected',
     async run(ctx) {
-      const focused = await ctx.openPage(ctx.fixture('/form.html'))
-      await waitUntil(async () => {
-        const active = expectOk(
-          await ctx.mcp.callTool('tabs', { action: 'active' }),
-        )
-        return active.includes(`[${focused}]`)
-      }, 'the foreground page to receive focus')
       const result = await ctx.mcp.callTool('tabs', {
         action: 'new',
         url: ctx.fixture('/links.html'),
-        background: true,
       })
-      expectOk(result, 'tabs new background')
+      expectOk(result, 'tabs new')
       const opened = parsePageId(result)
       const active = expectOk(
         await ctx.mcp.callTool('tabs', { action: 'active' }),
@@ -95,9 +90,8 @@ export const tabsCases: ContractCase[] = [
         }),
         'tabs new hidden',
       )
-      // Track for cleanup — openPage was bypassed to control background creation.
+      // Track for cleanup — openPage was bypassed to call the tool directly.
       await ctx.mcp.callTool('tabs', { action: 'close', page: opened })
-      await ctx.mcp.callTool('tabs', { action: 'close', page: focused })
     },
   },
   {

--- a/packages/browseros-agent/contracts/claw-mcp/tests/rust-conformance.test.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/rust-conformance.test.ts
@@ -117,7 +117,6 @@ function makeContext(run: ServerRun): CaseContext {
       const result = await session.callTool('tabs', {
         action: 'new',
         url,
-        background: false,
       })
       if (result.isError) {
         throw new Error(`tabs new failed: ${textOf(result)}`)

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -489,6 +489,9 @@ fn tab_and_window_schemas_omit_hidden_controls() {
     let tabs = tool_by_name("tabs");
     let tabs_schema = Value::Object(tabs.input_schema.as_ref().clone());
     assert!(tabs_schema.pointer("/properties/hidden").is_none());
+    // Focus is the user's call: agents cannot ask for a foreground tab.
+    assert!(tabs_schema.pointer("/properties/background").is_none());
+    assert!(!tabs.description.contains("foreground"));
 
     let windows = tool_by_name("windows");
     let windows_schema = Value::Object(windows.input_schema.as_ref().clone());

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/mod.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/mod.rs
@@ -111,7 +111,3 @@ fn metadata_for_tool(name: &str) -> ToolMetadata {
         ),
     }
 }
-
-fn default_true() -> bool {
-    true
-}

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -35,7 +35,7 @@ const DESCRIPTION: &str = r#"The primary way to drive the browser - prefer run f
 The return shapes below are stable. Do NOT probe them at runtime (no typeof / Object.keys / getOwnPropertyNames) and do NOT re-open a page to inspect what a call returned; that just piles up duplicate tabs. Reuse a pageId across steps.
 
 Pages (pageId is a NUMBER):
-  browser.pages.newPage(url)   -> pageId (number). Use it directly; it is not an object. Opens in the background so it does not steal the user's focus; pass { background: false } only when the user asks to bring the tab to the front.
+  browser.pages.newPage(url)   -> pageId (number). Use it directly; it is not an object. Always opens in the background; it never switches the user's tab.
   browser.pages.close(pageId)  -> undefined. Closes a page you own.
   browser.pages.list()         -> [{ pageId, url, title, ownership, ownerLabel, ... }] for EVERY open tab in the browser, including the user's and other agents'. `ownership` is "mine" | "user" | "other-agent"; "other-agent" tabs also carry ownerLabel. Act only on your own ("mine") tabs. Leave "user" and "other-agent" tabs alone unless the user explicitly asks you to work on one.
   browser.pages.getInfo(pageId)-> { pageId, url, title, ... } or null
@@ -655,12 +655,10 @@ impl BrowserBridge {
                     .race(self.ctx.session.pages.new_page(
                         &url,
                         NewPageOptions {
-                            // Default to a background tab so a working agent does
-                            // not steal the user's focus, matching the granular
-                            // tabs-new default. An explicit background:false opens
-                            // it active, which the agent should do only when the
-                            // user asks to bring a tab to the front.
-                            background: optional_bool_field(opts, "background")?.or(Some(true)),
+                            // Always a background tab: an agent must never switch
+                            // the user's tab. A `background` option is ignored
+                            // rather than rejected so older scripts keep working.
+                            background: Some(true),
                             window_id,
                             tab_group_id,
                         },
@@ -1042,17 +1040,6 @@ fn optional_object_arg(
         None | Some(Value::Null) => Ok(None),
         Some(Value::Object(value)) => Ok(Some(value)),
         Some(_) => Err(format!("argument {index} must be an object")),
-    }
-}
-
-fn optional_bool_field(
-    object: Option<&Map<String, Value>>,
-    name: &str,
-) -> Result<Option<bool>, String> {
-    match object.and_then(|object| object.get(name)) {
-        None | Some(Value::Null) => Ok(None),
-        Some(Value::Bool(value)) => Ok(Some(*value)),
-        Some(_) => Err(format!("{name} must be a boolean")),
     }
 }
 
@@ -2159,7 +2146,7 @@ return { pageId: page.pageId, tabId: page.tabId, url: page.url, title: page.titl
         let result = run_tool_with_ctx(
             r#"
 return await browser.pages.newPage('https://new.example', {
-  background: true,
+  background: false,
   windowId: 88,
   tabGroupId: 'group-opts',
 });
@@ -2184,6 +2171,8 @@ return await browser.pages.newPage('https://new.example', {
             create_params.first().and_then(|params| params.get("url")),
             Some(&json!("https://new.example"))
         );
+        // `background: false` is accepted but ignored: agents never get a
+        // foreground tab.
         assert_eq!(
             create_params
                 .first()

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/tabs.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/tabs.rs
@@ -123,3 +123,26 @@ fn format_page_line(page: &browseros_core::pages::PageInfo) -> String {
         format!("[{}] {} ({})", page.page_id.0, page.url, page.title)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{TabsAction, TabsArgs};
+    use serde_json::json;
+
+    #[test]
+    fn retired_background_field_is_accepted_and_ignored() -> anyhow::Result<()> {
+        // Clients that cached the old schema still send it; it must not trip
+        // `deny_unknown_fields`, and it must not influence the tab's focus.
+        let args: TabsArgs =
+            serde_json::from_value(json!({ "action": "new", "background": false }))?;
+        assert!(matches!(args.action, TabsAction::New));
+        assert_eq!(args._background, Some(false));
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_fields_are_still_rejected() {
+        let result = serde_json::from_value::<TabsArgs>(json!({ "action": "new", "hidden": true }));
+        assert!(result.is_err_and(|error| error.to_string().contains("hidden")));
+    }
+}

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/tabs.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/tabs.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 
 const DESCRIPTION: &str = "\
 Manage browser tabs: list open pages (with their page ids), show the active page, \
-open a new page (snapshot attached), or close one. \
+open a new page in the background (snapshot attached), or close one. \
 Use the returned page id with snapshot/act/navigate.";
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
@@ -29,9 +29,12 @@ struct TabsArgs {
     action: TabsAction,
     /// URL for action="new" (defaults to about:blank).
     url: Option<String>,
-    /// Open without stealing focus for action="new".
-    #[serde(default = "super::default_true")]
-    background: bool,
+    /// Retired: new pages always open in the background so an agent never
+    /// switches the user's tab. Still accepted, and ignored, so clients that
+    /// cached the old schema do not trip `deny_unknown_fields`.
+    #[serde(default, rename = "background")]
+    #[schemars(skip)]
+    _background: Option<bool>,
     /// Page id for action="close".
     page: Option<u32>,
 }
@@ -87,7 +90,9 @@ fn handler<'a>(
                     .new_page(
                         args.url.as_deref().unwrap_or("about:blank"),
                         NewPageOptions {
-                            background: Some(args.background),
+                            // Never foreground: focus decisions belong to the user
+                            // (cockpit Watch), not to the agent.
+                            background: Some(true),
                             window_id: ctx.defaults.default_window_id.clone(),
                             tab_group_id: ctx.defaults.default_tab_group_id.clone(),
                         },

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_prefs.cc b/chrome/browser/browseros/core/browseros_prefs.cc
 new file mode 100644
-index 0000000000000..274fa0c0a3d79
+index 0000000000000000000000000000000000000000..68597d68ae413015f8783404d822d8a3f7dacb44
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_prefs.cc
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,133 @@
 +// Copyright 2025 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -39,6 +39,10 @@ index 0000000000000..274fa0c0a3d79
 +
 +  registry->RegisterBooleanPref(prefs::kNtpFocusContent, false);
 +  registry->RegisterBooleanPref(prefs::kOnboardingCompleted, false);
++  // BrowserClaw is a browser for agents: they work in the background by
++  // default. BrowserOS keeps stock focus behaviour.
++  registry->RegisterBooleanPref(prefs::kAutomationNeverStealsFocus,
++                                IsBrowserClawProduct());
 +}
 +
 +bool ShouldShowLLMChat(PrefService* pref_service) {
@@ -102,6 +106,10 @@ index 0000000000000..274fa0c0a3d79
 +
 +bool IsNtpFocusContentEnabled(PrefService* pref_service) {
 +  return pref_service->GetBoolean(prefs::kNtpFocusContent);
++}
++
++bool AutomationNeverStealsFocus(PrefService* pref_service) {
++  return pref_service->GetBoolean(prefs::kAutomationNeverStealsFocus);
 +}
 +
 +const char* GetVisibilityPrefForAction(actions::ActionId id) {

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_prefs.h b/chrome/browser/browseros/core/browseros_prefs.h
 new file mode 100644
-index 0000000000000..b04a6ef039a6b
+index 0000000000000000000000000000000000000000..893ade589e58d07c85848b790079481c2452b9e7
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_prefs.h
-@@ -0,0 +1,111 @@
+@@ -0,0 +1,125 @@
 +// Copyright 2025 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -58,6 +58,16 @@ index 0000000000000..b04a6ef039a6b
 +
 +inline constexpr char kOnboardingCompleted[] = "browseros.onboarding_completed";
 +
++// Boolean: Automation-driven tabs never pull the user's attention. A tab counts
++// as automation-driven while a DevTools client is attached to it, which is
++// every tab the claw-server (or any CDP client) acts on. With the pref on such
++// a tab cannot switch the user's active tab or raise the window, and tabs or
++// popups its pages open land in the background. Gates live in
++// Browser::ActivateContents, Browser::AddNewContents and the DevTools
++// BrowserHandler. Default: true for BrowserClaw, false for BrowserOS.
++inline constexpr char kAutomationNeverStealsFocus[] =
++    "browseros.automation_never_steals_focus";
++
 +}  // namespace prefs
 +
 +// Registers BrowserOS profile preferences.
@@ -108,6 +118,10 @@ index 0000000000000..b04a6ef039a6b
 +
 +// Check if NTP content should receive focus instead of the omnibox.
 +bool IsNtpFocusContentEnabled(PrefService* pref_service);
++
++// Check if automation-driven tabs must never steal focus. Callers decide per
++// tab by combining this with content::DevToolsAgentHost::IsDebuggerAttached().
++bool AutomationNeverStealsFocus(PrefService* pref_service);
 +
 +// Get the visibility pref key for an action, or nullptr if none exists.
 +const char* GetVisibilityPrefForAction(actions::ActionId id);

--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/devtools/protocol/browser_handler.cc b/chrome/browser/devtools/protocol/browser_handler.cc
-index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424deb8a0e93 100644
+index ccf5dd29d87387ffed251ea944406722a87c2997..c4d79a5695ad5fdffda5875b6f9506e100bf4bb8 100644
 --- a/chrome/browser/devtools/protocol/browser_handler.cc
 +++ b/chrome/browser/devtools/protocol/browser_handler.cc
-@@ -8,18 +8,31 @@
+@@ -8,18 +8,32 @@
  #include <vector>
  
  #include "base/functional/bind.h"
@@ -11,6 +11,7 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
 +#include "base/strings/utf_string_conversions.h"
 +#include "build/build_config.h"
  #include "chrome/app/chrome_command_ids.h"
++#include "chrome/browser/browseros/core/browseros_prefs.h"
  #include "chrome/browser/devtools/chrome_devtools_manager_delegate.h"
  #include "chrome/browser/devtools/devtools_dock_tile.h"
  #include "chrome/browser/profiles/profile.h"
@@ -34,7 +35,7 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
  #include "content/public/browser/browser_task_traits.h"
  #include "content/public/browser/browser_thread.h"
  #include "content/public/browser/devtools_agent_host.h"
-@@ -33,6 +46,10 @@ using protocol::Response;
+@@ -33,6 +47,19 @@ using protocol::Response;
  
  namespace {
  
@@ -42,10 +43,19 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
 +    "Hidden windows are no longer supported.";
 +constexpr char kHiddenTabsRetired[] = "Hidden tabs are no longer supported.";
 +
++// BrowserOS: true when the profile behind |bwi| forbids automation from
++// pulling the user's attention (browseros::prefs::kAutomationNeverStealsFocus).
++// Every command in this handler comes from a CDP client, so the pref alone
++// decides; no per-tab attachment check is needed here.
++bool NeverStealFocus(BrowserWindowInterface* bwi) {
++  Profile* profile = bwi ? bwi->GetProfile() : nullptr;
++  return profile && browseros::AutomationNeverStealsFocus(profile->GetPrefs());
++}
++
  BrowserWindow* GetBrowserWindow(int window_id) {
    BrowserWindow* result = nullptr;
    ForEachCurrentBrowserWindowInterfaceOrderedByActivation(
-@@ -49,18 +66,22 @@ BrowserWindow* GetBrowserWindow(int window_id) {
+@@ -49,18 +76,22 @@ BrowserWindow* GetBrowserWindow(int window_id) {
  std::unique_ptr<protocol::Browser::Bounds> GetBrowserWindowBounds(
      ui::BaseWindow* window) {
    std::string window_state = "normal";
@@ -73,7 +83,7 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
    return protocol::Browser::Bounds::Create()
        .SetLeft(bounds.x())
        .SetTop(bounds.y())
-@@ -70,14 +91,406 @@ std::unique_ptr<protocol::Browser::Bounds> GetBrowserWindowBounds(
+@@ -70,14 +101,406 @@ std::unique_ptr<protocol::Browser::Bounds> GetBrowserWindowBounds(
        .Build();
  }
  
@@ -482,7 +492,7 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
  }
  
  BrowserHandler::~BrowserHandler() = default;
-@@ -88,8 +501,9 @@ Response BrowserHandler::GetWindowForTarget(
+@@ -88,8 +511,9 @@ Response BrowserHandler::GetWindowForTarget(
      std::unique_ptr<protocol::Browser::Bounds>* out_bounds) {
    auto host =
        content::DevToolsAgentHost::GetForId(target_id.value_or(target_id_));
@@ -493,7 +503,7 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
    content::WebContents* web_contents = host->GetWebContents();
    if (!web_contents) {
      return Response::ServerError("No web contents in the target");
-@@ -118,12 +532,74 @@ Response BrowserHandler::GetWindowForTarget(
+@@ -118,12 +542,74 @@ Response BrowserHandler::GetWindowForTarget(
    return Response::Success();
  }
  
@@ -569,7 +579,7 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
  
    *out_bounds = GetBrowserWindowBounds(window);
    return Response::Success();
-@@ -138,8 +614,9 @@ Response BrowserHandler::SetWindowBounds(
+@@ -138,8 +624,9 @@ Response BrowserHandler::SetWindowBounds(
      int window_id,
      std::unique_ptr<protocol::Browser::Bounds> window_bounds) {
    BrowserWindow* window = GetBrowserWindow(window_id);
@@ -580,7 +590,7 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
    gfx::Rect bounds = window->GetBounds();
    const bool set_bounds = window_bounds->HasLeft() || window_bounds->HasTop() ||
                            window_bounds->HasWidth() ||
-@@ -295,3 +772,650 @@ protocol::Response BrowserHandler::AddPrivacySandboxEnrollmentOverride(
+@@ -295,3 +782,668 @@ protocol::Response BrowserHandler::AddPrivacySandboxEnrollmentOverride(
        net::SchemefulSite(url_to_add));
    return Response::Success();
  }
@@ -649,7 +659,13 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
 +  GURL navigate_url = url.has_value() ? GURL(url.value()) : GURL();
 +  chrome::AddTabAt(browser, navigate_url, -1, true);
 +
-+  browser->window()->Show();
++  // Show() activates the window (and on macOS the whole app); when automation
++  // must not steal focus the new window is shown behind the user's work.
++  if (browseros::AutomationNeverStealsFocus(profile->GetPrefs())) {
++    browser->window()->ShowInactive();
++  } else {
++    browser->window()->Show();
++  }
 +
 +  BrowserWindowInterface* bwi =
 +      GetBrowserWindowInterface(browser->session_id().id());
@@ -678,6 +694,11 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
 +  if (!bwi) {
 +    return Response::ServerError("Browser window not found");
 +  }
++  // Raising a window is exactly what the never-steal-focus pref forbids.
++  // Report success so callers proceed as if the window had been raised.
++  if (NeverStealFocus(bwi)) {
++    return Response::Success();
++  }
 +  bwi->GetWindow()->Activate();
 +  return Response::Success();
 +}
@@ -697,7 +718,7 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
 +    return Response::InvalidParams(kHiddenWindowsRetired);
 +  }
 +
-+  if (activate.value_or(false)) {
++  if (activate.value_or(false) && !NeverStealFocus(bwi)) {
 +    bwi->GetWindow()->Show();
 +    bwi->GetWindow()->Activate();
 +  } else {
@@ -805,7 +826,10 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
 +  Browser* browser = bwi->GetBrowserForMigrationOnly();
 +  GURL navigate_url = url.has_value() ? GURL(url.value()) : GURL();
 +  int insert_index = index.value_or(-1);
-+  bool foreground = !background.value_or(false);
++  // Default to a background tab: an agent opening pages must not switch the
++  // user's tab. An explicit background=false selects the tab within its
++  // window; nothing in this command ever raises the window.
++  bool foreground = !background.value_or(true);
 +
 +  content::WebContents* new_wc = chrome::AddAndReturnTabAt(
 +      browser, navigate_url, insert_index, foreground);
@@ -847,7 +871,11 @@ index ccf5dd29d87387ffed251ea944406722a87c2997..13cddad401eefb140d81139e59d6424d
 +  }
 +
 +  lookup.bwi->GetTabStripModel()->ActivateTabAt(lookup.tab_index);
-+  lookup.bwi->GetWindow()->Activate();
++  // Under the never-steal-focus pref this selects the tab within its window
++  // but leaves raising the window to the user.
++  if (!NeverStealFocus(lookup.bwi)) {
++    lookup.bwi->GetWindow()->Activate();
++  }
 +  return Response::Success();
 +}
 +

--- a/packages/browseros/chromium_patches/chrome/browser/ui/browser.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/browser.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/browser.cc b/chrome/browser/ui/browser.cc
-index 0777bf71430c810f7b6ae41a7708cdd069b6c5a4..a70c2a696db38e36aa8744258a0b7da16c46295b 100644
+index 0777bf71430c810f7b6ae41a7708cdd069b6c5a4..5b9c9d1d371ff49436c0deedfa031d18f53192cc 100644
 --- a/chrome/browser/ui/browser.cc
 +++ b/chrome/browser/ui/browser.cc
 @@ -47,6 +47,7 @@
@@ -10,7 +10,30 @@ index 0777bf71430c810f7b6ae41a7708cdd069b6c5a4..a70c2a696db38e36aa8744258a0b7da1
  #include "chrome/browser/buildflags.h"
  #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
  #include "chrome/browser/content_settings/mixed_content_settings_tab_helper.h"
-@@ -555,11 +556,17 @@ Browser::Browser(const CreateParams& params)
+@@ -331,6 +332,22 @@ constexpr base::TimeDelta kUIUpdateCoalescingTime = base::Milliseconds(200);
+ BASE_FEATURE(kBackgroundActorTaskPopupsOpenInBackground,
+              base::FEATURE_ENABLED_BY_DEFAULT);
+ 
++// BrowserOS: whether |contents| is an automation-driven tab whose activity must
++// never pull the user's attention; see
++// browseros::prefs::kAutomationNeverStealsFocus. "Automation-driven" is
++// approximated by a DevTools client being attached,
++// which covers every tab the claw-server or any other CDP client acts on. The
++// claw-server never detaches its page sessions, so this stays true for a tab an
++// agent touched earlier in the browser session even after the agent is done.
++// That is accepted for now because every such tab was opened by an agent; if a
++// human-owned tab ever needs to shed the flag, detach on ownership release or
++// switch to an explicit per-tab marker.
++bool ShouldSuppressAutomationFocus(Profile* profile, WebContents* contents) {
++  return contents && profile &&
++         browseros::AutomationNeverStealsFocus(profile->GetPrefs()) &&
++         content::DevToolsAgentHost::IsDebuggerAttached(contents);
++}
++
+ const extensions::Extension* GetExtensionForOrigin(
+     Profile* profile,
+     const GURL& security_origin) {
+@@ -555,11 +572,17 @@ Browser::Browser(const CreateParams& params)
  
    tab_strip_model_->AddObserver(this);
  
@@ -28,7 +51,46 @@ index 0777bf71430c810f7b6ae41a7708cdd069b6c5a4..a70c2a696db38e36aa8744258a0b7da1
  
    ProfileMetrics::LogProfileLaunch(profile_);
  
-@@ -1824,6 +1831,11 @@ bool Browser::ShouldFocusLocationBarByDefault(WebContents* source) {
+@@ -1684,6 +1707,24 @@ content::WebContents* Browser::AddNewContents(
+     }
+   }
+ 
++  // BrowserOS: the same treatment for automation-driven tabs. A click an agent
++  // synthesized over CDP is a trusted gesture, so a target=_blank link would
++  // open an active tab and window.open would raise a popup window. When the
++  // source tab is not the one the user is looking at, keep both in the
++  // background. As with the actor gate above, an active source tab means the
++  // user is watching and normal behaviour applies.
++  if (source && ShouldSuppressAutomationFocus(profile_, source)) {
++    tabs::TabInterface* source_tab =
++        tabs::TabInterface::MaybeGetFromContents(source);
++    if (!source_tab || !source_tab->IsActivated()) {
++      if (disposition == WindowOpenDisposition::NEW_POPUP) {
++        window_action = NavigateParams::WindowAction::kShowWindowInactive;
++      } else if (disposition == WindowOpenDisposition::NEW_FOREGROUND_TAB) {
++        disposition = WindowOpenDisposition::NEW_BACKGROUND_TAB;
++      }
++    }
++  }
++
+   return chrome::AddWebContents(this, source, std::move(new_contents),
+                                 target_url, disposition, window_features,
+                                 window_action, user_gesture);
+@@ -1696,6 +1737,13 @@ void Browser::ActivateContents(WebContents* contents) {
+   if (index == TabStripModel::kNoTab) {
+     return;
+   }
++  // BrowserOS: this is the single funnel for renderer- and CDP-initiated
++  // activation (Page.bringToFront, Target.activateTarget, a popup's
++  // window.focus(), fullscreen requests). An automation-driven tab must not
++  // switch the user's tab or raise the window through it.
++  if (ShouldSuppressAutomationFocus(profile_, contents)) {
++    return;
++  }
+   tab_strip_model_->ActivateTabAt(index);
+   window_->Activate();
+ }
+@@ -1824,6 +1872,11 @@ bool Browser::ShouldFocusLocationBarByDefault(WebContents* source) {
        source->GetController().GetPendingEntry()
            ? source->GetController().GetPendingEntry()
            : source->GetController().GetLastCommittedEntry();
@@ -40,7 +102,7 @@ index 0777bf71430c810f7b6ae41a7708cdd069b6c5a4..a70c2a696db38e36aa8744258a0b7da1
    if (entry) {
      const GURL& url = entry->GetURL();
      const GURL& virtual_url = entry->GetVirtualURL();
-@@ -1836,15 +1848,18 @@ bool Browser::ShouldFocusLocationBarByDefault(WebContents* source) {
+@@ -1836,15 +1889,18 @@ bool Browser::ShouldFocusLocationBarByDefault(WebContents* source) {
           url.host() == chrome::kChromeUINewTabHost) ||
          (virtual_url.SchemeIs(content::kChromeUIScheme) &&
           virtual_url.host() == chrome::kChromeUINewTabHost)) {

--- a/packages/browseros/chromium_patches/third_party/blink/public/devtools_protocol/domains/Browser.pdl
+++ b/packages/browseros/chromium_patches/third_party/blink/public/devtools_protocol/domains/Browser.pdl
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/public/devtools_protocol/domains/Browser.pdl b/third_party/blink/public/devtools_protocol/domains/Browser.pdl
-index 6015a94554c21..43dd32ff0983d 100644
+index 6015a94554c21ff42cabaadecd3a368c9b5f831d..c5dbcc26202e7097443262534f3f06519cbcfcb3 100644
 --- a/third_party/blink/public/devtools_protocol/domains/Browser.pdl
 +++ b/third_party/blink/public/devtools_protocol/domains/Browser.pdl
 @@ -8,6 +8,16 @@
@@ -19,7 +19,7 @@ index 6015a94554c21..43dd32ff0983d 100644
  
    # The state of the browser window.
    experimental type WindowState extends string
-@@ -31,6 +41,224 @@ domain Browser
+@@ -31,6 +41,227 @@ domain Browser
        # The window state. Default to normal.
        optional WindowState windowState
  
@@ -131,6 +131,9 @@ index 6015a94554c21..43dd32ff0983d 100644
 +      optional string url
 +      optional WindowID windowId
 +      optional integer index
++      # Open the tab without selecting it. Defaults to true so an agent never
++      # switches the user's tab; false selects the tab within its window. The
++      # window itself is never raised by this command.
 +      optional boolean background
 +      optional boolean pinned
 +      optional BrowserContextID browserContextId
@@ -244,7 +247,7 @@ index 6015a94554c21..43dd32ff0983d 100644
    experimental type PermissionType extends string
      enum
        ar
-@@ -294,6 +522,28 @@ domain Browser
+@@ -294,6 +525,28 @@ domain Browser
        # position and size are returned.
        Bounds bounds
  


### PR DESCRIPTION
## Summary
- New profile pref `browseros.automation_never_steals_focus` (default on for BrowserClaw, off for BrowserOS). A tab with a DevTools client attached can no longer switch the user's active tab or raise the window: `Browser::ActivateContents` becomes a no-op for it, and tabs or popups its pages open after an agent click land in the background (`Browser::AddNewContents`, mirroring upstream's actor gate).
- `Browser.createTab` defaults to background; an explicit `background:false` only selects the tab within its window. Under the pref, `activateTab` stops raising the window, `activateWindow` is a no-op, and `createWindow` / `setWindowVisibility(activate)` show windows inactive.
- The MCP tools drop `background` from `tabs new` and `browser.pages.newPage()`: agents always open pages in the background. The field is still accepted and ignored so clients holding the old schema keep working.

## Design
Production traces showed two systematic focus stealers: agents passing `background:false` (14 of 63 `tabs new` calls), and page-opened tabs and popups triggered by agent clicks, which count as trusted gestures. Every path funnels through two cross-platform Chromium functions plus the BrowserOS DevTools handler, so the gates live there and work identically on macOS, Linux and Windows. "Agent-driven" is approximated by `DevToolsAgentHost::IsDebuggerAttached`; claw-server sessions never detach, so this stays true for any tab an agent touched this browser session, which is acceptable because every such tab was opened by an agent (recorded in a comment at the gate). Full investigation: `.llm/260902-0807_agent_focus_steal/findings.html`.

## Test plan
- [x] `autoninja -C out/Default_browseros_arm64 chrome` green on the task branch (`task/agent_focus_steal` in chromium-3)
- [x] Patches byte-match `git diff BASE_COMMIT..tip --full-index` and apply cleanly onto the bare base tree (5/5)
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p browseros-mcp`, `cargo test -p claw-server-rust`
- [ ] Manual, with a BrowserClaw build: `tabs new` never switches the active tab; an agent click on a `target=_blank` link opens a background tab; a popup from an agent tab does not raise the app; Ctrl+T and cockpit Watch unchanged
- [ ] `bun run test:claw-mcp-contract` against the new build (conformance cases updated; they need a local browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwxGoD3ZW8cVTwhyi4z3Q6