### PR TITLE
feat(dev): run the agent dev loop on Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Most contributors start with BrowserOS neo or BrowserOS. Both live in `packages/
 
 Install it by following [the Bun installation guide](https://bun.sh/docs/installation). CI installs the exact pinned version by reading that same `package.json`, so matching it locally keeps you on the same dependency resolution. Check yours with `bun --version`.
 
-The per-path guides list what else each one needs.
+The per-path guides list what else each one needs. Both agent dev loops run on macOS and Linux; on Linux the supervisor resolves installed BrowserOS builds from `/usr/lib/<product>/` (or `/opt/<product>/` for AppImage layouts), or set `BROWSEROS_BINARY` to point at any build.
 
 ## Browser development
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Your sessions, screenshots, history, and settings live under `~/.browserclaw/` a
 Yes. Both browsers are Chromium forks, so Chrome extensions work and your bookmarks, passwords, and settings import in one click.
 
 **What platforms are supported?**
-BrowserOS neo runs on macOS and Windows. BrowserOS runs on macOS, Windows, and Linux. System requirements match Google Chrome.
+BrowserOS neo ships installers for macOS and Windows today; the browser itself already builds and releases for Linux from this repo, and the agent dev loop runs on macOS and Linux. BrowserOS ships installers for macOS, Windows, and Linux. System requirements match Google Chrome.
 
 ## Get help
 

--- a/packages/browseros-agent/.env.development.example
+++ b/packages/browseros-agent/.env.development.example
@@ -7,8 +7,9 @@
 # CDP protocol JSON input for browser protocol codegen.
 # CDP_PROTOCOL_JSON=/path/to/chromium/src/out/Default_arm64/gen/third_party/blink/public/devtools_protocol/protocol.json
 
-# BrowserOS binary used by app and Claw development.
-BROWSEROS_BINARY=/Applications/BrowserOS.app/Contents/MacOS/BrowserOS
+# BrowserOS binary used by app and Claw development. Optional: when
+# unset, each platform falls back to its install locations.
+# BROWSEROS_BINARY=/Applications/BrowserOS.app/Contents/MacOS/BrowserOS
 
 # --- app ---
 

--- a/packages/browseros-agent/CONTRIBUTING.BrowserOS.md
+++ b/packages/browseros-agent/CONTRIBUTING.BrowserOS.md
@@ -20,13 +20,13 @@ The extension talks GraphQL to the server. The schema lives at [`apps/app/schema
 | Tool | Why | Install |
 |---|---|---|
 | **Bun** | The package manager and runtime. Version pinned in `package.json` | `curl -fsSL https://bun.sh/install \| bash` |
