### PR TITLE
fix: wait for bundled extensions before first-run handoff

### DIFF
--- a/packages/browseros/chromium_patches/.features.yaml
+++ b/packages/browseros/chromium_patches/.features.yaml
@@ -481,3 +481,14 @@ features:
     description: "feat: macOS passkey entitlements"
     files:
       - chrome/app/app-entitlements-browseros.plist
+
+  extension-startup-readiness:
+    description: "feat: bundled extension startup readiness"
+    files:
+      - chrome/browser/chrome_content_browser_client_navigation_throttles.cc
+      - chrome/browser/extensions/external_provider_impl.h
+      - chrome/browser/extensions/external_provider_manager.cc
+      - extensions/browser/crx_installer.cc
+      - extensions/browser/crx_installer.h
+      - extensions/browser/external_install_info.cc
+      - extensions/browser/external_install_info.h

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_installer.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_installer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_installer.cc b/chrome/browser/browseros/extensions/browseros_extension_installer.cc
 new file mode 100644
-index 0000000000000..ed44e6788a59e
+index 0000000000000000000000000000000000000000..2b60bbcfad7a34e6366be030d15bdb6adf81ed8b
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_installer.cc
-@@ -0,0 +1,309 @@
+@@ -0,0 +1,131 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -13,303 +13,125 @@ index 0000000000000..ed44e6788a59e
 +#include <optional>
 +#include <utility>
 +
-+#include "base/feature_list.h"
 +#include "base/files/file_util.h"
++#include "base/functional/bind.h"
 +#include "base/json/json_reader.h"
 +#include "base/logging.h"
 +#include "base/path_service.h"
 +#include "base/task/thread_pool.h"
-+#include "chrome/browser/browser_features.h"
++#include "base/version.h"
 +#include "chrome/browser/browseros/core/browseros_constants.h"
 +#include "chrome/browser/extensions/external_provider_impl.h"
-+#include "chrome/browser/profiles/profile.h"
 +#include "chrome/common/chrome_paths.h"
-+#include "content/public/browser/storage_partition.h"
-+#include "net/base/load_flags.h"
-+#include "net/traffic_annotation/network_traffic_annotation.h"
-+#include "services/network/public/cpp/resource_request.h"
-+#include "services/network/public/cpp/simple_url_loader.h"
++#include "content/public/browser/browser_thread.h"
 +
 +namespace browseros {
 +
 +namespace {
 +
-+constexpr net::NetworkTrafficAnnotationTag kTrafficAnnotation =
-+    net::DefineNetworkTrafficAnnotation("browseros_extension_install", R"(
-+        semantics {
-+          sender: "BrowserOS Extension Installer"
-+          description:
-+            "Fetches JSON configuration specifying which extensions should "
-+            "be installed for BrowserOS users."
-+          trigger: "Browser startup when no bundled extensions available."
-+          data: "No user data. GET request only."
-+          destination: OTHER
-+          destination_other: "BrowserOS configuration server."
-+        }
-+        policy {
-+          cookies_allowed: NO
-+          setting: "Controlled via command-line flags or enterprise policies."
-+          policy_exception_justification: "BrowserOS feature."
-+        })");
++constexpr size_t kMaxBundledManifestBytes = 1024 * 1024;
 +
 +}  // namespace
 +
-+InstallResult::InstallResult() = default;
-+InstallResult::~InstallResult() = default;
-+InstallResult::InstallResult(InstallResult&&) = default;
-+InstallResult& InstallResult::operator=(InstallResult&&) = default;
++BundleDiscoveryResult::BundleDiscoveryResult() = default;
++BundleDiscoveryResult::~BundleDiscoveryResult() = default;
++BundleDiscoveryResult::BundleDiscoveryResult(BundleDiscoveryResult&&) = default;
++BundleDiscoveryResult& BundleDiscoveryResult::operator=(
++    BundleDiscoveryResult&&) = default;
 +
-+BrowserOSExtensionInstaller::BrowserOSExtensionInstaller(Profile* profile)
-+    : profile_(profile) {
-+  for (const std::string& id : GetActiveBrowserOSExtensionIds()) {
-+    extension_ids_.insert(id);
-+  }
-+}
-+
++BrowserOSExtensionInstaller::BrowserOSExtensionInstaller() = default;
 +BrowserOSExtensionInstaller::~BrowserOSExtensionInstaller() = default;
 +
-+void BrowserOSExtensionInstaller::StartInstallation(
-+    const GURL& config_url,
-+    InstallCompleteCallback callback) {
-+  config_url_ = config_url;
-+  callback_ = std::move(callback);
++void BrowserOSExtensionInstaller::DiscoverBundled(DiscoveryCallback callback) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 +
-+  LOG(INFO) << "browseros: Starting extension installation";
-+
-+  if (TryLoadFromBundled()) {
-+    return;
-+  }
-+
-+  FetchFromRemote();
-+}
-+
-+bool BrowserOSExtensionInstaller::TryLoadFromBundled() {
-+  base::FilePath bundled_path;
-+  if (!base::PathService::Get(chrome::DIR_BROWSEROS_BUNDLED_EXTENSIONS,
-+                              &bundled_path)) {
-+    LOG(INFO) << "browseros: Bundled path not available";
-+    return false;
-+  }
-+
-+  base::FilePath manifest_path =
-+      bundled_path.Append(FILE_PATH_LITERAL("bundled_extensions.json"));
-+
-+  LOG(INFO) << "browseros: Loading from bundled at " << bundled_path.value();
-+
-+  // Manifest existence is checked on the blocking task below (missing file
-+  // yields empty prefs and OnBundledLoadComplete falls back to remote), so
-+  // startup never touches the disk on the UI thread here.
-+
++  // Resolve product membership on UI, then perform all filesystem work on the
++  // pool. USER_VISIBLE keeps first-run discovery prompt without blocking input.
 +  base::ThreadPool::PostTaskAndReplyWithResult(
-+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_BLOCKING},
++      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
 +      base::BindOnce(&BrowserOSExtensionInstaller::ReadBundledManifest,
-+                     manifest_path, bundled_path),
++                     GetActiveBrowserOSExtensionIds()),
 +      base::BindOnce(&BrowserOSExtensionInstaller::OnBundledLoadComplete,
-+                     weak_ptr_factory_.GetWeakPtr(), bundled_path));
-+
-+  return true;
++                     weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
 +}
 +
 +// static
