### PR TITLE
fix: wait for the server before running the one-time imports

### DIFF
--- a/packages/browseros-agent/apps/app/modules/local-first-migration/start-local-first-migration.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/start-local-first-migration.ts
@@ -12,6 +12,7 @@ import {
   scheduledJobRunStorage,
   scheduledJobStorage,
 } from '@/lib/schedules/scheduleStorage'
+import { sentry } from '@/lib/sentry/sentry'
 import { resolveAgentServerUrlWithRetry } from '@/modules/browseros/agent-server-url.helpers'
 import { putDefaultProvider } from '@/modules/llm-providers/llm-providers.api'
 import { importScheduledJobRuns } from '@/modules/schedules/schedules.api'
@@ -25,6 +26,7 @@ import {
   parseProviderBackup,
   type ScheduledJobImport,
 } from './local-first-migration.helpers'
+import { waitForAgentServer } from './wait-for-agent-server'
 
 /**
  * Per profile, because extension storage is per profile. Losing it costs a
@@ -83,35 +85,77 @@ async function importScheduledJobs(jobs: ScheduledJobImport[]): Promise<void> {
   }
 }
 
-/** Fire and forget from the background; a failure retries on next startup. */
+/**
+ * Runs the one-time imports once the server is up.
+ *
+ * Everything here happens when the background starts, which is also when the
+ * server starts, so firing straight away meant importing into a socket nothing
+ * was listening on. Each import then failed, and because a failed run leaves
+ * its marker unset it lost the same race on the next launch too, so a user
+ * upgrading saw their providers and scheduled tasks simply never arrive while
+ * the database migration looked like it had worked.
+ *
+ * Waiting on health first removes the race. A failure past that point is worth
+ * seeing rather than swallowing: it is the difference between a slow start and
+ * data that never came across.
+ */
 export function startLocalFirstMigration(): void {
-  // The default is chained onto the provider import rather than fired
-  // alongside it: the id it names has to exist server side before it can be
-  // made default. The run history is independent and does not wait.
-  void runLocalFirstMigration({
-    isDone: () => migrationDoneStorage.getValue(),
-    markDone: () => migrationDoneStorage.setValue(true),
-    loadStoredProviders: async () => (await providersStorage.getValue()) ?? [],
-    loadBackupProviders,
-    loadScheduledJobs: async () => (await scheduledJobStorage.getValue()) ?? [],
-    importProviders,
-    importScheduledJobs,
-  })
-    .then(() =>
-      runDefaultProviderMigration({
+  void (async () => {
+    if (!(await waitForAgentServer())) {
+      sentry.captureException(
+        new Error('Agent server unreachable before the local-first import'),
+        {
+          extra: {
+            message:
+              'Imports deferred to the next start; markers remain unset so they will run again',
+          },
+        },
+      )
+      return
+    }
+
+    // The default is chained onto the provider import rather than run
+    // alongside it: the id it names has to exist server side before it can be
+    // made default. The run history is independent and does not wait.
+    try {
+      await runLocalFirstMigration({
+        isDone: () => migrationDoneStorage.getValue(),
+        markDone: () => migrationDoneStorage.setValue(true),
+        loadStoredProviders: async () =>
+          (await providersStorage.getValue()) ?? [],
+        loadBackupProviders,
+        loadScheduledJobs: async () =>
+          (await scheduledJobStorage.getValue()) ?? [],
+        importProviders,
+        importScheduledJobs,
+      })
+      await runDefaultProviderMigration({
         isDone: () => defaultMigrationDoneStorage.getValue(),
         markDone: () => defaultMigrationDoneStorage.setValue(true),
         loadStoredDefaultId: async () =>
           (await defaultProviderIdStorage.getValue()) || null,
         setDefault: putDefaultProvider,
-      }),
-    )
-    .catch(() => null)
+      })
+    } catch (error) {
+      // Reported rather than swallowed: a silent failure here is
+      // indistinguishable from the user's data having vanished, which is
+      // exactly how this went unnoticed.
+      sentry.captureException(error, {
+        extra: { message: 'Provider and scheduled job import failed' },
+      })
+    }
 
-  void runScheduledRunsMigration({
-    isDone: () => runsMigrationDoneStorage.getValue(),
-    markDone: () => runsMigrationDoneStorage.setValue(true),
-    loadRuns: async () => (await scheduledJobRunStorage.getValue()) ?? [],
-    importRuns: importScheduledJobRuns,
-  }).catch(() => null)
+    try {
+      await runScheduledRunsMigration({
+        isDone: () => runsMigrationDoneStorage.getValue(),
+        markDone: () => runsMigrationDoneStorage.setValue(true),
+        loadRuns: async () => (await scheduledJobRunStorage.getValue()) ?? [],
+        importRuns: importScheduledJobRuns,
+      })
+    } catch (error) {
+      sentry.captureException(error, {
+        extra: { message: 'Scheduled run history import failed' },
+      })
+    }
+  })()
 }

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/wait-for-agent-server.test.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/wait-for-agent-server.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, it } from 'bun:test'
-import { waitForAgentServer } from './wait-for-agent-server'
+import { describe, expect, it, mock } from 'bun:test'
+
+// The agent server and the mcp proxy listen on different ports and can become
+// ready at different moments, so the probe has to ask the one the imports
+// actually address.
+mock.module('@/lib/browseros/helpers', () => ({
+  getAgentServerUrl: async () => 'http://127.0.0.1:9105',
+  getProxyPort: async () => 9106,
+  getMcpPort: async () => 9105,
+  getHealthCheckUrl: async () => 'http://127.0.0.1:9106/system/health',
+  getMcpServerUrl: async () => 'http://127.0.0.1:9106/mcp',
+}))
+
+const { waitForAgentServer, agentServerHealthUrl } = await import(
+  './wait-for-agent-server'
+)
 
 function harness(healthyAfter: number) {
   let calls = 0
@@ -89,5 +103,13 @@ describe('waitForAgentServer', () => {
     expect(result).toBe(true)
     expect(calls).toBe(3)
     expect(clock).toBe(2_000)
+  })
+
+  // Probing the proxy would answer the wrong question: it can be up while the
+  // agent server is still starting, which leaves the original race open.
+  it('probes the agent server, not the proxy', async () => {
+    expect(await agentServerHealthUrl()).toBe(
+      'http://127.0.0.1:9105/system/health',
+    )
   })
 })

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/wait-for-agent-server.test.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/wait-for-agent-server.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'bun:test'
+import { waitForAgentServer } from './wait-for-agent-server'
+
+function harness(healthyAfter: number) {
+  let calls = 0
+  let clock = 0
+  return {
+    calls: () => calls,
+    elapsed: () => clock,
+    opts: {
+      isHealthy: async () => {
+        calls += 1
+        return calls > healthyAfter
+      },
+      now: () => clock,
+      sleep: async (ms: number) => {
+        clock += ms
+      },
+      timeoutMs: 60_000,
+      intervalMs: 1_000,
+    },
+  }
+}
+
+describe('waitForAgentServer', () => {
+  it('returns immediately when the server is already up', async () => {
+    const h = harness(0)
+
+    expect(await waitForAgentServer(h.opts)).toBe(true)
+    expect(h.calls()).toBe(1)
+    expect(h.elapsed()).toBe(0)
+  })
+
+  // The case this exists for: the background starts at the same moment as the
+  // server, so the first few probes find nothing listening.
+  it('waits out a server that is still starting', async () => {
+    const h = harness(6)
+
+    expect(await waitForAgentServer(h.opts)).toBe(true)
+    expect(h.calls()).toBe(7)
+    expect(h.elapsed()).toBe(6_000)
+  })
+
+  // Six seconds is roughly what was observed between the browser launching and
+  // the server answering, and the previous behaviour gave up inside two.
+  it('outlasts the gap that made the import fail', async () => {
+    const h = harness(6)
+    await waitForAgentServer(h.opts)
+
+    expect(h.elapsed()).toBeGreaterThan(1_500)
+  })
+
+  // Giving up rather than throwing is what lets the caller leave the markers
+  // unset, so the next start tries again.
+  it('reports failure rather than throwing when the server never answers', async () => {
+    const h = harness(Number.POSITIVE_INFINITY)
+
+    expect(await waitForAgentServer(h.opts)).toBe(false)
+  })
+
+  it('stops probing once the deadline passes', async () => {
+    const h = harness(Number.POSITIVE_INFINITY)
+    await waitForAgentServer(h.opts)
+
+    expect(h.elapsed()).toBeLessThanOrEqual(60_000)
+    expect(h.calls()).toBeLessThanOrEqual(62)
+  })
+
+  // Connection refused is the expected state early on, so a probe that throws
+  // has to read as not reachable rather than end the wait.
+  it('treats a throwing probe as not reachable and keeps waiting', async () => {
+    let calls = 0
+    let clock = 0
+
+    const result = await waitForAgentServer({
+      isHealthy: async () => {
+        calls += 1
+        if (calls < 3) throw new Error('connection refused')
+        return true
+      },
+      now: () => clock,
+      sleep: async (ms) => {
+        clock += ms
+      },
+      timeoutMs: 60_000,
+      intervalMs: 1_000,
+    })
+
+    expect(result).toBe(true)
+    expect(calls).toBe(3)
+    expect(clock).toBe(2_000)
+  })
+})

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/wait-for-agent-server.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/wait-for-agent-server.ts
@@ -1,0 +1,67 @@
+import { getHealthCheckUrl } from '@/lib/browseros/helpers'
+
+/**
+ * Long enough to cover a cold start where the server is booting alongside the
+ * browser and has migrations of its own to apply, short enough that a genuinely
+ * absent server does not keep a background task alive all session.
+ */
+export const SERVER_WAIT_TIMEOUT_MS = 60_000
+export const SERVER_WAIT_INTERVAL_MS = 1_000
+
+export interface WaitForAgentServerOptions {
+  isHealthy?: () => Promise<boolean>
+  timeoutMs?: number
+  intervalMs?: number
+  now?: () => number
+  sleep?: (ms: number) => Promise<void>
+}
+
+async function defaultIsHealthy(): Promise<boolean> {
+  try {
+    const response = await fetch(await getHealthCheckUrl())
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Waits until the local server answers, or gives up.
+ *
+ * The one-time import runs when the background starts, which is the same moment
+ * the server starts. It used to fire straight into a socket nothing was
+ * listening on yet and fail, and because a failed run leaves its marker unset
+ * it simply lost the same race on the next launch, so the imported data never
+ * appeared at all.
+ *
+ * Polling health first is what makes the import wait for its dependency rather
+ * than race it. Returning false rather than throwing keeps the caller's
+ * decision explicit: leave the markers unset and try again next start.
+ */
+export async function waitForAgentServer({
+  isHealthy = defaultIsHealthy,
+  timeoutMs = SERVER_WAIT_TIMEOUT_MS,
+  intervalMs = SERVER_WAIT_INTERVAL_MS,
+  now = Date.now,
+  sleep = defaultSleep,
+}: WaitForAgentServerOptions = {}): Promise<boolean> {
+  const deadline = now() + timeoutMs
+
+  while (true) {
+    // A probe that throws means not reachable, not a reason to abandon the
+    // wait. The default one already swallows fetch errors; catching here means
+    // any probe behaves the same way.
+    let healthy = false
+    try {
+      healthy = await isHealthy()
+    } catch {
+      healthy = false
+    }
+    if (healthy) return true
+    if (now() >= deadline) return false
+    await sleep(intervalMs)
+  }
+}

--- a/packages/browseros-agent/apps/app/modules/local-first-migration/wait-for-agent-server.ts
+++ b/packages/browseros-agent/apps/app/modules/local-first-migration/wait-for-agent-server.ts
@@ -1,4 +1,4 @@
-import { getHealthCheckUrl } from '@/lib/browseros/helpers'
+import { getAgentServerUrl } from '@/lib/browseros/helpers'
 
 /**
  * Long enough to cover a cold start where the server is booting alongside the
@@ -16,9 +16,23 @@ export interface WaitForAgentServerOptions {
   sleep?: (ms: number) => Promise<void>
 }
 
+/**
+ * Health on the agent server itself, not `getHealthCheckUrl`.
+ *
+ * That helper resolves the proxy port, while the imports address the agent
+ * server on the mcp port. They are separate services that can become ready at
+ * different moments, so probing the proxy would answer a question nobody
+ * asked: a proxy up first would wave the imports through into the same race
+ * this exists to close, and a proxy that is down would defer imports the agent
+ * server was ready to accept.
+ */
+export async function agentServerHealthUrl(): Promise<string> {
+  return `${await getAgentServerUrl()}/system/health`
+}
+
 async function defaultIsHealthy(): Promise<boolean> {
   try {
-    const response = await fetch(await getHealthCheckUrl())
+    const response = await fetch(await agentServerHealthUrl())
     return response.ok
   } catch {
     return false


### PR DESCRIPTION
Found running the upgrade against a real profile: the database migration worked, extension storage was intact, and still no providers or scheduled tasks appeared. It looked exactly like data loss.

## What was happening

The one-time imports run when the background starts, which is the same moment the server starts.

```
18:44:13  browser launches AND server starts, same second
18:44:13  background runs the imports
            -> fires into a socket nothing is listening on yet, throws
            -> failure swallowed, marker never set
18:44:20  a tab opens, the UI query runs, server is up by now
            -> succeeds, seeds the built-in provider
```

That seven second gap is the whole bug. The UI worked because it ran later. The background did not because it ran first.

The important part is what happens next: a failed run deliberately leaves its marker unset so it retries on the following start. But the following start loses the same race, so it never completes. The data stays in extension storage indefinitely while the database migration looks like it succeeded.

## Why the existing retry did not cover it

```ts
const baseUrl = await resolveAgentServerUrlWithRetry()   // 3 x 500ms
const response = await client.import.$post({ ... })      // one attempt
```

`resolveAgentServerUrlWithRetry` retries `getAgentServerUrl`, which is a preference read and effectively never fails. All three attempts succeed instantly, so the retry budget is spent before the call that needed it, and the request itself gets a single shot at a server that is still booting.

## The fix

The imports wait on the health endpoint before running, so they wait for their dependency rather than race it. Sixty seconds at one second intervals, which covers a cold start where the server has migrations of its own to apply.

Giving up returns false rather than throwing, so the markers stay unset on purpose and the next start tries again, which is the behaviour that was already intended.

Failures are reported through Sentry rather than swallowed. Silence is what made this present as lost data rather than a slow start, and a background failure otherwise has nowhere to surface.

A probe that throws counts as not reachable rather than ending the wait, since connection refused is the expected state early on.

## Verification

- Seven tests on the wait, including one asserting it outlasts the roughly six second gap that was actually observed, one that a still starting server is waited out, and one that a throwing probe keeps the wait alive rather than aborting it.
- Three of them fail if the wait is reduced back to a single probe, which is how I checked they exercise the fix rather than the surrounding code.
- App and server suites green, `tsc --noEmit` clean on both, biome clean.

## Not covered here

This does not change what happens if the server is genuinely absent for a whole session: the imports defer to the next start, as before, but now say so. Nor does it retry an import that fails for a reason other than the server being down, which is correct, since a validation failure would only fail again.
