### PR TITLE
ci: grant nightly call sites the permissions their workflows declare

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -182,8 +182,6 @@ jobs:
     name: Build signed BrowserOS nightly
     needs: [transaction, verify-components]
     uses: ./.github/workflows/nightly-macos-product.yml
-    permissions:
-      contents: read
     with:
       product: browseros
       state_ref: ${{ needs.transaction.outputs.state_ref }}
@@ -199,8 +197,6 @@ jobs:
     name: Build signed BrowserOS neo nightly
     needs: [transaction, verify-components]
     uses: ./.github/workflows/nightly-macos-product.yml
-    permissions:
-      contents: read
     with:
       product: browserclaw
       state_ref: ${{ needs.transaction.outputs.state_ref }}
@@ -279,8 +275,7 @@ jobs:
     needs: [transaction, finalize-server]
     uses: ./.github/workflows/publish-server-ota.yml
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     with:
       product: browseros
       version: ${{ needs.transaction.outputs.server_version }}
@@ -294,8 +289,7 @@ jobs:
     needs: [transaction, finalize-claw-server]
     uses: ./.github/workflows/publish-server-ota.yml
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     with:
       product: browserclaw
       version: ${{ needs.transaction.outputs.claw_server_version }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,6 +101,7 @@ jobs:
     uses: ./.github/workflows/release-claw-server.yml
     permissions:
       contents: write
+      pull-requests: write
     with:
       mode: build
       defer_finalize: true
@@ -181,6 +182,8 @@ jobs:
     name: Build signed BrowserOS nightly
     needs: [transaction, verify-components]
     uses: ./.github/workflows/nightly-macos-product.yml
+    permissions:
+      contents: read
     with:
       product: browseros
       state_ref: ${{ needs.transaction.outputs.state_ref }}
@@ -196,6 +199,8 @@ jobs:
     name: Build signed BrowserOS neo nightly
     needs: [transaction, verify-components]
     uses: ./.github/workflows/nightly-macos-product.yml
+    permissions:
+      contents: read
     with:
       product: browserclaw
       state_ref: ${{ needs.transaction.outputs.state_ref }}
@@ -228,6 +233,7 @@ jobs:
     uses: ./.github/workflows/release-claw-server.yml
     permissions:
       contents: write
+      pull-requests: write
     with:
       mode: finalize
       state_owner: suite
@@ -273,7 +279,8 @@ jobs:
     needs: [transaction, finalize-server]
     uses: ./.github/workflows/publish-server-ota.yml
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     with:
       product: browseros
       version: ${{ needs.transaction.outputs.server_version }}
@@ -287,7 +294,8 @@ jobs:
     needs: [transaction, finalize-claw-server]
     uses: ./.github/workflows/publish-server-ota.yml
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     with:
       product: browserclaw
       version: ${{ needs.transaction.outputs.claw_server_version }}


### PR DESCRIPTION
## Summary
The nightly family workflow has never successfully started. Run [33689075661](https://github.com/browseros-ai/BrowserOS/actions/runs/33689075661) ended in `startup_failure` with zero jobs — GitHub rejected the workflow at validation time.

A called workflow can only ever *narrow* the caller's `GITHUB_TOKEN`. Because `nightly.yml` sets `permissions: {}` at the top, each call site's own block is the whole ceiling — and six of them sat below what the workflow they call declares:

| Call site | Granted | Declared by callee |
|---|---|---|
| `prepare-claw-server`, `finalize-claw-server` | `contents: write` | `+ pull-requests: write` (`publish-ota`, `reflect-version`) |
| `build-browseros`, `build-browserclaw` | *(none — inherited `permissions: {}`)* | `contents: read` |
| `server-ota`, `claw-server-ota` | `contents: read` | `contents: write`, `pull-requests: write` |

The claw-server case is the one that actually blocked startup, and it's counter-intuitive: both offending jobs are skipped in this workflow (`publish_ota: false`, `state_owner: suite`), but permission validation is static and happens before any `if:` is evaluated.

## Design
Ceilings now match what `release-browseros.yml` and `release-browserclaw.yml` — both of which run green — already grant for the same called workflows. `release-browserclaw.yml:58-61` calls `release-claw-server.yml` with exactly `contents: write` + `pull-requests: write`. No workflow logic changed; only the six `permissions:` blocks.

## Test plan
- [x] `nightly.yml` parses as YAML
- [x] Audited every reusable-workflow call site against the union of its callee's top-level and job-level `permissions` (recursively): 6 failures before, 0 after
- [x] Same audit run against `release-browseros.yml` and `release-browserclaw.yml` as controls — both clean, matching their green run history
- [ ] `gh workflow run nightly.yml --ref main` reaches the `transaction` job instead of `startup_failure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151CqoL1nywZykEGMvLv86t