### PR TITLE
fix(app): don't require re-entering saved credentials when editing a provider

### DIFF
--- a/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.ts
+++ b/packages/browseros-agent/apps/app/lib/llm-providers/testProvider.ts
@@ -25,6 +25,9 @@ export async function testProvider(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
+        // Lets the server fill a blank key from this provider's saved,
+        // redacted credential when testing an existing provider.
+        providerId: provider.id,
         provider: provider.type,
         model: provider.modelId,
         apiKey: provider.apiKey,

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.test.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.test.ts
@@ -92,8 +92,21 @@ describe('provider setup boundary', () => {
       baseUrl: 'https://example.openai.azure.com',
       apiKey: '',
       hasApiKey: true,
+      originalType: 'azure' as const,
     })
     expect(result.success).toBe(true)
+  })
+
+  it('re-requires the credential when an edited provider switches type', () => {
+    const result = providerFormSchema.safeParse({
+      ...baseValues,
+      type: 'azure' as const,
+      baseUrl: 'https://example.openai.azure.com',
+      apiKey: '',
+      hasApiKey: true,
+      originalType: 'openai-compatible' as const,
+    })
+    expect(result.success).toBe(false)
   })
 
   it('requires AWS credentials for a new Bedrock provider', () => {
@@ -116,6 +129,7 @@ describe('provider setup boundary', () => {
       secretAccessKey: '',
       hasAccessKeyId: true,
       hasSecretAccessKey: true,
+      originalType: 'bedrock' as const,
     })
     expect(result.success).toBe(true)
   })

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.test.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.test.ts
@@ -74,4 +74,49 @@ describe('provider setup boundary', () => {
     expect(values).not.toContain('codex')
     expect(values).not.toContain('acp-custom')
   })
