### PR TITLE
fix(mcp): stop the default timeout silently shortening a wait pause

### DIFF
--- a/packages/browseros-agent/contracts/claw-mcp/tests/cases-capture-io.ts
+++ b/packages/browseros-agent/contracts/claw-mcp/tests/cases-capture-io.ts
@@ -216,6 +216,19 @@ export const captureIoCases: ContractCase[] = [
       if (elapsed < 700) {
         throw new Error(`wait time returned too early: ${elapsed}ms`)
       }
+
+      // A pause longer than the default timeout is still the requested pause.
+      const longStarted = Date.now()
+      expectOk(
+        await ctx.mcp.callTool('wait', { page, for: 'time', value: 3_000 }),
+        'wait time beyond the default timeout',
+      )
+      const longElapsed = Date.now() - longStarted
+      if (longElapsed < 2_700) {
+        throw new Error(
+          `wait time was cut short by the default timeout: ${longElapsed}ms`,
+        )
+      }
     },
   },
   {

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -1230,6 +1230,25 @@ fn wait_parse_ms_matches_ts_fallback_rules() {
     assert_eq!(wait::parse_wait_ms(Some("1500.6"), 2_000), 1_501);
 }
 
+#[test]
+fn wait_time_pause_is_not_shortened_by_the_default_timeout() {
+    // An explicit pause is honoured: the default timeout is the same 2s as the default
+    // pause, so capping by it silently turned every longer request into 2s.
+    assert_eq!(wait::pause_duration_ms(Some("10000"), None), 10_000);
+    // No pause given still means the documented default.
+    assert_eq!(wait::pause_duration_ms(None, None), wait::DEFAULT_PAUSE_MS);
+    // A caller-supplied timeout is their own ceiling and still applies.
+    assert_eq!(wait::pause_duration_ms(Some("10000"), Some(5_000.0)), 5_000);
+    // A pause under a supplied timeout is untouched.
+    assert_eq!(wait::pause_duration_ms(Some("800"), Some(5_000.0)), 800);
+    // The tool's own maximum remains the hard ceiling either way.
+    assert_eq!(wait::pause_duration_ms(Some("120000"), None), 30_000);
+    assert_eq!(
+        wait::pause_duration_ms(Some("120000"), Some(120_000.0)),
+        30_000
+    );
+}
+
 fn assert_no_boolean_schema_nodes(tool_name: &str, schema_kind: &str, schema: &Value) {
     let mut paths = Vec::new();
     collect_boolean_paths(schema, "$".to_string(), &mut paths);
@@ -1323,4 +1342,30 @@ fn collect_permissive_object_paths(value: &Value, path: String, paths: &mut Vec<
         }
         _ => {}
     }
+}
+
+#[tokio::test(start_paused = true)]
+async fn wait_for_time_honours_a_pause_longer_than_the_default_timeout() {
+    // The clock is paused, so the pause resolves instantly while the tool still reports
+    // the duration it decided on.
+    let (ctx, _connection, page) = harness_ctx().await;
+    let wait = tool_by_name("wait");
+
+    let result = execute_tool(
+        &wait,
+        json!({ "page": page, "for": "time", "value": 10_000 }),
+        &ctx,
+    )
+    .await
+    .unwrap_or_else(|err| panic!("execute should return a tool result: {err}"));
+
+    assert_eq!(
+        result
+            .structured_content
+            .as_ref()
+            .and_then(|structured| structured.pointer("/waitedMs")),
+        Some(&json!(10_000)),
+        "an explicit pause should not be cut down to the default timeout: {}",
+        result_text(&result)
+    );
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/wait.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/wait.rs
@@ -43,7 +43,8 @@ struct WaitArgs {
     wait_for: WaitFor,
     /// Optional. For for="time", ms to pause (default 2000). For "text"/"selector", the substring or CSS selector to wait for.
     value: Option<WaitValue>,
-    /// Max wait in ms before giving up (default 2000).
+    /// Max wait in ms before giving up on "text"/"selector" (default 2000). For for="time"
+    /// it caps the pause only when you set it; otherwise the requested pause governs.
     timeout: Option<f64>,
 }
 
@@ -76,7 +77,7 @@ fn handler<'a>(
         let timeout = clamp_timeout(args.timeout, DEFAULT_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS);
         let value = args.value.as_ref().map(wait_value_to_string);
         if matches!(args.wait_for, WaitFor::Time) {
-            let wait_ms = parse_wait_ms(value.as_deref(), DEFAULT_PAUSE_MS).min(timeout);
+            let wait_ms = pause_duration_ms(value.as_deref(), args.timeout);
             abortable_delay(ctx, Duration::from_millis(wait_ms)).await?;
             return Ok(Some(text_result(
                 format!("waited {wait_ms}ms"),
@@ -131,6 +132,22 @@ fn handler<'a>(
             Some(json!({ "matched": false })),
         )))
     })
