### PR TITLE
fix: preserve ACP message boundaries in provider 1.0.0

### DIFF
--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -321,7 +321,7 @@
     },
     "packages/acpx-ai-provider": {
       "name": "@browseros/acpx-ai-provider",
-      "version": "0.0.6",
+      "version": "1.0.0",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.0",
         "@ai-sdk/provider-utils": "^5.0.0",

--- a/packages/browseros-agent/packages/acpx-ai-provider/PROVENANCE.md
+++ b/packages/browseros-agent/packages/acpx-ai-provider/PROVENANCE.md
@@ -14,7 +14,7 @@ BrowserOS wants to edit the provider in place without a round-trip through npm p
 
 ## Current compatibility and upstream review
 
-The original snapshot targeted AI SDK v6. BrowserOS has since migrated this fork to AI SDK v7 (`@ai-sdk/provider ^4`, `@ai-sdk/provider-utils ^5`) and incorporated upstream changes. The workspace version still records `0.0.6`; it does not describe the current code's compatibility or upstream coverage.
+The original snapshot targeted AI SDK v6. BrowserOS has since migrated this fork to AI SDK v7 (`@ai-sdk/provider ^4`, `@ai-sdk/provider-utils ^5`) and incorporated upstream changes. The workspace package is now version `1.0.0`; the snapshot version above records its original provenance.
 
 Reviewed against upstream `main` at `1afa195fd576ff4d8af7859c5af8e2d672639ef5` on 2026-09-08; the latest published provider was `1.0.0`. Live usage events, available-command subscriptions, slash-command event routing, defensive-copy getters, tool-input ID correlation, and the explicit event-emitter type were already present locally. Ported the remaining selected-agent compaction lookup fix from upstream commit `0390bb75183bce4a51a13932475c20ea52aada53` (#80).
 

--- a/packages/browseros-agent/packages/acpx-ai-provider/PROVENANCE.md
+++ b/packages/browseros-agent/packages/acpx-ai-provider/PROVENANCE.md
@@ -12,13 +12,19 @@ Inlined snapshot of `acpx-ai-provider` from https://github.com/DaniAkash/agent-t
 
 BrowserOS wants to edit the provider in place without a round-trip through npm publish. The upstream package continues to exist and may keep publishing separately; this copy is a hard fork with no automatic upstream sync.
 
-## Version pin (v6, not v7)
+## Current compatibility and upstream review
 
-Upstream `main` has since migrated to the AI SDK v7 beta line under the same `0.0.6` label (it demands `ai >=7.0.0-beta.0`, `@ai-sdk/provider@4-beta`, `@ai-sdk/provider-utils@5-beta`). BrowserOS runs `ai@6`, so this snapshot is deliberately taken at the `acpx-ai-provider-v0.0.6` tag, which is the last v6-compatible source and matches the published `acpx-ai-provider@0.0.6` dist that BrowserOS previously depended on. Do not refresh from `main` without also migrating BrowserOS to AI SDK v7.
+The original snapshot targeted AI SDK v6. BrowserOS has since migrated this fork to AI SDK v7 (`@ai-sdk/provider ^4`, `@ai-sdk/provider-utils ^5`) and incorporated upstream changes. The workspace version still records `0.0.6`; it does not describe the current code's compatibility or upstream coverage.
+
+Reviewed against upstream `main` at `1afa195fd576ff4d8af7859c5af8e2d672639ef5` on 2026-09-08; the latest published provider was `1.0.0`. Live usage events, available-command subscriptions, slash-command event routing, defensive-copy getters, tool-input ID correlation, and the explicit event-emitter type were already present locally. Ported the remaining selected-agent compaction lookup fix from upstream commit `0390bb75183bce4a51a13932475c20ea52aada53` (#80).
+
+Upstream's event translator still groups only by text/reasoning stream at that revision. The message-boundary handling described below is a BrowserOS fix.
+
+Also synchronized five stale usage-test expectations with upstream: `size` is exposed as `providerMetadata.acpx.contextWindow`, not as cached input tokens. The implementation already followed this contract.
 
 ## Divergence policy
 
-Edits to this directory are made freely. There is no obligation to sync back to upstream. If upstream ships a v6-compatible bugfix worth pulling, apply it as an ordinary PR touching just this directory and update the upstream-commit SHA above so the divergence point stays discoverable.
+Edits to this directory are made freely. There is no obligation to sync back to upstream. Apply compatible upstream fixes as ordinary changes to this directory and record their revisions here. Preserve the original snapshot revision above and review local adaptations before replacing source wholesale.
 
 ## Third-party source
 
@@ -29,3 +35,6 @@ None incorporated. This is a clean-room provider built on the acpx runtime; its 
 - Stripped explicit `.ts` extensions from internal relative imports across `src/` and `test/` (`from './x.ts'` becomes `from './x'`). Required because the consuming `apps/server` typechecks under `moduleResolution: bundler` without `allowImportingTsExtensions`, and it deep-checks the imported source; explicit `.ts` specifiers would trip TS5097. Matches the extensionless-import convention already used by the sibling `agent-mcp-manager` package.
 - Verified clean against the repo's Biome config; `biome check` reports no changes (no reformatting was needed).
 - Not vendored: `test/e2e/` (spawns real Claude/Codex/Gemini agents) and `bunup.config.ts` (no build step here; the package exports raw TS source).
+- AI SDK v7 file-data normalization and inline text/JSON attachments; these are not present in the upstream source reviewed above.
+- Optional persistent-state deletion on `close()` and structured argv in agent-registry overrides.
+- ACP `messageId` boundaries produce separate AI SDK text/reasoning blocks. Missing IDs continue the current block; a newly identified message separates preceding untagged text. Text is preserved verbatim, and generated block IDs avoid collisions across tools and text/reasoning transitions.

--- a/packages/browseros-agent/packages/acpx-ai-provider/README.md
+++ b/packages/browseros-agent/packages/acpx-ai-provider/README.md
@@ -10,13 +10,10 @@
 > [PROVENANCE.md](./PROVENANCE.md) for the pinned upstream revision and local
 > adaptations.
 
-> [!WARNING]
-> **Alpha software.** Both this package and its underlying runtime
-> ([`acpx`](https://www.npmjs.com/package/acpx)) are pre-1.0. Public
-> APIs may change in any minor release. Pin a version in production
-> and read the [Known limitations](#known-limitations) section before
-> picking it up — most of the rough edges flow through from
-> `acpx/runtime`, which is itself still stabilizing its event shape.
+> This workspace package is version **1.0.0** and supports AI SDK v7.
+> Its underlying [`acpx`](https://www.npmjs.com/package/acpx) runtime is
+> still pre-1.0; see [Known limitations](#known-limitations) for the
+> integration's current constraints.
 
 ## Why
 
@@ -43,7 +40,7 @@ spawn config.
   "dependencies": {
     "@browseros/acpx-ai-provider": "workspace:*",
     "acpx": "^0.13.0",
-    "ai": "6.0.230"
+    "ai": "^7.0.0"
   }
 }
 ```

--- a/packages/browseros-agent/packages/acpx-ai-provider/package.json
+++ b/packages/browseros-agent/packages/acpx-ai-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/acpx-ai-provider",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "description": "Vercel AI SDK provider on top of the acpx ACP runtime. Inlined snapshot of acpx-ai-provider from DaniAkash/agent-toolkit.",
   "license": "MIT",
   "author": "Dani Akash",

--- a/packages/browseros-agent/packages/acpx-ai-provider/src/convert-events.ts
+++ b/packages/browseros-agent/packages/acpx-ai-provider/src/convert-events.ts
@@ -82,6 +82,7 @@ export class EventTranslator {
   ) => void
   private currentBlock: BlockKind = null
   private currentBlockId: string | null = null
+  private currentMessageId: string | null = null
   private readonly toolCalls = new Map<string, ToolCallState>()
   private lastUsageEvent: UsageUpdateEvent | undefined
 
@@ -175,7 +176,14 @@ export class EventTranslator {
     const target: TextStream = event.stream === 'thought' ? 'thought' : 'output'
     const parts: LanguageModelV2StreamPart[] = []
 
-    if (this.currentBlock !== target) {
+    // ACP chunks are token fragments, so only a new message ID or stream
+    // starts a separate AI SDK block. Missing IDs continue the current block;
+    // the first identified message also separates any preceding untagged text.
+    // Keep generated block IDs: one ACP message can contain both text and
+    // reasoning, or resume its text after a tool call.
+    const messageChanged =
+      event.messageId && event.messageId !== this.currentMessageId
+    if (this.currentBlock !== target || messageChanged) {
       parts.push(...this.closeCurrentBlock())
       const id = this.generateId()
       parts.push({
@@ -184,6 +192,7 @@ export class EventTranslator {
       })
       this.currentBlock = target
       this.currentBlockId = id
+      this.currentMessageId = event.messageId ?? null
     }
 
     if (event.text.length > 0 && this.currentBlockId) {
@@ -205,6 +214,7 @@ export class EventTranslator {
     }
     this.currentBlock = null
     this.currentBlockId = null
+    this.currentMessageId = null
     return [part]
   }
 

--- a/packages/browseros-agent/packages/acpx-ai-provider/src/provider.ts
+++ b/packages/browseros-agent/packages/acpx-ai-provider/src/provider.ts
@@ -292,7 +292,10 @@ export class AcpxProvider {
   async compact(
     opts: { sessionKey?: string; agent?: string } = {},
   ): Promise<void> {
-    const sessionKey = this.resolveSessionKey({ sessionKey: opts.sessionKey })
+    const sessionKey = this.resolveSessionKey({
+      sessionKey: opts.sessionKey,
+      agent: opts.agent,
+    })
     const cmds = this.lastCommands.get(sessionKey) ?? []
     const cmd = cmds.find((c) => {
       const stripped = c.name.replace(/^\//, '').toLowerCase()

--- a/packages/browseros-agent/packages/acpx-ai-provider/test/integration/compact-session.test.ts
+++ b/packages/browseros-agent/packages/acpx-ai-provider/test/integration/compact-session.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'bun:test'
+import { createAcpxProvider } from '../../src/index'
+import { MockAcpRuntime } from '../helpers/mock-acp-runtime'
+
+test('compact uses the selected agent for command lookup and execution', async () => {
+  const runtime = new MockAcpRuntime({
+    turnScripts: [
+      {
+        events: [
+          {
+            type: 'status',
+            text: '',
+            tag: 'available_commands_update',
+            availableCommands: [
+              {
+                name: '/condense',
+                description: 'Compact context',
+                hasInput: false,
+              },
+            ],
+          },
+        ],
+        result: { status: 'completed', stopReason: 'end_turn' },
+      },
+      { events: [], result: { status: 'completed', stopReason: 'end_turn' } },
+    ],
+  })
+  // Leave sessionKey unspecified so the provider derives it from the agent.
+  // An explicit key would hide a lookup accidentally using the default agent.
+  const provider = createAcpxProvider({
+    agent: 'claude',
+    cwd: '/tmp/test',
+    runtime,
+  })
+  await provider.languageModel(undefined, { agent: 'codex' }).doGenerate({
+    prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+  })
+
+  await provider.compact({ agent: 'codex' })
+
+  expect(runtime.startTurnCalls.at(-1)?.text).toBe('/condense')
+  expect(runtime.startTurnCalls.at(-1)?.handle).toEqual(
+    runtime.startTurnCalls[0]?.handle,
+  )
+  expect(runtime.ensureSessionCalls).toHaveLength(1)
+  expect(runtime.ensureSessionCalls[0]?.agent).toBe('codex')
+  await provider.close()
+})

--- a/packages/browseros-agent/packages/acpx-ai-provider/test/integration/do-generate.test.ts
+++ b/packages/browseros-agent/packages/acpx-ai-provider/test/integration/do-generate.test.ts
@@ -94,7 +94,10 @@ describe('doGenerate', () => {
     const result = await provider.languageModel().doGenerate(baseCall)
     expect(result.usage).toMatchObject({
       totalTokens: 50,
-      cachedInputTokens: 1024,
+      cachedInputTokens: undefined,
+    })
+    expect(result.providerMetadata?.acpx).toMatchObject({
+      contextWindow: 1024,
     })
   })
 

--- a/packages/browseros-agent/packages/acpx-ai-provider/test/integration/do-stream.test.ts
+++ b/packages/browseros-agent/packages/acpx-ai-provider/test/integration/do-stream.test.ts
@@ -194,7 +194,10 @@ describe('doStream — usage and finish', () => {
         inputTokens: undefined,
         outputTokens: undefined,
         totalTokens: 123,
-        cachedInputTokens: 4096,
+        cachedInputTokens: undefined,
+      },
+      providerMetadata: {
+        acpx: { contextWindow: 4096 },
       },
     })
   })

--- a/packages/browseros-agent/packages/acpx-ai-provider/test/integration/message-boundaries.test.ts
+++ b/packages/browseros-agent/packages/acpx-ai-provider/test/integration/message-boundaries.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test'
+import type { AcpRuntimeEvent } from 'acpx/runtime'
+import { readUIMessageStream, streamText } from 'ai'
+import { createAcpxProvider } from '../../src/index'
+import { MockAcpRuntime } from '../helpers/mock-acp-runtime'
+
+type Content = { type: 'text' | 'reasoning'; text: string }
+
+const text = (
+  value: string,
+  messageId?: string,
+  stream: 'output' | 'thought' = 'output',
+): AcpRuntimeEvent => ({ type: 'text_delta', text: value, messageId, stream })
+
+const cases: {
+  name: string
+  events: AcpRuntimeEvent[]
+  expected: Content[]
+}[] = [
+  {
+    name: 'same-message chunks preserve tokens and existing newlines',
+    events: [text('Hel', 'a'), text('lo\n\nworld', 'a')],
+    expected: [{ type: 'text', text: 'Hello\n\nworld' }],
+  },
+  {
+    name: 'different messages become separate text parts',
+    events: [text('First.', 'a'), text('Sec', 'b'), text('ond.', 'b')],
+    expected: [
+      { type: 'text', text: 'First.' },
+      { type: 'text', text: 'Second.' },
+    ],
+  },
+  {
+    name: 'an identified reply starts after an unidentified notice',
+    events: [text('Adapter notice.'), text('The answer.', 'a')],
+    expected: [
+      { type: 'text', text: 'Adapter notice.' },
+      { type: 'text', text: 'The answer.' },
+    ],
+  },
+  {
+    name: 'agents without message IDs keep streaming into one part',
+    events: [text('Hel'), text('lo')],
+    expected: [{ type: 'text', text: 'Hello' }],
+  },
+  {
+    name: 'missing IDs do not erase the current message identity',
+    events: [
+      text('First', 'a'),
+      text(' continued'),
+      text('.', 'a'),
+      text('Second.', 'b'),
+    ],
+    expected: [
+      { type: 'text', text: 'First continued.' },
+      { type: 'text', text: 'Second.' },
+    ],
+  },
+  {
+    name: 'empty chunks can identify a new message before its text',
+    events: [text('First.', 'a'), text('', 'b'), text('Second.')],
+    expected: [
+      { type: 'text', text: 'First.' },
+      { type: 'text', text: 'Second.' },
+    ],
+  },
+  {
+    name: 'reasoning respects message boundaries too',
+    events: [
+      text('First plan.', 'a', 'thought'),
+      text('New plan.', 'b', 'thought'),
+    ],
+    expected: [
+      { type: 'reasoning', text: 'First plan.' },
+      { type: 'reasoning', text: 'New plan.' },
+    ],
+  },
+  {
+    name: 'stream changes still separate content within one message',
+    events: [
+      text('Before', 'a'),
+      text('Think', 'a', 'thought'),
+      text('After', 'a'),
+    ],
+    expected: [
+      { type: 'text', text: 'Before' },
+      { type: 'reasoning', text: 'Think' },
+      { type: 'text', text: 'After' },
+    ],
+  },
+]
+
+function providerFor(events: AcpRuntimeEvent[]) {
+  return createAcpxProvider({
+    agent: 'claude',
+    runtime: new MockAcpRuntime({
+      turnScripts: [
+        { events, result: { status: 'completed', stopReason: 'end_turn' } },
+      ],
+    }),
+  })
+}
+
+describe('ACP message boundaries', () => {
+  // Exercise the AI SDK conversion as well as the provider: these UI parts
+  // are what BrowserOS persists and renders as separate Markdown blocks.
+  test.each(cases)('UI stream: $name', async ({ events, expected }) => {
+    const provider = providerFor(events)
+    const result = streamText({ model: provider.languageModel(), prompt: 'hi' })
+    let content: Content[] = []
+    for await (const message of readUIMessageStream({
+      stream: result.toUIMessageStream(),
+    })) {
+      content = message.parts.flatMap((part) =>
+        part.type === 'text' || part.type === 'reasoning'
+          ? [{ type: part.type, text: part.text }]
+          : [],
+      )
+    }
+    expect(content).toEqual(expected)
+    await provider.close()
+  })
+
+  test.each(cases)('doGenerate: $name', async ({ events, expected }) => {
+    const provider = providerFor(events)
+    const result = await provider.languageModel().doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    })
+    expect(result.content).toEqual(expected)
+    await provider.close()
+  })
+})

--- a/packages/browseros-agent/packages/acpx-ai-provider/test/integration/with-generate-text.test.ts
+++ b/packages/browseros-agent/packages/acpx-ai-provider/test/integration/with-generate-text.test.ts
@@ -26,7 +26,7 @@ describe('generateText — text-only', () => {
     expect(finishReason).toBe('stop')
   })
 
-  test('exposes accumulated cachedInputTokens from a usage_update', async () => {
+  test('reports contextWindow metadata from a usage_update', async () => {
     const runtime = new MockAcpRuntime({
       turnScripts: [
         {
@@ -37,12 +37,13 @@ describe('generateText — text-only', () => {
     })
     const provider = createAcpxProvider({ agent: 'claude', runtime })
 
-    const { usage } = await generateText({
+    const { usage, providerMetadata } = await generateText({
       model: provider.languageModel(),
       prompt: 'hi',
       stopWhen: stepCountIs(1),
     })
-    expect(usage.inputTokenDetails?.cacheReadTokens).toBe(1024)
+    expect(usage.inputTokenDetails?.cacheReadTokens).toBeUndefined()
+    expect(providerMetadata?.acpx?.contextWindow).toBe(1024)
   })
 
   test('reasoning content is preserved alongside text', async () => {

--- a/packages/browseros-agent/packages/acpx-ai-provider/test/integration/with-stream-text.test.ts
+++ b/packages/browseros-agent/packages/acpx-ai-provider/test/integration/with-stream-text.test.ts
@@ -43,7 +43,7 @@ describe('streamText — text-only turn', () => {
     expect(await result.finishReason).toBe('stop')
   })
 
-  test('usage resolves with cachedInputTokens from the size field', async () => {
+  test('reports contextWindow metadata from the size field', async () => {
     const runtime = new MockAcpRuntime({
       turnScripts: [
         {
@@ -60,7 +60,9 @@ describe('streamText — text-only turn', () => {
       stopWhen: stepCountIs(1),
     })
     const usage = await result.usage
-    expect(usage.inputTokenDetails?.cacheReadTokens).toBe(4096)
+    expect(usage.inputTokenDetails?.cacheReadTokens).toBeUndefined()
+    const metadata = await result.providerMetadata
+    expect(metadata?.acpx?.contextWindow).toBe(4096)
   })
 
   test('textStream yields the same content', async () => {

--- a/packages/browseros-agent/packages/acpx-ai-provider/test/unit/convert-events.test.ts
+++ b/packages/browseros-agent/packages/acpx-ai-provider/test/unit/convert-events.test.ts
@@ -362,7 +362,7 @@ describe('tool_call — completed and failed', () => {
 })
 
 describe('status — usage_update', () => {
-  test('captures used and size for a later finish() call', () => {
+  test('reports size as the context window, separately from token usage', () => {
     const t = newTranslator()
     const parts = feed(t, [
       status({ tag: 'usage_update', used: 100, size: 4096 }),
@@ -377,7 +377,10 @@ describe('status — usage_update', () => {
         inputTokens: undefined,
         outputTokens: undefined,
         totalTokens: 100,
-        cachedInputTokens: 4096,
+        cachedInputTokens: undefined,
+      },
+      providerMetadata: {
+        acpx: { contextWindow: 4096 },
       },
     })
   })


### PR DESCRIPTION
Consecutive ACP messages were appended to one Markdown block, joining adapter notices directly to assistant replies. Preserve ACP message IDs as AI SDK text/reasoning block boundaries; chunks within a message retain their original text. An identified reply starts a new block after an untagged notice, and agents without IDs retain their existing streaming behavior.

Bump `@browseros/acpx-ai-provider` to `1.0.0`, including the workspace lockfile and compatibility notes. Port upstream's selected-agent `/compact` lookup fix and synchronize five stale usage-test expectations with the existing context-window metadata behavior. The upstream source comparison and BrowserOS-specific adaptations are recorded in `PROVENANCE.md`.

Validation:

- 231 provider tests and 37 server ACP tests pass after merging current `main`.
- Provider and server typechecks, repository lint, and a frozen-lockfile install pass.
- Live unpatched Claude Haiku verification confirms the resumed Auto warning and reply are separate streamed and persisted text parts.