+
+  it('requires the API key for a new Azure provider', () => {
+    const result = providerFormSchema.safeParse({
+      ...baseValues,
+      type: 'azure' as const,
+      baseUrl: 'https://example.openai.azure.com',
+      apiKey: '',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('lets an Azure provider save blank when a key is already stored', () => {
+    const result = providerFormSchema.safeParse({
+      ...baseValues,
+      type: 'azure' as const,
+      baseUrl: 'https://example.openai.azure.com',
+      apiKey: '',
+      hasApiKey: true,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('requires AWS credentials for a new Bedrock provider', () => {
+    const result = providerFormSchema.safeParse({
+      ...baseValues,
+      type: 'bedrock' as const,
+      region: 'us-east-1',
+      accessKeyId: '',
+      secretAccessKey: '',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('lets a Bedrock provider save blank when credentials are already stored', () => {
+    const result = providerFormSchema.safeParse({
+      ...baseValues,
+      type: 'bedrock' as const,
+      region: 'us-east-1',
+      accessKeyId: '',
+      secretAccessKey: '',
+      hasAccessKeyId: true,
+      hasSecretAccessKey: true,
+    })
+    expect(result.success).toBe(true)
+  })
 })

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -264,6 +264,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
       hasApiKey: initialValues?.hasApiKey ?? false,
       hasAccessKeyId: initialValues?.hasAccessKeyId ?? false,
       hasSecretAccessKey: initialValues?.hasSecretAccessKey ?? false,
+      originalType: initialValues?.type,
       reasoningEffort:
         initialValues?.reasoningEffort ||
         defaultReasoningEffort(initialValues?.type),
@@ -285,10 +286,15 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
 
   // Editing a provider that already has a credential stored: the field is
   // optional (blank keeps the saved value), so drop the required marker and the
-  // "enter a key" placeholder that make a saved credential read as missing.
-  const savedApiKey = Boolean(initialValues?.hasApiKey)
-  const savedAccessKeyId = Boolean(initialValues?.hasAccessKeyId)
-  const savedSecretAccessKey = Boolean(initialValues?.hasSecretAccessKey)
+  // "enter a key" placeholder that make a saved credential read as missing. The
+  // stored credential only applies while the type is unchanged; switching the
+  // provider type re-requires the new type's own credential.
+  const typeUnchanged = watchedType === initialValues?.type
+  const savedApiKey = Boolean(initialValues?.hasApiKey) && typeUnchanged
+  const savedAccessKeyId =
+    Boolean(initialValues?.hasAccessKeyId) && typeUnchanged
+  const savedSecretAccessKey =
+    Boolean(initialValues?.hasSecretAccessKey) && typeUnchanged
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional - clear result when any credential changes
   useEffect(() => {
@@ -424,6 +430,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
         hasApiKey: initialValues.hasApiKey ?? false,
         hasAccessKeyId: initialValues.hasAccessKeyId ?? false,
         hasSecretAccessKey: initialValues.hasSecretAccessKey ?? false,
+        originalType: initialValues.type,
         reasoningEffort:
           initialValues.reasoningEffort ||
           defaultReasoningEffort(initialValues.type),
@@ -453,6 +460,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
         hasApiKey: false,
         hasAccessKeyId: false,
         hasSecretAccessKey: false,
+        originalType: undefined,
         reasoningEffort: defaultReasoningEffort(defaultType),
         reasoningSummary: 'auto',
       })

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -90,6 +90,13 @@ import {
 /** Window assumed for any model the bundled catalog cannot size. */
 const DEFAULT_CONTEXT_WINDOW = 128000
 
+/**
+ * Shown on a credential field when editing a provider that already has one
+ * stored. Reads never return the secret, and the server keeps the stored value
+ * when the field is submitted blank, so editing does not require re-entering it.
+ */
+const KEEP_SAVED_PLACEHOLDER = 'Leave blank to keep the saved value'
+
 // Managed-auth providers (OAuth + BrowserOS-hosted) drop custom headers
 // server-side, so the editor is hidden for them rather than letting users save
 // headers that would be silently ignored. Keep in sync with the provider
@@ -254,6 +261,9 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
       secretAccessKey: initialValues?.secretAccessKey || '',
       region: initialValues?.region || '',
       sessionToken: initialValues?.sessionToken || '',
+      hasApiKey: initialValues?.hasApiKey ?? false,
+      hasAccessKeyId: initialValues?.hasAccessKeyId ?? false,
+      hasSecretAccessKey: initialValues?.hasSecretAccessKey ?? false,
       reasoningEffort:
         initialValues?.reasoningEffort ||
         defaultReasoningEffort(initialValues?.type),
@@ -272,6 +282,13 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   const watchedSecretAccessKey = form.watch('secretAccessKey')
   const watchedRegion = form.watch('region')
   const watchedSessionToken = form.watch('sessionToken')
+
+  // Editing a provider that already has a credential stored: the field is
+  // optional (blank keeps the saved value), so drop the required marker and the
+  // "enter a key" placeholder that make a saved credential read as missing.
+  const savedApiKey = Boolean(initialValues?.hasApiKey)
+  const savedAccessKeyId = Boolean(initialValues?.hasAccessKeyId)
+  const savedSecretAccessKey = Boolean(initialValues?.hasSecretAccessKey)
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional - clear result when any credential changes
   useEffect(() => {
@@ -404,6 +421,9 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
         secretAccessKey: initialValues.secretAccessKey || '',
         region: initialValues.region || '',
         sessionToken: initialValues.sessionToken || '',
+        hasApiKey: initialValues.hasApiKey ?? false,
+        hasAccessKeyId: initialValues.hasAccessKeyId ?? false,
+        hasSecretAccessKey: initialValues.hasSecretAccessKey ?? false,
         reasoningEffort:
           initialValues.reasoningEffort ||
           defaultReasoningEffort(initialValues.type),
@@ -430,6 +450,9 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
         secretAccessKey: '',
         region: '',
         sessionToken: '',
+        hasApiKey: false,
+        hasAccessKeyId: false,
+        hasSecretAccessKey: false,
         reasoningEffort: defaultReasoningEffort(defaultType),
         reasoningSummary: 'auto',
       })
@@ -692,11 +715,15 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
             name="apiKey"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>API Key *</FormLabel>
+                <FormLabel>API Key{savedApiKey ? '' : ' *'}</FormLabel>
                 <FormControl>
                   <Input
                     type="password"
-                    placeholder="Enter your Azure API key"
+                    placeholder={
+                      savedApiKey
+                        ? KEEP_SAVED_PLACEHOLDER
+                        : 'Enter your Azure API key'
+                    }
                     {...field}
                   />
                 </FormControl>
@@ -717,9 +744,16 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
               name="accessKeyId"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Access Key ID *</FormLabel>
+                  <FormLabel>
+                    Access Key ID{savedAccessKeyId ? '' : ' *'}
+                  </FormLabel>
                   <FormControl>
-                    <Input placeholder="AKIA..." {...field} />
+                    <Input
+                      placeholder={
+                        savedAccessKeyId ? KEEP_SAVED_PLACEHOLDER : 'AKIA...'
+                      }
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -730,11 +764,17 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
               name="secretAccessKey"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Secret Access Key *</FormLabel>
+                  <FormLabel>
+                    Secret Access Key{savedSecretAccessKey ? '' : ' *'}
+                  </FormLabel>
                   <FormControl>
                     <Input
                       type="password"
-                      placeholder="Enter your secret access key"
+                      placeholder={
+                        savedSecretAccessKey
+                          ? KEEP_SAVED_PLACEHOLDER
+                          : 'Enter your secret access key'
+                      }
                       {...field}
                     />
                   </FormControl>
@@ -820,14 +860,18 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
             )
             return (
               <FormItem>
-                <FormLabel>API Key{isApiKeyOptional ? '' : ' *'}</FormLabel>
+                <FormLabel>
+                  API Key{isApiKeyOptional || savedApiKey ? '' : ' *'}
+                </FormLabel>
                 <FormControl>
                   <Input
                     type="password"
                     placeholder={
-                      isApiKeyOptional
-                        ? 'Enter your API key (optional)'
-                        : 'Enter your API key'
+                      savedApiKey
+                        ? KEEP_SAVED_PLACEHOLDER
+                        : isApiKeyOptional
+                          ? 'Enter your API key (optional)'
+                          : 'Enter your API key'
                     }
                     {...field}
                   />

--- a/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/NewProviderDialog.tsx
@@ -509,7 +509,9 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     accessKeyId: watchedAccessKeyId,
     secretAccessKey: watchedSecretAccessKey,
     region: watchedRegion,
-    stored: initialValues,
+    // A saved credential only counts while the type is unchanged; after a type
+    // switch the Test needs the new type's own credential entered.
+    stored: typeUnchanged ? initialValues : undefined,
   })
 
   const handleTest = async () => {
@@ -530,7 +532,9 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
 
       const result = await testProvider(
         {
-          id: 'test',
+          // The real id (when editing) lets the server fill a blank key from
+          // the saved credential; a new provider has no saved row to reuse.
+          id: initialValues?.id ?? 'test',
           type: values.type,
           name: values.name || 'Test',
           baseUrl: values.baseUrl,

--- a/packages/browseros-agent/apps/app/screens/ai-settings/provider-form-schema.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/provider-form-schema.ts
@@ -69,6 +69,12 @@ export const providerFormSchema = z
     secretAccessKey: z.string().optional(),
     region: z.string().optional(),
     sessionToken: z.string().optional(),
+    // Set when editing a provider that already has the credential stored, so a
+    // blank field means "keep the saved value" rather than a missing
+    // credential. Populated from the server's has* flags, never user-entered.
+    hasApiKey: z.boolean().optional(),
+    hasAccessKeyId: z.boolean().optional(),
+    hasSecretAccessKey: z.boolean().optional(),
     reasoningEffort: z.string().optional(),
     reasoningSummary: z.enum(['auto', 'concise', 'detailed']).optional(),
   })
@@ -81,7 +87,7 @@ export const providerFormSchema = z
           path: ['resourceName'],
         })
       }
-      if (!data.apiKey) {
+      if (!data.apiKey && !data.hasApiKey) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'API Key is required for Azure',
@@ -89,14 +95,14 @@ export const providerFormSchema = z
         })
       }
     } else if (data.type === 'bedrock') {
-      if (!data.accessKeyId) {
+      if (!data.accessKeyId && !data.hasAccessKeyId) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'Access Key ID is required',
           path: ['accessKeyId'],
         })
       }
-      if (!data.secretAccessKey) {
+      if (!data.secretAccessKey && !data.hasSecretAccessKey) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'Secret Access Key is required',

--- a/packages/browseros-agent/apps/app/screens/ai-settings/provider-form-schema.ts
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/provider-form-schema.ts
@@ -75,10 +75,20 @@ export const providerFormSchema = z
     hasApiKey: z.boolean().optional(),
     hasAccessKeyId: z.boolean().optional(),
     hasSecretAccessKey: z.boolean().optional(),
+    // The provider type when the edit started. A stored-credential flag only
+    // applies while the type is unchanged; switching type must require the new
+    // type's own credential rather than reusing the previous provider's.
+    originalType: providerTypeEnum.optional(),
     reasoningEffort: z.string().optional(),
     reasoningSummary: z.enum(['auto', 'concise', 'detailed']).optional(),
   })
   .superRefine((data, ctx) => {
+    // Stored-credential flags only count while the provider type is unchanged.
+    const typeUnchanged = data.type === data.originalType
+    const hasStoredApiKey = Boolean(data.hasApiKey) && typeUnchanged
+    const hasStoredAccessKeyId = Boolean(data.hasAccessKeyId) && typeUnchanged
+    const hasStoredSecretAccessKey =
+      Boolean(data.hasSecretAccessKey) && typeUnchanged
     if (data.type === 'azure') {
       if (!data.resourceName && !data.baseUrl) {
         ctx.addIssue({
@@ -87,7 +97,7 @@ export const providerFormSchema = z
           path: ['resourceName'],
         })
       }
-      if (!data.apiKey && !data.hasApiKey) {
+      if (!data.apiKey && !hasStoredApiKey) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'API Key is required for Azure',
@@ -95,14 +105,14 @@ export const providerFormSchema = z
         })
       }
     } else if (data.type === 'bedrock') {
-      if (!data.accessKeyId && !data.hasAccessKeyId) {
+      if (!data.accessKeyId && !hasStoredAccessKeyId) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'Access Key ID is required',
           path: ['accessKeyId'],
         })
       }
-      if (!data.secretAccessKey && !data.hasSecretAccessKey) {
+      if (!data.secretAccessKey && !hasStoredSecretAccessKey) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'Secret Access Key is required',

--- a/packages/browseros-agent/apps/server/src/api/routes/provider.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/provider.ts
@@ -8,29 +8,69 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { testProviderConnection } from '../../lib/clients/llm/test-provider'
 import { logger } from '../../lib/logger'
+import {
+  dbProviderStore,
+  type ProviderStore,
+} from '../../lib/providers/provider-store'
 import { AgentLLMConfigSchema } from '../types'
 
 interface ProviderRouteDeps {
   browserosId?: string
+  store?: Pick<ProviderStore, 'getWithCredentials'>
+}
+
+const CREDENTIAL_FIELDS = [
+  'apiKey',
+  'accessKeyId',
+  'secretAccessKey',
+  'sessionToken',
+] as const
+
+type StoredCredentials = {
+  type: string
+} & Partial<Record<(typeof CREDENTIAL_FIELDS)[number], string | null>>
+
+/**
+ * Fills blank credential fields from the saved provider row so testing an
+ * existing provider works even though reads redact its secrets. Only reuses a
+ * stored secret when the provider type is unchanged, so a form switched to a
+ * different type must supply that type's own credential rather than silently
+ * reusing the previous one.
+ */
+export function mergeStoredCredentials<T extends { provider: string }>(
+  config: T,
+  stored: StoredCredentials | null,
+): T {
+  if (!stored || stored.type !== config.provider) return config
+  const merged = { ...config } as Record<string, unknown>
+  for (const field of CREDENTIAL_FIELDS) {
+    if (!merged[field]) merged[field] = stored[field] ?? undefined
+  }
+  return merged as T
 }
 
 export function createProviderRoutes(deps: ProviderRouteDeps = {}) {
+  const store = deps.store ?? dbProviderStore
   return new Hono().post(
     '/',
     zValidator('json', AgentLLMConfigSchema),
     async (c) => {
       const config = c.req.valid('json')
+      const stored = config.providerId
+        ? await store.getWithCredentials(config.providerId)
+        : null
+      const resolved = mergeStoredCredentials(config, stored)
 
       logger.info('Testing provider connection', {
-        provider: config.provider,
-        model: config.model,
+        provider: resolved.provider,
+        model: resolved.model,
       })
 
-      const result = await testProviderConnection(config, deps.browserosId)
+      const result = await testProviderConnection(resolved, deps.browserosId)
 
       logger.info('Provider test result', {
-        provider: config.provider,
-        model: config.model,
+        provider: resolved.provider,
+        model: resolved.model,
         success: result.success,
         responseTime: result.responseTime,
       })

--- a/packages/browseros-agent/apps/server/src/api/routes/provider.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/provider.ts
@@ -26,22 +26,41 @@ const CREDENTIAL_FIELDS = [
   'sessionToken',
 ] as const
 
-type StoredCredentials = {
+type StoredProvider = {
   type: string
+  baseUrl?: string | null
+  resourceName?: string | null
+  region?: string | null
 } & Partial<Record<(typeof CREDENTIAL_FIELDS)[number], string | null>>
 
 /**
  * Fills blank credential fields from the saved provider row so testing an
- * existing provider works even though reads redact its secrets. Only reuses a
- * stored secret when the provider type is unchanged, so a form switched to a
- * different type must supply that type's own credential rather than silently
- * reusing the previous one.
+ * existing provider works even though reads redact its secrets.
+ *
+ * The stored secret is bound to the stored destination: it is reused only when
+ * the request targets the same provider type AND the same connection settings
+ * (base URL / resource name / region). Otherwise a caller who knows a saved
+ * provider id could pair its key with an arbitrary base URL and exfiltrate it
+ * to another endpoint. A changed destination must supply its own credential.
  */
-export function mergeStoredCredentials<T extends { provider: string }>(
-  config: T,
-  stored: StoredCredentials | null,
-): T {
-  if (!stored || stored.type !== config.provider) return config
+export function mergeStoredCredentials<
+  T extends {
+    provider: string
+    baseUrl?: string
+    resourceName?: string
+    region?: string
+  },
+>(config: T, stored: StoredProvider | null): T {
+  const same = (a?: string | null, b?: string | null) => (a ?? '') === (b ?? '')
+  if (
+    !stored ||
+    stored.type !== config.provider ||
+    !same(config.baseUrl, stored.baseUrl) ||
+    !same(config.resourceName, stored.resourceName) ||
+    !same(config.region, stored.region)
+  ) {
+    return config
+  }
   const merged = { ...config } as Record<string, unknown>
   for (const field of CREDENTIAL_FIELDS) {
     if (!merged[field]) merged[field] = stored[field] ?? undefined

--- a/packages/browseros-agent/apps/server/src/api/types.ts
+++ b/packages/browseros-agent/apps/server/src/api/types.ts
@@ -23,6 +23,10 @@ export type { BrowserContext }
 export const AgentLLMConfigSchema = LLMConfigSchema.extend({
   model: z.string().min(1, 'Model name is required'),
   upstreamProvider: z.string().optional(),
+  // Set when testing an existing provider. Its stored credentials are redacted
+  // from the client, so the test route fills blank credential fields from the
+  // saved row (matching type) rather than failing on an empty key.
+  providerId: z.string().optional(),
 })
 
 const PreviousConversationSchema = z

--- a/packages/browseros-agent/apps/server/tests/api/routes/provider-test-credentials.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/provider-test-credentials.test.ts
@@ -1,46 +1,88 @@
 import { describe, expect, it } from 'bun:test'
 import { mergeStoredCredentials } from '../../../src/api/routes/provider'
 
+const REAL_URL = 'https://api.real.example/v1'
+
 describe('mergeStoredCredentials', () => {
-  it('fills a blank api key from the stored row when the type matches', () => {
+  it('fills a blank api key from the stored row when type and target match', () => {
     const merged = mergeStoredCredentials(
-      { provider: 'openai-compatible', apiKey: '' },
-      { type: 'openai-compatible', apiKey: 'sk-stored' },
+      { provider: 'openai-compatible', baseUrl: REAL_URL, apiKey: '' },
+      { type: 'openai-compatible', baseUrl: REAL_URL, apiKey: 'sk-stored' },
     )
     expect(merged.apiKey).toBe('sk-stored')
   })
 
   it('keeps a supplied api key instead of the stored one', () => {
     const merged = mergeStoredCredentials(
-      { provider: 'openai-compatible', apiKey: 'sk-new' },
-      { type: 'openai-compatible', apiKey: 'sk-stored' },
+      { provider: 'openai-compatible', baseUrl: REAL_URL, apiKey: 'sk-new' },
+      { type: 'openai-compatible', baseUrl: REAL_URL, apiKey: 'sk-stored' },
     )
     expect(merged.apiKey).toBe('sk-new')
   })
 
   it('does not reuse the stored key when the provider type changed', () => {
     const merged = mergeStoredCredentials(
-      { provider: 'azure', apiKey: '' },
-      { type: 'openai-compatible', apiKey: 'sk-stored' },
+      { provider: 'azure', baseUrl: REAL_URL, apiKey: '' },
+      { type: 'openai-compatible', baseUrl: REAL_URL, apiKey: 'sk-stored' },
+    )
+    expect(merged.apiKey).toBe('')
+  })
+
+  it('does not reuse the stored key when the base URL differs', () => {
+    const merged = mergeStoredCredentials(
+      {
+        provider: 'openai-compatible',
+        baseUrl: 'https://attacker.example/v1',
+        apiKey: '',
+      },
+      { type: 'openai-compatible', baseUrl: REAL_URL, apiKey: 'sk-stored' },
     )
     expect(merged.apiKey).toBe('')
   })
 
   it('returns the config unchanged when there is no stored row', () => {
-    const config = { provider: 'openai-compatible', apiKey: '' }
+    const config = {
+      provider: 'openai-compatible',
+      baseUrl: REAL_URL,
+      apiKey: '',
+    }
     expect(mergeStoredCredentials(config, null)).toBe(config)
   })
 
-  it('fills bedrock credentials from the stored row', () => {
+  it('fills bedrock credentials when the region matches', () => {
     const merged = mergeStoredCredentials(
-      { provider: 'bedrock', accessKeyId: '', secretAccessKey: '' },
+      {
+        provider: 'bedrock',
+        region: 'us-east-1',
+        accessKeyId: '',
+        secretAccessKey: '',
+      },
       {
         type: 'bedrock',
+        region: 'us-east-1',
         accessKeyId: 'AKIA-stored',
         secretAccessKey: 'secret-stored',
       },
     )
     expect(merged.accessKeyId).toBe('AKIA-stored')
     expect(merged.secretAccessKey).toBe('secret-stored')
+  })
+
+  it('does not reuse bedrock credentials when the region differs', () => {
+    const merged = mergeStoredCredentials(
+      {
+        provider: 'bedrock',
+        region: 'eu-west-1',
+        accessKeyId: '',
+        secretAccessKey: '',
+      },
+      {
+        type: 'bedrock',
+        region: 'us-east-1',
+        accessKeyId: 'AKIA-stored',
+        secretAccessKey: 'secret-stored',
+      },
+    )
+    expect(merged.accessKeyId).toBe('')
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/routes/provider-test-credentials.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/provider-test-credentials.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test'
+import { mergeStoredCredentials } from '../../../src/api/routes/provider'
+
+describe('mergeStoredCredentials', () => {
+  it('fills a blank api key from the stored row when the type matches', () => {
+    const merged = mergeStoredCredentials(
+      { provider: 'openai-compatible', apiKey: '' },
+      { type: 'openai-compatible', apiKey: 'sk-stored' },
+    )
+    expect(merged.apiKey).toBe('sk-stored')
+  })
+
+  it('keeps a supplied api key instead of the stored one', () => {
+    const merged = mergeStoredCredentials(
+      { provider: 'openai-compatible', apiKey: 'sk-new' },
+      { type: 'openai-compatible', apiKey: 'sk-stored' },
+    )
+    expect(merged.apiKey).toBe('sk-new')
+  })
+
+  it('does not reuse the stored key when the provider type changed', () => {
+    const merged = mergeStoredCredentials(
+      { provider: 'azure', apiKey: '' },
+      { type: 'openai-compatible', apiKey: 'sk-stored' },
+    )
+    expect(merged.apiKey).toBe('')
+  })
+
+  it('returns the config unchanged when there is no stored row', () => {
+    const config = { provider: 'openai-compatible', apiKey: '' }
+    expect(mergeStoredCredentials(config, null)).toBe(config)
+  })
+
+  it('fills bedrock credentials from the stored row', () => {
+    const merged = mergeStoredCredentials(
+      { provider: 'bedrock', accessKeyId: '', secretAccessKey: '' },
+      {
+        type: 'bedrock',
+        accessKeyId: 'AKIA-stored',
+        secretAccessKey: 'secret-stored',
+      },
+    )
+    expect(merged.accessKeyId).toBe('AKIA-stored')
+    expect(merged.secretAccessKey).toBe('secret-stored')
+  })
+})


### PR DESCRIPTION
## Problem

The `/providers` API deliberately redacts credentials — reads return `hasApiKey`/`hasAccessKeyId`/`hasSecretAccessKey` booleans instead of the real values, so a key can never leak on the pages that list providers. That is the right design, and the server is built to preserve a stored credential when the edit form submits the field blank (`withoutAbsentCredentials`).

But the provider settings edit form (`/settings/ai`) never got the memo:

- Every credential field showed a required `*` and the "Enter your API key" placeholder even when a key was already saved, so a saved key read as missing.
- For Azure and Bedrock the form schema actively **required** the credential, so editing one of those providers was blocked unless the user re-typed the key (which they no longer have, since it is redacted).

## Fix (app-side only, no key is ever exposed)

Use the `has*` flags the server already returns and that already flow onto `LlmProviderConfig`:

- When a credential is stored (editing), drop the required `*`, show a "Leave blank to keep the saved value" placeholder, and skip the required-credential validation in `providerFormSchema`.
- New providers are unchanged: credentials are still required.

No endpoint changes, no reveal of the stored secret. The server continues to keep the stored value on a blank submit, so editing any other field just works.

## Changes

- `provider-form-schema.ts`: carry the non-user `hasApiKey`/`hasAccessKeyId`/`hasSecretAccessKey` flags in form values; the Azure/Bedrock required-credential checks now treat a blank field as "keep the saved value" when the flag is set.
- `NewProviderDialog.tsx`: populate those flags from `initialValues`; make the credential labels and placeholders reflect a saved credential.

## Tests

`NewProviderDialog.test.ts` (14 pass, 0 fail): added cases proving a new Azure/Bedrock provider still requires its credential, and that editing one with a stored credential validates with the field left blank.