+}
+
+/// How long a `for="time"` pause actually lasts.
+///
+/// The requested pause governs. `timeout` caps it only when the caller set one themselves:
+/// capping by the default would silently shorten every explicit pause longer than
+/// [`DEFAULT_WAIT_TIMEOUT_MS`], which is the same 2s as the default pause, so asking for
+/// 10s quietly produced 2s. Either way the tool's own [`MAX_WAIT_TIMEOUT_MS`] is the ceiling.
+pub fn pause_duration_ms(value: Option<&str>, timeout: Option<f64>) -> u64 {
+    let requested = parse_wait_ms(value, DEFAULT_PAUSE_MS);
+    let ceiling = if timeout.is_some() {
+        clamp_timeout(timeout, DEFAULT_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS)
+    } else {
+        MAX_WAIT_TIMEOUT_MS
+    };
+    requested.min(ceiling)
 }
 
 pub fn parse_wait_ms(value: Option<&str>, fallback: u64) -> u64 {


### PR DESCRIPTION
## The bug

`wait` with `for="time"` capped the requested pause at `timeout`:

```rust
let timeout = clamp_timeout(args.timeout, DEFAULT_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS);
let wait_ms = parse_wait_ms(value.as_deref(), DEFAULT_PAUSE_MS).min(timeout);
```

`DEFAULT_WAIT_TIMEOUT_MS` and `DEFAULT_PAUSE_MS` are both `2_000`. So the cap never bites on a default call — it only bites when the caller explicitly asks for something longer, which is exactly when they meant it. And it bites silently:

```
wait { page, for: "time", value: 10000 }  ->  "waited 2000ms",  matched: true
```

A fifth of the requested pause, reported as a success. Nothing in the description mentions the cap — it says `for="time" (default) pauses value ms (default 2000)`. 10s is well inside the tool's own 30s `MAX_WAIT_TIMEOUT_MS`; only the *default* of an unrelated argument blocked it.

The existing contract case is already named **"wait: for=time elapses at least the requested duration"** but only exercised `value: 800`, under the default — so the invariant it names was never actually tested at a value that could break it.

## The fix

The requested pause governs. A caller-supplied `timeout` still caps it, because that is their own explicit ceiling, and `MAX_WAIT_TIMEOUT_MS` stays the hard limit either way.

| call | before | after |
| --- | --- | --- |
| `value: 10000` | 2000 | 10000 |
| `value: 10000, timeout: 5000` | 5000 | 5000 |
| `value: 800, timeout: 5000` | 800 | 800 |
| `value: 120000` | 2000 | 30000 (tool max) |
| neither | 2000 | 2000 |

The `timeout` doc comment now says what it actually does, rather than leaving the interaction undocumented.

`for="text"` and `for="selector"` are untouched — `timeout` is their deadline and always was.

## Tests

`wait_for_time_honours_a_pause_longer_than_the_default_timeout` drives the tool through `execute_tool` under `#[tokio::test(start_paused = true)]`, so it asserts real handler behaviour and still runs instantly. On the old logic:

```
assertion `left == right` failed: an explicit pause should not be cut down to the default timeout: waited 2000ms
  left: Some(Number(2000))
 right: Some(Number(10000))
```

Plus table-driven unit coverage of `pause_duration_ms` for every row above, and the contract case extended to a 3s pause — the case that was broken.

```
cargo test -p browseros-mcp                              79 passed, 0 failed
cargo clippy --workspace --all-targets -- -D warnings    clean
cargo fmt --all --check                                  clean
bunx tsc --noEmit                                        clean
biome check <contract file>                              clean
```

**Not run:** the gated `BROWSEROS_BINARY` contract suite — no local BrowserOS build — so the extended contract case is unverified against a real browser. The Rust-side behaviour it mirrors is covered by the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
