### PR TITLE
fix: restore original agent starter prompt defaults

### DIFF
--- a/packages/browseros-agent/apps/app/modules/chat/starter-prompts.test.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/starter-prompts.test.ts
@@ -50,7 +50,7 @@ describe('starter prompt preferences', () => {
     const prompts = getDefaultStarterPrompts('agent')
     prompts[0].display = 'My draft'
     expect(getDefaultStarterPrompts('agent')[0].display).toBe(
-      'Summarize this page',
+      'Read about our vision and upvote',
     )
     expect(getDefaultStarterPrompts('chat')[1].display).toBe(
       'What topics does this page talk about?',

--- a/packages/browseros-agent/apps/app/modules/chat/starter-prompts.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/starter-prompts.ts
@@ -44,17 +44,19 @@ const defaults: Record<ChatMode, StarterPrompt[]> = {
   ],
   agent: [
     {
-      display: 'Summarize this page',
+      display: 'Read about our vision and upvote',
       prompt:
-        'Read the current page. Summarize the main points in 5 bullets, then list anything that needs a closer look.',
+        'Go to https://dub.sh/browseros-launch in current tab. Find and click the upvote button',
     },
     {
-      display: 'Compare my open tabs',
-      prompt: 'Compare my open tabs and highlight the differences.',
+      display: 'Support BrowserOS on Github',
+      prompt:
+        'Go to http://git.new/browseros in current tab and star the repository',
     },
     {
-      display: 'Find the best price',
-      prompt: 'Find the best price for the product on the current page.',
+      display: 'Open amazon.com and order Sensodyne toothpaste',
+      prompt:
+        'Open amazon.com in current tab and add sensodyne toothpaste to cart',
     },
   ],
 }


### PR DESCRIPTION
Restore the original Agent starter shortcuts and their exact prompts: BrowserOS vision/upvote, GitHub support, and Sensodyne toothpaste. Users can customize these defaults through the existing inline editor; saved custom prompts remain intact.

Validation: all nine preference/storage tests and focused Biome checks passed. Verified both chat surfaces and the editor in BrowserOS, and the user tested and approved the preview.
