### PR TITLE
chore: upgrade Bun runtime to 1.4.2

### DIFF
--- a/.github/workflows/release-app-onboard.yml
+++ b/.github/workflows/release-app-onboard.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.6"
+          bun-version-file: packages/browseros-agent/package.json
 
       - name: Install browseros-agent dependencies
         working-directory: packages/browseros-agent

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -277,7 +277,7 @@ jobs:
         # falls back to latest. Keep in sync with packageManager.
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.6"
+          bun-version: "1.4.2"
 
       - name: Install BrowserOS server dependencies
         if: steps.inputs.outputs.resource_mode == 'source' && steps.inputs.outputs.products == 'browseros'

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -104,13 +104,13 @@
     "yaml": "2.9.0"
   },
   "engines": {
-    "bun": "1.3.6",
+    "bun": "1.4.2",
     "node": "please-use-bun",
     "npm": "please-use-bun",
     "yarn": "please-use-bun",
     "pnpm": "please-use-bun"
   },
-  "packageManager": "bun@1.3.6",
+  "packageManager": "bun@1.4.2",
   "overrides": {
     "serialize-javascript": "7.0.3",
     "lodash-es": "^4.18.0",


### PR DESCRIPTION
BrowserOS packaged Bun 1.3.6 and used the same older runtime for development and CI. Upgrade to 1.4.2 by updating the package manager and engine pins, updating the macOS release job's explicit pin, and making the app-onboard release workflow read the shared version from package.json.

The macOS workflow keeps its literal pin because it builds from a persistent checkout outside GITHUB_WORKSPACE. The separate vendor-upload tool has refreshed the five Bun binaries and their manifest in R2; these binaries are operational artifacts rather than files committed to this PR. The public manifest now reports bun-v1.4.2, and each uploaded binary was read back and verified against its SHA256.

Validation under Bun 1.4.2:

- Frozen dependency install succeeded without lockfile changes.
- Repository lint and typechecks passed; Fallow completed with its existing advisory findings.
- Full test command: 1,998 passed, 3 skipped; app-onboard suite: 84 passed.
- Production extension build and server compilation/packaging for all five targets passed.
- The compiled macOS ARM64 server returned its version successfully.
- All five upstream vendor archives passed SHA256 verification.
- A full macOS ARM64 resource bundle built from R2 includes Bun 1.4.2; both its Bun and compiled server executables passed version smoke checks.
