### PR TITLE
fix(mcp): stop emitting null inside nullable enum tool schemas

### DIFF
--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -509,6 +509,13 @@ fn collapse_nullable_enum(object: &mut JsonObject) {
     if !values.iter().any(Value::is_null) {
         return;
     }
+    let Some(Value::Array(types)) = object.get("type") else {
+        return;
+    };
+    if !types.iter().any(|entry| entry.as_str() == Some("null")) {
+        return;
+    }
+
     let kept_values: Vec<Value> = values
         .iter()
         .filter(|value| !value.is_null())
@@ -518,11 +525,7 @@ fn collapse_nullable_enum(object: &mut JsonObject) {
     if kept_values.is_empty() {
         return;
     }
-    object.insert("enum".to_string(), Value::Array(kept_values));
 
-    let Some(Value::Array(types)) = object.get("type") else {
-        return;
-    };
     let mut kept_types: Vec<Value> = types
         .iter()
         .filter(|entry| entry.as_str() != Some("null"))
@@ -533,6 +536,7 @@ fn collapse_nullable_enum(object: &mut JsonObject) {
         1 => kept_types.remove(0),
         _ => Value::Array(kept_types),
     };
+    object.insert("enum".to_string(), Value::Array(kept_values));
     object.insert("type".to_string(), replacement);
 }
 

--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -656,3 +656,61 @@ pub fn page_json(page: &browseros_core::pages::PageInfo) -> Value {
     }
     value
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn normalized(schema: Value) -> Value {
+        let Value::Object(object) = schema else {
+            panic!("test schema should be an object");
+        };
+        Value::Object((*normalize_schema_object(object)).clone())
+    }
+
+    #[test]
+    fn nullable_enum_normalization_collapses_schemars_option_enum_shape() {
+        let schema = normalized(json!({
+            "type": "object",
+            "properties": {
+                "button": {
+                    "type": ["string", "null"],
+                    "enum": ["left", "right", null]
+                }
+            }
+        }));
+
+        assert_eq!(
+            schema.pointer("/properties/button"),
+            Some(&json!({
+                "type": "string",
+                "enum": ["left", "right"]
+            }))
+        );
+    }
+
+    #[test]
+    fn nullable_enum_normalization_preserves_non_nullable_enum_schemas() {
+        let schema = normalized(json!({
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string",
+                    "enum": ["ready", null]
+                },
+                "implicit": {
+                    "enum": ["ready", null]
+                }
+            }
+        }));
+
+        assert_eq!(
+            schema.pointer("/properties/state/enum"),
+            Some(&json!(["ready", null]))
+        );
+        assert_eq!(
+            schema.pointer("/properties/implicit/enum"),
+            Some(&json!(["ready", null]))
+        );
+    }
+}

--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -447,6 +447,8 @@ fn normalize_schema_value(value: &mut Value) {
                 object.remove("default");
             }
 
+            collapse_nullable_enum(object);
+
             for key in [
                 "additionalItems",
                 "additionalProperties",
@@ -490,6 +492,48 @@ fn normalize_schema_value(value: &mut Value) {
         }
         _ => {}
     }
