### PR TITLE
fix: update Claude and Codex ACP adapters

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/config.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/config.ts
@@ -12,15 +12,21 @@ interface HostAcpAdapterConfig {
   acpBin: string
 }
 
+/**
+ * Runtime npm packages launched by both chat and provider discovery. Their version
+ * ranges also key Bun's executable cache, so raise the minimum when a release needs
+ * newer agent support (Codex ACP 1.10.0 brings the CLI required by Astra).
+ * These adapters carry their own agent runtimes; updating a host CLI is insufficient.
+ */
 export const HOST_ACP_ADAPTER_CONFIG = {
   claude: {
-    acpArgv: ['npx', '-y', '@agentclientprotocol/claude-agent-acp@^0.31.0'],
-    acpPackageSpec: '@agentclientprotocol/claude-agent-acp@^0.31.0',
+    acpArgv: ['npx', '-y', '@agentclientprotocol/claude-agent-acp@^0.75.1'],
+    acpPackageSpec: '@agentclientprotocol/claude-agent-acp@^0.75.1',
     acpBin: 'claude-agent-acp',
   },
   codex: {
-    acpArgv: ['npx', '-y', '@agentclientprotocol/codex-acp@^1.0.2'],
-    acpPackageSpec: '@agentclientprotocol/codex-acp@^1.0.2',
+    acpArgv: ['npx', '-y', '@agentclientprotocol/codex-acp@^1.10.0'],
+    acpPackageSpec: '@agentclientprotocol/codex-acp@^1.10.0',
     acpBin: 'codex-acp',
   },
 } as const satisfies Record<HostAcpAdapter, HostAcpAdapterConfig>

--- a/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.test.ts
@@ -73,7 +73,7 @@ describe('probeAcpAgent — input shape', () => {
     await probeAcpAgent({ type: 'claude' })
     expect(lastCall?.agent).toBeUndefined()
     expect(lastCall?.argv).toContain(
-      '@agentclientprotocol/claude-agent-acp@^0.31.0',
+      '@agentclientprotocol/claude-agent-acp@^0.75.1',
     )
     expect(lastCall?.authPolicy).toBe('skip')
   })
@@ -136,7 +136,7 @@ describe('probeAcpAgent — bundled-Bun launcher swap', () => {
     expect(lastCall?.agent).toBeUndefined()
     expect(lastCall?.argv).toContain(bunPath)
     expect(lastCall?.argv).toContain(
-      '@agentclientprotocol/claude-agent-acp@^0.31.0',
+      '@agentclientprotocol/claude-agent-acp@^0.75.1',
     )
 
     fs.rmSync(tmpRoot, { recursive: true, force: true })
@@ -147,7 +147,7 @@ describe('probeAcpAgent — bundled-Bun launcher swap', () => {
     await probeAcpAgent({ type: 'claude' })
     expect(lastCall?.agent).toBeUndefined()
     expect(lastCall?.argv).toContain(
-      '@agentclientprotocol/claude-agent-acp@^0.31.0',
+      '@agentclientprotocol/claude-agent-acp@^0.75.1',
     )
   })
 
@@ -158,7 +158,7 @@ describe('probeAcpAgent — bundled-Bun launcher swap', () => {
       resourcesDir: '/nonexistent/path/that/has/no/bundled/bun',
     })
     expect(lastCall?.agent).toBeUndefined()
-    expect(lastCall?.argv).toContain('@agentclientprotocol/codex-acp@^1.0.2')
+    expect(lastCall?.argv).toContain('@agentclientprotocol/codex-acp@^1.10.0')
   })
 })
 

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acp/acp-agent-policy.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acp/acp-agent-policy.test.ts
@@ -92,7 +92,7 @@ describe('buildAcpAgentPolicy', () => {
     expect(policy.cwd).toBe('/work/project')
     expect(policy.sessionKey).toBe('acp:claude-agent-id:conversation-1')
     expect(agentArgv(policy, 'claude')).toContain(
-      '@agentclientprotocol/claude-agent-acp@^0.31.0',
+      '@agentclientprotocol/claude-agent-acp@^0.75.1',
     )
     expect(policy.mcpServers.map((server) => server.name)).toEqual([
       'browseros',

--- a/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/launcher.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/launcher.test.ts
@@ -185,7 +185,7 @@ describe('resolveAcpSpawnCommand', () => {
       '/c',
     ])
     expect(payload.argv[4]).toContain('npx')
-    expect(payload.argv[4]).toContain('@agentclientprotocol/codex-acp@^^1.0.2')
+    expect(payload.argv[4]).toContain('@agentclientprotocol/codex-acp@^^1.10.0')
     expect(payload.env.INITIAL_AGENT_MODE).toBe('agent-full-access')
   })
 
@@ -204,7 +204,7 @@ describe('resolveAcpSpawnCommand', () => {
     const payload = decodeEnvironmentPayload(out.argv[3])
     expect(payload.argv[0]).toBe('C:\\Windows\\System32\\cmd.exe')
     expect(payload.argv[4]).toContain(
-      '@agentclientprotocol/claude-agent-acp@^^0.31.0',
+      '@agentclientprotocol/claude-agent-acp@^^0.75.1',
     )
   })
 


### PR DESCRIPTION
BrowserOS can launch a cached Codex ACP adapter whose bundled CLI rejects `gpt-6-astra`. The Claude adapter is also restricted to the old `0.31.x` line.

Raise the runtime package ranges to `@agentclientprotocol/codex-acp@^1.10.0` and `@agentclientprotocol/claude-agent-acp@^0.75.1` for both conversation launches and provider discovery. The new package specifications select fresh Bun executable-cache entries when the updated server starts an adapter. Codex ACP 1.10.0 depends on Codex CLI `^0.153.3`.

Validation:
- 49 focused launcher, discovery, policy, and runtime tests pass, including Windows command escaping and legacy session recovery.
- Server typecheck and Biome checks pass.
- Live checks using the worktree launch configuration and BrowserOS's bundled Bun 1.3.6: Astra and Claude Haiku are selected correctly, reply successfully, and retain conversation state after closing and recreating the adapter process. Provider discovery returns models for both adapters.

Ships through the server release; the existing ACP bridge is compatible with both adapters.
