### PR TITLE
fix: scope server OTA fragments by product

### DIFF
--- a/.github/workflows/publish-server-ota.yml
+++ b/.github/workflows/publish-server-ota.yml
@@ -288,10 +288,12 @@ jobs:
             --product "$PRODUCT" \
             --platform "$PLATFORM"
 
+      # Both products share a nightly run's artifact namespace. Include the
+      # product so each publisher downloads only its own appcast fragments.
       - name: Upload platform appcast fragment
         uses: actions/upload-artifact@v7
         with:
-          name: server-ota-fragment-${{ matrix.target }}
+          name: server-ota-fragment-${{ inputs.product }}-${{ matrix.target }}
           path: ${{ inputs.snapshot_path }}
           if-no-files-found: error
           retention-days: 1
@@ -318,7 +320,7 @@ jobs:
 
       - uses: actions/download-artifact@v7
         with:
-          pattern: server-ota-fragment-*
+          pattern: server-ota-fragment-${{ inputs.product }}-*
           path: server-ota-fragments
 
       - name: Setup uv
@@ -336,7 +338,7 @@ jobs:
           fragments=()
           for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64 windows-x64; do
             platform="${target//-/_}"
-            fragment="server-ota-fragments/server-ota-fragment-${target}/${snapshot_name}"
+            fragment="server-ota-fragments/server-ota-fragment-${PRODUCT}-${target}/${snapshot_name}"
             if [ ! -f "$fragment" ]; then
               echo "::error::Missing OTA fragment for $target"
               exit 1

--- a/packages/browseros-agent/scripts/release/publish-server-ota-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/publish-server-ota-workflow.test.ts
@@ -41,13 +41,21 @@ describe('publish-server-ota workflow', () => {
     expect(build).toContain('--platform "$PLATFORM"')
     expect(build).toContain('--release-sha "$RELEASE_SHA"')
     expect(build).toContain('actions/upload-artifact@v7')
+    expect(build).toContain(
+      `name: server-ota-fragment-${dollar}{{ inputs.product }}-${dollar}{{ matrix.target }}`,
+    )
   })
 
   it('persists all fragments through a pull request before live publication', () => {
     const publish = section('  publish:')
     expect(publish).toContain('- build-payloads')
     expect(publish).toContain('actions/download-artifact@v7')
-    expect(publish).toContain('pattern: server-ota-fragment-*')
+    expect(publish).toContain(
+      `pattern: server-ota-fragment-${dollar}{{ inputs.product }}-*`,
+    )
+    expect(publish).toContain(
+      `fragment="server-ota-fragments/server-ota-fragment-${dollar}{PRODUCT}-${dollar}{target}/${dollar}{snapshot_name}"`,
+    )
     expect(publish).toContain('ota server assemble-appcast')
     expect(publish).toContain('ota server release-appcast')
     expect(publish).toContain('--channel alpha')

--- a/packages/browseros/chromium_patches/.features.yaml
+++ b/packages/browseros/chromium_patches/.features.yaml
@@ -165,7 +165,6 @@ features:
     files:
       - chrome/browser/browseros/metrics/
       - chrome/browser/metrics/chrome_metrics_service_client.cc
-      - chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
       - chrome/browser/ui/webui/settings/browseros_metrics_handler.cc
       - chrome/browser/ui/webui/settings/browseros_metrics_handler.h
       - chrome/browser/ui/webui/settings/settings_ui.cc


### PR DESCRIPTION
When BrowserOS and BrowserClaw publish server OTA fragments in the same run, their target-only artifact names collide. The downloader can select the other product's fragment, so appcast assembly fails after the payload jobs succeed.

Include the product in upload names, the download filter, and assembly paths. Each product now receives its own five platform fragments. Update the existing workflow assertions to check the product-scoped upload name, download pattern, and assembly path.

CI also found a stale metrics feature-manifest entry for a patch deliberately deleted in #2530. Remove that one orphaned entry so the repository consistency check passes; no Chromium source or patch content changes.

Validation: a local handoff simulation reproduced both failures with the original workflow and ran the updated assembly shell successfully for both products using ten distinct artifacts. Bash syntax and whitespace checks passed. Local actionlint reports only the same pre-existing unsupported `concurrency.queue` diagnostic; excluding that unchanged diagnostic passes. No native builds or release publication were run.

The read-only patch doctor reports no repository consistency errors after the manifest cleanup.

The four existing server OTA workflow tests and Biome check pass locally.
