### PR TITLE
feat: widen new-tab chat layout

### DIFF
--- a/packages/browseros-agent/apps/app/screens/newtab/index/NewTabChat.tsx
+++ b/packages/browseros-agent/apps/app/screens/newtab/index/NewTabChat.tsx
@@ -127,18 +127,18 @@ export const NewTabChat: FC = () => {
 
   return (
     <div className="absolute inset-0 flex flex-col overflow-hidden">
-      <div className="mx-auto w-full max-w-3xl">
-        <ChatHeader
-          selectedProvider={selectedProvider}
-          providers={providers}
-          onSelectProvider={handleSelectProvider}
-          onNewConversation={handleNewConversation}
-          hasMessages={messages.length > 0}
-          hideHistory
-        />
-      </div>
+      <ChatHeader
+        selectedProvider={selectedProvider}
+        providers={providers}
+        onSelectProvider={handleSelectProvider}
+        onNewConversation={handleNewConversation}
+        hasMessages={messages.length > 0}
+        hideHistory
+        className="shrink-0 px-4 sm:px-8"
+      />
 
-      <main className="styled-scrollbar [&_[data-streamdown='code-block']]:!max-w-full [&_[data-streamdown='code-block']]:!w-auto [&_[data-streamdown='table-wrapper']]:!max-w-full [&_[data-streamdown='table-wrapper']]:!w-auto mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col space-y-4 overflow-y-auto overflow-x-hidden px-4 pt-4 [&_[data-streamdown='code-block']]:overflow-x-auto [&_[data-streamdown='table-wrapper']]:overflow-x-auto">
+      {/* Keep transcript and composer widths in sync; only the header spans the page. */}
+      <main className="styled-scrollbar [&_[data-streamdown='code-block']]:!max-w-full [&_[data-streamdown='code-block']]:!w-auto [&_[data-streamdown='table-wrapper']]:!max-w-full [&_[data-streamdown='table-wrapper']]:!w-auto mx-auto flex min-h-0 w-full max-w-5xl flex-1 flex-col space-y-4 overflow-y-auto overflow-x-hidden px-4 pt-4 sm:w-[calc(100%-4rem)] [&_[data-streamdown='code-block']]:overflow-x-auto [&_[data-streamdown='table-wrapper']]:overflow-x-auto">
         {isRestoringConversation ? (
           <div className="flex flex-1 items-center justify-center">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -181,7 +181,7 @@ export const NewTabChat: FC = () => {
         )}
       </main>
 
-      <div className="mx-auto w-full max-w-3xl flex-shrink-0 px-4 pb-2">
+      <div className="mx-auto w-full max-w-5xl flex-shrink-0 px-4 pb-2 sm:w-[calc(100%-4rem)]">
         <ChatFooter
           mode={mode}
           onModeChange={handleModeChange}

--- a/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatHeader.tsx
+++ b/packages/browseros-agent/apps/app/screens/sidepanel/index/ChatHeader.tsx
@@ -17,6 +17,7 @@ import { Feature } from '@/lib/browseros/capabilities'
 import { productRepositoryUrl } from '@/lib/constants/productUrls'
 import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { ProviderType } from '@/lib/llm-providers/types'
+import { cn } from '@/lib/utils'
 import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
 import { useCredits } from '@/modules/credits/credits.hooks'
 
@@ -39,6 +40,8 @@ export interface ChatHeaderProps {
   onNewConversation: () => void
   hasMessages: boolean
   hideHistory?: boolean
+  /** Lets the full-page chat opt into spacing without changing the sidepanel. */
+  className?: string
 }
 
 export const ChatHeader: FC<ChatHeaderProps> = ({
@@ -48,6 +51,7 @@ export const ChatHeader: FC<ChatHeaderProps> = ({
   onNewConversation,
   hasMessages,
   hideHistory,
+  className,
 }) => {
   const location = useLocation()
   const navigate = useNavigate()
@@ -59,7 +63,12 @@ export const ChatHeader: FC<ChatHeaderProps> = ({
   }
 
   return (
-    <header className="flex items-center justify-between border-border/40 border-b bg-background/80 px-3 py-2.5 backdrop-blur-md">
+    <header
+      className={cn(
+        'flex items-center justify-between border-border/40 border-b bg-background/80 px-3 py-2.5 backdrop-blur-md',
+        className,
+      )}
+    >
       <div className="flex items-center gap-2">
         {/* Provider Selector */}
         <ChatProviderSelector


### PR DESCRIPTION
New-tab conversations were confined to a 768px column, leaving excessive empty space on larger windows. Implement the approved Paper variant 2: let the header span the page, and expand the transcript and composer to a shared 1024px maximum with responsive side spacing.

Header spacing is optional on the shared component, preserving the existing sidepanel layout. This change is independent of the upcoming history feature.

Validation:
- App typecheck, lint, and the complete existing app test suite passed.
- Checked the live extension at 1440px, 1280px, 960px, and 600px widths.
- Verified long conversations scroll while the composer stays visible, and long code does not cause horizontal page overflow.
- Confirmed the 360px sidepanel retains its existing header spacing.
