### PR TITLE
fix(ota): reuse Windows signer and preserve verification failures

### DIFF
--- a/packages/browseros/bos_build/release/ota/sign_binary.py
+++ b/packages/browseros/bos_build/release/ota/sign_binary.py
@@ -2,7 +2,6 @@
 """Platform-specific binary signing for OTA binaries"""
 
 import os
-import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -18,12 +17,9 @@ from ...lib.utils import (
     log_info,
     log_error,
     log_success,
-    log_warning,
     IS_MACOS,
-    IS_WINDOWS,
-    get_command_secret_values,
-    redact_sensitive_text,
 )
+from ...steps.sign.windows import sign_with_codesigntool
 
 
 def sign_macos_binary(
@@ -245,103 +241,13 @@ def sign_windows_binary(
     binary_path: Path,
     env: Optional[EnvConfig] = None,
 ) -> bool:
-    """Sign a Windows binary with SSL.com CodeSignTool
+    """Use the browser build's Windows signer for OTA binaries.
 
-    Args:
-        binary_path: Path to binary to sign
-        env: Environment config with eSigner credentials
-
-    Returns:
-        True on success, False on failure
+    Sharing the signer keeps credentials out of cmd.exe parsing when the
+    bundled Java launcher is available, and reports redacted tool errors
+    before a later Authenticode check can obscure the original failure.
     """
-    if env is None:
-        env = EnvConfig()
-
-    # Prefer CODE_SIGN_TOOL_EXE (direct path), fall back to CODE_SIGN_TOOL_PATH + .bat
-    if env.code_sign_tool_exe:
-        codesigntool_path = Path(env.code_sign_tool_exe)
-    elif env.code_sign_tool_path:
-        codesigntool_path = Path(env.code_sign_tool_path) / "CodeSignTool.bat"
-    else:
-        log_warning("CODE_SIGN_TOOL_EXE not set - skipping Windows signing")
-        return True
-
-    if not codesigntool_path.exists():
-        log_error(f"CodeSignTool not found at: {codesigntool_path}")
-        return False
-
-    if not all([env.esigner_username, env.esigner_password, env.esigner_totp_secret]):
-        log_error("Missing eSigner credentials")
-        return False
-
-    log_info(f"Signing {binary_path.name}...")
-
-    secret_values: tuple[str, ...] = ()
-    try:
-        temp_output_dir = binary_path.parent / "signed_temp"
-        temp_output_dir.mkdir(exist_ok=True)
-
-        cmd = [
-            str(codesigntool_path),
-            "sign",
-            "-username", env.esigner_username,
-            "-password", f'"{env.esigner_password}"',
-        ]
-
-        if env.esigner_credential_id:
-            cmd.extend(["-credential_id", env.esigner_credential_id])
-
-        cmd.extend([
-            "-totp_secret", env.esigner_totp_secret,
-            "-input_file_path", str(binary_path),
-            "-output_dir_path", str(temp_output_dir),
-            "-override",
-        ])
-
-        secret_values = get_command_secret_values(cmd)
-        result = subprocess.run(
-            " ".join(cmd),
-            shell=True,
-            capture_output=True,
-            text=True,
-            cwd=str(codesigntool_path.parent),
-        )
-
-        if result.stdout and "Error:" in result.stdout:
-            safe_output = redact_sensitive_text(result.stdout, secret_values)
-            log_error(f"Signing failed: {safe_output}")
-            return False
-
-        signed_file = temp_output_dir / binary_path.name
-        if signed_file.exists():
-            shutil.move(str(signed_file), str(binary_path))
-
-        try:
-            temp_output_dir.rmdir()
-        except Exception:
-            pass
-
-        # Verify signature on Windows only (PowerShell not available on macOS/Linux)
-        if IS_WINDOWS():
-            verify_cmd = [
-                "powershell", "-Command",
-                f"(Get-AuthenticodeSignature '{binary_path}').Status",
-            ]
-            verify_result = subprocess.run(verify_cmd, capture_output=True, text=True)
-            if "Valid" in verify_result.stdout:
-                log_success(f"Signed and verified {binary_path.name}")
-            else:
-                log_error(f"Signature verification failed: {verify_result.stdout.strip()}")
-                return False
-        else:
-            log_success(f"Signed {binary_path.name} (verification skipped on non-Windows)")
-
-        return True
-
-    except Exception as e:
-        safe_error = redact_sensitive_text(str(e), secret_values)
-        log_error(f"Signing failed: {safe_error}")
-        return False
+    return sign_with_codesigntool([binary_path], env)
 
 
 def sign_server_bundle_macos(

--- a/packages/browseros/bos_build/release/ota/sign_binary_test.py
+++ b/packages/browseros/bos_build/release/ota/sign_binary_test.py
@@ -13,6 +13,7 @@ from unittest import mock
 from ...lib.env import EnvConfig
 from ...products.browserclaw.product import BROWSERCLAW_SERVER_BUNDLE
 from ...products.browseros.product import BROWSEROS_SERVER_BUNDLE
+from ...steps.sign import windows as windows_signing
 from . import sign_binary
 
 
@@ -93,42 +94,130 @@ class SignServerBundleWindowsTest(unittest.TestCase):
             signer.assert_not_called()
 
 
-class SignWindowsBinaryLoggingTest(unittest.TestCase):
-    def test_redacts_credentials_echoed_in_codesigntool_error(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            tool = root / "CodeSignTool.bat"
-            binary = root / "browseros_server.exe"
-            _write_exe(tool)
-            _write_exe(binary)
-            env = cast(
-                EnvConfig,
-                SimpleNamespace(
-                    code_sign_tool_exe=str(tool),
-                    code_sign_tool_path=None,
-                    esigner_username="build@example.test",
-                    esigner_password=FAKE_PASSWORD,
-                    esigner_totp_secret=FAKE_TOTP,
-                    esigner_credential_id="fake-credential-id",
-                ),
-            )
-            result = subprocess.CompletedProcess(
-                "fake codesign command",
-                1,
-                stdout=f"Error: {FAKE_PASSWORD} {FAKE_TOTP}",
-                stderr="",
+class SignWindowsBinaryTest(unittest.TestCase):
+    """Exercise OTA through the real signer with fake subprocesses and captured logs."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        self.tool_dir = root / "signing tool"
+        self.java = self.tool_dir / "jdk-11.0.2" / "bin" / "java.exe"
+        self.jar = self.tool_dir / "jar" / "code_sign_tool-1.3.2.jar"
+        self.resources = root / "staged resources"
+        self.binary = self.resources / "bin" / "browseros_server.exe"
+        for path in (
+            self.java, self.jar, self.tool_dir / "CodeSignTool.bat", self.binary
+        ):
+            _write_exe(path)
+        self.password = FAKE_PASSWORD + ' ^%!"'
+        self.env = cast(
+            EnvConfig,
+            SimpleNamespace(
+                code_sign_tool_exe=None,
+                code_sign_tool_path=str(self.tool_dir),
+                esigner_username="build@example.test",
+                esigner_password=self.password,
+                esigner_totp_secret=FAKE_TOTP,
+                esigner_credential_id="fake-credential-id",
+            ),
+        )
+        self.logs = []
+        for module in (sign_binary, windows_signing):
+            for name in ("log_info", "log_error", "log_success"):
+                patcher = mock.patch.object(module, name, side_effect=self.logs.append)
+                patcher.start()
+                self.addCleanup(patcher.stop)
+
+    def test_bundle_signing_preserves_arguments_and_installs_verified_output(self):
+        signed = self.binary.parent / "signed_temp" / self.binary.name
+        signed.parent.mkdir()
+        signed.write_bytes(b"signed executable")
+        with mock.patch.object(
+            subprocess,
+            "run",
+            side_effect=[
+                subprocess.CompletedProcess([], 0, "Signed successfully", ""),
+                subprocess.CompletedProcess([], 0, "Valid\n", ""),
+            ],
+        ) as run:
+            self.assertTrue(
+                sign_binary.sign_server_bundle_windows(
+                    self.resources, self.env, BROWSEROS_SERVER_BUNDLE
+                )
             )
 
-            with (
-                mock.patch.object(sign_binary.subprocess, "run", return_value=result),
-                mock.patch.object(sign_binary, "log_error") as log_error,
-            ):
-                self.assertFalse(sign_binary.sign_windows_binary(binary, env))
+        command = run.call_args_list[0].args[0]
+        self.assertIsInstance(command, list)
+        self.assertEqual(command[:4], [str(self.java), "-jar", str(self.jar), "sign"])
+        self.assertFalse(run.call_args_list[0].kwargs["shell"])
+        self.assertEqual(command[command.index("-password") + 1], self.password)
+        self.assertEqual(command[command.index("-input_file_path") + 1], str(self.binary))
+        self.assertEqual(run.call_count, 2)
+        self.assertEqual(self.binary.read_bytes(), b"signed executable")
+        self.assertFalse(signed.parent.exists())
 
-        logged = "\n".join(str(call.args[0]) for call in log_error.call_args_list)
-        self.assertNotIn(FAKE_PASSWORD, logged)
-        self.assertNotIn(FAKE_TOTP, logged)
-        self.assertIn("Signing failed: Error: *** ***", logged)
+    def test_signer_errors_are_reported_and_redacted_before_verification(self):
+        for returncode, stdout, stderr in (
+            (3, "", f"Provider rejected {self.password} {FAKE_TOTP}"),
+            (0, f"Error: Provider rejected {self.password} {FAKE_TOTP}", ""),
+        ):
+            with self.subTest(returncode=returncode):
+                self.logs.clear()
+                with mock.patch.object(
+                    subprocess,
+                    "run",
+                    return_value=subprocess.CompletedProcess(
+                        [], returncode, stdout, stderr
+                    ),
+                ) as run:
+                    self.assertFalse(
+                        sign_binary.sign_windows_binary(self.binary, self.env)
+                    )
+
+                run.assert_called_once()
+                self.assertEqual(self.binary.read_bytes(), b"exe")
+                logged = "\n".join(self.logs)
+                self.assertNotIn(self.password, logged)
+                self.assertNotIn(FAKE_TOTP, logged)
+                self.assertIn("Provider rejected *** ***", logged)
+
+    def test_windows_verification_exception_prevents_release(self):
+        with (
+            mock.patch.object(windows_signing, "IS_WINDOWS", return_value=True),
+            mock.patch.object(
+                subprocess,
+                "run",
+                side_effect=[
+                    subprocess.CompletedProcess([], 0, "Signed successfully", ""),
+                    FileNotFoundError("powershell"),
+                ],
+            ),
+        ):
+            self.assertFalse(sign_binary.sign_windows_binary(self.binary, self.env))
+
+    def test_redacts_whitespace_bearing_credentials_before_trimming_output(self):
+        password = FAKE_PASSWORD + " "
+        for stream in ("stdout", "stderr"):
+            with self.subTest(stream=stream):
+                self.logs.clear()
+                output = {"stdout": "", "stderr": ""}
+                output[stream] = f"Error: Provider rejected {password}\n"
+                with (
+                    mock.patch.object(self.env, "esigner_password", password),
+                    mock.patch.object(
+                        subprocess,
+                        "run",
+                        return_value=subprocess.CompletedProcess([], 3, **output),
+                    ),
+                ):
+                    self.assertFalse(
+                        sign_binary.sign_windows_binary(self.binary, self.env)
+                    )
+
+                logged = "\n".join(self.logs)
+                self.assertNotIn(FAKE_PASSWORD, logged)
+                self.assertIn("Error: Provider rejected ***", logged)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/steps/sign/windows.py
+++ b/packages/browseros/bos_build/steps/sign/windows.py
@@ -370,14 +370,19 @@ def sign_with_codesigntool(
                     cwd=str(tool_root),
                 )
 
+            # Redact the original streams before normalizing whitespace: a
+            # credential may itself contain spaces or newlines, and trimming
+            # first would prevent the exact-value redactor from matching it.
             if result.stdout:
-                for line in result.stdout.split("\n"):
+                safe_stdout = redact_sensitive_text(result.stdout, secret_values)
+                for line in safe_stdout.splitlines():
                     if line.strip():
-                        log_info(redact_sensitive_text(line.strip(), secret_values))
+                        log_info(line.strip())
             if result.stderr:
-                for line in result.stderr.split("\n"):
+                safe_stderr = redact_sensitive_text(result.stderr, secret_values)
+                for line in safe_stderr.splitlines():
                     if line.strip() and "WARNING" not in line:
-                        log_error(redact_sensitive_text(line.strip(), secret_values))
+                        log_error(line.strip())
 
             if getattr(result, "returncode", 0) != 0 or (
                 result.stdout and "Error:" in result.stdout
@@ -415,8 +420,18 @@ def sign_with_codesigntool(
                         f"✗ {binary.name} signing verification failed - Status: {verify_result.stdout.strip()}"
                     )
                     all_success = False
-            except Exception:
-                log_warning(f"Could not verify signature for {binary.name}")
+            except Exception as e:
+                # Windows releases require successful Authenticode verification.
+                # Cross-signing hosts may lack PowerShell, but a broken verifier
+                # on Windows must stop packaging and OTA publication.
+                if IS_WINDOWS():
+                    safe_error = redact_sensitive_text(str(e), secret_values)
+                    log_error(
+                        f"Could not verify signature for {binary.name}: {safe_error}"
+                    )
+                    all_success = False
+                else:
+                    log_warning(f"Could not verify signature for {binary.name}")
 
         except Exception as e:
             safe_error = redact_sensitive_text(str(e), secret_values)


### PR DESCRIPTION
Windows server OTA signing could leave the executable unsigned while hiding the CodeSignTool error: the OTA wrapper ignored nonzero exit codes and stderr, then reported only `NotSigned`.

Reuse the browser build's Windows signer so OTA gets direct Java argument passing, redacted tool diagnostics, and failure propagation. Preserve the existing bundle selection and missing-binary checks. Tighten the shared signer to fail when Windows cannot verify Authenticode, and redact raw output before trimming so whitespace-bearing credentials stay hidden.

Validation: 1,235 build-system tests passed (2 skipped), plus 10 release-secret tests and 47 vendor-upload tests. Ruff and CLI smoke checks passed. Regression checks through the real OTA-to-signer path failed before the corresponding fixes and passed afterward; subprocesses were mocked. An independent local review covered the final change.

Live SSL.com signing still needs verification in a fresh server release after merge; rerunning the old release would use its original pinned commit.
