### PR TITLE
feat(providers): add custom headers with conversation IDs

### DIFF
--- a/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.test.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.test.ts
@@ -43,6 +43,12 @@ function baseProvider(
 }
 
 describe('testProvider — request body', () => {
+  it('passes custom header templates to the local test endpoint', async () => {
+    const headers = { 'x-opencode-session': '{{conversationId}}' }
+    await testProvider(baseProvider({ headers }), 'http://127.0.0.1:9000')
+    expect(lastCall?.body.headers).toEqual(headers)
+  })
+
   it('forwards model-backed fields for non-ACP providers', async () => {
     await testProvider(baseProvider(), 'http://127.0.0.1:9000')
     expect(lastCall?.url).toBe('http://127.0.0.1:9000/test-provider')

--- a/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.ts
@@ -29,6 +29,7 @@ export async function testProvider(
         model: provider.modelId,
         apiKey: provider.apiKey,
         baseUrl: provider.baseUrl,
+        headers: provider.headers,
         // Azure
         resourceName: provider.resourceName,
         // Bedrock

--- a/packages/browseros-agent/apps/app/lib/llm-providers/types.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/types.ts
@@ -28,6 +28,7 @@ export interface LlmProviderConfig {
   name: string
   /** Base API URL (optional for Azure with resourceName, not used for Bedrock) */
   baseUrl?: string
+  headers?: Record<string, string>
   /** Model identifier */
   modelId: string
   /** API key (encrypted and stored locally) */

--- a/packages/browseros-agent/apps/app/modules/llm-providers/llm-providers.helpers.test.ts
+++ b/packages/browseros-agent/apps/app/modules/llm-providers/llm-providers.helpers.test.ts
@@ -49,6 +49,15 @@ function config(overrides: Partial<LlmProviderConfig> = {}) {
 }
 
 describe('toProviderConfig', () => {
+  it('preserves headers through the settings read and write payloads', () => {
+    const headers = { 'x-opencode-session': '{{conversationId}}' }
+    const converted = toProviderConfig(row({ headers }))
+    expect(converted?.headers).toEqual(headers)
+    expect(toProviderPayload(converted as LlmProviderConfig).headers).toEqual(
+      headers,
+    )
+  })
+
   // The column is nullable but the config type uses undefined, and the two are
   // not interchangeable to anything doing `'apiKey' in provider`.
   it('turns absent columns into undefined rather than null', () => {

--- a/packages/browseros-agent/apps/app/modules/llm-providers/llm-providers.helpers.ts
+++ b/packages/browseros-agent/apps/app/modules/llm-providers/llm-providers.helpers.ts
@@ -14,6 +14,7 @@ export interface ProviderRow {
   type: string
   name: string
   baseUrl: string | null
+  headers?: Record<string, string> | null
   // Nullable since the table holds coding agents too, and those carry neither.
   modelId: string | null
   supportsImages: boolean
@@ -66,6 +67,7 @@ export function toProviderConfig(row: ProviderRow): LlmProviderConfig | null {
     type: row.type,
     name: row.name,
     baseUrl: orUndefined(row.baseUrl),
+    headers: orUndefined(row.headers),
     modelId: row.modelId,
     supportsImages: row.supportsImages,
     contextWindow: row.contextWindow,
@@ -95,6 +97,7 @@ export function toProviderPayload(config: LlmProviderConfig) {
     type: config.type,
     name: config.name,
     baseUrl: config.baseUrl,
+    headers: config.headers,
     modelId: config.modelId,
     supportsImages: config.supportsImages,
     contextWindow: config.contextWindow,

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.test.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.test.ts
@@ -14,6 +14,40 @@ const baseValues = {
 }
 
 describe('provider setup boundary', () => {
+  it('normalizes custom headers and keeps conversation placeholders for the server', () => {
+    const values = providerFormSchema.parse({
+      ...baseValues,
+      type: 'openai-compatible',
+      baseUrl: 'http://localhost:1234',
+      headers: [{ name: 'x-opencode-session', value: '{{conversationId}}' }],
+    })
+    expect(normalizeProviderFormValues(values).headers).toEqual({
+      'x-opencode-session': '{{conversationId}}',
+    })
+    expect(
+      normalizeProviderFormValues({ ...values, headers: [] }).headers,
+    ).toEqual({})
+  })
+
+  it.each([
+    [{ name: '', value: 'a' }],
+    [{ name: 'bad name', value: 'a' }],
+    [{ name: 'x-test', value: 'a\nb' }],
+    [
+      { name: 'X-Test', value: 'a' },
+      { name: 'x-test', value: 'b' },
+    ],
+  ])('rejects invalid header rows %j', (...headers) => {
+    expect(
+      providerFormSchema.safeParse({
+        ...baseValues,
+        type: 'openai-compatible',
+        baseUrl: 'http://localhost:1234',
+        headers,
+      }).success,
+    ).toBe(false)
+  })
+
   for (const type of ['claude-code', 'codex', 'acp-custom']) {
     it(`rejects removed ACP provider type ${type}`, () => {
       expect(

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -79,6 +79,7 @@ import {
   type ModelInfo,
   modelSupportsReasoning,
 } from './models'
+import { ProviderHeadersFields } from './ProviderHeadersFields'
 import {
   isCredentiallessProviderType,
   normalizeProviderFormValues,
@@ -88,6 +89,10 @@ import {
 
 /** Window assumed for any model the bundled catalog cannot size. */
 const DEFAULT_CONTEXT_WINDOW = 128000
+
+function headerEntries(headers: LlmProviderConfig['headers']) {
+  return Object.entries(headers ?? {}).map(([name, value]) => ({ name, value }))
+}
 
 function defaultReasoningEffort(type?: ProviderType) {
   return type === 'chatgpt-pro' ? 'medium' : 'high'
@@ -229,6 +234,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
         initialValues?.baseUrl || getDefaultBaseUrlForProviders('openai'),
       modelId: initialValues?.modelId || '',
       apiKey: initialValues?.apiKey || '',
+      headers: headerEntries(initialValues?.headers),
       supportsImages: initialValues?.supportsImages ?? false,
       contextWindow: initialValues?.contextWindow || DEFAULT_CONTEXT_WINDOW,
       temperature: initialValues?.temperature ?? 0.2,
@@ -247,6 +253,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   const watchedType = form.watch('type')
   const watchedModelId = form.watch('modelId')
 
+  const watchedHeaders = form.watch('headers')
   const watchedApiKey = form.watch('apiKey')
   const watchedBaseUrl = form.watch('baseUrl')
   const watchedResourceName = form.watch('resourceName')
@@ -268,6 +275,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     watchedSecretAccessKey,
     watchedRegion,
     watchedSessionToken,
+    watchedHeaders,
   ])
 
   const modelInfoList = getModelsForProvider(watchedType as ProviderType)
@@ -376,6 +384,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
           getDefaultBaseUrlForProviders(initialValues.type || 'openai'),
         modelId: initialValues.modelId || '',
         apiKey: initialValues.apiKey || '',
+        headers: headerEntries(initialValues.headers),
         supportsImages: initialValues.supportsImages ?? false,
         contextWindow: initialValues.contextWindow || DEFAULT_CONTEXT_WINDOW,
         temperature: initialValues.temperature ?? 0.2,
@@ -401,6 +410,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
         baseUrl: getDefaultBaseUrlForProviders(defaultType),
         modelId: '',
         apiKey: '',
+        headers: [],
         supportsImages: false,
         contextWindow: DEFAULT_CONTEXT_WINDOW,
         temperature: 0.2,
@@ -461,6 +471,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   })
 
   const handleTest = async () => {
+    if (!(await form.trigger('headers'))) return
     if (!agentServerUrl) {
       setTestResult({
         success: false,
@@ -473,7 +484,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     setTestResult(null)
 
     try {
-      const values = form.getValues()
+      const values = normalizeProviderFormValues(form.getValues())
 
       const result = await testProvider(
         {
@@ -481,6 +492,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
           type: values.type,
           name: values.name || 'Test',
           baseUrl: values.baseUrl,
+          headers: values.headers,
           modelId: values.modelId,
           apiKey: values.apiKey,
           supportsImages: values.supportsImages,
@@ -1108,6 +1120,8 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                 />
               </div>
             </div>
+
+            <ProviderHeadersFields />
 
             {testResult && (
               <div

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -90,6 +90,17 @@ import {
 /** Window assumed for any model the bundled catalog cannot size. */
 const DEFAULT_CONTEXT_WINDOW = 128000
 
+// Managed-auth providers (OAuth + BrowserOS-hosted) drop custom headers
+// server-side, so the editor is hidden for them rather than letting users save
+// headers that would be silently ignored. Keep in sync with the provider
+// factories that omit config.headers.
+const HEADERLESS_PROVIDER_TYPES = new Set<string>([
+  'browseros',
+  'chatgpt-pro',
+  'github-copilot',
+  'qwen-code',
+])
+
 function headerEntries(headers: LlmProviderConfig['headers']) {
   return Object.entries(headers ?? {}).map(([name, value]) => ({ name, value }))
 }
@@ -1129,7 +1140,9 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
               </div>
             </div>
 
-            <ProviderHeadersFields />
+            {!HEADERLESS_PROVIDER_TYPES.has(watchedType) && (
+              <ProviderHeadersFields />
+            )}
 
             {testResult && (
               <div

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -788,6 +788,14 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                   OpenAI Compatible provider template instead.
                 </FormDescription>
               )}
+              {watchedType === 'openai-compatible' && (
+                <FormDescription>
+                  <code>/chat/completions</code> is appended automatically, so
+                  enter only the base URL (e.g.{' '}
+                  <code>https://opencode.ai/zen/go/v1</code>), not the full
+                  endpoint.
+                </FormDescription>
+              )}
               <FormMessage />
             </FormItem>
           )}

--- a/packages/browseros-agent/apps/app/screens/ai-settings/ProviderHeadersFields.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/ProviderHeadersFields.tsx
@@ -1,0 +1,102 @@
+import { CONVERSATION_ID_PLACEHOLDER } from '@browseros/shared/schemas/llm'
+import { Plus, Trash2 } from 'lucide-react'
+import { useFieldArray, useFormContext } from 'react-hook-form'
+import { Button } from '@/components/ui/button'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import type { ProviderFormValues } from './provider-form-schema'
+
+export function ProviderHeadersFields() {
+  const form = useFormContext<ProviderFormValues>()
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'headers',
+  })
+
+  return (
+    <fieldset className="space-y-3">
+      <legend className="font-medium text-sm">Custom headers</legend>
+      <p className="text-muted-foreground text-xs">
+        Sent with every request to this provider. Use{' '}
+        <code>{CONVERSATION_ID_PLACEHOLDER}</code> for a stable ID within each
+        conversation. Connection tests use a separate session ID.
+      </p>
+      {fields.map((header, index) => (
+        <div key={header.id} className="space-y-2">
+          <div className="flex items-start gap-2">
+            <FormField
+              control={form.control}
+              name={`headers.${index}.name`}
+              render={({ field }) => (
+                <FormItem className="min-w-0 flex-1">
+                  <FormLabel>Header name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="x-opencode-session" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name={`headers.${index}.value`}
+              render={({ field }) => (
+                <FormItem className="min-w-0 flex-1">
+                  <FormLabel>Header value</FormLabel>
+                  <FormControl>
+                    <Input
+                      autoComplete="off"
+                      placeholder={CONVERSATION_ID_PLACEHOLDER}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="mt-6"
+              aria-label={`Remove header ${index + 1}`}
+              onClick={() => remove(index)}
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          </div>
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            className="h-auto p-0"
+            onClick={() =>
+              form.setValue(
+                `headers.${index}.value`,
+                CONVERSATION_ID_PLACEHOLDER,
+                { shouldDirty: true, shouldValidate: true },
+              )
+            }
+          >
+            Use conversation ID
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => append({ name: '', value: '' })}
+      >
+        <Plus className="mr-2 size-4" />
+        Add header
+      </Button>
+    </fieldset>
+  )
+}

--- a/packages/browseros-agent/apps/app/screens/ai-settings/ProviderHeadersFields.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/ProviderHeadersFields.tsx
@@ -37,7 +37,7 @@ export function ProviderHeadersFields() {
                 <FormItem className="min-w-0 flex-1">
                   <FormLabel>Header name</FormLabel>
                   <FormControl>
-                    <Input placeholder="x-opencode-session" {...field} />
+                    <Input placeholder="X-Custom-Header" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -50,11 +50,7 @@ export function ProviderHeadersFields() {
                 <FormItem className="min-w-0 flex-1">
                   <FormLabel>Header value</FormLabel>
                   <FormControl>
-                    <Input
-                      autoComplete="off"
-                      placeholder={CONVERSATION_ID_PLACEHOLDER}
-                      {...field}
-                    />
+                    <Input autoComplete="off" placeholder="value" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/packages/browseros-agent/apps/app/screens/ai-settings/provider-form-schema.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/provider-form-schema.ts
@@ -1,3 +1,7 @@
+import {
+  HEADER_NAME_PATTERN,
+  HEADER_VALUE_PATTERN,
+} from '@browseros/shared/schemas/llm'
 import { z } from 'zod/v3'
 
 const providerTypeEnum = z.enum([
@@ -26,6 +30,35 @@ export const providerFormSchema = z
     type: providerTypeEnum,
     name: z.string().min(1, 'Provider name is required').max(50),
     baseUrl: z.string().optional(),
+    headers: z
+      .array(
+        z.object({
+          name: z
+            .string()
+            .regex(HEADER_NAME_PATTERN, 'Enter a valid HTTP header name'),
+          value: z
+            .string()
+            .regex(
+              HEADER_VALUE_PATTERN,
+              'Header values cannot contain newlines or unsupported characters',
+            ),
+        }),
+      )
+      .superRefine((headers, ctx) => {
+        const names = new Set<string>()
+        headers.forEach(({ name }, index) => {
+          const normalized = name.toLowerCase()
+          if (names.has(normalized)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Duplicate header name',
+              path: [index, 'name'],
+            })
+          }
+          names.add(normalized)
+        })
+      })
+      .optional(),
     modelId: z.string().min(1, 'Model ID is required'),
     apiKey: z.string().optional(),
     supportsImages: z.boolean(),
@@ -105,6 +138,14 @@ export function isCredentiallessProviderType(
 
 export function normalizeProviderFormValues(
   values: ProviderFormValues,
-): ProviderFormValues {
-  return values
+): Omit<ProviderFormValues, 'headers'> & { headers?: Record<string, string> } {
+  const { headers, ...rest } = values
+  return {
+    ...rest,
+    ...(headers && {
+      headers: Object.fromEntries(
+        headers.map(({ name, value }) => [name, value]),
+      ),
+    }),
+  }
 }

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -9,6 +9,7 @@ import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import type { LanguageModel } from 'ai'
 import { createBrowserOSFetch } from '../lib/browseros-fetch'
+import { resolveProviderHeaders } from '../lib/clients/llm/headers'
 import {
   createMockBrowserOSLanguageModel,
   shouldUseMockBrowserOSLLM,
@@ -28,6 +29,7 @@ function createAnthropicFactory(
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('Anthropic provider requires apiKey')
   return createAnthropic({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     ...(config.baseUrl && { baseURL: config.baseUrl }),
   })
@@ -45,6 +47,7 @@ function createOpenAIFactory(
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('OpenAI provider requires apiKey')
   return createOpenAI({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     ...(config.baseUrl && { baseURL: config.baseUrl }),
   })
@@ -55,6 +58,7 @@ function createGoogleFactory(
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('Google provider requires apiKey')
   return createGoogleGenerativeAI({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     ...(config.baseUrl && { baseURL: config.baseUrl }),
   })
@@ -65,6 +69,7 @@ function createOpenRouterFactory(
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('OpenRouter provider requires apiKey')
   return createOpenRouter({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     extraBody: { reasoning: {} },
     fetch: createOpenRouterCompatibleFetch(),
@@ -86,6 +91,7 @@ function createAzureFactory(
     )
   }
   return createAzure({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     ...(config.resourceName && { resourceName: config.resourceName }),
     ...(config.baseUrl && { baseURL: config.baseUrl }),
@@ -97,6 +103,7 @@ function createLMStudioFactory(
 ): (modelId: string) => unknown {
   if (!config.baseUrl) throw new Error('LMStudio provider requires baseUrl')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'lmstudio',
     baseURL: config.baseUrl,
     ...(config.apiKey && { apiKey: config.apiKey }),
@@ -108,6 +115,7 @@ function createOllamaFactory(
 ): (modelId: string) => unknown {
   if (!config.baseUrl) throw new Error('Ollama provider requires baseUrl')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'ollama',
     baseURL: config.baseUrl,
     ...(config.apiKey && { apiKey: config.apiKey }),
@@ -123,6 +131,7 @@ function createBedrockFactory(
     )
   }
   return createAmazonBedrock({
+    ...(config.headers && { headers: config.headers }),
     region: config.region,
     accessKeyId: config.accessKeyId,
     secretAccessKey: config.secretAccessKey,
@@ -141,6 +150,7 @@ function createBrowserOSFactory(
 
   if (upstreamProvider === LLM_PROVIDERS.OPENROUTER) {
     return createOpenRouter({
+      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -148,6 +158,7 @@ function createBrowserOSFactory(
   }
   if (upstreamProvider === LLM_PROVIDERS.ANTHROPIC) {
     return createAnthropic({
+      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -155,6 +166,7 @@ function createBrowserOSFactory(
   }
   if (upstreamProvider === LLM_PROVIDERS.AZURE) {
     return createAzure({
+      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -162,6 +174,7 @@ function createBrowserOSFactory(
   }
   logger.debug('Creating OpenAI-compatible provider for BrowserOS')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'browseros',
     baseURL: baseUrl,
     ...(apiKey && { apiKey }),
@@ -175,6 +188,7 @@ function createOpenAICompatibleFactory(
   if (!config.baseUrl)
     throw new Error('OpenAI-compatible provider requires baseUrl')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'openai-compatible',
     baseURL: config.baseUrl,
     ...(config.apiKey && { apiKey: config.apiKey }),
@@ -187,6 +201,7 @@ function createMoonshotFactory(
   if (!config.baseUrl) throw new Error('Moonshot provider requires baseUrl')
   if (!config.apiKey) throw new Error('Moonshot provider requires apiKey')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'moonshot',
     baseURL: config.baseUrl,
     apiKey: config.apiKey,
@@ -198,6 +213,7 @@ function createQwenCodeFactory(
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('Qwen Code requires OAuth authentication')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'qwen-code',
     baseURL: EXTERNAL_URLS.QWEN_CODE_API,
     apiKey: config.apiKey,
@@ -210,6 +226,7 @@ function createGitHubCopilotFactory(
   if (!config.apiKey)
     throw new Error('GitHub Copilot requires OAuth authentication')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'github-copilot',
     baseURL: EXTERNAL_URLS.GITHUB_COPILOT_API,
     apiKey: config.apiKey,
@@ -222,6 +239,7 @@ function createChatGPTProFactory(
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('ChatGPT requires OAuth authentication')
   return createOpenAI({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     fetch: createCodexFetch(config.accountId) as typeof globalThis.fetch,
   }).responses
@@ -257,5 +275,10 @@ export async function createLanguageModel(
   const provider = config.provider as string
   const factory = PROVIDER_FACTORIES[provider]
   if (!factory) throw new Error(`Unknown provider: ${provider}`)
-  return { model: factory(config)(config.model) as LanguageModel }
+  return {
+    model: factory({
+      ...config,
+      headers: resolveProviderHeaders(config.headers, config.conversationId),
+    })(config.model) as LanguageModel,
+  }
 }

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -148,9 +148,11 @@ function createBrowserOSFactory(
     ? createBrowserOSFetch(browserosId)
     : createOpenRouterCompatibleFetch()
 
+  // BrowserOS-hosted provider: user custom headers are deliberately not
+  // forwarded. Its credential is X-BrowserOS-ID (injected by browserosFetch)
+  // and there is no user-facing custom-header path for it.
   if (upstreamProvider === LLM_PROVIDERS.OPENROUTER) {
     return createOpenRouter({
-      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -158,7 +160,6 @@ function createBrowserOSFactory(
   }
   if (upstreamProvider === LLM_PROVIDERS.ANTHROPIC) {
     return createAnthropic({
-      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -166,7 +167,6 @@ function createBrowserOSFactory(
   }
   if (upstreamProvider === LLM_PROVIDERS.AZURE) {
     return createAzure({
-      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -174,7 +174,6 @@ function createBrowserOSFactory(
   }
   logger.debug('Creating OpenAI-compatible provider for BrowserOS')
   return createOpenAICompatible({
-    ...(config.headers && { headers: config.headers }),
     name: 'browseros',
     baseURL: baseUrl,
     ...(apiKey && { apiKey }),
@@ -212,8 +211,8 @@ function createQwenCodeFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('Qwen Code requires OAuth authentication')
+  // Managed OAuth provider: user custom headers are deliberately not forwarded.
   return createOpenAICompatible({
-    ...(config.headers && { headers: config.headers }),
     name: 'qwen-code',
     baseURL: EXTERNAL_URLS.QWEN_CODE_API,
     apiKey: config.apiKey,
@@ -225,8 +224,8 @@ function createGitHubCopilotFactory(
 ): (modelId: string) => unknown {
   if (!config.apiKey)
     throw new Error('GitHub Copilot requires OAuth authentication')
+  // Managed OAuth provider: user custom headers are deliberately not forwarded.
   return createOpenAICompatible({
-    ...(config.headers && { headers: config.headers }),
     name: 'github-copilot',
     baseURL: EXTERNAL_URLS.GITHUB_COPILOT_API,
     apiKey: config.apiKey,
@@ -238,8 +237,8 @@ function createChatGPTProFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('ChatGPT requires OAuth authentication')
+  // Managed OAuth provider: user custom headers are deliberately not forwarded.
   return createOpenAI({
-    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     fetch: createCodexFetch(config.accountId) as typeof globalThis.fetch,
   }).responses

--- a/packages/browseros-agent/apps/server/src/agent/types.ts
+++ b/packages/browseros-agent/apps/server/src/agent/types.ts
@@ -25,6 +25,7 @@ export interface ResolvedAgentConfig {
   model: string
   apiKey?: string
   baseUrl?: string
+  headers?: Record<string, string>
   upstreamProvider?: string
   resourceName?: string
   region?: string

--- a/packages/browseros-agent/apps/server/src/api/routes/providers.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/providers.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { LLMHeadersSchema } from '@browseros/shared/schemas/llm'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
@@ -27,6 +28,7 @@ const UpsertProviderSchema = z.object({
   type: z.string().min(1),
   name: z.string().min(1),
   baseUrl: z.string().nullish(),
+  headers: LLMHeadersSchema.nullish(),
   modelId: z.string().min(1),
   supportsImages: z.boolean().optional(),
   contextWindow: z.number(),

--- a/packages/browseros-agent/apps/server/src/api/services/chat-provider-config.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-provider-config.ts
@@ -39,6 +39,7 @@ function toLlmConfig(
     model: row.modelId ?? undefined,
     apiKey: row.apiKey ?? undefined,
     baseUrl: row.baseUrl ?? undefined,
+    headers: row.headers ?? undefined,
     resourceName: row.resourceName ?? undefined,
     region: row.region ?? undefined,
     accessKeyId: row.accessKeyId ?? undefined,

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -197,6 +197,7 @@ export class ChatService {
       model: llmConfig.model,
       apiKey: llmConfig.apiKey,
       baseUrl: llmConfig.baseUrl,
+      headers: llmConfig.headers,
       upstreamProvider: llmConfig.upstreamProvider,
       resourceName: llmConfig.resourceName,
       region: llmConfig.region,

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/headers.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/headers.ts
@@ -1,0 +1,17 @@
+import {
+  CONVERSATION_ID_PLACEHOLDER,
+  LLMHeadersSchema,
+} from '@browseros/shared/schemas/llm'
+
+export function resolveProviderHeaders(
+  headers: Record<string, string> | undefined,
+  conversationId: string = crypto.randomUUID(),
+): Record<string, string> | undefined {
+  if (!headers) return undefined
+  return Object.fromEntries(
+    Object.entries(LLMHeadersSchema.parse(headers)).map(([name, value]) => [
+      name,
+      value.replaceAll(CONVERSATION_ID_PLACEHOLDER, conversationId),
+    ]),
+  )
+}

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
@@ -1,3 +1,4 @@
+import { resolveProviderHeaders } from './headers'
 /**
  * @license
  * Copyright 2025 BrowserOS
@@ -37,6 +38,7 @@ type ProviderFactory = (config: ResolvedLLMConfig) => LanguageModel
 function createAnthropicModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('Anthropic provider requires apiKey')
   return createAnthropic({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     ...(config.baseUrl && { baseURL: config.baseUrl }),
   })(config.model)
@@ -45,6 +47,7 @@ function createAnthropicModel(config: ResolvedLLMConfig): LanguageModel {
 function createOpenAIModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('OpenAI provider requires apiKey')
   return createOpenAI({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     ...(config.baseUrl && { baseURL: config.baseUrl }),
   })(config.model)
@@ -53,6 +56,7 @@ function createOpenAIModel(config: ResolvedLLMConfig): LanguageModel {
 function createGoogleModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('Google provider requires apiKey')
   return createGoogleGenerativeAI({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     ...(config.baseUrl && { baseURL: config.baseUrl }),
   })(config.model)
@@ -61,6 +65,7 @@ function createGoogleModel(config: ResolvedLLMConfig): LanguageModel {
 function createOpenRouterModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('OpenRouter provider requires apiKey')
   return createOpenRouter({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     extraBody: { reasoning: {} },
     fetch: createOpenRouterCompatibleFetch(),
@@ -78,6 +83,7 @@ function createAzureModel(config: ResolvedLLMConfig): LanguageModel {
     )
   }
   return createAzure({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     ...(config.resourceName && { resourceName: config.resourceName }),
     ...(config.baseUrl && { baseURL: config.baseUrl }),
@@ -87,6 +93,7 @@ function createAzureModel(config: ResolvedLLMConfig): LanguageModel {
 function createOllamaModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.baseUrl) throw new Error('Ollama provider requires baseUrl')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'ollama',
     baseURL: config.baseUrl,
     ...(config.apiKey && { apiKey: config.apiKey }),
@@ -96,6 +103,7 @@ function createOllamaModel(config: ResolvedLLMConfig): LanguageModel {
 function createLMStudioModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.baseUrl) throw new Error('LMStudio provider requires baseUrl')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'lmstudio',
     baseURL: config.baseUrl,
     ...(config.apiKey && { apiKey: config.apiKey }),
@@ -109,6 +117,7 @@ function createBedrockModel(config: ResolvedLLMConfig): LanguageModel {
     )
   }
   return createAmazonBedrock({
+    ...(config.headers && { headers: config.headers }),
     region: config.region,
     accessKeyId: config.accessKeyId,
     secretAccessKey: config.secretAccessKey,
@@ -125,6 +134,7 @@ function createBrowserOSModel(config: ResolvedLLMConfig): LanguageModel {
 
   if (upstreamProvider === LLM_PROVIDERS.OPENROUTER) {
     return createOpenRouter({
+      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -132,6 +142,7 @@ function createBrowserOSModel(config: ResolvedLLMConfig): LanguageModel {
   }
   if (upstreamProvider === LLM_PROVIDERS.ANTHROPIC) {
     return createAnthropic({
+      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -139,6 +150,7 @@ function createBrowserOSModel(config: ResolvedLLMConfig): LanguageModel {
   }
   if (upstreamProvider === LLM_PROVIDERS.AZURE) {
     return createAzure({
+      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -146,6 +158,7 @@ function createBrowserOSModel(config: ResolvedLLMConfig): LanguageModel {
   }
   logger.debug('Creating OpenAI-compatible provider for BrowserOS')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'browseros',
     baseURL: baseUrl,
     ...(apiKey && { apiKey }),
@@ -157,6 +170,7 @@ function createOpenAICompatibleModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.baseUrl)
     throw new Error('OpenAI-compatible provider requires baseUrl')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'openai-compatible',
     baseURL: config.baseUrl,
     ...(config.apiKey && { apiKey: config.apiKey }),
@@ -167,6 +181,7 @@ function createMoonshotModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.baseUrl) throw new Error('Moonshot provider requires baseUrl')
   if (!config.apiKey) throw new Error('Moonshot provider requires apiKey')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'moonshot',
     baseURL: config.baseUrl,
     apiKey: config.apiKey,
@@ -176,6 +191,7 @@ function createMoonshotModel(config: ResolvedLLMConfig): LanguageModel {
 function createQwenCodeModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('Qwen Code requires OAuth authentication')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'qwen-code',
     baseURL: EXTERNAL_URLS.QWEN_CODE_API,
     apiKey: config.apiKey,
@@ -186,6 +202,7 @@ function createGitHubCopilotModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey)
     throw new Error('GitHub Copilot requires OAuth authentication')
   return createOpenAICompatible({
+    ...(config.headers && { headers: config.headers }),
     name: 'github-copilot',
     baseURL: EXTERNAL_URLS.GITHUB_COPILOT_API,
     apiKey: config.apiKey,
@@ -196,6 +213,7 @@ function createGitHubCopilotModel(config: ResolvedLLMConfig): LanguageModel {
 function createChatGPTProModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('ChatGPT requires OAuth authentication')
   return createOpenAI({
+    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     fetch: createCodexFetch(config.accountId) as typeof globalThis.fetch,
   }).responses(config.model)
@@ -224,5 +242,5 @@ export function createLLMProvider(config: ResolvedLLMConfig): LanguageModel {
   }
   const factory = PROVIDER_FACTORIES[config.provider]
   if (!factory) throw new Error(`Unknown provider: ${config.provider}`)
-  return factory(config)
+  return factory({ ...config, headers: resolveProviderHeaders(config.headers) })
 }

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
@@ -132,9 +132,11 @@ function createBrowserOSModel(config: ResolvedLLMConfig): LanguageModel {
     ? createBrowserOSFetch(browserosId)
     : createOpenRouterCompatibleFetch()
 
+  // BrowserOS-hosted provider: user custom headers are deliberately not
+  // forwarded. Its credential is X-BrowserOS-ID (injected by browserosFetch)
+  // and there is no user-facing custom-header path for it.
   if (upstreamProvider === LLM_PROVIDERS.OPENROUTER) {
     return createOpenRouter({
-      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -142,7 +144,6 @@ function createBrowserOSModel(config: ResolvedLLMConfig): LanguageModel {
   }
   if (upstreamProvider === LLM_PROVIDERS.ANTHROPIC) {
     return createAnthropic({
-      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -150,7 +151,6 @@ function createBrowserOSModel(config: ResolvedLLMConfig): LanguageModel {
   }
   if (upstreamProvider === LLM_PROVIDERS.AZURE) {
     return createAzure({
-      ...(config.headers && { headers: config.headers }),
       baseURL: baseUrl,
       ...(apiKey && { apiKey }),
       fetch: browserosFetch,
@@ -158,7 +158,6 @@ function createBrowserOSModel(config: ResolvedLLMConfig): LanguageModel {
   }
   logger.debug('Creating OpenAI-compatible provider for BrowserOS')
   return createOpenAICompatible({
-    ...(config.headers && { headers: config.headers }),
     name: 'browseros',
     baseURL: baseUrl,
     ...(apiKey && { apiKey }),
@@ -190,8 +189,8 @@ function createMoonshotModel(config: ResolvedLLMConfig): LanguageModel {
 
 function createQwenCodeModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('Qwen Code requires OAuth authentication')
+  // Managed OAuth provider: user custom headers are deliberately not forwarded.
   return createOpenAICompatible({
-    ...(config.headers && { headers: config.headers }),
     name: 'qwen-code',
     baseURL: EXTERNAL_URLS.QWEN_CODE_API,
     apiKey: config.apiKey,
@@ -201,8 +200,8 @@ function createQwenCodeModel(config: ResolvedLLMConfig): LanguageModel {
 function createGitHubCopilotModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey)
     throw new Error('GitHub Copilot requires OAuth authentication')
+  // Managed OAuth provider: user custom headers are deliberately not forwarded.
   return createOpenAICompatible({
-    ...(config.headers && { headers: config.headers }),
     name: 'github-copilot',
     baseURL: EXTERNAL_URLS.GITHUB_COPILOT_API,
     apiKey: config.apiKey,
@@ -212,8 +211,8 @@ function createGitHubCopilotModel(config: ResolvedLLMConfig): LanguageModel {
 
 function createChatGPTProModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('ChatGPT requires OAuth authentication')
+  // Managed OAuth provider: user custom headers are deliberately not forwarded.
   return createOpenAI({
-    ...(config.headers && { headers: config.headers }),
     apiKey: config.apiKey,
     fetch: createCodexFetch(config.accountId) as typeof globalThis.fetch,
   }).responses(config.model)

--- a/packages/browseros-agent/apps/server/src/lib/db/client.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/client.ts
@@ -158,6 +158,12 @@ function bootstrapCurrentSchema(sqlite: BunDatabase): void {
     for (const statement of currentSchemaStatements) {
       sqlite.exec(statement)
     }
+    const providerColumns = sqlite
+      .query<{ name: string }, []>('PRAGMA table_info(providers)')
+      .all()
+    if (!providerColumns.some((column) => column.name === 'headers')) {
+      sqlite.exec('ALTER TABLE providers ADD COLUMN headers text')
+    }
     const insertMigration = sqlite.prepare(`
       INSERT INTO __drizzle_migrations ("hash", "created_at")
       SELECT ?, ?
@@ -241,6 +247,11 @@ const currentMigrationHistory = [
     hash: 'eb0fa2687c80caf919248f28cda5cd955e01a671b2104308b4d04ec55d450611',
     createdAt: 1788426855683,
   },
+  {
+    tag: '0012_add_provider_headers',
+    hash: '5e1894d0aebf4a5b708425f565795b01e4efdb997a1e1e6fc6479f229bd022da',
+    createdAt: 1788724664440,
+  },
 ]
 
 // TODO(nikhil): Remove this fallback once Windows/Linux packaging always includes Drizzle migrations.
@@ -258,6 +269,7 @@ const currentSchemaStatements = [
       created_at integer NOT NULL,
       updated_at integer NOT NULL,
       base_url text,
+      headers text,
       supports_images integer DEFAULT true NOT NULL,
       context_window integer,
       temperature real DEFAULT 0.2 NOT NULL,

--- a/packages/browseros-agent/apps/server/src/lib/db/migrations/0012_add_provider_headers.sql
+++ b/packages/browseros-agent/apps/server/src/lib/db/migrations/0012_add_provider_headers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `providers` ADD `headers` text;

--- a/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/0012_snapshot.json
+++ b/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,645 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "63c51be9-ed36-4771-b7c5-ea8cf1962de4",
+  "prevId": "e20078ea-5f98-4bb8-9bf6-f02a2be1badc",
+  "tables": {
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_user_message": {
+          "name": "last_user_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_messaged_at": {
+          "name": "last_messaged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversations_last_messaged_at_idx": {
+          "name": "conversations_last_messaged_at_idx",
+          "columns": [
+            "last_messaged_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_tokens": {
+      "name": "oauth_tokens",
+      "columns": {
+        "browseros_id": {
+          "name": "browseros_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_tokens_browseros_id_idx": {
+          "name": "oauth_tokens_browseros_id_idx",
+          "columns": [
+            "browseros_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "oauth_tokens_browseros_id_provider_pk": {
+          "columns": [
+            "browseros_id",
+            "provider"
+          ],
+          "name": "oauth_tokens_browseros_id_provider_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_images": {
+          "name": "supports_images",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.2
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_key_id": {
+          "name": "access_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secret_access_key": {
+          "name": "secret_access_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_summary": {
+          "name": "reasoning_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "working_directory": {
+          "name": "working_directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "custom_config": {
+          "name": "custom_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "providers_profile_id_idx": {
+          "name": "providers_profile_id_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        },
+        "providers_kind_updated_at_idx": {
+          "name": "providers_kind_updated_at_idx",
+          "columns": [
+            "kind",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "providers_one_default": {
+          "name": "providers_one_default",
+          "columns": [
+            "is_default"
+          ],
+          "isUnique": true,
+          "where": "\"providers\".\"is_default\" = 1"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "providers_llm_requires_model_and_context": {
+          "name": "providers_llm_requires_model_and_context",
+          "value": "\"providers\".\"kind\" <> 'llm' OR (\"providers\".\"model_id\" IS NOT NULL AND \"providers\".\"context_window\" IS NOT NULL)"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "final_result": {
+          "name": "final_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_log": {
+          "name": "execution_log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_job_runs_started_at_idx": {
+          "name": "scheduled_job_runs_started_at_idx",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_time": {
+          "name": "schedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_profile_id_idx": {
+          "name": "scheduled_jobs_profile_id_idx",
+          "columns": [
+            "profile_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_jobs_enabled_idx": {
+          "name": "scheduled_jobs_enabled_idx",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_jobs_provider_id_providers_id_fk": {
+          "name": "scheduled_jobs_provider_id_providers_id_fk",
+          "tableFrom": "scheduled_jobs",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/_journal.json
+++ b/packages/browseros-agent/apps/server/src/lib/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1788426855683,
       "tag": "0011_drop_split_provider_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1788724664440,
+      "tag": "0012_add_provider_headers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/browseros-agent/apps/server/src/lib/db/schema/providers.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/schema/providers.ts
@@ -51,6 +51,7 @@ export const providers = sqliteTable(
     updatedAt: integer('updated_at').notNull(),
 
     baseUrl: text('base_url'),
+    headers: text('headers', { mode: 'json' }).$type<Record<string, string>>(),
     supportsImages: integer('supports_images', { mode: 'boolean' })
       .notNull()
       .default(true),

--- a/packages/browseros-agent/apps/server/src/lib/providers/provider-store.ts
+++ b/packages/browseros-agent/apps/server/src/lib/providers/provider-store.ts
@@ -35,6 +35,7 @@ const publicColumns = {
   createdAt: providers.createdAt,
   updatedAt: providers.updatedAt,
   baseUrl: providers.baseUrl,
+  headers: providers.headers,
   supportsImages: providers.supportsImages,
   contextWindow: providers.contextWindow,
   temperature: providers.temperature,

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-baseurl.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-baseurl.test.ts
@@ -94,6 +94,46 @@ beforeEach(() => {
 
 const CUSTOM_URL = 'https://api.minimax.io/anthropic'
 
+describe('provider header forwarding', () => {
+  for (const provider of [
+    'anthropic',
+    'openai',
+    'google',
+    'openrouter',
+    'azure',
+  ] as const) {
+    it(`forwards resolved headers to ${provider} in both provider pipelines`, async () => {
+      const config = {
+        provider,
+        model: 'test-model',
+        apiKey: 'local-test-key',
+        baseUrl: 'http://127.0.0.1:1234',
+        headers: {
+          'x-session': 'chat-{{conversationId}}',
+          'x-static': 'value',
+        },
+      }
+      await createLanguageModel({ ...config, conversationId: 'conversation-1' })
+      expect(lastCallArgs[provider]?.headers).toEqual({
+        'x-session': 'chat-conversation-1',
+        'x-static': 'value',
+      })
+      const { createLLMProvider } = await import(
+        '../../src/lib/clients/llm/provider'
+      )
+      createLLMProvider(config)
+      expect(lastCallArgs[provider]?.headers).toMatchObject({
+        'x-static': 'value',
+      })
+      expect(
+        (
+          lastCallArgs[provider]?.headers as Record<string, string> | undefined
+        )?.['x-session'],
+      ).toMatch(/^chat-[0-9a-f-]{36}$/)
+    })
+  }
+})
+
 describe('createAnthropicFactory baseUrl handling', () => {
   it('forwards a configured baseUrl as the SDK baseURL option', async () => {
     await createLanguageModel({

--- a/packages/browseros-agent/apps/server/tests/agent/provider-headers.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-headers.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { LLMConfigSchema } from '@browseros/shared/schemas/llm'
+import { generateText, streamText } from 'ai'
+import { createLanguageModel } from '../../src/agent/provider-factory'
+import { createLLMProvider } from '../../src/lib/clients/llm/provider'
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('provider headers', () => {
+  it('keeps header templates in the request schema', () => {
+    const headers = { 'x-opencode-session': '{{conversationId}}' }
+    expect(
+      LLMConfigSchema.parse({ provider: 'openai-compatible', headers }).headers,
+    ).toEqual(headers)
+  })
+
+  it.each([
+    { 'bad name': 'value' },
+    { 'x-test\n': 'value' },
+    { 'x-test': 'value\n' },
+    { 'x-test': 'value\r' },
+    { 'x-test': 'value\u0000' },
+    { 'x-test': 'injected\r\nAuthorization: secret' },
+    { 'x-test': 'a', 'X-Test': 'b' },
+    { 'x-test': 123 },
+  ])('rejects invalid headers: %j', (headers) => {
+    expect(
+      LLMConfigSchema.safeParse({ provider: 'openai-compatible', headers })
+        .success,
+    ).toBe(false)
+  })
+
+  it('sends stable conversation headers on streaming, follow-up, and retry requests', async () => {
+    const requests: Headers[] = []
+    globalThis.fetch = (async (_url, init) => {
+      requests.push(new Headers(init?.headers))
+      if (requests.length === 1) return new Response('retry', { status: 503 })
+      return new Response(
+        'data: {"id":"test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n\n' +
+          'data: {"id":"test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n' +
+          'data: [DONE]\n\n',
+        { headers: { 'Content-Type': 'text/event-stream' } },
+      )
+    }) as typeof fetch
+    const headers = {
+      'x-opencode-session': '{{conversationId}}',
+      'x-custom': 'literal',
+    }
+    for (const conversationId of [
+      'conversation-a',
+      'conversation-a',
+      'conversation-b',
+    ]) {
+      const { model } = await createLanguageModel({
+        conversationId,
+        provider: 'openai-compatible',
+        model: 'test-model',
+        apiKey: 'local-test-key',
+        baseUrl: 'http://127.0.0.1:1234/v1',
+        headers,
+      })
+      expect(
+        await streamText({ model, prompt: 'hello', maxRetries: 1 }).text,
+      ).toBe('ok')
+    }
+    expect(
+      requests.map((request) => request.get('x-opencode-session')),
+    ).toEqual([
+      'conversation-a',
+      'conversation-a',
+      'conversation-a',
+      'conversation-b',
+    ])
+    for (const request of requests) {
+      expect(request.get('x-custom')).toBe('literal')
+      expect(request.get('authorization')).toBe('Bearer local-test-key')
+    }
+    expect(headers['x-opencode-session']).toBe('{{conversationId}}')
+  })
+
+  it('gives non-chat operations a unique session that stays stable across requests', async () => {
+    const sessions: (string | null)[] = []
+    globalThis.fetch = (async (_url, init) => {
+      sessions.push(new Headers(init?.headers).get('x-opencode-session'))
+      return Response.json({
+        id: 'test',
+        object: 'chat.completion',
+        created: 1,
+        model: 'test-model',
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+      })
+    }) as typeof fetch
+    const config = {
+      provider: 'openai-compatible' as const,
+      model: 'test-model',
+      baseUrl: 'http://127.0.0.1:1234/v1',
+      headers: { 'x-opencode-session': '{{conversationId}}' },
+    }
+    const model = createLLMProvider(config)
+    await generateText({ model, prompt: 'test' })
+    await generateText({ model, prompt: 'retry' })
+    await generateText({ model: createLLMProvider(config), prompt: 'new test' })
+    expect(sessions[0]).toMatch(/^[0-9a-f-]{36}$/)
+    expect(sessions[1]).toBe(sessions[0])
+    expect(sessions[2]).not.toBe(sessions[0])
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/routes/providers.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/providers.test.ts
@@ -75,6 +75,32 @@ const body = {
 }
 
 describe('llm provider routes', () => {
+  it('round-trips custom headers through provider writes and reads', async () => {
+    const routes = createProvidersRoutes(memoryStore())
+    const headers = { 'x-opencode-session': '{{conversationId}}' }
+    const response = await routes.request(`/${PROVIDER_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...body, headers }),
+    })
+    expect(response.status).toBe(200)
+    expect(
+      await (await routes.request(`/${PROVIDER_ID}`)).json(),
+    ).toMatchObject({ provider: { headers } })
+  })
+
+  it('rejects malformed custom headers before saving', async () => {
+    const { store, rows } = memoryStore()
+    const routes = createProvidersRoutes({ store })
+    const response = await routes.request(`/${PROVIDER_ID}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...body, headers: { 'x-test': 'a\r\nb' } }),
+    })
+    expect(response.status).toBe(400)
+    expect(rows.size).toBe(0)
+  })
+
   it('lists providers', async () => {
     const routes = createProvidersRoutes(memoryStore([row()]))
     const response = await routes.request('/')

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-provider-config.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-provider-config.test.ts
@@ -19,6 +19,7 @@ function row(overrides: Partial<ProviderRow> = {}): ProviderRow {
     createdAt: 1,
     updatedAt: 2,
     baseUrl: null,
+    headers: null,
     supportsImages: true,
     contextWindow: 200000,
     temperature: 0.2,
@@ -54,6 +55,20 @@ function request(
 }
 
 describe('hydrateChatProvider', () => {
+  it('hydrates stored header templates and replaces stale inline headers', async () => {
+    const headers = { 'x-opencode-session': '{{conversationId}}' }
+    const result = await hydrateChatProvider(
+      request({ headers: { 'x-stale': 'value' } }),
+      lookup([row({ isDefault: true, headers })]),
+    )
+    expect(result.ok && result.request.headers).toEqual(headers)
+    const cleared = await hydrateChatProvider(
+      request({ headers }),
+      lookup([row({ isDefault: true, headers: null })]),
+    )
+    expect(cleared.ok && cleared.request.headers).toBeUndefined()
+  })
+
   it('fills the configuration from a named provider', async () => {
     const result = await hydrateChatProvider(
       request({ target: { type: 'browseros', providerId: 'anthropic-1' } }),

--- a/packages/browseros-agent/apps/server/tests/lib/db/index.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/db/index.test.ts
@@ -45,6 +45,35 @@ describe('database initialization', () => {
     expect(second).toBe(first)
   })
 
+  it.each([false, true])(
+    'upgrades an existing provider without changing credentials or selection (missing migrations: %s)',
+    (missingMigrations) => {
+      const dbPath = join(mkTempDir(), 'browseros.sqlite')
+      const old = initializeDb({ dbPath })
+      old.sqlite.exec('ALTER TABLE providers DROP COLUMN headers')
+      old.sqlite
+        .query('DELETE FROM __drizzle_migrations WHERE created_at = ?')
+        .run(expectedMigrationHistory.at(-1).createdAt)
+      old.sqlite.exec(
+        "INSERT INTO providers (id, kind, type, name, model_id, context_window, api_key, is_default, created_at, updated_at) VALUES ('existing', 'llm', 'openai', 'Existing', 'model', 128000, 'local-key', 1, 1, 1)",
+      )
+      closeDb()
+
+      const upgraded = initializeDb({
+        dbPath,
+        ...(missingMigrations && {
+          migrationsDir: join(mkTempDir(), 'missing'),
+        }),
+      })
+      expect(upgraded.db.select().from(providers).get()).toMatchObject({
+        id: 'existing',
+        headers: null,
+        apiKey: 'local-key',
+        isDefault: true,
+      })
+    },
+  )
+
   it('bootstraps the current schema when migration files are unavailable', () => {
     const dir = mkTempDir()
     const handle = initializeDb({

--- a/packages/browseros-agent/apps/server/tests/lib/providers/provider-store.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/providers/provider-store.test.ts
@@ -37,6 +37,27 @@ describe('dbProviderStore', () => {
     initializeDb({ dbPath: join(dir, 'db', 'browseros.sqlite') })
   }
 
+  test('persists header templates across reopen, edits, and explicit removal', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'browseros-providers-test-'))
+    tempDirs.push(dir)
+    const options = { dbPath: join(dir, 'browseros.sqlite') }
+    initializeDb(options)
+    const headers = {
+      'x-opencode-session': '{{conversationId}}',
+      'x-test': 'value',
+    }
+    await dbProviderStore.upsert({ ...baseProvider(), headers })
+    closeDb()
+    initializeDb(options)
+    expect((await dbProviderStore.get(PROVIDER_ID))?.headers).toEqual(headers)
+    await dbProviderStore.upsert({ ...baseProvider(), name: 'Renamed' })
+    expect(
+      (await dbProviderStore.getWithCredentials(PROVIDER_ID))?.headers,
+    ).toEqual(headers)
+    await dbProviderStore.upsert({ ...baseProvider(), headers: {} })
+    expect((await dbProviderStore.get(PROVIDER_ID))?.headers).toEqual({})
+  })
+
   test('insertIfAbsent writes a provider that is not there yet', async () => {
     useTempDb()
 

--- a/packages/browseros-agent/packages/shared/src/schemas/llm.ts
+++ b/packages/browseros-agent/packages/shared/src/schemas/llm.ts
@@ -51,6 +51,31 @@ export const LLMProviderSchema = z.enum([
 
 export type LLMProvider = z.infer<typeof LLMProviderSchema>
 
+export const CONVERSATION_ID_PLACEHOLDER = '{{conversationId}}'
+// Unlike $, the final assertion rejects trailing newlines too.
+export const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+(?![\s\S])/
+export const HEADER_VALUE_PATTERN = /^[\t\x20-\x7e\x80-\xff]*(?![\s\S])/
+
+export const LLMHeadersSchema = z
+  .record(
+    z.string().regex(HEADER_NAME_PATTERN),
+    z.string().regex(HEADER_VALUE_PATTERN),
+  )
+  .superRefine((headers, ctx) => {
+    const names = new Set<string>()
+    for (const name of Object.keys(headers)) {
+      const normalized = name.toLowerCase()
+      if (names.has(normalized)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Duplicate header name',
+          path: [name],
+        })
+      }
+      names.add(normalized)
+    }
+  })
+
 /**
  * LLM configuration schema
  * Used by SDK endpoints and agent configuration
@@ -61,6 +86,7 @@ export const LLMConfigSchema = z.object({
   model: z.string().optional(),
   apiKey: z.string().optional(),
   baseUrl: z.string().optional(),
+  headers: LLMHeadersSchema.optional(),
   // Azure-specific
   resourceName: z.string().optional(),
   // AWS Bedrock-specific

--- a/packages/browseros-agent/packages/shared/src/sentry/sanitize.test.ts
+++ b/packages/browseros-agent/packages/shared/src/sentry/sanitize.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'bun:test'
+import { sanitizeEvent } from './sanitize'
+
+test('redacts all custom header values from captured configuration', () => {
+  const event: { extra: Record<string, unknown> } = {
+    extra: {
+      provider: 'openai-compatible',
+      headers: { 'x-private-key': 'secret' },
+    },
+  }
+  expect(sanitizeEvent(event).extra).toEqual({
+    provider: 'openai-compatible',
+    headers: '[REDACTED]',
+  })
+})

--- a/packages/browseros-agent/packages/shared/src/sentry/sanitize.ts
+++ b/packages/browseros-agent/packages/shared/src/sentry/sanitize.ts
@@ -16,6 +16,7 @@ const SENSITIVE_KEY_PATTERNS = [
   'password',
   'secret',
   'credential',
+  'headers',
 ]
 
 function isSensitiveKey(key: string): boolean {


### PR DESCRIPTION
Providers such as OpenCode Go require a stable conversation header, but BrowserOS currently drops custom headers and provides no way to configure them. This adds editable provider headers and resolves `{{conversationId}}` using the BrowserOS conversation ID for chat requests, including subsequent inference requests and retries.

For OpenCode Go, add `x-opencode-session` with value `{{conversationId}}` under **Custom headers** in provider settings. The Test button and prompt refinement also send configured headers, using a separate generated session ID for each operation.

- Persist templates in the local provider database, including migration and fallback-schema upgrades, and carry them through provider reads, writes, imports, and chat hydration.
- Forward resolved headers through both SDK provider pipelines without modifying the saved template. Validate header names/values and reject case-insensitive duplicates; redact header values from Sentry configuration data.
- Provide add/remove controls, inline errors, and a **Use conversation ID** shortcut.

Validation performed locally, with external network access blocked during builds and tests and telemetry/upload credentials absent:

- **113 targeted tests passed** across provider requests, settings serialization/validation, persistence, database upgrades, and sanitization. Request tests inspect actual AI SDK fetch headers for streaming, retries, follow-up turns, and separate conversations.
- **Browser interaction check passed**: add, insert conversation ID, save, reject duplicates, remove all, and reload saved headers; no runtime errors. No screenshots or traces captured.
- `bun run build:agent` passed.
- `bun run check` passed on rerun, with lint/Fallow diagnostics. Earlier parallel typechecks intermittently reported TS2589 without a source location; a fresh standalone server typecheck also passed.
- `bun run test` completed with two failures: the CLI runtime integration test and HTTP server integration test timed out starting their BrowserOS CDP process. All other suites in that command passed; gated browser tests remained skipped.

Fixes #2543
