### PR TITLE
fix(app): restore tsconfig paths so bun test resolves @/ aliases

### DIFF
--- a/packages/browseros-agent/apps/app/tsconfig.json
+++ b/packages/browseros-agent/apps/app/tsconfig.json
@@ -7,7 +7,14 @@
     // wxt 0.21's generated base turns on noUncheckedIndexedAccess and verbatimModuleSyntax; opt back out until the codebase adopts them deliberately (verbatim needs codegen's useTypeImports for the generated graphql client).
     "noUncheckedIndexedAccess": false,
     "verbatimModuleSyntax": false,
-    // WXT owns the app aliases; workspace packages resolve through their exports.
+    // WXT owns these aliases for the build, but `bun test` resolves imports from
+    // tsconfig paths directly (it does not go through WXT/Vite). Without them,
+    // test files fail with "Cannot find module '@/...'" whenever the generated
+    // .wxt/tsconfig.json is absent (e.g. a clean CI checkout).
+    "paths": {
+      "@/*": ["./*"],
+      "@browseros/shared/*": ["../../packages/shared/src/*"]
+    },
     "plugins": [
       {
         "name": "@0no-co/graphqlsp",


### PR DESCRIPTION
## Problem

The `Tests / agent` check (`cd apps/app && bun run test`) fails on every PR with a batch of module-resolution errors on paths that clearly exist:

```
Cannot find module '@/components/ui/input' from '.../screens/ai-settings/AddProviderSection.tsx'
Cannot find module '@browseros/shared/schemas/llm' from '.../screens/ai-settings/provider-form-schema.ts'
Cannot find module '@/lib/llm-providers/providerTemplates' from '.../modules/llm-providers/llm-providers.helpers.ts'
... (and other @/ and @browseros/shared imports)
```

## When it started

`Tests / agent` was green through early September and turned red starting with the "remove voice and unship source maps" change, and has stayed red since. That change removed the `paths` block from `apps/app/tsconfig.json` with the rationale that WXT owns the app aliases.

## Root cause

That rationale holds for the WXT/Vite **build** (it resolves `@/` through its own Vite aliases), but **`bun test` resolves imports from tsconfig `paths` directly** and does not go through WXT. With the block removed, the only remaining source of the aliases was the generated `./.wxt/tsconfig.json` (via `extends`). On a clean CI checkout that generated file is absent, so bun cannot resolve `@/*` or `@browseros/shared/*` and the whole app suite fails. It appeared "flaky" only because a locally-generated `.wxt/tsconfig.json` masked it on dev machines.

Reproduced in a clean checkout (no `.wxt/tsconfig.json`): the app tests fail with the same `Cannot find module '@browseros/shared/...'` errors.

## Fix

Restore the `paths` block in `apps/app/tsconfig.json`:

```jsonc
"paths": {
  "@/*": ["./*"],
  "@browseros/shared/*": ["../../packages/shared/src/*"]
}
```

The WXT build is unaffected (it uses its own Vite aliases, not tsconfig paths). A child tsconfig's `paths` overrides the extended `.wxt` config, so this simply re-establishes the mapping bun test needs.

## Verification

In a clean checkout with **no `.wxt/tsconfig.json` present**, the previously-failing suites now pass:

```
42 pass, 0 fail across the provider/settings test files (NewProviderDialog, testProvider,
llm-providers.helpers, add-provider.helpers) — all resolving @/ and @browseros/shared directly.
```