### PR TITLE
feat: add diagnostics pages and share snapshots with Reporter

### DIFF
--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "claw-api",
  "futures-util",
  "harness-integrations",
+ "os_info",
  "posthog-rs",
  "pulldown-cmark",
  "rand 0.9.4",

--- a/packages/browseros-agent/apps/app/components/sidebar/SettingsSidebar.tsx
+++ b/packages/browseros-agent/apps/app/components/sidebar/SettingsSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  Activity,
   ArrowLeft,
   BookOpen,
   Bot,
@@ -88,6 +89,7 @@ const primarySettingsSections: NavSection[] = [
 const helpItems: NavItem[] = [
   { name: 'Docs', href: 'https://docs.browseros.com/', icon: BookOpen },
   { name: 'Features', to: '/features', icon: Compass },
+  { name: 'Diagnostics', to: '/settings/diagnostics', icon: Activity },
 ]
 
 export const SettingsSidebar: FC = () => {

--- a/packages/browseros-agent/apps/app/entrypoints/app/App.tsx
+++ b/packages/browseros-agent/apps/app/entrypoints/app/App.tsx
@@ -1,3 +1,4 @@
+import { DiagnosticsPage } from '@browseros/diagnostics/view'
 import type { FC } from 'react'
 import { HashRouter, Navigate, Route, Routes, useParams } from 'react-router'
 import { AuthLayout } from '@/components/layout/AuthLayout'
@@ -78,6 +79,7 @@ export const App: FC = () => {
             <Route path="chat" element={<LlmHubPage />} />
             <Route path="mcp" element={<MCPSettingsPage />} />
             <Route path="customization" element={<CustomizationPage />} />
+            <Route path="diagnostics" element={<DiagnosticsPage />} />
             <Route
               path="search"
               element={<Navigate to="/settings/ai" replace />}

--- a/packages/browseros-agent/apps/app/entrypoints/background/index.ts
+++ b/packages/browseros-agent/apps/app/entrypoints/background/index.ts
@@ -1,7 +1,12 @@
+import { registerDiagnostics } from '@browseros/diagnostics/extension'
 import { storage } from '@wxt-dev/storage'
 import { Capabilities } from '@/lib/browseros/capabilities'
 import { createConversationPanelBroker } from '@/lib/browseros/conversationPanelBroker.browser'
-import { getHealthCheckUrl, getMcpServerUrl } from '@/lib/browseros/helpers'
+import {
+  getAgentServerUrl,
+  getHealthCheckUrl,
+  getMcpServerUrl,
+} from '@/lib/browseros/helpers'
 import {
   initializeSidePanelOptions,
   openSidePanel,
@@ -39,6 +44,7 @@ const cleanupLegacyToolApprovalStorage = async () => {
 }
 
 export default defineBackground(() => {
+  registerDiagnostics('browseros', getAgentServerUrl)
   // One background broker owns the long-lived server subscription and all
   // panel-routing effects; individual React panels can come and go freely.
   const conversationPanelBroker = createConversationPanelBroker()

--- a/packages/browseros-agent/apps/app/lib/diagnostics/diagnostics-messaging.test.ts
+++ b/packages/browseros-agent/apps/app/lib/diagnostics/diagnostics-messaging.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, expect, it, mock } from 'bun:test'
+import { parseDiagnostics } from '@browseros/diagnostics/contract'
+import { requestDiagnostics } from '@browseros/diagnostics/extension'
+import fixture from '../../../../packages/diagnostics/tests/fixture.json'
+
+const listeners = new Set<(message: unknown) => unknown>()
+mock.module('webextension-polyfill', () => ({
+  default: {
+    runtime: {
+      onMessage: {
+        addListener: (listener: (message: unknown) => unknown) =>
+          listeners.add(listener),
+        removeListener: (listener: (message: unknown) => unknown) =>
+          listeners.delete(listener),
+      },
+    },
+  },
+}))
+const { defineExtensionMessaging } = await import('@webext-core/messaging')
+const originalChrome = globalThis.chrome
+afterEach(() => {
+  globalThis.chrome = originalChrome
+  listeners.clear()
+})
+
+it('receives fresh diagnostics alongside the app messaging handlers', async () => {
+  const snapshot = parseDiagnostics(fixture)
+  if (!snapshot) throw new Error('Invalid diagnostics fixture')
+  const messaging = defineExtensionMessaging<{ unrelated(): void }>()
+  messaging.onMessage('unrelated', () => {})
+  globalThis.chrome = {
+    runtime: {
+      sendMessage: async (request: unknown) => {
+        // Chrome delivers to every handler. An unrelated handler's protocol
+        // error can win the response race before diagnostics finishes reading.
+        for (const listener of listeners) listener(request)
+        return { snapshot, cached: false }
+      },
+    },
+    storage: { local: { get: async () => ({}) } },
+  } as unknown as typeof chrome
+
+  await expect(requestDiagnostics(0)).resolves.toEqual({
+    snapshot,
+    cached: false,
+  })
+  messaging.removeAllListeners()
+})

--- a/packages/browseros-agent/apps/app/package.json
+++ b/packages/browseros-agent/apps/app/package.json
@@ -10,7 +10,7 @@
     "build": "bun run codegen && wxt build",
     "build:dev": "bun --env-file=../../.env.development wxt build --mode development",
     "zip": "wxt zip",
-    "test": "bun run ../../scripts/run-bun-test.ts ./apps/app",
+    "test": "bun --env-file=../../.env.development wxt prepare && bun run ../../scripts/run-bun-test.ts --cwd=apps/app ./apps/app",
     "compile": "bun --env-file=../../.env.development wxt prepare && tsc --noEmit",
     "lint": "bunx @biomejs/biome check",
     "typecheck": "bun --env-file=../../.env.development wxt prepare && tsc --noEmit",
@@ -87,7 +87,8 @@
     "tw-animate-css": "^1.4.0",
     "use-deep-compare-effect": "^1.8.1",
     "use-stick-to-bottom": "^1.1.6",
-    "zod": "^4.5.2"
+    "zod": "^4.5.2",
+    "@browseros/diagnostics": "workspace:*"
   },
   "devDependencies": {
     "@0no-co/graphqlsp": "^1.17.5",

--- a/packages/browseros-agent/apps/app/tsconfig.json
+++ b/packages/browseros-agent/apps/app/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  // WXT owns import aliases. The test command prepares this base before Bun runs.
   "extends": "./.wxt/tsconfig.json",
   "compilerOptions": {
     "types": ["chrome", "bun"],
@@ -7,14 +8,6 @@
     // wxt 0.21's generated base turns on noUncheckedIndexedAccess and verbatimModuleSyntax; opt back out until the codebase adopts them deliberately (verbatim needs codegen's useTypeImports for the generated graphql client).
     "noUncheckedIndexedAccess": false,
     "verbatimModuleSyntax": false,
-    // WXT owns these aliases for the build, but `bun test` resolves imports from
-    // tsconfig paths directly (it does not go through WXT/Vite). Without them,
-    // test files fail with "Cannot find module '@/...'" whenever the generated
-    // .wxt/tsconfig.json is absent (e.g. a clean CI checkout).
-    "paths": {
-      "@/*": ["./*"],
-      "@browseros/shared/*": ["../../packages/shared/src/*"]
-    },
     "plugins": [
       {
         "name": "@0no-co/graphqlsp",

--- a/packages/browseros-agent/apps/app/wxt.config.ts
+++ b/packages/browseros-agent/apps/app/wxt.config.ts
@@ -1,3 +1,4 @@
+import { REPORTER_EXTENSION_ID } from '@browseros/diagnostics/contract'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'wxt'
@@ -30,6 +31,7 @@ export default defineConfig({
     update_url: 'https://cdn.browseros.com/extensions/update-manifest.xml',
     // update_url: 'https://cdn.browseros.com/extensions/update-manifest.alpha.xml',
     externally_connectable: {
+      ids: [REPORTER_EXTENSION_ID],
       matches: [`https://${apiPattern}/*`, `https://*.${apiPattern}/*`],
     },
     web_accessible_resources: [
@@ -59,6 +61,8 @@ export default defineConfig({
       default_title: 'Ask BrowserOS',
     },
     permissions: [
+      'system.cpu',
+      'system.memory',
       'topSites',
       'storage',
       'unlimitedStorage',

--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { helpItems, openHelpTarget, SidebarHelp } from './SidebarHelp'
 
@@ -16,18 +17,23 @@ describe('SidebarHelp', () => {
   it('renders the help label and both entries when expanded', () => {
     const html = renderToStaticMarkup(
       <TooltipProvider>
-        <SidebarHelp expanded />
+        <MemoryRouter initialEntries={['/diagnostics']}>
+          <SidebarHelp expanded />
+        </MemoryRouter>
       </TooltipProvider>,
     )
     expect(html).toContain('Help')
     expect(html).toContain('Docs')
     expect(html).toContain('Revisit Onboarding')
+    expect(html).toContain('Diagnostics')
+    expect(html).toContain('aria-current="page"')
   })
 
   it('pins Docs and onboarding to their exact targets', () => {
     expect(helpItems.map((item) => [item.name, item.url])).toEqual([
       ['Docs', 'https://docs.browseros.com/browserclaw'],
       ['Revisit Onboarding', 'chrome://browseros-onboarding'],
+      ['Diagnostics', '/diagnostics'],
     ])
   })
 

--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.tsx
@@ -1,5 +1,6 @@
-import { BookOpen, RotateCcw } from 'lucide-react'
+import { Activity, BookOpen, RotateCcw } from 'lucide-react'
 import type { ComponentType, SVGProps } from 'react'
+import { useLocation, useNavigate } from 'react-router'
 import {
   Tooltip,
   TooltipContent,
@@ -14,6 +15,7 @@ export interface SidebarHelpProps {
 interface HelpItem {
   name: string
   url: string
+  internal?: boolean
   icon: ComponentType<SVGProps<SVGSVGElement>>
 }
 
@@ -28,6 +30,7 @@ export const helpItems: HelpItem[] = [
     url: 'chrome://browseros-onboarding',
     icon: RotateCcw,
   },
+  { name: 'Diagnostics', url: '/diagnostics', icon: Activity, internal: true },
 ]
 
 /**
@@ -41,6 +44,8 @@ export function openHelpTarget(url: string): void {
 }
 
 export function SidebarHelp({ expanded = false }: SidebarHelpProps) {
+  const navigate = useNavigate()
+  const location = useLocation()
   return (
     <div className="overflow-hidden border-border border-t p-2">
       <div
@@ -58,8 +63,20 @@ export function SidebarHelp({ expanded = false }: SidebarHelpProps) {
           const button = (
             <button
               type="button"
-              onClick={() => openHelpTarget(item.url)}
-              className="flex h-9 w-full items-center gap-3 overflow-hidden whitespace-nowrap rounded-md px-2.5 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              onClick={() =>
+                item.internal ? navigate(item.url) : openHelpTarget(item.url)
+              }
+              aria-current={
+                item.internal && location.pathname === item.url
+                  ? 'page'
+                  : undefined
+              }
+              className={cn(
+                item.internal &&
+                  location.pathname === item.url &&
+                  'bg-sidebar-accent text-sidebar-accent-foreground',
+                'flex h-9 w-full items-center gap-3 overflow-hidden whitespace-nowrap rounded-md px-2.5 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+              )}
             >
               <Icon className="size-5 shrink-0" />
               <span

--- a/packages/browseros-agent/apps/claw-app/entrypoints/background.ts
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/background.ts
@@ -1,3 +1,4 @@
+import { registerDiagnostics } from '@browseros/diagnostics/extension'
 /**
  * @license
  * Copyright 2025 BrowserOS
@@ -10,6 +11,7 @@ import { createRecordingsRelay } from '@/modules/recorder'
 
 /** Supplies Chrome's trusted tab/document identity to the durable recorder relay. */
 export default defineBackground(() => {
+  registerDiagnostics('browseros-neo', resolveBrowserOSServerBaseUrl)
   const relay = createRecordingsRelay({
     resolveServerBaseUrl: resolveBrowserOSServerBaseUrl,
   })

--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/App.tsx
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/App.tsx
@@ -1,3 +1,4 @@
+import { DiagnosticsPage } from '@browseros/diagnostics/view'
 import type { ReactNode } from 'react'
 import { HashRouter, Navigate, Route, Routes } from 'react-router'
 import { CockpitShell } from '@/components/layout/CockpitShell'
@@ -19,6 +20,14 @@ export function App() {
         <Route element={<CockpitShell />}>
           <Route path="/" element={<Cockpit />} />
           <Route path="/mcp" element={<Mcp />} />
+          <Route
+            path="/diagnostics"
+            element={
+              <div className="mx-auto max-w-5xl px-6 py-10">
+                <DiagnosticsPage />
+              </div>
+            }
+          />
           <Route path="/skills" element={<Skills />} />
           <Route path="/skills/:name" element={<SkillDetail />} />
           <Route

--- a/packages/browseros-agent/apps/claw-app/package.json
+++ b/packages/browseros-agent/apps/claw-app/package.json
@@ -63,7 +63,8 @@
     "tailwind-merge": "^3.4.0",
     "tokenlens": "^1.3.1",
     "use-stick-to-bottom": "^1.1.6",
-    "zod": "^4.5.2"
+    "zod": "^4.5.2",
+    "@browseros/diagnostics": "workspace:*"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",

--- a/packages/browseros-agent/apps/claw-app/wxt.config.ts
+++ b/packages/browseros-agent/apps/claw-app/wxt.config.ts
@@ -1,3 +1,4 @@
+import { REPORTER_EXTENSION_ID } from '@browseros/diagnostics/contract'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'wxt'
 
@@ -12,12 +13,15 @@ export default defineConfig({
   modules: ['@wxt-dev/module-react'],
   manifest: {
     name: 'BrowserOS neo',
+    externally_connectable: { ids: [REPORTER_EXTENSION_ID] },
     description: 'BrowserOS neo — the browser for AI agents.',
     key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyXbY2XVCs1/yJqGd53ei1rHdoUGIvZ8uq+x9YKmUc+jnb6NogIrq0USPeRNb6uzszio45GR8BW0O0pgbFKmhlhrCwgs9gEW8mufksE29E1g8Q2ug1sowzj38X6jmitO4I9cBbQMx7+gJZJS8pS5DZ+V7Bl8Uka2LWHMTP/Pf10YjbeNNCA0wj6kQkkTb8lg80r5Vm+gFqyo2xDFaxj8lN2kE73yFBjCt6B4ycntXvnnUTPX4IJqH+eQuwsFWPuqdYEwdvaaIOQ+lCxcYyZusX58zhxr0pkMxQjnEoJqAk6Av5O/JiNIOZYzbwUjm6aA+p9j9/6xzvmG+Lvp74Dk9pwIDAQAB',
     update_url: 'https://cdn.browseros.com/extensions/update-manifest.xml',
     // Keep shared permissions in sync with apps/app/wxt.config.ts; additions
     // re-prompt or disable existing installs on update.
     permissions: [
+      'system.cpu',
+      'system.memory',
       'topSites',
       'storage',
       'unlimitedStorage',

--- a/packages/browseros-agent/apps/claw-server-rust/Cargo.toml
+++ b/packages/browseros-agent/apps/claw-server-rust/Cargo.toml
@@ -14,6 +14,7 @@ name = "browseros-claw-server-rs"
 path = "src/main.rs"
 
 [dependencies]
+os_info = "3.15.0"
 harness-integrations.workspace = true
 browseros-cdp.workspace = true
 browseros-core.workspace = true

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/mod.rs
@@ -37,6 +37,7 @@ pub(super) const RECORDING_INGEST_MAX_BYTES: usize = 16 * 1024 * 1024;
 pub fn router(state: AppState) -> Router<AppState> {
     Router::new()
         .route("/system/health", get(system::health))
+        .route("/system/diagnostics", get(system::diagnostics))
         .route("/system/shutdown", post(system::shutdown))
         .route("/api/v1/system", get(system::info))
         .route("/api/v1/cockpit/stats", get(cockpit::stats))

--- a/packages/browseros-agent/apps/claw-server-rust/src/api/http/system.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/api/http/system.rs
@@ -1,7 +1,7 @@
 use crate::{AppState, VERSION};
 use axum::{Json, extract::State};
 use claw_api::models::{
-    HealthResponse, ShutdownResponse, SystemCapabilities, SystemInfo,
+    HealthResponse, ShutdownResponse, SystemCapabilities, SystemDiagnostics, SystemInfo,
     system_capabilities::RecordingIngestVersion,
 };
 
@@ -30,4 +30,43 @@ pub(super) async fn info(State(state): State<AppState>) -> Json<SystemInfo> {
         Some(i64::try_from(super::RECORDING_INGEST_MAX_BYTES).unwrap_or(i64::MAX));
     info.capabilities = Some(Box::new(capabilities));
     Json(info)
+}
+
+/// OS discovery can read files or invoke platform APIs; keep it off Tokio's executor.
+/// Cache only process-stable public metadata, never environment or account details.
+pub(super) async fn diagnostics() -> Json<SystemDiagnostics> {
+    static DETAILS: std::sync::LazyLock<SystemDiagnostics> = std::sync::LazyLock::new(|| {
+        let info = os_info::get();
+        let mut details =
+            SystemDiagnostics::new(VERSION.to_string(), info.os_type().to_string(), None);
+        details.os_version = match info.version() {
+            os_info::Version::Unknown => None,
+            version => Some(version.to_string()),
+        };
+        details
+    });
+    let details = tokio::task::spawn_blocking(|| DETAILS.clone())
+        .await
+        .unwrap_or_else(|_| {
+            SystemDiagnostics::new(VERSION.to_string(), std::env::consts::OS.to_string(), None)
+        });
+    Json(details)
+}
+
+#[cfg(test)]
+mod diagnostics_tests {
+    #[tokio::test]
+    async fn only_public_metadata_is_serialized() -> Result<(), Box<dyn std::error::Error>> {
+        let result = super::diagnostics().await.0;
+        assert_eq!(result.version, crate::VERSION);
+        assert!(!result.os.is_empty());
+        let value = serde_json::to_value(result)?;
+        let object = value.as_object().ok_or("diagnostics must be an object")?;
+        assert!(
+            object
+                .keys()
+                .all(|key| ["version", "os", "osVersion"].contains(&key.as_str()))
+        );
+        Ok(())
+    }
 }

--- a/packages/browseros-agent/apps/server/src/api/routes/diagnostics.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/diagnostics.ts
@@ -1,0 +1,54 @@
+/** Public system metadata for the extension's diagnostics snapshot; no environment or identity data. */
+import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { platform, release } from 'node:os'
+import { promisify } from 'node:util'
+import { Hono } from 'hono'
+
+export function parseOsRelease(contents: string): {
+  os: string
+  osVersion: string | null
+} {
+  const fields = new Map<string, string>()
+  for (const line of contents.split('\n')) {
+    const match = /^(NAME|VERSION_ID)=(.*)$/.exec(line)
+    if (match)
+      fields.set(
+        match[1],
+        match[2].replace(/^(["'])(.*)\1$/, '$2').slice(0, 200),
+      )
+  }
+  return {
+    os: fields.get('NAME') || 'Linux',
+    osVersion: fields.get('VERSION_ID') || null,
+  }
+}
+
+async function systemDetails() {
+  if (platform() === 'darwin') {
+    // os.release() is the Darwin kernel, not the macOS release shown to users.
+    const result = await promisify(execFile)(
+      '/usr/bin/sw_vers',
+      ['-productVersion'],
+      { timeout: 1000 },
+    ).catch(() => null)
+    return { os: 'macOS', osVersion: result?.stdout.trim() || null }
+  }
+  if (platform() === 'linux') {
+    const contents = await readFile('/etc/os-release', 'utf8').catch(() => '')
+    return parseOsRelease(contents)
+  }
+  return {
+    os: platform() === 'win32' ? 'Windows' : platform(),
+    osVersion: release(),
+  }
+}
+
+export function createDiagnosticsRoute(version: string) {
+  // OS metadata is stable for this process. Share one read across simultaneous requests.
+  let details: ReturnType<typeof systemDetails> | undefined
+  return new Hono().get('/', async (c) => {
+    details ??= systemDetails()
+    return c.json({ version, ...(await details) })
+  })
+}

--- a/packages/browseros-agent/apps/server/src/api/routes/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/index.ts
@@ -1,3 +1,4 @@
+import { createDiagnosticsRoute } from './diagnostics'
 /**
  * @license
  * Copyright 2025 BrowserOS
@@ -84,6 +85,7 @@ export function createApiRoutes(deps: CreateApiRoutesDeps) {
       .use('/*', cors(defaultCorsConfig))
       .use('/*', requireTrustedOrigin())
       .route('/system/health', createHealthRoute({ browser }))
+      .route('/system/diagnostics', createDiagnosticsRoute(version))
       .route('/system/shutdown', createShutdownRoute({ onShutdown }))
       // Compatibility aliases for shipped browsers that still probe root paths
       // while the server binary can update independently during OTA.

--- a/packages/browseros-agent/apps/server/tests/api/routes/diagnostics.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/diagnostics.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  createDiagnosticsRoute,
+  parseOsRelease,
+} from '../../../src/api/routes/diagnostics'
+
+describe('system diagnostics metadata', () => {
+  it('returns only public metadata and the running server version', async () => {
+    const route = createDiagnosticsRoute('test-build')
+    const response = await route.request('/')
+    const body = await response.json()
+    expect(response.status).toBe(200)
+    expect(body.version).toBe('test-build')
+    expect(Object.keys(body).sort()).toEqual(['os', 'osVersion', 'version'])
+    expect(typeof body.os).toBe('string')
+  })
+  it('reads Linux distribution metadata without treating it as shell code', () => {
+    expect(
+      parseOsRelease('NAME="Ubuntu"\nVERSION_ID="24.04"\nOTHER=$(bad)'),
+    ).toEqual({ os: 'Ubuntu', osVersion: '24.04' })
+    expect(parseOsRelease('NAME=Fedora\nVERSION_ID=40')).toEqual({
+      os: 'Fedora',
+      osVersion: '40',
+    })
+    expect(parseOsRelease('')).toEqual({ os: 'Linux', osVersion: null })
+  })
+})

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -28,6 +28,7 @@
       "version": "0.0.152",
       "dependencies": {
         "@ai-sdk/react": "^4.0.87",
+        "@browseros/diagnostics": "workspace:*",
         "@browseros/server": "workspace:*",
         "@browseros/shared": "workspace:*",
         "@hookform/resolvers": "^5.9.1",
@@ -157,6 +158,7 @@
         "@base-ui/react": "^1.7.0",
         "@browseros/claw-api": "workspace:*",
         "@browseros/claw-api-client": "workspace:*",
+        "@browseros/diagnostics": "workspace:*",
         "@browseros/shared": "workspace:*",
         "@fontsource-variable/jetbrains-mono": "^5.3.0",
         "@fontsource-variable/schibsted-grotesk": "^5.3.0",
@@ -385,6 +387,17 @@
       "dependencies": {
         "@browseros/claw-api": "workspace:*",
         "openapi-fetch": "0.17.0",
+      },
+    },
+    "packages/diagnostics": {
+      "name": "@browseros/diagnostics",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/chrome": "^0.2.7",
+        "@types/react": "^19.2.18",
+      },
+      "peerDependencies": {
+        "react": "^19.2.8",
       },
     },
     "packages/onboarding-video": {
@@ -650,6 +663,8 @@
     "@browseros/claw-onboard": ["@browseros/claw-onboard@workspace:apps/claw-onboard"],
 
     "@browseros/claw-server-rust": ["@browseros/claw-server-rust@workspace:apps/claw-server-rust"],
+
+    "@browseros/diagnostics": ["@browseros/diagnostics@workspace:packages/diagnostics"],
 
     "@browseros/harness-integrations-rust": ["@browseros/harness-integrations-rust@workspace:crates/harness-integrations"],
 

--- a/packages/browseros-agent/contracts/claw-api/openapi.yaml
+++ b/packages/browseros-agent/contracts/claw-api/openapi.yaml
@@ -6,6 +6,8 @@ info:
 servers:
   - url: http://127.0.0.1:9200
 paths:
+  /system/diagnostics:
+    $ref: ./paths/system.yaml#/diagnostics
   /system/health:
     $ref: ./paths/system.yaml#/health
   /system/shutdown:
@@ -94,6 +96,8 @@ components:
       $ref: ./schemas/system.yaml#/HealthResponse
     ShutdownResponse:
       $ref: ./schemas/system.yaml#/ShutdownResponse
+    SystemDiagnostics:
+      $ref: ./schemas/system.yaml#/SystemDiagnostics
     SystemInfo:
       $ref: ./schemas/system.yaml#/SystemInfo
     SystemCapabilities:

--- a/packages/browseros-agent/contracts/claw-api/paths/system.yaml
+++ b/packages/browseros-agent/contracts/claw-api/paths/system.yaml
@@ -34,3 +34,16 @@ shutdown:
               $ref: ../schemas/system.yaml#/ShutdownResponse
       '500':
         $ref: ../responses.yaml#/InternalError
+
+diagnostics:
+  get:
+    operationId: getSystemDiagnostics
+    responses:
+      '200':
+        description: Public server version and operating-system release for support diagnostics.
+        content:
+          application/json:
+            schema:
+              $ref: ../schemas/system.yaml#/SystemDiagnostics
+      '500':
+        $ref: ../responses.yaml#/InternalError

--- a/packages/browseros-agent/contracts/claw-api/schemas/system.yaml
+++ b/packages/browseros-agent/contracts/claw-api/schemas/system.yaml
@@ -42,3 +42,17 @@ SystemCapabilities:
       format: int64
       minimum: 1
       description: Maximum UTF-8 encoded request-body bytes accepted by canonical recording ingest.
+
+SystemDiagnostics:
+  type: object
+  additionalProperties: false
+  required: [version, os, osVersion]
+  properties:
+    version:
+      type: string
+    os:
+      type: string
+    osVersion:
+      type: string
+      nullable: true
+      description: User-facing OS release; unavailable when it cannot be determined.

--- a/packages/browseros-agent/crates/claw-api/src/generated/system.rs
+++ b/packages/browseros-agent/crates/claw-api/src/generated/system.rs
@@ -124,6 +124,27 @@ pub mod system_capabilities {
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SystemDiagnostics {
+    #[serde(rename = "version")]
+    pub version: String,
+    #[serde(rename = "os")]
+    pub os: String,
+    /// User-facing OS release; unavailable when it cannot be determined.
+    #[serde(rename = "osVersion", deserialize_with = "Option::deserialize")]
+    pub os_version: Option<String>,
+}
+
+impl SystemDiagnostics {
+    pub fn new(version: String, os: String, os_version: Option<String>) -> SystemDiagnostics {
+        SystemDiagnostics {
+            version,
+            os,
+            os_version,
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SystemInfo {
     #[serde(rename = "product")]
     pub product: String,

--- a/packages/browseros-agent/packages/claw-api-client/src/generated/openapi.ts
+++ b/packages/browseros-agent/packages/claw-api-client/src/generated/openapi.ts
@@ -5,6 +5,22 @@
  */
 
 export interface paths {
+  '/system/diagnostics': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['getSystemDiagnostics']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/system/health': {
     parameters: {
       query?: never
@@ -432,6 +448,12 @@ export interface components {
     ShutdownResponse: {
       /** @enum {string} */
       status: 'ok'
+    }
+    SystemDiagnostics: {
+      version: string
+      os: string
+      /** @description User-facing OS release; unavailable when it cannot be determined. */
+      osVersion: string | null
     }
     SystemInfo: {
       product: string
@@ -963,6 +985,27 @@ export interface components {
 }
 export type $defs = Record<string, never>
 export interface operations {
+  getSystemDiagnostics: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Public server version and operating-system release for support diagnostics. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SystemDiagnostics']
+        }
+      }
+      500: components['responses']['InternalError']
+    }
+  }
   getHealth: {
     parameters: {
       query?: never

--- a/packages/browseros-agent/packages/claw-api/src/generated/models/system.ts
+++ b/packages/browseros-agent/packages/claw-api/src/generated/models/system.ts
@@ -90,6 +90,32 @@ export type SystemCapabilitiesRecordingIngestVersionEnum = typeof SystemCapabili
 /**
  *
  * @export
+ * @interface SystemDiagnostics
+ */
+export interface SystemDiagnostics {
+    /**
+     *
+     * @type {string}
+     * @memberof SystemDiagnostics
+     */
+    version: string;
+    /**
+     *
+     * @type {string}
+     * @memberof SystemDiagnostics
+     */
+    os: string;
+    /**
+     * User-facing OS release; unavailable when it cannot be determined.
+     * @type {string}
+     * @memberof SystemDiagnostics
+     */
+    osVersion: string | null;
+}
+
+/**
+ *
+ * @export
  * @interface SystemInfo
  */
 export interface SystemInfo {

--- a/packages/browseros-agent/packages/diagnostics/package.json
+++ b/packages/browseros-agent/packages/diagnostics/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@browseros/diagnostics",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test ./tests"
+  },
+  "exports": {
+    "./contract": "./src/contract.ts",
+    "./extension": "./src/extension.ts",
+    "./view": "./src/DiagnosticsPage.tsx",
+    "./styles.css": "./src/styles.css"
+  },
+  "peerDependencies": {
+    "react": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.2.7",
+    "@types/react": "^19.2.18"
+  }
+}

--- a/packages/browseros-agent/packages/diagnostics/src/DiagnosticsPage.tsx
+++ b/packages/browseros-agent/packages/diagnostics/src/DiagnosticsPage.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { DiagnosticsResult } from './collector'
+import { diagnosticSections, formatDiagnostics } from './contract'
+import { requestDiagnostics } from './extension'
+import './styles.css'
+
+/** The same snapshot powers the visible rows and clipboard across both products. */
+export function DiagnosticsPage() {
+  const [result, setResult] = useState<DiagnosticsResult | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [copyFallback, setCopyFallback] = useState(false)
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    setCopied(false)
+    setCopyFallback(false)
+    try {
+      setResult(await requestDiagnostics())
+    } catch (failure) {
+      setError(
+        failure instanceof Error ? failure.message : 'Diagnostics unavailable',
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+  useEffect(() => {
+    if (!copied) return
+    const timer = setTimeout(() => setCopied(false), 2000)
+    return () => clearTimeout(timer)
+  }, [copied])
+
+  const copy = () => {
+    if (!result) return
+    // Keep the clipboard write in the user's gesture; collection happens separately.
+    try {
+      void navigator.clipboard
+        .writeText(formatDiagnostics(result.snapshot))
+        .then(() => {
+          setCopied(true)
+          setCopyFallback(false)
+        })
+        .catch(() => setCopyFallback(true))
+    } catch {
+      setCopyFallback(true)
+    }
+  }
+
+  return (
+    <section
+      className="browseros-diagnostics ph-no-capture"
+      aria-labelledby="diagnostics-title"
+    >
+      <p className="diagnostics-breadcrumb">
+        Help <span>/</span> Diagnostics
+      </p>
+      <div className="diagnostics-header">
+        <div>
+          <h1 id="diagnostics-title">Diagnostics</h1>
+          <p>Version and system details to help us troubleshoot.</p>
+        </div>
+        <div className="diagnostics-actions">
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            disabled={loading}
+          >
+            <span aria-hidden="true">↻</span>{' '}
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+          <button
+            type="button"
+            className="diagnostics-copy"
+            onClick={copy}
+            disabled={!result || loading}
+          >
+            {copied ? 'Copied' : 'Copy diagnostics'}
+          </button>
+        </div>
+      </div>
+      <p className="diagnostics-timestamp" role="status">
+        {result
+          ? `${result.cached ? 'Cached sample' : 'Collected'} · ${new Date(result.snapshot.collectedAt).toLocaleString()}`
+          : loading
+            ? 'Collecting diagnostics…'
+            : 'No sample available'}
+      </p>
+      {error && (
+        <p role="alert">
+          {error}
+          {result ? ' Showing the previous sample.' : ''}
+        </p>
+      )}
+      {result &&
+        diagnosticSections(result.snapshot).map((section) => (
+          <section
+            className="diagnostics-section"
+            key={section.title}
+            aria-label={section.title}
+          >
+            <div className="diagnostics-section-heading">
+              <h2>{section.title}</h2>
+              {section.title === 'Memory' && <span>At time of collection</span>}
+            </div>
+            <dl>
+              {section.rows.map(([label, value]) => (
+                <div className="diagnostics-row" key={label}>
+                  <dt>{label}</dt>
+                  <dd>{value ?? 'Unavailable'}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        ))}
+      {result && (
+        <p className="diagnostics-note">
+          Copy includes these details and the collection time. No browsing
+          history or account information.
+        </p>
+      )}
+      {copyFallback && result && (
+        <label className="diagnostics-fallback">
+          Clipboard unavailable. Select and copy these details:
+          <textarea
+            readOnly
+            value={formatDiagnostics(result.snapshot)}
+            onFocus={(event) => event.currentTarget.select()}
+            rows={16}
+          />
+        </label>
+      )}
+    </section>
+  )
+}

--- a/packages/browseros-agent/packages/diagnostics/src/collector.ts
+++ b/packages/browseros-agent/packages/diagnostics/src/collector.ts
@@ -34,12 +34,14 @@ export function createDiagnosticsCollector(deps: {
 }) {
   let pending: Promise<DiagnosticsResult> | undefined
   let latest: DiagnosticsSnapshot | null = null
-  async function refresh(maxAgeMs: number): Promise<DiagnosticsResult> {
+  let requestedMaxAge = 0
+  async function refresh(): Promise<DiagnosticsResult> {
     const stored = await within(deps.load, 200).catch(() => null)
     latest ??= parseDiagnostics(stored)
-    if (latest && maxAgeMs > 0) {
+    if (latest && requestedMaxAge > 0) {
       const age = Date.now() - Date.parse(latest.collectedAt)
-      if (age >= 0 && age < maxAgeMs) return { snapshot: latest, cached: true }
+      if (age >= 0 && age < requestedMaxAge)
+        return { snapshot: latest, cached: true }
     }
     try {
       const snapshot = await within(deps.read, 2300)
@@ -53,7 +55,10 @@ export function createDiagnosticsCollector(deps: {
   }
   return {
     get(maxAgeMs: number): Promise<DiagnosticsResult> {
-      pending ??= refresh(maxAgeMs).finally(() => {
+      // A manual Refresh upgrades a concurrent cache-accepting request before
+      // cache selection; all callers then share the fresh sample.
+      requestedMaxAge = pending ? Math.min(requestedMaxAge, maxAgeMs) : maxAgeMs
+      pending ??= refresh().finally(() => {
         pending = undefined
       })
       return pending

--- a/packages/browseros-agent/packages/diagnostics/src/collector.ts
+++ b/packages/browseros-agent/packages/diagnostics/src/collector.ts
@@ -1,0 +1,62 @@
+import { type DiagnosticsSnapshot, parseDiagnostics } from './contract'
+
+export interface DiagnosticsResult {
+  snapshot: DiagnosticsSnapshot
+  cached: boolean
+}
+
+/** Bounds each dependency independently; a broken source cannot stall the report. */
+export async function within<T>(
+  task: () => Promise<T>,
+  milliseconds: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      Promise.resolve().then(task),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error('Diagnostics timed out')),
+          milliseconds,
+        )
+      }),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** One worker owns the cache and in-flight sample for all pages and external requests. */
+export function createDiagnosticsCollector(deps: {
+  read: () => Promise<DiagnosticsSnapshot>
+  load: () => Promise<unknown>
+  save: (snapshot: DiagnosticsSnapshot) => Promise<void>
+}) {
+  let pending: Promise<DiagnosticsResult> | undefined
+  let latest: DiagnosticsSnapshot | null = null
+  async function refresh(maxAgeMs: number): Promise<DiagnosticsResult> {
+    const stored = await within(deps.load, 200).catch(() => null)
+    latest ??= parseDiagnostics(stored)
+    if (latest && maxAgeMs > 0) {
+      const age = Date.now() - Date.parse(latest.collectedAt)
+      if (age >= 0 && age < maxAgeMs) return { snapshot: latest, cached: true }
+    }
+    try {
+      const snapshot = await within(deps.read, 2300)
+      latest = snapshot
+      await within(() => deps.save(snapshot), 200).catch(() => {})
+      return { snapshot, cached: false }
+    } catch (error) {
+      if (latest) return { snapshot: latest, cached: true }
+      throw error
+    }
+  }
+  return {
+    get(maxAgeMs: number): Promise<DiagnosticsResult> {
+      pending ??= refresh(maxAgeMs).finally(() => {
+        pending = undefined
+      })
+      return pending
+    },
+  }
+}

--- a/packages/browseros-agent/packages/diagnostics/src/contract.ts
+++ b/packages/browseros-agent/packages/diagnostics/src/contract.ts
@@ -26,10 +26,6 @@ export interface DiagnosticsSnapshot {
 
 export const DIAGNOSTICS_REQUEST = 'browseros:diagnostics:get'
 export const REPORTER_VERSION_REQUEST = 'browseros:diagnostics:reporter-version'
-export const APP_EXTENSION_IDS = [
-  'bflpfmnmnokmjhmgnolecpppdbdophmk',
-  'pjimfkbpehlcllblajnpfamdfjhhlgkc',
-] as const
 export const REPORTER_EXTENSION_ID = 'adlpneommgkgeanpaekgoaolcpncohkf'
 export const DIAGNOSTICS_MAX_AGE_MS = 60_000
 export const DIAGNOSTICS_TIMEOUT_MS = 3_000

--- a/packages/browseros-agent/packages/diagnostics/src/contract.ts
+++ b/packages/browseros-agent/packages/diagnostics/src/contract.ts
@@ -1,0 +1,193 @@
+/**
+ * Diagnostics v1 wire contract shared by the app, Reporter and feedback service.
+ * Independent releases keep a copy of this small allowlist; unknown fields are
+ * discarded at each boundary so preferences or account data cannot hitch a ride.
+ */
+export interface DiagnosticsSnapshot {
+  schemaVersion: 1
+  product: 'browseros' | 'browseros-neo' | 'browseros-feedback'
+  collectedAt: string
+  versions: {
+    browseros: string | null
+    chromium: string | null
+    server: string | null
+    appExtension: string | null
+    reporterExtension: string | null
+  }
+  system: {
+    os: string | null
+    osVersion: string | null
+    architecture: string | null
+    processor: string | null
+    logicalCores: number | null
+  }
+  memory: { totalBytes: number | null; availableBytes: number | null }
+}
+
+export const DIAGNOSTICS_REQUEST = 'browseros:diagnostics:get'
+export const REPORTER_VERSION_REQUEST = 'browseros:diagnostics:reporter-version'
+export const APP_EXTENSION_IDS = [
+  'bflpfmnmnokmjhmgnolecpppdbdophmk',
+  'pjimfkbpehlcllblajnpfamdfjhhlgkc',
+] as const
+export const REPORTER_EXTENSION_ID = 'adlpneommgkgeanpaekgoaolcpncohkf'
+export const DIAGNOSTICS_MAX_AGE_MS = 60_000
+export const DIAGNOSTICS_TIMEOUT_MS = 3_000
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    throw new Error('Expected object')
+  return value as Record<string, unknown>
+}
+
+function text(value: unknown): string | null {
+  if (value === null) return null
+  if (typeof value !== 'string' || value.length > 200)
+    throw new Error('Invalid text')
+  // One-line fields keep clipboard and notification formatting predictable.
+  return (
+    Array.from(value, (char) => {
+      const code = char.charCodeAt(0)
+      return code < 32 || code === 127 ? ' ' : char
+    })
+      .join('')
+      .trim() || null
+  )
+}
+
+function count(value: unknown): number | null {
+  if (value === null) return null
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0)
+    throw new Error('Invalid count')
+  return value
+}
+
+/** Returns a new allowlisted object, never the untrusted input object. */
+export function parseDiagnostics(value: unknown): DiagnosticsSnapshot | null {
+  try {
+    const data = record(value)
+    if (
+      data.schemaVersion !== 1 ||
+      !['browseros', 'browseros-neo', 'browseros-feedback'].includes(
+        String(data.product),
+      )
+    )
+      return null
+    if (
+      typeof data.collectedAt !== 'string' ||
+      data.collectedAt.length > 35 ||
+      !/^\d{4}-\d{2}-\d{2}T/.test(data.collectedAt) ||
+      !Number.isFinite(Date.parse(data.collectedAt))
+    )
+      return null
+    const versions = record(data.versions)
+    const system = record(data.system)
+    const memory = record(data.memory)
+    const snapshot: DiagnosticsSnapshot = {
+      schemaVersion: 1,
+      product: data.product as DiagnosticsSnapshot['product'],
+      collectedAt: data.collectedAt,
+      versions: {
+        browseros: text(versions.browseros),
+        chromium: text(versions.chromium),
+        server: text(versions.server),
+        appExtension: text(versions.appExtension),
+        reporterExtension: text(versions.reporterExtension),
+      },
+      system: {
+        os: text(system.os),
+        osVersion: text(system.osVersion),
+        architecture: text(system.architecture),
+        processor: text(system.processor),
+        logicalCores: count(system.logicalCores),
+      },
+      memory: {
+        totalBytes: count(memory.totalBytes),
+        availableBytes: count(memory.availableBytes),
+      },
+    }
+    if (
+      snapshot.system.logicalCores !== null &&
+      snapshot.system.logicalCores > 65536
+    )
+      return null
+    if (
+      snapshot.memory.totalBytes !== null &&
+      snapshot.memory.availableBytes !== null &&
+      snapshot.memory.availableBytes > snapshot.memory.totalBytes
+    )
+      return null
+    return snapshot
+  } catch {
+    return null
+  }
+}
+
+export function productName(product: DiagnosticsSnapshot['product']): string {
+  return product === 'browseros-neo'
+    ? 'BrowserOS neo'
+    : product === 'browseros-feedback'
+      ? 'BrowserOS (Reporter fallback)'
+      : 'BrowserOS'
+}
+
+export function formatMemory(bytes: number | null): string {
+  return bytes === null
+    ? 'Unavailable'
+    : `${(bytes / 1024 ** 3).toFixed(1)} GiB`
+}
+
+export function diagnosticSections(snapshot: DiagnosticsSnapshot) {
+  const { versions, system, memory } = snapshot
+  return [
+    {
+      title: 'Versions',
+      rows: [
+        ['BrowserOS', versions.browseros],
+        ['Chromium', versions.chromium],
+        [
+          snapshot.product === 'browseros-neo' ? 'MCP server' : 'Agent server',
+          versions.server,
+        ],
+        ['App extension', versions.appExtension],
+        ['Bug Reporter extension', versions.reporterExtension],
+      ],
+    },
+    {
+      title: 'System',
+      rows: [
+        [
+          'Operating system',
+          [system.os, system.osVersion].filter(Boolean).join(' ') || null,
+        ],
+        ['Architecture', system.architecture],
+        ['Processor', system.processor],
+        ['Logical cores', system.logicalCores?.toString() ?? null],
+      ],
+    },
+    {
+      title: 'Memory',
+      rows: [
+        ['Total system memory', formatMemory(memory.totalBytes)],
+        ['Available system memory', formatMemory(memory.availableBytes)],
+      ],
+    },
+  ]
+}
+
+/** Plain text is also the canonical content for the copy button and support messages. */
+export function formatDiagnostics(snapshot: DiagnosticsSnapshot): string {
+  return [
+    `${productName(snapshot.product)} diagnostics (v1)`,
+    `Collected at: ${snapshot.collectedAt}`,
+    ...diagnosticSections(snapshot).flatMap((section) => [
+      '',
+      section.title,
+      ...section.rows.map(
+        ([label, value]) => `${label}: ${value ?? 'Unavailable'}`,
+      ),
+    ]),
+    '',
+    'Memory is a system-wide sample at collection time.',
+  ].join('\n')
+}

--- a/packages/browseros-agent/packages/diagnostics/src/extension.ts
+++ b/packages/browseros-agent/packages/diagnostics/src/extension.ts
@@ -196,7 +196,15 @@ export async function requestDiagnostics(
 ): Promise<DiagnosticsResult> {
   try {
     const response = await within(
-      () => chrome.runtime.sendMessage({ type: DIAGNOSTICS_REQUEST, maxAgeMs }),
+      () =>
+        chrome.runtime.sendMessage({
+          type: DIAGNOSTICS_REQUEST,
+          maxAgeMs,
+          // The app's @webext-core listeners share this runtime channel and
+          // validate the envelope before checking the type. Without a timestamp
+          // they reject our request before the diagnostics handler can answer.
+          timestamp: Date.now(),
+        }),
       DIAGNOSTICS_TIMEOUT_MS,
     )
     const snapshot = parseDiagnostics(response?.snapshot)

--- a/packages/browseros-agent/packages/diagnostics/src/extension.ts
+++ b/packages/browseros-agent/packages/diagnostics/src/extension.ts
@@ -1,0 +1,215 @@
+import {
+  createDiagnosticsCollector,
+  type DiagnosticsResult,
+  within,
+} from './collector'
+import {
+  DIAGNOSTICS_MAX_AGE_MS,
+  DIAGNOSTICS_REQUEST,
+  DIAGNOSTICS_TIMEOUT_MS,
+  type DiagnosticsSnapshot,
+  parseDiagnostics,
+  REPORTER_EXTENSION_ID,
+  REPORTER_VERSION_REQUEST,
+} from './contract'
+
+const CACHE_KEY = 'browseros.diagnostics.v1'
+const REFRESH_ALARM = 'browseros.diagnostics.refresh'
+type Product = 'browseros' | 'browseros-neo'
+interface NativeVersions {
+  getVersionNumber?: (callback: (value: string) => void) => void
+  getBrowserosVersionNumber?: (callback: (value: string) => void) => void
+}
+interface ServerDetails {
+  version: string | null
+  os: string | null
+  osVersion: string | null
+}
+const emptyServer: ServerDetails = { version: null, os: null, osVersion: null }
+const valueText = (value: unknown): string | null =>
+  typeof value === 'string' ? value.slice(0, 200) : null
+
+async function nativeVersion(
+  api: NativeVersions | undefined,
+  name: keyof NativeVersions,
+): Promise<string | null> {
+  if (!api?.[name]) return null
+  return new Promise((resolve, reject) => {
+    api[name]?.((value) => {
+      const error = chrome.runtime.lastError
+      if (error) reject(new Error(error.message))
+      else resolve(valueText(value))
+    })
+  })
+}
+
+async function readServer(
+  resolveServerUrl: () => Promise<string>,
+): Promise<ServerDetails> {
+  const baseUrl = await resolveServerUrl()
+  const response = await fetch(`${baseUrl}/system/diagnostics`, {
+    signal: AbortSignal.timeout(1800),
+  })
+  if (!response.ok) throw new Error('Server diagnostics unavailable')
+  const data = await response.json()
+  return {
+    version: valueText(data.version),
+    os: valueText(data.os),
+    osVersion: valueText(data.osVersion),
+  }
+}
+
+/** Native reads survive a stopped agent server. Only selected metadata enters the snapshot. */
+export async function collectBrowserDiagnostics(
+  product: Product,
+  resolveServerUrl: () => Promise<string>,
+): Promise<DiagnosticsSnapshot> {
+  const api = (chrome as unknown as { browserOS?: NativeVersions }).browserOS
+  const safe = <T>(task: () => Promise<T>) =>
+    within(task, 2000).catch(() => null)
+  const [browseros, chromium, platform, cpu, memory, server, reporter] =
+    await Promise.all([
+      safe(() => nativeVersion(api, 'getBrowserosVersionNumber')),
+      safe(() => nativeVersion(api, 'getVersionNumber')),
+      safe(() => chrome.runtime.getPlatformInfo()),
+      safe(() => chrome.system.cpu.getInfo()),
+      safe(() => chrome.system.memory.getInfo()),
+      safe(() => readServer(resolveServerUrl)),
+      safe(() =>
+        chrome.runtime.sendMessage(REPORTER_EXTENSION_ID, {
+          type: REPORTER_VERSION_REQUEST,
+        }),
+      ),
+    ])
+  const osNames: Record<string, string> = {
+    mac: 'macOS',
+    win: 'Windows',
+    linux: 'Linux',
+    cros: 'ChromeOS',
+    android: 'Android',
+    openbsd: 'OpenBSD',
+  }
+  const details = server ?? emptyServer
+  return {
+    schemaVersion: 1,
+    product,
+    collectedAt: new Date().toISOString(),
+    versions: {
+      browseros,
+      chromium,
+      server: details.version,
+      appExtension: chrome.runtime.getManifest().version,
+      reporterExtension: valueText(reporter?.version),
+    },
+    system: {
+      os:
+        details.os ?? (platform ? (osNames[platform.os] ?? platform.os) : null),
+      osVersion: details.osVersion,
+      architecture: platform?.arch ?? null,
+      processor: valueText(cpu?.modelName),
+      logicalCores: cpu?.numOfProcessors ?? null,
+    },
+    memory: {
+      totalBytes: memory?.capacity ?? null,
+      availableBytes: memory?.availableCapacity ?? null,
+    },
+  }
+}
+
+/** Separate own extension pages from content scripts and external websites. */
+export function canReadDiagnostics(
+  sender: { id?: string; url?: string },
+  ownId: string,
+  external: boolean,
+): boolean {
+  if (external) return sender.id === REPORTER_EXTENSION_ID
+  return (
+    sender.id === ownId &&
+    !!sender.url?.startsWith(`chrome-extension://${ownId}/`)
+  )
+}
+
+/**
+ * Register synchronously at worker startup, before any server connection awaits.
+ * Chrome wakes this worker on a message; cache persistence handles later suspension.
+ */
+export function registerDiagnostics(
+  product: Product,
+  resolveServerUrl: () => Promise<string>,
+): void {
+  const collector = createDiagnosticsCollector({
+    read: () => collectBrowserDiagnostics(product, resolveServerUrl),
+    load: async () => (await chrome.storage.local.get(CACHE_KEY))[CACHE_KEY],
+    save: async (snapshot) => {
+      await chrome.storage.local.set({ [CACHE_KEY]: snapshot })
+    },
+  })
+  const listener =
+    (external: boolean) =>
+    (
+      request: unknown,
+      sender: chrome.runtime.MessageSender,
+      respond: (result: unknown) => void,
+    ) => {
+      if (
+        !request ||
+        typeof request !== 'object' ||
+        !('type' in request) ||
+        request.type !== DIAGNOSTICS_REQUEST
+      )
+        return false
+      if (!canReadDiagnostics(sender, chrome.runtime.id, external)) return false
+      const age =
+        'maxAgeMs' in request &&
+        typeof request.maxAgeMs === 'number' &&
+        Number.isFinite(request.maxAgeMs)
+          ? Math.min(DIAGNOSTICS_MAX_AGE_MS, Math.max(0, request.maxAgeMs))
+          : DIAGNOSTICS_MAX_AGE_MS
+      void collector
+        .get(age)
+        .then(respond)
+        .catch(() => respond({ snapshot: null, cached: false }))
+      // Shipped Chromium versions require this for asynchronous sendResponse.
+      return true
+    }
+  chrome.runtime.onMessage.addListener(listener(false))
+  chrome.runtime.onMessageExternal.addListener(listener(true))
+  const refresh = () => {
+    void collector.get(0).catch(() => {})
+  }
+  const start = () => {
+    void chrome.alarms
+      .create(REFRESH_ALARM, { periodInMinutes: 360 })
+      .catch(() => {})
+    refresh()
+  }
+  chrome.runtime.onInstalled.addListener(start)
+  chrome.runtime.onStartup.addListener(start)
+  chrome.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === REFRESH_ALARM) refresh()
+  })
+}
+
+/** UI requests share the worker's collector; they never infer system facts themselves. */
+export async function requestDiagnostics(
+  maxAgeMs = 0,
+): Promise<DiagnosticsResult> {
+  try {
+    const response = await within(
+      () => chrome.runtime.sendMessage({ type: DIAGNOSTICS_REQUEST, maxAgeMs }),
+      DIAGNOSTICS_TIMEOUT_MS,
+    )
+    const snapshot = parseDiagnostics(response?.snapshot)
+    if (snapshot) return { snapshot, cached: response.cached === true }
+  } catch {}
+  const saved = await within(
+    () => chrome.storage.local.get(CACHE_KEY),
+    200,
+  ).catch(() => ({}))
+  const snapshot = parseDiagnostics(
+    (saved as Record<string, unknown>)[CACHE_KEY],
+  )
+  if (!snapshot)
+    throw new Error('Diagnostics could not be collected. Try refreshing.')
+  return { snapshot, cached: true }
+}

--- a/packages/browseros-agent/packages/diagnostics/src/styles.css
+++ b/packages/browseros-agent/packages/diagnostics/src/styles.css
@@ -1,0 +1,128 @@
+/* Shared layout inherits each product's typography and semantic theme colors. */
+.browseros-diagnostics {
+  color: var(--foreground);
+  padding: 8px 0 32px;
+  width: 100%;
+}
+.browseros-diagnostics p {
+  color: var(--muted-foreground);
+  font-size: 14px;
+}
+.browseros-diagnostics .diagnostics-breadcrumb {
+  font-size: 12px;
+  margin: 0 0 20px;
+}
+.diagnostics-breadcrumb span {
+  padding: 0 12px;
+}
+.diagnostics-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+.diagnostics-header h1 {
+  font-size: 28px;
+  font-weight: 650;
+  line-height: 1.3;
+  margin: 0 0 8px;
+  letter-spacing: -0.03em;
+}
+.diagnostics-header p {
+  margin: 0;
+}
+.diagnostics-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+.diagnostics-actions button {
+  cursor: pointer;
+  padding: 10px 14px;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 500;
+}
+.diagnostics-actions button:hover {
+  background: var(--muted);
+}
+.diagnostics-actions .diagnostics-copy {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.diagnostics-actions .diagnostics-copy:hover {
+  opacity: 0.9;
+  background: var(--primary);
+}
+.diagnostics-actions button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.diagnostics-actions button:focus-visible,
+.diagnostics-fallback textarea:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 3px;
+}
+.browseros-diagnostics .diagnostics-timestamp {
+  margin: 24px 0 34px;
+  font-size: 12px;
+}
+.diagnostics-section {
+  margin-bottom: 30px;
+}
+.diagnostics-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+.diagnostics-section h2 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+.diagnostics-section-heading span {
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+.diagnostics-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 26%) minmax(0, 1fr);
+  gap: 24px;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+.diagnostics-row dt {
+  color: var(--muted-foreground);
+}
+.diagnostics-row dd {
+  font-family: var(--font-mono, monospace);
+  overflow-wrap: anywhere;
+}
+.browseros-diagnostics .diagnostics-note {
+  font-size: 12px;
+}
+.diagnostics-fallback {
+  display: block;
+  font-size: 13px;
+  margin-top: 20px;
+}
+.diagnostics-fallback textarea {
+  display: block;
+  width: 100%;
+  margin-top: 8px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: monospace;
+}
+@media (max-width: 540px) {
+  .diagnostics-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+}

--- a/packages/browseros-agent/packages/diagnostics/src/styles.d.ts
+++ b/packages/browseros-agent/packages/diagnostics/src/styles.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css'

--- a/packages/browseros-agent/packages/diagnostics/tests/collector.test.ts
+++ b/packages/browseros-agent/packages/diagnostics/tests/collector.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test'
+import { createDiagnosticsCollector } from '../src/collector'
+import { formatDiagnostics, parseDiagnostics } from '../src/contract'
+import fixture from './fixture.json'
+
+const snapshot = parseDiagnostics(fixture)
+if (!snapshot) throw new Error('Invalid fixture')
+
+describe('diagnostics collection ownership', () => {
+  it('coalesces concurrent refreshes and persists a serializable snapshot', async () => {
+    let reads = 0
+    let saved: unknown
+    const collector = createDiagnosticsCollector({
+      read: async () => {
+        reads++
+        await Promise.resolve()
+        return snapshot
+      },
+      load: async () => null,
+      save: async (value) => {
+        saved = value
+      },
+    })
+    const [first, second] = await Promise.all([
+      collector.get(0),
+      collector.get(0),
+    ])
+    expect(reads).toBe(1)
+    expect(first).toEqual(second)
+    expect(saved).toEqual(snapshot)
+  })
+
+  it('preserves the timestamp and labels a fallback after refresh failure', async () => {
+    const collector = createDiagnosticsCollector({
+      read: async () => {
+        throw new Error('unavailable')
+      },
+      load: async () => snapshot,
+      save: async () => {},
+    })
+    expect(await collector.get(0)).toEqual({ snapshot, cached: true })
+  })
+
+  it('returns current data even when storage fails', async () => {
+    const collector = createDiagnosticsCollector({
+      read: async () => snapshot,
+      load: async () => {
+        throw new Error('storage failed')
+      },
+      save: async () => {
+        throw new Error('storage full')
+      },
+    })
+    expect(await collector.get(0)).toEqual({ snapshot, cached: false })
+  })
+
+  it('formats exactly the snapshot and rejects invalid memory without leaking fields', () => {
+    expect(formatDiagnostics(snapshot)).toContain(fixture.collectedAt)
+    expect(formatDiagnostics(snapshot)).toContain('36.0 GiB')
+    expect(
+      parseDiagnostics({ ...fixture, secret: 'hidden' }),
+    ).not.toHaveProperty('secret')
+    expect(
+      parseDiagnostics({
+        ...fixture,
+        memory: { totalBytes: 1, availableBytes: 2 },
+      }),
+    ).toBeNull()
+  })
+})

--- a/packages/browseros-agent/packages/diagnostics/tests/collector.test.ts
+++ b/packages/browseros-agent/packages/diagnostics/tests/collector.test.ts
@@ -30,6 +30,24 @@ describe('diagnostics collection ownership', () => {
     expect(saved).toEqual(snapshot)
   })
 
+  it('honors Refresh when it overlaps a cache-accepting Reporter request', async () => {
+    let reads = 0
+    const current = { ...snapshot, collectedAt: new Date().toISOString() }
+    const collector = createDiagnosticsCollector({
+      read: async () => {
+        reads++
+        return current
+      },
+      load: async () => current,
+      save: async () => {},
+    })
+    const reporter = collector.get(60_000)
+    const refresh = collector.get(0)
+    await Promise.all([reporter, refresh])
+    expect(reads).toBe(1)
+    expect((await refresh).cached).toBe(false)
+  })
+
   it('preserves the timestamp and labels a fallback after refresh failure', async () => {
     const collector = createDiagnosticsCollector({
       read: async () => {

--- a/packages/browseros-agent/packages/diagnostics/tests/extension.test.ts
+++ b/packages/browseros-agent/packages/diagnostics/tests/extension.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { within } from '../src/collector'
+import { REPORTER_EXTENSION_ID } from '../src/contract'
+import { canReadDiagnostics, collectBrowserDiagnostics } from '../src/extension'
+
+const original = globalThis.chrome
+afterEach(() => {
+  globalThis.chrome = original
+})
+
+describe('diagnostics browser boundary', () => {
+  it('only accepts Reporter externally and extension pages internally', () => {
+    expect(canReadDiagnostics({ id: REPORTER_EXTENSION_ID }, 'app', true)).toBe(
+      true,
+    )
+    expect(canReadDiagnostics({ id: 'other' }, 'app', true)).toBe(false)
+    expect(
+      canReadDiagnostics({ url: 'https://browseros.com' }, 'app', true),
+    ).toBe(false)
+    expect(
+      canReadDiagnostics(
+        { id: 'app', url: 'https://example.com' },
+        'app',
+        false,
+      ),
+    ).toBe(false)
+    expect(
+      canReadDiagnostics(
+        { id: 'app', url: 'chrome-extension://app/app.html' },
+        'app',
+        false,
+      ),
+    ).toBe(true)
+  })
+  it('maps both native version functions correctly when the server and Reporter fail', async () => {
+    globalThis.chrome = {
+      runtime: {
+        getManifest: () => ({ version: 'extension-version' }),
+        getPlatformInfo: async () => ({ os: 'mac', arch: 'arm64' }),
+        sendMessage: async () => {
+          throw new Error('Reporter missing')
+        },
+      },
+      browserOS: {
+        getVersionNumber: (callback: (value: string) => void) =>
+          callback('chromium-version'),
+        getBrowserosVersionNumber: (callback: (value: string) => void) =>
+          callback('browseros-version'),
+      },
+      system: {
+        cpu: {
+          getInfo: async () => ({
+            modelName: 'Example CPU',
+            numOfProcessors: 8,
+          }),
+        },
+        memory: {
+          getInfo: async () => ({ capacity: 4096, availableCapacity: 2048 }),
+        },
+      },
+    } as unknown as typeof chrome
+    const snapshot = await collectBrowserDiagnostics('browseros', async () => {
+      throw new Error('server unavailable')
+    })
+    expect(snapshot.versions).toEqual({
+      browseros: 'browseros-version',
+      chromium: 'chromium-version',
+      server: null,
+      appExtension: 'extension-version',
+      reporterExtension: null,
+    })
+    expect(snapshot.system.os).toBe('macOS')
+    expect(snapshot.system.osVersion).toBeNull()
+    expect(snapshot.memory.availableBytes).toBe(2048)
+  })
+  it('bounds a source which never answers', async () => {
+    await expect(within(() => new Promise(() => {}), 5)).rejects.toThrow(
+      'timed out',
+    )
+  })
+})

--- a/packages/browseros-agent/packages/diagnostics/tests/fixture.json
+++ b/packages/browseros-agent/packages/diagnostics/tests/fixture.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "product": "browseros",
+  "collectedAt": "2026-09-08T17:18:00.000Z",
+  "versions": {
+    "browseros": "0.50.4",
+    "chromium": "145.0.7632.0",
+    "server": "0.54.0",
+    "appExtension": "0.54.0",
+    "reporterExtension": "54.0.0.0"
+  },
+  "system": {
+    "os": "macOS",
+    "osVersion": "15.6",
+    "architecture": "arm64",
+    "processor": "Apple M3 Pro",
+    "logicalCores": 12
+  },
+  "memory": { "totalBytes": 38654705664, "availableBytes": 10522669875 }
+}

--- a/packages/browseros-agent/packages/diagnostics/tsconfig.json
+++ b/packages/browseros-agent/packages/diagnostics/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "types": ["chrome", "node", "bun"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/browseros-agent/scripts/run-test-suite.ts
+++ b/packages/browseros-agent/scripts/run-test-suite.ts
@@ -13,6 +13,11 @@ const bun = process.execPath
 const testSuites = {
   all: [
     {
+      label: 'diagnostics tests',
+      cwd: resolve(projectRoot, 'packages/diagnostics'),
+      argv: [bun, 'run', 'test'],
+    },
+    {
       label: 'server tests',
       cwd: resolve(projectRoot, 'apps/server'),
       argv: [bun, 'run', 'test'],


### PR DESCRIPTION
Add Diagnostics as the last Help item in BrowserOS settings and neo. Both pages use one collector and view for BrowserOS/Chromium/server/extension versions, OS, processor and physical RAM, with Refresh and Copy diagnostics.

A background worker owns bounded source reads and a timestamped local cache. Only the known Bug Reporter extension can request external snapshots; own extension pages use the same collector. Missing servers leave useful browser/system data available. Startup/update and six-hour refreshes warm the cache, and a manual Refresh takes precedence over a concurrent cache lookup. Internal requests coexist with the app’s existing runtime message handlers, so their validation cannot intercept a diagnostics response. Both local servers expose public OS release and running-version metadata at /system/diagnostics; the Rust route and generated API contract agree.

Also prepare WXT before app tests and let its generated config own aliases, fixing existing Bun alias failures; update the neo sidebar test for its new internal route. No Chromium changes or deployment.

Validation: full app, neo and TypeScript server suites; 8 diagnostics tests plus an integration regression against the app messaging library; 13 API contract tests; typechecks; touched-file Biome; targeted Rust tests and all-targets clippy; generated API drift check; both extension builds. An isolated BrowserOS profile exercised native collection, both pages, copy/fallback, real extension messaging, and intercepted Reporter submissions with and without diagnostics. Independent review is clean.

Companion receiver: https://github.com/browseros-ai/cloudflare-cdn/pull/14. Companion Bug Reporter: https://github.com/browseros-ai/BrowserOS-feedback-extension/pull/9. Deploy the receiver before distributing extension updates.
