### PR TITLE
fix(app): restore local-only conversation from the local server

### DIFF
--- a/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
+++ b/packages/browseros-agent/apps/app/modules/chat/chat-session.hooks.ts
@@ -692,10 +692,14 @@ export const useChatSession = (options?: ChatSessionOptions) => {
           conversationIdParam as ReturnType<typeof crypto.randomUUID>,
         )
         setMessages(restoredMessages)
+        setRestoredConversationId(conversationIdParam)
+        setSearchParams({}, { replace: true })
+        return
       }
-      setRestoredConversationId(conversationIdParam)
-      setSearchParams({}, { replace: true })
-      return
+      // Not in the cloud. Since #2542 the local server owns a signed-in user's
+      // history too, so a conversation opened from the local history list has
+      // no cloud record: read it from the server instead of giving up, which
+      // left the side panel snapping back to its previous view (#2665).
     }
 
     if (isLoadingProviders || isLoadingAgentUrl) return


### PR DESCRIPTION
Closes #2665.

## What was wrong

Since #2542 the local server owns chat history for signed-in users too, and the side panel history always lists those local conversations first. Opening one still went through the cloud query only, the path from before #2542: for a conversation without a cloud record the query resolved to nothing, the `conversationId` param was cleared and the panel snapped back to its previous view. Cloud-backed conversations kept working, which is exactly the split reported in #2665 (local-only fails, account-backed opens).

#2625 added the local restore for the new tab and for logged-out users (`restoreLocally`), but the signed-in side panel never reached it.

## Change

In the side panel restore effect, when the cloud has no record of the requested conversation, fall through to the same local server restore that logged-out and new-tab users already use (`fetchServerConversation` via `restoreServerConversation`). A conversation that does exist in the cloud is restored from there as before, so nothing changes for account-backed history. On a real miss the local path settles the UI the same way the cloud miss did (param cleared, no error banner in the side panel).

## Validation

- `bun run scripts/run-bun-test.ts --cwd=apps/app ./apps/app`: 433 pass, 0 fail across 61 files.
- `bunx wxt prepare && tsc --noEmit` in `apps/app`: clean (GraphQL types generated from `schema/schema.graphql`).
- `bunx @biomejs/biome check` on the changed file: clean.

Not done here: a browser check against a running local server. The change is confined to the branch that already runs for logged-out users, so the manual check that would help most is a signed-in user opening a local-only conversation from the side panel history.