### PR TITLE
chore(claw-app): remove task success rate displays

### DIFF
--- a/packages/browseros-agent/apps/claw-app/screens/skills/SkillDetail.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/SkillDetail.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Static-markup checks for the task detail stat cards (Tokens saved + Success
- * rate). Stubs the data hook so no backend is needed.
+ * Static-markup checks for the task detail stat cards.
+ * Stubs the data hook so no backend is needed.
  */
 
 import { describe, expect, it, mock } from 'bun:test'
@@ -89,35 +89,7 @@ describe('Task detail stat cards', () => {
     expect(renderApp()).toContain('No measured runs yet')
   })
 
-  it('shows a color-coded Success rate and keeps the without-error line', () => {
-    dataOverride = { ...dataOverride, detail: detail() }
-    const html = renderApp()
-    expect(html).toContain('Success rate')
-    // 4 of 5 clean = 80% -> amber band
-    expect(html).toContain('80%')
-    expect(html).toContain('text-amber')
-    expect(html).toContain('4 of 5 runs finished without a tool error')
-    expect(html).not.toContain('Safe to leave alone')
-  })
-
-  it('greens a perfect success rate and reds a poor one', () => {
-    dataOverride = {
-      ...dataOverride,
-      detail: detail({
-        skill: { ...sampleSkill, runCount: 5, cleanRunCount: 5 },
-      }),
-    }
-    expect(renderApp()).toContain('text-green')
-    dataOverride = {
-      ...dataOverride,
-      detail: detail({
-        skill: { ...sampleSkill, runCount: 5, cleanRunCount: 2 },
-      }),
-    }
-    expect(renderApp()).toContain('text-red')
-  })
-
-  it('shows "not run" for a skill with no runs', () => {
+  it('shows the empty run history for a skill with no runs', () => {
     dataOverride = {
       ...dataOverride,
       detail: detail({
@@ -132,6 +104,5 @@ describe('Task detail stat cards', () => {
     }
     const html = renderApp()
     expect(html).toContain('not run')
-    expect(html).toContain('0 of 0 runs finished without a tool error')
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/skills/SkillDetail.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/SkillDetail.tsx
@@ -26,7 +26,6 @@ import {
   formatRelativeTime,
   formatTokens,
   skillCommand,
-  successRate,
 } from './skills.helpers'
 
 const AGENT_LABELS: Record<string, string> = {
@@ -40,8 +39,7 @@ function agentLabel(id: string): string {
   return AGENT_LABELS[id] ?? id
 }
 
-/** Task detail: the SKILL.md, its token savings and success rate, which agents
- *  it is linked into, and its run history. */
+/** Shows the task's SKILL.md, token savings, linked coding agents, and run history. */
 export function SkillDetail() {
   const { detail, isLoading, isError } = useSkillDetailData()
   const navigate = useNavigate()
@@ -120,9 +118,8 @@ function DetailBody({
         </div>
       </header>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <TokensSavedCard tokenSavings={tokenSavings} />
-        <SuccessRateCard skill={skill} />
         <LinkedIntoCard skill={skill} />
       </div>
 
@@ -178,34 +175,6 @@ function TokensSavedCard({
         </span>{' '}
         tokens in other browsers
       </p>
-    </StatCard>
-  )
-}
-
-/** How often the skill runs end to end without a tool error, color-coded. */
-function SuccessRateCard({ skill }: { skill: Skill }) {
-  const { hasRuns, percent, colorClass } = successRate(
-    skill.cleanRunCount,
-    skill.runCount,
-  )
-  return (
-    <StatCard title="Success rate">
-      <div className="flex items-baseline gap-1">
-        <span
-          className={cn('font-extrabold text-3xl tabular-nums', colorClass)}
-        >
-          {hasRuns ? `${percent}%` : 'not run'}
-        </span>
-      </div>
-      <p className="text-ink-2 text-sm">
-        {skill.cleanRunCount} of {skill.runCount} runs finished without a tool
-        error.
-      </p>
-      {skill.lastRunAt !== undefined && (
-        <p className="text-ink-3 text-xs">
-          last run {formatRelativeTime(skill.lastRunAt)}
-        </p>
-      )}
     </StatCard>
   )
 }
@@ -376,8 +345,8 @@ function DetailSkeleton() {
   return (
     <div className="flex flex-col gap-6">
       <div className="h-9 w-48 animate-pulse rounded bg-card-tint" />
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        {['c1', 'c2', 'c3'].map((id) => (
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {['c1', 'c2'].map((id) => (
           <div
             key={id}
             className="h-32 animate-pulse rounded-9 border border-ledger-border bg-card-tint"

--- a/packages/browseros-agent/apps/claw-app/screens/skills/Skills.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/Skills.test.tsx
@@ -77,14 +77,11 @@ describe('Tasks list screen', () => {
     expect(renderApp()).toContain('Could not load')
   })
 
-  it('renders a row per skill with the command, description, and success rate', () => {
+  it('renders a row per skill with the command and description', () => {
     dataOverride = { ...baseData, skills: [sampleSkill] }
     const html = renderApp()
     expect(html).toContain('/inbox-sweep')
     expect(html).toContain('Check the inbox and draft what is owed')
-    // Clean ratio 4/5 and its color-coded 80% success rate.
-    expect(html).toContain('4/5')
-    expect(html).toContain('80%')
   })
 
   it('renders tokens saved for a measured skill', () => {
@@ -94,7 +91,7 @@ describe('Tasks list screen', () => {
     expect(html).toContain('saved')
   })
 
-  it('renders "not run" and "not measured" for a skill with no runs', () => {
+  it('renders "not measured" for a skill with no runs', () => {
     dataOverride = {
       ...baseData,
       skills: [
@@ -113,7 +110,6 @@ describe('Tasks list screen', () => {
       ],
     }
     const html = renderApp()
-    expect(html).toContain('not run')
     expect(html).toContain('not measured')
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/skills/Skills.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/Skills.tsx
@@ -22,14 +22,14 @@ import {
 } from '@/components/ui/table'
 import { cn } from '@/lib/utils'
 import { useSkillsScreenData } from './skills.data'
-import { formatTokens, skillCommand, successRate } from './skills.helpers'
+import { formatTokens, skillCommand } from './skills.helpers'
 
 const CELL_PADDING = 'px-2 py-3 first:pl-4 last:pr-4'
 
 /**
  * Tasks list. A task is a skill BrowserOS neo linked into the connected coding
- * agents; each row shows how often it has run, how clean those runs were, and
- * whether it is getting cheaper. Row click opens the SKILL.md and run history.
+ * agents; each row shows its run count and token savings. Row click opens
+ * the SKILL.md and run history.
  */
 export function Skills() {
   const { skills, isLoading, isError } = useSkillsScreenData()
@@ -105,14 +105,6 @@ export function Skills() {
                 <TableHead
                   className={cn(
                     CELL_PADDING,
-                    'h-auto w-32 text-right font-medium text-[12px] text-ledger-head-ink',
-                  )}
-                >
-                  Success rate
-                </TableHead>
-                <TableHead
-                  className={cn(
-                    CELL_PADDING,
                     'h-auto w-44 font-medium text-[12px] text-ledger-head-ink',
                   )}
                 >
@@ -137,7 +129,6 @@ export function Skills() {
 }
 
 function SkillRow({ skill, onOpen }: { skill: Skill; onOpen: () => void }) {
-  const rate = successRate(skill.cleanRunCount, skill.runCount)
   return (
     <TableRow
       data-testid={`skill-row-${skill.name}`}
@@ -173,16 +164,6 @@ function SkillRow({ skill, onOpen }: { skill: Skill; onOpen: () => void }) {
         ) : (
           <span className="text-[13px] text-ink-3">not measured</span>
         )}
-      </TableCell>
-      <TableCell className={cn(CELL_PADDING, 'text-right align-middle')}>
-        <div className="flex flex-col items-end gap-0.5">
-          <span className={cn('font-medium text-[13px]', rate.colorClass)}>
-            {rate.hasRuns ? `${rate.percent}%` : 'not run'}
-          </span>
-          <span className="text-[11px] text-ink-3">
-            {skill.cleanRunCount}/{skill.runCount}
-          </span>
-        </div>
       </TableCell>
       <TableCell
         className={cn(CELL_PADDING, 'align-middle')}

--- a/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.test.ts
@@ -5,7 +5,6 @@ import {
   neoName,
   parseSkillBody,
   skillCommand,
-  successRate,
   tokenDeltaPercent,
 } from './skills.helpers'
 
@@ -26,33 +25,6 @@ describe('neoName', () => {
 
   it('leaves an interior neo- untouched', () => {
     expect(neoName('weather-neo-check')).toBe('neo-weather-neo-check')
-  })
-})
-
-describe('successRate', () => {
-  it('is muted with no runs', () => {
-    expect(successRate(0, 0)).toEqual({
-      hasRuns: false,
-      percent: 0,
-      colorClass: 'text-ink-3',
-    })
-  })
-
-  it('is green at or above 90 percent', () => {
-    expect(successRate(2, 2)).toEqual({
-      hasRuns: true,
-      percent: 100,
-      colorClass: 'text-green',
-    })
-    expect(successRate(9, 10).colorClass).toBe('text-green')
-  })
-
-  it('is amber between 70 and 89 percent', () => {
-    expect(successRate(7, 10).colorClass).toBe('text-amber')
-  })
-
-  it('is red below 70 percent', () => {
-    expect(successRate(1, 2).colorClass).toBe('text-red')
   })
 })
 

--- a/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/skills/skills.helpers.ts
@@ -32,27 +32,6 @@ export function formatTokens(tokens: number): string {
 }
 
 /**
- * Success rate for a skill's runs, shared by the list column and the detail
- * card so they always agree. `colorClass` bands: green >= 90, amber >= 70, red
- * below; muted when the skill has never run.
- */
-export function successRate(
-  cleanRunCount: number,
-  runCount: number,
-): { hasRuns: boolean; percent: number; colorClass: string } {
-  const hasRuns = runCount > 0
-  const percent = hasRuns ? Math.round((cleanRunCount / runCount) * 100) : 0
-  const colorClass = !hasRuns
-    ? 'text-ink-3'
-    : percent >= 90
-      ? 'text-green'
-      : percent >= 70
-        ? 'text-amber'
-        : 'text-red'
-  return { hasRuns, percent, colorClass }
-}
-
-/**
  * Percent change from the first run's tokens to the latest run's, so a negative
  * value means the skill got cheaper. `null` when there is nothing to compare.
  */


### PR DESCRIPTION
Removes the Success rate column from the Tasks table and its card from task details in `apps/claw-app`. The remaining detail cards and loading placeholders now use two columns; the unused formatter and obsolete test assertions are removed.

Validation: all 388 claw-app tests passed, typecheck passed, and Biome passed.