-+base::DictValue BrowserOSExtensionInstaller::ReadBundledManifest(
-+    const base::FilePath& manifest_path,
-+    const base::FilePath& bundled_path) {
++BundleDiscoveryResult BrowserOSExtensionInstaller::ReadBundledManifest(
++    std::vector<std::string> active_ids) {
++  BundleDiscoveryResult result;
++  if (!base::PathService::Get(chrome::DIR_BROWSEROS_BUNDLED_EXTENSIONS,
++                              &result.bundled_path)) {
++    LOG(WARNING) << "browseros: Bundled extension path unavailable";
++    return result;
++  }
++
++  const base::FilePath manifest_path =
++      result.bundled_path.Append(FILE_PATH_LITERAL("bundled_extensions.json"));
 +  std::string json_content;
-+  if (!base::ReadFileToString(manifest_path, &json_content)) {
-+    LOG(INFO) << "browseros: No bundled manifest at " << manifest_path.value();
-+    return base::DictValue();
++  if (!base::ReadFileToStringWithMaxSize(manifest_path, &json_content,
++                                         kMaxBundledManifestBytes)) {
++    LOG(WARNING) << "browseros: Bundled manifest missing or unreadable at "
++                 << manifest_path.value();
++    return result;
 +  }
 +
 +  std::optional<base::Value> parsed =
 +      base::JSONReader::Read(json_content, base::JSON_PARSE_RFC);
 +  if (!parsed || !parsed->is_dict()) {
 +    LOG(ERROR) << "browseros: Invalid bundled manifest JSON";
-+    return base::DictValue();
++    return result;
 +  }
 +
-+  base::DictValue prefs;
-+
-+  for (const auto [extension_id, config] : parsed->GetDict()) {
-+    if (!config.is_dict()) {
++  // Iterate the active catalog rather than trusting manifest membership. A
++  // valid secondary entry must not make a missing primary look like success.
++  for (const std::string& id : active_ids) {
++    const base::DictValue* config = parsed->GetDict().FindDict(id);
++    if (!config) {
++      continue;
++    }
++    const std::string* crx_file = config->FindString("external_crx");
++    const std::string* version = config->FindString("external_version");
++    if (!crx_file || !version || !base::Version(*version).IsValid()) {
++      LOG(WARNING) << "browseros: Invalid bundled crx/version for " << id;
 +      continue;
 +    }
 +
-+    if (!IsActiveBrowserOSExtension(extension_id)) {
-+      LOG(WARNING) << "browseros: Skipping inactive or unregistered extension "
-+                   << extension_id;
++    const base::FilePath relative_path =
++        base::FilePath::FromUTF8Unsafe(*crx_file);
++    if (relative_path.empty() || relative_path.IsAbsolute() ||
++        relative_path.ReferencesParent() ||
++        !relative_path.MatchesExtension(FILE_PATH_LITERAL(".crx"))) {
++      LOG(WARNING) << "browseros: Invalid bundled CRX path for " << id;
 +      continue;
 +    }
 +
-+    const base::DictValue& config_dict = config.GetDict();
-+    const std::string* crx_file = config_dict.FindString("external_crx");
-+    const std::string* version = config_dict.FindString("external_version");
-+
-+    if (!crx_file || !version) {
-+      LOG(WARNING) << "browseros: Bundled config missing crx/version for "
-+                   << extension_id;
++    const base::FilePath crx_path = result.bundled_path.Append(relative_path);
++    base::File::Info info;
++    if (!base::GetFileInfo(crx_path, &info) || info.is_directory ||
++        info.size <= 0 || base::IsLink(crx_path)) {
++      LOG(WARNING) << "browseros: Bundled CRX missing or invalid for " << id;
 +      continue;
 +    }
 +
-+    base::FilePath crx_path =
-+        bundled_path.Append(base::FilePath::FromUTF8Unsafe(*crx_file));
-+
-+    if (!base::PathExists(crx_path)) {
-+      LOG(WARNING) << "browseros: CRX not found: " << crx_path.value();
-+      continue;
-+    }
-+
-+    base::DictValue ext_prefs;
-+    ext_prefs.Set(extensions::ExternalProviderImpl::kExternalCrx,
-+                  crx_path.AsUTF8Unsafe());
-+    ext_prefs.Set(extensions::ExternalProviderImpl::kExternalVersion, *version);
-+
-+    prefs.Set(extension_id, std::move(ext_prefs));
-+    LOG(INFO) << "browseros: Prepared bundled " << extension_id << " v"
-+              << *version;
++    base::DictValue prefs;
++    prefs.Set(extensions::ExternalProviderImpl::kExternalCrx,
++              crx_path.AsUTF8Unsafe());
++    prefs.Set(extensions::ExternalProviderImpl::kExternalVersion, *version);
++    result.prefs.Set(id, std::move(prefs));
 +  }
 +
-+  return prefs;
++  result.complete =
++      !active_ids.empty() && result.prefs.size() == active_ids.size();
++  return result;
 +}
 +
 +void BrowserOSExtensionInstaller::OnBundledLoadComplete(
-+    const base::FilePath& bundled_path,
-+    base::DictValue prefs) {
-+  LOG(INFO) << "browseros: Bundled load complete, " << prefs.size()
-+            << " extensions from " << bundled_path.value();
-+
-+  if (prefs.empty()) {
-+    LOG(INFO) << "browseros: No bundled prefs, falling back to remote";
-+    FetchFromRemote();
-+    return;
-+  }
-+
-+  InstallResult result;
-+  result.bundled_path = bundled_path;
-+  result.from_bundled = true;
-+  result.prefs = std::move(prefs);
-+
-+  for (const auto [extension_id, _] : result.prefs) {
-+    result.extension_ids.insert(extension_id);
-+  }
-+
-+  Complete(std::move(result));
-+}
-+
-+void BrowserOSExtensionInstaller::FetchFromRemote() {
-+  if (!config_url_.is_valid()) {
-+    LOG(ERROR) << "browseros: Invalid config URL";
-+    Complete(InstallResult());
-+    return;
-+  }
-+
-+  LOG(INFO) << "browseros: Fetching config from " << config_url_.spec();
-+
-+  if (!url_loader_factory_) {
-+    url_loader_factory_ = profile_->GetDefaultStoragePartition()
-+                              ->GetURLLoaderFactoryForBrowserProcess();
-+  }
-+
-+  auto request = std::make_unique<network::ResourceRequest>();
-+  request->url = config_url_;
-+  request->method = "GET";
-+  request->load_flags = net::LOAD_BYPASS_CACHE | net::LOAD_DISABLE_CACHE;
-+
-+  url_loader_ =
-+      network::SimpleURLLoader::Create(std::move(request), kTrafficAnnotation);
-+
-+  url_loader_->DownloadToStringOfUnboundedSizeUntilCrashAndDie(
-+      url_loader_factory_.get(),
-+      base::BindOnce(&BrowserOSExtensionInstaller::OnRemoteFetchComplete,
-+                     weak_ptr_factory_.GetWeakPtr()));
-+}
-+
-+void BrowserOSExtensionInstaller::OnRemoteFetchComplete(
-+    std::optional<std::string> response_body) {
-+  if (!response_body.has_value()) {
-+    LOG(ERROR) << "browseros: Failed to fetch config";
-+    Complete(InstallResult());
-+    return;
-+  }
-+
-+  base::DictValue extensions_config = ParseConfigJson(*response_body);
-+
-+  if (extensions_config.empty()) {
-+    Complete(InstallResult());
-+    return;
-+  }
-+
-+  InstallResult result;
-+  result.config = extensions_config.Clone();
-+  result.from_bundled = false;
-+
-+  for (const auto [extension_id, config] : extensions_config) {
-+    if (!config.is_dict()) {
-+      continue;
-+    }
-+
-+    if (!IsActiveBrowserOSExtension(extension_id)) {
-+      LOG(WARNING) << "browseros: Skipping inactive or unregistered extension "
-+                   << extension_id;
-+      continue;
-+    }
-+
-+    result.extension_ids.insert(extension_id);
-+
-+    const base::DictValue& config_dict = config.GetDict();
-+    base::DictValue ext_prefs;
-+
-+    if (const std::string* update_url = config_dict.FindString(
-+            extensions::ExternalProviderImpl::kExternalUpdateUrl)) {
-+      ext_prefs.Set(extensions::ExternalProviderImpl::kExternalUpdateUrl,
-+                    *update_url);
-+    }
-+
-+    if (const std::string* crx = config_dict.FindString(
-+            extensions::ExternalProviderImpl::kExternalCrx)) {
-+      ext_prefs.Set(extensions::ExternalProviderImpl::kExternalCrx, *crx);
-+    }
-+
-+    if (const std::string* version = config_dict.FindString(
-+            extensions::ExternalProviderImpl::kExternalVersion)) {
-+      ext_prefs.Set(extensions::ExternalProviderImpl::kExternalVersion,
-+                    *version);
-+    }
-+
-+    if (!ext_prefs.empty()) {
-+      result.prefs.Set(extension_id, std::move(ext_prefs));
-+    }
-+  }
-+
-+  LOG(INFO) << "browseros: Loaded " << result.prefs.size()
-+            << " extensions from remote config";
-+
-+  Complete(std::move(result));
-+}
-+
-+base::DictValue BrowserOSExtensionInstaller::ParseConfigJson(
-+    const std::string& json_content) {
-+  std::optional<base::Value> parsed =
-+      base::JSONReader::Read(json_content, base::JSON_PARSE_RFC);
-+
-+  if (!parsed || !parsed->is_dict()) {
-+    LOG(ERROR) << "browseros: Invalid config JSON";
-+    return base::DictValue();
-+  }
-+
-+  const base::DictValue* extensions = parsed->GetDict().FindDict("extensions");
-+
-+  if (!extensions) {
-+    LOG(ERROR) << "browseros: No 'extensions' key in config";
-+    return base::DictValue();
-+  }
-+
-+  return extensions->Clone();
-+}
-+
-+void BrowserOSExtensionInstaller::Complete(InstallResult result) {
-+  if (callback_) {
-+    std::move(callback_).Run(std::move(result));
-+  }
++    DiscoveryCallback callback,
++    BundleDiscoveryResult result) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  LOG(INFO) << "browseros: Local extension metadata ready, "
++            << result.prefs.size() << " entries; complete=" << result.complete;
++  std::move(callback).Run(std::move(result));
 +}
 +
 +}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_installer.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_installer.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_installer.h b/chrome/browser/browseros/extensions/browseros_extension_installer.h
 new file mode 100644
-index 0000000000000..944dc8fa738b6
+index 0000000000000000000000000000000000000000..8e742db3257743875031450614cb0ea831779ad5
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_installer.h
-@@ -0,0 +1,100 @@
+@@ -0,0 +1,61 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -11,92 +11,53 @@ index 0000000000000..944dc8fa738b6
 +#ifndef CHROME_BROWSER_BROWSEROS_EXTENSIONS_BROWSEROS_EXTENSION_INSTALLER_H_
 +#define CHROME_BROWSER_BROWSEROS_EXTENSIONS_BROWSEROS_EXTENSION_INSTALLER_H_
 +
-+#include <memory>
-+#include <optional>
-+#include <set>
 +#include <string>
++#include <vector>
 +
 +#include "base/files/file_path.h"
 +#include "base/functional/callback.h"
-+#include "base/memory/raw_ptr.h"
-+#include "base/memory/scoped_refptr.h"
 +#include "base/memory/weak_ptr.h"
 +#include "base/values.h"
-+#include "url/gurl.h"
-+
-+namespace network {
-+class SharedURLLoaderFactory;
-+class SimpleURLLoader;
-+}  // namespace network
-+
-+class Profile;
 +
 +namespace browseros {
 +
-+// Result of initial extension installation.
-+struct InstallResult {
-+  InstallResult();
-+  ~InstallResult();
-+  InstallResult(InstallResult&&);
-+  InstallResult& operator=(InstallResult&&);
++// Local provider metadata, not an installation result. Valid entries survive a
++// partial bundle so the coordinator can publish them and retain them for Retry.
++struct BundleDiscoveryResult {
++  BundleDiscoveryResult();
++  ~BundleDiscoveryResult();
++  BundleDiscoveryResult(BundleDiscoveryResult&&);
++  BundleDiscoveryResult& operator=(BundleDiscoveryResult&&);
 +
-+  base::DictValue prefs;           // Extension prefs for ExternalProviderImpl
-+  base::DictValue config;          // Raw config for maintenance
-+  std::set<std::string> extension_ids;
-+  base::FilePath bundled_path;       // Set if loaded from bundled
-+  bool from_bundled = false;
++  base::DictValue prefs;
++  base::FilePath bundled_path;
++  bool complete = false;
 +};
 +
-+// Handles one-time initial installation of BrowserOS extensions.
-+// Tries bundled CRX files first, falls back to remote config.
++// Discovers local CRXs for Chromium's external provider. This helper never
++// installs or fetches anything: provider readiness must not depend on network,
++// and the loader separately observes the primary extension's registry READY.
 +class BrowserOSExtensionInstaller {
 + public:
-+  using InstallCompleteCallback =
-+      base::OnceCallback<void(InstallResult result)>;
++  using DiscoveryCallback =
++      base::OnceCallback<void(BundleDiscoveryResult result)>;
 +
-+  explicit BrowserOSExtensionInstaller(Profile* profile);
++  BrowserOSExtensionInstaller();
 +  ~BrowserOSExtensionInstaller();
 +
 +  BrowserOSExtensionInstaller(const BrowserOSExtensionInstaller&) = delete;
 +  BrowserOSExtensionInstaller& operator=(const BrowserOSExtensionInstaller&) =
 +      delete;
 +
-+  // Starts the installation process. Calls |callback| when complete.
-+  void StartInstallation(const GURL& config_url,
-+                         InstallCompleteCallback callback);
++  // Replies on the calling UI sequence, including for an absent/invalid bundle.
++  // Destruction cancels the reply; it does not interrupt the bounded file read.
++  void DiscoverBundled(DiscoveryCallback callback);
 +
 + private:
-+  // Attempts to load from bundled CRX files. Returns true if attempting.
-+  bool TryLoadFromBundled();
-+
-+  // Reads bundled manifest on FILE thread.
-+  static base::DictValue ReadBundledManifest(
-+      const base::FilePath& manifest_path,
-+      const base::FilePath& bundled_path);
-+
-+  // Called when bundled manifest read completes.
-+  void OnBundledLoadComplete(const base::FilePath& bundled_path,
-+                             base::DictValue prefs);
-+
-+  // Fetches config from remote URL.
-+  void FetchFromRemote();
-+
-+  // Called when remote fetch completes.
-+  void OnRemoteFetchComplete(std::optional<std::string> response_body);
-+
-+  // Parses config JSON and returns extensions dict.
-+  base::DictValue ParseConfigJson(const std::string& json_content);
-+
-+  // Completes the installation with the given result.
-+  void Complete(InstallResult result);
-+
-+  raw_ptr<Profile> profile_;
-+  GURL config_url_;
-+  InstallCompleteCallback callback_;
-+  std::set<std::string> extension_ids_;
-+
-+  std::unique_ptr<network::SimpleURLLoader> url_loader_;
-+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
++  static BundleDiscoveryResult ReadBundledManifest(
++      std::vector<std::string> active_ids);
++  void OnBundledLoadComplete(DiscoveryCallback callback,
++                             BundleDiscoveryResult result);
 +
 +  base::WeakPtrFactory<BrowserOSExtensionInstaller> weak_ptr_factory_{this};
 +};

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_loader.cc b/chrome/browser/browseros/extensions/browseros_extension_loader.cc
 new file mode 100644
-index 0000000000000..f3665bd1ba8d9
+index 0000000000000000000000000000000000000000..f687bc2c1a5353117d53dfbd56e85ef95c32d6b8
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_loader.cc
-@@ -0,0 +1,279 @@
+@@ -0,0 +1,456 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -13,273 +13,450 @@ index 0000000000000..f3665bd1ba8d9
 +#include <utility>
 +
 +#include "base/feature_list.h"
++#include "base/functional/bind.h"
 +#include "base/logging.h"
++#include "base/supports_user_data.h"
 +#include "base/task/single_thread_task_runner.h"
 +#include "base/version.h"
 +#include "chrome/browser/browser_features.h"
 +#include "chrome/browser/browseros/core/browseros_constants.h"
 +#include "chrome/browser/extensions/external_provider_impl.h"
-+#include "chrome/browser/extensions/updater/extension_updater.h"
 +#include "chrome/browser/profiles/profile.h"
-+#include "extensions/browser/crx_file_info.h"
-+#include "extensions/browser/crx_installer.h"
-+#include "extensions/browser/extension_registry.h"
++#include "content/public/browser/browser_thread.h"
++#include "extensions/browser/disable_reason.h"
++#include "extensions/browser/extension_prefs.h"
++#include "extensions/browser/extension_registrar.h"
++#include "extensions/browser/extensions_browser_client.h"
 +#include "extensions/browser/pending_extension_manager.h"
 +#include "extensions/common/extension.h"
-+#include "extensions/common/mojom/manifest.mojom-shared.h"
-+#include "extensions/common/verifier_formats.h"
 +
 +namespace browseros {
++namespace {
 +
-+BrowserOSExtensionLoader::BrowserOSExtensionLoader(Profile* profile)
-+    : profile_(profile) {
-+  config_url_ =
-+      GURL(base::FeatureList::IsEnabled(features::kBrowserOsAlphaFeatures)
-+               ? kBrowserOSAlphaConfigUrl
-+               : kBrowserOSConfigUrl);
++constexpr char kLoaderReferenceKey[] = "browseros.extension_loader";
++constexpr base::TimeDelta kReadinessTimeout = base::Seconds(45);
++constexpr base::TimeDelta kMaintenanceInterval = base::Minutes(15);
 +
-+  for (const std::string& id : GetActiveBrowserOSExtensionIds()) {
-+    extension_ids_.insert(id);
-+  }
++// The external provider retains ownership. Profile data is only a weak lookup
++// for native callers, and never extends a provider or profile's lifetime.
++struct LoaderReference : public base::SupportsUserData::Data {
++  explicit LoaderReference(base::WeakPtr<BrowserOSExtensionLoader> loader)
++      : loader(std::move(loader)) {}
++  base::WeakPtr<BrowserOSExtensionLoader> loader;
++};
++
++void PostResult(BrowserOSExtensionLoader::ReadyCallback callback, bool ready) {
++  base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
++      FROM_HERE, base::BindOnce(std::move(callback), ready));
 +}
 +
-+BrowserOSExtensionLoader::~BrowserOSExtensionLoader() = default;
++}  // namespace
++
++BrowserOSExtensionLoader::BrowserOSExtensionLoader(Profile* profile)
++    : profile_(profile),
++      config_url_(
++          base::FeatureList::IsEnabled(features::kBrowserOsAlphaFeatures)
++              ? kBrowserOSAlphaConfigUrl
++              : kBrowserOSConfigUrl),
++      primary_id_(IsBrowserClawProduct() ? kBrowserClawExtensionId
++                                         : kAgentExtensionId),
++      installer_(std::make_unique<BrowserOSExtensionInstaller>()),
++      maintainer_(std::make_unique<BrowserOSExtensionMaintainer>(profile)) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  profile_->SetUserData(
++      kLoaderReferenceKey,
++      std::make_unique<LoaderReference>(weak_ptr_factory_.GetWeakPtr()));
++  profile_observation_.Observe(profile_);
++}
++
++BrowserOSExtensionLoader::~BrowserOSExtensionLoader() {
++  Shutdown();
++}
++
++// static
++void BrowserOSExtensionLoader::EnsurePrimaryExtensionReady(
++    Profile* profile,
++    ReadyCallback callback) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  auto* reference = static_cast<LoaderReference*>(
++      profile->GetOriginalProfile()->GetUserData(kLoaderReferenceKey));
++  if (!reference || !reference->loader) {
++    PostResult(std::move(callback), false);
++    return;
++  }
++  reference->loader->EnsureReady(std::move(callback));
++}
 +
 +void BrowserOSExtensionLoader::SetConfigUrl(const GURL& url) {
 +  config_url_ = url;
 +}
 +
 +void BrowserOSExtensionLoader::StartLoading() {
-+  LOG(INFO) << "browseros: Extension loader starting";
-+
-+  installer_ = std::make_unique<BrowserOSExtensionInstaller>(profile_);
-+  maintainer_ = std::make_unique<BrowserOSExtensionMaintainer>(profile_);
-+
-+  installer_->StartInstallation(
-+      config_url_, base::BindOnce(&BrowserOSExtensionLoader::OnInstallComplete,
-+                                  weak_ptr_factory_.GetWeakPtr()));
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  if (!profile_) {
++    return;
++  }
++  if (local_discovery_complete_) {
++    // Each provider visit expects its metadata callback, even after discovery.
++    // Replay the retained snapshot; Chromium deduplicates pending installs.
++    LoadFinished(BuildDesiredPrefs());
++    return;
++  }
++  if (started_) {
++    return;
++  }
++  // Chromium may ask the provider to load repeatedly. Never replace helpers:
++  // their weak replies belong to this single discovery operation.
++  started_ = true;
++  installer_->DiscoverBundled(
++      base::BindOnce(&BrowserOSExtensionLoader::OnLocalDiscoveryComplete,
++                     weak_ptr_factory_.GetWeakPtr()));
 +}
 +
-+void BrowserOSExtensionLoader::OnInstallComplete(InstallResult result) {
-+  LOG(INFO) << "browseros: OnInstallComplete from_bundled="
-+            << result.from_bundled << " prefs=" << result.prefs.size()
-+            << " ids=" << result.extension_ids.size();
-+
-+  if (result.from_bundled) {
-+    bundled_crx_base_path_ = result.bundled_path;
-+
-+    for (const auto [ext_id, pref_value] : result.prefs) {
-+      if (pref_value.is_dict()) {
-+        const std::string* version = pref_value.GetDict().FindString(
-+            extensions::ExternalProviderImpl::kExternalVersion);
-+        if (version) {
-+          bundled_versions_[ext_id] = *version;
-+        }
-+      }
-+    }
++void BrowserOSExtensionLoader::EnsureReady(ReadyCallback callback) {
++  if (!profile_) {
++    PostResult(std::move(callback), false);
++    return;
 +  }
-+
-+  extension_ids_.merge(result.extension_ids);
-+  last_config_ = std::move(result.config);
-+
-+  base::DictValue prefs_to_load = std::move(result.prefs);
-+
-+  if (prefs_to_load.empty()) {
-+    LOG(WARNING) << "browseros: Install returned empty prefs, "
-+                 << "reconstructing from installed extensions";
-+    prefs_to_load = ReconstructPrefsFromInstalledExtensions();
-+    LOG(INFO) << "browseros: Reconstructed prefs for " << prefs_to_load.size()
-+              << " installed extensions";
++  if (local_discovery_complete_ && IsPrimaryReady()) {
++    PostResult(std::move(callback), true);
++    return;
 +  }
-+
-+  LoadFinished(std::move(prefs_to_load));
-+  OnStartupComplete(result.from_bundled);
++  ready_callbacks_.push_back(std::move(callback));
++  if (waiting_for_ready_) {
++    return;
++  }
++  // Only a new attempt resets failed local metadata. Calls during an attempt
++  // join its observation, timeout and install; they cannot queue another CRX.
++  const auto* pending =
++      extensions::PendingExtensionManager::Get(profile_)->GetById(primary_id_);
++  // Failed downloads retain a URL pending record. Chromium will reject a
++  // same-source local file while that record exists, so Retry must reannounce
++  // the URL to the updater rather than silently waiting on an unqueued file.
++  if (!pending || pending->update_url().is_empty()) {
++    failed_bundles_.erase(primary_id_);
++  }
++  BeginReadiness();
++  if (!started_) {
++    StartLoading();
++  }
++  if (local_discovery_complete_) {
++    PublishUpdates();
++    AdvanceReadiness();
++  }
 +}
 +
-+base::DictValue
-+BrowserOSExtensionLoader::ReconstructPrefsFromInstalledExtensions() {
-+  base::DictValue prefs;
++void BrowserOSExtensionLoader::OnLocalDiscoveryComplete(
++    BundleDiscoveryResult result) {
++  bundled_crx_base_path_ = std::move(result.bundled_path);
++  bundled_prefs_ = std::move(result.prefs);
++  local_discovery_complete_ = true;
++  LOG(INFO) << "browseros: Local extension discovery complete: "
++            << bundled_prefs_.size()
++            << " entries, complete=" << result.complete;
 +
-+  extensions::ExtensionRegistry* registry =
-+      extensions::ExtensionRegistry::Get(profile_);
-+  if (!registry) {
-+    return prefs;
-+  }
-+
-+  const std::string update_url =
-+      base::FeatureList::IsEnabled(features::kBrowserOsAlphaFeatures)
-+          ? kBrowserOSAlphaUpdateUrl
-+          : kBrowserOSUpdateUrl;
-+
-+  for (const std::string& id : GetActiveBrowserOSExtensionIds()) {
-+    const extensions::Extension* ext = registry->GetInstalledExtension(id);
-+    if (!ext) {
-+      continue;
-+    }
-+
-+    base::DictValue ext_pref;
-+    ext_pref.Set(extensions::ExternalProviderImpl::kExternalUpdateUrl,
-+                 update_url);
-+    prefs.Set(id, std::move(ext_pref));
-+
-+    LOG(INFO) << "browseros: Reconstructed pref for installed extension " << id
-+              << " v" << ext->version().GetString();
-+  }
-+
-+  return prefs;
++  BeginReadiness();
++  // LoadFinished acknowledges metadata, NOT successful installation. Even an
++  // empty/partial bundle must release Chromium's external-provider barrier.
++  LoadFinished(BuildDesiredPrefs());
++  // Updates can call the updater, which is not alive during ExtensionService
++  // initialization. Cross that startup seam before any recovery/maintenance.
++  base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
++      FROM_HERE, base::BindOnce(&BrowserOSExtensionLoader::AdvanceReadiness,
++                                weak_ptr_factory_.GetWeakPtr()));
 +}
 +
 +const base::FilePath BrowserOSExtensionLoader::GetBaseCrxFilePath() {
 +  return bundled_crx_base_path_;
 +}
 +
-+void BrowserOSExtensionLoader::OnStartupComplete(bool from_bundled) {
-+  LOG(INFO) << "browseros: Startup complete (from_bundled=" << from_bundled
-+            << ")";
++bool BrowserOSExtensionLoader::NeedsLocalInstall(const std::string& id) const {
++  const base::DictValue* local = bundled_prefs_.FindDict(id);
++  if (!local || failed_bundles_.contains(id)) {
++    return false;
++  }
++  const auto* installed =
++      extensions::ExtensionRegistry::Get(profile_)->GetInstalledExtension(id);
++  const base::Version version(
++      *local->FindString(extensions::ExternalProviderImpl::kExternalVersion));
++  return !installed || installed->version().CompareTo(version) < 0;
++}
 +
-+  // Posted (not called synchronously) because StartLoading() can run inside
-+  // ExtensionService::Init(); one message-loop hop guarantees the extension
-+  // system is fully up (ExtensionUpdater::InstallPendingNow CHECKs alive_).
-+  if (from_bundled) {
++bool BrowserOSExtensionLoader::HasUsableLocalPrimary() const {
++  auto* registry = extensions::ExtensionRegistry::Get(profile_);
++  return (bundled_prefs_.contains(primary_id_) &&
++          !failed_bundles_.contains(primary_id_)) ||
++         registry->enabled_extensions().Contains(primary_id_) ||
++         registry->terminated_extensions().Contains(primary_id_);
++}
++
++bool BrowserOSExtensionLoader::IsPrimaryReady() const {
++  if (!profile_ || !local_discovery_complete_) {
++    return false;
++  }
++  return extensions::ExtensionRegistry::Get(profile_)
++             ->ready_extensions()
++             .Contains(primary_id_) &&
++         !NeedsLocalInstall(primary_id_);
++}
++
++base::DictValue BrowserOSExtensionLoader::BuildDesiredPrefs() const {
++  base::DictValue prefs;
++  auto* registry = extensions::ExtensionRegistry::Get(profile_);
++  for (const std::string& id : GetActiveBrowserOSExtensionIds()) {
++    const auto* local = bundled_prefs_.FindDict(id);
++    const auto* remote = remote_prefs_.FindDict(id);
++    if (NeedsLocalInstall(id)) {
++      prefs.Set(id, local->Clone());
++    } else if (remote) {
++      prefs.Set(id, remote->Clone());
++    } else if (local && !failed_bundles_.contains(id)) {
++      prefs.Set(id, local->Clone());
++    } else if (registry->GetInstalledExtension(id)) {
++      // Retain installed active extensions when bundle metadata is absent.
++      // Omitting them would make external-provider orphan cleanup uninstall
++      // them. Chromium skips URL installs for an already installed extension.
++      base::DictValue retained;
++      retained.Set(
++          extensions::ExternalProviderImpl::kExternalUpdateUrl,
++          base::FeatureList::IsEnabled(features::kBrowserOsAlphaFeatures)
++              ? kBrowserOSAlphaUpdateUrl
++              : kBrowserOSUpdateUrl);
++      prefs.Set(id, std::move(retained));
++    }
++  }
++  return prefs;
++}
++
++void BrowserOSExtensionLoader::BeginReadiness() {
++  if (waiting_for_ready_ || !profile_) {
++    return;
++  }
++  waiting_for_ready_ = true;
++  remote_requested_ = false;
++  if (!install_observation_.IsObserving()) {
++    // Secondary local installs can finish after the primary is READY. Track
++    // their failures throughout maintenance so a bad bundle can fall back to
++    // the remote provider instead of being retried forever.
++    install_observation_.Observe(
++        extensions::ExtensionsBrowserClient::Get()->GetInstallTracker(
++            profile_));
++  }
++  if (IsPrimaryReady()) {
++    FinishReadiness(true);
++    return;
++  }
++  // Registry access and registration share the UI sequence. Always inspect
++  // the READY set as well as observing: installed profiles may already be
++  // ready.
++  registry_observation_.Observe(extensions::ExtensionRegistry::Get(profile_));
++  readiness_timer_.Start(
++      FROM_HERE, kReadinessTimeout,
++      base::BindOnce(&BrowserOSExtensionLoader::OnReadinessTimeout,
++                     weak_ptr_factory_.GetWeakPtr()));
++}
++
++void BrowserOSExtensionLoader::RestorePrimaryExtension() {
++  auto* registry = extensions::ExtensionRegistry::Get(profile_);
++  auto* registrar = extensions::ExtensionRegistrar::Get(profile_);
++  if (registry->terminated_extensions().Contains(primary_id_)) {
++    registrar->ReloadExtension(primary_id_);
++  } else if (registry->disabled_extensions().Contains(primary_id_)) {
++    // Recover user/prompt disablement of a managed product extension, but do
++    // not clear corruption, policy or other safety-related disable reasons.
++    const auto reasons =
++        extensions::ExtensionPrefs::Get(profile_)->GetDisableReasons(
++            primary_id_);
++    for (auto reason : reasons) {
++      if (reason != extensions::disable_reason::DISABLE_USER_ACTION &&
++          reason != extensions::disable_reason::DISABLE_EXTERNAL_EXTENSION &&
++          reason != extensions::disable_reason::DISABLE_PERMISSIONS_INCREASE) {
++        return;
++      }
++    }
++    registrar->EnableExtension(primary_id_);
++  }
++}
++
++void BrowserOSExtensionLoader::AdvanceReadiness() {
++  if (!profile_ || !waiting_for_ready_ || !local_discovery_complete_) {
++    return;
++  }
++  if (IsPrimaryReady()) {
++    FinishReadiness(true);
++    return;
++  }
++  RestorePrimaryExtension();
++  if (!waiting_for_ready_) {
++    return;  // Enabling can synchronously notify READY.
++  }
++  if (IsPrimaryReady()) {
++    FinishReadiness(true);
++    return;
++  }
++  if (!HasUsableLocalPrimary() && !remote_requested_) {
++    // Config fetches never delay LoadFinished. Only the absence of a usable
++    // local primary permits recovery before READY; all other network work is
++    // background maintenance after a successful registry result.
++    CheckForUpdates();
++  }
++}
++
++void BrowserOSExtensionLoader::PublishUpdates() {
++  if (profile_ && local_discovery_complete_ && has_owner()) {
++    // Full desired-state snapshots preserve ownership of every active ID.
++    // Chromium deduplicates pending files and refuses same/older versions.
++    OnUpdated(BuildDesiredPrefs());
++  }
++}
++
++void BrowserOSExtensionLoader::CheckForUpdates() {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  if (!profile_ || !local_discovery_complete_ || remote_requested_ ||
++      (!maintenance_started_ && !waiting_for_ready_) ||
++      (waiting_for_ready_ && HasUsableLocalPrimary())) {
++    return;
++  }
++  remote_requested_ = true;
++  maintainer_->CheckForUpdates(
++      config_url_,
++      base::BindOnce(&BrowserOSExtensionLoader::OnRemoteConfigLoaded,
++                     weak_ptr_factory_.GetWeakPtr()));
++}
++
++void BrowserOSExtensionLoader::OnRemoteConfigLoaded(base::DictValue prefs) {
++  // Preserve the last valid remote entry when a config is partial. Neither
++  // network failure nor a missing config member revokes product ownership.
++  for (auto [id, pref] : prefs) {
++    remote_prefs_.Set(id, pref.Clone());
++  }
++  if (waiting_for_ready_ && !HasUsableLocalPrimary() &&
++      !remote_prefs_.contains(primary_id_)) {
++    FinishReadiness(false);
++    return;
++  }
++  PublishUpdates();
++  if (maintenance_started_ && !waiting_for_ready_) {
++    // OnUpdated already asks Chromium's updater to check both pending and
++    // installed extensions. Do not enqueue a second CheckNow here. Installed
++    // extensions use their manifest URL and only accept a newer version.
++    remote_requested_ = false;
++  }
++}
++
++void BrowserOSExtensionLoader::FinishReadiness(bool ready) {
++  if (!waiting_for_ready_) {
++    return;
++  }
++  waiting_for_ready_ = false;
++  readiness_timer_.Stop();
++  registry_observation_.Reset();
++  maintainer_->Cancel();
++  remote_requested_ = false;
++  LOG(INFO) << "browseros: Primary extension readiness "
++            << (ready ? "READY" : "failed; retry available");
++  auto callbacks = std::move(ready_callbacks_);
++  ready_callbacks_.clear();
++  // Post results rather than destroying the onboarding window inside a
++  // registry notification. Weak callbacks at the UI boundary cancel safely.
++  for (auto& callback : callbacks) {
++    PostResult(std::move(callback), ready);
++  }
++  if (ready && !maintenance_started_) {
++    maintenance_started_ = true;
++    maintenance_timer_.Start(
++        FROM_HERE, kMaintenanceInterval, this,
++        &BrowserOSExtensionLoader::MaintainInstalledExtensions);
 +    base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
 +        FROM_HERE,
-+        base::BindOnce(&BrowserOSExtensionLoader::InstallBundledExtensionsNow,
++        base::BindOnce(&BrowserOSExtensionLoader::MaintainInstalledExtensions,
 +                       weak_ptr_factory_.GetWeakPtr()));
-+  } else {
-+    base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
-+        FROM_HERE,
-+        base::BindOnce(&BrowserOSExtensionLoader::InstallRemoteExtensionsNow,
-+                       weak_ptr_factory_.GetWeakPtr(), last_config_.Clone()));
-+  }
-+
-+  // Maintainer owns the config now
-+  maintainer_->Start(config_url_, extension_ids_, std::move(last_config_));
-+}
-+
-+void BrowserOSExtensionLoader::InstallRemoteExtensionsNow(
-+    base::DictValue config) {
-+  if (!profile_ || extension_ids_.empty() || config.empty()) {
-+    return;
-+  }
-+
-+  extensions::ExtensionRegistry* registry =
-+      extensions::ExtensionRegistry::Get(profile_);
-+  extensions::PendingExtensionManager* pending =
-+      extensions::PendingExtensionManager::Get(profile_);
-+
-+  if (!registry || !pending) {
-+    return;
-+  }
-+
-+  LOG(INFO) << "browseros: Installing " << extension_ids_.size()
-+            << " remote extensions immediately";
-+
-+  for (const std::string& id : extension_ids_) {
-+    if (registry->GetInstalledExtension(id)) {
-+      continue;
-+    }
-+
-+    const base::DictValue* ext_config = config.FindDict(id);
-+    if (!ext_config) {
-+      continue;
-+    }
-+
-+    const std::string* update_url = ext_config->FindString(
-+        extensions::ExternalProviderImpl::kExternalUpdateUrl);
-+    if (!update_url) {
-+      continue;
-+    }
-+
-+    GURL url(*update_url);
-+    if (!url.is_valid()) {
-+      continue;
-+    }
-+
-+    pending->AddFromExternalUpdateUrl(
-+        id, std::string(), url,
-+        extensions::mojom::ManifestLocation::kExternalComponent,
-+        extensions::Extension::WAS_INSTALLED_BY_DEFAULT, false);
-+  }
-+
-+  extensions::ExtensionUpdater* updater =
-+      extensions::ExtensionUpdater::Get(profile_);
-+  if (updater) {
-+    extensions::ExtensionUpdater::CheckParams params;
-+    params.ids = std::list<extensions::ExtensionId>(extension_ids_.begin(),
-+                                                    extension_ids_.end());
-+    params.install_immediately = true;
-+    params.fetch_priority = extensions::DownloadFetchPriority::kForeground;
-+    updater->InstallPendingNow(std::move(params));
 +  }
 +}
 +
-+void BrowserOSExtensionLoader::InstallBundledExtensionsNow() {
-+  if (!profile_ || extension_ids_.empty() || bundled_crx_base_path_.empty()) {
++void BrowserOSExtensionLoader::MaintainInstalledExtensions() {
++  if (!profile_ || waiting_for_ready_) {
 +    return;
 +  }
++  // Keep local housekeeping independent of network success. The coordinator
++  // schedules both halves; the helper cannot initiate an overlapping install.
++  maintainer_->MaintainInstalledExtensions();
++  CheckForUpdates();
++}
 +
-+  extensions::ExtensionRegistry* registry =
-+      extensions::ExtensionRegistry::Get(profile_);
-+  extensions::PendingExtensionManager* pending =
-+      extensions::PendingExtensionManager::Get(profile_);
++void BrowserOSExtensionLoader::OnReadinessTimeout() {
++  // This is a UX bound, never evidence that installation succeeded. Chromium
++  // may still finish its own CRX work; Retry joins that work through the
++  // provider.
++  FinishReadiness(false);
++}
 +
-+  if (!registry || !pending) {
++void BrowserOSExtensionLoader::OnExtensionReady(
++    content::BrowserContext* context,
++    const extensions::Extension* extension) {
++  if (extension->id() == primary_id_ && IsPrimaryReady()) {
++    FinishReadiness(true);
++  }
++}
++
++void BrowserOSExtensionLoader::OnFinishCrxInstall(
++    content::BrowserContext* context,
++    const base::FilePath& source_file,
++    const std::string& extension_id,
++    const extensions::Extension* extension,
++    bool success) {
++  if (success || !IsActiveBrowserOSExtension(extension_id)) {
 +    return;
 +  }
-+
-+  for (const std::string& id : extension_ids_) {
-+    if (pending->IsIdPending(id)) {
-+      continue;
-+    }
-+
-+    auto it = bundled_versions_.find(id);
-+    if (it == bundled_versions_.end()) {
-+      continue;
-+    }
-+
-+    base::Version bundled_version(it->second);
-+    if (!bundled_version.IsValid()) {
-+      continue;
-+    }
-+
-+    // Install when missing, or upgrade when the bundled CRX is newer than
-+    // the installed version; waiting for the OTA update check instead would
-+    // leave users on the old version for up to a maintenance cycle.
-+    const extensions::Extension* installed =
-+        registry->GetInstalledExtension(id);
-+    if (installed && installed->version().CompareTo(bundled_version) >= 0) {
-+      continue;
-+    }
-+
-+    base::FilePath crx_path = bundled_crx_base_path_.Append(
-+        base::FilePath::FromUTF8Unsafe(id + ".crx"));
-+
-+    if (installed) {
-+      LOG(INFO) << "browseros: Upgrading " << id << " v"
-+                << installed->version().GetString() << " -> v" << it->second
-+                << " from bundled CRX";
-+    } else {
-+      LOG(INFO) << "browseros: Installing bundled " << id << " v" << it->second;
-+    }
-+
-+    pending->AddFromExternalFile(
-+        id, extensions::mojom::ManifestLocation::kExternalComponent,
-+        bundled_version, extensions::Extension::WAS_INSTALLED_BY_DEFAULT,
-+        false);
-+
-+    scoped_refptr<extensions::CrxInstaller> installer(
-+        extensions::CrxInstaller::CreateSilent(profile_));
-+    installer->set_install_source(
-+        extensions::mojom::ManifestLocation::kExternalComponent);
-+    installer->set_expected_id(id);
-+    installer->set_install_immediately(true);
-+    installer->set_creation_flags(
-+        extensions::Extension::WAS_INSTALLED_BY_DEFAULT);
-+
-+    extensions::CRXFileInfo file_info(crx_path,
-+                                      extensions::GetExternalVerifierFormat());
-+    installer->InstallCrxFile(file_info);
++  const auto* local = bundled_prefs_.FindDict(extension_id);
++  if (local &&
++      source_file.AsUTF8Unsafe() ==
++          *local->FindString(extensions::ExternalProviderImpl::kExternalCrx)) {
++    failed_bundles_.insert(extension_id);
++  } else if (extension_id == primary_id_) {
++    FinishReadiness(false);
++    return;
 +  }
++  // The failed pending record is removed by a posted installer callback.
++  // Recovery fetches metadata asynchronously before publishing the URL, so
++  // that stale file record cannot suppress the subsequent provider update.
++  base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
++      FROM_HERE,
++      base::BindOnce(waiting_for_ready_
++                         ? &BrowserOSExtensionLoader::AdvanceReadiness
++                         : &BrowserOSExtensionLoader::CheckForUpdates,
++                     weak_ptr_factory_.GetWeakPtr()));
++}
++
++void BrowserOSExtensionLoader::OnShutdown(
++    extensions::ExtensionRegistry* registry) {
++  Shutdown();
++}
++
++void BrowserOSExtensionLoader::OnShutdown() {
++  Shutdown();
++}
++
++void BrowserOSExtensionLoader::OnProfileWillBeDestroyed(Profile* profile) {
++  Shutdown();
++}
++
++void BrowserOSExtensionLoader::Shutdown() {
++  if (!profile_) {
++    return;
++  }
++  // Cancel replies and observations while profile services are still alive.
++  // ExternalLoader itself may outlive them through the provider's references.
++  weak_ptr_factory_.InvalidateWeakPtrs();
++  FinishReadiness(false);
++  maintenance_timer_.Stop();
++  maintainer_.reset();
++  installer_.reset();
++  registry_observation_.Reset();
++  install_observation_.Reset();
++  profile_observation_.Reset();
++  profile_->RemoveUserData(kLoaderReferenceKey);
++  profile_ = nullptr;
 +}
 +
 +}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_loader.h b/chrome/browser/browseros/extensions/browseros_extension_loader.h
 new file mode 100644
-index 0000000000000..9673304e2eecb
+index 0000000000000000000000000000000000000000..14982f96c6dc7545680517da758b5b7b05ba82ef
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_loader.h
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,118 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -11,82 +11,111 @@ index 0000000000000..9673304e2eecb
 +#ifndef CHROME_BROWSER_BROWSEROS_EXTENSIONS_BROWSEROS_EXTENSION_LOADER_H_
 +#define CHROME_BROWSER_BROWSEROS_EXTENSIONS_BROWSEROS_EXTENSION_LOADER_H_
 +
-+#include <map>
 +#include <memory>
 +#include <set>
 +#include <string>
++#include <vector>
 +
-+#include "base/files/file_path.h"
 +#include "base/memory/weak_ptr.h"
++#include "base/scoped_observation.h"
++#include "base/timer/timer.h"
 +#include "chrome/browser/browseros/extensions/browseros_extension_installer.h"
 +#include "chrome/browser/browseros/extensions/browseros_extension_maintainer.h"
 +#include "chrome/browser/extensions/external_loader.h"
-+#include "url/gurl.h"
++#include "chrome/browser/profiles/profile_observer.h"
++#include "extensions/browser/extension_registry.h"
++#include "extensions/browser/extension_registry_observer.h"
++#include "extensions/browser/install_observer.h"
++#include "extensions/browser/install_tracker.h"
 +
 +class Profile;
 +
 +namespace browseros {
 +
-+// Loads BrowserOS extensions from bundled CRX files or remote configuration.
-+//
-+// Lifecycle:
-+//   1. STARTUP: Installer loads from bundled CRX (preferred) or remote
-+//   2. POST-STARTUP: Both paths converge to start maintenance
-+//   3. MAINTENANCE: Periodic tasks via Maintainer
-+//
-+// After startup, extensions receive updates via their manifest.json update_url,
-+// triggered by ForceUpdateCheck() during maintenance.
-+class BrowserOSExtensionLoader : public extensions::ExternalLoader {
++// One per-profile coordinator owns desired extension state. Discovery supplies
++// provider preferences; only Chromium's external provider executes installs.
++// Provider readiness is local metadata availability, whereas navigation waits
++// for registry READY (safe to create an extension process, even for lazy MV3).
++class BrowserOSExtensionLoader : public extensions::ExternalLoader,
++                                 public extensions::ExtensionRegistryObserver,
++                                 public extensions::InstallObserver,
++                                 public ProfileObserver {
 + public:
-+  explicit BrowserOSExtensionLoader(Profile* profile);
++  using ReadyCallback = base::OnceCallback<void(bool)>;
 +
++  explicit BrowserOSExtensionLoader(Profile* profile);
 +  BrowserOSExtensionLoader(const BrowserOSExtensionLoader&) = delete;
 +  BrowserOSExtensionLoader& operator=(const BrowserOSExtensionLoader&) = delete;
 +
-+  // Sets config URL (for command-line override).
++  // UI-sequence callers join the existing operation. A false result is
++  // recoverable: another call retries local publication or remote recovery.
++  // The profile must be the browsing profile, not the onboarding picker.
++  static void EnsurePrimaryExtensionReady(Profile* profile,
++                                          ReadyCallback callback);
++  void CheckForUpdates();
 +  void SetConfigUrl(const GURL& url);
 +
 + protected:
 +  ~BrowserOSExtensionLoader() override;
-+
-+  // ExternalLoader:
 +  void StartLoading() override;
 +  const base::FilePath GetBaseCrxFilePath() override;
 +
 + private:
 +  friend class base::RefCountedThreadSafe<extensions::ExternalLoader>;
 +
-+  // Called when installer completes.
-+  void OnInstallComplete(InstallResult result);
++  void EnsureReady(ReadyCallback callback);
++  void OnLocalDiscoveryComplete(BundleDiscoveryResult result);
++  void BeginReadiness();
++  void AdvanceReadiness();
++  void FinishReadiness(bool ready);
++  bool IsPrimaryReady() const;
++  bool HasUsableLocalPrimary() const;
++  bool NeedsLocalInstall(const std::string& id) const;
++  base::DictValue BuildDesiredPrefs() const;
++  void PublishUpdates();
++  void OnRemoteConfigLoaded(base::DictValue prefs);
++  void OnReadinessTimeout();
++  void RestorePrimaryExtension();
++  void MaintainInstalledExtensions();
++  void Shutdown();
 +
-+  // Convergence point for both startup paths.
-+  void OnStartupComplete(bool from_bundled);
-+
-+  // Reconstructs minimal prefs from already-installed BrowserOS extensions.
-+  // Used as a fallback when both bundled CRX and remote config fail,
-+  // preventing orphan detection from uninstalling existing extensions.
-+  base::DictValue ReconstructPrefsFromInstalledExtensions();
-+
-+  // Installs remote extensions immediately via PendingExtensionManager +
-+  // updater.
-+  void InstallRemoteExtensionsNow(base::DictValue config);
-+
-+  // Installs bundled CRX extensions immediately via CrxInstaller. Covers
-+  // fresh installs and upgrades where the bundled version is newer than the
-+  // installed one (e.g. right after an app update shipped a newer CRX).
-+  void InstallBundledExtensionsNow();
++  void OnExtensionReady(content::BrowserContext* context,
++                        const extensions::Extension* extension) override;
++  void OnFinishCrxInstall(content::BrowserContext* context,
++                          const base::FilePath& source_file,
++                          const std::string& extension_id,
++                          const extensions::Extension* extension,
++                          bool success) override;
++  void OnShutdown(extensions::ExtensionRegistry* registry) override;
++  void OnShutdown() override;
++  void OnProfileWillBeDestroyed(Profile* profile) override;
 +
 +  raw_ptr<Profile> profile_;
 +  GURL config_url_;
++  const std::string primary_id_;
 +  base::FilePath bundled_crx_base_path_;
-+
-+  std::set<std::string> extension_ids_;
-+  std::map<std::string, std::string> bundled_versions_;
-+  base::DictValue last_config_;
++  base::DictValue bundled_prefs_;
++  base::DictValue remote_prefs_;
++  // Failed packages remain in bundled_prefs_ for an explicit local Retry.
++  std::set<std::string> failed_bundles_;
++  bool started_ = false;
++  bool local_discovery_complete_ = false;
++  bool waiting_for_ready_ = false;
++  bool remote_requested_ = false;
++  bool maintenance_started_ = false;
++  std::vector<ReadyCallback> ready_callbacks_;
++  base::OneShotTimer readiness_timer_;
++  base::RepeatingTimer maintenance_timer_;
 +
 +  std::unique_ptr<BrowserOSExtensionInstaller> installer_;
 +  std::unique_ptr<BrowserOSExtensionMaintainer> maintainer_;
-+
++  base::ScopedObservation<Profile, ProfileObserver> profile_observation_{this};
++  base::ScopedObservation<extensions::ExtensionRegistry,
++                          extensions::ExtensionRegistryObserver>
++      registry_observation_{this};
++  base::ScopedObservation<extensions::InstallTracker,
++                          extensions::InstallObserver>
++      install_observation_{this};
 +  base::WeakPtrFactory<BrowserOSExtensionLoader> weak_ptr_factory_{this};
 +};
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc b/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
 new file mode 100644
-index 0000000000000000000000000000000000000000..cd6efceea5b413943945375a55c70d96458f6698
+index 0000000000000000000000000000000000000000..f061377c17fccfdaf687ab5201b4c82f6dea3fcc
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
-@@ -0,0 +1,440 @@
+@@ -0,0 +1,292 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -13,36 +13,34 @@ index 0000000000000000000000000000000000000000..cd6efceea5b413943945375a55c70d96
 +#include <optional>
 +#include <utility>
 +
++#include "base/functional/bind.h"
 +#include "base/json/json_reader.h"
 +#include "base/logging.h"
-+#include "base/task/single_thread_task_runner.h"
++#include "base/time/time.h"
 +#include "chrome/browser/browseros/core/browseros_constants.h"
 +#include "chrome/browser/browseros/metrics/browseros_metrics.h"
-+#include "chrome/browser/extensions/extension_service.h"
 +#include "chrome/browser/extensions/external_provider_impl.h"
-+#include "chrome/browser/extensions/updater/extension_updater.h"
 +#include "chrome/browser/profiles/profile.h"
++#include "content/public/browser/browser_thread.h"
 +#include "content/public/browser/storage_partition.h"
 +#include "extensions/browser/disable_reason.h"
 +#include "extensions/browser/extension_prefs.h"
 +#include "extensions/browser/extension_registrar.h"
 +#include "extensions/browser/extension_registry.h"
-+#include "extensions/browser/pending_extension_manager.h"
 +#include "extensions/browser/uninstall_reason.h"
 +#include "extensions/common/extension.h"
-+#include "extensions/common/manifest_handlers/manifest_url_handlers.h"
-+#include "extensions/common/mojom/manifest.mojom-shared.h"
 +#include "net/base/load_flags.h"
 +#include "net/traffic_annotation/network_traffic_annotation.h"
 +#include "services/network/public/cpp/resource_request.h"
 +#include "services/network/public/cpp/simple_url_loader.h"
++#include "url/url_constants.h"
 +
 +namespace browseros {
 +
 +namespace {
 +
-+constexpr base::TimeDelta kMaintenanceInterval = base::Minutes(15);
-+constexpr base::TimeDelta kInitialMaintenanceDelay = base::Seconds(60);
++constexpr size_t kMaxConfigBytes = 1024 * 1024;
++constexpr base::TimeDelta kConfigTimeout = base::Seconds(15);
 +
 +constexpr net::NetworkTrafficAnnotationTag kTrafficAnnotation =
 +    net::DefineNetworkTrafficAnnotation("browseros_extension_maintenance", R"(
@@ -50,7 +48,9 @@ index 0000000000000000000000000000000000000000..cd6efceea5b413943945375a55c70d96
 +          sender: "BrowserOS Extension Maintainer"
 +          description:
 +            "Fetches JSON configuration for BrowserOS extension maintenance."
-+          trigger: "Periodic maintenance cycle (every 15 minutes)."
++          trigger:
++            "Background maintenance or recovery when no usable local primary "
++            "extension exists. Never blocks external provider discovery."
 +          data: "No user data. GET request only."
 +          destination: OTHER
 +          destination_other: "BrowserOS configuration server."
@@ -68,48 +68,16 @@ index 0000000000000000000000000000000000000000..cd6efceea5b413943945375a55c70d96
 +
 +BrowserOSExtensionMaintainer::~BrowserOSExtensionMaintainer() = default;
 +
-+void BrowserOSExtensionMaintainer::Start(const GURL& config_url,
-+                                         std::set<std::string> extension_ids,
-+                                         base::DictValue initial_config) {
-+  config_url_ = config_url;
-+  extension_ids_.clear();
-+  for (const std::string& id : extension_ids) {
-+    if (IsActiveBrowserOSExtension(id)) {
-+      extension_ids_.insert(id);
-+    }
-+  }
-+  last_config_ = std::move(initial_config);
-+
-+  LOG(INFO) << "browseros: Maintainer started, " << extension_ids_.size()
-+            << " extensions, scheduling in "
-+            << kInitialMaintenanceDelay.InSeconds() << "s";
-+
-+  base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
-+      FROM_HERE,
-+      base::BindOnce(&BrowserOSExtensionMaintainer::RunMaintenanceCycle,
-+                     weak_ptr_factory_.GetWeakPtr()),
-+      kInitialMaintenanceDelay);
-+}
-+
-+void BrowserOSExtensionMaintainer::UpdateExtensionIds(
-+    std::set<std::string> ids) {
-+  extension_ids_.clear();
-+  for (const std::string& id : ids) {
-+    if (IsActiveBrowserOSExtension(id)) {
-+      extension_ids_.insert(id);
-+    }
-+  }
-+}
-+
-+void BrowserOSExtensionMaintainer::RunMaintenanceCycle() {
-+  if (!profile_) {
-+    ScheduleNextMaintenance();
++void BrowserOSExtensionMaintainer::CheckForUpdates(const GURL& config_url,
++                                                   UpdateCallback callback) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  callbacks_.push_back(std::move(callback));
++  if (url_loader_) {
 +    return;
 +  }
 +
-+  if (!config_url_.is_valid()) {
-+    ExecuteMaintenanceTasks();
-+    ScheduleNextMaintenance();
++  if (!config_url.is_valid() || !config_url.SchemeIs(url::kHttpsScheme)) {
++    Complete(base::DictValue());
 +    return;
 +  }
 +
@@ -119,84 +87,96 @@ index 0000000000000000000000000000000000000000..cd6efceea5b413943945375a55c70d96
 +  }
 +
 +  auto request = std::make_unique<network::ResourceRequest>();
-+  request->url = config_url_;
-+  request->method = "GET";
++  request->url = config_url;
 +  request->load_flags = net::LOAD_BYPASS_CACHE | net::LOAD_DISABLE_CACHE;
-+
-+  auto loader =
++  request->credentials_mode = network::mojom::CredentialsMode::kOmit;
++  url_loader_ =
 +      network::SimpleURLLoader::Create(std::move(request), kTrafficAnnotation);
 +
-+  auto* loader_ptr = loader.get();
-+  loader_ptr->DownloadToStringOfUnboundedSizeUntilCrashAndDie(
++  // Remote discovery has its own bound and lifetime. Cancelling the owning
++  // loader drops this request; no network completion can revive a timed-out
++  // startup attempt or keep external-provider readiness pending.
++  url_loader_->SetTimeoutDuration(kConfigTimeout);
++  url_loader_->DownloadToString(
 +      url_loader_factory_.get(),
 +      base::BindOnce(&BrowserOSExtensionMaintainer::OnConfigFetched,
-+                     weak_ptr_factory_.GetWeakPtr(), std::move(loader)));
++                     weak_ptr_factory_.GetWeakPtr()),
++      kMaxConfigBytes);
++}
++
++void BrowserOSExtensionMaintainer::Cancel() {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  weak_ptr_factory_.InvalidateWeakPtrs();
++  url_loader_.reset();
++  callbacks_.clear();
 +}
 +
 +void BrowserOSExtensionMaintainer::OnConfigFetched(
-+    std::unique_ptr<network::SimpleURLLoader> loader,
 +    std::optional<std::string> response_body) {
-+  if (response_body.has_value()) {
-+    base::DictValue config = ParseConfigJson(*response_body);
-+    if (!config.empty()) {
-+      last_config_ = std::move(config);
-+
-+      for (const auto [id, _] : last_config_) {
-+        if (IsActiveBrowserOSExtension(id)) {
-+          extension_ids_.insert(id);
-+        }
-+      }
-+
-+      LOG(INFO) << "browseros: Updated config with " << last_config_.size()
-+                << " extensions";
-+    } else {
-+      LOG(WARNING) << "browseros: Fetched config parsed as empty";
-+    }
-+  } else {
-+    LOG(WARNING) << "browseros: Failed to fetch maintenance config";
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  if (!response_body) {
++    LOG(WARNING) << "browseros: Remote extension metadata unavailable";
++    Complete(base::DictValue());
++    return;
 +  }
-+
-+  ExecuteMaintenanceTasks();
-+  ScheduleNextMaintenance();
++  Complete(ParseConfigJson(*response_body));
 +}
 +
++// static
 +base::DictValue BrowserOSExtensionMaintainer::ParseConfigJson(
 +    const std::string& json_content) {
 +  std::optional<base::Value> parsed =
 +      base::JSONReader::Read(json_content, base::JSON_PARSE_RFC);
-+
 +  if (!parsed || !parsed->is_dict()) {
-+    LOG(ERROR) << "browseros: Invalid config JSON";
++    return base::DictValue();
++  }
++  const base::DictValue* configs = parsed->GetDict().FindDict("extensions");
++  if (!configs) {
 +    return base::DictValue();
 +  }
 +
-+  const base::DictValue* extensions = parsed->GetDict().FindDict("extensions");
++  base::DictValue prefs;
++  for (const auto [id, config] : *configs) {
++    if (!IsActiveBrowserOSExtension(id) || !config.is_dict()) {
++      continue;
++    }
++    const std::string* update_url = config.GetDict().FindString(
++        extensions::ExternalProviderImpl::kExternalUpdateUrl);
++    if (!update_url) {
++      continue;
++    }
++    const GURL url(*update_url);
++    if (!url.is_valid() || !url.SchemeIs(url::kHttpsScheme) ||
++        url.has_username() || url.has_password()) {
++      continue;
++    }
 +
-+  if (!extensions) {
-+    LOG(ERROR) << "browseros: No 'extensions' key in config";
-+    return base::DictValue();
++    // Remote metadata can only nominate an update URL. Local file paths and
++    // version claims from this response cannot bypass Chromium's signed updater
++    // or replace the bundle's version floor.
++    base::DictValue entry;
++    entry.Set(extensions::ExternalProviderImpl::kExternalUpdateUrl, url.spec());
++    prefs.Set(id, std::move(entry));
 +  }
-+
-+  return extensions->Clone();
++  return prefs;
 +}
 +
-+void BrowserOSExtensionMaintainer::ExecuteMaintenanceTasks() {
-+  LOG(INFO) << "browseros: Executing maintenance tasks";
++void BrowserOSExtensionMaintainer::Complete(base::DictValue prefs) {
++  url_loader_.reset();
++  // Move replies out before invoking user code: a callback may Retry or destroy
++  // the coordinator and this helper. Joined callers receive the same result.
++  std::vector<UpdateCallback> callbacks = std::move(callbacks_);
++  callbacks_.clear();
++  for (auto& callback : callbacks) {
++    std::move(callback).Run(prefs.Clone());
++  }
++}
 +
++void BrowserOSExtensionMaintainer::MaintainInstalledExtensions() {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 +  UninstallInactiveProductExtensions();
-+  UninstallDeprecatedExtensions();
-+  ReinstallMissingExtensions();
 +  ReenableDisabledExtensions();
-+  ForceUpdateCheck();
 +  LogExtensionHealth("maintenance");
-+}
-+
-+void BrowserOSExtensionMaintainer::ScheduleNextMaintenance() {
-+  base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
-+      FROM_HERE,
-+      base::BindOnce(&BrowserOSExtensionMaintainer::RunMaintenanceCycle,
-+                     weak_ptr_factory_.GetWeakPtr()),
-+      kMaintenanceInterval);
 +}
 +
 +void BrowserOSExtensionMaintainer::UninstallInactiveProductExtensions() {
@@ -234,159 +214,31 @@ index 0000000000000000000000000000000000000000..cd6efceea5b413943945375a55c70d96
 +  }
 +}
 +
-+void BrowserOSExtensionMaintainer::UninstallDeprecatedExtensions() {
-+  if (!profile_ || last_config_.empty()) {
-+    return;
-+  }
-+
-+  extensions::ExtensionRegistry* registry =
-+      extensions::ExtensionRegistry::Get(profile_);
-+  extensions::ExtensionRegistrar* registrar =
-+      extensions::ExtensionRegistrar::Get(profile_);
-+
-+  if (!registry || !registrar) {
-+    return;
-+  }
-+
-+  std::set<std::string> server_ids;
-+  for (const auto [id, _] : last_config_) {
-+    server_ids.insert(id);
-+  }
-+
-+  for (const std::string& id : GetActiveBrowserOSExtensionIds()) {
-+    if (server_ids.contains(id)) {
-+      continue;
-+    }
-+
-+    const extensions::Extension* ext = registry->GetInstalledExtension(id);
-+    if (!ext) {
-+      continue;
-+    }
-+
-+    LOG(INFO) << "browseros: Uninstalling deprecated extension " << id;
-+
-+    std::u16string error;
-+    if (!registrar->UninstallExtension(
-+            id, extensions::UNINSTALL_REASON_ORPHANED_EXTERNAL_EXTENSION,
-+            &error)) {
-+      LOG(WARNING) << "browseros: Failed to uninstall " << id << ": " << error;
-+    }
-+  }
-+}
-+
-+void BrowserOSExtensionMaintainer::ReinstallMissingExtensions() {
-+  if (!profile_ || last_config_.empty()) {
-+    return;
-+  }
-+
-+  extensions::ExtensionRegistry* registry =
-+      extensions::ExtensionRegistry::Get(profile_);
-+  extensions::PendingExtensionManager* pending =
-+      extensions::PendingExtensionManager::Get(profile_);
-+
-+  if (!registry || !pending) {
-+    return;
-+  }
-+
-+  for (const std::string& id : extension_ids_) {
-+    if (registry->GetInstalledExtension(id)) {
-+      continue;
-+    }
-+
-+    const base::DictValue* config = last_config_.FindDict(id);
-+    if (!config) {
-+      continue;
-+    }
-+
-+    const std::string* update_url = config->FindString(
-+        extensions::ExternalProviderImpl::kExternalUpdateUrl);
-+    if (!update_url) {
-+      continue;
-+    }
-+
-+    GURL url(*update_url);
-+    if (!url.is_valid()) {
-+      continue;
-+    }
-+
-+    LOG(INFO) << "browseros: Reinstalling missing extension " << id;
-+
-+    pending->AddFromExternalUpdateUrl(
-+        id, std::string(), url,
-+        extensions::mojom::ManifestLocation::kExternalComponent,
-+        extensions::Extension::WAS_INSTALLED_BY_DEFAULT, false);
-+
-+    extensions::ExtensionUpdater* updater =
-+        extensions::ExtensionUpdater::Get(profile_);
-+    if (updater) {
-+      extensions::ExtensionUpdater::CheckParams params;
-+      params.ids = {id};
-+      params.install_immediately = true;
-+      params.fetch_priority = extensions::DownloadFetchPriority::kForeground;
-+      // Use InstallPendingNow - the extension is in PendingExtensionManager,
-+      // CheckNow with specific IDs only checks installed extensions.
-+      updater->InstallPendingNow(std::move(params));
-+    }
-+  }
-+}
-+
 +void BrowserOSExtensionMaintainer::ReenableDisabledExtensions() {
-+  if (!profile_) {
-+    return;
-+  }
-+
-+  extensions::ExtensionRegistry* registry =
-+      extensions::ExtensionRegistry::Get(profile_);
-+  extensions::ExtensionRegistrar* registrar =
-+      extensions::ExtensionRegistrar::Get(profile_);
-+
-+  if (!registry || !registrar) {
-+    return;
-+  }
-+
-+  for (const std::string& id : extension_ids_) {
++  auto* registry = extensions::ExtensionRegistry::Get(profile_);
++  auto* registrar = extensions::ExtensionRegistrar::Get(profile_);
++  for (const auto& id : GetActiveBrowserOSExtensionIds()) {
 +    if (!registry->disabled_extensions().Contains(id)) {
 +      continue;
 +    }
-+
-+    LOG(INFO) << "browseros: Re-enabling disabled extension " << id;
-+    registrar->EnableExtension(id);
-+  }
-+}
-+
-+void BrowserOSExtensionMaintainer::ForceUpdateCheck() {
-+  if (!profile_ || extension_ids_.empty()) {
-+    return;
-+  }
-+
-+  extensions::ExtensionRegistry* registry =
-+      extensions::ExtensionRegistry::Get(profile_);
-+  extensions::ExtensionUpdater* updater =
-+      extensions::ExtensionUpdater::Get(profile_);
-+  if (!updater) {
-+    return;
-+  }
-+
-+  LOG(INFO) << "browseros: Force update check for " << extension_ids_.size()
-+            << " extensions";
-+
-+  for (const std::string& id : extension_ids_) {
-+    const extensions::Extension* ext =
-+        registry ? registry->GetInstalledExtension(id) : nullptr;
-+    if (ext) {
-+      LOG(INFO) << "browseros: ext=" << id << " v"
-+                << ext->version().GetString();
-+    } else {
-+      LOG(INFO) << "browseros: ext=" << id << " not installed";
++    // Keep product extensions usable, but never clear corruption, policy or
++    // other safety disablement just because a maintenance timer fired.
++    const auto reasons =
++        extensions::ExtensionPrefs::Get(profile_)->GetDisableReasons(id);
++    bool can_reenable = true;
++    for (auto reason : reasons) {
++      if (reason != extensions::disable_reason::DISABLE_USER_ACTION &&
++          reason != extensions::disable_reason::DISABLE_EXTERNAL_EXTENSION &&
++          reason != extensions::disable_reason::DISABLE_PERMISSIONS_INCREASE) {
++        can_reenable = false;
++        break;
++      }
++    }
++    if (can_reenable) {
++      LOG(INFO) << "browseros: Re-enabling managed extension " << id;
++      registrar->EnableExtension(id);
 +    }
 +  }
-+
-+  extensions::ExtensionUpdater::CheckParams params;
-+  params.ids = std::list<extensions::ExtensionId>(extension_ids_.begin(),
-+                                                  extension_ids_.end());
-+  params.install_immediately = true;
-+  params.fetch_priority = extensions::DownloadFetchPriority::kForeground;
-+  updater->CheckNow(std::move(params));
 +}
 +
 +void BrowserOSExtensionMaintainer::LogExtensionHealth(
@@ -403,7 +255,7 @@ index 0000000000000000000000000000000000000000..cd6efceea5b413943945375a55c70d96
 +    return;
 +  }
 +
-+  for (const std::string& id : extension_ids_) {
++  for (const std::string& id : GetActiveBrowserOSExtensionIds()) {
 +    if (registry->enabled_extensions().Contains(id)) {
 +      continue;
 +    }

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_maintainer.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_maintainer.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_maintainer.h b/chrome/browser/browseros/extensions/browseros_extension_maintainer.h
 new file mode 100644
-index 0000000000000..c70cbd4076100
+index 0000000000000000000000000000000000000000..91309ee51786772b70a1576f9148f646844fddb6
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_maintainer.h
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,74 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -13,9 +13,10 @@ index 0000000000000..c70cbd4076100
 +
 +#include <memory>
 +#include <optional>
-+#include <set>
 +#include <string>
++#include <vector>
 +
++#include "base/functional/callback.h"
 +#include "base/memory/raw_ptr.h"
 +#include "base/memory/scoped_refptr.h"
 +#include "base/memory/weak_ptr.h"
@@ -31,8 +32,14 @@ index 0000000000000..c70cbd4076100
 +
 +namespace browseros {
 +
++// Fetches bounded, validated remote provider metadata. The loader owns when to
++// recover/update and publishes the result through Chromium's external provider;
++// this helper never enqueues installs or independently schedules maintenance.
++// Local housekeeping runs only when requested by the same coordinator.
 +class BrowserOSExtensionMaintainer {
 + public:
++  using UpdateCallback = base::OnceCallback<void(base::DictValue prefs)>;
++
 +  explicit BrowserOSExtensionMaintainer(Profile* profile);
 +  ~BrowserOSExtensionMaintainer();
 +
@@ -40,31 +47,29 @@ index 0000000000000..c70cbd4076100
 +  BrowserOSExtensionMaintainer& operator=(const BrowserOSExtensionMaintainer&) =
 +      delete;
 +
-+  void Start(const GURL& config_url,
-+             std::set<std::string> extension_ids,
-+             base::DictValue initial_config);
++  // Concurrent callers join the current request. An empty result indicates
++  // failure or no usable metadata; it must never be interpreted as readiness.
++  void CheckForUpdates(const GURL& config_url, UpdateCallback callback);
 +
-+  void UpdateExtensionIds(std::set<std::string> ids);
++  // Preserves periodic product housekeeping without a second install owner.
++  // The coordinator calls this after READY and on each maintenance cycle.
++  void MaintainInstalledExtensions();
++
++  // Drops pending replies as well as the request, allowing Retry to start
++  // fresh.
++  void Cancel();
 +
 + private:
-+  void RunMaintenanceCycle();
-+  void OnConfigFetched(std::unique_ptr<network::SimpleURLLoader> loader,
-+                       std::optional<std::string> response_body);
-+  base::DictValue ParseConfigJson(const std::string& json_content);
-+  void ExecuteMaintenanceTasks();
-+  void ScheduleNextMaintenance();
++  void OnConfigFetched(std::optional<std::string> response_body);
++  static base::DictValue ParseConfigJson(const std::string& json_content);
++  void Complete(base::DictValue prefs);
 +  void UninstallInactiveProductExtensions();
-+  void UninstallDeprecatedExtensions();
-+  void ReinstallMissingExtensions();
 +  void ReenableDisabledExtensions();
-+  void ForceUpdateCheck();
 +  void LogExtensionHealth(const std::string& context);
 +
 +  raw_ptr<Profile> profile_;
-+  GURL config_url_;
-+  std::set<std::string> extension_ids_;
-+  base::DictValue last_config_;
-+
++  std::vector<UpdateCallback> callbacks_;
++  std::unique_ptr<network::SimpleURLLoader> url_loader_;
 +  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
 +
 +  base::WeakPtrFactory<BrowserOSExtensionMaintainer> weak_ptr_factory_{this};

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding.cc b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
 new file mode 100644
-index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
+index 0000000000000000000000000000000000000000..0809951dcf660ba1f9a3704bdcf5cbf88b3d9646
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
-@@ -0,0 +1,605 @@
+@@ -0,0 +1,794 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -21,9 +21,11 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +#include "base/functional/bind.h"
 +#include "base/functional/callback.h"
 +#include "base/location.h"
++#include "base/memory/weak_ptr.h"
 +#include "base/notreached.h"
 +#include "base/strings/stringprintf.h"
 +#include "base/strings/utf_string_conversions.h"
++#include "base/supports_user_data.h"
 +#include "base/task/sequenced_task_runner.h"
 +#include "base/values.h"
 +#include "chrome/browser/browser_process.h"
@@ -36,6 +38,10 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +#include "chrome/grit/browseros_onboarding_resources.h"
 +#include "chrome/grit/browseros_onboarding_resources_map.h"
 +#include "components/user_data_importer/common/importer_data_types.h"
++#include "content/public/browser/navigation_entry.h"
++#include "content/public/browser/navigation_handle.h"
++#include "content/public/browser/navigation_throttle.h"
++#include "content/public/browser/navigation_throttle_registry.h"
 +#include "content/public/browser/visibility.h"
 +#include "content/public/browser/web_contents.h"
 +#include "content/public/browser/web_ui.h"
@@ -47,6 +53,31 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +namespace {
 +
 +constexpr int kBrowserOSOnboardingApiVersion = 1;
++constexpr char kOnboardingBindingsKey[] = "browseros.onboarding.bindings";
++
++// A reload replaces the WebUI controller, but retains its WebContents. Keep
++// the step's weak flow callbacks and shared state here so the new handler can
++// rejoin preparation; none of these bindings keeps the first-run flow alive.
++struct OnboardingBindings : public base::SupportsUserData::Data {
++  base::RepeatingClosure completion_callback;
++  BrowserOSOnboardingEnsureReady ensure_ready;
++  scoped_refptr<BrowserOSOnboardingSetupState> setup_state;
++};
++// Old BrowserClaw resources send COMPLETE and immediately navigate to newtab.
++// Cancel that renderer handoff without showing an error page. Native completion
++// opens a separate browsing window after READY, so the two release orders work.
++class OnboardingNavigationThrottle : public content::NavigationThrottle {
++ public:
++  explicit OnboardingNavigationThrottle(
++      content::NavigationThrottleRegistry& registry)
++      : content::NavigationThrottle(registry) {}
++
++  ThrottleCheckResult WillStartRequest() override { return CANCEL_AND_IGNORE; }
++  const char* GetNameForLogging() override {
++    return "BrowserOSOnboardingNavigationThrottle";
++  }
++};
++
 +constexpr uint16_t kBrowserOSImportableItems =
 +    user_data_importer::HISTORY | user_data_importer::FAVORITES |
 +    user_data_importer::COOKIES | user_data_importer::PASSWORDS |
@@ -132,6 +163,9 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +
 +}  // namespace
 +
++BrowserOSOnboardingSetupState::BrowserOSOnboardingSetupState() = default;
++BrowserOSOnboardingSetupState::~BrowserOSOnboardingSetupState() = default;
++
 +class BrowserOSOnboardingHandler : public content::WebUIMessageHandler,
 +                                   public importer::ImporterProgressObserver {
 + public:
@@ -145,8 +179,16 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +    }
 +  }
 +
-+  void SetCompletionCallback(base::RepeatingClosure completion_callback) {
++  void SetCompletionCallback(
++      base::RepeatingClosure completion_callback,
++      BrowserOSOnboardingEnsureReady ensure_ready,
++      scoped_refptr<BrowserOSOnboardingSetupState> setup_state) {
 +    completion_callback_ = std::move(completion_callback);
++    ensure_ready_ = std::move(ensure_ready);
++    setup_state_ = std::move(setup_state);
++    if (IsJavascriptAllowed()) {
++      ResumeSetup();
++    }
 +  }
 +
 + private:
@@ -186,6 +228,10 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +        "browserosOnboardingComplete",
 +        base::BindRepeating(&BrowserOSOnboardingHandler::HandleComplete,
 +                            base::Unretained(this)));
++    web_ui()->RegisterMessageCallback(
++        "browserosOnboardingRetrySetup",
++        base::BindRepeating(&BrowserOSOnboardingHandler::HandleRetrySetup,
++                            base::Unretained(this)));
 +  }
 +
 +  void OnJavascriptDisallowed() override {
@@ -209,6 +255,7 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +    ResetImportState();
 +    SendState("detecting");
 +    DetectSources();
++    ResumeSetup();
 +  }
 +
 +  void HandleRefreshSources(const base::ListValue& args) {
@@ -275,20 +322,82 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +    importer_host_->set_observer(this);
 +    Profile* profile = Profile::FromWebUI(web_ui());
 +    SendState("importing");
-+    importer_host_->StartImportSettings(source_profile, profile,
-+                                        imported_items_,
-+                                        new ProfileWriter(profile));
++    importer_host_->StartImportSettings(
++        source_profile, profile, imported_items_, new ProfileWriter(profile));
 +  }
 +
 +  void HandleComplete(const base::ListValue& args) {
-+    if (completion_handled_) {
++    if (!setup_state_ || setup_state_->completion_handled ||
++        setup_state_->status == SetupStatus::kPreparing) {
 +      return;
 +    }
-+    completion_handled_ = true;
++    // COMPLETE remains a request, so old UI resources also remain open until
++    // the target browsing profile's primary extension reaches registry READY.
++    StartSetup();
++  }
 +
++  void HandleRetrySetup(const base::ListValue& args) {
++    if (setup_state_ && setup_state_->status == SetupStatus::kFailed) {
++      StartSetup();
++    }
++  }
++
++  void StartSetup() {
++    ++setup_state_->attempt;
++    setup_state_->status = SetupStatus::kPreparing;
++    SendState(last_import_status_);
++    WaitForPrimaryExtension();
++  }
++
++  void ResumeSetup() {
++    if (!setup_state_ || setup_state_->completion_handled) {
++      return;
++    }
++    SendState(last_import_status_);
++    if (setup_state_->status == SetupStatus::kPreparing ||
++        setup_state_->status == SetupStatus::kReady) {
++      // A replacement WebUI joins the same native operation. Recheck READY
++      // after reload rather than trusting a result delivered to the old page.
++      setup_state_->status = SetupStatus::kPreparing;
++      WaitForPrimaryExtension();
++    }
++  }
++
++  void WaitForPrimaryExtension() {
++    if (!ensure_ready_) {
++      OnPrimaryExtensionReady(false);
++      return;
++    }
++    ensure_ready_.Run(base::BindOnce(
++        [](scoped_refptr<BrowserOSOnboardingSetupState> state,
++           unsigned int attempt,
++           base::WeakPtr<BrowserOSOnboardingHandler> handler, bool ready) {
++          if (state->attempt != attempt || state->completion_handled) {
++            return;
++          }
++          state->status = ready ? SetupStatus::kReady : SetupStatus::kFailed;
++          if (handler) {
++            handler->OnPrimaryExtensionReady(ready);
++          }
++        },
++        setup_state_, setup_state_->attempt, weak_ptr_factory_.GetWeakPtr()));
++  }
++
++  void OnPrimaryExtensionReady(bool ready) {
++    if (!ready) {
++      setup_state_->status = SetupStatus::kFailed;
++      SendState(last_import_status_);
++      return;
++    }
++    if (setup_state_->completion_handled) {
++      return;
++    }
++    setup_state_->status = SetupStatus::kReady;
++    setup_state_->completion_handled = true;
 +    SendState("completed");
-+
 +    if (completion_callback_) {
++      // Navigation can tear down this handler and the picker; never run it
++      // inline while delivering a registry result or a WebUI message.
 +      base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
 +          FROM_HERE, completion_callback_);
 +    }
@@ -345,7 +454,8 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +    }
 +
 +    selection->source_index = *browser_index;
-+    selection->source_id = SourceIdForIndex(static_cast<size_t>(*browser_index));
++    selection->source_id =
++        SourceIdForIndex(static_cast<size_t>(*browser_index));
 +    selection->selected_items = user_data_importer::NONE;
 +    selection->has_selected_items = false;
 +    return true;
@@ -403,8 +513,7 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +      std::string browser_name =
 +          base::UTF16ToUTF8(source_profile.importer_name);
 +      std::string profile_name = base::UTF16ToUTF8(source_profile.profile);
-+      std::string account_name =
-+          base::UTF16ToUTF8(source_profile.account_name);
++      std::string account_name = base::UTF16ToUTF8(source_profile.account_name);
 +
 +      base::DictValue source;
 +      source.Set("id", SourceIdForIndex(i));
@@ -464,7 +573,34 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +    return progress;
 +  }
 +
++  void AddSetupState(base::DictValue& state) const {
++    if (!setup_state_) {
++      return;
++    }
++    const char* status = "idle";
++    switch (setup_state_->status) {
++      case SetupStatus::kIdle:
++        break;
++      case SetupStatus::kPreparing:
++        status = "preparing";
++        break;
++      case SetupStatus::kFailed: {
++        status = "failed";
++        base::DictValue error;
++        error.Set("code", "setup_failed");
++        error.Set("message", "Setup did not finish. Please retry.");
++        state.Set("error", std::move(error));
++        break;
++      }
++      case SetupStatus::kReady:
++        status = "ready";
++        break;
++    }
++    state.Set("setupState", status);
++  }
++
 +  void SendState(std::string_view status) {
++    last_import_status_ = std::string(status);
 +    if (IsJavascriptAllowed()) {
 +      base::DictValue state;
 +      state.Set("apiVersion", kBrowserOSOnboardingApiVersion);
@@ -476,6 +612,7 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +      if (imported_items_ || import_result_) {
 +        state.Set("progress", BuildProgress());
 +      }
++      AddSetupState(state);
 +      CallJavascriptFunction("browserosOnboarding.receiveState", state);
 +    }
 +  }
@@ -487,6 +624,7 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +  void SendFailure(std::string_view status,
 +                   const std::string& code,
 +                   const std::string& message) {
++    last_import_status_ = std::string(status);
 +    if (IsJavascriptAllowed()) {
 +      base::DictValue state;
 +      state.Set("apiVersion", kBrowserOSOnboardingApiVersion);
@@ -502,6 +640,7 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +      error.Set("code", code);
 +      error.Set("message", message);
 +      state.Set("error", std::move(error));
++      AddSetupState(state);
 +      CallJavascriptFunction("browserosOnboarding.receiveState", state);
 +    }
 +  }
@@ -571,6 +710,10 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +    import_result_.reset();
 +  }
 +
++  using SetupStatus = BrowserOSOnboardingSetupState::Status;
++  BrowserOSOnboardingEnsureReady ensure_ready_;
++  scoped_refptr<BrowserOSOnboardingSetupState> setup_state_;
++  std::string last_import_status_ = "idle";
 +  std::unique_ptr<ImporterList> importer_list_;
 +  raw_ptr<ExternalProcessImporterHost> importer_host_ = nullptr;
 +  base::RepeatingClosure completion_callback_;
@@ -580,7 +723,7 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +  uint16_t imported_items_ = user_data_importer::NONE;
 +  bool importer_list_loaded_ = false;
 +  bool import_did_succeed_ = false;
-+  bool completion_handled_ = false;
++  base::WeakPtrFactory<BrowserOSOnboardingHandler> weak_ptr_factory_{this};
 +};
 +
 +BrowserOSOnboardingUIConfig::BrowserOSOnboardingUIConfig()
@@ -597,15 +740,61 @@ index 0000000000000..372f36bcb4864f440e38a461e9cf4ab982b191dd
 +  auto handler = std::make_unique<BrowserOSOnboardingHandler>();
 +  handler_ = handler.get();
 +  web_ui->AddMessageHandler(std::move(handler));
++  auto* bindings = static_cast<OnboardingBindings*>(
++      web_ui->GetWebContents()->GetUserData(kOnboardingBindingsKey));
++  if (bindings) {
++    handler_->SetCompletionCallback(bindings->completion_callback,
++                                    bindings->ensure_ready,
++                                    bindings->setup_state);
++  }
 +}
 +
 +BrowserOSOnboarding::~BrowserOSOnboarding() = default;
 +
-+void BrowserOSOnboarding::SetCompletionCallback(
-+    base::RepeatingClosure completion_callback) {
-+  if (handler_) {
-+    handler_->SetCompletionCallback(std::move(completion_callback));
++// static
++void BrowserOSOnboarding::MaybeCreateNavigationThrottle(
++    content::NavigationThrottleRegistry& registry) {
++  auto& handle = registry.GetNavigationHandle();
++  const GURL& source = handle.GetWebContents()->GetLastCommittedURL();
++  const GURL& target = handle.GetURL();
++  if (!handle.IsInPrimaryMainFrame() || !handle.IsRendererInitiated() ||
++      !source.SchemeIs(content::kChromeUIScheme) ||
++      source.host() != chrome::kChromeUIBrowserOSOnboardingHost) {
++    return;
 +  }
++  // Newtab may already be rewritten to an extension or the fallback NTP when
++  // no extension is installed. Inspect its virtual URL as well as the target,
++  // without gating unrelated links or reloads of the onboarding document.
++  const auto* entry = handle.GetNavigationEntry();
++  const GURL virtual_target = entry ? entry->GetVirtualURL() : GURL();
++  auto is_new_tab = [](const GURL& url) {
++    return url.SchemeIs(content::kChromeUIScheme) &&
++           (url.host() == chrome::kChromeUINewTabHost ||
++            url.host() == chrome::kChromeUINewTabPageHost ||
++            url.host() == chrome::kChromeUINewTabPageThirdPartyHost);
++  };
++  if (target.SchemeIs("chrome-extension") || is_new_tab(target) ||
++      is_new_tab(virtual_target)) {
++    registry.AddThrottle(
++        std::make_unique<OnboardingNavigationThrottle>(registry));
++  }
++}
++
++void BrowserOSOnboarding::SetCompletionCallback(
++    base::RepeatingClosure completion_callback,
++    BrowserOSOnboardingEnsureReady ensure_ready,
++    scoped_refptr<BrowserOSOnboardingSetupState> setup_state) {
++  auto bindings = std::make_unique<OnboardingBindings>();
++  bindings->completion_callback = std::move(completion_callback);
++  bindings->ensure_ready = std::move(ensure_ready);
++  bindings->setup_state = std::move(setup_state);
++  if (handler_) {
++    handler_->SetCompletionCallback(bindings->completion_callback,
++                                    bindings->ensure_ready,
++                                    bindings->setup_state);
++  }
++  web_ui()->GetWebContents()->SetUserData(kOnboardingBindingsKey,
++                                          std::move(bindings));
 +}
 +
 +WEB_UI_CONTROLLER_TYPE_IMPL(BrowserOSOnboarding)

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding.h b/chrome/browser/browseros/onboarding/browseros_onboarding.h
 new file mode 100644
-index 0000000000000..6d84599152fc6
+index 0000000000000000000000000000000000000000..7126c2accebe176d3803c2e3c5f4590c37cdcb02
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding.h
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,68 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -13,8 +13,31 @@ index 0000000000000..6d84599152fc6
 +
 +#include "base/functional/callback_forward.h"
 +#include "base/memory/raw_ptr.h"
++#include "base/memory/ref_counted.h"
 +#include "content/public/browser/web_ui_controller.h"
 +#include "content/public/browser/webui_config.h"
++
++// The first-run step owns this across WebUI reloads. The page observes native
++// completion state; it does not own the registry wait or infer readiness.
++struct BrowserOSOnboardingSetupState
++    : public base::RefCounted<BrowserOSOnboardingSetupState> {
++  BrowserOSOnboardingSetupState();
++  enum class Status { kIdle, kPreparing, kFailed, kReady };
++  Status status = Status::kIdle;
++  unsigned int attempt = 0;
++  bool completion_handled = false;
++
++ private:
++  friend class base::RefCounted<BrowserOSOnboardingSetupState>;
++  ~BrowserOSOnboardingSetupState();
++};
++
++using BrowserOSOnboardingEnsureReady =
++    base::RepeatingCallback<void(base::OnceCallback<void(bool)>)>;
++
++namespace content {
++class NavigationThrottleRegistry;
++}
 +
 +class BrowserOSOnboardingHandler;
 +class BrowserOSOnboarding;
@@ -32,7 +55,15 @@ index 0000000000000..6d84599152fc6
 +  BrowserOSOnboarding& operator=(const BrowserOSOnboarding&) = delete;
 +  ~BrowserOSOnboarding() override;
 +
-+  void SetCompletionCallback(base::RepeatingClosure completion_callback);
++  // Legacy resources navigate immediately after COMPLETE. Retain the native
++  // setup page until the flow opens its destination after the READY callback.
++  static void MaybeCreateNavigationThrottle(
++      content::NavigationThrottleRegistry& registry);
++
++  void SetCompletionCallback(
++      base::RepeatingClosure completion_callback,
++      BrowserOSOnboardingEnsureReady ensure_ready,
++      scoped_refptr<BrowserOSOnboardingSetupState> setup_state);
 +
 + private:
 +  raw_ptr<BrowserOSOnboardingHandler> handler_ = nullptr;

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts b/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
 new file mode 100644
-index 0000000000000..2bf836fe76daa
+index 0000000000000000000000000000000000000000..c7d8b69521bef220e2b0c0aaea3c0794c679b252
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,99 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -16,11 +16,15 @@ index 0000000000000..2bf836fe76daa
 +export type BrowserOSImportStatus =
 +    'idle'|'detecting'|'ready'|'importing'|'succeeded'|'failed'|'completed';
 +
++// Optional v1 extension: UI resources and native Chromium ship independently.
++export type BrowserOSSetupState = 'idle'|'preparing'|'failed'|'ready';
++
 +export const BrowserOSOnboardingMessage = {
 +  PAGE_READY: 'browserosOnboardingPageReady',
 +  REFRESH_SOURCES: 'browserosOnboardingRefreshSources',
 +  START_IMPORT: 'browserosOnboardingStartImport',
 +  COMPLETE: 'browserosOnboardingComplete',
++  RETRY_SETUP: 'browserosOnboardingRetrySetup',
 +} as const;
 +
 +export type BrowserOSOnboardingMessage =
@@ -64,6 +68,7 @@ index 0000000000000..2bf836fe76daa
 +export interface BrowserOSOnboardingState {
 +  apiVersion: typeof BROWSEROS_ONBOARDING_API_VERSION;
 +  status: BrowserOSImportStatus;
++  setupState?: BrowserOSSetupState;
 +  sources: BrowserOSImportSource[];
 +  progress?: BrowserOSImportProgress;
 +  error?: BrowserOSOnboardingError;

--- a/packages/browseros/chromium_patches/chrome/browser/chrome_content_browser_client_navigation_throttles.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/chrome_content_browser_client_navigation_throttles.cc
@@ -1,0 +1,23 @@
+diff --git a/chrome/browser/chrome_content_browser_client_navigation_throttles.cc b/chrome/browser/chrome_content_browser_client_navigation_throttles.cc
+index 8de81338cce093a3fa4aebccaec37591c1b54976..0415111febcce81c7fbbda1f3bf809168da97e6f 100644
+--- a/chrome/browser/chrome_content_browser_client_navigation_throttles.cc
++++ b/chrome/browser/chrome_content_browser_client_navigation_throttles.cc
+@@ -89,6 +89,7 @@
+ #endif  // BUILDFLAG(DFMIFY_DEV_UI)
+ 
+ #else  // BUILDFLAG(IS_ANDROID)
++#include "chrome/browser/browseros/onboarding/browseros_onboarding.h"
+ #include "chrome/browser/devtools/devtools_navigation_throttle.h"
+ #include "chrome/browser/page_info/web_view_side_panel_throttle.h"
+ #include "chrome/browser/themes/theme_service_factory.h"
+@@ -290,6 +291,10 @@ void CreateAndAddChromeThrottlesForNavigation(
+     // NavigationThrottleRegistry::AddThrottle().
+     page_load_metrics::MetricsNavigationThrottle::CreateAndAdd(registry);
+ 
++#if !BUILDFLAG(IS_ANDROID)
++    BrowserOSOnboarding::MaybeCreateNavigationThrottle(registry);
++#endif
++
+     // Appends the X-Geo header to the navigation request if needed.
+     if (auto throttle =
+             GeolocationNavigationThrottle::MaybeCreateThrottleFor(registry)) {

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/external_provider_impl.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/external_provider_impl.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/external_provider_impl.cc b/chrome/browser/extensions/external_provider_impl.cc
-index 074cfef37f0b0956dcddcfe4813bee1cdc275467..6bacca205623e11debd535131a15acb8af335edc 100644
+index 074cfef37f0b0956dcddcfe4813bee1cdc275467..4df8d0632c7a427e10bdc66d42b0f8b39c5493fe 100644
 --- a/chrome/browser/extensions/external_provider_impl.cc
 +++ b/chrome/browser/extensions/external_provider_impl.cc
 @@ -30,6 +30,8 @@
@@ -11,7 +11,16 @@ index 074cfef37f0b0956dcddcfe4813bee1cdc275467..6bacca205623e11debd535131a15acb8
  #include "chrome/browser/extensions/extension_management.h"
  #include "chrome/browser/extensions/extension_migrator.h"
  #include "chrome/browser/extensions/external_component_loader.h"
-@@ -922,6 +924,40 @@ void ExternalProviderImpl::CreateExternalProviders(
+@@ -503,7 +505,7 @@ void ExternalProviderImpl::RetrieveExtensionsFromPrefs(
+       }
+       external_file_extensions->emplace_back(
+           extension_id, version, path, crx_location_, creation_flags,
+-          auto_acknowledge_, install_immediately_);
++          auto_acknowledge_, install_immediately_, external_install_priority_);
+     } else {                       // if (external_update_url)
+       CHECK(external_update_url);  // Checking of keys above ensures this.
+       if (download_location_ == ManifestLocation::kInvalidLocation) {
+@@ -922,6 +924,44 @@ void ExternalProviderImpl::CreateExternalProviders(
      provider_list->push_back(std::move(initial_external_extensions_provider));
    }
  #endif  // BUILDFLAG(ENABLE_EXTENSIONS)
@@ -47,6 +56,10 @@ index 074cfef37f0b0956dcddcfe4813bee1cdc275467..6bacca205623e11debd535131a15acb8
 +    browseros_provider->set_auto_acknowledge(true);
 +    browseros_provider->set_allow_updates(true);
 +    browseros_provider->set_install_immediately(true);
++    // Bundled files are needed for the first-run handoff. Raise only this local
++    // install's scheduling urgency, keeping default-install provenance intact.
++    browseros_provider->set_external_install_priority(
++        ExternalInstallPriority::kForeground);
 +    provider_list->push_back(std::move(browseros_provider));
 +  }
  }

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/external_provider_impl.h
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/external_provider_impl.h
@@ -1,0 +1,35 @@
+diff --git a/chrome/browser/extensions/external_provider_impl.h b/chrome/browser/extensions/external_provider_impl.h
+index 3959d466ab6d3fc30f22f4d4fab51fbf06b4c943..e03613dc8238d616dbd3ee26bb3f4a05365d517d 100644
+--- a/chrome/browser/extensions/external_provider_impl.h
++++ b/chrome/browser/extensions/external_provider_impl.h
+@@ -15,6 +15,7 @@
+ #include "base/memory/scoped_refptr.h"
+ #include "base/values.h"
+ #include "chrome/browser/extensions/external_loader.h"
++#include "extensions/browser/external_install_info.h"
+ #include "extensions/browser/external_provider_interface.h"
+ #include "extensions/buildflags/buildflags.h"
+ #include "extensions/common/manifest.h"
+@@ -101,6 +102,12 @@ class ExternalProviderImpl : public ExternalProviderInterface {
+ 
+   void set_allow_updates(bool allow_updates) { allow_updates_ = allow_updates; }
+ 
++  // Applies to CRX file announcements only; remote updater work keeps its own
++  // scheduling policy. This does not change provenance or update-delay rules.
++  void set_external_install_priority(ExternalInstallPriority priority) {
++    external_install_priority_ = priority;
++  }
++
+   const std::optional<base::DictValue>& prefs_for_test() { return prefs_; }
+ 
+  private:
+@@ -159,6 +166,9 @@ class ExternalProviderImpl : public ExternalProviderInterface {
+   // Whether the extensions from this provider should be installed immediately.
+   bool install_immediately_ = false;
+ 
++  ExternalInstallPriority external_install_priority_ =
++      ExternalInstallPriority::kDefault;
++
+   // Whether the provider should be allowed to update the set of external
+   // extensions it provides.
+   bool allow_updates_ = false;

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/external_provider_manager.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/external_provider_manager.cc
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/extensions/external_provider_manager.cc b/chrome/browser/extensions/external_provider_manager.cc
+index 02b5f23cb062594d555990a29fc81b51ef6170bc..505b4eb29d9adce6dada808be288e4aedd03d70a 100644
+--- a/chrome/browser/extensions/external_provider_manager.cc
++++ b/chrome/browser/extensions/external_provider_manager.cc
+@@ -291,6 +291,7 @@ bool ExternalProviderManager::OnExternalExtensionFileFound(
+   installer->set_expected_version(info.version,
+                                   true /* fail_install_if_unexpected */);
+   installer->set_install_immediately(info.install_immediately);
++  installer->set_external_install_priority(info.install_priority);
+   installer->set_creation_flags(info.creation_flags);
+ 
+   CRXFileInfo file_info(

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_browser_creator.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_browser_creator.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/startup/startup_browser_creator.cc b/chrome/browser/ui/startup/startup_browser_creator.cc
-index bed74e910df0667b636c5b1e404df913febbc019..95ccc7b99b2f22bb8b6651237aa742d1a0a7010b 100644
+index bed74e910df0667b636c5b1e404df913febbc019..1ede5472b8f5666bee2fbeca32eb47ea38f5e85a 100644
 --- a/chrome/browser/ui/startup/startup_browser_creator.cc
 +++ b/chrome/browser/ui/startup/startup_browser_creator.cc
 @@ -41,6 +41,9 @@
@@ -12,7 +12,7 @@ index bed74e910df0667b636c5b1e404df913febbc019..95ccc7b99b2f22bb8b6651237aa742d1
  #include "chrome/browser/extensions/startup_helper.h"
  #include "chrome/browser/first_run/first_run.h"
  #include "chrome/browser/lifetime/browser_shutdown.h"
-@@ -476,6 +479,62 @@ void OpenNewWindowForFirstRun(const base::CommandLine& command_line,
+@@ -476,6 +479,69 @@ void OpenNewWindowForFirstRun(const base::CommandLine& command_line,
  }
  #endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)
  
@@ -45,11 +45,14 @@ index bed74e910df0667b636c5b1e404df913febbc019..95ccc7b99b2f22bb8b6651237aa742d1
 +
 +  if (status == ProfilePicker::FirstRunExitStatus::kCompleted) {
 +    ProfilePicker::SetOpenCommandLineUrlsInNextProfileOpened(true);
++    // kCompleted is posted only after the target profile's primary extension
++    // enters ExtensionRegistry::ready_extensions(). Do not move this URL into
++    // the picker launch: supplying provider prefs alone cannot authorize it.
 +    // BrowserOS onboarding hands off to the agent extension so the user
 +    // can finish setting up a provider or coding agent; a chrome:// page
 +    // cannot navigate there itself. The agent extension only exists on
-+    // BrowserOS builds, so other products append nothing here and route
-+    // themselves. The target is the first-run setup step, not the settings
++    // BrowserOS builds. BrowserClaw instead hands off to its MCP page.
++    // The BrowserOS target is the first-run setup step, not the settings
 +    // page: it drops the user straight into the new tab page once they
 +    // connect something.
 +    std::vector<GURL> tabs = first_run_urls;
@@ -57,6 +60,10 @@ index bed74e910df0667b636c5b1e404df913febbc019..95ccc7b99b2f22bb8b6651237aa742d1
 +      tabs.emplace_back(std::string("chrome-extension://") +
 +                        browseros::kAgentExtensionId +
 +                        "/app.html#/onboarding/ai");
++    } else if (browseros::IsBrowserClawProduct()) {
++      // The native callback now owns the final MCP CTA as well; UI resources
++      // must not navigate the picker before its primary extension is ready.
++      tabs.emplace_back("chrome://newtab/#/mcp");
 +    }
 +    ProfilePicker::SetFirstRunTabsInNextProfileOpened(tabs);
 +    return;
@@ -75,7 +82,7 @@ index bed74e910df0667b636c5b1e404df913febbc019..95ccc7b99b2f22bb8b6651237aa742d1
  #if BUILDFLAG(IS_CHROMEOS)
  // Returns the app id of the kiosk app associated with the current user session.
  // Returns nullopt for non-kiosk user sessions and for ARCVM kiosk sessions,
-@@ -714,6 +773,26 @@ void StartupBrowserCreator::LaunchBrowser(
+@@ -714,6 +780,26 @@ void StartupBrowserCreator::LaunchBrowser(
        command_line, {profile, StartupProfileMode::kBrowserWindow});
  
    if (!IsSilentLaunchEnabled(command_line, profile)) {

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/profiles/first_run_flow_controller.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/profiles/first_run_flow_controller.cc
@@ -1,17 +1,18 @@
 diff --git a/chrome/browser/ui/views/profiles/first_run_flow_controller.cc b/chrome/browser/ui/views/profiles/first_run_flow_controller.cc
-index 24848513afc0ffa5649fbe690055d0d018c8d367..cec22cfee5f76501ce331030f8ad8cba9502a0e7 100644
+index 24848513afc0ffa5649fbe690055d0d018c8d367..c8b51bbd69806159c0f1279daa73926bbaaa47c5 100644
 --- a/chrome/browser/ui/views/profiles/first_run_flow_controller.cc
 +++ b/chrome/browser/ui/views/profiles/first_run_flow_controller.cc
-@@ -26,6 +26,8 @@
+@@ -26,6 +26,9 @@
  #include "base/time/time.h"
  #include "base/version_info/channel.h"
  #include "chrome/browser/browser_process.h"
++#include "chrome/browser/browseros/extensions/browseros_extension_loader.h"
 +#include "chrome/browser/browseros/onboarding/browseros_onboarding.h"
 +#include "chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h"
  #include "chrome/browser/enterprise/util/managed_browser_utils.h"
  #include "chrome/browser/policy/cloud/user_policy_signin_service.h"
  #include "chrome/browser/policy/cloud/user_policy_signin_service_factory.h"
-@@ -255,6 +257,60 @@ class IntroStepController : public ProfileManagementStepController {
+@@ -255,6 +258,66 @@ class IntroStepController : public ProfileManagementStepController {
    base::WeakPtrFactory<IntroStepController> weak_ptr_factory_{this};
  };
  
@@ -19,9 +20,11 @@ index 24848513afc0ffa5649fbe690055d0d018c8d367..cec22cfee5f76501ce331030f8ad8cba
 +    : public ProfileManagementStepController {
 + public:
 +  BrowserOSOnboardingStepController(ProfilePickerWebContentsHost* host,
-+                                    base::RepeatingClosure completion_callback)
++                                    base::RepeatingClosure completion_callback,
++                                    BrowserOSOnboardingEnsureReady ensure_ready)
 +      : ProfileManagementStepController(host),
-+        completion_callback_(std::move(completion_callback)) {}
++        completion_callback_(std::move(completion_callback)),
++        ensure_ready_(std::move(ensure_ready)) {}
 +
 +  ~BrowserOSOnboardingStepController() override = default;
 +
@@ -60,10 +63,14 @@ index 24848513afc0ffa5649fbe690055d0d018c8d367..cec22cfee5f76501ce331030f8ad8cba
 +                              ->GetController()
 +                              ->GetAs<BrowserOSOnboarding>();
 +    DCHECK(onboarding_ui);
-+    onboarding_ui->SetCompletionCallback(completion_callback_);
++    onboarding_ui->SetCompletionCallback(completion_callback_, ensure_ready_,
++                                          setup_state_);
 +  }
 +
 +  base::RepeatingClosure completion_callback_;
++  BrowserOSOnboardingEnsureReady ensure_ready_;
++  scoped_refptr<BrowserOSOnboardingSetupState> setup_state_ =
++      base::MakeRefCounted<BrowserOSOnboardingSetupState>();
 +
 +  base::WeakPtrFactory<BrowserOSOnboardingStepController> weak_ptr_factory_{
 +      this};
@@ -72,7 +79,7 @@ index 24848513afc0ffa5649fbe690055d0d018c8d367..cec22cfee5f76501ce331030f8ad8cba
  class DefaultBrowserStepController : public ProfileManagementStepController {
   public:
    explicit DefaultBrowserStepController(
-@@ -965,47 +1021,12 @@ void FirstRunFlowController::StartBrowsing() {
+@@ -965,47 +1028,25 @@ void FirstRunFlowController::StartBrowsing() {
  void FirstRunFlowController::Init() {
    RegisterStep(
        Step::kIntro,
@@ -86,6 +93,19 @@ index 24848513afc0ffa5649fbe690055d0d018c8d367..cec22cfee5f76501ce331030f8ad8cba
 -                              base::Unretained(this))));
 +          base::BindRepeating(
 +              &FirstRunFlowController::HandleBrowserOSOnboardingComplete,
++              weak_ptr_factory_.GetWeakPtr()),
++          base::BindRepeating(
++              [](base::WeakPtr<FirstRunFlowController> flow,
++                 base::OnceCallback<void(bool)> callback) {
++                if (!flow) {
++                  std::move(callback).Run(false);
++                  return;
++                }
++                // Picker contents can belong to a different profile. The
++                // extension handoff must wait for the actual browsing profile.
++                browseros::BrowserOSExtensionLoader::EnsurePrimaryExtensionReady(
++                    flow->profile_, std::move(callback));
++              },
 +              weak_ptr_factory_.GetWeakPtr())));
    SwitchToStep(Step::kIntro, /*reset_state=*/true);
 -
@@ -124,7 +144,7 @@ index 24848513afc0ffa5649fbe690055d0d018c8d367..cec22cfee5f76501ce331030f8ad8cba
  }
  
  void FirstRunFlowController::CancelSigninFlow() {
-@@ -1060,6 +1081,11 @@ void FirstRunFlowController::HandleIntroSigninChoice(IntroChoice choice) {
+@@ -1060,6 +1101,11 @@ void FirstRunFlowController::HandleIntroSigninChoice(IntroChoice choice) {
        kAccessPoint, profile_->GetPath());
  }
  

--- a/packages/browseros/chromium_patches/extensions/browser/crx_installer.cc
+++ b/packages/browseros/chromium_patches/extensions/browser/crx_installer.cc
@@ -1,0 +1,25 @@
+diff --git a/extensions/browser/crx_installer.cc b/extensions/browser/crx_installer.cc
+index d093f443863b06d96b091889ddcef71eb192084f..6c519923e6ebd8d8e346166180c51cc23669ea52 100644
+--- a/extensions/browser/crx_installer.cc
++++ b/extensions/browser/crx_installer.cc
+@@ -1293,9 +1293,20 @@ void CrxInstaller::ConfirmReEnable() {
+   }
+ }
+ 
++void CrxInstaller::set_external_install_priority(
++    ExternalInstallPriority priority) {
++  DCHECK_CURRENTLY_ON(BrowserThread::UI);
++  CHECK(!unpacker_task_runner_);
++  external_install_priority_ = priority;
++}
++
+ base::SequencedTaskRunner* CrxInstaller::GetUnpackerTaskRunner() {
+   if (!unpacker_task_runner_) {
++    // Foreground external files unblock a visible setup surface. Keep the
++    // historical policy for all other installs, including future updater work;
++    // scheduler urgency must not be encoded in persisted creation flags.
+     bool low_priority =
++        external_install_priority_ != ExternalInstallPriority::kForeground &&
+         (creation_flags_ & Extension::WAS_INSTALLED_BY_DEFAULT) &&
+         !(creation_flags_ & Extension::WAS_INSTALLED_BY_OEM);
+     unpacker_task_runner_ = GetOneShotFileTaskRunner(

--- a/packages/browseros/chromium_patches/extensions/browser/crx_installer.h
+++ b/packages/browseros/chromium_patches/extensions/browser/crx_installer.h
@@ -1,0 +1,35 @@
+diff --git a/extensions/browser/crx_installer.h b/extensions/browser/crx_installer.h
+index b12d3bdac536ee86554c72ca6d9e3def25848616..e77160c9fd4914213c3acfeffdf81ad7b27e32b0 100644
+--- a/extensions/browser/crx_installer.h
++++ b/extensions/browser/crx_installer.h
+@@ -21,6 +21,7 @@
+ #include "components/sync/model/string_ordinal.h"
+ #include "extensions/browser/extension_install_prompt_client.h"
+ #include "extensions/browser/extension_system.h"
++#include "extensions/browser/external_install_info.h"
+ #include "extensions/browser/install_flag.h"
+ #include "extensions/browser/manifest_check_level.h"
+ #include "extensions/browser/preload_check.h"
+@@ -249,6 +250,12 @@ class CrxInstaller : public SandboxedUnpackerClient {
+   void set_install_immediately(bool val) {
+     set_install_flag(kInstallFlagInstallImmediately, val);
+   }
++
++  // Set before installation starts: the unpacker owns a sequenced task runner
++  // whose priority is fixed when it is first created. Unlike install_immediately
++  // (which bypasses update delay), this only controls file-work scheduling.
++  void set_external_install_priority(ExternalInstallPriority priority);
++
+   void set_do_not_sync(bool val) {
+     set_install_flag(kInstallFlagDoNotSync, val);
+   }
+@@ -546,6 +553,9 @@ class CrxInstaller : public SandboxedUnpackerClient {
+   // Sequenced task runner where most file I/O operations will be performed.
+   scoped_refptr<base::SequencedTaskRunner> shared_file_task_runner_;
+ 
++  ExternalInstallPriority external_install_priority_ =
++      ExternalInstallPriority::kDefault;
++
+   // Sequenced task runner where the SandboxedUnpacker will run. Because the
+   // unpacker uses its own temp dir, it won't hit race conditions, and can use a
+   // separate task runner per instance (for better performance).

--- a/packages/browseros/chromium_patches/extensions/browser/external_install_info.cc
+++ b/packages/browseros/chromium_patches/extensions/browser/external_install_info.cc
@@ -1,0 +1,21 @@
+diff --git a/extensions/browser/external_install_info.cc b/extensions/browser/external_install_info.cc
+index 4605419ba144b5560d29a7c5dcc4f402e68b1c75..70b443ed262441d851036a0a219c2837b40d8893 100644
+--- a/extensions/browser/external_install_info.cc
++++ b/extensions/browser/external_install_info.cc
+@@ -22,12 +22,14 @@ ExternalInstallInfoFile::ExternalInstallInfoFile(
+     mojom::ManifestLocation crx_location,
+     int creation_flags,
+     bool mark_acknowledged,
+-    bool install_immediately)
++    bool install_immediately,
++    ExternalInstallPriority install_priority)
+     : ExternalInstallInfo(extension_id, creation_flags, mark_acknowledged),
+       version(version),
+       path(path),
+       crx_location(crx_location),
+-      install_immediately(install_immediately) {}
++      install_immediately(install_immediately),
++      install_priority(install_priority) {}
+ ExternalInstallInfoFile::ExternalInstallInfoFile(
+     ExternalInstallInfoFile&& other) = default;
+ 

--- a/packages/browseros/chromium_patches/extensions/browser/external_install_info.h
+++ b/packages/browseros/chromium_patches/extensions/browser/external_install_info.h
@@ -1,0 +1,40 @@
+diff --git a/extensions/browser/external_install_info.h b/extensions/browser/external_install_info.h
+index 44d216fb33fa837ec311f9c5594f7a286ef5026e..cef6df11da78279b546268bd7fd841012eab8509 100644
+--- a/extensions/browser/external_install_info.h
++++ b/extensions/browser/external_install_info.h
+@@ -14,6 +14,16 @@
+ 
+ namespace extensions {
+ 
++// Scheduling urgency for this external-file install only. It is not persisted
++// in extension preferences or creation flags, so later updates retain their
++// normal priority unless their provider explicitly requests foreground work.
++enum class ExternalInstallPriority {
++  // Preserve Chromium's existing priority derived from install provenance.
++  kDefault,
++  // Installation is needed by a visible surface, without blocking the UI thread.
++  kForeground,
++};
++
+ // Holds information about an external extension install from an external
+ // provider.
+ struct ExternalInstallInfo {
+@@ -37,7 +47,9 @@ struct ExternalInstallInfoFile : public ExternalInstallInfo {
+                           mojom::ManifestLocation crx_location,
+                           int creation_flags,
+                           bool mark_acknowledged,
+-                          bool install_immediately);
++                          bool install_immediately,
++                          ExternalInstallPriority install_priority =
++                              ExternalInstallPriority::kDefault);
+   ExternalInstallInfoFile(ExternalInstallInfoFile&& other);
+   ~ExternalInstallInfoFile() override;
+ 
+@@ -45,6 +57,7 @@ struct ExternalInstallInfoFile : public ExternalInstallInfo {
+   base::FilePath path;
+   mojom::ManifestLocation crx_location;
+   bool install_immediately;
++  ExternalInstallPriority install_priority;
+ };
+ 
+ struct ExternalInstallInfoUpdateUrl : public ExternalInstallInfo {


### PR DESCRIPTION
A fast first-run Skip could open the product extension before Chromium finished loading it. Bundle discovery also waited on an unbounded network request when local metadata was missing, and three overlapping installation paths could race.

This change makes discovery local-only, gives bundled file installs transient USER_VISIBLE priority, and uses one coordinator with Chromium's external provider as the install executor. Native onboarding waits for the target profile's primary extension registry READY event; completion and Retry callers join the same operation. Installed same/newer versions are retained, valid newer bundles install first, and bounded recovery/maintenance uses the provider's update interface. Periodic cleanup, safe re-enabling, and health reporting remain independent of network success.

The optional API v1 `setupState` field and `browserosOnboardingRetrySetup` message match the independently released onboarding UI in #2559. Import status remains separate, and setup state survives WebUI reloads. A native navigation guard keeps legacy BrowserClaw resources on onboarding; native opens its MCP destination after READY.

Validation:
- Chromium chrome build through the shared sfmux build slot.
- Context-free code review, including pending URL retries, secondary bundle failures, reloads, and shutdown.
- Extracted patches checked against the task branch and applied to the Chromium base.
- Chromium unit/browser tests omitted per repository instructions.
