### PR TITLE
fix(server): bind reused provider credentials to the stored endpoint

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/provider.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/provider.ts
@@ -37,11 +37,13 @@ type StoredProvider = {
  * Fills blank credential fields from the saved provider row so testing an
  * existing provider works even though reads redact its secrets.
  *
- * The stored secret is bound to the stored destination: it is reused only when
- * the request targets the same provider type AND the same connection settings
- * (base URL / resource name / region). Otherwise a caller who knows a saved
- * provider id could pair its key with an arbitrary base URL and exfiltrate it
- * to another endpoint. A changed destination must supply its own credential.
+ * A reused stored secret is bound to the stored destination: whenever a blank
+ * credential is filled in, the connection settings (base URL / resource name /
+ * region) are taken from the saved row too, so the secret can only ever be sent
+ * to the endpoint it was saved against, never a caller-supplied URL. A caller
+ * that supplies its own credential keeps its own settings, since no stored
+ * secret is at risk. The type must still match, so an openrouter key is never
+ * reused as, say, an azure provider.
  */
 export function mergeStoredCredentials<
   T extends {
@@ -51,19 +53,19 @@ export function mergeStoredCredentials<
     region?: string
   },
 >(config: T, stored: StoredProvider | null): T {
-  const same = (a?: string | null, b?: string | null) => (a ?? '') === (b ?? '')
-  if (
-    !stored ||
-    stored.type !== config.provider ||
-    !same(config.baseUrl, stored.baseUrl) ||
-    !same(config.resourceName, stored.resourceName) ||
-    !same(config.region, stored.region)
-  ) {
-    return config
-  }
+  if (!stored || stored.type !== config.provider) return config
   const merged = { ...config } as Record<string, unknown>
+  let reusedStoredSecret = false
   for (const field of CREDENTIAL_FIELDS) {
-    if (!merged[field]) merged[field] = stored[field] ?? undefined
+    if (!merged[field] && stored[field]) {
+      merged[field] = stored[field]
+      reusedStoredSecret = true
+    }
+  }
+  if (reusedStoredSecret) {
+    merged.baseUrl = stored.baseUrl ?? undefined
+    merged.resourceName = stored.resourceName ?? undefined
+    merged.region = stored.region ?? undefined
   }
   return merged as T
 }

--- a/packages/browseros-agent/apps/server/tests/api/routes/provider-test-credentials.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/provider-test-credentials.test.ts
@@ -4,12 +4,13 @@ import { mergeStoredCredentials } from '../../../src/api/routes/provider'
 const REAL_URL = 'https://api.real.example/v1'
 
 describe('mergeStoredCredentials', () => {
-  it('fills a blank api key from the stored row when type and target match', () => {
+  it('fills a blank api key from the stored row', () => {
     const merged = mergeStoredCredentials(
       { provider: 'openai-compatible', baseUrl: REAL_URL, apiKey: '' },
       { type: 'openai-compatible', baseUrl: REAL_URL, apiKey: 'sk-stored' },
     )
     expect(merged.apiKey).toBe('sk-stored')
+    expect(merged.baseUrl).toBe(REAL_URL)
   })
 
   it('keeps a supplied api key instead of the stored one', () => {
@@ -28,7 +29,7 @@ describe('mergeStoredCredentials', () => {
     expect(merged.apiKey).toBe('')
   })
 
-  it('does not reuse the stored key when the base URL differs', () => {
+  it('pins a reused key to the stored base URL, ignoring a caller-supplied one', () => {
     const merged = mergeStoredCredentials(
       {
         provider: 'openai-compatible',
@@ -37,7 +38,21 @@ describe('mergeStoredCredentials', () => {
       },
       { type: 'openai-compatible', baseUrl: REAL_URL, apiKey: 'sk-stored' },
     )
-    expect(merged.apiKey).toBe('')
+    expect(merged.apiKey).toBe('sk-stored')
+    expect(merged.baseUrl).toBe(REAL_URL)
+  })
+
+  it('keeps the caller base URL when the caller supplies its own key', () => {
+    const merged = mergeStoredCredentials(
+      {
+        provider: 'openai-compatible',
+        baseUrl: 'https://api.other.example/v1',
+        apiKey: 'sk-new',
+      },
+      { type: 'openai-compatible', baseUrl: REAL_URL, apiKey: 'sk-stored' },
+    )
+    expect(merged.apiKey).toBe('sk-new')
+    expect(merged.baseUrl).toBe('https://api.other.example/v1')
   })
 
   it('returns the config unchanged when there is no stored row', () => {
@@ -49,26 +64,7 @@ describe('mergeStoredCredentials', () => {
     expect(mergeStoredCredentials(config, null)).toBe(config)
   })
 
-  it('fills bedrock credentials when the region matches', () => {
-    const merged = mergeStoredCredentials(
-      {
-        provider: 'bedrock',
-        region: 'us-east-1',
-        accessKeyId: '',
-        secretAccessKey: '',
-      },
-      {
-        type: 'bedrock',
-        region: 'us-east-1',
-        accessKeyId: 'AKIA-stored',
-        secretAccessKey: 'secret-stored',
-      },
-    )
-    expect(merged.accessKeyId).toBe('AKIA-stored')
-    expect(merged.secretAccessKey).toBe('secret-stored')
-  })
-
-  it('does not reuse bedrock credentials when the region differs', () => {
+  it('fills bedrock credentials and pins them to the stored region', () => {
     const merged = mergeStoredCredentials(
       {
         provider: 'bedrock',
@@ -83,6 +79,8 @@ describe('mergeStoredCredentials', () => {
         secretAccessKey: 'secret-stored',
       },
     )
-    expect(merged.accessKeyId).toBe('')
+    expect(merged.accessKeyId).toBe('AKIA-stored')
+    expect(merged.secretAccessKey).toBe('secret-stored')
+    expect(merged.region).toBe('us-east-1')
   })
 })


### PR DESCRIPTION
## Problem

Testing a saved LLM provider without re-typing its (redacted) key backfills the key from the saved row. That backfill was gated on the provider type **and** the base URL, resource name, and region all matching the saved row exactly.

In practice the connection settings do not always match at test time: editing a provider can change the base URL, and the client can populate a default URL that differs from the stored one. When they diverge, the backfill was skipped and the test ran with a blank credential, so a provider that connects fine would fail its test.

## Fix

Drop the destination comparison. Keep the type match (an OpenRouter key is never reused as, say, an Azure provider), and when a blank credential is filled from the stored row, take the connection settings (base URL / resource name / region) from that same row. A reused secret can therefore only ever be sent to the endpoint it was saved against, never a caller-supplied URL. A caller that supplies its own credential keeps its own settings, since no stored secret is at risk.

This preserves the exfiltration guard (a saved key can't be paired with an arbitrary URL) while removing the fragile comparison that caused the false failures.

## Tests

`mergeStoredCredentials` unit tests updated to cover the new behavior:
- blank key filled from the stored row and pinned to the stored base URL
- a caller-supplied key keeps the caller's own settings
- a caller-supplied base URL with a blank key is pinned back to the stored URL (exfiltration guard)
- type change still blocks reuse
- Bedrock credentials filled and pinned to the stored region

`bun test` (7 pass), `tsc --noEmit`, and biome all clean.