### PR TITLE
fix(cli): give snapshot the -i/-d flags its own agent guide documents

### DIFF
--- a/packages/browseros-agent/apps/cli/cmd/llm_txt.md
+++ b/packages/browseros-agent/apps/cli/cmd/llm_txt.md
@@ -48,7 +48,7 @@ browseros-cli -p "$page" close                   # close a tab
 ## Observe the page
 
 ```bash
-browseros-cli -p $p snapshot -i        # interactive elements only (best default); -c compact, -d N max depth
+browseros-cli -p $p snapshot -i        # interactive elements only (best default); -d N caps tree depth
 browseros-cli -p $p read               # page as markdown (--text = plain, --links = links only)
 browseros-cli -p $p read --selector "#main"     # scope to CSS (also --viewport, --include-links, --images)
 browseros-cli -p $p grep "Sign in"     # search the snapshot/accessibility tree; keeps output small

--- a/packages/browseros-agent/apps/cli/cmd/llm_txt_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/llm_txt_test.go
@@ -51,3 +51,28 @@ func TestLLMTxtSkipsAutomaticUpdates(t *testing.T) {
 		t.Fatal("shouldSkipAutomaticUpdates([--llm-txt]) = false, want true")
 	}
 }
+
+func TestGuideSnapshotFlagsAreRegistered(t *testing.T) {
+	// The guide is the contract agents follow, so a flag it shows has to exist.
+	// `snapshot -i` was documented while snapshot registered no flags at all, and
+	// every agent that followed the guide got a silent failure.
+	snapshot, _, err := rootCmd.Find([]string{"snapshot"})
+	if err != nil {
+		t.Fatalf("rootCmd.Find(snapshot) error = %v", err)
+	}
+	for _, flag := range []struct{ name, short string }{
+		{"interactive", "i"},
+		{"depth", "d"},
+	} {
+		registered := snapshot.Flags().Lookup(flag.name)
+		if registered == nil {
+			t.Fatalf("snapshot does not register --%s", flag.name)
+		}
+		if registered.Shorthand != flag.short {
+			t.Fatalf("--%s shorthand = %q, want %q", flag.name, registered.Shorthand, flag.short)
+		}
+	}
+	if !strings.Contains(llmTxtGuide, "snapshot -i") {
+		t.Fatal("llmTxtGuide no longer documents snapshot -i")
+	}
+}

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -64,9 +64,18 @@ func TestSnapCommandShape(t *testing.T) {
 	if err := cmd.Args(cmd, []string{"extra"}); err == nil {
 		t.Fatal("snap Args accepted a positional argument")
 	}
-	for _, flag := range []string{"enhanced", "interactive", "compact", "depth"} {
+	// `interactive` and `depth` are thin pass-throughs to the snapshot tool's own
+	// mode/depth arguments, added to the server after this command was simplified.
+	// `enhanced` and `compact` stay out: the tool has no such modes, and the CLI is
+	// not to filter the tree itself again.
+	for _, flag := range []string{"enhanced", "compact"} {
 		if cmd.Flags().Lookup(flag) != nil {
 			t.Fatalf("snap command exposes unsupported %s flag", flag)
+		}
+	}
+	for _, flag := range []string{"interactive", "depth"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Fatalf("snap command is missing the %s flag", flag)
 		}
 	}
 }

--- a/packages/browseros-agent/apps/cli/cmd/snap.go
+++ b/packages/browseros-agent/apps/cli/cmd/snap.go
@@ -14,13 +14,18 @@ func init() {
 		Short:       "Capture the page accessibility tree",
 		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			interactive, _ := cmd.Flags().GetBool("interactive")
+			depth, _ := cmd.Flags().GetInt("depth")
+			if depth < 0 {
+				output.Error("depth must be 0 or greater", 3)
+			}
 			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
 			c := newClient()
 
-			result, err := c.CallTool("snapshot", map[string]any{"page": pageID})
+			result, err := c.CallTool("snapshot", snapshotToolArgs(pageID, interactive, depth))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -37,5 +42,21 @@ func init() {
 		},
 	}
 
+	cmd.Flags().BoolP("interactive", "i", false, "Only actionable elements, plus headings and ancestor context")
+	cmd.Flags().IntP("depth", "d", 0, "Maximum tree depth, 1-100 (0 leaves nesting uncapped)")
+
 	rootCmd.AddCommand(cmd)
+}
+
+// snapshotToolArgs maps the snapshot flags onto the tool's mode and depth inputs.
+// Both are omitted when unset so the server keeps its own defaults.
+func snapshotToolArgs(pageID int, interactive bool, depth int) map[string]any {
+	toolArgs := map[string]any{"page": pageID}
+	if interactive {
+		toolArgs["mode"] = "interactive"
+	}
+	if depth > 0 {
+		toolArgs["depth"] = depth
+	}
+	return toolArgs
 }

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -137,6 +137,20 @@ func TestCompactToolMappings(t *testing.T) {
 				"limit":   5,
 			},
 		},
+		{
+			name: "snapshot defaults",
+			got:  snapshotToolArgs(7, false, 0),
+			want: map[string]any{"page": 7},
+		},
+		{
+			name: "snapshot interactive with depth",
+			got:  snapshotToolArgs(7, true, 3),
+			want: map[string]any{
+				"page":  7,
+				"mode":  "interactive",
+				"depth": 3,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`browseros-cli --llm-txt` is the contract agents follow, and it tells them to run `snapshot -i` — five times, including the advice "Prefer `snapshot -i` plus `grep` over dumping the whole page — it keeps token use low."

`snapshot` registers no flags at all, so an agent that follows the guide gets a failure instead. This is the gap @athul-22 set aside in #2429 ("The missing `-i`/`-d` flags are a separate gap and I'll file that on its own"); I could not find an issue for it, so this PR carries the explanation.

## How three parts of the repo drifted apart

| Date | Commit | What happened |
| --- | --- | --- |
| 2026-06-24 | `05c0a0b71` | "simplify CLI snapshot command" — deleted `snapshot_filter.go` (149 lines of **client-side** tree filtering) and asserted the flags stay gone |
| 2026-06-25 | `0d11db15d` | shipped the agent guide, still documenting `snapshot -i` |
| 2026-07-06 | `ee8bc0aa4` | "add compact snapshot modes" — gave the snapshot **tool** real `mode` and `depth` arguments |

The capability came back properly, server-side, two weeks after the CLI dropped it. Nothing reconnected the two, and the guide has been wrong ever since.

## What this changes

`-i/--interactive` maps to `mode: "interactive"` and `-d/--depth N` maps to `depth: N` — thin pass-throughs to arguments `SnapshotArgs` already accepts. Both are omitted when unset so the server keeps its defaults. No filtering returns to the client; the CLI shapes args and the server owns the tool, per `apps/cli/CLAUDE.md`.

**I am modifying one of your assertions, so flagging it directly.** `TestSnapCommandShape` currently requires `enhanced`, `interactive`, `compact` and `depth` to all be absent. I split it: `enhanced` and `compact` must still not exist, and the two the tool actually supports must. If the intent of `05c0a0b71` was that the command stays flagless regardless of what the server grew later, then the right fix is the opposite one — drop `-i`, `-c` and `-d` from `llm_txt.md` — and I am happy to push that instead. I went this way because the guide's own advice depends on the capability.

Two smaller consequences:

- The guide's `-c compact` is **dropped rather than implemented**: `SnapshotMode` is `Full` or `Interactive` only, so there is no compact mode to map to.
- **Batch steps are left alone.** `validateBatchCommand` still rejects `snapshot -i` and `TestBatchSnapshotRejectsArguments` is untouched, because the guide advertises no flags on a batch `snapshot` step. Happy to extend it if you want the surfaces symmetrical.

## Verification

I audited every flag the guide shows against what the built binary registers, which is how the gap was pinned down — `snapshot -i` was the only real mismatch (`open -r` turned out to be `jq -r` after a pipe).

```
$ browseros-cli snapshot --help
Flags:
  -d, --depth int     Maximum tree depth, 1-100 (0 leaves nesting uncapped)
  -i, --interactive   Only actionable elements, plus headings and ancestor context

$ browseros-cli snapshot -d -5 ; echo $?
Error: depth must be 0 or greater
3                                        # 3 = invalid argument, per apps/cli/CLAUDE.md
```

Tests added: the `snapshotToolArgs` mapping (defaults and `-i -d 3`) in `TestCompactToolMappings`, and `TestGuideSnapshotFlagsAreRegistered`, which ties the guide text to the registered flags so this cannot silently drift again.

```
gofmt -l .      clean
go vet ./...    clean
go build ./...  ok
go test ./...   ok (all packages)
```

Integration tests (`-tags integration`) were not run — they need a live dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
