### PR TITLE
fix(agent-server): return the MCP session handle in _meta, not structuredContent

### DIFF
--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp-dual-era.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp-dual-era.test.ts
@@ -42,6 +42,38 @@ async function post(
   }
 }
 
+const TAB = {
+  pageId: 1,
+  targetId: 'target-1',
+  tabId: 11,
+  url: 'https://example.com',
+  title: 'Example',
+  isActive: true,
+  isLoading: false,
+  loadProgress: 1,
+  isPinned: false,
+}
+
+function tabSession() {
+  return { pages: { list: async () => [TAB] } }
+}
+
+const SESSION_META_KEY = 'com.browseros/session'
+
+function sessionHandle(result: Record<string, unknown> | undefined) {
+  const meta = result?._meta as Record<string, unknown> | undefined
+  return meta?.[SESSION_META_KEY] as string | undefined
+}
+
+function textOf(result: Record<string, unknown> | undefined): string {
+  const content =
+    (result?.content as Array<{ type?: string; text?: string }>) ?? []
+  return content
+    .filter((c) => c.type === 'text' && typeof c.text === 'string')
+    .map((c) => c.text as string)
+    .join('\n')
+}
+
 describe('mcp dual-era serving', () => {
   it('serves legacy clients over initialize, as JSON, negotiating 2025-11-25', async () => {
     const app = route()
@@ -126,5 +158,107 @@ describe('mcp dual-era serving', () => {
     expect(typeof structured?.value).toBe('string')
     expect(structured?.value).toContain('UNTRUSTED_PAGE_CONTENT')
     expect(structured?.value).toContain('42')
+  })
+
+  // Regression for #2651: for a lease-less external client the server mints a
+  // session handle. It must ride in `_meta`, never replace a schemaless tool's
+  // result in `structuredContent`, and never collide with run's output schema.
+  it('modern: schemaless tool returns its result in content with the handle in _meta', async () => {
+    const app = route(tabSession())
+
+    const call = await post(
+      app,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'tabs',
+          arguments: { action: 'list' },
+          _meta: CLIENT_META,
+        },
+      },
+      {
+        'MCP-Protocol-Version': '2026-07-28',
+        'Mcp-Method': 'tools/call',
+        'Mcp-Name': 'tabs',
+      },
+    )
+
+    expect(call.status).toBe(200)
+    expect(call.json.error).toBeUndefined()
+    const result = call.json.result as Record<string, unknown>
+    // The real tab list reaches the client through content, not replaced.
+    expect(textOf(result)).toContain('https://example.com')
+    // tabs declares no output schema and the route leaves structured content
+    // off, so nothing (least of all a session-only object) rides it.
+    expect(result.structuredContent).toBeUndefined()
+    // The handle is delivered out-of-band in _meta.
+    expect(typeof sessionHandle(result)).toBe('string')
+    expect(sessionHandle(result)).toHaveLength(36)
+  })
+
+  it('legacy 2025-11-25: schemaless tool returns its result in content with the handle in _meta', async () => {
+    const app = route(tabSession())
+
+    const init = await post(app, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-11-25',
+        capabilities: {},
+        clientInfo: { name: 't', version: '1' },
+      },
+    })
+    expect(
+      (init.json.result as { protocolVersion?: string })?.protocolVersion,
+    ).toBe('2025-11-25')
+
+    const call = await post(app, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'tabs', arguments: { action: 'list' } },
+    })
+
+    expect(call.status).toBe(200)
+    expect(call.json.error).toBeUndefined()
+    const result = call.json.result as Record<string, unknown>
+    expect(textOf(result)).toContain('https://example.com')
+    expect(result.structuredContent).toBeUndefined()
+    expect(typeof sessionHandle(result)).toBe('string')
+  })
+
+  it('modern: run keeps a schema-valid structuredContent free of the handle, which rides in _meta', async () => {
+    const app = route()
+
+    const call = await post(
+      app,
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: {
+          name: 'run',
+          arguments: { code: 'return 42' },
+          _meta: CLIENT_META,
+        },
+      },
+      {
+        'MCP-Protocol-Version': '2026-07-28',
+        'Mcp-Method': 'tools/call',
+        'Mcp-Name': 'run',
+      },
+    )
+
+    // No -32600: the handle no longer collides with the RunOutput schema.
+    expect(call.status).toBe(200)
+    expect(call.json.error).toBeUndefined()
+    const result = call.json.result as Record<string, unknown>
+    const structured = result.structuredContent as Record<string, unknown>
+    expect(structured).toBeDefined()
+    expect(structured.session).toBeUndefined()
+    expect(typeof sessionHandle(result)).toBe('string')
   })
 })

