### PR TITLE
chore: simplify usage and billing guidance

### DIFF
--- a/packages/browseros-agent/apps/app/screens/usage/UsagePage.tsx
+++ b/packages/browseros-agent/apps/app/screens/usage/UsagePage.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Clock, Coins, CreditCard, Zap } from 'lucide-react'
+import { AlertCircle, Clock, Coins, Zap } from 'lucide-react'
 import type { FC } from 'react'
 import { Button } from '@/components/ui/button'
 import {
@@ -104,38 +104,25 @@ export const UsagePage: FC = () => {
         </div>
       </div>
 
-      <div className="rounded-xl border p-5">
-        <div className="flex items-center gap-3">
-          <CreditCard className="h-5 w-5 text-muted-foreground" />
-          <div>
-            <p className="flex items-center gap-2 font-semibold text-sm">
-              Need more credits?
-              <span className="rounded-full bg-muted px-2 py-0.5 font-medium text-[10px] text-muted-foreground uppercase tracking-wide">
-                Coming soon
-              </span>
-            </p>
-            <p className="text-muted-foreground text-xs">
-              Additional credit packages will be available soon
-            </p>
-          </div>
-        </div>
-      </div>
-
       <div className="rounded-xl border border-[var(--accent-orange)]/30 bg-[var(--accent-orange)]/5 p-5">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Zap className="h-5 w-5 text-[var(--accent-orange)]" />
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <Zap className="mt-0.5 h-5 w-5 shrink-0 text-[var(--accent-orange)]" />
             <div>
-              <p className="font-semibold text-sm">Want unlimited usage?</p>
-              <p className="text-muted-foreground text-xs">
-                Add your own LLM provider — no credit limits
+              <p className="font-semibold text-sm">
+                Keep going with your own API keys
+              </p>
+              <p className="mt-1 text-muted-foreground text-xs leading-relaxed">
+                The BrowserOS provider is here to help you get started. We
+                recommend adding your own API keys to use BrowserOS without
+                daily credit limits.
               </p>
             </div>
           </div>
           <Button
             variant="outline"
             size="sm"
-            className="border-[var(--accent-orange)] bg-[var(--accent-orange)]/10 text-[var(--accent-orange)] hover:bg-[var(--accent-orange)]/20"
+            className="shrink-0 self-start border-[var(--accent-orange)] bg-[var(--accent-orange)]/10 text-[var(--accent-orange)] hover:bg-[var(--accent-orange)]/20 sm:self-auto"
             asChild
           >
             <a href="/app.html#/settings/ai">Add Provider</a>


### PR DESCRIPTION
Usage & Billing advertised credit packages as coming soon. Remove that placeholder and consolidate the guidance into one card explaining that the BrowserOS provider helps users get started and recommending their own API keys to avoid daily credit limits. Keep the Add Provider link and allow the card to stack on narrow screens.

Validation: Biome and app typecheck passed. All 411 app tests passed across 66 files with the generated WXT tsconfig temporarily set aside to match CI (the generated config causes local Bun alias-resolution failures). Verified the rendered page and Add Provider navigation in BrowserOS; screenshot approved by the requester.
