### PR TITLE
feat(claw-server): let stateless agents declare their own name

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.test.tsx
@@ -35,7 +35,7 @@ describe('AuditHoverPreview', () => {
   // pass even if the dot came back.
   it('renders the agent label without a per-agent colour dot', () => {
     const html = render(task)
-    expect(html).toContain('Claude Code')
+    expect(html).toContain('claude-code')
     expect(html).not.toContain('style="background:')
   })
 

--- a/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.tsx
@@ -57,7 +57,7 @@ export function AuditHoverPreview({ task }: AuditHoverPreviewProps) {
           data-caption-tone="blue"
         >
           <div className="flex items-center gap-2 font-mono text-[10px] text-white/75 uppercase tracking-[0.08em]">
-            <span className="truncate text-white/95">{task.label}</span>
+            <span className="truncate text-white/95">{task.slug}</span>
             {task.status === 'live' && <LiveChip />}
           </div>
           <p className="truncate font-semibold text-[13px] text-white leading-tight">

--- a/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
@@ -77,7 +77,7 @@ export function FilterBar({
           {selectedAgent ? (
             <>
               <AgentDot slug={selectedAgent.slug} />
-              {selectedAgent.agentLabel}
+              {selectedAgent.slug}
             </>
           ) : (
             'Agent'
@@ -98,7 +98,7 @@ export function FilterBar({
               onClick={() => onAgentChange(opt.slug)}
             >
               <AgentDot slug={opt.slug} className="mr-1.5" />
-              <span className="flex-1">{opt.agentLabel}</span>
+              <span className="flex-1">{opt.slug}</span>
               <span className="ml-2 text-[11.5px] text-ink-3">{opt.count}</span>
               {selectedAgentSlug === opt.slug && (
                 <Check className="ml-2 size-3.5" />

--- a/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
@@ -59,7 +59,7 @@ export function TaskHeader({ detail }: TaskHeaderProps) {
           <div className="space-y-2">
             <div className="flex items-center gap-2">
               <AgentDot slug={task.slug} />
-              <span className="font-semibold text-ink">{task.label}</span>
+              <span className="font-semibold text-ink">{task.slug}</span>
               <StatusBadge status={task.status} />
               {task.errorCount > 0 && (
                 <span className="text-[12.5px] text-red-600 dark:text-red-400">

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
@@ -94,7 +94,6 @@ export function AgentRunningCard({
               style={{ background: session.color }}
             />
             <span className="truncate text-white">{session.label}</span>
-            <span className="shrink-0 text-white/45">{session.harness}</span>
           </span>
           {showingLive ? (
             <span className="inline-flex shrink-0 items-center gap-1.5 text-[#8fb4ff]">

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
@@ -86,7 +86,6 @@ function session(
     slug: 'codex',
     label: 'Codex',
     name: 'Research BrowserClaw',
-    harness: 'Codex',
     color: '#0254ec',
     startedAt: 100,
     state: 'active',

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
@@ -109,7 +109,6 @@ describe('Audit screen', () => {
       agentOptions: [
         {
           slug: 'claude-code',
-          agentLabel: 'Claude Code',
           count: 1,
         },
       ],
@@ -117,6 +116,7 @@ describe('Audit screen', () => {
       siteOptions: [{ site: 'example.com', count: 1 }],
     }
     const html = renderApp()
+    // The row cell renders the session label; the agent filter chip renders the slug.
     expect(html).toContain('Claude Code')
     expect(html).toContain('Browsed example.com')
     // DONE is the silent default; only the exceptional states

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
@@ -117,7 +117,7 @@ describe('Audit screen', () => {
     }
     const html = renderApp()
     // The row cell renders the session label; the agent filter chip renders the slug.
-    expect(html).toContain('Claude Code')
+    expect(html).toContain('claude-code')
     expect(html).toContain('Browsed example.com')
     // DONE is the silent default; only the exceptional states
     // (LIVE / FAILED / STOPPED) render a chip in the agent cell.

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
@@ -26,11 +26,11 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
   {
     id: 'agent',
     header: 'Agent',
-    accessorKey: 'agentLabel',
+    accessorKey: 'slug',
     cell: ({ row }) => (
       <div className="flex items-center gap-2">
         <span className="min-w-0 truncate text-[12px] text-ledger-link">
-          {row.original.label}
+          {row.original.slug}
         </span>
         {row.original.status === 'live' && <LiveInlineChip />}
         {row.original.status === 'failed' && <FailedInlineChip />}

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.helpers.ts
@@ -104,10 +104,15 @@ export function abbreviateSequence(seq: string[], cap = 5): string {
 
 export interface AgentChip {
   slug: string
-  agentLabel: string
   count: number
 }
 
+/**
+ * Chips render the slug, not the session label. The label is whatever the client
+ * typed, so two sessions announcing "Claude Code" and "claude-code" group into one
+ * chip whose displayed name would otherwise depend on which arrived first. The slug
+ * is also what the tab strip shows, so both surfaces name the agent identically.
+ */
 export function agentChipsFor(tasks: TaskSummary[]): AgentChip[] {
   const map = new Map<string, AgentChip>()
   for (const t of tasks) {
@@ -116,11 +121,7 @@ export function agentChipsFor(tasks: TaskSummary[]): AgentChip[] {
       existing.count += 1
       continue
     }
-    map.set(t.slug, {
-      slug: t.slug,
-      agentLabel: t.label,
-      count: 1,
-    })
+    map.set(t.slug, { slug: t.slug, count: 1 })
   }
   return [...map.values()].sort((a, b) => b.count - a.count)
 }

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
@@ -156,7 +156,6 @@ function setConnectionsState(state: ConnectionsState) {
               state === 'installed'
                 ? [
                     {
-                      harness: 'Codex',
                       installed: true,
                       message: 'Configured in Codex.',
                     },
@@ -355,7 +354,6 @@ function liveSession(sessionId: string): LiveSessionCardRecord {
     slug: 'codex',
     label: 'Codex',
     name: 'Connected session',
-    harness: 'Codex',
     color: '#7A5AF8',
     startedAt: 100,
     state: 'idle',

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.test.ts
@@ -4,7 +4,6 @@ import {
   colorForSlug,
   formatRelative,
   formatToolTrail,
-  harnessForRow,
   sessionsToLiveCards,
   siteOf,
 } from './cockpit.helpers'
@@ -67,13 +66,6 @@ describe('display fallbacks', () => {
   it('keeps slug colors deterministic', () => {
     expect(colorForSlug('finance')).toBe(colorForSlug('finance'))
     expect(colorForSlug('travel')).toMatch(/^#[0-9A-F]{6}$/i)
-  })
-
-  it('keeps known harnesses and uses the existing fallback', () => {
-    expect(harnessForRow('Cursor')).toBe('Cursor')
-    expect(harnessForRow('Codex')).toBe('Codex')
-    expect(harnessForRow(undefined)).toBe('Claude Code')
-    expect(harnessForRow('Atlas-9000')).toBe('Claude Code')
   })
 })
 
@@ -258,7 +250,6 @@ describe('sessionsToLiveCards', () => {
     expect(card).toMatchObject({
       profileId: 'profile-parent',
       label: 'parent-slug',
-      harness: 'Claude Code',
       color: colorForSlug('parent-slug'),
     })
   })

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.ts
@@ -4,7 +4,6 @@ import type {
   SessionSummary,
   ToolEvent,
 } from '@browseros/claw-api'
-import { HARNESSES, type Harness } from '@/components/harness/harness.types'
 
 // Missing parent colors fall back to a stable slug hash so card identity does
 // not flicker between live-session polls.
@@ -62,21 +61,12 @@ export function formatToolTrail(
     .join(' -> ')
 }
 
-/** Coerces contract strings into the UI harness union with an honest fallback. */
-export function harnessForRow(value: string | undefined): Harness {
-  if (!value) return 'Claude Code'
-  return (HARNESSES as readonly string[]).includes(value)
-    ? (value as Harness)
-    : 'Claude Code'
-}
-
 export interface LiveSessionCardRecord {
   sessionId: string
   profileId?: string
   slug: string
   label: string
   name: string
-  harness: Harness
   color: string
   startedAt: number
   state: LiveSessionActivityState
@@ -139,7 +129,6 @@ export function sessionsToLiveCards(
       slug: session.slug,
       label: session.label || session.slug,
       name: session.name,
-      harness: harnessForRow(session.harness),
       color: session.color ?? colorForSlug(session.slug),
       startedAt: session.startedAt,
       state: session.live?.state ?? 'idle',

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -284,7 +284,6 @@ function replayData(
     sessionId: 'session-1',
     agentLabel: 'Codex',
     taskTitle: 'Replay test',
-    harness: 'Codex',
     status: 'done' as const,
     site: 'example.com',
     startedAt: 'Jul 18, 2026',

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -141,7 +141,7 @@ export function Replay() {
             {replay.taskTitle}
           </div>
           <div className="text-ink-3 text-xs">
-            {replay.agentLabel} · {replay.harness}
+            {replay.agentLabel}
             {replay.startedAt ? ` · ${replay.startedAt}` : ''}
           </div>
         </div>

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -51,7 +51,6 @@ export interface ReplayData {
   sessionId: string
   agentLabel: string
   taskTitle: string
-  harness: string
   status: RunStatus
   site: string
   startedAt: string
@@ -229,7 +228,6 @@ function buildReplayData(
     sessionId: task.sessionId,
     agentLabel: task.label || task.slug,
     taskTitle: task.name,
-    harness: task.profileId ?? 'unknown',
     status: mapTaskStatus(task.status),
     site: task.site ?? 'about:blank',
     startedAt: formatStartedAt(task.startedAt),

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.test.tsx
@@ -117,7 +117,7 @@ describe('TaskDetailPage', () => {
     }
     const html = render()
     expect(html).toContain('Browsed example.com')
-    expect(html).toContain('Claude Code')
+    expect(html).toContain('claude-code')
     expect(html).toContain('Timeline')
     expect(html).toContain('Screenshots')
     expect(html).toContain('Open final URL')

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/naming.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/naming.rs
@@ -17,12 +17,83 @@ pub fn normalize_small_name(raw: &str) -> String {
     name.trim_matches('-').to_string()
 }
 
-/// Returns the short client namespace used before the session label.
+const PREFIX_WORD_LIMIT: usize = 3;
+const PREFIX_MAX_LEN: usize = 20;
+
+/// Returns the client namespace used before the session label.
+///
+/// Keeps whole slug segments so a two-word product name survives intact:
+/// truncating at the first segment would render `claude-code` and `claude-desktop`
+/// as the same `claude` chip, which defeats the point of naming the owner. Bounded
+/// by a word count and a character budget so a long name cannot dominate the tab
+/// strip. Every step cuts from the right, so the result is always a prefix of the
+/// input and the borrow is preserved.
 #[must_use]
 pub fn client_prefix_from_slug(slug: &str) -> &str {
-    slug.split('-')
-        .find(|part| !part.is_empty())
-        .unwrap_or("agent")
+    let trimmed = slug.trim_matches('-');
+    if trimmed.is_empty() {
+        return "agent";
+    }
+    let named = &trimmed[..strip_trailing_version(trimmed)];
+    let capped = &named[..cap_segments(named)];
+    if capped.is_empty() { "agent" } else { capped }
+}
+
+/// Byte length of `slug` with a trailing run of all-digit segments removed. Some
+/// clients fold the version into the name, so `Claude Code 1.2.3` slugifies to
+/// `claude-code-1-2-3`. Only a trailing run is dropped, which is what keeps the
+/// interior digits of `gpt-4-turbo` intact. An all-digit slug is left whole rather
+/// than reduced to nothing.
+fn strip_trailing_version(slug: &str) -> usize {
+    let mut end = slug.len();
+    for segment in slug.rsplit('-') {
+        if segment.is_empty() || !segment.bytes().all(|byte| byte.is_ascii_digit()) {
+            break;
+        }
+        end = end.saturating_sub(segment.len() + 1);
+    }
+    if end == 0 { slug.len() } else { end }
+}
+
+/// Byte length of `slug` kept under both caps, never splitting a segment except when
+/// the first one alone already busts the budget.
+fn cap_segments(slug: &str) -> usize {
+    let mut end = 0;
+    let mut kept = 0;
+    let mut offset = 0;
+    for segment in slug.split('-') {
+        let start = offset;
+        offset += segment.len() + 1;
+        if segment.is_empty() {
+            continue;
+        }
+        if kept == PREFIX_WORD_LIMIT {
+            break;
+        }
+        let candidate = start + segment.len();
+        if kept > 0 && candidate > PREFIX_MAX_LEN {
+            break;
+        }
+        end = candidate;
+        kept += 1;
+    }
+    if end > PREFIX_MAX_LEN {
+        return floor_char_boundary(slug, PREFIX_MAX_LEN);
+    }
+    end
+}
+
+/// Largest index at or below `max` that lands on a char boundary. The slug is ASCII
+/// by construction, but this is a public entry point and a mid-codepoint slice panics.
+fn floor_char_boundary(text: &str, max: usize) -> usize {
+    if max >= text.len() {
+        return text.len();
+    }
+    text.char_indices()
+        .map(|(index, _)| index)
+        .take_while(|index| *index <= max)
+        .last()
+        .unwrap_or(0)
 }
 
 /// Builds the BrowserOS tab-group title for a named MCP session.
@@ -59,9 +130,15 @@ mod tests {
             "Codex".to_string(),
             tokio::time::Instant::now(),
         );
-        assert_eq!(desired_group_title(&session).await, "claude/agile-alpaca");
+        assert_eq!(
+            desired_group_title(&session).await,
+            "claude-code/agile-alpaca"
+        );
         session.rename("flight-search".to_string()).await;
-        assert_eq!(desired_group_title(&session).await, "claude/flight-search");
+        assert_eq!(
+            desired_group_title(&session).await,
+            "claude-code/flight-search"
+        );
     }
 
     #[test]
@@ -82,10 +159,47 @@ mod tests {
     }
 
     #[test]
-    fn client_prefix_matches_ts_vectors() {
-        assert_eq!(client_prefix_from_slug("claude-code"), "claude");
+    fn client_prefix_keeps_whole_multi_word_names() {
+        assert_eq!(client_prefix_from_slug("claude-code"), "claude-code");
         assert_eq!(client_prefix_from_slug("cursor"), "cursor");
+        assert_eq!(
+            client_prefix_from_slug("cowork-finance-ops"),
+            "cowork-finance-ops"
+        );
+    }
+
+    #[test]
+    fn client_prefix_no_longer_collides_distinct_products() {
+        assert_ne!(
+            client_prefix_from_slug("claude-code"),
+            client_prefix_from_slug("claude-desktop")
+        );
+    }
+
+    #[test]
+    fn client_prefix_drops_trailing_version_but_keeps_interior_digits() {
+        assert_eq!(client_prefix_from_slug("claude-code-1-2-3"), "claude-code");
+        assert_eq!(client_prefix_from_slug("gpt-4-turbo"), "gpt-4-turbo");
+        assert_eq!(client_prefix_from_slug("1-2-3"), "1-2-3");
+    }
+
+    #[test]
+    fn client_prefix_is_bounded() {
+        assert_eq!(client_prefix_from_slug("a-b-c-d-e"), "a-b-c");
+        assert_eq!(
+            client_prefix_from_slug("alpha-betagammadeltaepsilonzeta"),
+            "alpha"
+        );
+        assert_eq!(
+            client_prefix_from_slug("averyveryverylongsinglesegmentname"),
+            "averyveryverylongsin"
+        );
+    }
+
+    #[test]
+    fn client_prefix_falls_back_when_nothing_survives() {
         assert_eq!(client_prefix_from_slug(""), "agent");
+        assert_eq!(client_prefix_from_slug("---"), "agent");
     }
 
     #[test]

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
@@ -22,9 +22,12 @@ Shared with other agents:
   tabs action="new" and work on that copy; leave the original untouched.
 - Preserve useful pages: leave anything the user may want to inspect open
   instead of closing it when the task ends.
+- Say who you are: send agentName on every call (e.g. "claude-code", "codex").
+  It names this session, titles and colours your tab group, and is how the user
+  filters your runs in the audit log.
 - Name your session early with name_session: a 2-3 word task label, the category
   that best fits the task, and a short PII-free summary you can search for later;
-  tabs group as <client>/<name>.
+  tabs group as <agentName>/<name>.
 - The user oversees this browser from the BrowserOS neo cockpit (live view,
   audit, replay).
 

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/prompt.rs
@@ -22,9 +22,10 @@ Shared with other agents:
   tabs action="new" and work on that copy; leave the original untouched.
 - Preserve useful pages: leave anything the user may want to inspect open
   instead of closing it when the task ends.
-- Say who you are: send agentName on every call (e.g. "claude-code", "codex").
-  It names this session, titles and colours your tab group, and is how the user
-  filters your runs in the audit log.
+- Say who you are (e.g. "claude-code", "codex"): send it as the agentName
+  argument on every call if your tools take one, otherwise it comes from the
+  initialize handshake. It names this session, titles and colours your tab
+  group, and is how the user filters your runs in the audit log.
 - Name your session early with name_session: a 2-3 word task label, the category
   that best fits the task, and a short PII-free summary you can search for later;
   tabs group as <agentName>/<name>.

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -47,7 +47,7 @@ use uuid::Uuid;
 const SERVER_NAME: &str = "browseros-neo";
 const SERVER_TITLE: &str = "BrowserOS neo";
 const NAME_SESSION_TOOL_NAME: &str = "name_session";
-const NAME_SESSION_DESCRIPTION: &str = "Name this browser session at the start of a task: a small lowercase 2-3 word label for what it is doing, e.g. \"invoice processing\", a `category` for the kind of task, and a short `summary`. Tabs are grouped as <client>/<name>; the label stays on this machine, the summary powers audit search and is also recorded for analytics, and the category is used for anonymous aggregate analytics. Call again to update.";
+const NAME_SESSION_DESCRIPTION: &str = "Name this browser session at the start of a task: a small lowercase 2-3 word label for what it is doing, e.g. \"invoice processing\", a `category` for the kind of task, and a short `summary`. Tabs are grouped as <agentName>/<name>; the label stays on this machine, the summary powers audit search and is also recorded for analytics, and the category is used for anonymous aggregate analytics. Call again to update.";
 const NAME_SESSION_CATEGORY_DESCRIPTION: &str = "The kind of task, for anonymous aggregate analytics only; the free-form name is never sent. Pick the closest fit from the list.";
 const NAME_SESSION_SUMMARY_DESCRIPTION: &str = "One or two short lines saying what this task is, phrased so you can find it again by searching later. No names, emails, URLs, file paths, or account numbers.";
 const SUMMARY_MAX_LEN: usize = 200;
@@ -56,7 +56,9 @@ const NAME_SESSION_INPUT_MAX_LEN: usize = 64;
 /// convention (namespaced by owner). Clients read it from a tool result and echo it
 /// as the `session` argument on subsequent calls.
 const SESSION_META_KEY: &str = "com.browseros.neo/session";
+const AGENT_NAME_ARG: &str = "agentName";
 const SESSION_ARG_DESCRIPTION: &str = "Opaque session handle for this browser session. The server returns it in every tool result's `_meta` under the key `com.browseros.neo/session`; read it from there and pass it back as this `session` argument on every later call to keep the same browser session and its tab ownership. Omit it only on your first call to start a new session.";
+const AGENT_NAME_ARG_DESCRIPTION: &str = "Your own agent name, e.g. \"claude-code\", \"codex\", \"cursor\". Send it on every call. It names this browser session, titles and colours the tab group your tabs live in, and is how the operator filters your runs in the audit log. 2026-07-28 removed the initialize handshake, so this argument is the only way the server can learn who you are.";
 const SAVE_SKILL_TOOL_NAME: &str = "save_skill";
 const SAVE_SKILL_DESCRIPTION: &str = "When you finish a repeatable browser task the user is likely to run again, save it as a BrowserOS neo skill so it can be re-run by name later; save genuinely repeatable, user-valuable tasks, not one-offs. Give a lowercase-hyphen name, a one-line description, the ordered steps, and any shortcuts learned this run. In the steps, name the exact browser SDK calls you actually used this session (e.g. browser.wait, browser.read, browser.pages.newPage) so a later run reuses them verbatim; never invent, rename, or guess a method that is not in the run tool's SDK (there is no browser.waitFor, for example). The skill is saved and linked into your agents under a neo- prefix (neo-<name>) so it never clobbers your own skills and you can list them all by typing /neo; a name given without the prefix is namespaced automatically. Call again with the same name to update it in place.";
 const MARK_SKILL_RUN_TOOL_NAME: &str = "mark_skill_run";
@@ -109,16 +111,27 @@ impl ClawMcpService {
         self.catalog.iter().position(|tool| tool.name == name)
     }
 
-    fn listed_tools(&self) -> Vec<Tool> {
+    /// `declare_agent_name` gates the mandatory `agentName` argument to clients on
+    /// 2026-07-28 or later. Older peers negotiated `initialize`, still carry their
+    /// identity in the handshake, and must keep receiving the schema unchanged.
+    fn listed_tools(&self, declare_agent_name: bool) -> Vec<Tool> {
+        let decorate = |tool: Tool| {
+            let tool = with_session_arg(tool);
+            if declare_agent_name {
+                with_agent_name_arg(tool)
+            } else {
+                tool
+            }
+        };
         let mut tools = self
             .catalog
             .iter()
             .map(ToolDef::to_mcp_tool)
-            .map(with_session_arg)
+            .map(&decorate)
             .collect::<Vec<_>>();
-        tools.push(with_session_arg(self.name_session_tool.clone()));
-        tools.push(with_session_arg(self.save_skill_tool.clone()));
-        tools.push(with_session_arg(self.mark_skill_run_tool.clone()));
+        tools.push(decorate(self.name_session_tool.clone()));
+        tools.push(decorate(self.save_skill_tool.clone()));
+        tools.push(decorate(self.mark_skill_run_tool.clone()));
         tools
     }
 
@@ -413,12 +426,17 @@ impl ClawMcpService {
     async fn resolve_modern_session(
         &self,
         provided: Option<SessionId>,
+        declared: Option<ClientInfo>,
         client: Option<ClientInfo>,
     ) -> Result<(StartedSession, SessionId), McpError> {
         // 2026-07-28 removed `initialize`, so a stateless call carries no handshake
-        // clientInfo. Use the per-request inline `_meta` clientInfo when the client
-        // sends it; otherwise fall back to the anonymous "agent" identity.
-        let client = client.unwrap_or_else(default_agent_client_info);
+        // clientInfo. The agent's own `agentName` argument wins because it is required
+        // of every agent; inline `_meta` clientInfo is only a fallback because SEP-2575
+        // leaves that key optional and most clients omit it. "agent" remains the last
+        // resort so a missing name never fails the call.
+        let client = declared
+            .or(client)
+            .unwrap_or_else(default_agent_client_info);
         if let Some(handle) = provided
             && let Some(session) = self.state.sessions.lookup(&handle).await
         {
@@ -542,15 +560,18 @@ impl ServerHandler for ClawMcpService {
         _request: Option<PaginatedRequestParams>,
         context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
-        // SEP-2549: 2026-07-28 clients require ttlMs + cacheScope on list results;
-        // emit them only for that revision so legacy peers keep the old wire shape
-        // (mirrors rmcp's #[tool_handler] macro). ttl 0 = do-not-cache; the tool
-        // catalog is identical across users, so the scope is public.
-        let supports_cache_hints = context
+        // Two things hang off this one revision check. SEP-2549: 2026-07-28 clients
+        // require ttlMs + cacheScope on list results, emitted only for that revision so
+        // legacy peers keep the old wire shape (mirrors rmcp's #[tool_handler] macro);
+        // ttl 0 = do-not-cache, and the tool catalog is identical across users so the
+        // scope is public. Separately, 2026-07-28 dropped `initialize`, so only those
+        // clients have to declare `agentName` per call; legacy peers still carry their
+        // identity in the handshake and must see the schema unchanged.
+        let is_modern_revision = context
             .protocol_version()
             .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28);
-        let mut result = ListToolsResult::with_all_items(self.listed_tools());
-        if supports_cache_hints {
+        let mut result = ListToolsResult::with_all_items(self.listed_tools(is_modern_revision));
+        if is_modern_revision {
             result = result.with_ttl_ms(0).with_cache_scope(CacheScope::Public);
         }
         std::future::ready(Ok(result))
@@ -604,8 +625,17 @@ impl ServerHandler for ClawMcpService {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(SessionId::new);
+        // Stripped on every path, including legacy, so no tool ever receives it as an
+        // argument even if an agent sends it against a schema that never offered it.
+        let declared_agent_name = raw_args
+            .get(AGENT_NAME_ARG)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
         if let Value::Object(map) = &mut raw_args {
             map.remove("session");
+            map.remove(AGENT_NAME_ARG);
         }
         let modern = protocol_version_from_extensions(&context.extensions)
             .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28)
@@ -617,8 +647,11 @@ impl ServerHandler for ClawMcpService {
                 .and_then(|meta| meta.client_info())
                 .as_ref()
                 .map(client_info_from_implementation);
+            let declared = declared_agent_name
+                .as_deref()
+                .map(client_info_from_declared_name);
             let (started, handle) = self
-                .resolve_modern_session(provided_handle, modern_client)
+                .resolve_modern_session(provided_handle, declared, modern_client)
                 .await?;
             (started, Some(handle))
         } else {
@@ -952,6 +985,16 @@ fn client_info_from_implementation(source: &Implementation) -> ClientInfo {
     }
 }
 
+/// Builds the session identity from an agent's self-declared `agentName`. Version is
+/// unknown by construction: the agent states who it is, not which build it is.
+fn client_info_from_declared_name(name: &str) -> ClientInfo {
+    ClientInfo {
+        name: clean_client_field(name, "agent"),
+        version: "unknown".to_string(),
+        title: None,
+    }
+}
+
 /// The anonymous fallback identity for a stateless client that sends no clientInfo.
 fn default_agent_client_info() -> ClientInfo {
     ClientInfo {
@@ -997,6 +1040,31 @@ fn with_session_arg(mut tool: Tool) -> Tool {
             "session".to_string(),
             json!({ "type": "string", "description": SESSION_ARG_DESCRIPTION }),
         );
+    }
+    tool.input_schema = Arc::new(schema);
+    tool
+}
+
+/// Adds the mandatory `agentName` argument. Only reaches clients on 2026-07-28 or
+/// later; `required` here is advisory, since the server never rejects a call that
+/// omits it and falls back through `_meta` clientInfo to the anonymous identity.
+fn with_agent_name_arg(mut tool: Tool) -> Tool {
+    let mut schema = tool.input_schema.as_ref().clone();
+    if let Some(Value::Object(properties)) = schema.get_mut("properties") {
+        properties.insert(
+            AGENT_NAME_ARG.to_string(),
+            json!({ "type": "string", "description": AGENT_NAME_ARG_DESCRIPTION }),
+        );
+    }
+    let required = schema
+        .entry("required")
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if let Value::Array(required) = required
+        && !required
+            .iter()
+            .any(|value| value.as_str() == Some(AGENT_NAME_ARG))
+    {
+        required.push(Value::String(AGENT_NAME_ARG.to_string()));
     }
     tool.input_schema = Arc::new(schema);
     tool
@@ -1108,7 +1176,7 @@ mod tests {
                 .is_some_and(|required| required.contains(&json!("session")))
         );
 
-        for tool in service.listed_tools() {
+        for tool in service.listed_tools(false) {
             let schema = Value::Object(tool.input_schema.as_ref().clone());
             assert_eq!(
                 schema["properties"]["session"]["type"],
@@ -1127,12 +1195,12 @@ mod tests {
         let service = ClawMcpService::new(call.state);
 
         let (first, minted) = service
-            .resolve_modern_session(None, None)
+            .resolve_modern_session(None, None, None)
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
 
         let (again, reused) = service
-            .resolve_modern_session(Some(minted.clone()), None)
+            .resolve_modern_session(Some(minted.clone()), None, None)
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
         assert_eq!(reused.to_string(), minted.to_string());
@@ -1143,7 +1211,7 @@ mod tests {
 
         let client_chosen = SessionId::new("client-picked-id");
         let (other, other_handle) = service
-            .resolve_modern_session(Some(client_chosen.clone()), None)
+            .resolve_modern_session(Some(client_chosen.clone()), None, None)
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
         assert_ne!(other_handle.to_string(), client_chosen.to_string());
@@ -1167,7 +1235,7 @@ mod tests {
             title: None,
         };
         let (named, handle) = service
-            .resolve_modern_session(None, Some(client))
+            .resolve_modern_session(None, None, Some(client))
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
         assert_eq!(named.session.agent().slug(), "test-harness-client");
@@ -1176,7 +1244,7 @@ mod tests {
         // Reusing that handle without clientInfo keeps the minted identity and label,
         // so a session's audit attribution never flips to "agent" mid-conversation.
         let (reused, _) = service
-            .resolve_modern_session(Some(handle), None)
+            .resolve_modern_session(Some(handle), None, None)
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
         assert_eq!(reused.session.agent().slug(), "test-harness-client");
@@ -1184,7 +1252,7 @@ mod tests {
 
         // A stateless client that sends no clientInfo falls back to "agent".
         let (anon, _) = service
-            .resolve_modern_session(None, None)
+            .resolve_modern_session(None, None, None)
             .await
             .map_err(|error| anyhow::anyhow!("{error:?}"))?;
         assert_eq!(anon.session.agent().slug(), "agent");
@@ -1357,7 +1425,10 @@ mod tests {
         assert!(instructions.contains("BrowserOS neo — the browser for agents"));
         assert!(instructions.contains("Reach for run first"));
         assert!(instructions.contains(
-            "- Name your session early with name_session: a 2-3 word task label, the category\n  that best fits the task, and a short PII-free summary you can search for later;\n  tabs group as <client>/<name>."
+            "- Say who you are: send agentName on every call (e.g. \"claude-code\", \"codex\").\n  It names this session, titles and colours your tab group, and is how the user\n  filters your runs in the audit log."
+        ));
+        assert!(instructions.contains(
+            "- Name your session early with name_session: a 2-3 word task label, the category\n  that best fits the task, and a short PII-free summary you can search for later;\n  tabs group as <agentName>/<name>."
         ));
         assert!(instructions.contains(
             "- If the user points you at a tab you don't own, open its URL with\n  tabs action=\"new\" and work on that copy; leave the original untouched."
@@ -1370,11 +1441,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn agent_name_is_required_only_for_modern_clients() -> anyhow::Result<()> {
+        let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let service = ClawMcpService::new(call.state);
+
+        // Legacy peers negotiated `initialize` and still carry identity in the
+        // handshake, so their schema must not gain a required argument.
+        for tool in service.listed_tools(false) {
+            let schema = Value::Object(tool.input_schema.as_ref().clone());
+            assert_eq!(schema["properties"][AGENT_NAME_ARG], Value::Null);
+            assert!(
+                !schema["required"]
+                    .as_array()
+                    .is_some_and(|required| required.contains(&json!(AGENT_NAME_ARG)))
+            );
+        }
+
+        for tool in service.listed_tools(true) {
+            let schema = Value::Object(tool.input_schema.as_ref().clone());
+            assert_eq!(
+                schema["properties"][AGENT_NAME_ARG]["type"],
+                json!("string")
+            );
+            assert!(
+                schema["required"]
+                    .as_array()
+                    .is_some_and(|required| required.contains(&json!(AGENT_NAME_ARG))),
+                "{} must be required for {}",
+                AGENT_NAME_ARG,
+                tool.name
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn declared_agent_name_outranks_meta_client_info() -> anyhow::Result<()> {
+        let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
+        let service = ClawMcpService::new(call.state);
+
+        let (declared, _) = service
+            .resolve_modern_session(
+                None,
+                Some(client_info_from_declared_name("claude-code")),
+                Some(ClientInfo {
+                    name: "Codex".to_string(),
+                    version: "1".to_string(),
+                    title: None,
+                }),
+            )
+            .await?;
+        assert_eq!(declared.session.agent().slug(), "claude-code");
+
+        // Falls back to inline clientInfo when the agent declares nothing, and to the
+        // anonymous identity when neither is present. A missing name never errors.
+        let (from_meta, _) = service
+            .resolve_modern_session(
+                None,
+                None,
+                Some(ClientInfo {
+                    name: "Codex".to_string(),
+                    version: "1".to_string(),
+                    title: None,
+                }),
+            )
+            .await?;
+        assert_eq!(from_meta.session.agent().slug(), "codex");
+
+        let (anonymous, _) = service.resolve_modern_session(None, None, None).await?;
+        assert_eq!(anonymous.session.agent().slug(), "agent");
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn tool_surface_exposes_full_catalog_including_run() -> anyhow::Result<()> {
         let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
         let service = ClawMcpService::new(call.state);
         let names: Vec<String> = service
-            .listed_tools()
+            .listed_tools(false)
             .iter()
             .map(|tool| tool.name.to_string())
             .collect();
@@ -1399,7 +1543,7 @@ mod tests {
         let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
         let service = ClawMcpService::new(call.state);
         let listed = service
-            .listed_tools()
+            .listed_tools(false)
             .into_iter()
             .find(|tool| tool.name == NAME_SESSION_TOOL_NAME)
             .ok_or_else(|| anyhow::anyhow!("name_session missing from list"))?;
@@ -1484,7 +1628,7 @@ mod tests {
         let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
         let service = ClawMcpService::new(call.state);
         let listed = service
-            .listed_tools()
+            .listed_tools(false)
             .into_iter()
             .find(|tool| tool.name == SAVE_SKILL_TOOL_NAME)
             .ok_or_else(|| anyhow::anyhow!("save_skill missing from list"))?;
@@ -1511,7 +1655,7 @@ mod tests {
         let call = crate::api::mcp::test_support::tool_call("tabs", json!({})).await?;
         let service = ClawMcpService::new(call.state);
         let listed = service
-            .listed_tools()
+            .listed_tools(false)
             .into_iter()
             .find(|tool| tool.name == MARK_SKILL_RUN_TOOL_NAME)
             .ok_or_else(|| anyhow::anyhow!("mark_skill_run missing from list"))?;

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/mcp/service.rs
@@ -1425,7 +1425,7 @@ mod tests {
         assert!(instructions.contains("BrowserOS neo — the browser for agents"));
         assert!(instructions.contains("Reach for run first"));
         assert!(instructions.contains(
-            "- Say who you are: send agentName on every call (e.g. \"claude-code\", \"codex\").\n  It names this session, titles and colours your tab group, and is how the user\n  filters your runs in the audit log."
+            "- Say who you are (e.g. \"claude-code\", \"codex\"): send it as the agentName\n  argument on every call if your tools take one, otherwise it comes from the\n  initialize handshake. It names this session, titles and colours your tab\n  group, and is how the user filters your runs in the audit log."
         ));
         assert!(instructions.contains(
             "- Name your session early with name_session: a 2-3 word task label, the category\n  that best fits the task, and a short PII-free summary you can search for later;\n  tabs group as <agentName>/<name>."

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -497,7 +497,7 @@ async fn mcp_name_session_lists_and_renames_while_disconnected() -> anyhow::Resu
         .ok_or_else(|| anyhow::anyhow!("name_session missing"))?;
     assert_eq!(
         tool["description"],
-        "Name this browser session at the start of a task: a small lowercase 2-3 word label for what it is doing, e.g. \"invoice processing\", a `category` for the kind of task, and a short `summary`. Tabs are grouped as <client>/<name>; the label stays on this machine, the summary powers audit search and is also recorded for analytics, and the category is used for anonymous aggregate analytics. Call again to update."
+        "Name this browser session at the start of a task: a small lowercase 2-3 word label for what it is doing, e.g. \"invoice processing\", a `category` for the kind of task, and a short `summary`. Tabs are grouped as <agentName>/<name>; the label stays on this machine, the summary powers audit search and is also recorded for analytics, and the category is used for anonymous aggregate analytics. Call again to update."
     );
     assert_eq!(
         tool["inputSchema"],
@@ -691,7 +691,7 @@ async fn mcp_session_naming_appends_five_tips_without_elicitation() -> anyhow::R
 
     let mut stream = McpSseStream::open(&app.router, &session_id).await?;
     let tip = format!(
-        "Tip: this session is \"claude/{generated}\" — rename it with name_session name=\"<2-3 word task label>\""
+        "Tip: this session is \"claude-code/{generated}\" — rename it with name_session name=\"<2-3 word task label>\""
     );
     for id in 3..=7 {
         let (status, _headers, body) = request_json_with_headers(

--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-tabs.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-tabs.ts
@@ -129,7 +129,7 @@ export const tabsCases: ContractCase[] = [
         groups = expectOk(
           await ctx.mcp.callTool('tab_groups', { action: 'list' }),
         )
-        return groups.includes('claw/')
+        return groups.includes('claw-contract/')
       }, 'the convo tab group to appear')
     },
   },


### PR DESCRIPTION
## Why

Every agent tab group is titled `agent/<task>`, every one of them draws the same colour, and the audit screen's Agent filter collapses unrelated runs into a single `agent` bucket.

The 2026-07-28 MCP revision removed the `initialize` handshake, so a stateless call carries no `clientInfo` and the server has no moment where a client says who it is. We already read the per-request `_meta` clientInfo, but SEP-2575 leaves that key **optional** (only `protocolVersion` and `clientCapabilities` are required), so a fully conformant client can send nothing identifying and there is no transport setting that forces it to. The only party that always knows the agent's name is the agent.

## What changed

**`agentName`, declared by the agent.** An argument injected into every tool alongside `session`, marked required in the schema, consulted only when a session is minted:

```
1. agentName argument      required of every agent, wins
2. _meta clientInfo        fallback, most clients omit it
3. "agent"                 last resort, a missing name never fails the call
```

`required` is advisory here. The server does not validate arguments against the schema, so nothing rejects a call that omits it.

**Legacy clients are untouched.** The argument is gated on the negotiated revision, reusing the check that already decides SEP-2549 cache hints. Anything below 2026-07-28 still negotiates `initialize`, still resolves its name from the handshake, and receives the tool schema byte-identical to before. `get_tool` is deliberately left alone: rmcp only calls it to validate `Mcp-Param-*` headers, and it is cached per tool name with no protocol context, so injecting there would apply one revision's schema to every revision.

**Prefix truncation removed.** `client_prefix_from_slug` kept only the first slug segment, so `claude-code` and `claude-desktop` both rendered as `claude`. Two distinct agents drawing one chip defeats the point of naming the owner. It now keeps whole segments under a word and character budget:

| slug | before | after |
|---|---|---|
| `claude-code` | `claude` | `claude-code` |
| `claude-desktop` | `claude` | `claude-desktop` |
| `claude-code-1-2-3` | `claude` | `claude-code` |
| `gpt-4-turbo` | `gpt` | `gpt-4-turbo` |
| `a-b-c-d-e` | `a` | `a-b-c` |
| `---` | `agent` | `agent` |

A trailing run of pure digits is dropped, since some clients fold the version into the name. Only trailing, which is what keeps the interior digits of `gpt-4-turbo`. Every step cuts from the right, so the function still returns a borrow of its input and no call site changed.

This one is not revision gated. Legacy clients are the ones whose names already resolve correctly, so they benefit most, and gating it would mean threading the negotiated revision into a pure naming function reached from effects that carry no request context.

**Audit chips render the slug.** `agentChipsFor` grouped by slug but displayed the session label, so `Codex` rendered title-cased beside kebab-case `claude-code`, and two sessions announcing `"Claude Code"` and `"claude-code"` merged into one chip whose displayed name depended on which arrived first. Chips now show the slug, so the filter and the tab strip name an agent identically. `AgentChip.agentLabel` was carrying the same value as `slug` afterwards and has been removed.

## Verification

- `cargo test --package claw-server-rust --locked`, all suites pass.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- claw-app: `tsc --noEmit` clean, 388 tests pass, biome clean.
- New coverage: the revision gate asserts `agentName` is absent and not required for legacy listings and present and required for modern ones; the precedence test covers declared-wins, `_meta` fallback, and the anonymous fallback.
- One integration expectation changed on purpose: a legacy client identifying as `Claude Code` now gets `claude-code/<task>` where it previously got `claude/<task>`.

## Not in scope

The audit **table** still renders the session label per row, which is the right level of detail there; only the filter chip changed. Group colour needed no change, since `color_for_slug` and the app's mirrored `hexForSlug` already hash the slug, so a correct name fixes the colour for free.

---

## Also: stop showing a guessed harness next to the agent name

A running Codex session rendered as **`CODEX  CLAUDE CODE`** in the Running now card. Two fields sat side by side and only the first was real:

```tsx
<span className="text-white">{session.label}</span>       // CODEX        announced
<span className="text-white/45">{session.harness}</span>  // CLAUDE CODE  invented
```

`harness` is only ever populated from a matched agent profile (`harness: profile.map(...)` in `cockpit/query.rs`). An agent with no configured profile resolves to `ClientIdentity::Ephemeral`, so the field never reaches the client and this fires:

```ts
/** Coerces contract strings into the UI harness union with an honest fallback. */
export function harnessForRow(value: string | undefined): Harness {
  if (!value) return 'Claude Code'
  return HARNESSES.includes(value) ? value : 'Claude Code'
}
```

There is a second path to the same wrong answer: `HARNESSES` needs an exact match against seven strings, so an announced name like `codex-mcp-client` misses and also lands on `'Claude Code'`. A unit test pinned exactly that behaviour, `expect(harnessForRow('Atlas-9000')).toBe('Claude Code')`.

The replay subtitle had the same shape for a different reason, `harness: task.profileId ?? 'unknown'`, so it printed a raw profile id or the literal word `unknown` under the label of a harness.

Both display sites are removed, along with the now-unused coercion, type fields and fixtures. **Kept deliberately:** the `/mcp` connect screen and cockpit onboarding chips still list harnesses, because that list is a real user choice about which configs are connected rather than an inference from session identity.

This belongs here rather than in its own PR: it is the display-side sibling of the identity work above, the same habit of guessing an agent's identity from a closed set instead of using what the agent announced.
