### PR TITLE
feat(onboarding): clarify macOS import permissions in both apps

### DIFF
--- a/packages/browseros-agent/apps/app-onboard/scripts/verify-chromium-build.ts
+++ b/packages/browseros-agent/apps/app-onboard/scripts/verify-chromium-build.ts
@@ -3,9 +3,8 @@ import path from 'node:path'
 
 const buildDir = path.resolve(import.meta.dir, '../dist/chromium')
 const textResourceFiles = ['app.css', 'app.js', 'index.html']
-// Everything static lives under icon/ because listResourceFiles rejects any
-// other subdirectory outright; keychain-prompt.png is the import step's macOS
-// dialog screenshot, kept under icon/ to satisfy the directory guard.
+// Keep the legacy screenshot packaged: already-shipped Chromium resource lists
+// still enumerate it, although the UI now renders a CSS illustration.
 const iconResourceFiles = [
   'icon/16.png',
   'icon/32.png',

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/browseros-onboarding-bridge.test.ts
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/browseros-onboarding-bridge.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from 'bun:test'
-import type { BrowserOSOnboardingState } from './browseros-onboarding-api'
+import type {
+  BrowserOSOnboardingState,
+  BrowserOSStartImportRequest,
+} from './browseros-onboarding-api'
 import { BrowserOSOnboardingMessage } from './browseros-onboarding-api'
 import { createBrowserOSOnboardingBridge } from './browseros-onboarding-bridge'
 import { MOCK_BROWSEROS_IMPORT_SOURCES } from './onboarding-v2.helpers'
@@ -324,4 +327,62 @@ describe('native setup lifecycle', () => {
       }
     })
   }
