### PR TITLE
fix: restore ACP conversation history reliably

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/acp/acp-agent-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acp/acp-agent-runtime.ts
@@ -12,7 +12,7 @@ import {
   createAcpxProvider,
 } from '@browseros/acpx-ai-provider'
 import type { BrowserContext } from '@browseros/shared/schemas/browser-context'
-import { createFileSessionStore } from 'acpx/runtime'
+import { type AcpSessionRecord, createFileSessionStore } from 'acpx/runtime'
 import {
   convertToModelMessages,
   createUIMessageStream,
@@ -314,13 +314,7 @@ export class AcpAgentRuntime {
       }).load(policy.sessionKey)
       // An agent may emit startup notices during prepare(). Only user turns
       // prove it has conversation context; otherwise seed it from SQLite.
-      hasHistory =
-        persistedRecord?.messages.some(
-          (message) =>
-            typeof message === 'object' &&
-            message !== null &&
-            'User' in message,
-        ) ?? false
+      hasHistory = persistedRecord?.messages.some(isAcpUserMessage) ?? false
     } catch (error) {
       await provider.close('prepare-failed').catch(() => {})
       throw error
@@ -383,6 +377,13 @@ export class AcpAgentRuntime {
     }
     idleTimer.unref?.()
   }
+}
+
+// ACPX validates records on load; the only non-object variant is a resume marker.
+function isAcpUserMessage(
+  message: AcpSessionRecord['messages'][number],
+): boolean {
+  return typeof message !== 'string' && 'User' in message
 }
 
 /**

--- a/packages/browseros-agent/apps/server/src/lib/agents/acp/acp-agent-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acp/acp-agent-runtime.ts
@@ -15,6 +15,8 @@ import type { BrowserContext } from '@browseros/shared/schemas/browser-context'
 import { createFileSessionStore } from 'acpx/runtime'
 import {
   convertToModelMessages,
+  createUIMessageStream,
+  type ModelMessage,
   stepCountIs,
   streamText,
   type UIMessage,
@@ -73,6 +75,11 @@ export class AcpAgentPreparationError extends Error {
   }
 }
 
+/**
+ * Owns the persistent ACP process for each agent/conversation pair. Saved display
+ * messages seed fresh sessions; a pre-prompt resume retry shares the same UI
+ * response and turn lock, so neither replies nor browser actions are duplicated.
+ */
 export class AcpAgentRuntime {
   private readonly serverPort: number
   private readonly resourcesDir: string | null
@@ -127,48 +134,99 @@ export class AcpAgentRuntime {
         resourcesDir: this.resourcesDir,
         browserosDir: this.browserosDir,
       })
