### PR TITLE
fix(build): disable Chromium test field trials in Windows releases

### DIFF
--- a/packages/browseros/bos_build/config/gn/flags.windows.release.gn
+++ b/packages/browseros/bos_build/config/gn/flags.windows.release.gn
@@ -4,6 +4,8 @@ use_siso=false
 is_debug = false
 is_component_build = false
 is_official_build = true
+# Non-Chrome branded builds otherwise enable Chromium's test-only experiments.
+disable_fieldtrial_testing_config = true
 symbol_level = 0
 is_clang=true
 chrome_pgo_phase = 0

--- a/packages/browseros/bos_build/steps/setup/configure_test.py
+++ b/packages/browseros/bos_build/steps/setup/configure_test.py
@@ -53,6 +53,18 @@ class ConfigureValidateTest(unittest.TestCase):
 
 
 class ConfigureExecuteTest(unittest.TestCase):
+    def test_release_presets_exclude_chromium_testing_experiments(self):
+        presets = Path(configure.__file__).resolve().parents[2] / "config" / "gn"
+        for platform in ("windows", "macos", "linux"):
+            with self.subTest(platform=platform):
+                flags = (presets / f"flags.{platform}.release.gn").read_text()
+                ctx, chromium, _ = self._execute("release", flags=flags)
+                args_gn = (chromium.src / ctx.out_dir / "args.gn").read_text()
+                self.assertRegex(
+                    args_gn,
+                    r"(?m)^\s*disable_fieldtrial_testing_config\s*=\s*true\s*$",
+                )
+
     def _execute(
         self,
         build_type: str,


### PR DESCRIPTION
## Problem

Related to #2408. cc @shadowfax92

The Windows release preset omits `disable_fieldtrial_testing_config = true`, although the Windows debug, macOS release, and Linux release presets already set it. For non-Google-Chrome-branded builds, `is_official_build = true` does not prevent Chromium's field-trial testing configuration from being applied.

At the pinned Chromium base `8f5d36bc16f57115aeeff34baf4ad6aa964d509c`, that testing configuration enables `BrowserDynamicCodeDisabled` on Windows. The browser enables ACG before TSF activation. On the affected Windows 10 machine, Sogou's in-process initialization uses Xbyak, throws `Xbyak::Error` 14 (`ERR_CANT_PROTECT`), and calls `ExitProcess(3)`. The live policy at the exception was `BlockDynamicCode=ON`, `AllowThreadsToOptOut=ON`. This explains why reinstalling did not resolve the observed failure and why `--no-sandbox` was an unnecessarily broad workaround.

## Change

Disable test-only field trials in Windows release builds, matching the other release presets. Add a regression test that runs release presets through the GN-argument generation path and checks this invariant in the generated `args.gn`. Explicit custom GN overrides remain supported.

This restores production feature defaults; it does not disable Chromium's sandbox or override enterprise dynamic-code policy. A separate experimental TSF thread-opt-out patch is not included.

## Validation

- The new test failed for Windows before the preset change; all 13 `bos_build.steps.setup.configure_test` tests pass afterward.
- On the affected machine, official BrowserOS 0.50.3 launched and restarted successfully with the equivalent `--disable-field-trial-config` switch. Both `SogouTSF.ime` and `SogouPY.ime` were loaded, Sogou remained enabled in Windows, and no `--no-sandbox` switch was used.
- A separate native TSF/ACG probe reproduced exit 3 with the installed Sogou provider, supporting the diagnosis.
- `git diff --check` passes.

A full Chromium rebuild, a newly packaged neo binary, and Chinese composition/candidate-window regression tests have not been run. The runtime-switch result validates the configuration diagnosis, not a newly built installer. Please validate the next Windows build against #2408 before considering the issue fully resolved.

## CLA

I have read the CLA Document and I hereby sign the CLA
