### PR TITLE
feat: add collapsible local chat history to new tab

### DIFF
--- a/packages/browseros-agent/apps/app/components/layout/SidebarLayout.tsx
+++ b/packages/browseros-agent/apps/app/components/layout/SidebarLayout.tsx
@@ -7,16 +7,20 @@ import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { RpcClientProvider } from '@/lib/rpc/RpcClientProvider'
+import { cn } from '@/lib/utils'
+import { ActiveConversationProvider } from '@/modules/conversations/active-conversation-context'
 import { ShortcutsDialog } from '@/screens/newtab/index/ShortcutsDialog'
 
 const COLLAPSE_DELAY = 150
 
-export const SidebarLayout: FC = () => {
+const SidebarLayoutContent: FC = () => {
   const location = useLocation()
+  const isChatPage = location.pathname === '/home/chat'
   const isMobile = useIsMobile()
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [mobileOpen, setMobileOpen] = useState(false)
   const [shortcutsDialogOpen, setShortcutsDialogOpen] = useState(false)
+  const sidebarRef = useRef<HTMLDivElement>(null)
   const collapseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const openShortcuts = useCallback(() => {
@@ -45,33 +49,51 @@ export const SidebarLayout: FC = () => {
 
   const handleMouseLeave = useCallback(() => {
     collapseTimeoutRef.current = setTimeout(() => {
-      setSidebarOpen(false)
+      // Keyboard focus keeps the rail open even when the pointer leaves it.
+      if (!sidebarRef.current?.contains(document.activeElement))
+        setSidebarOpen(false)
     }, COLLAPSE_DELAY)
   }, [])
 
   if (isMobile) {
     return (
       <RpcClientProvider>
-        <div className="flex min-h-screen flex-col bg-background">
+        <div
+          className={cn(
+            'flex flex-col bg-background',
+            isChatPage ? 'h-dvh' : 'min-h-screen',
+          )}
+        >
           <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
             <Button
               variant="ghost"
               size="icon"
               className="-ml-1 size-7"
               onClick={() => setMobileOpen(true)}
+              aria-label="Open navigation"
             >
               <Menu className="size-4" />
             </Button>
             <span className="font-semibold">BrowserOS</span>
           </header>
-          <main className="flex-1 overflow-y-auto">
-            <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+          {isChatPage ? (
+            <main className="relative min-h-0 flex-1 overflow-hidden">
               <Outlet />
-            </div>
-          </main>
+            </main>
+          ) : (
+            <main className="flex-1 overflow-y-auto">
+              <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+                <Outlet />
+              </div>
+            </main>
+          )}
           <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
             <SheetContent side="left" className="w-72 p-0">
-              <AppSidebar expanded onOpenShortcuts={openShortcuts} />
+              <AppSidebar
+                expanded
+                onOpenShortcuts={openShortcuts}
+                onNavigate={() => setMobileOpen(false)}
+              />
             </SheetContent>
           </Sheet>
           <ShortcutsDialog
@@ -90,15 +112,31 @@ export const SidebarLayout: FC = () => {
         {/* Sidebar - fixed overlay */}
         {/* biome-ignore lint/a11y/noStaticElementInteractions: hover interactions needed */}
         <div
+          ref={sidebarRef}
           className="fixed inset-y-0 left-0 z-40"
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
+          onFocusCapture={handleMouseEnter}
+          onBlurCapture={(event) => {
+            if (
+              !event.currentTarget.contains(event.relatedTarget) &&
+              !event.currentTarget.matches(':hover')
+            )
+              handleMouseLeave()
+          }}
         >
           <AppSidebar expanded={sidebarOpen} onOpenShortcuts={openShortcuts} />
         </div>
 
-        {location.pathname === '/home/chat' ? (
-          <main className="relative h-dvh overflow-hidden">
+        {isChatPage ? (
+          // The expanded rail adds 200px beyond the 56px already reserved.
+          // Keep the transcript readable while browsing history in narrow windows.
+          <main
+            className={cn(
+              'relative h-dvh overflow-hidden transition-[margin] duration-200',
+              sidebarOpen && 'ml-[200px]',
+            )}
+          >
             <Outlet />
           </main>
         ) : (
@@ -116,3 +154,9 @@ export const SidebarLayout: FC = () => {
     </RpcClientProvider>
   )
 }
+
+export const SidebarLayout: FC = () => (
+  <ActiveConversationProvider>
+    <SidebarLayoutContent />
+  </ActiveConversationProvider>
+)

--- a/packages/browseros-agent/apps/app/components/sidebar/AppSidebar.tsx
+++ b/packages/browseros-agent/apps/app/components/sidebar/AppSidebar.tsx
@@ -7,11 +7,13 @@ import { SidebarUserFooter } from './SidebarUserFooter'
 export interface AppSidebarProps {
   expanded?: boolean
   onOpenShortcuts?: () => void
+  onNavigate?: () => void
 }
 
 export const AppSidebar: FC<AppSidebarProps> = ({
   expanded = false,
   onOpenShortcuts,
+  onNavigate,
 }) => {
   return (
     <div
@@ -21,7 +23,7 @@ export const AppSidebar: FC<AppSidebarProps> = ({
       )}
     >
       <SidebarBranding expanded={expanded} />
-      <SidebarNavigation expanded={expanded} />
+      <SidebarNavigation expanded={expanded} onNavigate={onNavigate} />
       <SidebarUserFooter
         expanded={expanded}
         onOpenShortcuts={onOpenShortcuts}

--- a/packages/browseros-agent/apps/app/components/sidebar/SidebarHistory.tsx
+++ b/packages/browseros-agent/apps/app/components/sidebar/SidebarHistory.tsx
@@ -81,7 +81,8 @@ export function SidebarHistory({
   return (
     <div>
       {/* Keep the trigger mounted while expanding; replacing it on focus can swallow the first click. */}
-      <Tooltip>
+      {/* Content is absent while expanded; close from the trigger rather than the content's hover region. */}
+      <Tooltip disableHoverableContent>
         <TooltipTrigger asChild>{trigger}</TooltipTrigger>
         {!expanded && <TooltipContent side="right">History</TooltipContent>}
       </Tooltip>

--- a/packages/browseros-agent/apps/app/components/sidebar/SidebarHistory.tsx
+++ b/packages/browseros-agent/apps/app/components/sidebar/SidebarHistory.tsx
@@ -1,0 +1,198 @@
+import { ChevronDown, History, Loader2, Search } from 'lucide-react'
+import { useEffect, useId, useState } from 'react'
+import { Link } from 'react-router'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { useActiveConversation } from '@/modules/conversations/active-conversation-context'
+import { useServerConversations } from '@/modules/conversations/conversations.hooks'
+import {
+  conversationTitle,
+  HISTORY_PAGE_SIZE,
+  historyList,
+  historyTimestamp,
+} from '@/modules/conversations/history-list'
+
+/** Compact navigation into SQLite history. It never queries the legacy cloud archive. */
+export function SidebarHistory({
+  expanded,
+  onNavigate,
+}: {
+  expanded: boolean
+  onNavigate?: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const [limit, setLimit] = useState(HISTORY_PAGE_SIZE)
+  const [now, setNow] = useState(() => new Date())
+  const { id: activeId } = useActiveConversation()
+  const contentId = useId()
+  const visible = open && expanded
+  // Poll only while visible: another tab or the side panel can finish a turn
+  // independently of this window's query cache.
+  const { data, isPending, isError, refetch } = useServerConversations(
+    visible,
+    5_000,
+  )
+  const { groups, hasMore, total } = historyList(data ?? [], search, limit, now)
+
+  useEffect(() => {
+    if (!visible) return
+    setNow(new Date())
+    const interval = setInterval(() => setNow(new Date()), 60_000)
+    return () => clearInterval(interval)
+  }, [visible])
+
+  const trigger = (
+    <button
+      type="button"
+      aria-label="History"
+      aria-expanded={visible}
+      aria-controls={contentId}
+      onClick={() => setOpen((value) => !value)}
+      className={cn(
+        'flex h-9 w-full items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        open && 'bg-[var(--accent-orange)]/10',
+      )}
+    >
+      <History className="size-4 shrink-0" />
+      <span
+        className={cn(
+          'flex-1 text-left transition-opacity duration-200',
+          !expanded && 'opacity-0',
+        )}
+      >
+        History
+      </span>
+      {expanded && (
+        <ChevronDown
+          className={cn(
+            'size-3.5 shrink-0 text-muted-foreground transition-transform',
+            !open && '-rotate-90',
+          )}
+        />
+      )}
+    </button>
+  )
+
+  return (
+    <div>
+      {/* Keep the trigger mounted while expanding; replacing it on focus can swallow the first click. */}
+      <Tooltip>
+        <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+        {!expanded && <TooltipContent side="right">History</TooltipContent>}
+      </Tooltip>
+      <div id={contentId} hidden={!visible}>
+        <div className="mx-3 my-3 space-y-2">
+          <label className="flex h-8 items-center gap-2 rounded-md border bg-background px-2 focus-within:ring-2 focus-within:ring-ring">
+            <Search className="size-3.5 shrink-0 text-muted-foreground" />
+            <input
+              type="search"
+              aria-label="Search conversations"
+              placeholder="Search conversations"
+              value={search}
+              onChange={(event) => {
+                setSearch(event.target.value)
+                setLimit(HISTORY_PAGE_SIZE)
+              }}
+              className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+            />
+          </label>
+          <section
+            className="styled-scrollbar max-h-[min(28rem,50dvh)] space-y-2 overflow-y-auto"
+            aria-label="Recent conversations"
+          >
+            {isPending && !isError && (
+              <p
+                role="status"
+                className="flex items-center gap-2 px-2 py-3 text-muted-foreground text-xs"
+              >
+                <Loader2 className="size-3.5 animate-spin" />
+                Loading conversations…
+              </p>
+            )}
+            {isError && (
+              <div
+                role="alert"
+                className="px-2 py-2 text-muted-foreground text-xs"
+              >
+                <p>Couldn’t load history.</p>
+                <button
+                  type="button"
+                  onClick={() => void refetch()}
+                  className="mt-1 underline underline-offset-2"
+                >
+                  Try again
+                </button>
+              </div>
+            )}
+            {!isPending && !isError && total === 0 && (
+              <p
+                role="status"
+                className="px-2 py-3 text-muted-foreground text-xs"
+              >
+                {search.trim()
+                  ? 'No conversations found.'
+                  : 'Your conversations will appear here.'}
+              </p>
+            )}
+            {groups.map((group) => (
+              <section key={group.label} aria-label={group.label}>
+                <h3 className="px-2 pt-2 pb-1 font-medium text-muted-foreground text-xs">
+                  {group.label}
+                </h3>
+                <ul className="space-y-1">
+                  {group.conversations.map((conversation) => {
+                    const title = conversationTitle(
+                      conversation.lastUserMessage,
+                    )
+                    return (
+                      <li key={conversation.id}>
+                        <Link
+                          to={`/home/chat?conversationId=${encodeURIComponent(conversation.id)}`}
+                          onClick={onNavigate}
+                          aria-current={
+                            activeId === conversation.id ? 'page' : undefined
+                          }
+                          title={title}
+                          className={cn(
+                            'flex h-10 min-w-0 flex-col justify-center rounded-md px-2 hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                            activeId === conversation.id && 'bg-sidebar-accent',
+                          )}
+                        >
+                          <span className="truncate text-[13px] leading-[19px]">
+                            {title}
+                          </span>
+                          <time
+                            dateTime={new Date(
+                              conversation.lastMessagedAt,
+                            ).toISOString()}
+                            className="text-muted-foreground text-xs leading-[18px]"
+                          >
+                            {historyTimestamp(conversation.lastMessagedAt, now)}
+                          </time>
+                        </Link>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </section>
+            ))}
+            {hasMore && (
+              <button
+                type="button"
+                onClick={() => setLimit((value) => value + HISTORY_PAGE_SIZE)}
+                className="w-full rounded-md px-2 py-2 text-left text-muted-foreground text-xs hover:bg-sidebar-accent"
+              >
+                Show older
+              </button>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/app/components/sidebar/SidebarNavigation.tsx
+++ b/packages/browseros-agent/apps/app/components/sidebar/SidebarNavigation.tsx
@@ -82,7 +82,8 @@ export const SidebarNavigation: FC<SidebarNavigationProps> = ({
 
             return (
               <div key={item.to}>
-                <Tooltip>
+                {/* Expansion unmounts the content, so the trigger must own closing on pointer leave. */}
+                <Tooltip disableHoverableContent>
                   <TooltipTrigger asChild>{navItem}</TooltipTrigger>
                   {!expanded && (
                     <TooltipContent side="right">{item.name}</TooltipContent>

--- a/packages/browseros-agent/apps/app/components/sidebar/SidebarNavigation.tsx
+++ b/packages/browseros-agent/apps/app/components/sidebar/SidebarNavigation.tsx
@@ -8,9 +8,11 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { SidebarHistory } from './SidebarHistory'
 
 export interface SidebarNavigationProps {
   expanded?: boolean
+  onNavigate?: () => void
 }
 
 type NavItem = {
@@ -44,6 +46,7 @@ function isNavItemActive(item: NavItem, pathname: string): boolean {
 
 export const SidebarNavigation: FC<SidebarNavigationProps> = ({
   expanded = true,
+  onNavigate,
 }) => {
   const location = useLocation()
 
@@ -58,6 +61,7 @@ export const SidebarNavigation: FC<SidebarNavigationProps> = ({
             const navItem = (
               <NavLink
                 to={item.to}
+                onClick={onNavigate}
                 className={cn(
                   'flex h-9 items-center gap-2 overflow-hidden whitespace-nowrap rounded-md px-3 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
                   isActive &&
@@ -76,16 +80,19 @@ export const SidebarNavigation: FC<SidebarNavigationProps> = ({
               </NavLink>
             )
 
-            if (!expanded) {
-              return (
-                <Tooltip key={item.to}>
+            return (
+              <div key={item.to}>
+                <Tooltip>
                   <TooltipTrigger asChild>{navItem}</TooltipTrigger>
-                  <TooltipContent side="right">{item.name}</TooltipContent>
+                  {!expanded && (
+                    <TooltipContent side="right">{item.name}</TooltipContent>
+                  )}
                 </Tooltip>
-              )
-            }
-
-            return <div key={item.to}>{navItem}</div>
+                {item.to === '/home' && (
+                  <SidebarHistory expanded={expanded} onNavigate={onNavigate} />
+                )}
+              </div>
+            )
           })}
         </nav>
       </div>

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session-restore.test.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session-restore.test.ts
@@ -1,7 +1,66 @@
 import { describe, expect, it, mock } from 'bun:test'
-import { restoreServerConversation } from './chat-session-restore'
+import {
+  resolveRestoredChatTarget,
+  restoreServerConversation,
+} from './chat-session-restore'
+import type { SidepanelChatTarget } from './sidepanel-chat-targets'
 
 describe('restoreServerConversation', () => {
+  it('waits for target selection before enabling a restored conversation', async () => {
+    const steps: string[] = []
+    await restoreServerConversation({
+      conversationId: 'c1',
+      fetchConversation: async () => ({ id: 'c1', messages: [] }),
+      isCancelled: () => false,
+      onRestore: async () => {
+        steps.push('select agent')
+        await Promise.resolve()
+        steps.push('install transcript')
+      },
+      onError: () => {},
+      onSettled: () => {
+        steps.push('enable composer')
+      },
+    })
+    expect(steps).toEqual([
+      'select agent',
+      'install transcript',
+      'enable composer',
+    ])
+  })
+
+  it('reports a missing row so the composer cannot send into an unrelated chat', async () => {
+    const onMissing = mock(() => {})
+    await restoreServerConversation({
+      conversationId: 'deleted',
+      fetchConversation: async () => null,
+      isCancelled: () => false,
+      onRestore: () => {
+        throw new Error('must not restore')
+      },
+      onMissing,
+      onError: () => {},
+      onSettled: () => {},
+    })
+    expect(onMissing).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not settle a view cancelled while selecting its target', async () => {
+    let cancelled = false
+    const onSettled = mock(() => {})
+    await restoreServerConversation({
+      conversationId: 'c1',
+      fetchConversation: async () => ({ id: 'c1', messages: [] }),
+      isCancelled: () => cancelled,
+      onRestore: async () => {
+        await Promise.resolve()
+        cancelled = true
+      },
+      onError: () => {},
+      onSettled,
+    })
+    expect(onSettled).not.toHaveBeenCalled()
+  })
   it('applies the restored conversation and settles', async () => {
     const onRestore = mock(() => {})
     const onError = mock(() => {})
@@ -94,5 +153,56 @@ describe('restoreServerConversation', () => {
 
     expect(onError).not.toHaveBeenCalled()
     expect(onSettled).not.toHaveBeenCalled()
+  })
+})
+
+describe('conversation target ownership', () => {
+  const llm = { kind: 'llm', id: 'openai' } as SidepanelChatTarget
+  const codex = {
+    kind: 'acp',
+    id: 'codex',
+    agentId: 'codex',
+    agentType: 'codex',
+  } as SidepanelChatTarget
+  const otherCodex = {
+    kind: 'acp',
+    id: 'other',
+    agentId: 'other',
+    agentType: 'codex',
+  } as SidepanelChatTarget
+  const targets = [llm, codex, otherCodex]
+  it('resumes the exact ACP agent even if another agent is selected', () => {
+    expect(
+      resolveRestoredChatTarget(
+        { id: 'c1', messages: [], targetType: 'codex', agentId: 'codex' },
+        targets,
+        otherCodex,
+      ),
+    ).toBe(codex)
+  })
+  it('never substitutes another agent for a removed one', () => {
+    expect(
+      resolveRestoredChatTarget(
+        { id: 'c1', messages: [], targetType: 'codex', agentId: 'removed' },
+        targets,
+        codex,
+      ),
+    ).toBeUndefined()
+  })
+  it('restores native history using an LLM instead of the currently selected ACP agent', () => {
+    expect(
+      resolveRestoredChatTarget(
+        { id: 'c1', messages: [], targetType: 'browseros' },
+        targets,
+        codex,
+      ),
+    ).toBe(llm)
+    expect(
+      resolveRestoredChatTarget(
+        { id: 'c1', messages: [], targetType: 'browseros' },
+        targets,
+        llm,
+      ),
+    ).toBe(llm)
   })
 })

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session-restore.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session-restore.ts
@@ -1,8 +1,12 @@
 import type { UIMessage } from 'ai'
+import type { ServerConversation } from '../conversations/conversations.hooks'
+import type { SidepanelChatTarget } from './sidepanel-chat-targets'
 
 export interface RestoredServerConversation {
   id: string
   messages: UIMessage[]
+  targetType?: ServerConversation['targetType']
+  agentId?: string
 }
 
 interface RestoreServerConversationOptions {
@@ -11,13 +15,14 @@ interface RestoreServerConversationOptions {
     conversationId: string,
   ) => Promise<RestoredServerConversation | null>
   isCancelled: () => boolean
-  onRestore: (conversation: RestoredServerConversation) => void
+  onRestore: (conversation: RestoredServerConversation) => void | Promise<void>
+  onMissing?: () => void
   onError: (error: unknown) => void
   onSettled: () => void
 }
 
 /**
- * Restore a logged-out conversation from the local server. Unlike the old
+ * Restore a conversation from the local server. Unlike the old
  * extension-storage read this hits the network, so it guards two failure modes:
  * a conversation switch mid-flight must not apply a stale response
  * (`isCancelled`), and any failure must still settle the UI (`finally`) so it
@@ -28,17 +33,38 @@ export async function restoreServerConversation({
   fetchConversation,
   isCancelled,
   onRestore,
+  onMissing,
   onError,
   onSettled,
 }: RestoreServerConversationOptions): Promise<void> {
   try {
     const conversation = await fetchConversation(conversationId)
     if (isCancelled()) return
-    if (conversation) onRestore(conversation)
+    if (conversation) await onRestore(conversation)
+    else onMissing?.()
   } catch (error) {
     if (isCancelled()) return
     onError(error)
   } finally {
     if (!isCancelled()) onSettled()
   }
+}
+
+/** ACP history belongs to its exact agent. Native chats can use any LLM provider. */
+export function resolveRestoredChatTarget(
+  conversation: RestoredServerConversation,
+  targets: SidepanelChatTarget[],
+  selected: SidepanelChatTarget | undefined,
+): SidepanelChatTarget | undefined {
+  if (conversation.targetType && conversation.targetType !== 'browseros') {
+    return targets.find(
+      (target) =>
+        target.kind === 'acp' &&
+        target.agentId === conversation.agentId &&
+        target.agentType === conversation.targetType,
+    )
+  }
+  return selected?.kind === 'llm'
+    ? selected
+    : targets.find((target) => target.kind === 'llm')
 }

--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -1,4 +1,5 @@
 import { useChat } from '@ai-sdk/react'
+import { useQueryClient } from '@tanstack/react-query'
 import { DefaultChatTransport, type FileUIPart, type UIMessage } from 'ai'
 import { compact } from 'es-toolkit/array'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -34,7 +35,10 @@ import { stopAgentStorage } from '@/lib/stop-agent/stop-agent-storage'
 import { selectedWorkspaceStorage } from '@/lib/workspace/workspace-storage'
 import { resolveAgentServerUrlWithRetry } from '@/modules/browseros/agent-server-url.helpers'
 import { useAgentServerUrl } from '@/modules/browseros/agent-server-url.hooks'
-import { fetchServerConversation } from '@/modules/conversations/conversations.hooks'
+import {
+  fetchServerConversation,
+  SERVER_CONVERSATIONS_QUERY_KEY,
+} from '@/modules/conversations/conversations.hooks'
 import { useInvalidateCredits } from '@/modules/credits/credits.hooks'
 import { useGraphqlQuery } from '@/modules/graphql/graphql-query.hooks'
 import { useChatRefs } from './chat-refs.hooks'
@@ -48,7 +52,10 @@ import {
   prepareSidepanelSendMessagesRequest,
   toProviderOption,
 } from './chat-session-request'
-import { restoreServerConversation } from './chat-session-restore'
+import {
+  resolveRestoredChatTarget,
+  restoreServerConversation,
+} from './chat-session-restore'
 import type { ChatMode } from './chat-types'
 import { addContentFilterNotice } from './content-filter-notice'
 import {
@@ -187,6 +194,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     isLoadingProviders,
   } = useChatRefs()
   const invalidateCredits = useInvalidateCredits()
+  const queryClient = useQueryClient()
 
   // Incognito chats are never written to history or the cloud (#1189). Resolved
   // from the hosting window on mount (chrome.extension.inIncognitoContext is
@@ -219,6 +227,14 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   const setSearchParamsRef = useRef(setSearchParams)
   setSearchParamsRef.current = setSearchParams
   const conversationIdParam = searchParams.get('conversationId')
+  const restoreLocally = options?.origin === 'newtab' || !isLoggedIn
+  const [restoreError, setRestoreError] = useState<string | null>(null)
+  const [restoreAttempt, setRestoreAttempt] = useState(0)
+  const [restoredConversationId, setRestoredConversationId] = useState<
+    string | null
+  >(null)
+  const isRestoringConversation =
+    !!conversationIdParam && restoredConversationId !== conversationIdParam
 
   // 'local': the local server owns history, persisting it to SQLite during
   // /chat. Every signed-in user now takes this path too, where the client used
@@ -237,7 +253,12 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     agentUrlRef.current = agentServerUrl
   }, [agentServerUrl])
 
-  const canSend = !isLoadingAgentUrl && !agentUrlError && !!agentServerUrl
+  const canSend =
+    !isLoadingAgentUrl &&
+    !agentUrlError &&
+    !!agentServerUrl &&
+    !isRestoringConversation &&
+    !restoreError
 
   const providers: Provider[] = chatTargets.map(toProviderOption)
 
@@ -512,6 +533,14 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     await streamRequestRef.current?.catch(() => undefined)
   }, [detachStream])
 
+  useEffect(() => {
+    if (options?.origin !== 'newtab') return
+    // Leaving a routed chat detaches its view; the server still owns the run.
+    return () => {
+      void detachView()
+    }
+  }, [detachView, options?.origin])
+
   const stop = useCallback(async () => {
     // First detach this view so the UI responds immediately, then cancel the
     // server-owned run explicitly. Aborting the fetch alone is intentionally
@@ -639,20 +668,18 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     GetConversationWithMessagesDocument,
     { conversationId: conversationIdParam ?? '' },
     {
-      enabled: !!conversationIdParam && isLoggedIn,
+      enabled: !!conversationIdParam && !restoreLocally,
     },
   )
 
-  const [restoredConversationId, setRestoredConversationId] = useState<
-    string | null
-  >(null)
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: restore should only run when query data arrives or conversationIdParam changes
+  // The URL is retained in new tabs for refresh/back navigation. Its keyed
+  // provider isolates each selection; sidepanel keeps its existing transient URL.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: target selection changes during restore; only restart for route/load/retry changes
   useEffect(() => {
     if (!conversationIdParam) return
     if (restoredConversationId === conversationIdParam) return
 
-    if (isLoggedIn) {
+    if (!restoreLocally) {
       if (!isRemoteConversationFetched) return
 
       if (remoteConversationData?.conversation) {
@@ -671,30 +698,73 @@ export const useChatSession = (options?: ChatSessionOptions) => {
       return
     }
 
+    if (isLoadingProviders || isLoadingAgentUrl) return
     let cancelled = false
+    setRestoreError(null)
     void restoreServerConversation({
       conversationId: conversationIdParam,
-      fetchConversation: fetchServerConversation,
-      isCancelled: () => cancelled,
-      onRestore: (conversation) => {
-        setConversationId(
-          conversation.id as ReturnType<typeof crypto.randomUUID>,
-        )
-        setMessages(conversation.messages)
+      fetchConversation: async (id) => {
+        await detachView()
+        return fetchServerConversation(id)
       },
-      onError: (error) =>
+      isCancelled: () => cancelled,
+      onRestore: async (conversation) => {
+        // Select before enabling the composer. ACP sessions are keyed by both
+        // conversation and agent, so a different agent would lose their context.
+        const target = resolveRestoredChatTarget(
+          conversation,
+          chatTargets,
+          selectedChatTargetRef.current,
+        )
+        if (
+          options?.origin === 'newtab' &&
+          target &&
+          (target.id !== selectedChatTargetRef.current?.id ||
+            target.kind !== selectedChatTargetRef.current?.kind)
+        ) {
+          await selectChatTarget(target)
+        }
+        if (cancelled) return
+        const id = conversation.id as ReturnType<typeof crypto.randomUUID>
+        conversationIdRef.current = id
+        messagesRef.current = conversation.messages
+        setConversationId(id)
+        setMessages(conversation.messages)
+        if (options?.origin === 'newtab' && !target)
+          setRestoreError(
+            'The agent used for this conversation is no longer available. Restore it in Settings to continue.',
+          )
+      },
+      onMissing: () => {
+        if (options?.origin === 'newtab')
+          setRestoreError(
+            'This conversation is no longer available. Choose another conversation or start a new one.',
+          )
+      },
+      onError: (error) => {
+        if (options?.origin === 'newtab')
+          setRestoreError('Couldn’t open this conversation. Please try again.')
         sentry.captureException(error, {
           extra: { conversationId: conversationIdParam },
-        }),
+        })
+      },
       onSettled: () => {
         setRestoredConversationId(conversationIdParam)
-        setSearchParams({}, { replace: true })
+        if (options?.origin !== 'newtab') setSearchParams({}, { replace: true })
       },
     })
     return () => {
       cancelled = true
     }
-  }, [conversationIdParam, remoteConversationData, isLoggedIn])
+  }, [
+    conversationIdParam,
+    remoteConversationData,
+    isRemoteConversationFetched,
+    restoreLocally,
+    isLoadingProviders,
+    isLoadingAgentUrl,
+    restoreAttempt,
+  ])
 
   // Keep messagesRef in sync on every change (cheap ref assignment)
   useEffect(() => {
@@ -732,6 +802,10 @@ export const useChatSession = (options?: ChatSessionOptions) => {
 
     // The local server persists every turn during /chat, so the client has no
     // history write of its own left. Incognito still writes nowhere (#1189).
+    if (persistHistory)
+      void queryClient.invalidateQueries({
+        queryKey: [SERVER_CONVERSATIONS_QUERY_KEY],
+      })
 
     invalidateCredits()
   }, [status])
@@ -833,6 +907,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     action?: ChatAction
     files?: FileUIPart[]
   }) => {
+    if (isRestoringConversation || restoreError) return
     if (!isIntegrationsSyncedRef.current || !agentUrlRef.current) {
       pendingMessageRef.current = params
       return
@@ -909,6 +984,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     setLiked({})
     setDisliked({})
     setRestoredConversationId(null)
+    setRestoreError(null)
     // Clearing the restore param also cancels any in-flight logged-out restore
     // (via the restore effect's cleanup), so a stale response can't revive the
     // old conversation over this new blank session.
@@ -966,9 +1042,6 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     resetConversationState()
   }
 
-  const isRestoringConversation =
-    !!conversationIdParam && restoredConversationId !== conversationIdParam
-
   return {
     mode,
     setMode,
@@ -983,6 +1056,11 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     isSyncing: !isIntegrationsSynced,
     isIncognito,
     isRestoringConversation,
+    restoreError,
+    retryRestoreConversation: () => {
+      setRestoredConversationId(null)
+      setRestoreAttempt((value) => value + 1)
+    },
     agentUrlError,
     chatError,
     retryLastTurn: () => runLocalRequest(() => regenerate()),

--- a/packages/browseros-agent/apps/app/modules/conversations/active-conversation-context.tsx
+++ b/packages/browseros-agent/apps/app/modules/conversations/active-conversation-context.tsx
@@ -1,0 +1,29 @@
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useState,
+} from 'react'
+
+/** The routed chat owns this identity; the surrounding navigation only displays it. */
+const ActiveConversationContext = createContext<{
+  id: string | null
+  setId: Dispatch<SetStateAction<string | null>>
+}>({ id: null, setId: () => {} })
+
+export const useActiveConversation = () => useContext(ActiveConversationContext)
+
+export function ActiveConversationProvider({
+  children,
+}: {
+  children: ReactNode
+}) {
+  const [id, setId] = useState<string | null>(null)
+  return (
+    <ActiveConversationContext.Provider value={{ id, setId }}>
+      {children}
+    </ActiveConversationContext.Provider>
+  )
+}

--- a/packages/browseros-agent/apps/app/modules/conversations/conversations.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/conversations.hooks.ts
@@ -14,6 +14,13 @@ export interface ServerConversationSummary {
   lastUserMessage: string
 }
 
+export interface ServerConversation {
+  id: string
+  messages: UIMessage[]
+  targetType: 'browseros' | 'claude' | 'codex' | 'custom'
+  agentId?: string
+}
+
 async function conversationsClient() {
   const baseUrl = await resolveAgentServerUrlWithRetry()
   return hc<ConversationRoutes>(`${baseUrl}/conversations`)
@@ -37,7 +44,7 @@ export async function fetchServerConversations(): Promise<
 
 export async function fetchServerConversation(
   conversationId: string,
-): Promise<{ id: string; messages: UIMessage[] } | null> {
+): Promise<ServerConversation | null> {
   const client = await conversationsClient()
   const response = await client[':conversationId'].$get({
     param: { conversationId },
@@ -55,7 +62,12 @@ export async function fetchServerConversation(
   // shape is UIMessage[] exactly as the server stored it, so assert it here at
   // the JSON boundary.
   const messages = data.conversation.messages as UIMessage[]
-  return { id: data.conversation.id, messages }
+  return {
+    id: data.conversation.id,
+    messages,
+    targetType: data.conversation.targetType,
+    agentId: data.conversation.agentId,
+  }
 }
 
 /** Deletes only the server row (tolerating 404); leaves execution history. */
@@ -78,12 +90,18 @@ export async function deleteServerConversation(
   await removeConversationExecutionHistory(conversationId)
 }
 
-export function useServerConversations(enabled = true) {
+export function useServerConversations(
+  enabled = true,
+  refetchInterval?: number,
+) {
   const { baseUrl, isLoading } = useAgentServerUrl()
   return useQuery({
     queryKey: [SERVER_CONVERSATIONS_QUERY_KEY, baseUrl],
     queryFn: fetchServerConversations,
-    enabled: Boolean(baseUrl) && !isLoading && enabled,
+    // Even if discovery failed, let the query report/retry that failure instead
+    // of leaving history in a permanently disabled "pending" state.
+    enabled: !isLoading && enabled,
+    refetchInterval,
   })
 }
 

--- a/packages/browseros-agent/apps/app/modules/conversations/history-list.test.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/history-list.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  conversationTitle,
+  historyDateGroup,
+  historyList,
+  historyTimestamp,
+} from './history-list'
+
+const now = new Date(2026, 8, 8, 12)
+const row = (id: string, date: Date, text = id) => ({
+  id,
+  lastMessagedAt: date.getTime(),
+  lastUserMessage: text,
+})
+
+describe('local history navigation', () => {
+  it('sorts recent first, caps the combined groups, and searches older rows before capping', () => {
+    const conversations = [
+      row('old', new Date(2026, 8, 1), 'Weekend trip'),
+      row('yesterday', new Date(2026, 8, 7, 20)),
+      row('today', new Date(2026, 8, 8, 11)),
+    ]
+    expect(historyList(conversations, '', 2, now)).toEqual({
+      groups: [
+        { label: 'Today', conversations: [conversations[2]] },
+        { label: 'Yesterday', conversations: [conversations[1]] },
+      ],
+      hasMore: true,
+      total: 3,
+    })
+    const result = historyList(conversations, ' WEEKEND ', 2, now)
+    expect(result.groups[0]).toEqual({
+      label: 'Earlier',
+      conversations: [conversations[0]],
+    })
+    expect(result.hasMore).toBe(false)
+    expect(conversations[0]?.id).toBe('old')
+  })
+
+  it('groups a message before midnight as yesterday, even a minute later', () => {
+    const midnight = new Date(2026, 8, 8, 0, 0)
+    expect(
+      historyDateGroup(new Date(2026, 8, 7, 23, 59).getTime(), midnight),
+    ).toBe('Yesterday')
+    expect(
+      historyDateGroup(new Date(2026, 8, 6, 23, 59).getTime(), midnight),
+    ).toBe('Earlier')
+  })
+
+  it('uses the previous calendar day across DST and year boundaries', () => {
+    const january = new Date(2027, 0, 1, 1)
+    expect(historyDateGroup(new Date(2026, 11, 31, 2).getTime(), january)).toBe(
+      'Yesterday',
+    )
+    const afterSpringChange = new Date(2026, 2, 9, 0, 10)
+    expect(
+      historyDateGroup(new Date(2026, 2, 8, 0, 1).getTime(), afterSpringChange),
+    ).toBe('Yesterday')
+  })
+
+  it('moves a continued conversation into Today without duplicating its id', () => {
+    const before = [
+      row('trip', new Date(2026, 8, 7)),
+      row('email', new Date(2026, 8, 8, 9)),
+    ]
+    const after = before.map((item) =>
+      item.id === 'trip' ? row('trip', now, 'Make it a three-day trip') : item,
+    )
+    const result = historyList(after, '', 6, now)
+    expect(result.groups).toHaveLength(1)
+    expect(result.groups[0]?.conversations.map((item) => item.id)).toEqual([
+      'trip',
+      'email',
+    ])
+    expect(result.groups[0]?.conversations[0]?.lastUserMessage).toBe(
+      'Make it a three-day trip',
+    )
+  })
+
+  it('handles untitled, empty and unmatched histories', () => {
+    expect(conversationTitle('  ')).toBe('Untitled conversation')
+    expect(historyList([], '', 6, now)).toEqual({
+      groups: [],
+      total: 0,
+      hasMore: false,
+    })
+    expect(historyList([row('1', now)], 'missing', 6, now).total).toBe(0)
+    expect(historyList([row('1', now, '')], 'untitled', 6, now).total).toBe(1)
+  })
+
+  it('formats recent timestamps without negative ages', () => {
+    expect(historyTimestamp(now.getTime() + 1000, now)).toBe('Just now')
+    expect(historyTimestamp(now.getTime() - 60_000, now)).toBe('1 minute ago')
+    expect(historyTimestamp(now.getTime() - 120_000, now)).toBe('2 minutes ago')
+    expect(historyTimestamp(now.getTime() - 3_600_000, now)).toBe('1 hour ago')
+  })
+})

--- a/packages/browseros-agent/apps/app/modules/conversations/history-list.ts
+++ b/packages/browseros-agent/apps/app/modules/conversations/history-list.ts
@@ -1,0 +1,75 @@
+import type { ServerConversationSummary } from './conversations.hooks'
+
+export const HISTORY_PAGE_SIZE = 6
+
+export function conversationTitle(lastUserMessage: string): string {
+  return lastUserMessage.trim() || 'Untitled conversation'
+}
+
+/** Group by local calendar days, not elapsed hours (which breaks at midnight/DST). */
+export function historyDateGroup(timestamp: number, now: Date): string {
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+  if (timestamp >= today.getTime()) return 'Today'
+  if (timestamp >= yesterday.getTime()) return 'Yesterday'
+  return 'Earlier'
+}
+
+export function historyTimestamp(timestamp: number, now: Date): string {
+  if (historyDateGroup(timestamp, now) === 'Today') {
+    const minutes = Math.max(
+      0,
+      Math.floor((now.getTime() - timestamp) / 60_000),
+    )
+    if (minutes < 1) return 'Just now'
+    if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+    const hours = Math.floor(minutes / 60)
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  }
+  return new Date(timestamp).toLocaleString(
+    undefined,
+    historyDateGroup(timestamp, now) === 'Yesterday'
+      ? { hour: 'numeric', minute: '2-digit' }
+      : {
+          month: 'short',
+          day: 'numeric',
+          ...(new Date(timestamp).getFullYear() !== now.getFullYear()
+            ? { year: 'numeric' as const }
+            : {}),
+        },
+  )
+}
+
+/** Search all locally stored summaries before limiting the visible rows. */
+export function historyList(
+  conversations: ServerConversationSummary[],
+  search: string,
+  limit: number,
+  now: Date,
+) {
+  const query = search.trim().toLocaleLowerCase()
+  const matching = conversations
+    .filter((item) =>
+      conversationTitle(item.lastUserMessage)
+        .toLocaleLowerCase()
+        .includes(query),
+    )
+    .sort(
+      (a, b) => b.lastMessagedAt - a.lastMessagedAt || a.id.localeCompare(b.id),
+    )
+  const groups: {
+    label: string
+    conversations: ServerConversationSummary[]
+  }[] = []
+  for (const conversation of matching.slice(0, limit)) {
+    const label = historyDateGroup(conversation.lastMessagedAt, now)
+    let group = groups.at(-1)
+    if (group?.label !== label) {
+      group = { label, conversations: [] }
+      groups.push(group)
+    }
+    group.conversations.push(conversation)
+  }
+  return { groups, hasMore: matching.length > limit, total: matching.length }
+}

--- a/packages/browseros-agent/apps/app/screens/newtab/index/NewTabChat.tsx
+++ b/packages/browseros-agent/apps/app/screens/newtab/index/NewTabChat.tsx
@@ -17,6 +17,8 @@ import {
 import { track } from '@/lib/metrics/track'
 import { consumePendingHomeMessage } from '@/modules/chat/pending-home-message'
 import { useChatActions } from '@/modules/chat-actions/chat-actions.hooks'
+import { useActiveConversation } from '@/modules/conversations/active-conversation-context'
+import { conversationTitle } from '@/modules/conversations/history-list'
 import { ChatEmptyState } from '@/screens/sidepanel/index/ChatEmptyState'
 import { ChatError } from '@/screens/sidepanel/index/ChatError'
 import { ChatFooter } from '@/screens/sidepanel/index/ChatFooter'
@@ -26,6 +28,7 @@ import { ChatMessages } from '@/screens/sidepanel/index/ChatMessages'
 export const NewTabChat: FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const hasSentInitialRef = useRef(false)
+  const { setId: setActiveConversationId } = useActiveConversation()
 
   const {
     mode,
@@ -42,6 +45,9 @@ export const NewTabChat: FC = () => {
     disliked,
     onClickDislike,
     isRestoringConversation,
+    restoreError,
+    retryRestoreConversation,
+    conversationId,
     providers,
     selectedProvider,
     handleSelectProvider,
@@ -68,11 +74,17 @@ export const NewTabChat: FC = () => {
     },
   })
 
+  useEffect(() => {
+    setActiveConversationId(isRestoringConversation ? null : conversationId)
+    return () => setActiveConversationId(null)
+  }, [conversationId, isRestoringConversation, setActiveConversationId])
+
   // Send the initial message from URL query params (from /home search bar).
   // Guarded by ref to prevent double-fire in React Strict Mode.
   // biome-ignore lint/correctness/useExhaustiveDependencies: must only run once on mount
   useEffect(() => {
     if (hasSentInitialRef.current) return
+    if (searchParams.has('conversationId')) return
     const pending = consumePendingHomeMessage(searchParams.get('handoff'))
     const query = pending?.text ?? searchParams.get('q') ?? ''
     const chatMode = searchParams.get('mode')
@@ -143,26 +155,60 @@ export const NewTabChat: FC = () => {
           <div className="flex flex-1 items-center justify-center">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
           </div>
-        ) : messages.length === 0 ? (
+        ) : messages.length === 0 && !restoreError ? (
           <ChatEmptyState
             mode={mode}
             mounted={mounted}
             onSuggestionClick={handleSuggestionClick}
           />
         ) : (
-          <ChatMessages
-            messages={messages}
-            status={status}
-            getActionForMessage={getActionForMessage}
-            liked={liked}
-            onClickLike={onClickLike}
-            disliked={disliked}
-            onClickDislike={onClickDislike}
-            showJtbdPopup={false}
-            showDontShowAgain={false}
-            onTakeSurvey={() => {}}
-            onDismissJtbdPopup={() => {}}
-          />
+          <>
+            {searchParams.has('conversationId') && messages.length > 0 && (
+              <h1 className="mb-2 line-clamp-2 font-semibold text-lg">
+                {conversationTitle(
+                  messages
+                    .findLast((message) => message.role === 'user')
+                    ?.parts.filter((part) => part.type === 'text')
+                    .map((part) => part.text)
+                    .join(' ') ?? '',
+                )}
+              </h1>
+            )}
+            <ChatMessages
+              messages={messages}
+              status={status}
+              getActionForMessage={getActionForMessage}
+              liked={liked}
+              onClickLike={onClickLike}
+              disliked={disliked}
+              onClickDislike={onClickDislike}
+              showJtbdPopup={false}
+              showDontShowAgain={false}
+              onTakeSurvey={() => {}}
+              onDismissJtbdPopup={() => {}}
+            />
+          </>
+        )}
+        {restoreError && (
+          <div role="alert" className="rounded-lg border p-4 text-sm">
+            <p>{restoreError}</p>
+            <div className="mt-3 flex gap-4">
+              <button
+                type="button"
+                onClick={retryRestoreConversation}
+                className="underline underline-offset-2"
+              >
+                Try again
+              </button>
+              <button
+                type="button"
+                onClick={handleNewConversation}
+                className="underline underline-offset-2"
+              >
+                New conversation
+              </button>
+            </div>
+          </div>
         )}
         {agentUrlError && (
           <ChatError

--- a/packages/browseros-agent/apps/app/screens/newtab/layout/NewTabLayout.tsx
+++ b/packages/browseros-agent/apps/app/screens/newtab/layout/NewTabLayout.tsx
@@ -17,5 +17,14 @@ export const NewTabLayout: FC = () => {
 
   if (!useChatSession) return content
 
-  return <ChatSessionProvider origin="newtab">{content}</ChatSessionProvider>
+  // Each history selection gets its own SDK session and composer. A late
+  // stream or restore from the previous selection cannot replace this view.
+  const conversationId = new URLSearchParams(location.search).get(
+    'conversationId',
+  )
+  return (
+    <ChatSessionProvider key={conversationId ?? 'new'} origin="newtab">
+      {content}
+    </ChatSessionProvider>
+  )
 }


### PR DESCRIPTION
Add a collapsible History section beneath Home so users can reopen local conversations from the new-tab page. It shows six recent SQLite conversations grouped by date, with search, Show older, active selection, and loading/empty/error states.

Selecting a conversation restores it in the new tab and retains its URL for refresh and back navigation. Each selection owns isolated chat state, restoring selects the saved ACP agent, and unavailable agents leave a readable transcript. History refreshes after completed turns and while visible. Also fixes sidebar tooltips remaining visible after navigation expands.

Validation: 433 app tests passed, app TypeScript passed, and Biome passed for all 13 changed files after merging current main. Browser checks covered selection, rapid switching, local-only restore for signed-in users, missing conversations/agents, retry, mobile layout, and dark mode. A real local server with isolated SQLite and a deterministic model verified a resumed conversation received prior context and saved the follow-up under the same ID.

This PR contains the history UI and client restoration changes. ACP runtime session recovery and assistant message persistence fixes are maintained separately on `fix/agent-history-resume`.