-      const acquired = await this.acquireSession(policy)
-      const session = acquired.session
-      createdSession = acquired.created
-      if (input.abortSignal?.aborted) {
-        throw input.abortSignal.reason ?? new Error('ACP turn was aborted')
+      let session: ActiveAcpSession
+      let recovered = false
+      const prepare = async () => {
+        input.abortSignal?.throwIfAborted()
+        const acquired = await this.acquireSession(policy)
+        session = acquired.session
+        createdSession ||= acquired.created
+        input.abortSignal?.throwIfAborted()
+        await applyFullAccess(session.provider, policy)
+        await applyReasoningEffort(session.provider, input.agent)
+      }
+      const canRecover = (error: unknown) =>
+        !recovered && !input.abortSignal?.aborted && isResumeFailure(error)
+      const recover = async (error: unknown) => {
+        if (!canRecover(error)) throw error
+        recovered = true
+        logger.warn('Starting a fresh ACP session after resume failed', {
+          agentId: input.agent.id,
+          conversationId: input.conversationId,
+        })
+        await this.resetSession(policy.sessionKey)
+        await prepare()
+        session.hasHistory = false
+      }
+      try {
+        await prepare()
+      } catch (error) {
+        await recover(error)
       }
 
-      await applyFullAccess(session.provider, policy)
-      await applyReasoningEffort(session.provider, input.agent)
-
-      const messages = session.hasHistory
-        ? latestUserTurn(input.messages)
-        : input.messages
-      const modelMessages = await convertToModelMessages(messages)
-      const result = streamText({
-        model: session.provider.languageModel(),
-        messages: modelMessages,
-        abortSignal: input.abortSignal,
-        stopWhen: stepCountIs(1),
-        onError: ({ error }) => {
+      // One UI response spans a possible pre-prompt resume retry. The failed
+      // attempt must not create an empty assistant reply or persist its error.
+      const responseId = crypto.randomUUID()
+      let failed = false
+      const stream = createUIMessageStream<UIMessage>({
+        originalMessages: input.messages,
+        generateId: () => responseId,
+        execute: async ({ writer }) => {
+          writer.write({ type: 'start', messageId: responseId })
+          while (true) {
+            input.abortSignal?.throwIfAborted()
+            const messages = session.hasHistory
+              ? latestUserTurn(input.messages)
+              : input.messages
+            const modelMessages = await convertHistory(messages)
+            let turnError: unknown
+            const result = streamText({
+              model: session.provider.languageModel(),
+              messages: modelMessages,
+              abortSignal: input.abortSignal,
+              stopWhen: stepCountIs(1),
+              onError: ({ error }) => {
+                turnError = error
+              },
+            })
+            const outcome = await forwardAttempt(
+              result.toUIMessageStream({
+                sendStart: false,
+                onError: (error) => {
+                  turnError = error
+                  return acpUiErrorMessage(error)
+                },
+              }),
+              (chunk) => writer.write(chunk),
+              () => canRecover(turnError),
+            )
+            if (outcome === 'retry') {
+              await recover(turnError)
+              continue
+            }
+            failed = outcome === 'failed'
+            return
+          }
+        },
+        onFinish: async ({ messages, isAborted }) => {
+          if (!failed && !isAborted) session.hasHistory = true
+          await input.onFinish?.({ messages, isAborted })
+        },
+        onError: (error) => {
+          failed = true
           logger.error('ACP agent stream failed', {
             agentId: input.agent.id,
             conversationId: input.conversationId,
             error: error instanceof Error ? error.message : String(error),
           })
+          return acpUiErrorMessage(error)
         },
-      })
-      const stream = result.toUIMessageStream({
-        originalMessages: messages,
-        onFinish: async ({ messages: finishedMessages, isAborted }) => {
-          session.hasHistory = true
-          await input.onFinish?.({
-            messages: finishedMessages,
-            isAborted,
-          })
-        },
-        onError: acpUiErrorMessage,
       })
       streamStarted = true
       return releaseOnEnd(stream, () => {
         this.activeTurns.delete(sessionKey)
-        this.scheduleIdleClose(sessionKey, session)
+        const active = this.sessions.get(sessionKey)
+        if (active) this.scheduleIdleClose(sessionKey, active)
       })
     } catch (error) {
       if (createdSession) {
@@ -254,9 +312,15 @@ export class AcpAgentRuntime {
       const persistedRecord = await createFileSessionStore({
         stateDir: this.stateDir,
       }).load(policy.sessionKey)
-      hasHistory = persistedRecord
-        ? persistedRecord.messages.length > 0
-        : (existing?.hasHistory ?? false)
+      // An agent may emit startup notices during prepare(). Only user turns
+      // prove it has conversation context; otherwise seed it from SQLite.
+      hasHistory =
+        persistedRecord?.messages.some(
+          (message) =>
+            typeof message === 'object' &&
+            message !== null &&
+            'User' in message,
+        ) ?? false
     } catch (error) {
       await provider.close('prepare-failed').catch(() => {})
       throw error
@@ -270,6 +334,26 @@ export class AcpAgentRuntime {
     }
     this.sessions.set(policy.sessionKey, session)
     return { session, created: true }
+  }
+
+  private async resetSession(sessionKey: string): Promise<void> {
+    const session = this.sessions.get(sessionKey)
+    this.sessions.delete(sessionKey)
+    if (session) {
+      clearIdleTimer(session)
+      await session.provider.close('resume-failed')
+    }
+    const store = createFileSessionStore({ stateDir: this.stateDir })
+    const record = await store.load(sessionKey)
+    if (record) {
+      // ACP session/close is optional and may itself fail for a stale session.
+      // Ask ACPX to replace its local session on the next ensure, retaining
+      // SQLite and the old record until the replacement is ready.
+      await store.save({
+        ...record,
+        acpx: { ...record.acpx, reset_on_next_ensure: true },
+      })
+    }
   }
 
   private scheduleIdleClose(
@@ -299,6 +383,40 @@ export class AcpAgentRuntime {
     }
     idleTimer.unref?.()
   }
+}
+
+/**
+ * Forward one attempt, holding its step envelope until work starts. A resume
+ * failure can be hidden and retried only before any text/reasoning/tool activity;
+ * drain that failed attempt before replacing its agent process.
+ */
+async function forwardAttempt(
+  stream: ReadableStream<UIMessageChunk>,
+  write: (chunk: UIMessageChunk) => void,
+  canRecover: () => boolean,
+): Promise<'completed' | 'failed' | 'retry'> {
+  let outcome: 'completed' | 'failed' | 'retry' = 'completed'
+  let hasOutput = false
+  const pending: UIMessageChunk[] = []
+  for await (const chunk of stream) {
+    if (outcome === 'retry') continue
+    if (chunk.type === 'error' && !hasOutput && canRecover()) {
+      outcome = 'retry'
+      continue
+    }
+    if (!hasOutput && chunk.type === 'start-step') {
+      pending.push(chunk)
+      continue
+    }
+    hasOutput = true
+    for (const prefix of pending.splice(0)) write(prefix)
+    if (chunk.type === 'error') outcome = 'failed'
+    write(chunk)
+  }
+  if (outcome !== 'retry') {
+    for (const prefix of pending) write(prefix)
+  }
+  return outcome
 }
 
 function clearIdleTimer(session: ActiveAcpSession): void {
@@ -393,6 +511,40 @@ async function applyReasoningEffort(
       reasoningEffort: agent.reasoningEffort,
       error: error instanceof Error ? error.message : String(error),
     })
+  }
+}
+
+// ACPX uses these detail codes only before a prompt can execute. Other
+// failures (auth, quota, tool errors) must surface without replaying the turn.
+function isResumeFailure(error: unknown): boolean {
+  const visited = new Set<unknown>()
+  while (error && typeof error === 'object' && !visited.has(error)) {
+    visited.add(error)
+    const detail = 'detailCode' in error ? error.detailCode : undefined
+    if (
+      detail === 'SESSION_RESUME_REQUIRED' ||
+      detail === 'SESSION_MODE_REPLAY_FAILED' ||
+      detail === 'SESSION_MODEL_REPLAY_FAILED' ||
+      detail === 'SESSION_CONFIG_OPTION_REPLAY_FAILED'
+    )
+      return true
+    error = 'cause' in error ? error.cause : undefined
+  }
+  return false
+}
+
+async function convertHistory(messages: UIMessage[]): Promise<ModelMessage[]> {
+  try {
+    return await convertToModelMessages(messages, {
+      ignoreIncompleteToolCalls: true,
+    })
+  } catch (error) {
+    const latest = latestUserTurn(messages)
+    if (latest.length === messages.length) throw error
+    // Legacy display records can outlive their message schema. Keep the user's
+    // new request usable even when the old transcript cannot be replayed.
+    logger.warn('Continuing ACP turn without incompatible saved history')
+    return convertToModelMessages(latest)
   }
 }
 

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acp/acp-agent-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acp/acp-agent-runtime.test.ts
@@ -24,6 +24,7 @@ import type {
 } from 'acpx/runtime'
 import { createFileSessionStore } from 'acpx/runtime'
 import type { UIMessage, UIMessageChunk } from 'ai'
+import { ChatService } from '../../../../src/api/services/chat-service'
 import {
   AcpAgentPreparationError,
   AcpAgentRuntime,
@@ -31,6 +32,8 @@ import {
 } from '../../../../src/lib/agents/acp/acp-agent-runtime'
 import { BROWSEROS_ACP_INSTRUCTIONS } from '../../../../src/lib/agents/acp/browseros-instructions'
 import type { AcpAgentDefinition } from '../../../../src/lib/agents/agent-types'
+import { DbConversationStore } from '../../../../src/lib/conversations/conversation-store'
+import { openBrowserOsDatabase } from '../../../../src/lib/db/client'
 
 const temporaryDirectories: string[] = []
 const BROWSER_TOOL_LEASE_TOKEN = 'runtime-test-lease'
@@ -214,7 +217,7 @@ describe('AcpAgentRuntime', () => {
     expect(fixture.providerSettings).toHaveLength(1)
   })
 
-  it('sends complete history when ACPX replaces a legacy session during prepare', async () => {
+  it('restores history when a replacement session emits only a startup notice', async () => {
     const fixture = await runtimeFixture({})
     const sessionKey = 'acp:claude-agent-id:legacy-conversation'
     const store = createFileSessionStore({ stateDir: fixture.stateDir })
@@ -248,7 +251,16 @@ describe('AcpAgentRuntime', () => {
         acpSessionId: 'fresh-session',
         agentCommand: 'env PATH=/bin claude-agent-acp',
         agentArgv: ['env', 'PATH=/bin', 'claude-agent-acp'],
-        messages: [],
+        messages: [
+          {
+            Agent: {
+              content: [
+                { Text: 'Auto mode unavailable; using Accept edits instead.' },
+              ],
+              tool_results: {},
+            },
+          },
+        ],
       })
     }
 
@@ -273,6 +285,323 @@ describe('AcpAgentRuntime', () => {
       'previous UI answer',
     )
     expect(fixture.acpRuntime.startTurnCalls[0]?.text).toContain('new prompt')
+  })
+
+  it('assigns a distinct nonempty ID to every streamed assistant reply', async () => {
+    const fixture = await runtimeFixture({
+      idleTimeoutMs: 0,
+      runtime: new RecordingAcpRuntime({
+        turns: [
+          [{ type: 'text_delta', text: 'first answer', stream: 'output' }],
+          [{ type: 'text_delta', text: 'second answer', stream: 'output' }],
+        ],
+      }),
+    })
+    const history: UIMessage[] = []
+    for (const turn of [1, 2]) {
+      history.push(textMessage(`user-${turn}`, 'user', `question ${turn}`))
+      await collect(
+        await fixture.runtime.stream({
+          agent: fixture.agent,
+          conversationId: 'unique-replies',
+          browserToolLeaseToken: BROWSER_TOOL_LEASE_TOKEN,
+          readOnly: false,
+          messages: [...history],
+          onFinish: ({ messages }) => {
+            const reply = messages.at(-1)
+            if (!reply) throw new Error('Missing assistant reply')
+            expect(reply.role).toBe('assistant')
+            expect(reply.id).not.toBe('')
+            expect(history.some((message) => message.id === reply.id)).toBe(
+              false,
+            )
+            history.push(reply)
+          },
+        }),
+      )
+    }
+    expect(
+      history.filter((message) => message.role === 'assistant'),
+    ).toHaveLength(2)
+    await fixture.runtime.closeAllForAgent(fixture.agent.id)
+  })
+
+  it('sends only the latest turn when a persisted agent has real user history', async () => {
+    const fixture = await runtimeFixture({})
+    await saveAgentRecord(fixture, 'resumed', [
+      { User: { id: 'old', content: [{ Text: 'old question' }] } },
+    ])
+    await collect(
+      await fixture.runtime.stream(historyInput(fixture, 'resumed')),
+    )
+    expect(fixture.acpRuntime.startTurnCalls[0]?.text).toBe(
+      'User: new question',
+    )
+  })
+
+  it('starts fresh when restoring the old agent fails during setup', async () => {
+    const fixture = await runtimeFixture({})
+    const store = await saveAgentRecord(fixture, 'setup-failure', [
+      { User: { id: 'old', content: [{ Text: 'old question' }] } },
+    ])
+    fixture.acpRuntime.setModeHook = async () => {
+      if (fixture.acpRuntime.ensureSessionCalls.length === 1)
+        throw resumeError()
+    }
+    fixture.acpRuntime.ensureSessionHook = async (input) => {
+      if (fixture.acpRuntime.ensureSessionCalls.length === 2) {
+        const record = await store.load(input.sessionKey)
+        if (!record) throw new Error('Missing saved agent session')
+        expect(record.acpx?.reset_on_next_ensure).toBe(true)
+        await store.save({ ...record, messages: [], acpx: {} })
+      }
+    }
+    await collect(
+      await fixture.runtime.stream(historyInput(fixture, 'setup-failure')),
+    )
+    expect(fixture.acpRuntime.ensureSessionCalls).toHaveLength(2)
+    expect(fixture.acpRuntime.startTurnCalls).toHaveLength(1)
+    expect(fixture.acpRuntime.startTurnCalls[0]?.text).toContain('old answer')
+    expect(fixture.acpRuntime.startTurnCalls[0]?.text).toContain('new question')
+  })
+
+  it('retries a resume failure before output and persists only the successful reply', async () => {
+    const fixture = await runtimeFixture({
+      runtime: new RecordingAcpRuntime({
+        turns: [
+          [],
+          [{ type: 'text_delta', text: 'recovered answer', stream: 'output' }],
+        ],
+        results: [resumeFailure()],
+      }),
+    })
+    await saveAgentRecord(fixture, 'stream-failure', [
+      { User: { id: 'old', content: [{ Text: 'old question' }] } },
+    ])
+    const finished: UIMessage[][] = []
+    const parts = await collect(
+      await fixture.runtime.stream({
+        ...historyInput(fixture, 'stream-failure'),
+        onFinish: ({ messages }) => {
+          finished.push(messages)
+        },
+      }),
+    )
+    expect(fixture.acpRuntime.startTurnCalls).toHaveLength(2)
+    expect(fixture.acpRuntime.startTurnCalls[0]?.text).toBe(
+      'User: new question',
+    )
+    expect(fixture.acpRuntime.startTurnCalls[1]?.text).toContain('old answer')
+    expect(parts.filter((part) => part.type === 'error')).toEqual([])
+    expect(parts.filter((part) => part.type === 'start')).toHaveLength(1)
+    expect(parts.filter((part) => part.type === 'finish')).toHaveLength(1)
+    expect(finished).toHaveLength(1)
+    expect(finished[0]?.at(-1)?.parts).toContainEqual({
+      type: 'text',
+      text: 'recovered answer',
+      state: 'done',
+    })
+  })
+
+  it('stops after one fresh-session retry', async () => {
+    const fixture = await runtimeFixture({
+      runtime: new RecordingAcpRuntime({
+        results: [resumeFailure(), resumeFailure()],
+      }),
+    })
+    const parts = await collect(
+      await fixture.runtime.stream(historyInput(fixture, 'twice-failed')),
+    )
+    expect(fixture.acpRuntime.startTurnCalls).toHaveLength(2)
+    expect(parts.filter((part) => part.type === 'error')).toHaveLength(1)
+  })
+
+  for (const activity of [
+    { type: 'text_delta', text: 'already started', stream: 'output' },
+    {
+      type: 'tool_call',
+      toolCallId: 'tool-1',
+      title: 'Click button',
+      status: 'in_progress',
+      rawInput: { button: 'Submit' },
+    },
+  ] satisfies AcpRuntimeEvent[]) {
+    it(`does not retry after ${activity.type} activity`, async () => {
+      const fixture = await runtimeFixture({
+        runtime: new RecordingAcpRuntime({
+          turns: [[activity]],
+          results: [resumeFailure()],
+        }),
+      })
+      const parts = await collect(
+        await fixture.runtime.stream(historyInput(fixture, 'already-started')),
+      )
+      expect(fixture.acpRuntime.startTurnCalls).toHaveLength(1)
+      expect(fixture.acpRuntime.closeCalls).toHaveLength(0)
+      expect(parts.filter((part) => part.type === 'error')).toHaveLength(1)
+    })
+  }
+
+  it('honors cancellation while recovering a stale session', async () => {
+    const controller = new AbortController()
+    const fixture = await runtimeFixture({
+      runtime: new RecordingAcpRuntime({ results: [resumeFailure()] }),
+    })
+    fixture.acpRuntime.closeHook = async () => controller.abort()
+    await collect(
+      await fixture.runtime.stream({
+        ...historyInput(fixture, 'cancel-recovery'),
+        abortSignal: controller.signal,
+      }),
+    )
+    expect(fixture.acpRuntime.startTurnCalls).toHaveLength(1)
+    expect(fixture.acpRuntime.ensureSessionCalls).toHaveLength(1)
+  })
+
+  it('keeps the conversation locked while replacing a stale agent', async () => {
+    const fixture = await runtimeFixture({
+      runtime: new RecordingAcpRuntime({ results: [resumeFailure()] }),
+    })
+    const closing = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    fixture.acpRuntime.closeHook = async () => {
+      closing.resolve()
+      await release.promise
+    }
+    const input = historyInput(fixture, 'locked-recovery')
+    const first = await fixture.runtime.stream(input)
+    await closing.promise
+    try {
+      await expect(fixture.runtime.stream(input)).rejects.toBeInstanceOf(
+        AcpAgentSessionBusyError,
+      )
+    } finally {
+      release.resolve()
+    }
+    await collect(first)
+    expect(fixture.acpRuntime.startTurnCalls).toHaveLength(2)
+  })
+
+  it('restores saved text while omitting an interrupted tool call', async () => {
+    const fixture = await runtimeFixture({})
+    const input = historyInput(fixture, 'interrupted-tool')
+    input.messages[1].parts.push({
+      type: 'dynamic-tool',
+      toolName: 'browser_click',
+      toolCallId: 'partial',
+      state: 'input-streaming',
+      input: undefined,
+    })
+    const parts = await collect(await fixture.runtime.stream(input))
+    expect(parts.filter((part) => part.type === 'error')).toEqual([])
+    expect(fixture.acpRuntime.startTurnCalls[0]?.text).toContain('old answer')
+    expect(fixture.acpRuntime.startTurnCalls[0]?.text).not.toContain(
+      'browser_click',
+    )
+  })
+
+  it('continues with the new request when legacy display messages cannot be converted', async () => {
+    const fixture = await runtimeFixture({})
+    const input = historyInput(fixture, 'legacy-message')
+    input.messages[1] = {
+      id: 'legacy',
+      role: 'assistant',
+      content: 'old schema',
+    } as unknown as UIMessage
+    await collect(await fixture.runtime.stream(input))
+    expect(fixture.acpRuntime.startTurnCalls[0]?.text).toBe(
+      'User: new question',
+    )
+  })
+
+  it('persists every reply in SQLite across newtab, sidepanel, and a cold restart', async () => {
+    const fixture = await runtimeFixture({
+      idleTimeoutMs: 0,
+      runtime: new RecordingAcpRuntime({
+        turns: ['opened HN', 'we highlighted comments', 'I remember'].map(
+          (text) => [{ type: 'text_delta', text, stream: 'output' }],
+        ),
+      }),
+    })
+    const handle = openBrowserOsDatabase({
+      dbPath: join(fixture.stateDir, 'history.sqlite'),
+    })
+    const store = new DbConversationStore({ db: handle.db })
+    const conversationId = 'persisted-history'
+    const initial = [
+      textMessage('original-user', 'user', 'Highlight insightful comments'),
+      textMessage('', 'assistant', 'I highlighted 10 comments'),
+    ]
+    try {
+      await store.save({
+        id: conversationId,
+        targetType: 'claude',
+        agentId: fixture.agent.id,
+        messages: initial,
+      })
+      for (const [index, message] of [
+        'open hn',
+        'what did we do before?',
+        'remember this',
+      ].entries()) {
+        if (index === 2)
+          await fixture.runtime.closeAllForAgent(fixture.agent.id)
+        // A new service instance must reload the transcript from SQLite.
+        const service = new ChatService({
+          sessionStore: {
+            get: () => undefined,
+            set: () => {},
+            remove: () => false,
+            delete: async () => false,
+            count: () => 0,
+          } as never,
+          browser: { resolveTabIds: async () => new Map() } as never,
+          browserMcp: {
+            createLease: () => ({
+              token: BROWSER_TOOL_LEASE_TOKEN,
+              updateBrowserContext: () => {},
+              revoke: () => {},
+            }),
+          } as never,
+          serverPort: 9100,
+          acpAgentStore: { get: async () => fixture.agent },
+          acpRuntime: fixture.runtime,
+          conversationStore: store,
+        })
+        const response = await service.processMessage(
+          {
+            target: { type: 'claude', agentId: fixture.agent.id },
+            conversationId,
+            message,
+            isScheduledTask: false,
+            mode: 'agent',
+            origin: index === 0 ? 'newtab' : 'sidepanel',
+          },
+          new AbortController().signal,
+        )
+        expect(await response.text()).not.toContain('"type":"error"')
+      }
+      const saved = await store.get(conversationId)
+      if (!saved) throw new Error('Missing saved conversation')
+      expect(saved.messages).toHaveLength(8)
+      expect(saved.messages.slice(0, 2)).toEqual(initial)
+      const replies = saved.messages
+        .filter((message) => message.role === 'assistant')
+        .slice(1)
+      expect(replies).toHaveLength(3)
+      expect(replies.every((message) => message.id.length > 0)).toBe(true)
+      expect(new Set(replies.map((message) => message.id)).size).toBe(3)
+      expect(fixture.acpRuntime.startTurnCalls[2]?.text).toContain(
+        'I highlighted 10 comments',
+      )
+      expect(fixture.acpRuntime.startTurnCalls[2]?.text).toContain(
+        'we highlighted comments',
+      )
+      expect(saved.lastUserMessage).toBe('remember this')
+    } finally {
+      await fixture.runtime.closeAllForAgent(fixture.agent.id)
+      handle.sqlite.close()
+    }
   })
 
   it('uses Codex config and falls back across full-access mode ids', async () => {
@@ -503,6 +832,71 @@ describe('AcpAgentRuntime', () => {
   })
 })
 
+function historyInput(
+  fixture: Awaited<ReturnType<typeof runtimeFixture>>,
+  conversationId: string,
+) {
+  return {
+    agent: fixture.agent,
+    conversationId,
+    browserToolLeaseToken: BROWSER_TOOL_LEASE_TOKEN,
+    readOnly: false,
+    messages: [
+      textMessage('old-user', 'user', 'old question'),
+      textMessage('old-assistant', 'assistant', 'old answer'),
+      textMessage('new-user', 'user', 'new question'),
+    ],
+  }
+}
+
+function resumeError() {
+  return Object.assign(
+    new Error('Persistent ACP session could not be resumed'),
+    { detailCode: 'SESSION_RESUME_REQUIRED' },
+  )
+}
+
+function resumeFailure(): AcpRuntimeTurnResult {
+  return {
+    status: 'failed',
+    error: {
+      code: 'RUNTIME_ERROR',
+      detailCode: 'SESSION_RESUME_REQUIRED',
+      message: 'Persistent ACP session could not be resumed',
+    },
+  }
+}
+
+async function saveAgentRecord(
+  fixture: Awaited<ReturnType<typeof runtimeFixture>>,
+  conversationId: string,
+  messages: AcpSessionRecord['messages'],
+) {
+  const timestamp = new Date(0).toISOString()
+  const store = createFileSessionStore({ stateDir: fixture.stateDir })
+  await store.save({
+    schema: 'acpx.session.v1',
+    acpxRecordId: `acp:${fixture.agent.id}:${conversationId}`,
+    acpSessionId: 'saved-session',
+    agentCommand: 'claude-agent-acp',
+    cwd: fixture.stateDir,
+    createdAt: timestamp,
+    lastUsedAt: timestamp,
+    lastSeq: 0,
+    eventLog: {
+      active_path: 'events.jsonl',
+      segment_count: 0,
+      max_segment_bytes: 1024,
+      max_segments: 1,
+    },
+    messages,
+    updated_at: timestamp,
+    cumulative_token_usage: {},
+    request_token_usage: {},
+  })
+  return store
+}
+
 interface RecordingAcpRuntimeOptions {
   turns?: AcpRuntimeEvent[][]
   results?: AcpRuntimeTurnResult[]
@@ -521,6 +915,8 @@ class RecordingAcpRuntime implements AcpRuntime {
     discardPersistentState?: boolean
   }> = []
   ensureSessionHook?: (input: AcpRuntimeEnsureInput) => Promise<void>
+  setModeHook?: () => Promise<void>
+  closeHook?: () => Promise<void>
   private turnIndex = 0
 
   constructor(private options: RecordingAcpRuntimeOptions = {}) {}
@@ -544,6 +940,7 @@ class RecordingAcpRuntime implements AcpRuntime {
     this.turnIndex += 1
     return {
       requestId: `request-${this.turnIndex}`,
+      promptStarted: Promise.resolve(),
       events: iterate(events),
       result: Promise.resolve<AcpRuntimeTurnResult>(
         this.options.results?.[turnIndex] ?? {
@@ -566,6 +963,7 @@ class RecordingAcpRuntime implements AcpRuntime {
     mode: string
   }): Promise<void> {
     this.setModeCalls.push(input.mode)
+    await this.setModeHook?.()
     if (this.options.rejectedModes?.includes(input.mode)) {
       throw new Error(`unsupported mode: ${input.mode}`)
     }
@@ -595,6 +993,7 @@ class RecordingAcpRuntime implements AcpRuntime {
       reason: input.reason,
       discardPersistentState: input.discardPersistentState,
     })
+    await this.closeHook?.()
   }
 }
 


### PR DESCRIPTION
## Summary

Reopening an ACP conversation could show its saved messages while the agent received only the latest request: startup notices were incorrectly counted as prior conversation history. Assistant replies also shared an empty message ID, causing later replies to be dropped from SQLite.

Use a typed user-message predicate to decide when a fresh ACP session needs the saved transcript, and assign a unique ID to each assistant response. If native restoration explicitly fails before any response or tool activity, replace the stale session once and seed it with saved history. Legacy history that cannot be converted falls back to the latest request. Existing incomplete tool calls are omitted during conversion.

## Design

Keep native ACP sessions for continuity and use SQLite history to seed fresh sessions. Recovery shares one visible assistant response and retains the conversation lock through replacement. Structured ACPX error codes control recovery; startup notices and error messages are never matched by their text. Cancellation and failures after response/tool activity are not retried.

## Validation

- 75 focused server tests passed, covering startup notices, persisted history, unique reply IDs, SQLite persistence, cold restarts, recovery, cancellation, and overlapping turns.
- Real ACPX subprocess smoke passed: an expired native session is replaced, the previous request and reply reach the fresh agent, and no prompt is duplicated.
- Server typecheck, repository Biome lint, and diff checks passed. Fallow exited successfully but reported repository-wide advisory findings.
- The broader provider suite previously showed five existing usage-accounting expectation failures, also reproduced on unchanged main; provider implementation files are unchanged here.

Previously missing assistant replies are not reconstructed by this change.
