### PR TITLE
ci: cover the permissions the nightly's build and OTA callees declare

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -182,6 +182,8 @@ jobs:
     name: Build signed BrowserOS nightly
     needs: [transaction, verify-components]
     uses: ./.github/workflows/nightly-macos-product.yml
+    permissions:
+      contents: read
     with:
       product: browseros
       state_ref: ${{ needs.transaction.outputs.state_ref }}
@@ -197,6 +199,8 @@ jobs:
     name: Build signed BrowserOS neo nightly
     needs: [transaction, verify-components]
     uses: ./.github/workflows/nightly-macos-product.yml
+    permissions:
+      contents: read
     with:
       product: browserclaw
       state_ref: ${{ needs.transaction.outputs.state_ref }}
@@ -275,7 +279,8 @@ jobs:
     needs: [transaction, finalize-server]
     uses: ./.github/workflows/publish-server-ota.yml
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     with:
       product: browseros
       version: ${{ needs.transaction.outputs.server_version }}
@@ -289,7 +294,8 @@ jobs:
     needs: [transaction, finalize-claw-server]
     uses: ./.github/workflows/publish-server-ota.yml
     permissions:
-      contents: read
+      contents: write
+      pull-requests: write
     with:
       product: browserclaw
       version: ${{ needs.transaction.outputs.claw_server_version }}

--- a/packages/browseros/bos_build/ci_workflow_test.py
+++ b/packages/browseros/bos_build/ci_workflow_test.py
@@ -1687,7 +1687,14 @@ class FamilyNightlyWorkflowTest(unittest.TestCase):
             self.assertEqual(job["uses"], "./.github/workflows/publish-server-ota.yml")
             self.assertEqual(job["with"]["product"], product)
             self.assertEqual(job["with"]["state_owner"], "suite")
-            self.assertEqual(job["permissions"], {"contents": "read"})
+            # A called workflow can only narrow the caller's GITHUB_TOKEN, so the
+            # ceiling must cover what publish-server-ota.yml declares. Granting
+            # less rejects the whole run at validation time, before any job is
+            # created — see run 33689075661.
+            self.assertEqual(
+                job["permissions"],
+                {"contents": "write", "pull-requests": "write"},
+            )
 
         reconcile = jobs["reconcile-state"]
         self.assertTrue(set(finalizers).issubset(set(reconcile["needs"])))


### PR DESCRIPTION
## Summary
Follow-up to #2532. The nightly still ended in `startup_failure` after that fix ([run 33691010478](https://github.com/browseros-ai/BrowserOS/actions/runs/33691010478)), so I stopped inferring and bisected it: push-triggered copies of the workflow on a scratch branch, narrowing job-by-job. Two more call sites were short, each proven in isolation:

| Call site | Granted | Callee declares |
|---|---|---|
| `build-browseros`, `build-browserclaw` | *(no block — inherited `permissions: {}`)* | `contents: read` |
| `server-ota`, `claw-server-ota` | `contents: read` | `contents: write`, `pull-requests: write` |

A called workflow can only ever narrow the caller's `GITHUB_TOKEN`, and GitHub checks that statically across the whole nested tree *before creating any job* — so one short ceiling rejects the entire run with no logs and no jobs.

## Design
Bisection evidence, each a separate run:

| Probe | Scope | Result |
|---|---|---|
| a | `transaction` only | started |
| b | + all `prepare-*`, `verify-components` | started |
| c | + `build-*` | **startup_failure** |
| c2 | c, with `contents: read` on `build-*` | started |
| d2 | + `finalize-*` | started |
| e2 | + `*-ota` | **startup_failure** |
| f2 | full workflow, both ceilings fixed | **started — all 17 jobs created**, stopped at the intended `must run from refs/heads/main` guard |

`ci_workflow_test` asserted the `contents: read` ceiling that caused the second failure, so the test encoded the bug; it now asserts the ceiling that actually validates. The scratch branch and its probe workflows have been deleted.

## Test plan
- [x] `uv run python -m unittest bos_build.ci_workflow_test` — 80 tests, OK
- [x] `uv run ruff check bos_build` — clean
- [x] Probe f2 (identical to this change) created all 17 jobs instead of failing at startup
- [ ] `gh workflow run nightly.yml --ref main` reaches the `transaction` job

Note: `bos_build / unittest + ruff` is red on `main` independently of this PR — #2530 deleted `chromium_patches/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc` but left its `.features.yaml` entry, so `test_repo_features_consistent_with_patches` fails. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151CqoL1nywZykEGMvLv86t