-| **Go** | The dev supervisor is a Go program compiled on every run | `brew install go` |
-| **Lima** | The dev supervisor requires it and refuses to start without it | `brew install lima` |
+| **Go** | The dev supervisor is a Go program compiled on every run | `brew install go` (macOS) or your package manager |
+| **Lima** | macOS only: the supervisor requires it there and refuses to start without it | `brew install lima` |
 | **BrowserOS** | The supervisor launches the installed app | [Download](https://files.browseros.com/download/BrowserOS.dmg) |
 
 Rust is not needed for this path. It is only required for the BrowserOS neo backend.
 
-The dev loop is macOS only today. The supervisor resolves the browser through a hard-coded `/Applications/...` path, so Linux and Windows contributors can install dependencies and run the checks, but cannot launch either product yet.
+The dev loop runs on macOS and Linux. On macOS the supervisor launches the installed app from `/Applications`; on Linux it resolves the build from `/usr/lib/browseros/browseros` (Debian) or `/opt/browseros/browseros` (AppImage layout), and `BROWSEROS_BINARY` always wins. Windows contributors can install dependencies and run the checks, but cannot launch either product yet.
 
 ## Setup
 

--- a/packages/browseros-agent/CONTRIBUTING.md
+++ b/packages/browseros-agent/CONTRIBUTING.md
@@ -22,13 +22,13 @@ The wire types are generated on both sides. [`packages/claw-api`](packages/claw-
 | Tool | Why | Install |
 |---|---|---|
 | **Bun** | The package manager and runtime. Version pinned in `package.json` | `curl -fsSL https://bun.sh/install \| bash` |
-| **Go** | The dev supervisor is a Go program compiled on every run | `brew install go` |
-| **Lima** | The dev supervisor requires it and refuses to start without it | `brew install lima` |
+| **Go** | The dev supervisor is a Go program compiled on every run | `brew install go` (macOS) or your package manager |
+| **Lima** | macOS only: the supervisor requires it there and refuses to start without it | `brew install lima` |
 | **Rust** | `claw-server-rust` is built and run with cargo | `brew install rustup && rustup-init` |
 | **BrowserOS neo** | The supervisor launches the installed app | [Download](https://cdn.browseros.com/download/BrowserOS_neo.dmg) |
 | **Docker** | Only if you change the API contract. `codegen:claw-api` runs the generator in a pinned container | [Docker Desktop](https://www.docker.com/products/docker-desktop/) |
 
-The dev loop is macOS only today. The supervisor resolves the browser through a hard-coded `/Applications/...` path, so Linux and Windows contributors can install dependencies and run the checks, but cannot launch either product yet.
+The dev loop runs on macOS and Linux. On macOS the supervisor launches the installed app from `/Applications`; on Linux it resolves the neo build from `/usr/lib/browserclaw/browserclaw` (Debian) or `/opt/browserclaw/browserclaw` (AppImage layout), falling back to an installed BrowserOS, and `BROWSEROS_BINARY` always wins. Windows contributors can install dependencies and run the checks, but cannot launch either product yet.
 
 ## Setup
 

--- a/packages/browseros-agent/apps/app/web-ext.config.ts
+++ b/packages/browseros-agent/apps/app/web-ext.config.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdirSync } from 'node:fs'
+import { existsSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -87,8 +87,14 @@ if (env.BROWSEROS_EXTENSION_PORT) {
  */
 function defaultBrowserBinary(): string {
   if (process.platform === 'linux') {
-    // Debian lib_dir then AppImage appimage_dir layouts from bos_build.
-    return '/usr/lib/browseros/browseros'
+    // Prefer the Debian install, then the extracted AppImage layout.
+    const candidates = [
+      '/usr/lib/browseros/browseros',
+      '/opt/browseros/browseros',
+    ]
+    return (
+      candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]
+    )
   }
   return '/Applications/BrowserOS.app/Contents/MacOS/BrowserOS'
 }

--- a/packages/browseros-agent/apps/app/web-ext.config.ts
+++ b/packages/browseros-agent/apps/app/web-ext.config.ts
@@ -53,7 +53,8 @@ function browserOSProduct(defaultProduct: 'browseros' | 'browserclaw') {
 }
 
 const chromiumArgs = [
-  '--use-mock-keychain',
+  // macOS-only keychain-testing flag; skip it on other platforms.
+  ...(process.platform === 'darwin' ? ['--use-mock-keychain'] : []),
   // web-ext 9.x launches Chromium with --disable-blink-features=AutomationControlled,
   // which trips Chromium's "unsupported command-line flag" infobar. --test-type
   // marks this as a dev browser and suppresses that banner.
@@ -80,11 +81,21 @@ if (env.BROWSEROS_EXTENSION_PORT) {
   )
 }
 
+/**
+ * Platform default for the installed BrowserOS binary. The supervisor and
+ * tests accept a BROWSEROS_BINARY override; this only covers bare launches.
+ */
+function defaultBrowserBinary(): string {
+  if (process.platform === 'linux') {
+    // Debian lib_dir then AppImage appimage_dir layouts from bos_build.
+    return '/usr/lib/browseros/browseros'
+  }
+  return '/Applications/BrowserOS.app/Contents/MacOS/BrowserOS'
+}
+
 export default defineWebExtConfig({
   binaries: {
-    chrome:
-      env.BROWSEROS_BINARY ||
-      '/Applications/BrowserOS.app/Contents/MacOS/BrowserOS',
+    chrome: env.BROWSEROS_BINARY || defaultBrowserBinary(),
   },
   chromiumArgs,
   chromiumProfile: chromiumProfile(),

--- a/packages/browseros-agent/apps/claw-app/web-ext.config.ts
+++ b/packages/browseros-agent/apps/claw-app/web-ext.config.ts
@@ -54,7 +54,8 @@ function browserOSProduct(defaultProduct: 'browseros' | 'browserclaw') {
 }
 
 const chromiumArgs = [
-  '--use-mock-keychain',
+  // macOS-only keychain-testing flag; skip it on other platforms.
+  ...(process.platform === 'darwin' ? ['--use-mock-keychain'] : []),
   // web-ext 9.x launches Chromium with --disable-blink-features=AutomationControlled,
   // which trips Chromium's "unsupported command-line flag" infobar. --test-type
   // marks this as a dev browser and suppresses that banner.
@@ -79,11 +80,22 @@ if (env.BROWSEROS_SERVER_PORT) {
   // port falls back to server port.
   chromiumArgs.push(`--browseros-proxy-port=${env.BROWSEROS_SERVER_PORT}`)
 }
+
+/**
+ * Platform default for the installed BrowserOS neo binary. The supervisor and
+ * tests accept a BROWSEROS_BINARY override; this only covers bare launches.
+ */
+function defaultBrowserBinary(): string {
+  if (process.platform === 'linux') {
+    // Debian lib_dir then AppImage appimage_dir layouts from bos_build.
+    return '/usr/lib/browserclaw/browserclaw'
+  }
+  return '/Applications/BrowserOS neo.app/Contents/MacOS/BrowserOS neo'
+}
+
 export default defineWebExtConfig({
   binaries: {
-    chrome:
-      env.BROWSEROS_BINARY ||
-      '/Applications/BrowserOS.app/Contents/MacOS/BrowserOS',
+    chrome: env.BROWSEROS_BINARY || defaultBrowserBinary(),
   },
   chromiumArgs,
   chromiumProfile: chromiumProfile(),

--- a/packages/browseros-agent/apps/claw-app/web-ext.config.ts
+++ b/packages/browseros-agent/apps/claw-app/web-ext.config.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdirSync } from 'node:fs'
+import { existsSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -87,8 +87,16 @@ if (env.BROWSEROS_SERVER_PORT) {
  */
 function defaultBrowserBinary(): string {
   if (process.platform === 'linux') {
-    // Debian lib_dir then AppImage appimage_dir layouts from bos_build.
-    return '/usr/lib/browserclaw/browserclaw'
+    // Prefer the Debian install, then the extracted AppImage layout.
+    const candidates = [
+      '/usr/lib/browserclaw/browserclaw',
+      '/opt/browserclaw/browserclaw',
+      '/usr/lib/browseros/browseros',
+      '/opt/browseros/browseros',
+    ]
+    return (
+      candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]
+    )
   }
   return '/Applications/BrowserOS neo.app/Contents/MacOS/BrowserOS neo'
 }

--- a/packages/browseros-agent/apps/server/tests/__helpers__/test-runtime.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/test-runtime.ts
@@ -6,7 +6,9 @@ import { TEST_PORTS } from '@browseros/shared/constants/ports'
 
 const DEFAULT_BINARY_PATH =
   process.env.BROWSEROS_BINARY ??
-  '/Applications/BrowserOS.app/Contents/MacOS/BrowserOS'
+  (process.platform === 'linux'
+    ? '/usr/lib/browseros/browseros'
+    : '/Applications/BrowserOS.app/Contents/MacOS/BrowserOS')
 const PORT_SCAN_RANGE = 100
 
 export interface RuntimePorts {

--- a/packages/browseros-agent/packages/shared/src/env/registry.ts
+++ b/packages/browseros-agent/packages/shared/src/env/registry.ts
@@ -52,12 +52,14 @@ export const ENV_REGISTRY: readonly EnvKeySpec[] = [
   {
     key: 'BROWSEROS_BINARY',
     section: 'dev-tools',
-    description: 'BrowserOS binary used by app and Claw development.',
+    description:
+      'BrowserOS binary used by app and Claw development. Optional: when\nunset, each platform falls back to its install locations.',
     secret: false,
     schema: stringSchema,
     modes: {
       development: {
         value: '/Applications/BrowserOS.app/Contents/MacOS/BrowserOS',
+        commented: true,
       },
     },
   },

--- a/packages/browseros-agent/tools/dev/browser/args.go
+++ b/packages/browseros-agent/tools/dev/browser/args.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"browseros-dev/proc"
 )
@@ -21,9 +22,35 @@ const (
 	ProductBrowserOS   = "browseros"
 	ProductBrowserClaw = "browserclaw"
 
+	// macOS app-bundle binary paths. These double as the canonical install
+	// locations documented for each product; Linux resolves its own layout in
+	// linuxBinaryPaths below.
 	BrowserOSBinaryPath   = "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS"
 	BrowserClawBinaryPath = "/Applications/BrowserOS neo.app/Contents/MacOS/BrowserOS neo"
 )
+
+// linuxBinaryPaths lists candidate Chromium binaries per product on Linux,
+// mirroring the Debian (lib_dir) and AppImage (appimage_dir) layouts produced
+// by bos_build's linux_packaging for each product id.
+func linuxBinaryPaths(product string) []string {
+	if product == ProductBrowserClaw {
+		return []string{
+			"/usr/lib/browserclaw/browserclaw",
+			"/opt/browserclaw/browserclaw",
+		}
+	}
+	return []string{
+		"/usr/lib/browseros/browseros",
+		"/opt/browseros/browseros",
+	}
+}
+
+// EnvBinaryPath returns the developer override for the browser binary, if set.
+// BROWSEROS_BINARY already flows through WXT (web-ext.config.ts) and the test
+// runtime, so the supervisor honors the same variable.
+func EnvBinaryPath() string {
+	return os.Getenv("BROWSEROS_BINARY")
+}
 
 type BinaryResolution struct {
 	Product       string
@@ -34,7 +61,41 @@ type BinaryResolution struct {
 
 // ResolveBinary chooses the Chromium app binary for a product with an injectable existence check.
 func ResolveBinary(product string, exists func(string) bool) BinaryResolution {
+	return resolveBinaryFor(product, runtime.GOOS, exists)
+}
+
+// resolveBinaryFor is ResolveBinary with an injectable GOOS so tests can cover
+// every platform from one host.
+func resolveBinaryFor(product string, goos string, exists func(string) bool) BinaryResolution {
 	product = normalizeProduct(product)
+	if goos == "linux" {
+		candidates := linuxBinaryPaths(product)
+		for _, candidate := range candidates {
+			if exists != nil && exists(candidate) {
+				return BinaryResolution{
+					Product:       product,
+					Path:          candidate,
+					PreferredPath: candidates[0],
+				}
+			}
+		}
+		if product != ProductBrowserClaw {
+			return BinaryResolution{
+				Product:       product,
+				Path:          candidates[0],
+				PreferredPath: candidates[0],
+			}
+		}
+		// Mirror the macOS fallback: neo reuses an installed BrowserOS build
+		// when the neo install is absent.
+		return BinaryResolution{
+			Product:       product,
+			Path:          linuxBinaryPaths(ProductBrowserOS)[0],
+			PreferredPath: candidates[0],
+			Fallback:      true,
+		}
+	}
+
 	resolution := BinaryResolution{
 		Product:       product,
 		Path:          BrowserOSBinaryPath,
@@ -53,17 +114,29 @@ func ResolveBinary(product string, exists func(string) bool) BinaryResolution {
 	return resolution
 }
 
-// ResolveInstalledBinary resolves the product binary against the local macOS app bundle paths.
+// ResolveInstalledBinary resolves the product binary against the local
+// platform's install paths. BROWSEROS_BINARY wins over everything.
 func ResolveInstalledBinary(product string) BinaryResolution {
+	if env := EnvBinaryPath(); env != "" {
+		return BinaryResolution{
+			Product:       normalizeProduct(product),
+			Path:          env,
+			PreferredPath: env,
+		}
+	}
 	return ResolveBinary(product, binaryExists)
 }
 
 // BuildArgs returns the BrowserOS Chromium command for non-WXT dev/test launches.
 func BuildArgs(cfg ArgsConfig) []string {
-	return buildArgs(cfg, ResolveInstalledBinary)
+	return buildArgsForGOOS(cfg, runtime.GOOS, ResolveInstalledBinary)
 }
 
 func buildArgs(cfg ArgsConfig, resolveBinary func(string) BinaryResolution) []string {
+	return buildArgsForGOOS(cfg, runtime.GOOS, resolveBinary)
+}
+
+func buildArgsForGOOS(cfg ArgsConfig, goos string, resolveBinary func(string) BinaryResolution) []string {
 	product := cfg.Product
 	if product == "" {
 		product = ProductBrowserOS
@@ -76,8 +149,13 @@ func buildArgs(cfg ArgsConfig, resolveBinary func(string) BinaryResolution) []st
 		args = append(args, "--no-first-run", "--no-default-browser-check")
 	}
 
+	// --use-mock-keychain is a macOS keychain-testing flag; keep it off other
+	// platforms so dev launches stay identical to documented Chromium ones.
+	if goos == "darwin" {
+		args = append(args, "--use-mock-keychain")
+	}
+
 	args = append(args,
-		"--use-mock-keychain",
 		"--show-component-extension-options",
 		"--disable-browseros-server",
 		"--browseros-dock-icon=dev",

--- a/packages/browseros-agent/tools/dev/browser/args.go
+++ b/packages/browseros-agent/tools/dev/browser/args.go
@@ -88,9 +88,20 @@ func resolveBinaryFor(product string, goos string, exists func(string) bool) Bin
 		}
 		// Mirror the macOS fallback: neo reuses an installed BrowserOS build
 		// when the neo install is absent.
+		browserOSCandidates := linuxBinaryPaths(ProductBrowserOS)
+		for _, candidate := range browserOSCandidates {
+			if exists != nil && exists(candidate) {
+				return BinaryResolution{
+					Product:       product,
+					Path:          candidate,
+					PreferredPath: candidates[0],
+					Fallback:      true,
+				}
+			}
+		}
 		return BinaryResolution{
 			Product:       product,
-			Path:          linuxBinaryPaths(ProductBrowserOS)[0],
+			Path:          browserOSCandidates[0],
 			PreferredPath: candidates[0],
 			Fallback:      true,
 		}

--- a/packages/browseros-agent/tools/dev/browser/args_test.go
+++ b/packages/browseros-agent/tools/dev/browser/args_test.go
@@ -39,6 +39,29 @@ func TestBuildArgsUsesProductFlag(t *testing.T) {
 	}
 }
 
+func TestBuildArgsSkipsMockKeychainOutsideMacOS(t *testing.T) {
+	build := func(goos string) string {
+		args := buildArgsForGOOS(ArgsConfig{
+			Root:        "/repo/packages/browseros-agent",
+			Ports:       proc.Ports{CDP: 9005, Server: 9105, Extension: 9305},
+			UserDataDir: "/tmp/browseros-dev",
+		}, goos, func(product string) BinaryResolution {
+			return BinaryResolution{Product: product, Path: "/browser", PreferredPath: "/browser"}
+		})
+		return strings.Join(args, "\n")
+	}
+
+	if !strings.Contains(build("darwin"), "--use-mock-keychain") {
+		t.Fatal("expected --use-mock-keychain on darwin")
+	}
+	if strings.Contains(build("linux"), "--use-mock-keychain") {
+		t.Fatal("did not expect --use-mock-keychain on linux")
+	}
+	if strings.Contains(build("windows"), "--use-mock-keychain") {
+		t.Fatal("did not expect --use-mock-keychain on windows")
+	}
+}
+
 func TestResolveBinary(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -90,12 +113,66 @@ func TestResolveBinary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ResolveBinary(tt.product, func(path string) bool {
+			got := resolveBinaryFor(tt.product, "darwin", func(path string) bool {
 				return tt.existingPaths[path]
 			})
 			if got.Product != tt.wantProduct || got.Path != tt.wantPath || got.PreferredPath != tt.wantPreferred || got.Fallback != tt.wantFallback {
 				t.Fatalf("ResolveBinary got %#v", got)
 			}
 		})
+	}
+}
+
+func TestResolveBinaryOnLinuxPrefersDebianLayout(t *testing.T) {
+	got := resolveBinaryFor(ProductBrowserClaw, "linux", func(path string) bool {
+		return path == "/opt/browserclaw/browserclaw"
+	})
+	if got.Product != ProductBrowserClaw {
+		t.Fatalf("expected browserclaw product, got %q", got.Product)
+	}
+	if got.PreferredPath != "/usr/lib/browserclaw/browserclaw" {
+		t.Fatalf("expected Debian layout preferred path, got %q", got.PreferredPath)
+	}
+	if got.Path != "/opt/browserclaw/browserclaw" {
+		t.Fatalf("expected AppImage-layout install to win, got %q", got.Path)
+	}
+	if got.Fallback {
+		t.Fatal("expected a found neo install not to be a fallback")
+	}
+}
+
+func TestResolveBinaryOnLinuxFallsBackToBrowserOS(t *testing.T) {
+	got := resolveBinaryFor(ProductBrowserClaw, "linux", func(path string) bool {
+		return path == "/usr/lib/browseros/browseros"
+	})
+	if got.Product != ProductBrowserClaw {
+		t.Fatalf("expected browserclaw product, got %q", got.Product)
+	}
+	if got.Path != "/usr/lib/browseros/browseros" {
+		t.Fatalf("expected BrowserOS fallback on Linux, got %q", got.Path)
+	}
+	if got.PreferredPath != "/usr/lib/browserclaw/browserclaw" {
+		t.Fatalf("expected neo preferred path, got %q", got.PreferredPath)
+	}
+	if !got.Fallback {
+		t.Fatal("expected BrowserOS reuse to be flagged as fallback")
+	}
+}
+
+func TestResolveBinaryOnLinuxDefaultsToDebianPathWhenNothingInstalled(t *testing.T) {
+	got := resolveBinaryFor(ProductBrowserOS, "linux", func(string) bool { return false })
+	if got.Path != "/usr/lib/browseros/browseros" {
+		t.Fatalf("expected Debian layout default, got %q", got.Path)
+	}
+	if got.PreferredPath != got.Path || got.Fallback {
+		t.Fatalf("expected unchanged preferred path without fallback, got %#v", got)
+	}
+
+	claw := resolveBinaryFor(ProductBrowserClaw, "linux", func(string) bool { return false })
+	if claw.Path != "/usr/lib/browseros/browseros" {
+		t.Fatalf("expected neo to default to the BrowserOS path like macOS, got %q", claw.Path)
+	}
+	if claw.PreferredPath != "/usr/lib/browserclaw/browserclaw" || !claw.Fallback {
+		t.Fatalf("expected neo preferred path with fallback set, got %#v", claw)
 	}
 }

--- a/packages/browseros-agent/tools/dev/browser/args_test.go
+++ b/packages/browseros-agent/tools/dev/browser/args_test.go
@@ -159,6 +159,18 @@ func TestResolveBinaryOnLinuxFallsBackToBrowserOS(t *testing.T) {
 	}
 }
 
+func TestResolveBinaryOnLinuxFallsBackToBrowserOSAppImage(t *testing.T) {
+	got := resolveBinaryFor(ProductBrowserClaw, "linux", func(path string) bool {
+		return path == "/opt/browseros/browseros"
+	})
+	if got.Path != "/opt/browseros/browseros" {
+		t.Fatalf("expected BrowserOS AppImage fallback on Linux, got %q", got.Path)
+	}
+	if !got.Fallback {
+		t.Fatal("expected BrowserOS reuse to be flagged as fallback")
+	}
+}
+
 func TestResolveBinaryOnLinuxDefaultsToDebianPathWhenNothingInstalled(t *testing.T) {
 	got := resolveBinaryFor(ProductBrowserOS, "linux", func(string) bool { return false })
 	if got.Path != "/usr/lib/browseros/browseros" {

--- a/packages/browseros-agent/tools/dev/cmd/watch.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -62,8 +63,12 @@ func runWatch(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	if err := ensureLimactlPresent(); err != nil {
-		return err
+	// Lima is the macOS VM runtime the supervisor relies on; a Linux host
+	// runs natively and has no use for it.
+	if runtime.GOOS == "darwin" {
+		if err := ensureLimactlPresent(); err != nil {
+			return err
+		}
 	}
 
 	defaultPorts, err := resolveWatchDefaultPorts(root, watchClaw)
@@ -314,7 +319,7 @@ func buildClawWatchEnv(env []string, p proc.Ports) []string {
 
 func logClawBrowserBinary(resolution browser.BinaryResolution) {
 	if resolution.Fallback {
-		proc.LogMsgf(proc.TagInfo, "BrowserOS neo app not found at %s; using %s", browser.BrowserClawBinaryPath, resolution.Path)
+		proc.LogMsgf(proc.TagInfo, "BrowserOS neo app not found; using %s", resolution.Path)
 		return
 	}
 	proc.LogMsgf(proc.TagInfo, "Browser app: %s", resolution.Path)

--- a/packages/browseros-agent/tools/dev/cmd/watch_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -381,6 +382,9 @@ func TestRustWatchSnapshotDetectsSourceChangesAndSkipsTargetDirs(t *testing.T) {
 }
 
 func TestEnsureLimactlPresentMissingMessage(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Lima prerequisite is only enforced on macOS")
+	}
 	t.Setenv("PATH", t.TempDir())
 
 	err := ensureLimactlPresent()
@@ -398,6 +402,9 @@ func TestEnsureLimactlPresentMissingMessage(t *testing.T) {
 }
 
 func TestEnsureLimactlPresentFindsPathBinary(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Lima prerequisite is only enforced on macOS")
+	}
 	binDir := t.TempDir()
 	limactlPath := filepath.Join(binDir, "limactl")
 	if err := os.WriteFile(limactlPath, []byte("#!/bin/sh\n"), 0o755); err != nil {

--- a/packages/browseros-agent/tools/dev/proc/ports.go
+++ b/packages/browseros-agent/tools/dev/proc/ports.go
@@ -134,7 +134,9 @@ func (r *PortReservations) ReleaseAll() {
 }
 
 func KillPort(port int) {
-	exec.Command("sh", "-c", fmt.Sprintf("lsof -ti:%d | xargs kill -9 2>/dev/null || true", port)).Run()
+	// lsof is not installed everywhere (minimal Linux images); fuser covers
+	// those cases and lsof keeps macOS behavior unchanged.
+	exec.Command("sh", "-c", fmt.Sprintf("(lsof -ti:%d 2>/dev/null || fuser %d/tcp 2>/dev/null) | xargs kill -9 2>/dev/null || true", port, port)).Run()
 }
 
 func KillPortAndWait(port int, timeout time.Duration) error {

--- a/packages/browseros-agent/tools/dev/proc/process.go
+++ b/packages/browseros-agent/tools/dev/proc/process.go
@@ -428,8 +428,13 @@ func isBrowserProcessForUserDataDir(command string, userDataDirs []string, inclu
 }
 
 func isBrowserAppCommand(command string) bool {
+	// macOS launches resolve through the app bundle binaries; Linux runs the
+	// bare browseros/browserclaw binaries from /usr/lib or /opt (or an
+	// extracted AppImage using the same names).
 	return strings.Contains(command, "BrowserOS.app/Contents/MacOS/BrowserOS") ||
-		strings.Contains(command, "BrowserOS neo.app/Contents/MacOS/BrowserOS neo")
+		strings.Contains(command, "BrowserOS neo.app/Contents/MacOS/BrowserOS neo") ||
+		strings.Contains(command, "/browseros/browseros") ||
+		strings.Contains(command, "/browserclaw/browserclaw")
 }
 
 func watchRunPaths(baseDir string, identity WatchRunIdentity) watchRunPathsResult {

--- a/packages/browseros-agent/tools/dev/proc/process_test.go
+++ b/packages/browseros-agent/tools/dev/proc/process_test.go
@@ -69,6 +69,22 @@ func TestBrowserProfilePIDsFromPSSelectsOnlyDevAndTestProfiles(t *testing.T) {
 	}
 }
 
+func TestBrowserProfilePIDsFromPSMatchesLinuxBrowserPaths(t *testing.T) {
+	output := strings.Join([]string{
+		"  10  10 /usr/lib/browseros/browseros --user-data-dir=/tmp/browseros-dev",
+		"  20  20 /usr/lib/browserclaw/browserclaw --user-data-dir=/tmp/browseros-dev-abcd",
+		"  30  30 /opt/browserclaw/browserclaw --user-data-dir=/var/tmp/browseros-test-abcd",
+		"  40  40 /tmp/.mount_BrowserOS/opt/browserclaw/browserclaw --user-data-dir=/tmp/browseros-dev-mount",
+		"  50  50 grep browseros-dev-",
+	}, "\n") + "\n"
+
+	pids := browserProfilePIDsFromPS(output)
+
+	if len(pids) != 4 || pids[0] != 10 || pids[1] != 20 || pids[2] != 30 || pids[3] != 40 {
+		t.Fatalf("expected Linux dev/test browser pids, got %#v", pids)
+	}
+}
+
 func TestDefaultDevUserDataDirIsWorktreeScoped(t *testing.T) {
 	first := filepath.Join(t.TempDir(), "main-2", "packages", "browseros-agent")
 	second := filepath.Join(t.TempDir(), "feat-new-mcp", "packages", "browseros-agent")

--- a/packages/browseros-agent/tools/dev/run.sh
+++ b/packages/browseros-agent/tools/dev/run.sh
@@ -6,7 +6,11 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 if ! command -v go &>/dev/null; then
   echo ""
   echo "  Go is required to build browseros-dev but is not installed."
-  echo "  Install it with:  brew install go"
+  if command -v brew &>/dev/null; then
+    echo "  Install it with:  brew install go"
+  else
+    echo "  Install it with your package manager (e.g. apt install golang-go)"
+  fi
   echo "  Or download from: https://go.dev/dl/"
   echo ""
   exit 1
@@ -34,7 +38,11 @@ fi
 if [ "$needs_cargo" = true ] && ! command -v cargo &>/dev/null; then
   echo ""
   echo "  Cargo is required for dev:claw-rust:watch but is not installed."
-  echo "  Install Rust with:  brew install rustup && rustup-init"
+  if command -v brew &>/dev/null; then
+    echo "  Install Rust with:  brew install rustup && rustup-init"
+  else
+    echo "  Install Rust with:  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+  fi
   echo "  Or download from: https://rustup.rs/"
   echo ""
   exit 1


### PR DESCRIPTION
## What
 
Makes the BrowserOS / BrowserOS neo dev supervisor (`bun run dev:watch`, `dev:claw:watch`) work on Linux instead of failing at startup.
 
## Why
 
The dev loop was macOS-only in practice: the supervisor required `limactl` (a macOS VM runtime) before doing anything and resolved the browser through hard-coded `/Applications/...` paths. Meanwhile the release pipeline already builds and ships Linux artifacts for both products (`release-linux.yml` has a browserclaw lane, the claw server releases linux-x64/arm64), so the dev loop was the last gap — contributors on Linux could install deps and run checks but never launch either product.
 
Closes #2650
Closes #2174
 
## How
 
- **Platform-aware binary resolution** (`tools/dev/browser/args.go`): on Linux the supervisor probes `/usr/lib/<product>/<product>` (deb `lib_dir`) then `/opt/<product>/<product>` (AppImage `appimage_dir`) — the exact layouts `bos_build`'s linux packaging installs. `browserclaw` falls back to an installed `browseros`, same fallback semantics as macOS. `BROWSEROS_BINARY` now wins over the platform defaults, consistent with how `web-ext.config.ts` and the server test runtime already treat it.
- **Lima prerequisite is darwin-only** (`tools/dev/cmd/watch.go`); Linux hosts run natively and have no use for a macOS VM runtime.
- **`--use-mock-keychain` gated to darwin** in the supervisor args and both web-ext configs (macOS keychain-testing flag).
- **Process matching** (`tools/dev/proc/process.go`) recognizes Linux browser binaries so profile takeover/cleanup still works.
- **Port cleanup falls back to `fuser`** when `lsof` is missing (minimal server images).
- `BROWSEROS_BINARY` is now commented/optional in `.env.development.example` since every consumer has platform defaults; `run.sh` hints are package-manager-neutral.
- New GOOS-injected Go tests cover Linux resolution (deb preference, AppImage candidate, fallback, nothing installed), flag gating, and Linux `ps` matching — so the suite still passes on macOS hosts.
- Contributing guides and README platform FAQ updated.
 
## Testing
 
- [x] `cd tools/dev && gofmt -l . && go test ./...`
- [x] `bun run check` and `bun test` in `packages/browseros-agent`
- [x] On Linux with a deb/AppImage install: `bun run dev:claw:watch:new` launches the browser
 
I have read the CLA Document and I hereby sign the CLA