+}
+
+/// Rewrites a nullable enum — `{"type": ["string", "null"], "enum": [..., null]}`, which is
+/// what schemars emits for an `Option<SomeEnum>` field — into the plain single-type form.
+///
+/// An optional argument is already optional by being absent from `required`, and the extra
+/// `null` is what strict MCP clients reject: a Pydantic-backed client decodes every `enum`
+/// entry as the declared type and fails the tool list outright on the trailing `None`.
+/// Arguments are deserialized with serde rather than validated against this schema, so
+/// dropping it changes what clients are told, not what the server accepts.
+fn collapse_nullable_enum(object: &mut JsonObject) {
+    let Some(Value::Array(values)) = object.get("enum") else {
+        return;
+    };
+    if !values.iter().any(Value::is_null) {
+        return;
+    }
+    let kept_values: Vec<Value> = values
+        .iter()
+        .filter(|value| !value.is_null())
+        .cloned()
+        .collect();
+    // An enum of nothing but `null` carries no variants to keep; leave it untouched.
+    if kept_values.is_empty() {
+        return;
+    }
+    object.insert("enum".to_string(), Value::Array(kept_values));
+
+    let Some(Value::Array(types)) = object.get("type") else {
+        return;
+    };
+    let mut kept_types: Vec<Value> = types
+        .iter()
+        .filter(|entry| entry.as_str() != Some("null"))
+        .cloned()
+        .collect();
+    let replacement = match kept_types.len() {
+        0 => return,
+        1 => kept_types.remove(0),
+        _ => Value::Array(kept_types),
+    };
+    object.insert("type".to_string(), replacement);
 }
 
 fn first_boolean_path(value: &Value) -> Option<String> {

--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -509,13 +509,6 @@ fn collapse_nullable_enum(object: &mut JsonObject) {
     if !values.iter().any(Value::is_null) {
         return;
     }
-    let Some(Value::Array(types)) = object.get("type") else {
-        return;
-    };
-    if !types.iter().any(|entry| entry.as_str() == Some("null")) {
-        return;
-    }
-
     let kept_values: Vec<Value> = values
         .iter()
         .filter(|value| !value.is_null())
@@ -526,18 +519,30 @@ fn collapse_nullable_enum(object: &mut JsonObject) {
         return;
     }
 
-    let mut kept_types: Vec<Value> = types
-        .iter()
-        .filter(|entry| entry.as_str() != Some("null"))
-        .cloned()
-        .collect();
-    let replacement = match kept_types.len() {
-        0 => return,
-        1 => kept_types.remove(0),
-        _ => Value::Array(kept_types),
+    // A strict client rejects a `null` enum entry whatever the `type` says, so the
+    // `null` is dropped from any enum that has one. When `type` is the
+    // `["<type>", "null"]` array schemars emits for an Option, collapse it in the
+    // same pass; a scalar or missing type is left as-is.
+    let type_replacement = match object.get("type") {
+        Some(Value::Array(types)) => {
+            let kept_types: Vec<Value> = types
+                .iter()
+                .filter(|entry| entry.as_str() != Some("null"))
+                .cloned()
+                .collect();
+            match kept_types.as_slice() {
+                [] => None,
+                [single] => Some(single.clone()),
+                _ => Some(Value::Array(kept_types)),
+            }
+        }
+        _ => None,
     };
+
     object.insert("enum".to_string(), Value::Array(kept_values));
-    object.insert("type".to_string(), replacement);
+    if let Some(replacement) = type_replacement {
+        object.insert("type".to_string(), replacement);
+    }
 }
 
 fn first_boolean_path(value: &Value) -> Option<String> {
@@ -690,7 +695,10 @@ mod tests {
     }
 
     #[test]
-    fn nullable_enum_normalization_preserves_non_nullable_enum_schemas() {
+    fn nullable_enum_normalization_strips_null_even_without_the_nullable_type_array() {
+        // A strict client rejects a `null` enum entry whatever `type` says, so the
+        // `null` is dropped whether `type` is a scalar string or absent; only the
+        // `["<type>", "null"]` array is additionally collapsed.
         let schema = normalized(json!({
             "type": "object",
             "properties": {
@@ -706,11 +714,15 @@ mod tests {
 
         assert_eq!(
             schema.pointer("/properties/state/enum"),
-            Some(&json!(["ready", null]))
+            Some(&json!(["ready"]))
+        );
+        assert_eq!(
+            schema.pointer("/properties/state/type"),
+            Some(&json!("string"))
         );
         assert_eq!(
             schema.pointer("/properties/implicit/enum"),
-            Some(&json!(["ready", null]))
+            Some(&json!(["ready"]))
         );
     }
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -1324,3 +1324,67 @@ fn collect_permissive_object_paths(value: &Value, path: String, paths: &mut Vec<
         _ => {}
     }
 }
+
+/// Collects every `enum` entry in a schema that is not a string, as `path = value`.
+fn non_string_enum_entries(schema: &Value, path: &str, found: &mut Vec<String>) {
+    match schema {
+        Value::Object(object) => {
+            if let Some(Value::Array(values)) = object.get("enum") {
+                for (index, value) in values.iter().enumerate() {
+                    if !value.is_string() {
+                        found.push(format!("{path}/enum/{index} = {value}"));
+                    }
+                }
+            }
+            for (key, child) in object {
+                non_string_enum_entries(child, &format!("{path}/{key}"), found);
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                non_string_enum_entries(child, &format!("{path}/{index}"), found);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn tool_schemas_never_put_null_inside_an_enum() {
+    // A Pydantic-backed MCP client decodes each `enum` entry as the declared type and
+    // rejects the whole tool list on a `null`, so an `Option<SomeEnum>` argument must not
+    // leak one. Optionality rides on `required` instead.
+    let mut found = Vec::new();
+    for tool in catalog() {
+        let input = Value::Object((*tool.input_schema).clone());
+        non_string_enum_entries(&input, &format!("{}/inputSchema", tool.name), &mut found);
+        if let Some(output) = tool.output_schema {
+            let output = Value::Object((*output).clone());
+            non_string_enum_entries(&output, &format!("{}/outputSchema", tool.name), &mut found);
+        }
+    }
+    assert!(found.is_empty(), "non-string enum entries: {found:#?}");
+}
+
+#[test]
+fn optional_enum_arguments_keep_their_variants_and_stay_optional() {
+    let act = tool_by_name("act");
+    let schema = Value::Object((*act.input_schema).clone());
+
+    // `button` is Option<Button> in the tool args: three variants, no null, plain string type.
+    assert_eq!(
+        schema.pointer("/properties/button/enum"),
+        Some(&json!(["left", "middle", "right"]))
+    );
+    assert_eq!(
+        schema.pointer("/properties/button/type"),
+        Some(&json!("string"))
+    );
+
+    // Optionality is carried by `required`, which is why dropping the null is safe.
+    let required = schema
+        .pointer("/required")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("act should declare required arguments"));
+    assert!(!required.iter().any(|entry| entry == "button"));
+}

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -1325,24 +1325,26 @@ fn collect_permissive_object_paths(value: &Value, path: String, paths: &mut Vec<
     }
 }
 
-/// Collects every `enum` entry in a schema that is not a string, as `path = value`.
-fn non_string_enum_entries(schema: &Value, path: &str, found: &mut Vec<String>) {
+/// Collects every `null` entry inside an `enum` array, as `path = value`. The
+/// compatibility problem is specific to `null` (from `Option<SomeEnum>`);
+/// numeric or boolean enums are valid JSON Schema and must not be flagged.
+fn null_enum_entries(schema: &Value, path: &str, found: &mut Vec<String>) {
     match schema {
         Value::Object(object) => {
             if let Some(Value::Array(values)) = object.get("enum") {
                 for (index, value) in values.iter().enumerate() {
-                    if !value.is_string() {
+                    if value.is_null() {
                         found.push(format!("{path}/enum/{index} = {value}"));
                     }
                 }
             }
             for (key, child) in object {
-                non_string_enum_entries(child, &format!("{path}/{key}"), found);
+                null_enum_entries(child, &format!("{path}/{key}"), found);
             }
         }
         Value::Array(items) => {
             for (index, child) in items.iter().enumerate() {
-                non_string_enum_entries(child, &format!("{path}/{index}"), found);
+                null_enum_entries(child, &format!("{path}/{index}"), found);
             }
         }
         _ => {}
@@ -1357,13 +1359,13 @@ fn tool_schemas_never_put_null_inside_an_enum() {
     let mut found = Vec::new();
     for tool in catalog() {
         let input = Value::Object((*tool.input_schema).clone());
-        non_string_enum_entries(&input, &format!("{}/inputSchema", tool.name), &mut found);
+        null_enum_entries(&input, &format!("{}/inputSchema", tool.name), &mut found);
         if let Some(output) = tool.output_schema {
             let output = Value::Object((*output).clone());
-            non_string_enum_entries(&output, &format!("{}/outputSchema", tool.name), &mut found);
+            null_enum_entries(&output, &format!("{}/outputSchema", tool.name), &mut found);
         }
     }
-    assert!(found.is_empty(), "non-string enum entries: {found:#?}");
+    assert!(found.is_empty(), "null enum entries: {found:#?}");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #2479

## The bug

schemars renders an `Option<SomeEnum>` tool argument as:

```json
{ "type": ["string", "null"], "enum": ["left", "middle", "right", null] }
```

A Pydantic-backed MCP client decodes every `enum` entry against the declared type, so the trailing `null` fails the whole tool list before any prompt runs — exactly the reported error, where `enum.3` is that `null`:

```
ValidationError: 1 validation error for Schema
enum.3
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

Three arguments in the catalog carry one today. I found them by walking every generated schema:

```
tab_groups/properties/color/enum = ["grey","blue","red","yellow","green","pink","purple","cyan","orange",null]
act/properties/button/enum       = ["left","middle","right",null]
act/properties/direction/enum    = ["up","down","left","right",null]
```

`act.button` is the reporter's `enum.3`. This also explains why the report says other harnesses work — a client that does not strictly type-check `enum` entries never notices.

## The fix

`framework.rs` already normalizes generated schemas into "the object-only form expected by strict MCP clients" — rewriting boolean schemas, stripping boolean defaults. The nullable enum belongs in that same pass, so `collapse_nullable_enum` drops the `null` from `enum` and collapses `["string","null"]` back to `"string"`.

Two reasons this is safe rather than a semantic loss:

- **Optionality is already carried by `required`.** `act.button` is absent from `required` both before and after; the added test asserts it.
- **The server never validates against this schema.** `parse_args` deserializes with serde, and there is no JSON-Schema validator in the crate. `Option<Button>` still accepts an explicit `null` at runtime. The change alters what clients are *told*, not what the server accepts.

An enum consisting only of `null` is left alone rather than emptied.

## Tests

- `tool_schemas_never_put_null_inside_an_enum` walks every input and output schema in the catalog, so a future `Option<Enum>` argument fails CI instead of shipping.
- `optional_enum_arguments_keep_their_variants_and_stay_optional` pins `act.button` to its three variants, a plain `"string"` type, and absence from `required`.

Both fail on `main` and pass with the fix:

```
test tests::optional_enum_arguments_keep_their_variants_and_stay_optional ... FAILED
  left: Some(Array [String("left"), String("middle"), String("right"), Null])
 right: Some(Array [String("left"), String("middle"), String("right")])
test tests::tool_schemas_never_put_null_inside_an_enum ... FAILED
```

```
cargo test -p browseros-mcp                              79 passed, 0 failed
cargo clippy --workspace --all-targets -- -D warnings    clean
cargo fmt --all --check                                  clean
```

**Not run:** the gated `BROWSEROS_BINARY` contract suite — no local BrowserOS build. The change is confined to schema generation and is covered by the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