+})
+
+describe('native import handoff', () => {
+  it('locks repeated submissions before native acknowledgment and permits retry after failure', () => {
+    installWindow()
+    const sent: string[] = []
+    const states: BrowserOSOnboardingState[] = []
+    const bridge = createBrowserOSOnboardingBridge({
+      chrome: {
+        send(message) {
+          sent.push(message)
+        },
+      },
+    })
+    bridge.registerReceiver((state) => states.push(state))
+    window.browserosOnboarding?.receiveState({
+      apiVersion: 1,
+      status: 'ready',
+      sources: [...MOCK_BROWSEROS_IMPORT_SOURCES],
+    })
+    const request: BrowserOSStartImportRequest = {
+      sourceId: MOCK_BROWSEROS_IMPORT_SOURCES[0].id,
+      items: ['cookies'],
+    }
+    bridge.startImport(request)
+    bridge.startImport(request)
+    expect(sent).toEqual([BrowserOSOnboardingMessage.START_IMPORT])
+    expect(states.at(-1)?.status).toBe('importing')
+    expect(states.at(-1)?.progress?.completedItems).toEqual([])
+    window.browserosOnboarding?.receiveState({
+      apiVersion: 1,
+      status: 'failed',
+      sources: [...MOCK_BROWSEROS_IMPORT_SOURCES],
+    })
+    bridge.startImport(request)
+    expect(sent).toHaveLength(2)
+  })
+
+  it('preserves a synchronous native failure instead of overwriting it with pending state', () => {
+    installWindow()
+    const states: BrowserOSOnboardingState[] = []
+    const bridge = createBrowserOSOnboardingBridge({
+      chrome: {
+        send() {
+          window.browserosOnboarding?.receiveState({
+            apiVersion: 1,
+            status: 'failed',
+            sources: [],
+            error: { code: 'import_failed', message: 'Import denied' },
+          })
+        },
+      },
+    })
+    bridge.registerReceiver((state) => states.push(state))
+    bridge.startImport({ sourceId: 'source-0', items: ['cookies'] })
+    expect(states.map((state) => state.status)).toEqual(['importing', 'failed'])
+    expect(states.at(-1)?.error?.message).toBe('Import denied')
+  })
 })

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/browseros-onboarding-bridge.ts
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/browseros-onboarding-bridge.ts
@@ -273,7 +273,30 @@ export function createBrowserOSOnboardingBridge(
     },
     startImport(request) {
       if (request.items && request.items.length === 0) return
+      if (currentState?.status === 'importing') return
       if (!isMock) {
+        const source = currentState?.sources.find(
+          (source) => source.id === request.sourceId,
+        )
+        // Publish before chrome.send: this locks Copy/Skip during the native
+        // handoff and prevents duplicate submissions. Native failures replace
+        // this snapshot and permit retry, including synchronous replies.
+        // Keep send on the click stack: Chromium requires recent interaction.
+        updateState({
+          apiVersion: BROWSEROS_ONBOARDING_API_VERSION,
+          ...currentState,
+          status: 'importing',
+          sources: currentState?.sources ?? [],
+          error: undefined,
+          progress: {
+            currentSourceId: request.sourceId,
+            currentSourceName: source?.displayName,
+            completedItems: [],
+            totalItems:
+              request.items?.length ?? source?.recommendedItems.length ?? 0,
+          },
+          results: [],
+        })
         chromeBridge.send(BrowserOSOnboardingMessage.START_IMPORT, [request])
         return
       }

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/components/ImportItemChecklist.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/components/ImportItemChecklist.tsx
@@ -38,14 +38,14 @@ export function ImportItemChecklist({
   }
 
   return (
-    <div className="mb-4 rounded-xl border border-border-2 bg-card p-4">
+    <div className="mb-5 border-border-2 border-t pt-5">
       <div className="mb-3 flex items-center justify-between gap-3">
         <div className="font-bold text-[12.5px] text-ink-2">What to copy</div>
         <div className="font-mono text-[11.5px] text-ink-3">
-          {checkedItems.length} selected
+          {checkedItems.length} categories selected
         </div>
       </div>
-      <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-2.5 min-[420px]:grid-cols-2">
         {defaultItems.map(renderRow)}
       </div>
       {optionalItems.length > 0 && (
@@ -57,7 +57,7 @@ export function ImportItemChecklist({
               ({optionalItems.map(importItemLabel).join(', ').toLowerCase()})
             </span>
           </summary>
-          <div className="mt-2.5 grid grid-cols-2 gap-x-4 gap-y-2.5">
+          <div className="mt-2.5 grid grid-cols-1 gap-x-4 gap-y-2.5 min-[420px]:grid-cols-2">
             {optionalItems.map(renderRow)}
           </div>
         </details>

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/components/ImportSourceTile.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/components/ImportSourceTile.tsx
@@ -1,10 +1,6 @@
 import { CheckCircle2, Circle, User } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { BrowserOSImportSource } from '../browseros-onboarding-api'
-import {
-  defaultImportItemsForSource,
-  importItemListLabel,
-} from '../onboarding-v2.helpers'
 
 interface ImportSourceTileProps {
   source: BrowserOSImportSource
@@ -18,15 +14,10 @@ export function ImportSourceTile({
   selected,
   onSelect,
 }: ImportSourceTileProps) {
-  // Describe the profile by what will actually be copied, not by everything
-  // Chromium could hand over: listing all seven items reads as a browser
-  // migration, which is the opposite of what this step does.
-  const defaultItems = defaultImportItemsForSource(source)
-  const itemCount = defaultItems.length
   return (
     <label
       className={cn(
-        'flex w-full cursor-pointer items-center gap-3 rounded-xl border px-4 py-3 text-left transition-colors',
+        'flex w-full cursor-pointer items-center gap-3 rounded-xl border px-4 py-2.5 text-left transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-accent has-[:focus-visible]:ring-offset-2',
         selected
           ? 'border-accent bg-accent-tint'
           : 'border-border-2 bg-card hover:border-border-strong',
@@ -49,14 +40,11 @@ export function ImportSourceTile({
       </span>
       <div className="min-w-0 flex-1">
         <div className="font-bold text-[13.5px] text-ink">
-          {source.displayName}
+          {source.profileName || source.displayName}
         </div>
         <div className="truncate text-[11.5px] text-ink-3">
-          {importItemListLabel(defaultItems)}
+          {source.browserName}
         </div>
-      </div>
-      <div className="shrink-0 text-right font-mono text-[11.5px] text-ink-2">
-        {itemCount} {itemCount === 1 ? 'item' : 'items'}
       </div>
     </label>
   )

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/components/ImportingProgressCard.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/components/ImportingProgressCard.tsx
@@ -16,7 +16,11 @@ export function ImportingProgressCard({
 }: ImportingProgressCardProps) {
   const percent = total === 0 ? 0 : Math.min(100, (progress / total) * 100)
   return (
-    <div className="rounded-xl border border-border-2 bg-card p-5">
+    <div
+      role="status"
+      aria-live="polite"
+      className="rounded-xl border border-border-2 bg-card p-5"
+    >
       <div className="mb-3.5 flex items-center gap-2.5">
         <RefreshCw className="size-[18px] animate-spin text-accent" />
         <span className="font-bold text-[14px]">

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/components/MacKeychainDialog.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/components/MacKeychainDialog.tsx
@@ -1,0 +1,92 @@
+import { Dialog } from '@base-ui/react/dialog'
+import { ArrowRight, Lock, X } from 'lucide-react'
+import { type RefObject, useRef } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  MacKeychainPermissionNote,
+  MacKeychainPreview,
+} from './MacKeychainNotice'
+
+interface MacKeychainDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onContinue: () => void
+  returnFocus: RefObject<HTMLButtonElement | null>
+}
+
+/** Prepares the user before Chromium requests Keychain access, without handling credentials. */
+export function MacKeychainDialog({
+  open,
+  onOpenChange,
+  onContinue,
+  returnFocus,
+}: MacKeychainDialogProps) {
+  const titleRef = useRef<HTMLHeadingElement>(null)
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-40 bg-ink/25 backdrop-blur-[3px]" />
+        <Dialog.Popup
+          initialFocus={titleRef}
+          finalFocus={returnFocus}
+          className="fixed top-1/2 left-1/2 z-50 flex max-h-[calc(100dvh-32px)] w-[600px] max-w-[calc(100vw-32px)] -translate-x-1/2 -translate-y-1/2 flex-col gap-5 overflow-y-auto rounded-[20px] border border-border-2 bg-card p-5 text-ink shadow-[0_24px_70px_#16244a26] outline-none sm:p-7"
+        >
+          <div className="flex items-center justify-between">
+            <span className="flex size-10 items-center justify-center rounded-[13px] bg-accent-tint text-accent">
+              <Lock aria-hidden className="size-6" />
+            </span>
+            <Dialog.Close
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Back to import options"
+                />
+              }
+            >
+              <X className="size-[18px]" />
+            </Dialog.Close>
+          </div>
+          <div>
+            <Dialog.Title
+              ref={titleRef}
+              tabIndex={-1}
+              className="mb-3 font-semibold text-[26px] leading-[34px] tracking-tight outline-none"
+            >
+              Import your Chrome logins
+            </Dialog.Title>
+            <Dialog.Description className="text-[15px] text-ink-2 leading-[23px]">
+              BrowserOS needs your permission to import your logins from Chrome.
+              <br />
+              When macOS asks, enter your Mac login password and click{' '}
+              <strong className="font-semibold text-ink">Allow</strong>.
+            </Dialog.Description>
+          </div>
+          <MacKeychainPreview />
+          <MacKeychainPermissionNote />
+          <div className="flex justify-end gap-2.5 pt-1">
+            <Dialog.Close
+              render={
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="h-[46px] rounded-lg px-5"
+                />
+              }
+            >
+              Back
+            </Dialog.Close>
+            <Button
+              type="button"
+              size="lg"
+              className="h-[46px] rounded-lg px-5"
+              onClick={onContinue}
+            >
+              Continue <ArrowRight aria-hidden className="size-4" />
+            </Button>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/components/MacKeychainNotice.test.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/components/MacKeychainNotice.test.tsx
@@ -1,31 +1,33 @@
 import { describe, expect, it } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { MacKeychainNotice } from './MacKeychainNotice'
+import {
+  MacKeychainPermissionNote,
+  MacKeychainPreview,
+  MacKeychainReminder,
+} from './MacKeychainNotice'
 
-describe('MacKeychainNotice', () => {
-  it('renders the keychain screenshot from the chromium-allowlisted icon path', () => {
-    const html = renderToStaticMarkup(<MacKeychainNotice />)
-
-    // A literal /icon/... path keeps the chromium build allowlist happy; an
-    // import would emit a new hashed asset and fail verify-chromium-build.ts.
-    expect(html).toContain('src="/icon/keychain-prompt.png"')
+describe('MacKeychainPreview', () => {
+  it('illustrates the native prompt without collecting credentials or adding controls', () => {
+    const html = renderToStaticMarkup(<MacKeychainPreview />)
+    expect(html).toContain('Example macOS dialog')
+    expect(html).toContain('Chrome Safe Storage')
+    expect(html).toContain('Always Allow')
+    expect(html.indexOf('Always Allow')).toBeLessThan(html.indexOf('Deny'))
+    expect(html).not.toMatch(/<(img|input|button)\b/)
+    expect(html).not.toContain('tabindex')
   })
 
-  // The importer reads the Keychain once per run, so Always Allow is both
-  // unnecessary and a permanent ACL grant for a one-off step. The screenshot
-  // highlights Allow, and copy that named the other button would contradict
-  // the figure sitting right beneath it.
-  it('tells the user to click Allow, not Always Allow', () => {
-    const html = renderToStaticMarkup(<MacKeychainNotice />)
+  it('explains that Allow applies to this import', () => {
+    expect(renderToStaticMarkup(<MacKeychainPermissionNote />)).toContain(
+      'Allow gives access for this import.',
+    )
+  })
 
+  it('keeps the progress reminder conditional because prompt state is unknown', () => {
+    const html = renderToStaticMarkup(<MacKeychainReminder />)
+    expect(html).toContain('If macOS asks')
+    expect(html).toContain('Mac login password')
     expect(html).toContain('Allow')
     expect(html).not.toContain('Always Allow')
-    expect(html).not.toContain('only asks once')
-  })
-
-  it('warns that a password is required', () => {
-    const html = renderToStaticMarkup(<MacKeychainNotice />)
-
-    expect(html).toContain('macOS will ask for your password')
   })
 })

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/components/MacKeychainNotice.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/components/MacKeychainNotice.tsx
@@ -1,40 +1,63 @@
-import { Lock } from 'lucide-react'
+import { Info, Lock } from 'lucide-react'
 
-/**
- * Explains the macOS Keychain prompt shown during Chrome data import, with a
- * shot of the real dialog so the button to press is unmistakable.
- *
- * Says Allow, not Always Allow: the importer reads the Keychain exactly once
- * per run (chrome_importer.cc extracts the Chrome Safe Storage key up front
- * and caches it for both cookies and passwords), so a one-time grant is
- * enough. Always Allow would only save a click across repeated imports, and
- * it writes a permanent ACL entry for a one-off onboarding step.
- */
-export function MacKeychainNotice() {
+/** An inert illustration of the OS-owned prompt; credentials only go to macOS. */
+export function MacKeychainPreview() {
   return (
-    <div className="mb-4 rounded-xl border border-accent/25 bg-accent-tint p-4">
-      <div className="flex items-start gap-3">
-        <Lock className="mt-0.5 size-[18px] shrink-0 text-accent" />
-        <div className="text-[12.5px] text-ink-2 leading-[1.5]">
-          <span className="font-semibold text-ink">
-            macOS will ask for your password
-          </span>{' '}
-          to read Chrome&rsquo;s saved data. That&rsquo;s expected. It&rsquo;s
-          how your cookies and passwords get copied. Enter it and click{' '}
-          <span className="font-semibold text-ink">Allow</span>.
+    <figure className="m-0 min-w-0">
+      <figcaption className="mb-3 text-ink-2 text-xs">
+        Example macOS dialog
+      </figcaption>
+      <div className="keychain-preview" aria-hidden="true">
+        <div className="keychain-preview-content">
+          <div className="keychain-lock">
+            <span />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="m-0 font-bold text-[13px] leading-[17px]">
+              BrowserOS Helper wants to use your confidential information stored
+              in &ldquo;Chrome Safe Storage&rdquo; in your keychain.
+            </p>
+            <p className="my-3 text-xs leading-[17px]">
+              To allow this, enter the &ldquo;login&rdquo; keychain password.
+            </p>
+            <div className="flex items-center gap-2 text-xs">
+              <span>Password:</span>
+              <span className="keychain-password">••••••••</span>
+            </div>
+          </div>
+        </div>
+        <div className="keychain-preview-actions">
+          <span className="keychain-help">?</span>
+          <span className="keychain-button">Always Allow</span>
+          <span className="flex-1" />
+          <span className="keychain-button">Deny</span>
+          <span className="keychain-allow">
+            <span className="keychain-button">Allow</span>
+          </span>
         </div>
       </div>
-      {/* Must stay a literal public path: importing the asset or inlining it
-          breaks scripts/verify-chromium-build.ts (allowlist, no data: URLs).
-          Intrinsic size is the native 832x334 at 1:2, so it renders crisp on
-          retina; width/height keep the step column from shifting on load. */}
-      <img
-        alt="The macOS Keychain prompt, with the Allow button highlighted."
-        className="mt-3 w-full max-w-[416px] rounded-lg border border-border-2"
-        height={167}
-        src="/icon/keychain-prompt.png"
-        width={416}
-      />
+    </figure>
+  )
+}
+
+export function MacKeychainPermissionNote() {
+  return (
+    <p className="m-0 flex items-start gap-2 text-[13px] text-ink-2 leading-[19px]">
+      <Info aria-hidden className="mt-0.5 size-4 shrink-0" />
+      Allow gives access for this import.
+    </p>
+  )
+}
+
+/** Native progress does not expose whether a Keychain prompt is currently open. */
+export function MacKeychainReminder() {
+  return (
+    <div className="mt-4 flex items-start gap-3 rounded-xl border border-accent/20 bg-accent-tint p-4 text-[13px] text-ink-2 leading-relaxed">
+      <Lock aria-hidden className="mt-0.5 size-4 shrink-0 text-accent" />
+      <p>
+        If macOS asks, enter your Mac login password and click{' '}
+        <strong className="font-semibold text-ink">Allow</strong>.
+      </p>
     </div>
   )
 }

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/components/OnboardingShell.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/components/OnboardingShell.tsx
@@ -19,9 +19,9 @@ export function OnboardingShell({
   return (
     <div className="flex h-screen overflow-hidden bg-bg-canvas">
       <VisualRail />
-      <main className="flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden px-12 pt-11 pb-10">
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overflow-x-hidden px-5 pt-8 pb-6 sm:px-8 lg:px-12 lg:pt-11">
         {showProgress && (
-          <div className="mb-[30px]">
+          <div className="mb-6">
             <StepDots step={step} total={totalSteps} />
           </div>
         )}

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/components/StepWrap.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/components/StepWrap.tsx
@@ -2,10 +2,14 @@ import type { ReactNode } from 'react'
 
 interface StepWrapProps {
   children: ReactNode
+  className?: string
 }
 
 /** Shared content width for each onboarding step. The entrance motion is
  * owned by the step-transition wrapper in Onboarding. */
-export function StepWrap({ children }: StepWrapProps) {
-  return <div className="w-full max-w-[560px]">{children}</div>
+export function StepWrap({
+  children,
+  className = 'max-w-[560px]',
+}: StepWrapProps) {
+  return <div className={`w-full ${className}`}>{children}</div>
 }

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/components/VisualRail.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/components/VisualRail.tsx
@@ -4,7 +4,7 @@ import { ArrowDownToLine, Cpu, ShieldCheck } from 'lucide-react'
 export function VisualRail() {
   return (
     <div
-      className="relative flex w-[360px] shrink-0 flex-col justify-between overflow-hidden border-border border-r p-9"
+      className="relative hidden w-[280px] shrink-0 flex-col justify-between overflow-hidden border-border border-r p-9 lg:flex xl:w-[360px]"
       style={{
         background:
           'linear-gradient(165deg, var(--color-accent-tint) 0%, var(--color-bg-sunken) 55%, var(--color-bg-canvas) 100%)',

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/onboarding-v2.helpers.test.ts
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/onboarding-v2.helpers.test.ts
@@ -9,6 +9,7 @@ import {
   importProgressTotal,
   importSourceSelectionChangeFor,
   MOCK_BROWSEROS_IMPORT_SOURCES,
+  needsMacKeychainPermission,
   OPTIONAL_IMPORT_ITEMS,
   sanitizeImportSelection,
   selectedSourceById,
@@ -206,7 +207,7 @@ describe('default and optional import items', () => {
 describe('import item display helpers', () => {
   it('formats import item labels for source tiles and summaries', () => {
     expect(importItemListLabel(['history', 'bookmarks', 'cookies'])).toBe(
-      'History, Bookmarks, Cookies',
+      'History, Bookmarks, Signed-in sessions (cookies)',
     )
   })
 
@@ -236,5 +237,36 @@ describe('import item display helpers', () => {
 
   it('falls back to selected item count when Chromium omits progress totals', () => {
     expect(importProgressTotal(2, undefined)).toBe(2)
+  })
+})
+
+describe('needsMacKeychainPermission', () => {
+  const source = MOCK_BROWSEROS_IMPORT_SOURCES[0]
+  it('gates only macOS Chrome imports containing supported encrypted data', () => {
+    expect(needsMacKeychainPermission(true, source, ['cookies'])).toBe(true)
+    expect(needsMacKeychainPermission(true, source, ['passwords'])).toBe(true)
+    for (const browserName of ['Safari', 'Microsoft Edge', 'Chromium']) {
+      expect(
+        needsMacKeychainPermission(true, { ...source, browserName }, [
+          'cookies',
+          'passwords',
+        ]),
+      ).toBe(false)
+    }
+    expect(
+      needsMacKeychainPermission(false, source, ['cookies', 'passwords']),
+    ).toBe(false)
+    expect(needsMacKeychainPermission(true, undefined, ['cookies'])).toBe(false)
+    expect(needsMacKeychainPermission(true, source, [])).toBe(false)
+    expect(
+      needsMacKeychainPermission(true, source, ['history', 'bookmarks']),
+    ).toBe(false)
+    expect(
+      needsMacKeychainPermission(
+        true,
+        { ...source, supportedItems: ['history'] },
+        ['cookies'],
+      ),
+    ).toBe(false)
   })
 })

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/onboarding-v2.helpers.ts
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/onboarding-v2.helpers.ts
@@ -72,8 +72,8 @@ export const DEFAULT_BROWSEROS_IMPORT_SOURCE_ID =
 const IMPORT_ITEM_LABELS: Record<string, string> = {
   history: 'History',
   bookmarks: 'Bookmarks',
-  cookies: 'Cookies',
-  passwords: 'Passwords',
+  cookies: 'Signed-in sessions (cookies)',
+  passwords: 'Saved passwords',
   searchEngines: 'Search engines',
   autofill: 'Autofill',
   extensions: 'Extensions',
@@ -192,4 +192,27 @@ export function importProgressTotal(
   progress: BrowserOSImportProgress | undefined,
 ): number {
   return progress?.totalItems ?? selectedItemCount
+}
+
+/** The native API omits platform; use browser platform hints, never source IDs. */
+export function isMacOS(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const client = navigator as Navigator & {
+    userAgentData?: { platform?: string }
+  }
+  const platform = client.userAgentData?.platform || client.platform
+  return /^(macOS|MacIntel|MacPPC|Mac68K)$/i.test(platform)
+}
+
+/** Match the Chrome-specific explanation only to supported encrypted data. */
+export function needsMacKeychainPermission(
+  isMac: boolean,
+  source: BrowserOSImportSource | undefined,
+  selectedItems: readonly BrowserOSImportItem[],
+): boolean {
+  if (!isMac || !source || !/^(Google )?Chrome$/i.test(source.browserName))
+    return false
+  return sanitizeImportSelection(source, selectedItems).some(
+    (item) => item === 'cookies' || item === 'passwords',
+  )
 }

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/steps/ImportStep.test.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/steps/ImportStep.test.tsx
@@ -126,12 +126,12 @@ function buttonMarkupFor(html: string, label: string): string {
 }
 
 describe('ImportStep', () => {
-  it('renders the picker, the Keychain notice, and a Copy button in picker phase', () => {
+  it('renders a compact picker without the permission dialog before Copy', () => {
     const html = render('picker')
     expect(html).toContain('Pick a profile')
-    expect(html).toContain('Google Chrome - Work')
-    expect(html).toContain('Google Chrome - Personal')
-    expect(html).toContain('Microsoft Edge - Default')
+    expect(html).toContain('Work')
+    expect(html).toContain('Personal')
+    expect(html).toContain('Microsoft Edge')
     expect(html).toContain('What to copy')
     for (const item of defaultImportItemsForSource(
       MOCK_BROWSEROS_IMPORT_SOURCES[0],
@@ -140,18 +140,11 @@ describe('ImportStep', () => {
         'aria-checked="true"',
       )
     }
-    expect(html).toContain('5 selected')
-    // JSX wraps "macOS will ask" in a semibold span, so the string
-    // "macOS will ask to read" is split by a </span> boundary in the
-    // rendered HTML. Assert on the positive plus a negative that
-    // explicitly rules out the old "macOS will ask permission"
-    // phrasing; together these pin the assertion to the new copy
-    // without fighting the JSX structure.
-    expect(html).toContain('macOS will ask')
-    expect(html).not.toContain('macOS will ask permission')
-    expect(html).toContain('Allow')
+    expect(html).toContain('5 categories selected')
+    expect(html).not.toContain('Example macOS dialog')
     expect(html).not.toContain('Always Allow')
-    expect(html).toContain('Copy 5 items from Work')
+    expect(html).not.toContain('/icon/keychain-prompt.png')
+    expect(html).toContain('Copy from Chrome')
     expect(html).not.toContain('Chrome is open')
     expect(html).not.toContain('Quit Chrome for me')
     expect(html).not.toContain('disabled=""')
@@ -164,13 +157,13 @@ describe('ImportStep', () => {
       selectedItems: defaultImportItemsForSource(source),
     })
 
-    expect(html).toContain('5 selected')
-    expect(html).toContain('Copy 5 items from Personal')
+    expect(html).toContain('5 categories selected')
+    expect(html).toContain('Copy from Chrome')
     for (const item of [
       'History',
       'Bookmarks',
-      'Cookies',
-      'Passwords',
+      'Signed-in sessions (cookies)',
+      'Saved passwords',
       'Autofill',
     ]) {
       const row = checklistRowFor(html, item)
@@ -193,8 +186,8 @@ describe('ImportStep', () => {
     for (const item of [
       'History',
       'Bookmarks',
-      'Cookies',
-      'Passwords',
+      'Signed-in sessions (cookies)',
+      'Saved passwords',
       'Autofill',
     ]) {
       expect(details).not.toContain(item)
@@ -204,19 +197,19 @@ describe('ImportStep', () => {
     }
   })
 
-  it('counts a custom mixed selection in the action label', () => {
+  it('counts only the selected categories', () => {
     const html = render('picker', readyState(), {
       selectedItems: ['cookies', 'passwords', 'history'],
     })
 
-    expect(html).toContain('3 selected')
-    expect(html).toContain('Copy 3 items from Work')
+    expect(html).toContain('3 categories selected')
+    expect(html).toContain('Copy from Chrome')
   })
 
   it('disables the copy action until at least one item is selected', () => {
     const html = render('picker', readyState(), { selectedItems: [] })
 
-    expect(html).toContain('0 selected')
+    expect(html).toContain('0 categories selected')
     expect(html).toContain('Select what to copy')
     expect(html).toContain('disabled=""')
   })
@@ -245,31 +238,13 @@ describe('ImportStep', () => {
     expect(html).toContain('disabled=""')
   })
 
-  it('uses the singular source tile item count for one supported item', () => {
-    const html = render(
-      'picker',
-      readyState({
-        sources: [
-          {
-            ...MOCK_BROWSEROS_IMPORT_SOURCES[0],
-            supportedItems: ['history'],
-            recommendedItems: ['history'],
-          },
-        ],
-      }),
-    )
-
-    expect(html).toContain('1 item')
-    expect(html).not.toContain('1 items')
-  })
-
-  it('uses the singular item label when one item is selected', () => {
+  it('allows copying one selected category', () => {
     const html = render('picker', readyState(), {
       selectedItems: ['history'],
     })
 
-    expect(html).toContain('1 selected')
-    expect(html).toContain('Copy 1 item from Work')
+    expect(html).toContain('1 categories selected')
+    expect(html).toContain('Copy from Chrome')
   })
 
   it('renders the importing progress card during importing phase', () => {
@@ -295,7 +270,7 @@ describe('ImportStep', () => {
         ],
       }),
     )
-    expect(html).toContain('Importing Cookies')
+    expect(html).toContain('Importing Signed-in sessions (cookies)')
     expect(html).toContain('Google Chrome - Work')
     expect(html).toContain('2 / 7 items')
   })
@@ -442,5 +417,20 @@ describe('ImportStep', () => {
     expect(PICK_PROFILE_MESSAGE).not.toBe('')
     expect(html).toContain('data-slot="form-message"')
     expect(html).toContain(PICK_PROFILE_MESSAGE)
+  })
+  it('shows four profiles while keeping a selection outside the first four visible', () => {
+    const sources = Array.from({ length: 7 }, (_, index) => ({
+      ...MOCK_BROWSEROS_IMPORT_SOURCES[0],
+      id: `profile-${index}`,
+      profileName: `Person ${index}`,
+    }))
+    const html = render('picker', readyState({ sources }), {
+      selectedSourceId: 'profile-6',
+    })
+    expect(html).toContain('Person 6')
+    expect(html).not.toContain('Person 3')
+    expect(html).not.toContain('Person 4')
+    expect(html).toContain('Show 3 more profiles')
+    expect(html.match(/type="radio"/g)).toHaveLength(4)
   })
 })

--- a/packages/browseros-agent/apps/app-onboard/src/onboarding/steps/ImportStep.tsx
+++ b/packages/browseros-agent/apps/app-onboard/src/onboarding/steps/ImportStep.tsx
@@ -1,9 +1,18 @@
-import { AlertTriangle, ArrowRight, Download, RefreshCw } from 'lucide-react'
+import {
+  AlertTriangle,
+  ArrowRight,
+  ChevronDown,
+  Download,
+  Lock,
+  RefreshCw,
+} from 'lucide-react'
+import { useId, useRef, useState } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { Button } from '@/components/ui/button'
 import { FormField, FormItem, FormMessage } from '@/components/ui/form'
 import type {
   BrowserOSImportItem,
+  BrowserOSImportSource,
   BrowserOSOnboardingState,
 } from '../browseros-onboarding-api'
 import { DisplayHeading, Em, StepCopy } from '../components/DisplayHeading'
@@ -11,7 +20,8 @@ import { ImportedSummaryCard } from '../components/ImportedSummaryCard'
 import { ImportItemChecklist } from '../components/ImportItemChecklist'
 import { ImportingProgressCard } from '../components/ImportingProgressCard'
 import { ImportSourceTile } from '../components/ImportSourceTile'
-import { MacKeychainNotice } from '../components/MacKeychainNotice'
+import { MacKeychainDialog } from '../components/MacKeychainDialog'
+import { MacKeychainReminder } from '../components/MacKeychainNotice'
 import { StepWrap } from '../components/StepWrap'
 import {
   completedImportItemCount,
@@ -19,6 +29,8 @@ import {
   importItemLabel,
   importItemListLabel,
   importProgressTotal,
+  isMacOS,
+  needsMacKeychainPermission,
   sanitizeImportSelection,
   selectedSourceById,
 } from '../onboarding-v2.helpers'
@@ -38,15 +50,26 @@ function importButtonLabelFor(
   hasSource: boolean,
   hasSupportedItems: boolean,
   checkedItems: readonly BrowserOSImportItem[],
-  sourceName: string,
+  browserName: string,
 ): string {
   if (!hasSource) return 'Pick a profile'
   if (!hasSupportedItems) return 'Nothing to copy from this profile'
   if (checkedItems.length === 0) return 'Select what to copy'
 
-  return `Copy ${checkedItems.length} ${
-    checkedItems.length === 1 ? 'item' : 'items'
-  } from ${sourceName}`
+  return `Copy from ${browserName.replace(/^Google /, '')}`
+}
+
+/** Collapsing the list must not hide the profile whose data will be copied. */
+function visibleProfiles(
+  sources: readonly BrowserOSImportSource[],
+  selectedSource: BrowserOSImportSource | undefined,
+  expanded: boolean,
+) {
+  if (expanded) return sources
+  const visible = sources.slice(0, 4)
+  if (selectedSource && !visible.includes(selectedSource))
+    visible[3] = selectedSource
+  return visible
 }
 
 export function ImportStep({
@@ -57,12 +80,26 @@ export function ImportStep({
   onRefresh,
   onContinue,
 }: ImportStepProps) {
+  const [permissionOpen, setPermissionOpen] = useState(false)
+  const [showAllProfiles, setShowAllProfiles] = useState(false)
+  const importButtonRef = useRef<HTMLButtonElement>(null)
+  const profileListId = useId()
   const selectedSourceId = form.watch('selectedSourceId')
   const selectedSource = selectedSourceById(state.sources, selectedSourceId)
   const sourceResult = state.results?.[0]
   const checkedItems = selectedSource
     ? sanitizeImportSelection(selectedSource, form.watch('selectedItems'))
     : []
+  const needsPermission = needsMacKeychainPermission(
+    isMacOS(),
+    selectedSource,
+    checkedItems,
+  )
+  const visibleSources = visibleProfiles(
+    state.sources,
+    selectedSource,
+    showAllProfiles,
+  )
   const sourceName =
     sourceResult?.displayName ||
     selectedSource?.profileName ||
@@ -94,8 +131,24 @@ export function ImportStep({
     Boolean(selectedSource),
     hasSupportedItems,
     checkedItems,
-    sourceName,
+    selectedSource?.browserName ?? 'browser',
   )
+
+  function requestImport() {
+    if (!isPickerValid) return
+    if (needsPermission) {
+      setPermissionOpen(true)
+      return
+    }
+    onImport()
+  }
+
+  function confirmImport() {
+    setPermissionOpen(false)
+    // Do not defer to an effect or animation: native import needs the recent
+    // Continue gesture. The bridge owns the pending lock until native replies.
+    if (isPickerValid && (phase === 'picker' || phase === 'failed')) onImport()
+  }
 
   function toggleImportItem(item: BrowserOSImportItem) {
     if (!selectedSource) return
@@ -113,7 +166,7 @@ export function ImportStep({
   }
 
   return (
-    <StepWrap>
+    <StepWrap className="max-w-[800px]">
       <DisplayHeading>
         Bring <Em>everything</Em> with you
       </DisplayHeading>
@@ -146,10 +199,12 @@ export function ImportStep({
             name="selectedSourceId"
             render={({ field }) => (
               <FormItem
-                className="mb-4 flex flex-col gap-2.5"
+                id={profileListId}
+                className="mb-3 flex flex-col gap-2"
                 role="radiogroup"
+                aria-label="Browser profiles"
               >
-                {state.sources.map((source) => (
+                {visibleSources.map((source) => (
                   <ImportSourceTile
                     key={source.id}
                     source={source}
@@ -181,6 +236,25 @@ export function ImportStep({
               </FormItem>
             )}
           />
+          {state.sources.length > 4 && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="mb-4 text-ink-2"
+              aria-expanded={showAllProfiles}
+              aria-controls={profileListId}
+              onClick={() => setShowAllProfiles(!showAllProfiles)}
+            >
+              <ChevronDown
+                aria-hidden
+                className={`size-3.5 ${showAllProfiles ? 'rotate-180' : ''}`}
+              />
+              {showAllProfiles
+                ? 'Show fewer profiles'
+                : `Show ${state.sources.length - 4} more profiles`}
+            </Button>
+          )}
           {selectedSource && hasSupportedItems && (
             <ImportItemChecklist
               items={selectedSource.supportedItems}
@@ -193,36 +267,52 @@ export function ImportStep({
               {state.error.message}
             </div>
           )}
-          <MacKeychainNotice />
-          <div className="flex flex-wrap items-center gap-3">
-            <Button
-              type="button"
-              size="lg"
-              onClick={onImport}
-              disabled={!isPickerValid}
-            >
-              <Download className="size-4" />
-              {importButtonLabel}
-            </Button>
-            <Button
-              type="button"
-              size="lg"
-              variant="ghost"
-              onClick={onContinue}
-            >
-              Skip for now
-            </Button>
+          <div className="sticky -bottom-6 z-10 border-border-2 border-t bg-bg-canvas py-4">
+            {needsPermission && (
+              <p className="mb-3 flex items-center gap-2 text-ink-3 text-xs">
+                <Lock aria-hidden className="size-3.5" />
+                macOS may ask for your Mac login password.
+              </p>
+            )}
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                type="button"
+                size="lg"
+                ref={importButtonRef}
+                onClick={requestImport}
+                disabled={!isPickerValid}
+              >
+                <Download className="size-4" />
+                {importButtonLabel}
+              </Button>
+              <Button
+                type="button"
+                size="lg"
+                variant="ghost"
+                onClick={onContinue}
+              >
+                Skip for now
+              </Button>
+              {selectedSource?.profileName && (
+                <span className="text-ink-3 text-xs">
+                  From {selectedSource.profileName}’s profile
+                </span>
+              )}
+            </div>
           </div>
         </>
       )}
 
       {phase === 'importing' && (
-        <ImportingProgressCard
-          currentItemLabel={currentItemLabel}
-          progress={completedItems}
-          sourceLabel={currentSourceLabel}
-          total={totalItems}
-        />
+        <>
+          <ImportingProgressCard
+            currentItemLabel={currentItemLabel}
+            progress={completedItems}
+            sourceLabel={currentSourceLabel}
+            total={totalItems}
+          />
+          {needsPermission && <MacKeychainReminder />}
+        </>
       )}
 
       {phase === 'failed' && (
@@ -234,14 +324,15 @@ export function ImportStep({
             </div>
             <div className="text-[12.5px] text-ink-2">
               {state.error?.message ??
-                "BrowserOS neo couldn't finish this import. Try again below, or refresh the profile list."}
+                "BrowserOS couldn't finish this import. Try again below, or refresh the profile list."}
             </div>
           </div>
           <div className="flex flex-wrap gap-2.5">
             <Button
               type="button"
               size="lg"
-              onClick={onImport}
+              ref={importButtonRef}
+              onClick={requestImport}
               disabled={!isPickerValid}
             >
               <Download className="size-4" />
@@ -276,6 +367,16 @@ export function ImportStep({
           </Button>
         </>
       )}
+      <MacKeychainDialog
+        open={
+          permissionOpen &&
+          isPickerValid &&
+          (phase === 'picker' || phase === 'failed')
+        }
+        onOpenChange={setPermissionOpen}
+        onContinue={confirmImport}
+        returnFocus={importButtonRef}
+      />
     </StepWrap>
   )
 }

--- a/packages/browseros-agent/apps/app-onboard/src/styles.css
+++ b/packages/browseros-agent/apps/app-onboard/src/styles.css
@@ -397,3 +397,140 @@
     animation: collapsible-up 0.2s ease-out;
   }
 }
+
+/* This is a noninteractive macOS example, not an app password form. Native
+   neutral colors stay recognizable across the two product themes. */
+.keychain-preview {
+  padding: 20px 18px 18px;
+  border: 1px solid #c7c7cf;
+  border-radius: 11px;
+  background: linear-gradient(#f1f1f5, #e9e9ee);
+  box-shadow: 0 4px 12px #25242f12;
+  color: #242426;
+  font-family: "Helvetica Neue", system-ui, sans-serif;
+}
+.keychain-preview-content {
+  display: flex;
+  align-items: start;
+  gap: 16px;
+}
+.keychain-lock {
+  position: relative;
+  flex-shrink: 0;
+  width: 62px;
+  height: 62px;
+}
+.keychain-lock::before {
+  content: "";
+  position: absolute;
+  top: 1px;
+  left: 13px;
+  width: 36px;
+  height: 40px;
+  border: 6px solid #bfc2c7;
+  border-radius: 22px 22px 0 0;
+  background: transparent;
+  box-shadow:
+    inset 1px 1px 2px #888c94,
+    0 -1px 1px #fff;
+}
+.keychain-lock span {
+  position: absolute;
+  top: 28px;
+  left: 6px;
+  width: 50px;
+  height: 34px;
+  border: 1px solid #ba871c;
+  border-radius: 4px;
+  background: linear-gradient(
+    100deg,
+    #f0b828,
+    #ffdb72 38%,
+    #eab131 75%,
+    #ce9320
+  );
+  box-shadow:
+    inset 0 1px 1px #fff3,
+    0 2px 3px #0002;
+}
+.keychain-password {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  height: 29px;
+  padding: 0 9px;
+  border: 2px solid #78b2f3;
+  border-radius: 6px;
+  background: white;
+  box-shadow: 0 0 0 2px #96c5f766;
+  color: #424246;
+  font-size: 14px;
+  letter-spacing: 0.05em;
+}
+.keychain-preview-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 20px;
+}
+.keychain-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 78px;
+  height: 29px;
+  padding: 0 12px;
+  border: 1px solid #d1d1d8;
+  border-radius: 5px;
+  background: linear-gradient(#fafafa, #dedee5);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.keychain-allow {
+  padding: 3px;
+  border: 2px solid var(--color-accent);
+  border-radius: 8px;
+}
+.keychain-allow .keychain-button {
+  min-width: 78px;
+}
+.keychain-help {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  margin-right: 8px;
+  border: 1px solid #c7c7ce;
+  border-radius: 50%;
+  background: linear-gradient(white, #e0e0e7);
+  font-size: 14px;
+  font-weight: 700;
+}
+@media (max-width: 480px) {
+  .keychain-preview {
+    padding: 16px 12px;
+  }
+  .keychain-preview-content {
+    gap: 10px;
+  }
+  .keychain-lock {
+    display: none;
+  }
+  .keychain-help {
+    display: none;
+  }
+  .keychain-preview-actions {
+    gap: 5px;
+  }
+  .keychain-button {
+    min-width: 0;
+    padding: 0 9px;
+  }
+  .keychain-allow .keychain-button {
+    min-width: 0;
+  }
+}

--- a/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
+++ b/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
@@ -3,9 +3,8 @@ import path from 'node:path'
 
 const buildDir = path.resolve(import.meta.dir, '../dist/chromium')
 const textResourceFiles = ['app.css', 'app.js', 'index.html']
-// Everything static lives under icon/ because listResourceFiles rejects any
-// other subdirectory outright; keychain-prompt.png is a screenshot, not an
-// icon, but moving it to img/ would fail the directory guard below.
+// Keep the legacy screenshot packaged: already-shipped Chromium resource lists
+// still enumerate it, although the UI now renders a CSS illustration.
 const iconResourceFiles = [
   'icon/16.png',
   'icon/32.png',

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/browseros-onboarding-bridge.test.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/browseros-onboarding-bridge.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from 'bun:test'
-import type { BrowserOSOnboardingState } from './browseros-onboarding-api'
+import type {
+  BrowserOSOnboardingState,
+  BrowserOSStartImportRequest,
+} from './browseros-onboarding-api'
 import { BrowserOSOnboardingMessage } from './browseros-onboarding-api'
 import { createBrowserOSOnboardingBridge } from './browseros-onboarding-bridge'
 import { MOCK_BROWSEROS_IMPORT_SOURCES } from './onboarding-v2.helpers'
@@ -324,4 +327,62 @@ describe('native setup lifecycle', () => {
       }
     })
   }
+})
+
+describe('native import handoff', () => {
+  it('locks repeated submissions before native acknowledgment and permits retry after failure', () => {
+    installWindow()
+    const sent: string[] = []
+    const states: BrowserOSOnboardingState[] = []
+    const bridge = createBrowserOSOnboardingBridge({
+      chrome: {
+        send(message) {
+          sent.push(message)
+        },
+      },
+    })
+    bridge.registerReceiver((state) => states.push(state))
+    window.browserosOnboarding?.receiveState({
+      apiVersion: 1,
+      status: 'ready',
+      sources: [...MOCK_BROWSEROS_IMPORT_SOURCES],
+    })
+    const request: BrowserOSStartImportRequest = {
+      sourceId: MOCK_BROWSEROS_IMPORT_SOURCES[0].id,
+      items: ['cookies'],
+    }
+    bridge.startImport(request)
+    bridge.startImport(request)
+    expect(sent).toEqual([BrowserOSOnboardingMessage.START_IMPORT])
+    expect(states.at(-1)?.status).toBe('importing')
+    expect(states.at(-1)?.progress?.completedItems).toEqual([])
+    window.browserosOnboarding?.receiveState({
+      apiVersion: 1,
+      status: 'failed',
+      sources: [...MOCK_BROWSEROS_IMPORT_SOURCES],
+    })
+    bridge.startImport(request)
+    expect(sent).toHaveLength(2)
+  })
+
+  it('preserves a synchronous native failure instead of overwriting it with pending state', () => {
+    installWindow()
+    const states: BrowserOSOnboardingState[] = []
+    const bridge = createBrowserOSOnboardingBridge({
+      chrome: {
+        send() {
+          window.browserosOnboarding?.receiveState({
+            apiVersion: 1,
+            status: 'failed',
+            sources: [],
+            error: { code: 'import_failed', message: 'Import denied' },
+          })
+        },
+      },
+    })
+    bridge.registerReceiver((state) => states.push(state))
+    bridge.startImport({ sourceId: 'source-0', items: ['cookies'] })
+    expect(states.map((state) => state.status)).toEqual(['importing', 'failed'])
+    expect(states.at(-1)?.error?.message).toBe('Import denied')
+  })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/browseros-onboarding-bridge.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/browseros-onboarding-bridge.ts
@@ -273,7 +273,30 @@ export function createBrowserOSOnboardingBridge(
     },
     startImport(request) {
       if (request.items && request.items.length === 0) return
+      if (currentState?.status === 'importing') return
       if (!isMock) {
+        const source = currentState?.sources.find(
+          (source) => source.id === request.sourceId,
+        )
+        // Publish before chrome.send: this locks Copy/Skip during the native
+        // handoff and prevents duplicate submissions. Native failures replace
+        // this snapshot and permit retry, including synchronous replies.
+        // Keep send on the click stack: Chromium requires recent interaction.
+        updateState({
+          apiVersion: BROWSEROS_ONBOARDING_API_VERSION,
+          ...currentState,
+          status: 'importing',
+          sources: currentState?.sources ?? [],
+          error: undefined,
+          progress: {
+            currentSourceId: request.sourceId,
+            currentSourceName: source?.displayName,
+            completedItems: [],
+            totalItems:
+              request.items?.length ?? source?.recommendedItems.length ?? 0,
+          },
+          results: [],
+        })
         chromeBridge.send(BrowserOSOnboardingMessage.START_IMPORT, [request])
         return
       }

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/ImportItemChecklist.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/ImportItemChecklist.tsx
@@ -38,14 +38,14 @@ export function ImportItemChecklist({
   }
 
   return (
-    <div className="mb-4 rounded-xl border border-border-2 bg-card p-4">
+    <div className="mb-5 border-border-2 border-t pt-5">
       <div className="mb-3 flex items-center justify-between gap-3">
         <div className="font-bold text-[12.5px] text-ink-2">What to copy</div>
         <div className="font-mono text-[11.5px] text-ink-3">
-          {checkedItems.length} selected
+          {checkedItems.length} categories selected
         </div>
       </div>
-      <div className="grid grid-cols-2 gap-x-4 gap-y-2.5">
+      <div className="grid grid-cols-1 gap-x-4 gap-y-2.5 min-[420px]:grid-cols-2">
         {defaultItems.map(renderRow)}
       </div>
       {optionalItems.length > 0 && (
@@ -57,7 +57,7 @@ export function ImportItemChecklist({
               ({optionalItems.map(importItemLabel).join(', ').toLowerCase()})
             </span>
           </summary>
-          <div className="mt-2.5 grid grid-cols-2 gap-x-4 gap-y-2.5">
+          <div className="mt-2.5 grid grid-cols-1 gap-x-4 gap-y-2.5 min-[420px]:grid-cols-2">
             {optionalItems.map(renderRow)}
           </div>
         </details>

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/ImportSourceTile.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/ImportSourceTile.tsx
@@ -1,10 +1,6 @@
 import { CheckCircle2, Circle, User } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { BrowserOSImportSource } from '../browseros-onboarding-api'
-import {
-  defaultImportItemsForSource,
-  importItemListLabel,
-} from '../onboarding-v2.helpers'
 
 interface ImportSourceTileProps {
   source: BrowserOSImportSource
@@ -18,15 +14,10 @@ export function ImportSourceTile({
   selected,
   onSelect,
 }: ImportSourceTileProps) {
-  // Describe the profile by what will actually be copied, not by everything
-  // Chromium could hand over: listing all seven items reads as a browser
-  // migration, which is the opposite of what this step does.
-  const defaultItems = defaultImportItemsForSource(source)
-  const itemCount = defaultItems.length
   return (
     <label
       className={cn(
-        'flex w-full cursor-pointer items-center gap-3 rounded-xl border px-4 py-3 text-left transition-colors',
+        'flex w-full cursor-pointer items-center gap-3 rounded-xl border px-4 py-2.5 text-left transition-colors has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-accent has-[:focus-visible]:ring-offset-2',
         selected
           ? 'border-accent bg-accent-tint'
           : 'border-border-2 bg-card hover:border-border-strong',
@@ -49,14 +40,11 @@ export function ImportSourceTile({
       </span>
       <div className="min-w-0 flex-1">
         <div className="font-bold text-[13.5px] text-ink">
-          {source.displayName}
+          {source.profileName || source.displayName}
         </div>
         <div className="truncate text-[11.5px] text-ink-3">
-          {importItemListLabel(defaultItems)}
+          {source.browserName}
         </div>
-      </div>
-      <div className="shrink-0 text-right font-mono text-[11.5px] text-ink-2">
-        {itemCount} {itemCount === 1 ? 'item' : 'items'}
       </div>
     </label>
   )

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/ImportingProgressCard.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/ImportingProgressCard.tsx
@@ -16,7 +16,11 @@ export function ImportingProgressCard({
 }: ImportingProgressCardProps) {
   const percent = total === 0 ? 0 : Math.min(100, (progress / total) * 100)
   return (
-    <div className="rounded-xl border border-border-2 bg-card p-5">
+    <div
+      role="status"
+      aria-live="polite"
+      className="rounded-xl border border-border-2 bg-card p-5"
+    >
       <div className="mb-3.5 flex items-center gap-2.5">
         <RefreshCw className="size-[18px] animate-spin text-accent" />
         <span className="font-bold text-[14px]">

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/MacKeychainDialog.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/MacKeychainDialog.tsx
@@ -1,0 +1,93 @@
+import { Dialog } from '@base-ui/react/dialog'
+import { ArrowRight, Lock, X } from 'lucide-react'
+import { type RefObject, useRef } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  MacKeychainPermissionNote,
+  MacKeychainPreview,
+} from './MacKeychainNotice'
+
+interface MacKeychainDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onContinue: () => void
+  returnFocus: RefObject<HTMLButtonElement | null>
+}
+
+/** Prepares the user before Chromium requests Keychain access, without handling credentials. */
+export function MacKeychainDialog({
+  open,
+  onOpenChange,
+  onContinue,
+  returnFocus,
+}: MacKeychainDialogProps) {
+  const titleRef = useRef<HTMLHeadingElement>(null)
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-40 bg-ink/25 backdrop-blur-[3px]" />
+        <Dialog.Popup
+          initialFocus={titleRef}
+          finalFocus={returnFocus}
+          className="fixed top-1/2 left-1/2 z-50 flex max-h-[calc(100dvh-32px)] w-[600px] max-w-[calc(100vw-32px)] -translate-x-1/2 -translate-y-1/2 flex-col gap-5 overflow-y-auto rounded-[20px] border border-border-2 bg-card p-5 text-ink shadow-[0_24px_70px_#16244a26] outline-none sm:p-7"
+        >
+          <div className="flex items-center justify-between">
+            <span className="flex size-10 items-center justify-center rounded-[13px] bg-accent-tint text-accent">
+              <Lock aria-hidden className="size-6" />
+            </span>
+            <Dialog.Close
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Back to import options"
+                />
+              }
+            >
+              <X className="size-[18px]" />
+            </Dialog.Close>
+          </div>
+          <div>
+            <Dialog.Title
+              ref={titleRef}
+              tabIndex={-1}
+              className="mb-3 font-semibold text-[26px] leading-[34px] tracking-tight outline-none"
+            >
+              Import your Chrome logins
+            </Dialog.Title>
+            <Dialog.Description className="text-[15px] text-ink-2 leading-[23px]">
+              BrowserOS neo needs your permission to import your logins from
+              Chrome.
+              <br />
+              When macOS asks, enter your Mac login password and click{' '}
+              <strong className="font-semibold text-ink">Allow</strong>.
+            </Dialog.Description>
+          </div>
+          <MacKeychainPreview />
+          <MacKeychainPermissionNote />
+          <div className="flex justify-end gap-2.5 pt-1">
+            <Dialog.Close
+              render={
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="h-[46px] rounded-lg px-5"
+                />
+              }
+            >
+              Back
+            </Dialog.Close>
+            <Button
+              type="button"
+              size="lg"
+              className="h-[46px] rounded-lg px-5"
+              onClick={onContinue}
+            >
+              Continue <ArrowRight aria-hidden className="size-4" />
+            </Button>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/MacKeychainNotice.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/MacKeychainNotice.test.tsx
@@ -1,31 +1,33 @@
 import { describe, expect, it } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { MacKeychainNotice } from './MacKeychainNotice'
+import {
+  MacKeychainPermissionNote,
+  MacKeychainPreview,
+  MacKeychainReminder,
+} from './MacKeychainNotice'
 
-describe('MacKeychainNotice', () => {
-  it('renders the keychain screenshot from the chromium-allowlisted icon path', () => {
-    const html = renderToStaticMarkup(<MacKeychainNotice />)
-
-    // A literal /icon/... path keeps the chromium build allowlist happy; an
-    // import would emit a new hashed asset and fail verify-chromium-build.ts.
-    expect(html).toContain('src="/icon/keychain-prompt.png"')
+describe('MacKeychainPreview', () => {
+  it('illustrates the native prompt without collecting credentials or adding controls', () => {
+    const html = renderToStaticMarkup(<MacKeychainPreview />)
+    expect(html).toContain('Example macOS dialog')
+    expect(html).toContain('Chrome Safe Storage')
+    expect(html).toContain('Always Allow')
+    expect(html.indexOf('Always Allow')).toBeLessThan(html.indexOf('Deny'))
+    expect(html).not.toMatch(/<(img|input|button)\b/)
+    expect(html).not.toContain('tabindex')
   })
 
-  // The importer reads the Keychain once per run, so Always Allow is both
-  // unnecessary and a permanent ACL grant for a one-off step. The screenshot
-  // highlights Allow, and copy that named the other button would contradict
-  // the figure sitting right beneath it.
-  it('tells the user to click Allow, not Always Allow', () => {
-    const html = renderToStaticMarkup(<MacKeychainNotice />)
+  it('explains that Allow applies to this import', () => {
+    expect(renderToStaticMarkup(<MacKeychainPermissionNote />)).toContain(
+      'Allow gives access for this import.',
+    )
+  })
 
+  it('keeps the progress reminder conditional because prompt state is unknown', () => {
+    const html = renderToStaticMarkup(<MacKeychainReminder />)
+    expect(html).toContain('If macOS asks')
+    expect(html).toContain('Mac login password')
     expect(html).toContain('Allow')
     expect(html).not.toContain('Always Allow')
-    expect(html).not.toContain('only asks once')
-  })
-
-  it('warns that a password is required', () => {
-    const html = renderToStaticMarkup(<MacKeychainNotice />)
-
-    expect(html).toContain('macOS will ask for your password')
   })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/MacKeychainNotice.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/MacKeychainNotice.tsx
@@ -1,40 +1,63 @@
-import { Lock } from 'lucide-react'
+import { Info, Lock } from 'lucide-react'
 
-/**
- * Explains the macOS Keychain prompt shown during Chrome data import, with a
- * shot of the real dialog so the button to press is unmistakable.
- *
- * Says Allow, not Always Allow: the importer reads the Keychain exactly once
- * per run (chrome_importer.cc extracts the Chrome Safe Storage key up front
- * and caches it for both cookies and passwords), so a one-time grant is
- * enough. Always Allow would only save a click across repeated imports, and
- * it writes a permanent ACL entry for a one-off onboarding step.
- */
-export function MacKeychainNotice() {
+/** An inert illustration of the OS-owned prompt; credentials only go to macOS. */
+export function MacKeychainPreview() {
   return (
-    <div className="mb-4 rounded-xl border border-blue/20 bg-accent-tint p-4">
-      <div className="flex items-start gap-3">
-        <Lock className="mt-0.5 size-[18px] shrink-0 text-blue" />
-        <div className="text-[12.5px] text-ink-2 leading-[1.5]">
-          <span className="font-semibold text-ink">
-            macOS will ask for your password
-          </span>{' '}
-          to read Chrome&rsquo;s saved data. That&rsquo;s expected &mdash;
-          it&rsquo;s how your cookies and passwords get copied. Enter it and
-          click <span className="font-semibold text-ink">Allow</span>.
+    <figure className="m-0 min-w-0">
+      <figcaption className="mb-3 text-ink-2 text-xs">
+        Example macOS dialog
+      </figcaption>
+      <div className="keychain-preview" aria-hidden="true">
+        <div className="keychain-preview-content">
+          <div className="keychain-lock">
+            <span />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="m-0 font-bold text-[13px] leading-[17px]">
+              BrowserOS neo Helper wants to use your confidential information
+              stored in &ldquo;Chrome Safe Storage&rdquo; in your keychain.
+            </p>
+            <p className="my-3 text-xs leading-[17px]">
+              To allow this, enter the &ldquo;login&rdquo; keychain password.
+            </p>
+            <div className="flex items-center gap-2 text-xs">
+              <span>Password:</span>
+              <span className="keychain-password">••••••••</span>
+            </div>
+          </div>
+        </div>
+        <div className="keychain-preview-actions">
+          <span className="keychain-help">?</span>
+          <span className="keychain-button">Always Allow</span>
+          <span className="flex-1" />
+          <span className="keychain-button">Deny</span>
+          <span className="keychain-allow">
+            <span className="keychain-button">Allow</span>
+          </span>
         </div>
       </div>
-      {/* Must stay a literal public path: importing the asset or inlining it
-          breaks scripts/verify-chromium-build.ts (allowlist, no data: URLs).
-          Intrinsic size is the native 832x334 at 1:2, so it renders crisp on
-          retina; width/height keep the step column from shifting on load. */}
-      <img
-        alt="The macOS Keychain prompt, with the Allow button highlighted."
-        className="mt-3 w-full max-w-[416px] rounded-lg border border-border-2"
-        height={167}
-        src="/icon/keychain-prompt.png"
-        width={416}
-      />
+    </figure>
+  )
+}
+
+export function MacKeychainPermissionNote() {
+  return (
+    <p className="m-0 flex items-start gap-2 text-[13px] text-ink-2 leading-[19px]">
+      <Info aria-hidden className="mt-0.5 size-4 shrink-0" />
+      Allow gives access for this import.
+    </p>
+  )
+}
+
+/** Native progress does not expose whether a Keychain prompt is currently open. */
+export function MacKeychainReminder() {
+  return (
+    <div className="mt-4 flex items-start gap-3 rounded-xl border border-accent/20 bg-accent-tint p-4 text-[13px] text-ink-2 leading-relaxed">
+      <Lock aria-hidden className="mt-0.5 size-4 shrink-0 text-accent" />
+      <p>
+        If macOS asks, enter your Mac login password and click{' '}
+        <strong className="font-semibold text-ink">Allow</strong>.
+      </p>
     </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/OnboardingShell.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/OnboardingShell.tsx
@@ -19,9 +19,9 @@ export function OnboardingShell({
   return (
     <div className="flex h-screen overflow-hidden bg-bg-canvas">
       <VisualRail />
-      <main className="flex min-h-0 flex-1 flex-col overflow-y-auto px-12 pt-11 pb-10">
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-5 pt-8 pb-6 sm:px-8 lg:px-12 lg:pt-11">
         {showProgress && (
-          <div className="mb-[30px]">
+          <div className="mb-6">
             <StepDots step={step} total={totalSteps} />
           </div>
         )}

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/StepWrap.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/StepWrap.tsx
@@ -2,9 +2,13 @@ import type { ReactNode } from 'react'
 
 interface StepWrapProps {
   children: ReactNode
+  className?: string
 }
 
 /** Applies the shared content width and entrance animation for each step. */
-export function StepWrap({ children }: StepWrapProps) {
-  return <div className="w-full max-w-[560px] animate-fade-up">{children}</div>
+export function StepWrap({
+  children,
+  className = 'max-w-[560px]',
+}: StepWrapProps) {
+  return <div className={`w-full animate-fade-up ${className}`}>{children}</div>
 }

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/VisualRail.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/VisualRail.tsx
@@ -4,7 +4,7 @@ import { Lock, ShieldCheck, Zap } from 'lucide-react'
 export function VisualRail() {
   return (
     <div
-      className="relative flex w-[360px] shrink-0 flex-col justify-between overflow-hidden border-border border-r p-9"
+      className="relative hidden w-[280px] shrink-0 flex-col justify-between overflow-hidden border-border border-r p-9 lg:flex xl:w-[360px]"
       style={{
         background:
           'linear-gradient(165deg, var(--color-secondary) 0%, var(--color-bg-sunken) 55%, var(--color-bg-canvas) 100%)',

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.test.ts
@@ -9,6 +9,7 @@ import {
   importProgressTotal,
   importSourceSelectionChangeFor,
   MOCK_BROWSEROS_IMPORT_SOURCES,
+  needsMacKeychainPermission,
   OPTIONAL_IMPORT_ITEMS,
   STARTER_PROMPTS,
   sanitizeImportSelection,
@@ -207,7 +208,7 @@ describe('default and optional import items', () => {
 describe('import item display helpers', () => {
   it('formats import item labels for source tiles and summaries', () => {
     expect(importItemListLabel(['history', 'bookmarks', 'cookies'])).toBe(
-      'History, Bookmarks, Cookies',
+      'History, Bookmarks, Signed-in sessions (cookies)',
     )
   })
 
@@ -243,5 +244,36 @@ describe('import item display helpers', () => {
 describe('STARTER_PROMPTS', () => {
   it('ships at least two suggestions for the Ready step', () => {
     expect(STARTER_PROMPTS.length).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe('needsMacKeychainPermission', () => {
+  const source = MOCK_BROWSEROS_IMPORT_SOURCES[0]
+  it('gates only macOS Chrome imports containing supported encrypted data', () => {
+    expect(needsMacKeychainPermission(true, source, ['cookies'])).toBe(true)
+    expect(needsMacKeychainPermission(true, source, ['passwords'])).toBe(true)
+    for (const browserName of ['Safari', 'Microsoft Edge', 'Chromium']) {
+      expect(
+        needsMacKeychainPermission(true, { ...source, browserName }, [
+          'cookies',
+          'passwords',
+        ]),
+      ).toBe(false)
+    }
+    expect(
+      needsMacKeychainPermission(false, source, ['cookies', 'passwords']),
+    ).toBe(false)
+    expect(needsMacKeychainPermission(true, undefined, ['cookies'])).toBe(false)
+    expect(needsMacKeychainPermission(true, source, [])).toBe(false)
+    expect(
+      needsMacKeychainPermission(true, source, ['history', 'bookmarks']),
+    ).toBe(false)
+    expect(
+      needsMacKeychainPermission(
+        true,
+        { ...source, supportedItems: ['history'] },
+        ['cookies'],
+      ),
+    ).toBe(false)
   })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/onboarding-v2.helpers.ts
@@ -72,8 +72,8 @@ export const DEFAULT_BROWSEROS_IMPORT_SOURCE_ID =
 const IMPORT_ITEM_LABELS: Record<string, string> = {
   history: 'History',
   bookmarks: 'Bookmarks',
-  cookies: 'Cookies',
-  passwords: 'Passwords',
+  cookies: 'Signed-in sessions (cookies)',
+  passwords: 'Saved passwords',
   searchEngines: 'Search engines',
   autofill: 'Autofill',
   extensions: 'Extensions',
@@ -198,3 +198,26 @@ export const STARTER_PROMPTS: readonly string[] = [
   'Search for the cheapest morning flight from SFO to NYC next Friday and show me the top three.',
   'Open the pull requests assigned to me on GitHub and summarize each.',
 ]
+
+/** The native API omits platform; use browser platform hints, never source IDs. */
+export function isMacOS(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const client = navigator as Navigator & {
+    userAgentData?: { platform?: string }
+  }
+  const platform = client.userAgentData?.platform || client.platform
+  return /^(macOS|MacIntel|MacPPC|Mac68K)$/i.test(platform)
+}
+
+/** Match the Chrome-specific explanation only to supported encrypted data. */
+export function needsMacKeychainPermission(
+  isMac: boolean,
+  source: BrowserOSImportSource | undefined,
+  selectedItems: readonly BrowserOSImportItem[],
+): boolean {
+  if (!isMac || !source || !/^(Google )?Chrome$/i.test(source.browserName))
+    return false
+  return sanitizeImportSelection(source, selectedItems).some(
+    (item) => item === 'cookies' || item === 'passwords',
+  )
+}

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.test.tsx
@@ -126,12 +126,12 @@ function buttonMarkupFor(html: string, label: string): string {
 }
 
 describe('ImportStep', () => {
-  it('renders the picker, the Keychain notice, and a Copy button in picker phase', () => {
+  it('renders a compact picker without the permission dialog before Copy', () => {
     const html = render('picker')
     expect(html).toContain('Pick a profile')
-    expect(html).toContain('Google Chrome - Work')
-    expect(html).toContain('Google Chrome - Personal')
-    expect(html).toContain('Microsoft Edge - Default')
+    expect(html).toContain('Work')
+    expect(html).toContain('Personal')
+    expect(html).toContain('Microsoft Edge')
     expect(html).toContain('What to copy')
     for (const item of defaultImportItemsForSource(
       MOCK_BROWSEROS_IMPORT_SOURCES[0],
@@ -140,18 +140,11 @@ describe('ImportStep', () => {
         'aria-checked="true"',
       )
     }
-    expect(html).toContain('5 selected')
-    // JSX wraps "macOS will ask" in a semibold span, so the string
-    // "macOS will ask to read" is split by a </span> boundary in the
-    // rendered HTML. Assert on the positive plus a negative that
-    // explicitly rules out the old "macOS will ask permission"
-    // phrasing; together these pin the assertion to the new copy
-    // without fighting the JSX structure.
-    expect(html).toContain('macOS will ask')
-    expect(html).not.toContain('macOS will ask permission')
-    expect(html).toContain('Allow')
+    expect(html).toContain('5 categories selected')
+    expect(html).not.toContain('Example macOS dialog')
     expect(html).not.toContain('Always Allow')
-    expect(html).toContain('Copy 5 items from Work')
+    expect(html).not.toContain('/icon/keychain-prompt.png')
+    expect(html).toContain('Copy from Chrome')
     expect(html).not.toContain('Chrome is open')
     expect(html).not.toContain('Quit Chrome for me')
     expect(html).not.toContain('disabled=""')
@@ -164,13 +157,13 @@ describe('ImportStep', () => {
       selectedItems: defaultImportItemsForSource(source),
     })
 
-    expect(html).toContain('5 selected')
-    expect(html).toContain('Copy 5 items from Personal')
+    expect(html).toContain('5 categories selected')
+    expect(html).toContain('Copy from Chrome')
     for (const item of [
       'History',
       'Bookmarks',
-      'Cookies',
-      'Passwords',
+      'Signed-in sessions (cookies)',
+      'Saved passwords',
       'Autofill',
     ]) {
       const row = checklistRowFor(html, item)
@@ -193,8 +186,8 @@ describe('ImportStep', () => {
     for (const item of [
       'History',
       'Bookmarks',
-      'Cookies',
-      'Passwords',
+      'Signed-in sessions (cookies)',
+      'Saved passwords',
       'Autofill',
     ]) {
       expect(details).not.toContain(item)
@@ -204,19 +197,19 @@ describe('ImportStep', () => {
     }
   })
 
-  it('counts a custom mixed selection in the action label', () => {
+  it('counts only the selected categories', () => {
     const html = render('picker', readyState(), {
       selectedItems: ['cookies', 'passwords', 'history'],
     })
 
-    expect(html).toContain('3 selected')
-    expect(html).toContain('Copy 3 items from Work')
+    expect(html).toContain('3 categories selected')
+    expect(html).toContain('Copy from Chrome')
   })
 
   it('disables the copy action until at least one item is selected', () => {
     const html = render('picker', readyState(), { selectedItems: [] })
 
-    expect(html).toContain('0 selected')
+    expect(html).toContain('0 categories selected')
     expect(html).toContain('Select what to copy')
     expect(html).toContain('disabled=""')
   })
@@ -245,31 +238,13 @@ describe('ImportStep', () => {
     expect(html).toContain('disabled=""')
   })
 
-  it('uses the singular source tile item count for one supported item', () => {
-    const html = render(
-      'picker',
-      readyState({
-        sources: [
-          {
-            ...MOCK_BROWSEROS_IMPORT_SOURCES[0],
-            supportedItems: ['history'],
-            recommendedItems: ['history'],
-          },
-        ],
-      }),
-    )
-
-    expect(html).toContain('1 item')
-    expect(html).not.toContain('1 items')
-  })
-
-  it('uses the singular item label when one item is selected', () => {
+  it('allows copying one selected category', () => {
     const html = render('picker', readyState(), {
       selectedItems: ['history'],
     })
 
-    expect(html).toContain('1 selected')
-    expect(html).toContain('Copy 1 item from Work')
+    expect(html).toContain('1 categories selected')
+    expect(html).toContain('Copy from Chrome')
   })
 
   it('renders the importing progress card during importing phase', () => {
@@ -295,7 +270,7 @@ describe('ImportStep', () => {
         ],
       }),
     )
-    expect(html).toContain('Importing Cookies')
+    expect(html).toContain('Importing Signed-in sessions (cookies)')
     expect(html).toContain('Google Chrome - Work')
     expect(html).toContain('2 / 7 items')
   })
@@ -442,5 +417,20 @@ describe('ImportStep', () => {
     expect(PICK_PROFILE_MESSAGE).not.toBe('')
     expect(html).toContain('data-slot="form-message"')
     expect(html).toContain(PICK_PROFILE_MESSAGE)
+  })
+  it('shows four profiles while keeping a selection outside the first four visible', () => {
+    const sources = Array.from({ length: 7 }, (_, index) => ({
+      ...MOCK_BROWSEROS_IMPORT_SOURCES[0],
+      id: `profile-${index}`,
+      profileName: `Person ${index}`,
+    }))
+    const html = render('picker', readyState({ sources }), {
+      selectedSourceId: 'profile-6',
+    })
+    expect(html).toContain('Person 6')
+    expect(html).not.toContain('Person 3')
+    expect(html).not.toContain('Person 4')
+    expect(html).toContain('Show 3 more profiles')
+    expect(html.match(/type="radio"/g)).toHaveLength(4)
   })
 })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
@@ -1,9 +1,18 @@
-import { AlertTriangle, ArrowRight, Download, RefreshCw } from 'lucide-react'
+import {
+  AlertTriangle,
+  ArrowRight,
+  ChevronDown,
+  Download,
+  Lock,
+  RefreshCw,
+} from 'lucide-react'
+import { useId, useRef, useState } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { Button } from '@/components/ui/button'
 import { FormField, FormItem, FormMessage } from '@/components/ui/form'
 import type {
   BrowserOSImportItem,
+  BrowserOSImportSource,
   BrowserOSOnboardingState,
 } from '../browseros-onboarding-api'
 import { DisplayHeading, Em, StepCopy } from '../components/DisplayHeading'
@@ -11,7 +20,8 @@ import { ImportedSummaryCard } from '../components/ImportedSummaryCard'
 import { ImportItemChecklist } from '../components/ImportItemChecklist'
 import { ImportingProgressCard } from '../components/ImportingProgressCard'
 import { ImportSourceTile } from '../components/ImportSourceTile'
-import { MacKeychainNotice } from '../components/MacKeychainNotice'
+import { MacKeychainDialog } from '../components/MacKeychainDialog'
+import { MacKeychainReminder } from '../components/MacKeychainNotice'
 import { StepWrap } from '../components/StepWrap'
 import {
   completedImportItemCount,
@@ -19,6 +29,8 @@ import {
   importItemLabel,
   importItemListLabel,
   importProgressTotal,
+  isMacOS,
+  needsMacKeychainPermission,
   sanitizeImportSelection,
   selectedSourceById,
 } from '../onboarding-v2.helpers'
@@ -38,15 +50,26 @@ function importButtonLabelFor(
   hasSource: boolean,
   hasSupportedItems: boolean,
   checkedItems: readonly BrowserOSImportItem[],
-  sourceName: string,
+  browserName: string,
 ): string {
   if (!hasSource) return 'Pick a profile'
   if (!hasSupportedItems) return 'Nothing to copy from this profile'
   if (checkedItems.length === 0) return 'Select what to copy'
 
-  return `Copy ${checkedItems.length} ${
-    checkedItems.length === 1 ? 'item' : 'items'
-  } from ${sourceName}`
+  return `Copy from ${browserName.replace(/^Google /, '')}`
+}
+
+/** Collapsing the list must not hide the profile whose data will be copied. */
+function visibleProfiles(
+  sources: readonly BrowserOSImportSource[],
+  selectedSource: BrowserOSImportSource | undefined,
+  expanded: boolean,
+) {
+  if (expanded) return sources
+  const visible = sources.slice(0, 4)
+  if (selectedSource && !visible.includes(selectedSource))
+    visible[3] = selectedSource
+  return visible
 }
 
 export function ImportStep({
@@ -57,12 +80,26 @@ export function ImportStep({
   onRefresh,
   onContinue,
 }: ImportStepProps) {
+  const [permissionOpen, setPermissionOpen] = useState(false)
+  const [showAllProfiles, setShowAllProfiles] = useState(false)
+  const importButtonRef = useRef<HTMLButtonElement>(null)
+  const profileListId = useId()
   const selectedSourceId = form.watch('selectedSourceId')
   const selectedSource = selectedSourceById(state.sources, selectedSourceId)
   const sourceResult = state.results?.[0]
   const checkedItems = selectedSource
     ? sanitizeImportSelection(selectedSource, form.watch('selectedItems'))
     : []
+  const needsPermission = needsMacKeychainPermission(
+    isMacOS(),
+    selectedSource,
+    checkedItems,
+  )
+  const visibleSources = visibleProfiles(
+    state.sources,
+    selectedSource,
+    showAllProfiles,
+  )
   const sourceName =
     sourceResult?.displayName ||
     selectedSource?.profileName ||
@@ -94,8 +131,24 @@ export function ImportStep({
     Boolean(selectedSource),
     hasSupportedItems,
     checkedItems,
-    sourceName,
+    selectedSource?.browserName ?? 'browser',
   )
+
+  function requestImport() {
+    if (!isPickerValid) return
+    if (needsPermission) {
+      setPermissionOpen(true)
+      return
+    }
+    onImport()
+  }
+
+  function confirmImport() {
+    setPermissionOpen(false)
+    // Do not defer to an effect or animation: native import needs the recent
+    // Continue gesture. The bridge owns the pending lock until native replies.
+    if (isPickerValid && (phase === 'picker' || phase === 'failed')) onImport()
+  }
 
   function toggleImportItem(item: BrowserOSImportItem) {
     if (!selectedSource) return
@@ -113,14 +166,13 @@ export function ImportStep({
   }
 
   return (
-    <StepWrap>
+    <StepWrap className="max-w-[800px]">
       <DisplayHeading>
         Your agents need your <Em>logins.</Em>
       </DisplayHeading>
       <StepCopy>
-        Gmail, GitHub, your bank &mdash; whatever Chrome is already signed into.
-        Copy these logins, which your Chrome already has. Everything is stored
-        locally on this machine.
+        Bring your signed-in sessions and saved data from Chrome. Everything is
+        copied locally to this machine.
       </StepCopy>
 
       {phase === 'picker' && (
@@ -147,10 +199,12 @@ export function ImportStep({
             name="selectedSourceId"
             render={({ field }) => (
               <FormItem
-                className="mb-4 flex flex-col gap-2.5"
+                id={profileListId}
+                className="mb-3 flex flex-col gap-2"
                 role="radiogroup"
+                aria-label="Browser profiles"
               >
-                {state.sources.map((source) => (
+                {visibleSources.map((source) => (
                   <ImportSourceTile
                     key={source.id}
                     source={source}
@@ -182,6 +236,25 @@ export function ImportStep({
               </FormItem>
             )}
           />
+          {state.sources.length > 4 && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="mb-4 text-ink-2"
+              aria-expanded={showAllProfiles}
+              aria-controls={profileListId}
+              onClick={() => setShowAllProfiles(!showAllProfiles)}
+            >
+              <ChevronDown
+                aria-hidden
+                className={`size-3.5 ${showAllProfiles ? 'rotate-180' : ''}`}
+              />
+              {showAllProfiles
+                ? 'Show fewer profiles'
+                : `Show ${state.sources.length - 4} more profiles`}
+            </Button>
+          )}
           {selectedSource && hasSupportedItems && (
             <ImportItemChecklist
               items={selectedSource.supportedItems}
@@ -194,36 +267,52 @@ export function ImportStep({
               {state.error.message}
             </div>
           )}
-          <MacKeychainNotice />
-          <div className="flex flex-wrap items-center gap-3">
-            <Button
-              type="button"
-              size="lg"
-              onClick={onImport}
-              disabled={!isPickerValid}
-            >
-              <Download className="size-4" />
-              {importButtonLabel}
-            </Button>
-            <Button
-              type="button"
-              size="lg"
-              variant="ghost"
-              onClick={onContinue}
-            >
-              Skip for now
-            </Button>
+          <div className="sticky -bottom-6 z-10 border-border-2 border-t bg-bg-canvas py-4">
+            {needsPermission && (
+              <p className="mb-3 flex items-center gap-2 text-ink-3 text-xs">
+                <Lock aria-hidden className="size-3.5" />
+                macOS may ask for your Mac login password.
+              </p>
+            )}
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                type="button"
+                size="lg"
+                ref={importButtonRef}
+                onClick={requestImport}
+                disabled={!isPickerValid}
+              >
+                <Download className="size-4" />
+                {importButtonLabel}
+              </Button>
+              <Button
+                type="button"
+                size="lg"
+                variant="ghost"
+                onClick={onContinue}
+              >
+                Skip for now
+              </Button>
+              {selectedSource?.profileName && (
+                <span className="text-ink-3 text-xs">
+                  From {selectedSource.profileName}’s profile
+                </span>
+              )}
+            </div>
           </div>
         </>
       )}
 
       {phase === 'importing' && (
-        <ImportingProgressCard
-          currentItemLabel={currentItemLabel}
-          progress={completedItems}
-          sourceLabel={currentSourceLabel}
-          total={totalItems}
-        />
+        <>
+          <ImportingProgressCard
+            currentItemLabel={currentItemLabel}
+            progress={completedItems}
+            sourceLabel={currentSourceLabel}
+            total={totalItems}
+          />
+          {needsPermission && <MacKeychainReminder />}
+        </>
       )}
 
       {phase === 'failed' && (
@@ -242,7 +331,8 @@ export function ImportStep({
             <Button
               type="button"
               size="lg"
-              onClick={onImport}
+              ref={importButtonRef}
+              onClick={requestImport}
               disabled={!isPickerValid}
             >
               <Download className="size-4" />
@@ -277,6 +367,16 @@ export function ImportStep({
           </Button>
         </>
       )}
+      <MacKeychainDialog
+        open={
+          permissionOpen &&
+          isPickerValid &&
+          (phase === 'picker' || phase === 'failed')
+        }
+        onOpenChange={setPermissionOpen}
+        onContinue={confirmImport}
+        returnFocus={importButtonRef}
+      />
     </StepWrap>
   )
 }

--- a/packages/browseros-agent/apps/claw-onboard/src/styles.css
+++ b/packages/browseros-agent/apps/claw-onboard/src/styles.css
@@ -272,3 +272,140 @@ body {
   --red-tint: #2b1414;
   --blue: #56b8d8;
 }
+
+/* This is a noninteractive macOS example, not an app password form. Native
+   neutral colors stay recognizable across the two product themes. */
+.keychain-preview {
+  padding: 20px 18px 18px;
+  border: 1px solid #c7c7cf;
+  border-radius: 11px;
+  background: linear-gradient(#f1f1f5, #e9e9ee);
+  box-shadow: 0 4px 12px #25242f12;
+  color: #242426;
+  font-family: "Helvetica Neue", system-ui, sans-serif;
+}
+.keychain-preview-content {
+  display: flex;
+  align-items: start;
+  gap: 16px;
+}
+.keychain-lock {
+  position: relative;
+  flex-shrink: 0;
+  width: 62px;
+  height: 62px;
+}
+.keychain-lock::before {
+  content: "";
+  position: absolute;
+  top: 1px;
+  left: 13px;
+  width: 36px;
+  height: 40px;
+  border: 6px solid #bfc2c7;
+  border-radius: 22px 22px 0 0;
+  background: transparent;
+  box-shadow:
+    inset 1px 1px 2px #888c94,
+    0 -1px 1px #fff;
+}
+.keychain-lock span {
+  position: absolute;
+  top: 28px;
+  left: 6px;
+  width: 50px;
+  height: 34px;
+  border: 1px solid #ba871c;
+  border-radius: 4px;
+  background: linear-gradient(
+    100deg,
+    #f0b828,
+    #ffdb72 38%,
+    #eab131 75%,
+    #ce9320
+  );
+  box-shadow:
+    inset 0 1px 1px #fff3,
+    0 2px 3px #0002;
+}
+.keychain-password {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  height: 29px;
+  padding: 0 9px;
+  border: 2px solid #78b2f3;
+  border-radius: 6px;
+  background: white;
+  box-shadow: 0 0 0 2px #96c5f766;
+  color: #424246;
+  font-size: 14px;
+  letter-spacing: 0.05em;
+}
+.keychain-preview-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 20px;
+}
+.keychain-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 78px;
+  height: 29px;
+  padding: 0 12px;
+  border: 1px solid #d1d1d8;
+  border-radius: 5px;
+  background: linear-gradient(#fafafa, #dedee5);
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.keychain-allow {
+  padding: 3px;
+  border: 2px solid var(--color-accent);
+  border-radius: 8px;
+}
+.keychain-allow .keychain-button {
+  min-width: 78px;
+}
+.keychain-help {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  margin-right: 8px;
+  border: 1px solid #c7c7ce;
+  border-radius: 50%;
+  background: linear-gradient(white, #e0e0e7);
+  font-size: 14px;
+  font-weight: 700;
+}
+@media (max-width: 480px) {
+  .keychain-preview {
+    padding: 16px 12px;
+  }
+  .keychain-preview-content {
+    gap: 10px;
+  }
+  .keychain-lock {
+    display: none;
+  }
+  .keychain-help {
+    display: none;
+  }
+  .keychain-preview-actions {
+    gap: 5px;
+  }
+  .keychain-button {
+    min-width: 0;
+    padding: 0 9px;
+  }
+  .keychain-allow .keychain-button {
+    min-width: 0;
+  }
+}


### PR DESCRIPTION
Chrome imports previously showed a large Keychain screenshot on every platform. Both onboarding apps now show a focused explanation after Copy only on macOS when Chrome cookies or passwords are selected. Continue starts the native import directly; the CSS example highlights **Allow**, and Back/Escape preserve the selection.

The picker shows four compact profile rows with an expansion control, clearer category labels, and visible actions. The native bridge prevents duplicate submissions while awaiting a reply and allows retry after failure. Both product themes and the existing Chromium resource contract are preserved.

Validation: 100 neo and 84 BrowserOS tests passed, including Chromium archive builds/typechecks; Biome passed. Browser checks covered platform/source/selection gates, cancel/focus, exact request payload, duplicate prevention, retry, and 1440/800/390px layouts. Independent review completed and its theme-token finding was fixed. Native Keychain itself was not exercised; browser tests stubbed the native bridge.
