### PR TITLE
feat: gate new-tab chat history behind alpha capability

### DIFF
--- a/packages/browseros-agent/apps/app/components/sidebar/SidebarNavigation.tsx
+++ b/packages/browseros-agent/apps/app/components/sidebar/SidebarNavigation.tsx
@@ -7,7 +7,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { Feature } from '@/lib/browseros/capabilities'
 import { cn } from '@/lib/utils'
+import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
 import { SidebarHistory } from './SidebarHistory'
 
 export interface SidebarNavigationProps {
@@ -49,6 +51,8 @@ export const SidebarNavigation: FC<SidebarNavigationProps> = ({
   onNavigate,
 }) => {
   const location = useLocation()
+  const { supports } = useCapabilities()
+  const showHistory = supports(Feature.NEWTAB_CHAT_HISTORY_SUPPORT)
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -89,7 +93,8 @@ export const SidebarNavigation: FC<SidebarNavigationProps> = ({
                     <TooltipContent side="right">{item.name}</TooltipContent>
                   )}
                 </Tooltip>
-                {item.to === '/home' && (
+                {/* Gate the mount so non-alpha navigation never starts history queries. */}
+                {item.to === '/home' && showHistory && (
                   <SidebarHistory expanded={expanded} onNavigate={onNavigate} />
                 )}
               </div>

--- a/packages/browseros-agent/apps/app/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/capabilities.ts
@@ -18,6 +18,7 @@ type FeatureConfig = {
 export enum Feature {
   ALPHA_FEATURES_SUPPORT = 'ALPHA_FEATURES_SUPPORT',
   NEWTAB_CHAT_SUPPORT = 'NEWTAB_CHAT_SUPPORT',
+  NEWTAB_CHAT_HISTORY_SUPPORT = 'NEWTAB_CHAT_HISTORY_SUPPORT',
   VERTICAL_TABS_SUPPORT = 'VERTICAL_TABS_SUPPORT',
   CHATGPT_PRO_SUPPORT = 'CHATGPT_PRO_SUPPORT',
   GITHUB_COPILOT_SUPPORT = 'GITHUB_COPILOT_SUPPORT',
@@ -29,6 +30,7 @@ export enum Feature {
 const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.ALPHA_FEATURES_SUPPORT]: { requiresAlphaFlag: true },
   [Feature.NEWTAB_CHAT_SUPPORT]: { minBrowserOSVersion: '0.40.0.0' },
+  [Feature.NEWTAB_CHAT_HISTORY_SUPPORT]: { requiresAlphaFlag: true },
   [Feature.VERTICAL_TABS_SUPPORT]: { minBrowserOSVersion: '0.42.0.0' },
   [Feature.CHATGPT_PRO_SUPPORT]: { minServerVersion: '0.0.77' },
   [Feature.GITHUB_COPILOT_SUPPORT]: { minServerVersion: '0.0.77' },


### PR DESCRIPTION
The new collapsible local chat history pane currently appears in all builds. Add `NEWTAB_CHAT_HISTORY_SUPPORT` with `requiresAlphaFlag: true` and gate the shared sidebar navigation mount on that capability.

This hides the History button and prevents its history-query component from mounting in non-alpha releases, covering both desktop and mobile navigation. Development builds retain access through the existing capability convention.

Validation:
- App lint, typecheck, and the complete existing test suite passed.
- Verified the new capability is disabled for production without alpha and enabled for alpha and development.
- Reviewed the full two-file diff; existing sidepanel history remains available.
