### PR TITLE
docs: add Parallel Search MCP setup example

### DIFF
--- a/docs/features/connect-mcps.mdx
+++ b/docs/features/connect-mcps.mdx
@@ -249,7 +249,7 @@ The real power of connected apps is combining them in a single request. The assi
 
 ## Add a Custom MCP Server
 
-You can connect any MCP-compatible server that exposes an SSE endpoint.
+You can connect remote MCP servers over Streamable HTTP or SSE. BrowserOS detects the transport from the server URL.
 
 1. Go to **Settings > Connected Apps**
 2. Click **Add custom app**
@@ -260,6 +260,21 @@ Custom servers appear alongside built-in apps and work the same way.
 <Tip>
 MCP has a growing ecosystem of servers. Browse [MCP servers on GitHub](https://github.com/modelcontextprotocol/servers) to find integrations for databases, APIs, and more.
 </Tip>
+
+### Example: Parallel Search
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides public web search and page extraction without a Parallel account or API key. Free access is rate limited.
+
+1. Open **Connect Apps** from the sidebar and click **Add custom app**.
+2. Enter **Parallel Search** as the **Server Name**.
+3. Enter `https://search.parallel.ai/mcp` as the **MCP Server URL**.
+4. Click **Add Server**. No sign-in, API key, or local proxy is needed.
+
+Try asking: "Use Parallel Search to find the BrowserOS documentation and fetch the page about connecting apps."
+
+The connection exposes `web_search` and `web_fetch`. Once added, the assistant can call these tools during its work, sending queries, requested URLs, and any supplied objective or context to Parallel. Use public URLs for page extraction; this service does not use your signed-in browser session.
+
+To stop using it, remove **Parallel Search** from **Connect Apps** and start a new conversation.
 
 ### Connect to OAuth-Protected Remote Servers
 


### PR DESCRIPTION
This adds a Parallel Search example to the custom MCP setup guide, so users can get public web search and page extraction without a Parallel account, API key, or local proxy. It also fixes the SSE-only wording: BrowserOS already detects Streamable HTTP.

Brave is the only search provider in the [managed connector catalog](https://github.com/browseros-ai/BrowserOS/blob/62b42ad9919b98372cff57f202a8869ade11cf25/packages/browseros-agent/apps/server/src/api/services/klavis/catalog.ts#L37), and BrowserOS [includes that catalog when opening its managed MCP session](https://github.com/browseros-ai/BrowserOS/blob/62b42ad9919b98372cff57f202a8869ade11cf25/packages/browseros-agent/apps/server/src/api/services/klavis/service.ts#L217-L223). Authentication is still separate. That's the comparison I focused on.

There's a good reason to try Parallel here. In [Artificial Analysis's August 31 results](https://artificialanalysis.ai/agents/search-api), Parallel advanced scored **80.6 on DeepSearchQA F1**, and Parallel fast scored **80.2**, versus **62.3 for Brave web** and **78.1 for Brave LLM context**. The [free MCP connection uses fast mode](https://docs.parallel.ai/integrations/mcp/search-mcp). That mode also averaged **19.2 seconds per task**, versus Brave web's **35.9** and Brave LLM context's **24.1**.

For research-heavy agent tasks, I'd consider testing Parallel as the default search option in place of Brave. Brave LLM context does score higher than Parallel fast on the overall index, 74.6 versus 73.1. These are [API benchmark results](https://artificialanalysis.ai/methodology/search-api), with task time including model and search time; BrowserOS's own agent still needs a comparison, and its Klavis connector doesn't pin which Brave API variant it uses.

This PR only changes docs. It leaves defaults and permissions alone, and explains what goes to Parallel, the free-access limits, and how to remove the connection.

Checked the example through BrowserOS's `BrowserContextSchema`, `buildMcpServerSpecs`, and `createMcpClients`, using its locked `@ai-sdk/mcp` 2.0.40 dependency with credentials absent. Transport detection, discovery, one `web_search`, one `web_fetch`, and cleanup passed. MDX syntax and `git diff --check` passed too. I didn't run the browser UI, a repository build, or the full test suite.

I work at Parallel, which operates this service.
