### PR TITLE
fix(claw-server): admit Electron-based MCP clients past the /mcp hygiene filter

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
@@ -122,8 +122,13 @@ pub(super) fn internal(request_id: &RequestId, source: AppError) -> CanonicalErr
     )
 }
 
-/// Rejects browser-page requests to the loopback MCP endpoint. Browser fetches
-/// carry `origin` or `sec-fetch-site`; native MCP clients do not.
+/// Rejects browser-page requests to the loopback MCP endpoint. `Origin` is the
+/// reliable signal: an MCP call is a POST with `application/json`, which is never
+/// a CORS simple request, so any webpage capable of making one always carries
+/// `Origin`. `Sec-Fetch-*` is not usable here: Chromium/Electron-based desktop
+/// MCP clients attach it to every request and cannot strip it, so its presence
+/// alone does not indicate a page. The content-type gate below covers the
+/// origin-less page vectors (navigations, no-cors simple requests).
 async fn mcp_request_hygiene(req: Request, next: Next) -> Response {
     // The nested /mcp service shadows the router's `/{*path}` preflight route,
     // so answer OPTIONS here to keep loopback preflight behavior consistent.
@@ -131,7 +136,7 @@ async fn mcp_request_hygiene(req: Request, next: Next) -> Response {
         return StatusCode::NO_CONTENT.into_response();
     }
     let headers = req.headers();
-    if headers.contains_key(header::ORIGIN) || headers.contains_key("sec-fetch-site") {
+    if headers.contains_key(header::ORIGIN) {
         return AppError::forbidden("unsupported request").into_response();
     }
     let needs_json = match *req.method() {

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -287,23 +287,14 @@ async fn system_shutdown_preserves_contract_body_and_defers_runtime_teardown() -
 async fn mcp_hygiene_rejects_browser_originated_requests() -> anyhow::Result<()> {
     let app = test_app().await?;
 
+    // `Origin` is the reliable page signal and stays blocked: any webpage that
+    // can make an MCP call (POST application/json) always carries it.
     let (status, _headers, body) = request_json_with_headers(
         &app.router,
         "POST",
         "/mcp",
         Some(json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}})),
         &[("origin", "http://evil.example")],
-    )
-    .await?;
-    assert_eq!(status, StatusCode::FORBIDDEN);
-    assert_eq!(body, json!({ "error": "unsupported request" }));
-
-    let (status, _headers, body) = request_json_with_headers(
-        &app.router,
-        "GET",
-        "/mcp",
-        None,
-        &[("sec-fetch-site", "cross-site")],
     )
     .await?;
     assert_eq!(status, StatusCode::FORBIDDEN);
@@ -331,6 +322,41 @@ async fn mcp_hygiene_rejects_browser_originated_requests() -> anyhow::Result<()>
     )
     .await?;
     assert_eq!(status, StatusCode::NO_CONTENT);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_hygiene_admits_electron_sec_fetch_clients() -> anyhow::Result<()> {
+    let app = test_app().await?;
+
+    // Chromium/Electron-based desktop MCP clients (e.g. Cherry Studio) attach
+    // browser-default Fetch Metadata to every request and cannot strip it. With
+    // no `Origin`, such a request is not a page fetch and must reach the service.
+    let initialize = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": { "name": "Cherry Studio", "version": "1.0" }
+        }
+    });
+    let (status, headers, body) = request_json_with_headers(
+        &app.router,
+        "POST",
+        "/mcp",
+        Some(initialize),
+        &[
+            ("sec-fetch-site", "same-site"),
+            ("sec-fetch-mode", "cors"),
+            ("sec-fetch-dest", "empty"),
+        ],
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK, "initialize body: {body:?}");
+    assert_eq!(body["result"]["serverInfo"]["name"], "browseros-neo");
+    assert!(headers.contains_key("mcp-session-id"));
     Ok(())
 }
 


### PR DESCRIPTION
## What

The loopback `/mcp` hygiene filter rejected any request carrying a `Sec-Fetch-*` header (`403 {"error":"unsupported request"}`). Chromium/Electron-based desktop MCP clients such as Cherry Studio attach browser-default Fetch Metadata to every outgoing request and cannot strip it, so they could not connect at all.

This drops the `Sec-Fetch-*` presence check and keeps the `Origin` rejection.

## Why this is safe

The filter exists to reject requests originating from a webpage, so a page the user visits cannot drive their browser through the loopback MCP endpoint. `Sec-Fetch-*` presence does not identify a webpage; only `Origin` does:

- An MCP call is a `POST` with `Content-Type: application/json`. That is never a CORS "simple request", so any webpage capable of making one always sends `Origin`, which stays rejected.
- The existing `application/json` content-type gate continues to cover the origin-less page vectors (navigations, no-cors simple requests), none of which can carry a JSON-RPC body.
- The remote-peer control (LAN callers) is a separate layer and is unchanged.

This restores parity with the previous MCP server, which accepted `Sec-Fetch-*` and rejected `Origin`, and which these clients connect to natively.

## Tests

- `mcp_hygiene_rejects_browser_originated_requests`: `Origin` still returns `403`.
- `mcp_hygiene_admits_electron_sec_fetch_clients` (new): an `initialize` POST carrying `Sec-Fetch-Site/Mode/Dest` and no `Origin` reaches the service and returns `200` with a session id.
- `mcp_hygiene_rejects_non_json_writes`: unchanged.

Reported behavior and reproduction in #2458.

Fixes #2458