--- a/packages/browseros-agent/packages/browser-mcp/src/mcp-server.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/mcp-server.test.ts
@@ -253,10 +253,16 @@ describe('createBrowserMcpServer', () => {
       action: 'new',
       url: 'https://example.com',
     })
-    const mintedSession = (minted?.structuredContent as { session?: string })
-      ?.session
+    const mintedMeta = (minted as { _meta?: Record<string, unknown> })?._meta
+    const mintedSession = mintedMeta?.['com.browseros/session'] as
+      | string
+      | undefined
     expect(typeof mintedSession).toBe('string')
     expect(mintedSession).toHaveLength(36)
+    // The handle rides in _meta, never in structuredContent (issue #2651).
+    expect(
+      (minted?.structuredContent as { session?: unknown } | undefined)?.session,
+    ).toBeUndefined()
     // The handle is attributed on the per-call log, not the aggregated metric.
     const started = debugLogs.find(
       (entry) => entry.msg === 'MCP browser tool started',
@@ -269,9 +275,11 @@ describe('createBrowserMcpServer', () => {
       url: 'https://example.com',
       session: 'agent-supplied-handle',
     })
-    expect((reused?.structuredContent as { session?: string })?.session).toBe(
-      'agent-supplied-handle',
-    )
+    expect(
+      (reused as { _meta?: Record<string, unknown> })?._meta?.[
+        'com.browseros/session'
+      ],
+    ).toBe('agent-supplied-handle')
   })
 
   it('threads the abort signal from extra.mcpReq.signal into the tool', async () => {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.test.ts
@@ -296,4 +296,32 @@ describe('registerBrowserTools', () => {
 
     expect(ends).toEqual([{ tool_name: 'tabs', source: 'unit-test' }])
   })
+
+  it('delivers the session handle in _meta when the handler catch fires, never in structuredContent', async () => {
+    const fake = createFakeServer()
+
+    // Throw from the executor seam so the handler's own catch block runs (the
+    // in-tool path returns isError instead of throwing). Regression for the
+    // exception path leaking structuredContent: { session } (#2651).
+    registerBrowserTools(
+      fake.server as never,
+      { pages: {} } as unknown as BrowserSession,
+      {},
+      {
+        sessionIdentity: true,
+        executor: async () => {
+          throw new Error('boom')
+        },
+      },
+    )
+
+    const result = await fake.handlers.get('tabs')?.({ action: 'new' })
+
+    expect(result?.isError).toBe(true)
+    // The error text stays in content, never shadowed by the handle (#2651).
+    expect(textOf(result)).toContain('boom')
+    expect(result).not.toHaveProperty('structuredContent')
+    const meta = (result as { _meta?: Record<string, unknown> })?._meta
+    expect(typeof meta?.['com.browseros/session']).toBe('string')
+  })
 })

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
@@ -301,11 +301,12 @@ export function registerBrowserTools(
             durationMs: duration(),
             error: errorText,
           })
-          return {
-            content: [{ type: 'text' as const, text: errorText }],
-            isError: true,
-            ...(sessionField && { structuredContent: sessionField }),
-          }
+          return buildToolResult(
+            { content: [{ type: 'text', text: errorText }], isError: true },
+            options.includeStructuredContent ?? true,
+            tool.output !== undefined,
+            sessionHandle,
+          )
         } finally {
           options.onToolExecutionEnd?.(lifecycleEvent)
         }

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
@@ -13,12 +13,16 @@ import {
 } from './output-file'
 import { BROWSER_TOOLS } from './registry'
 
