### PR TITLE
fix(claw-app): stop showing a guessed harness next to the agent name

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
@@ -94,7 +94,6 @@ export function AgentRunningCard({
               style={{ background: session.color }}
             />
             <span className="truncate text-white">{session.label}</span>
-            <span className="shrink-0 text-white/45">{session.harness}</span>
           </span>
           {showingLive ? (
             <span className="inline-flex shrink-0 items-center gap-1.5 text-[#8fb4ff]">

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
@@ -86,7 +86,6 @@ function session(
     slug: 'codex',
     label: 'Codex',
     name: 'Research BrowserClaw',
-    harness: 'Codex',
     color: '#0254ec',
     startedAt: 100,
     state: 'active',

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.test.tsx
@@ -156,7 +156,6 @@ function setConnectionsState(state: ConnectionsState) {
               state === 'installed'
                 ? [
                     {
-                      harness: 'Codex',
                       installed: true,
                       message: 'Configured in Codex.',
                     },
@@ -355,7 +354,6 @@ function liveSession(sessionId: string): LiveSessionCardRecord {
     slug: 'codex',
     label: 'Codex',
     name: 'Connected session',
-    harness: 'Codex',
     color: '#7A5AF8',
     startedAt: 100,
     state: 'idle',

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.test.ts
@@ -4,7 +4,6 @@ import {
   colorForSlug,
   formatRelative,
   formatToolTrail,
-  harnessForRow,
   sessionsToLiveCards,
   siteOf,
 } from './cockpit.helpers'
@@ -67,13 +66,6 @@ describe('display fallbacks', () => {
   it('keeps slug colors deterministic', () => {
     expect(colorForSlug('finance')).toBe(colorForSlug('finance'))
     expect(colorForSlug('travel')).toMatch(/^#[0-9A-F]{6}$/i)
-  })
-
-  it('keeps known harnesses and uses the existing fallback', () => {
-    expect(harnessForRow('Cursor')).toBe('Cursor')
-    expect(harnessForRow('Codex')).toBe('Codex')
-    expect(harnessForRow(undefined)).toBe('Claude Code')
-    expect(harnessForRow('Atlas-9000')).toBe('Claude Code')
   })
 })
 
@@ -258,7 +250,6 @@ describe('sessionsToLiveCards', () => {
     expect(card).toMatchObject({
       profileId: 'profile-parent',
       label: 'parent-slug',
-      harness: 'Claude Code',
       color: colorForSlug('parent-slug'),
     })
   })

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.ts
@@ -4,7 +4,6 @@ import type {
   SessionSummary,
   ToolEvent,
 } from '@browseros/claw-api'
-import { HARNESSES, type Harness } from '@/components/harness/harness.types'
 
 // Missing parent colors fall back to a stable slug hash so card identity does
 // not flicker between live-session polls.
@@ -62,21 +61,12 @@ export function formatToolTrail(
     .join(' -> ')
 }
 
-/** Coerces contract strings into the UI harness union with an honest fallback. */
-export function harnessForRow(value: string | undefined): Harness {
-  if (!value) return 'Claude Code'
-  return (HARNESSES as readonly string[]).includes(value)
-    ? (value as Harness)
-    : 'Claude Code'
-}
-
 export interface LiveSessionCardRecord {
   sessionId: string
   profileId?: string
   slug: string
   label: string
   name: string
-  harness: Harness
   color: string
   startedAt: number
   state: LiveSessionActivityState
@@ -139,7 +129,6 @@ export function sessionsToLiveCards(
       slug: session.slug,
       label: session.label || session.slug,
       name: session.name,
-      harness: harnessForRow(session.harness),
       color: session.color ?? colorForSlug(session.slug),
       startedAt: session.startedAt,
       state: session.live?.state ?? 'idle',

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.test.tsx
@@ -284,7 +284,6 @@ function replayData(
     sessionId: 'session-1',
     agentLabel: 'Codex',
     taskTitle: 'Replay test',
-    harness: 'Codex',
     status: 'done' as const,
     site: 'example.com',
     startedAt: 'Jul 18, 2026',

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -141,7 +141,7 @@ export function Replay() {
             {replay.taskTitle}
           </div>
           <div className="text-ink-3 text-xs">
-            {replay.agentLabel} · {replay.harness}
+            {replay.agentLabel}
             {replay.startedAt ? ` · ${replay.startedAt}` : ''}
           </div>
         </div>

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -51,7 +51,6 @@ export interface ReplayData {
   sessionId: string
   agentLabel: string
   taskTitle: string
-  harness: string
   status: RunStatus
   site: string
   startedAt: string
@@ -229,7 +228,6 @@ function buildReplayData(
     sessionId: task.sessionId,
     agentLabel: task.label || task.slug,
     taskTitle: task.name,
-    harness: task.profileId ?? 'unknown',
     status: mapTaskStatus(task.status),
     site: task.site ?? 'about:blank',
     startedAt: formatStartedAt(task.startedAt),


### PR DESCRIPTION
## The bug

A running Codex session renders as **`CODEX  CLAUDE CODE`** in the Running now card. Two fields sit side by side and only the first one is real:

```tsx
<span className="text-white">{session.label}</span>       // CODEX        announced
<span className="text-white/45">{session.harness}</span>  // CLAUDE CODE  invented
```

## Why it says Claude Code

```ts
/** Coerces contract strings into the UI harness union with an honest fallback. */
export function harnessForRow(value: string | undefined): Harness {
  if (!value) return 'Claude Code'
  return HARNESSES.includes(value) ? value : 'Claude Code'
}
```

`harness` is only ever populated from a matched agent profile:

```rust
harness: profile.map(|profile| profile.harness.to_string()),   // cockpit/query.rs
```

An agent with no configured profile resolves to `ClientIdentity::Ephemeral`, so `matched_profile` returns `None`, the field never reaches the client, and the fallback fires. There is a second path to the same wrong answer: `HARNESSES` requires an exact match against seven strings, so an announced name like `codex-mcp-client` misses and also lands on `'Claude Code'`.

The doc comment claims an honest fallback. Hard-coding one vendor's product name to mean "unknown" is the opposite, and a unit test pinned exactly that: `expect(harnessForRow('Atlas-9000')).toBe('Claude Code')`.

## The replay subtitle, same shape, different cause

```ts
harness: task.profileId ?? 'unknown',
```

That renders a raw profile id, or the literal word `unknown`, under the label of a harness. Also removed.

## What changed

Both display sites are gone, along with the now-unused coercion, type fields, and fixtures. Nothing computes or renders an inferred harness any more.

**Kept deliberately:** the `/mcp` connect screen and the cockpit onboarding chips still list harnesses. That list is a real user choice about which harness configs are connected, not an inference from session identity, so it stays exactly as it is.

## Verification

`tsc --noEmit` clean, 387 tests pass, biome clean on the changed files. The only removed assertions were the ones pinning the invented value.

## Note

This is the display-side sibling of the identity work in #2581. Same underlying habit: guessing an agent's identity from a small closed set instead of using what the agent actually announced. The two changes are independent and touch different files.