-const SESSION_ARG_DESCRIPTION =
-  'Opaque session handle returned by the server. Pass it back on every call to keep working in the same browser session; omit it to start a new session.'
+// The `_meta` key the server-minted session handle is returned under, per the
+// MCP `_meta` convention. The handle deliberately never rides in
+// `structuredContent`: a client that prefers structuredContent (e.g. Claude
+// Code) would otherwise receive only the handle for the schemaless tools that
+// emit no structured payload, and it would collide with `run`'s declared output
+// schema. See issue #2651 (and #2513, the same fix on the neo server).
+const SESSION_META_KEY = 'com.browseros/session'
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
+const SESSION_ARG_DESCRIPTION =
+  'Opaque session handle for this browser session. The server returns it in every tool result under `_meta` at the key `com.browseros/session`; read it from there and pass it back as this `session` argument on every later call to keep the same browser session and its tab ownership. Omit it only on the first call to start a new session.'
 
 function resolveSessionHandle(
   args: Record<string, unknown>,
@@ -32,9 +36,33 @@ function resolveSessionHandle(
   return { sessionHandle, toolArgs }
 }
 
-function mergeSessionHandle(base: unknown, sessionHandle: string | undefined) {
-  if (sessionHandle === undefined) return base
-  return { ...(isPlainObject(base) ? base : {}), session: sessionHandle }
+/**
+ * Assembles the MCP tool result. The session handle rides in `_meta`, never in
+ * `structuredContent`, so it never replaces a schemaless tool's result nor
+ * collides with a declared output schema (issue #2651). Structured content is
+ * emitted only when the caller opted in or the tool declares an output schema.
+ */
+function buildToolResult(
+  result: ToolResult,
+  includeStructured: boolean,
+  hasOutputSchema: boolean,
+  sessionHandle: string | undefined,
+): {
+  content: unknown
+  isError?: boolean
+  structuredContent?: unknown
+  _meta?: Record<string, unknown>
+} {
+  const structuredContent =
+    includeStructured || hasOutputSchema ? result.structuredContent : undefined
+  return {
+    content: result.content,
+    isError: result.isError,
+    ...(structuredContent !== undefined && { structuredContent }),
+    ...(sessionHandle !== undefined && {
+      _meta: { [SESSION_META_KEY]: sessionHandle },
+    }),
+  }
 }
 
 type RegisterFn = (
@@ -52,6 +80,7 @@ type RegisterFn = (
     content: unknown
     isError?: boolean
     structuredContent?: unknown
+    _meta?: Record<string, unknown>
   }>,
 ) => void
 
@@ -237,20 +266,17 @@ export function registerBrowserTools(
           const errorSummary = result.isError
             ? resultTextSummary(result.content)
             : undefined
-          const baseStructuredContent =
-            (options.includeStructuredContent ?? true) ||
-            tool.output !== undefined
-              ? result.structuredContent
-              : undefined
-          const structuredContent = mergeSessionHandle(
-            baseStructuredContent,
+          const toolResult = buildToolResult(
+            result,
+            options.includeStructuredContent ?? true,
+            tool.output !== undefined,
             sessionHandle,
           )
           options.logger?.debug?.('MCP browser tool completed', {
             ...logBase,
             durationMs,
             isError: Boolean(result.isError),
-            hasStructuredContent: structuredContent !== undefined,
+            hasStructuredContent: toolResult.structuredContent !== undefined,
           })
           if (result.isError) {
             options.logger?.info?.('MCP browser tool returned error', {
@@ -259,11 +285,7 @@ export function registerBrowserTools(
               errorSummary,
             })
           }
-          return {
-            content: result.content,
-            isError: result.isError,
-            ...(structuredContent !== undefined && { structuredContent }),
-          }
+          return toolResult
         } catch (error) {
           const errorText =
             error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
## Problem

Closes #2651.

On the agent server, a lease-less external MCP client is issued a server-minted session handle. That handle was merged into each tool result's `structuredContent`. Two consequences for a spec-compliant client that prefers `structuredContent` over `content` (Claude Code does):

- Every tool without an output schema (all of them except `run`) emitted `structuredContent: { session }`, so the client received only the handle and dropped the real result carried in `content`.
- `run` declares an output schema (`RunOutput`); the injected `session` collided with it, failing output validation on success.

This is the agent-server counterpart of #2423, fixed for the neo server in #2513.

## Fix

Deliver the session handle in the tool result's `_meta` under `com.browseros/session` (the MCP `_meta` convention, matching the neo server), never in `structuredContent`. Structured content is now emitted only when the caller opts in or the tool declares an output schema, so schemaless tools fall back to `content` and `run`'s structured output stays schema-valid. The `session` argument description points clients at the `_meta` key to read it back.

## Tests

- `mcp-dual-era.test.ts`: end-to-end regression over **both** protocol eras (modern `2026-07-28` and legacy `2025-11-25`) — a schemaless tool returns its payload in `content` with the handle in `_meta` and no result-replacing `structuredContent`; `run` keeps a schema-valid `structuredContent` free of the handle with no validation error.
- `mcp-server.test.ts`: the session-identity unit test now asserts the handle in `_meta`, not `structuredContent`.

`bun test` (browser-mcp + MCP-surface suites), `tsc`, and Biome all clean.